### PR TITLE
fix VS warning

### DIFF
--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -2896,7 +2896,7 @@ drop_location inventory_selector::get_only_choice() const
     for( const inventory_column *col : columns ) {
         const std::vector<inventory_entry *> ent = col->get_entries( return_item, true );
         if( !ent.empty() ) {
-            return { ent.front()->any_item(), ent.front()->get_available_count() };
+            return { ent.front()->any_item(), static_cast<int>( ent.front()->get_available_count() ) };
         }
     }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I was getting a warning when compiling in Visual Studio. I don't like getting warnings.
<details>

```
2>inventory_ui.cpp
2>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\utility(186,48): warning C4267: 'initializing': conversion from 'size_t' to '_Ty2', possible loss of data
2>        with
2>        [
2>            _Ty2=int
2>        ]
2>D:\GitHub\Cataclysm-DDA\src\inventory_ui.cpp(2899): message : see reference to function template instantiation 'std::pair<item_location,int>::pair<const item_location&,size_t,0>(_Other1,_Other2 &&) noexcept' being compiled
2>        with
2>        [
2>            _Other1=const item_location &,
2>            _Other2=size_t
2>        ]
2>D:\GitHub\Cataclysm-DDA\src\inventory_ui.cpp(2899): message : see reference to function template instantiation 'std::pair<item_location,int>::pair<const item_location&,size_t,0>(_Other1,_Other2 &&) noexcept' being compiled
2>        with
2>        [
2>            _Other1=const item_location &,
2>            _Other2=size_t
2>        ]
```
</details>

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
As Snup on discord suggested, `static_cast` the `size_t` to `int`.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Compiled.
Let the GitHub tests test this.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

There are still warnings in `condition.cpp` and `math_parser_diag.cpp` but they are more complicated:
<details>

