### PR TITLE
tied down fridge uses any rope, not only rope_30

### DIFF
--- a/data/json/recipes/other/vehicle.json
+++ b/data/json/recipes/other/vehicle.json
@@ -194,7 +194,7 @@
     "time": "30 s",
     "autolearn": true,
     "reversible": true,
-    "components": [ [ [ "fridge", 1 ] ], [ [ "rope_30", 1 ], [ "rope_6", 5 ] ] ]
+    "components": [ [ [ "fridge", 1 ] ], [ [ "rope_natural", 1, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -205,7 +205,7 @@
     "time": "30 s",
     "autolearn": true,
     "reversible": true,
-    "components": [ [ [ "glass_fridge", 1 ] ], [ [ "rope_30", 1 ], [ "rope_6", 5 ] ] ]
+    "components": [ [ [ "glass_fridge", 1 ] ], [ [ "rope_natural", 1, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -216,6 +216,6 @@
     "time": "30 s",
     "autolearn": true,
     "reversible": true,
-    "components": [ [ [ "freezer", 1 ] ], [ [ "rope_30", 1 ], [ "rope_6", 5 ] ] ]
+    "components": [ [ [ "freezer", 1 ] ], [ [ "rope_natural", 1, "LIST" ] ] ]
   }
 ]

--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -3305,7 +3305,7 @@
   {
     "type": "vehicle_part",
     "id": "stowed_fridge",
-    "name": { "str": "tied-down fridge" },
+    "name": { "str": "tied-down refrigerator" },
     "categories": [ "other" ],
     "color": "white",
     "damage_modifier": 5,
@@ -3332,7 +3332,7 @@
   {
     "type": "vehicle_part",
     "id": "stowed_glass_fridge",
-    "name": { "str": "tied-down glass door fridge" },
+    "name": { "str": "tied-down glass door refrigerator" },
     "categories": [ "other" ],
     "color": "white",
     "damage_modifier": 5,


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Someone in discord pointed inconsistency in tied-down fridge item
#### Describe the solution
Change the recipe to use any type of rope, not only rope 30
Also rename tied-down fridge to `tied-down refrigerator` for consistency
#### Testing
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/67688115/2b392bf9-b047-4ace-ab21-c10563786cb5)