### PR TITLE
Altered Mindstates partially resist Flaming Eyes

### DIFF
--- a/data/json/npcs/refugee_center/beggars/BEGGAR_2_Dino_Dave.json
+++ b/data/json/npcs/refugee_center/beggars/BEGGAR_2_Dino_Dave.json
@@ -235,7 +235,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_REFUGEE_BEGGAR_2_FLAMINGEYE_YES",
-    "dynamic_line": "Nobody's the same, not even twins.  But I'll tell you something.  The big eye is afraid of the voices.",
+    "dynamic_line": "Nobody's the same, not even twins.  But I'll tell you something.  The big eye looked at me.  It heard the voices, and it blinked.",
     "responses": [
       { "text": "What was that about cardboard?", "topic": "TALK_REFUGEE_BEGGAR_2_CARDBOARD" },
       { "text": "Why are you sitting out here?", "topic": "TALK_REFUGEE_BEGGAR_2_REFUGEE" },

--- a/data/json/npcs/refugee_center/beggars/BEGGAR_2_Dino_Dave.json
+++ b/data/json/npcs/refugee_center/beggars/BEGGAR_2_Dino_Dave.json
@@ -200,6 +200,47 @@
     "id": "TALK_REFUGEE_BEGGAR_2_WEARING",
     "dynamic_line": "You ask me what I can see, but I don't tell you what you see.  Sometimes we have shields up, to protect ourselves.",
     "responses": [
+      { "text": "Shields?", "topic": "TALK_REFUGEE_BEGGAR_2_FLAMINGEYE" },
+      { "text": "What was that about cardboard?", "topic": "TALK_REFUGEE_BEGGAR_2_CARDBOARD" },
+      { "text": "Why are you sitting out here?", "topic": "TALK_REFUGEE_BEGGAR_2_REFUGEE" },
+      { "text": "I think I have to get going…", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_REFUGEE_BEGGAR_2_FLAMINGEYE",
+    "dynamic_line": "Once I saw the full moon, but it was a huge eye, looking down on me - only it couldn't see me, because the sandman kept it away.  Understand?",
+    "responses": [
+      {
+        "condition": { "not": { "u_has_trait": "SCHIZOPHRENIC" } },
+        "text": "Can't say that I do.",
+        "topic": "TALK_REFUGEE_BEGGAR_2_FLAMINGEYE_NO"
+      },
+      {
+        "condition": { "u_has_trait": "SCHIZOPHRENIC" },
+        "text": "[Kaluptic Psychosis] I think I do.  Are we the same?",
+        "topic": "TALK_REFUGEE_BEGGAR_2_FLAMINGEYE_YES"
+      },
+      { "text": "What was that about cardboard?", "topic": "TALK_REFUGEE_BEGGAR_2_CARDBOARD" },
+      { "text": "Why are you sitting out here?", "topic": "TALK_REFUGEE_BEGGAR_2_REFUGEE" },
+      { "text": "I think I have to get going…", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_REFUGEE_BEGGAR_2_FLAMINGEYE_NO",
+    "dynamic_line": "That's OK, nobody's perfect, ha ha...",
+    "responses": [
+      { "text": "What was that about cardboard?", "topic": "TALK_REFUGEE_BEGGAR_2_CARDBOARD" },
+      { "text": "Why are you sitting out here?", "topic": "TALK_REFUGEE_BEGGAR_2_REFUGEE" },
+      { "text": "I think I have to get going…", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_REFUGEE_BEGGAR_2_FLAMINGEYE_YES",
+    "dynamic_line": "Nobody's the same, not even twins.  But I'll tell you something, don't take the pills they give you.  Not when the big eye is out.",
+    "responses": [
       { "text": "What was that about cardboard?", "topic": "TALK_REFUGEE_BEGGAR_2_CARDBOARD" },
       { "text": "Why are you sitting out here?", "topic": "TALK_REFUGEE_BEGGAR_2_REFUGEE" },
       { "text": "I think I have to get going…", "topic": "TALK_DONE" }

--- a/data/json/npcs/refugee_center/beggars/BEGGAR_2_Dino_Dave.json
+++ b/data/json/npcs/refugee_center/beggars/BEGGAR_2_Dino_Dave.json
@@ -225,7 +225,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_REFUGEE_BEGGAR_2_FLAMINGEYE_NO",
-    "dynamic_line": "That's OK, nobody's perfect, ha ha...",
+    "dynamic_line": "That's OK, nobody's perfect, ha ha…",
     "responses": [
       { "text": "What was that about cardboard?", "topic": "TALK_REFUGEE_BEGGAR_2_CARDBOARD" },
       { "text": "Why are you sitting out here?", "topic": "TALK_REFUGEE_BEGGAR_2_REFUGEE" },

--- a/data/json/npcs/refugee_center/beggars/BEGGAR_2_Dino_Dave.json
+++ b/data/json/npcs/refugee_center/beggars/BEGGAR_2_Dino_Dave.json
@@ -235,7 +235,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_REFUGEE_BEGGAR_2_FLAMINGEYE_YES",
-    "dynamic_line": "Nobody's the same, not even twins.  But I'll tell you something, don't take the pills they give you.  Not when the big eye is out.",
+    "dynamic_line": "Nobody's the same, not even twins.  But I'll tell you something.  The big eye is afraid of the voices.",
     "responses": [
       { "text": "What was that about cardboard?", "topic": "TALK_REFUGEE_BEGGAR_2_CARDBOARD" },
       { "text": "Why are you sitting out here?", "topic": "TALK_REFUGEE_BEGGAR_2_REFUGEE" },

--- a/data/json/npcs/refugee_center/beggars/BEGGAR_2_Dino_Dave.json
+++ b/data/json/npcs/refugee_center/beggars/BEGGAR_2_Dino_Dave.json
@@ -235,7 +235,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_REFUGEE_BEGGAR_2_FLAMINGEYE_YES",
-    "dynamic_line": "Nobody's the same, not even twins.  But I'll tell you something.  The big eye looked at me.  It heard the voices, and it blinked.",
+    "dynamic_line": "Nobody's the same, not even twins.  But I'll tell you something.  The big eye looked at me.  When it did, it heard the voices, and it blinked.",
     "responses": [
       { "text": "What was that about cardboard?", "topic": "TALK_REFUGEE_BEGGAR_2_CARDBOARD" },
       { "text": "Why are you sitting out here?", "topic": "TALK_REFUGEE_BEGGAR_2_REFUGEE" },

--- a/data/json/npcs/refugee_center/beggars/BEGGAR_2_Dino_Dave.json
+++ b/data/json/npcs/refugee_center/beggars/BEGGAR_2_Dino_Dave.json
@@ -209,18 +209,14 @@
   {
     "type": "talk_topic",
     "id": "TALK_REFUGEE_BEGGAR_2_FLAMINGEYE",
-    "dynamic_line": "Once I saw the full moon, but it was a huge eye, looking down on me - only it couldn't see me, because the sandman kept it away.  Understand?",
+    "dynamic_line": "Once I saw the full moon, and it was staring right at me - only it couldn't see me, because the sandman kept it away.  Understand?",
     "responses": [
-      {
-        "condition": { "not": { "u_has_trait": "SCHIZOPHRENIC" } },
-        "text": "Can't say that I do.",
-        "topic": "TALK_REFUGEE_BEGGAR_2_FLAMINGEYE_NO"
-      },
       {
         "condition": { "u_has_trait": "SCHIZOPHRENIC" },
         "text": "[Kaluptic Psychosis] I think I do.  Are we the same?",
         "topic": "TALK_REFUGEE_BEGGAR_2_FLAMINGEYE_YES"
       },
+      { "text": "No, I don't.", "topic": "TALK_REFUGEE_BEGGAR_2_FLAMINGEYE_NO" },
       { "text": "What was that about cardboard?", "topic": "TALK_REFUGEE_BEGGAR_2_CARDBOARD" },
       { "text": "Why are you sitting out here?", "topic": "TALK_REFUGEE_BEGGAR_2_REFUGEE" },
       { "text": "I think I have to get going…", "topic": "TALK_DONE" }

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -2882,7 +2882,8 @@ bool mattack::stare( monster *z )
             add_msg( m_warning, _( "You feel a strange reverberation across your body." ) );
             return true;
         }//Does the eye fear what it sees in the fractured mind, or is it simply unable to get a good look at it?
-        if( player_character.has_trait( trait_SCHIZOPHRENIC ) && !player_character.has_effect( effect_took_thorazine ) && x_in_y( 3.0, 4.0 ) ) {
+        if( player_character.has_trait( trait_SCHIZOPHRENIC ) &&
+            !player_character.has_effect( effect_took_thorazine ) && x_in_y( 3.0, 4.0 ) ) {
             if( player_character.sees( *z ) ) {
                 add_msg( m_warning, _( "The %s gazes toward you, then quickly turns away." ), z->name() );
                 return true;

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -2882,9 +2882,9 @@ bool mattack::stare( monster *z )
             add_msg( m_warning, _( "You feel a strange reverberation across your body." ) );
             return true;
         }//Does the eye fear what it sees in the fractured mind, or is it simply unable to get a good look at it?
-        if( player_character.has_trait( trait_SCHIZOPHRENIC ) && !player_character.has_effect( effect_took_thorazine ) && x_in_y( 3.0, 4.0 ) ) {
+        if( player_character.has_trait( trait_SCHIZOPHRENIC ) && !player_character.has_effect( effect_took_thorazine ) && x_in_y( 2.0, 3.0 ) ) {
             if( player_character.sees( *z ) ) {
-                add_msg( m_warning, _( "The %s gazes toward you, then quickly turns away." ), z->name() );
+                add_msg( m_warning, _( "The %s quickly looks away from you." ), z->name() );
                 return true;
             } else {
                 add_msg( m_warning, _( "A chorus of whispers chatter raucously around you." ) );

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -2893,7 +2893,8 @@ bool mattack::stare( monster *z )
             }
         }
         //Being drunk can protect you from The Horrors
-        if( player_character.has_effect( effect_drunk ) && ( rng( 1, 6 ) < player_character.get_effect_int( effect_drunk ) ) ) {
+        if( player_character.has_effect( effect_drunk ) &&
+            ( rng( 1, 6 ) < player_character.get_effect_int( effect_drunk ) ) ) {
             add_msg( m_warning, _( "The world lurches drunkenly around you." ) );
             player_character.add_effect( effect_stunned, 2_seconds );
             return true;

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -143,6 +143,7 @@ static const efftype_id effect_stunned( "stunned" );
 static const efftype_id effect_taint( "taint" );
 static const efftype_id effect_targeted( "targeted" );
 static const efftype_id effect_tindrift( "tindrift" );
+static const efftype_id effect_took_thorazine( "took thorazine" );
 
 static const gun_mode_id gun_mode_AUTO( "AUTO" );
 
@@ -2880,18 +2881,20 @@ bool mattack::stare( monster *z )
             player_character.has_flag( flag_DIMENSIONAL_ANCHOR ) ) {
             add_msg( m_warning, _( "You feel a strange reverberation across your body." ) );
             return true;
-        }//Does the eye fear what it sees in the fractured mind, or is it simply unable to get a fix on the target?
-        if( player_character.has_trait( trait_SCHIZOPHRENIC ) && player_character.has_effect( effect_hallu ) && one_in( 2 ) ) {
-            add_msg( m_warning, _( "The %s gazes toward you, then quickly turns away." ), z->name() );
-            return true;
+        }//Does the eye fear what it sees in the fractured mind, or is it simply unable to get a good look at it?
+        if( player_character.has_trait( trait_SCHIZOPHRENIC ) && !player_character.has_effect( effect_took_thorazine ) && x_in_y( 3.0, 4.0 ) ) {
+            if( player_character.sees( *z ) ) {
+                add_msg( m_warning, _( "The %s gazes toward you, then quickly turns away." ), z->name() );
+                return true;
+            } else {
+                add_msg( m_warning, _( "A chorus of whispers chatter raucously around you." ) );
+                return true;
+            }
         }
-        //Being blackout drunk can protect you from The Horrors
+        //Being drunk can protect you from The Horrors
         if( player_character.has_effect( effect_drunk ) && ( rng( 1, 6 ) < player_character.get_effect_int( effect_drunk ) ) ) {
             add_msg( m_warning, _( "The world lurches drunkenly around you." ) );
             player_character.add_effect( effect_stunned, 2_seconds );
-            return true;
-        } else {
-            add_msg( m_warning, _( "A chorus of whispers chatter raucously around you." ) );
             return true;
         }
         if( player_character.sees( *z ) ) {

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -2882,7 +2882,8 @@ bool mattack::stare( monster *z )
             add_msg( m_warning, _( "You feel a strange reverberation across your body." ) );
             return true;
         }//Does the eye fear what it sees in the fractured mind, or is it simply unable to get a good look at it?
-        if( player_character.has_trait( trait_SCHIZOPHRENIC ) && !player_character.has_effect( effect_took_thorazine ) && x_in_y( 2.0, 3.0 ) ) {
+        if( player_character.has_trait( trait_SCHIZOPHRENIC ) &&
+            !player_character.has_effect( effect_took_thorazine ) && x_in_y( 2.0, 3.0 ) ) {
             if( player_character.sees( *z ) ) {
                 add_msg( m_warning, _( "The %s quickly looks away from you." ), z->name() );
                 return true;
@@ -2892,7 +2893,8 @@ bool mattack::stare( monster *z )
             }
         }
         //Being drunk can protect you from The Horrors
-        if( player_character.has_effect( effect_drunk ) && ( rng( 1, 6 ) < player_character.get_effect_int( effect_drunk ) ) ) {
+        if( player_character.has_effect( effect_drunk ) &&
+            ( rng( 1, 6 ) < player_character.get_effect_int( effect_drunk ) ) ) {
             add_msg( m_warning, _( "The world lurches drunkenly around you." ) );
             player_character.add_effect( effect_stunned, 2_seconds );
             return true;

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -116,6 +116,7 @@ static const efftype_id effect_deaf( "deaf" );
 static const efftype_id effect_dermatik( "dermatik" );
 static const efftype_id effect_downed( "downed" );
 static const efftype_id effect_dragging( "dragging" );
+static const efftype_id effect_drunk( "drunk" );
 static const efftype_id effect_eyebot_assisted( "eyebot_assisted" );
 static const efftype_id effect_eyebot_depleted( "eyebot_depleted" );
 static const efftype_id effect_fearparalyze( "fearparalyze" );
@@ -231,6 +232,7 @@ static const trait_id trait_PROF_FED( "PROF_FED" );
 static const trait_id trait_PROF_PD_DET( "PROF_PD_DET" );
 static const trait_id trait_PROF_POLICE( "PROF_POLICE" );
 static const trait_id trait_PROF_SWAT( "PROF_SWAT" );
+static const trait_id trait_SCHIZOPHRENIC( "SCHIZOPHRENIC" );
 static const trait_id trait_TAIL_CATTLE( "TAIL_CATTLE" );
 static const trait_id trait_THRESH_MARLOSS( "THRESH_MARLOSS" );
 static const trait_id trait_THRESH_MYCUS( "THRESH_MYCUS" );
@@ -2877,6 +2879,19 @@ bool mattack::stare( monster *z )
         if( player_character.worn_with_flag( flag_DIMENSIONAL_ANCHOR ) ||
             player_character.has_flag( flag_DIMENSIONAL_ANCHOR ) ) {
             add_msg( m_warning, _( "You feel a strange reverberation across your body." ) );
+            return true;
+        }//Does the eye fear what it sees in the fractured mind, or is it simply unable to get a fix on the target?
+        if( player_character.has_trait( trait_SCHIZOPHRENIC ) && player_character.has_effect( effect_hallu ) && one_in( 2 ) ) {
+            add_msg( m_warning, _( "The %s gazes toward you, then quickly turns away." ), z->name() );
+            return true;
+        }
+        //Being blackout drunk can protect you from The Horrors
+        if( player_character.has_effect( effect_drunk ) && ( rng( 1, 6 ) < player_character.get_effect_int( effect_drunk ) ) ) {
+            add_msg( m_warning, _( "The world lurches drunkenly around you." ) );
+            player_character.add_effect( effect_stunned, 2_seconds );
+            return true;
+        } else {
+            add_msg( m_warning, _( "A chorus of whispers chatter raucously around you." ) );
             return true;
         }
         if( player_character.sees( *z ) ) {

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -2896,7 +2896,7 @@ bool mattack::stare( monster *z )
         if( player_character.has_effect( effect_drunk ) &&
             ( rng( 1, 6 ) < player_character.get_effect_int( effect_drunk ) ) ) {
             add_msg( m_warning, _( "The world lurches drunkenly around you." ) );
-            player_character.add_effect( effect_stunned, 2_seconds );
+            player_character.add_effect( effect_stunned, 4_seconds );
             return true;
         }
         if( player_character.sees( *z ) ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Drunkenness and Kaluptic Psychosis can sometimes resist flaming eye stares"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
I've always been bothered by the fact that flaming eyes can't be resisted except by an item which you won't have until you're pretty much done dealing with them, and that item just renders them totally harmless.

Their attack appears to be primarily mind-affecting, and it made me think of some Lovecraft stories where characters will escape from The Horrors with drink. I also realized this was a good time for Kaluptic Psychosis to actually do something useful.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

If you have Kaluptic Psychosis and have not taken your thorazine, the eye's stare attacks have a 66% chance to fail entirely. If you see this, you get:
"The flaming eye quickly looks away from you."
If not:
"A chorus of whispers chatter raucously around you."

If you are any level of drunk above tipsy, you have a chance to resist the flaming eye's stare attack. This chance scales with intensity, starting at 2/6 if you're Drunk and maxing out at 5/6 if you're Dead Drunk. If you resist the attack this way, you will gain the Stunned effect for two seconds, which randomizes your movement. This comes with the message: "The world lurches drunkenly around you."

It checks for Kaluptic Psychosis first, then booze.

I also added a somewhat obscure hint to Dino Dave's dialog. If you ask him about his dinosaur suit, he'll say his usual thing about shields. You can inquire further, asking, "Shields?"

He will answer: "Once I saw the full moon, and it was staring right at me - only it couldn't see me, because the sandman kept it away.  Understand?"

If you have Kaluptic Psychosis, you can ask him if you two are the same. He'll warn you not to take "the pills they give you" when the big eye is out. This is your hint that not taking antipsychotics is the key.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
Dave's hint could be more cryptic, but I'm worried people won't get it if I obscure it too much.

I also considered simply not doing this, but Roguelikes thrive on little interactions like these, and I think alcohol and Psychosis could do with some more of them. Also the thought of drinking a bunch of whiskey in order to escape an overrun lab with your sanity intact is pretty funny. Tainted mind and drunk both have a vomit_chance, so you will in all likelihood vomit up at least some of the alcohol you tried to chug to deal with this. Neither alcohol nor psychosis are a sure thing, but they might give you enough time to kill the eye before the hounds show up.

I looked at adding some other altered mindstates, but most of them either don't have intensities like alcohol, or aren't as debilitating. Sorry weedlords, this is one thing the kind herb can't cure.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
Drank a bunch of whiskey in a field and tried to box a flaming eye. It hit me with two stacks of tainted mind before I got near it, and only on the third gaze did the alcohol block it for me. Then I fell over and spent such a long time on the ground that I got a warning that the Hounds were coming. So it's really not a sure thing.

I started over and gave myself kaluptic psychosis. This actually blocked three stares in a row, but then I got hit twice after that.

Then I went and talked to Dave with Kaluptic Psychosis and without, and saw the extra topic pop up appropriately when I had it.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
Protect Dave at all costs.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