```
2>condition.cpp
2>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\functional(660,27): warning C4244: 'return': conversion from '__int64' to '_Rx', possible loss of data
2>        with
2>        [
2>            _Rx=double
2>        ]
2>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\functional(821): message : see reference to function template instantiation '_Rx std::_Invoker_ret<_Rx,false>::_Call<_Callable&,dialogue&>(_Fx,dialogue &) noexcept(false)' being compiled
2>        with
2>        [
2>            _Rx=double,
2>            _Callable=conditional_t::get_get_dbl::<lambda_20b10a5ad2f9abffb10f3bf899a3b9c2>,
2>            _Fx=conditional_t::get_get_dbl::<lambda_20b10a5ad2f9abffb10f3bf899a3b9c2> &
2>        ]
2>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\functional(822): message : see reference to function template instantiation '_Rx std::_Invoker_ret<_Rx,false>::_Call<_Callable&,dialogue&>(_Fx,dialogue &) noexcept(false)' being compiled
2>        with
2>        [
2>            _Rx=double,
2>            _Callable=conditional_t::get_get_dbl::<lambda_20b10a5ad2f9abffb10f3bf899a3b9c2>,
2>            _Fx=conditional_t::get_get_dbl::<lambda_20b10a5ad2f9abffb10f3bf899a3b9c2> &
2>        ]
2>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\functional(821): message : while compiling class template member function '_Rx std::_Func_impl_no_alloc<conditional_t::get_get_dbl::<lambda_20b10a5ad2f9abffb10f3bf899a3b9c2>,_Rx,dialogue &>::_Do_call(dialogue &)'
2>        with
2>        [
2>            _Rx=double
2>        ]
2>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\functional(717): message : see reference to class template instantiation 'std::_Func_impl_no_alloc<conditional_t::get_get_dbl::<lambda_20b10a5ad2f9abffb10f3bf899a3b9c2>,_Ret,dialogue &>' being compiled
2>        with
2>        [
2>            _Ret=double
2>        ]
2>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\functional(911): message : see reference to variable template 'const bool _Is_large<std::_Func_impl_no_alloc<<lambda_20b10a5ad2f9abffb10f3bf899a3b9c2>,double,dialogue &> >' being compiled
2>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\functional(1042): message : see reference to function template instantiation 'void std::_Func_class<_Ret,dialogue &>::_Reset<conditional_t::get_get_dbl::<lambda_20b10a5ad2f9abffb10f3bf899a3b9c2>>(_Fx &&)' being compiled
2>        with
2>        [
2>            _Ret=double,
2>            _Fx=conditional_t::get_get_dbl::<lambda_20b10a5ad2f9abffb10f3bf899a3b9c2>
2>        ]
2>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\functional(1042): message : see reference to function template instantiation 'void std::_Func_class<_Ret,dialogue &>::_Reset<conditional_t::get_get_dbl::<lambda_20b10a5ad2f9abffb10f3bf899a3b9c2>>(_Fx &&)' being compiled
2>        with
2>        [
2>            _Ret=double,
2>            _Fx=conditional_t::get_get_dbl::<lambda_20b10a5ad2f9abffb10f3bf899a3b9c2>
2>        ]
2>D:\GitHub\Cataclysm-DDA\src\condition.cpp(1990): message : see reference to function template instantiation 'std::function<double (dialogue &)>::function<conditional_t::get_get_dbl::<lambda_20b10a5ad2f9abffb10f3bf899a3b9c2>,0>(_Fx)' being compiled
2>        with
2>        [
2>            _Fx=conditional_t::get_get_dbl::<lambda_20b10a5ad2f9abffb10f3bf899a3b9c2>
2>        ]
2>D:\GitHub\Cataclysm-DDA\src\condition.cpp(1987): message : see reference to function template instantiation 'std::function<double (dialogue &)>::function<conditional_t::get_get_dbl::<lambda_20b10a5ad2f9abffb10f3bf899a3b9c2>,0>(_Fx)' being compiled
2>        with
2>        [
2>            _Fx=conditional_t::get_get_dbl::<lambda_20b10a5ad2f9abffb10f3bf899a3b9c2>
2>        ]
2>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\functional(660,27): warning C4244: 'return': conversion from 'unsigned __int64' to '_Rx', possible loss of data
2>        with
2>        [
2>            _Rx=double
2>        ]
2>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\functional(821): message : see reference to function template instantiation '_Rx std::_Invoker_ret<_Rx,false>::_Call<_Callable&,dialogue&>(_Fx,dialogue &) noexcept(false)' being compiled
2>        with
2>        [
2>            _Rx=double,
2>            _Callable=conditional_t::get_get_dbl::<lambda_685f07a1ed57d1afc47d937bbae5a553>,
2>            _Fx=conditional_t::get_get_dbl::<lambda_685f07a1ed57d1afc47d937bbae5a553> &
2>        ]
2>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\functional(822): message : see reference to function template instantiation '_Rx std::_Invoker_ret<_Rx,false>::_Call<_Callable&,dialogue&>(_Fx,dialogue &) noexcept(false)' being compiled
2>        with
2>        [
2>            _Rx=double,
2>            _Callable=conditional_t::get_get_dbl::<lambda_685f07a1ed57d1afc47d937bbae5a553>,
2>            _Fx=conditional_t::get_get_dbl::<lambda_685f07a1ed57d1afc47d937bbae5a553> &
2>        ]
2>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\functional(821): message : while compiling class template member function '_Rx std::_Func_impl_no_alloc<conditional_t::get_get_dbl::<lambda_685f07a1ed57d1afc47d937bbae5a553>,_Rx,dialogue &>::_Do_call(dialogue &)'
2>        with
2>        [
2>            _Rx=double
2>        ]
2>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\functional(717): message : see reference to class template instantiation 'std::_Func_impl_no_alloc<conditional_t::get_get_dbl::<lambda_685f07a1ed57d1afc47d937bbae5a553>,_Ret,dialogue &>' being compiled
2>        with
2>        [
2>            _Ret=double
2>        ]
2>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\functional(911): message : see reference to variable template 'const bool _Is_large<std::_Func_impl_no_alloc<<lambda_685f07a1ed57d1afc47d937bbae5a553>,double,dialogue &> >' being compiled
2>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\functional(1042): message : see reference to function template instantiation 'void std::_Func_class<_Ret,dialogue &>::_Reset<conditional_t::get_get_dbl::<lambda_685f07a1ed57d1afc47d937bbae5a553>>(_Fx &&)' being compiled
2>        with
2>        [
2>            _Ret=double,
2>            _Fx=conditional_t::get_get_dbl::<lambda_685f07a1ed57d1afc47d937bbae5a553>
2>        ]
2>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\functional(1042): message : see reference to function template instantiation 'void std::_Func_class<_Ret,dialogue &>::_Reset<conditional_t::get_get_dbl::<lambda_685f07a1ed57d1afc47d937bbae5a553>>(_Fx &&)' being compiled
2>        with
2>        [
2>            _Ret=double,
2>            _Fx=conditional_t::get_get_dbl::<lambda_685f07a1ed57d1afc47d937bbae5a553>
2>        ]
2>D:\GitHub\Cataclysm-DDA\src\condition.cpp(1941): message : see reference to function template instantiation 'std::function<double (dialogue &)>::function<conditional_t::get_get_dbl::<lambda_685f07a1ed57d1afc47d937bbae5a553>,0>(_Fx)' being compiled
2>        with
2>        [
2>            _Fx=conditional_t::get_get_dbl::<lambda_685f07a1ed57d1afc47d937bbae5a553>
2>        ]
2>D:\GitHub\Cataclysm-DDA\src\condition.cpp(1939): message : see reference to function template instantiation 'std::function<double (dialogue &)>::function<conditional_t::get_get_dbl::<lambda_685f07a1ed57d1afc47d937bbae5a553>,0>(_Fx)' being compiled
2>        with
2>        [
2>            _Fx=conditional_t::get_get_dbl::<lambda_685f07a1ed57d1afc47d937bbae5a553>
2>        ]
```
</details>

