### PR TITLE
Sewer monster rework and morale debuffs

### DIFF
--- a/data/json/effects_on_condition/misc_effect_on_condition.json
+++ b/data/json/effects_on_condition/misc_effect_on_condition.json
@@ -23,7 +23,15 @@
     "recurrence": [ "1 hours", "2 hours" ],
     "global": true,
     "condition": { "or": [ { "u_at_om_location": "lab_subway_ns" }, { "u_at_om_location": "lab_subway_ew" } ] },
-    "effect": [ { "u_message": "AMBIENT_LAB_SUBWAY", "snippet": true, "sound": true } ]
+    "effect": [ { "u_message": "<AMBIENT_LAB_SUBWAY>", "snippet": true, "sound": true } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "ambient_sewer",
+    "recurrence": [ "1 hours", "2 hours" ],
+    "global": true,
+    "condition": { "or": [ { "u_at_om_location": "sewer_ns" }, { "u_at_om_location": "sewer_ew" } ] },
+    "effect": [ { "u_message": "<AMBIENT_SEWER>", "snippet": true, "sound": true } ]
   },
   {
     "type": "effect_on_condition",
@@ -174,5 +182,40 @@
       ]
     },
     "effect": [ { "u_add_effect": "formication", "duration": "5 minutes", "target_part": "head" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "sewer_morale_debuff",
+    "global": false,
+    "recurrence": [ "20 minutes", "1 hour" ],
+    "condition": { "or": [ { "u_at_om_location": "sewer_ns" }, { "u_at_om_location": "sewer_ew" } ] },
+    "effect": [
+      { "u_message": "<SEWER_MORALE_DEBUFF>", "snippet": true },
+      {
+        "if": { "u_has_trait": "SQUEAMISH" },
+        "then": [
+          { "u_add_morale": "morale_hates_sewer", "bonus": -20, "max_bonus": -40, "duration": "1 hour", "decay_start": "1 hour" }
+        ],
+        "else": [
+          {
+            "u_add_morale": "morale_dislikes_sewer",
+            "bonus": -10,
+            "max_bonus": -20,
+            "duration": "1 hour",
+            "decay_start": "1 hour"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "morale_hates_sewer",
+    "type": "morale_type",
+    "text": "Hates being in sewer"
+  },
+  {
+    "id": "morale_dislikes_sewer",
+    "type": "morale_type",
+    "text": "Dislikes being in sewer"
   }
 ]

--- a/data/json/monstergroups/misc.json
+++ b/data/json/monstergroups/misc.json
@@ -356,23 +356,17 @@
   {
     "type": "monstergroup",
     "name": "GROUP_SEWER",
-    "//": "Freqs sum to 555 since there's no way to define spawn chance for map extras",
     "monsters": [
       { "monster": "mon_null", "weight": 370, "cost_multiplier": 0 },
-      { "monster": "mon_sewer_fish", "weight": 100, "cost_multiplier": 0 },
-      { "monster": "mon_sewer_snake", "weight": 100, "cost_multiplier": 0 },
-      { "monster": "mon_sewer_rat", "weight": 50, "cost_multiplier": 0, "pack_size": [ 3, 12 ] },
-      { "monster": "mon_gator", "weight": 25, "cost_multiplier": 2 },
-      { "monster": "mon_slug_small", "weight": 50, "ends": "180 hours" },
-      { "monster": "mon_slug_giant", "weight": 75, "starts": "180 hours" },
-      { "monster": "mon_sludge_crawler", "weight": 25 },
-      { "monster": "mon_zombie_mancroc", "weight": 100, "starts": "180 hours" },
-      { "monster": "mon_gastro_bufo", "weight": 5, "cost_multiplier": 3, "starts": "15 days" },
-      { "monster": "mon_zombullfrog", "weight": 10, "cost_multiplier": 2 },
-      { "monster": "mon_frog_mother", "weight": 5, "cost_multiplier": 3, "starts": "15 days" },
-      { "group": "GROUP_TADPOLES_SEWER", "weight": 75 },
-      { "group": "GROUP_FROGS_SEWER", "weight": 75 },
-      { "group": "GROUP_MUTAFROGS_SEWER", "weight": 50 }
+      { "monster": "mon_zombie_crawler", "weight": 75, "cost_multiplier": 0 },
+      { "monster": "mon_raccoon", "weight": 100, "cost_multiplier": 0 },
+      { "monster": "mon_fly", "weight": 100 },
+      { "monster": "mon_blob_sewer", "weight": 100 },
+      { "monster": "mon_sewer_rat", "weight": 100, "cost_multiplier": 0, "pack_size": [ 3, 12 ] },
+      { "group": "GROUP_STRAY_CATS", "weight": 20 },
+      { "group": "GROUP_TADPOLES_SEWER", "weight": 5 },
+      { "group": "GROUP_FROGS_SEWER", "weight": 5 },
+      { "group": "GROUP_MUTAFROGS_SEWER", "weight": 5 }
     ]
   },
   {

--- a/data/json/monstergroups/misc.json
+++ b/data/json/monstergroups/misc.json
@@ -363,6 +363,7 @@
       { "monster": "mon_fly", "weight": 100 },
       { "monster": "mon_blob_sewer", "weight": 100 },
       { "monster": "mon_sewer_rat", "weight": 100, "cost_multiplier": 0, "pack_size": [ 3, 12 ] },
+      { "group": "GROUP_ROACH", "weight": 75 },
       { "group": "GROUP_STRAY_CATS", "weight": 20 },
       { "group": "GROUP_TADPOLES_SEWER", "weight": 5 },
       { "group": "GROUP_FROGS_SEWER", "weight": 5 },

--- a/data/json/monsters/mammal.json
+++ b/data/json/monsters/mammal.json
@@ -2827,6 +2827,7 @@
     "families": [ "prof_intro_biology", "prof_physiology" ],
     "vision_night": 5,
     "stomach_size": 200,
+    "upgrades": { "half_life": 30, "into": "mon_raccoon_mutant" },
     "special_attacks": [ [ "EAT_FOOD", 60 ], [ "BROWSE", 50 ], [ "EAT_CARRION", 60 ] ],
     "anger_triggers": [ "FRIEND_ATTACKED", "HURT" ],
     "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "CLIMBS", "PATH_AVOID_DANGER_1", "WARM", "KEENNOSE", "EATS" ]

--- a/data/json/monsters/mutant_mammal.json
+++ b/data/json/monsters/mutant_mammal.json
@@ -677,5 +677,23 @@
     "harvest": "dog_small_with_skull",
     "upgrades": { "age_grow": 42, "into": "mon_dog_mutant_thrasher" },
     "extend": { "flags": [ "NO_BREED" ] }
+  },
+  {
+    "id": "mon_raccoon_mutant",
+    "type": "MONSTER",
+    "name": { "str": "dextrous raccoon" },
+    "description": "Their paws have grown to be longer, also enabling them to briefly stand on their back legs.  You wonder if these sleazy beasts are able to open doors yet.",
+    "copy-from": "mon_raccoon",
+    "volume": "10000 ml",
+    "weight": "10 kg",
+    "hp": 21,
+    "color": "white",
+    "aggression": 0,
+    "morale": 20,
+    "melee_skill": 2,
+    "melee_damage": [ { "damage_type": "cut", "amount": 2 } ],
+    "harvest": "raccoon_with_skull",
+    "families": [ "prof_intro_biology", "prof_physiology" ],
+    "extend": { "flags": [ "NO_BREED", "CAN_OPEN_DOORS" ] }
   }
 ]

--- a/data/json/monsters/slimes.json
+++ b/data/json/monsters/slimes.json
@@ -244,5 +244,22 @@
     },
     "flags": [ "IMMOBILE", "SEES", "NOHEAD", "POISON", "WARM", "ACIDPROOF" ],
     "armor": { "bash": 20, "electric": 3 }
+  },
+  {
+    "id": "mon_blob_sewer",
+    "type": "MONSTER",
+    "name": { "str": "sewer slime" },
+    "description": "This moving, black glob emits a foul stench.  It has incorporated the both the liquid and solid contents of the sewer water.",
+    "copy-from": "mon_blob",
+    "hp": 60,
+    "color": "green",
+    "melee_skill": 4,
+    "melee_damage": [ { "damage_type": "cut", "amount": 0 }, { "damage_type": "biological", "amount": 1 } ],
+    "special_attacks": [],
+    "death_function": {
+      "message": "The %s bursts, releasing its vile contents!",
+      "corpse_type": "NO_CORPSE",
+      "effect": { "id": "death_gas", "hit_self": true }
+    }
   }
 ]

