### PR TITLE
Convert character name to base64 in memorial and achievement

### DIFF
--- a/data/json/monsters/zed_misc.json
+++ b/data/json/monsters/zed_misc.json
@@ -1570,7 +1570,6 @@
     "burn_into": "mon_zombie_scorched",
     "flags": [
       "SEES",
-      "ALL_SEEING",
       "STUMBLES",
       "WARM",
       "GRABS",

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3368,7 +3368,7 @@ bool game::save_achievements()
             return !std::isgraph( c, locale );
         }, '_' );
     } else {
-        achievement_file_path << u.name;
+        achievement_file_path << base64_encode( u.name );
     }
 
     // Add a ~ if the player name was actually truncated.
@@ -3537,7 +3537,7 @@ void game::write_memorial_file( std::string sLastWords )
             return !std::isgraph( c, locale );
         }, '_' );
     } else {
-        memorial_file_path << u.name;
+        memorial_file_path << base64_encode( u.name );
     }
 
     // Add a ~ if the player name was actually truncated.


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fail to save when player name have / \ : ? * " < > | "
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

fix [Can't save the game when character name has special characters in it #71453](https://github.com/CleverRaven/Cataclysm-DDA/issues/71453)
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Convert name to base64 encode. @[ehughsbaird](https://github.com/ehughsbaird) tell this simple solution, my previous solution #71464 is ? bloat?(wait for more test).
When we give up current character when the name has special chars, or save the game, memorial json file and recently added achievements json file can't generate correctly.  So there need a filter.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

for better gameplay, we may be restrict to name. But sometimes it can be flexible.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

[aaaa-trimmed.tar.gz](https://github.com/CleverRaven/Cataclysm-DDA/files/14151483/aaaa-trimmed.tar.gz)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/65117312/6e66e725-47b5-4818-bf7e-70f7f575566b)
1. create a new character with name aaa"
2. create a new character with name aaa\ 
3. create a new character with name aaa:
4. create a new character with name aaa? 
5. create a new character with name aaa*
6. create a new character with name aaa"
7. create a new character with name aaa<
8. create a new character with name aaa>
9. create a new character with name aaa| 
10. then enter the game shift+Q give up the character see if save successfully, this action can test both memorial and achievement.


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

If there's anything wrong, pls let me know. And if someone can send me a simplified astyle converting cmd.....
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