<details>

```

2>math_parser_diag.cpp
2>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\functional(660,27): warning C4244: 'return': conversion from 'value_type' to '_Rx', possible loss of data
2>        with
2>        [
2>            value_type=int64_t
2>        ]
2>        and
2>        [
2>            _Rx=double
2>        ]
2>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\functional(821): message : see reference to function template instantiation '_Rx std::_Invoker_ret<_Rx,false>::_Call<_Callable&,dialogue&>(_Fx,dialogue &) noexcept(false)' being compiled
2>        with
2>        [
2>            _Rx=double,
2>            _Callable=`anonymous-namespace'::energy_eval::<lambda_acbf6dec4e32d39c03b980e6a95f3672>,
2>            _Fx=`anonymous-namespace'::energy_eval::<lambda_acbf6dec4e32d39c03b980e6a95f3672> &
2>        ]
2>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\functional(822): message : see reference to function template instantiation '_Rx std::_Invoker_ret<_Rx,false>::_Call<_Callable&,dialogue&>(_Fx,dialogue &) noexcept(false)' being compiled
2>        with
2>        [
2>            _Rx=double,
2>            _Callable=`anonymous-namespace'::energy_eval::<lambda_acbf6dec4e32d39c03b980e6a95f3672>,
2>            _Fx=`anonymous-namespace'::energy_eval::<lambda_acbf6dec4e32d39c03b980e6a95f3672> &
2>        ]
2>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\functional(821): message : while compiling class template member function '_Rx std::_Func_impl_no_alloc<`anonymous-namespace'::energy_eval::<lambda_acbf6dec4e32d39c03b980e6a95f3672>,_Rx,dialogue &>::_Do_call(dialogue &)'
2>        with
2>        [
2>            _Rx=double
2>        ]
2>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\functional(717): message : see reference to class template instantiation 'std::_Func_impl_no_alloc<`anonymous-namespace'::energy_eval::<lambda_acbf6dec4e32d39c03b980e6a95f3672>,_Ret,dialogue &>' being compiled
2>        with
2>        [
2>            _Ret=double
2>        ]
2>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\functional(911): message : see reference to variable template 'const bool _Is_large<std::_Func_impl_no_alloc<<lambda_acbf6dec4e32d39c03b980e6a95f3672>,double,dialogue &> >' being compiled
2>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\functional(1042): message : see reference to function template instantiation 'void std::_Func_class<_Ret,dialogue &>::_Reset<`anonymous-namespace'::energy_eval::<lambda_acbf6dec4e32d39c03b980e6a95f3672>>(_Fx &&)' being compiled
2>        with
2>        [
2>            _Ret=double,
2>            _Fx=`anonymous-namespace'::energy_eval::<lambda_acbf6dec4e32d39c03b980e6a95f3672>
2>        ]
2>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\functional(1042): message : see reference to function template instantiation 'void std::_Func_class<_Ret,dialogue &>::_Reset<`anonymous-namespace'::energy_eval::<lambda_acbf6dec4e32d39c03b980e6a95f3672>>(_Fx &&)' being compiled
2>        with
2>        [
2>            _Ret=double,
2>            _Fx=`anonymous-namespace'::energy_eval::<lambda_acbf6dec4e32d39c03b980e6a95f3672>
2>        ]
2>D:\GitHub\Cataclysm-DDA\src\math_parser_diag.cpp(723): message : see reference to function template instantiation 'std::function<double (dialogue &)>::function<`anonymous-namespace'::energy_eval::<lambda_acbf6dec4e32d39c03b980e6a95f3672>,0>(_Fx)' being compiled
2>        with
2>        [
2>            _Fx=`anonymous-namespace'::energy_eval::<lambda_acbf6dec4e32d39c03b980e6a95f3672>
2>        ]
2>D:\GitHub\Cataclysm-DDA\src\math_parser_diag.cpp(720): message : see reference to function template instantiation 'std::function<double (dialogue &)>::function<`anonymous-namespace'::energy_eval::<lambda_acbf6dec4e32d39c03b980e6a95f3672>,0>(_Fx)' being compiled
2>        with
2>        [
2>            _Fx=`anonymous-namespace'::energy_eval::<lambda_acbf6dec4e32d39c03b980e6a95f3672>
2>        ]
```
</details>

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