--- a/data/json/monsters/slimes.json
+++ b/data/json/monsters/slimes.json
@@ -255,7 +255,7 @@
     "color": "green",
     "melee_skill": 4,
     "melee_damage": [ { "damage_type": "cut", "amount": 0 }, { "damage_type": "biological", "amount": 1 } ],
-    "special_attacks": [],
+    "special_attacks": [  ],
     "death_function": {
       "message": "The %s bursts, releasing its vile contents!",
       "corpse_type": "NO_CORPSE",

--- a/data/json/snippets/effect_on_conditions.json
+++ b/data/json/snippets/effect_on_conditions.json
@@ -508,6 +508,30 @@
   },
   {
     "type": "snippet",
+    "category": "<AMBIENT_SEWER>",
+    "text": [
+      "You think you just saw a small, worm-like creature vanish into the filthy water.",
+      "Some of the sewage bubbles ominously for a second, but nothing happens.",
+      "The foul sewer odor vanishes for a moment, only to return even stronger.",
+      "The foul sewer odor gets stronger, but only for a moment.",
+      "The foul sewer odor lets up, maybe a manhole is nearby?",
+      "Something audibly scurries through one of the smaller pipes.  Maybe just a rat.",
+      "A pale, bloated and hairless rat cadaver floats in the sewage.  Yuck.",
+      "Inexplicable scratches cover the pipes.  You don't know which species they are from."
+    ]
+  },
+  {
+    "type": "snippet",
+    "category": "<SEWER_MORALE_DEBUFF>",
+    "text": [
+      "The vile sewer smell makes you sick.",
+      "You gag at the sight of various unpleasantries bobbing in the sewage.",
+      "The claustrophobic pipes and vile stench make you reconsider your choice of coming down here.",
+      "You would really love some fresh air right now."
+    ]
+  },
+  {
+    "type": "snippet",
     "category": "<AMBIENT_SUBWAY>",
     "text": [
       "The trains have long grown still, and your echoing footsteps are the only thing breaking the silence.  For now.",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "The sewers now feature different monsters and cause morale debuffs, especially for characters with the squeamish trait, for prolonged stays"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

Somewhat related to #70221, having sewer snakes, gators and seweranhas are just peak cliché.
They are not realistic at all.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

Changes mongroup that spawns in the sewers:
- No more sewerranhas, gators and sewer snakes.
- No more frogmothers.
- Tadpoles and frogs can still spawn, but rarely. Same as cats.
- It is mostly flies, rats and raccoons down there now. And sewer slimes.
- New monster: Sewer slime. Copied from the ordinary slime and does biological damage on hit, very rare or even unique for a monster, and explodes in a gas of toxic gas on death. I find this very fitting for the sewers and utilizes an already existing faction.
- New monster: Dextrous raccoon. Preparations for when I eventually do the same to subways. They can open doors and will try to eat your food, but are not overly hostile. More a nuisance than anything else.
- Crawling zombies can be down there, too. Imagine one falling down an open manhole, mangling its legs and thus becoming a crawling zombie.

Thanks to an EOC we also got ambient sewer messages now, which are purely cosmetic.
Another EOC I introduced inflicts morale debuffs onto the character for being in the sewers, making them more hostile but not necessarily more dangerous.

Source I used: https://ukdnwaterflow.co.uk/animals-found-drains-sewers-around-world/
Plus common sense. There are storm drains with mostly "clean" rainwater and sewers with yucky sewage. But there are most definitely cats that fell into sewers (Cat rescue org rescuing some kittens out of a sewer: https://www.youtube.com/watch?v=UrKeOQVjvqA), raccoons. rats, flies.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

- Adding larvae into sewers. That would make sense. Maybe later
- Adding random corpses. As in so many "rioters" died, they just threw them down a manhole. Would be story telling.
- Also targeting the sewage treatment plant. Maybe later. This is why I havent obsoleted those monsters yet.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

Loads and runs as expected.

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/59517351/7c7b40e3-9520-492d-9ac9-c9ff68127934)

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/59517351/2a85f564-4191-42df-971e-9ea2e2ab086f)

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Thanks GuardianDll for helping me fix the EOCS. I also fixed the issue where ambient lab subway sounds would not have triggered due to missing brackets.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
