### PR TITLE
Separate item category names for headers and descriptive text

### DIFF
--- a/data/json/item_category.json
+++ b/data/json/item_category.json
@@ -2,42 +2,48 @@
   {
     "id": "guns",
     "type": "ITEM_CATEGORY",
-    "name": { "str": "Guns" },
+    "name_header": { "str": "Guns" },
+    "name_noun": { "ctxt": "item_category", "str": "gun" },
     "zone": "LOOT_GUNS",
     "sort_rank": -23
   },
   {
     "id": "magazines",
     "type": "ITEM_CATEGORY",
-    "name": { "str": "Magazines" },
+    "name_header": { "str": "Magazines" },
+    "name_noun": { "ctxt": "item_category", "str": "magazine" },
     "zone": "LOOT_MAGAZINES",
     "sort_rank": -22
   },
   {
     "id": "ammo",
     "type": "ITEM_CATEGORY",
-    "name": { "str": "Ammo" },
+    "name_header": { "str": "Ammo" },
+    "name_noun": { "ctxt": "item_category", "str_sp": "ammo" },
     "zone": "LOOT_AMMO",
     "sort_rank": -21
   },
   {
     "id": "weapons",
     "type": "ITEM_CATEGORY",
-    "name": { "str": "Weapons" },
+    "name_header": { "str": "Weapons" },
+    "name_noun": { "ctxt": "item_category", "str": "weapon" },
     "zone": "LOOT_WEAPONS",
     "sort_rank": -20
   },
   {
     "id": "tools",
     "type": "ITEM_CATEGORY",
-    "name": { "str": "Tools" },
+    "name_header": { "str": "Tools" },
+    "name_noun": { "ctxt": "item_category", "str": "tool" },
     "zone": "LOOT_TOOLS",
     "sort_rank": -19
   },
   {
     "id": "clothing",
     "type": "ITEM_CATEGORY",
-    "name": { "str": "Clothing" },
+    "name_header": { "str": "Clothing" },
+    "name_noun": { "ctxt": "item_category", "str_sp": "clothing" },
     "priority_zones": [ { "id": "LOOT_FCLOTHING", "filthy": true } ],
     "zone": "LOOT_CLOTHING",
     "sort_rank": 19
@@ -45,161 +51,184 @@
   {
     "id": "food",
     "type": "ITEM_CATEGORY",
-    "name": { "str": "Food" },
+    "name_header": { "str": "Food" },
+    "name_noun": { "ctxt": "item_category", "str_sp": "food" },
     "//": "zone is hardcoded",
     "sort_rank": -18
   },
   {
     "id": "drugs",
     "type": "ITEM_CATEGORY",
-    "name": { "str": "Drugs" },
+    "name_header": { "str": "Drugs" },
+    "name_noun": { "ctxt": "item_category", "str_sp": "drug" },
     "zone": "LOOT_DRUGS",
     "sort_rank": -17
   },
   {
     "id": "manuals",
     "type": "ITEM_CATEGORY",
-    "name": { "str": "Manuals" },
+    "name_header": { "str": "Manuals" },
+    "name_noun": { "ctxt": "item_category", "str": "manual" },
     "zone": "LOOT_MANUALS",
     "sort_rank": -16
   },
   {
     "id": "books",
     "type": "ITEM_CATEGORY",
-    "name": { "str": "Books" },
+    "name_header": { "str": "Books" },
+    "name_noun": { "ctxt": "item_category", "str": "book" },
     "zone": "LOOT_BOOKS",
     "sort_rank": -15
   },
   {
     "id": "maps",
     "type": "ITEM_CATEGORY",
-    "name": { "str": "Maps" },
+    "name_header": { "str": "Maps" },
+    "name_noun": { "ctxt": "item_category", "str": "map" },
     "zone": "LOOT_MAPS",
     "sort_rank": -14
   },
   {
     "id": "mods",
     "type": "ITEM_CATEGORY",
-    "name": { "str": "Mods" },
+    "name_header": { "str": "Mods" },
+    "name_noun": { "ctxt": "item_category", "str": "mod" },
     "zone": "LOOT_MODS",
     "sort_rank": -13
   },
   {
     "id": "mutagen",
     "type": "ITEM_CATEGORY",
-    "name": { "str": "Mutagens" },
+    "name_header": { "str": "Mutagens" },
+    "name_noun": { "ctxt": "item_category", "str_sp": "mutagen" },
     "zone": "LOOT_MUTAGENS",
     "sort_rank": -12
   },
   {
     "id": "bionics",
     "type": "ITEM_CATEGORY",
-    "name": { "str": "Bionics" },
+    "name_header": { "str": "Bionics" },
+    "name_noun": { "ctxt": "item_category", "str": "bionic" },
     "zone": "LOOT_BIONICS",
     "sort_rank": -12
   },
   {
     "id": "currency",
     "type": "ITEM_CATEGORY",
-    "name": { "str": "Currency" },
+    "name_header": { "str": "Currency" },
+    "name_noun": { "ctxt": "item_category", "str_sp": "currency" },
     "zone": "LOOT_CURRENCY",
     "sort_rank": -11
   },
   {
     "id": "veh_parts",
     "type": "ITEM_CATEGORY",
-    "name": { "str": "Vehicle parts" },
+    "name_header": { "str": "Vehicle parts" },
+    "name_noun": { "ctxt": "item_category", "str": "vehicle part" },
     "zone": "LOOT_VEHICLE_PARTS",
     "sort_rank": -10
   },
   {
     "id": "other",
     "type": "ITEM_CATEGORY",
-    "name": { "str": "Other" },
+    "name_header": { "str": "Other" },
+    "name_noun": { "ctxt": "item_category", "str": "other" },
     "zone": "LOOT_OTHER",
     "sort_rank": -9
   },
   {
     "id": "fuel",
     "type": "ITEM_CATEGORY",
-    "name": { "str": "Fuel" },
+    "name_header": { "str": "Fuel" },
+    "name_noun": { "ctxt": "item_category", "str_sp": "fuel" },
     "zone": "LOOT_FUEL",
     "sort_rank": -8
   },
   {
     "id": "seeds",
     "type": "ITEM_CATEGORY",
-    "name": { "str": "Seeds" },
+    "name_header": { "str": "Seeds" },
+    "name_noun": { "ctxt": "item_category", "str": "seed" },
     "zone": "LOOT_SEEDS",
     "sort_rank": -7
   },
   {
     "id": "ma_manuals",
     "type": "ITEM_CATEGORY",
-    "name": { "str": "Martial arts manuals" },
+    "name_header": { "str": "Martial arts manuals" },
+    "name_noun": { "ctxt": "item_category", "str": "martial arts manual" },
     "zone": "LOOT_MA_MANUALS",
     "sort_rank": -6
   },
   {
     "id": "traps",
     "type": "ITEM_CATEGORY",
-    "name": { "str": "Traps" },
+    "name_header": { "str": "Traps" },
+    "name_noun": { "ctxt": "item_category", "str": "trap" },
     "zone": "LOOT_TRAPS",
     "sort_rank": -5
   },
   {
     "id": "chems",
     "type": "ITEM_CATEGORY",
-    "name": { "str": "Chemical stuff" },
+    "name_header": { "str": "Chemical stuff" },
+    "name_noun": { "ctxt": "item_category", "str_sp": "chemical" },
     "zone": "LOOT_CHEMICAL",
     "sort_rank": 5
   },
   {
     "id": "spare_parts",
     "type": "ITEM_CATEGORY",
-    "name": { "str": "Spare parts" },
+    "name_header": { "str": "Spare parts" },
+    "name_noun": { "ctxt": "item_category", "str": "spare part" },
     "zone": "LOOT_SPARE_PARTS",
     "sort_rank": 8
   },
   {
     "id": "container",
     "type": "ITEM_CATEGORY",
-    "name": { "str": "Containers" },
+    "name_header": { "str": "Containers" },
+    "name_noun": { "ctxt": "item_category", "str": "container" },
     "zone": "LOOT_CONTAINERS",
     "sort_rank": 9
   },
   {
     "id": "artifacts",
     "type": "ITEM_CATEGORY",
-    "name": { "str": "Artifacts" },
+    "name_header": { "str": "Artifacts" },
+    "name_noun": { "ctxt": "item_category", "str": "artifact" },
     "zone": "LOOT_ARTIFACTS",
     "sort_rank": 10
   },
   {
     "id": "keys",
     "type": "ITEM_CATEGORY",
-    "name": { "str": "Keys" },
+    "name_header": { "str": "Keys" },
+    "name_noun": { "ctxt": "item_category", "str": "key" },
     "zone": "LOOT_KEYS",
     "sort_rank": 11
   },
   {
     "id": "corpses",
     "type": "ITEM_CATEGORY",
-    "name": { "str": "Corpses" },
+    "name_header": { "str": "Corpses" },
+    "name_noun": { "ctxt": "item_category", "str": "corpse" },
     "zone": "LOOT_CORPSES",
     "sort_rank": 12
   },
   {
     "id": "tool_magazine",
     "type": "ITEM_CATEGORY",
-    "name": { "str": "Tool magazines" },
+    "name_header": { "str": "Tool magazines" },
+    "name_noun": { "ctxt": "item_category", "str": "tool magazine" },
     "zone": "LOOT_TOOL_MAGAZINE",
     "sort_rank": -15
   },
   {
     "id": "armor",
     "type": "ITEM_CATEGORY",
-    "name": { "str": "Armor" },
+    "name_header": { "str": "Armor" },
+    "name_noun": { "ctxt": "item_category", "str_sp": "armor" },
     "priority_zones": [ { "id": "LOOT_FARMOR", "filthy": true } ],
     "zone": "LOOT_ARMOR",
     "sort_rank": 20
@@ -207,32 +236,37 @@
   {
     "id": "exosuit",
     "type": "ITEM_CATEGORY",
-    "name": { "str": "Exosuit" },
+    "name_header": { "str": "Exosuit" },
+    "name_noun": { "ctxt": "item_category", "str": "exosuit" },
     "zone": "LOOT_EXOSUIT",
     "sort_rank": 20
   },
   {
     "id": "ITEMS_WORN",
     "type": "ITEM_CATEGORY",
-    "name": { "str": "Items worn" },
+    "name_header": { "str": "Items worn" },
+    "name_noun": { "ctxt": "item_category", "str": "item worn", "str_pl": "items worn" },
     "sort_rank": -100
   },
   {
     "id": "INTEGRATED",
     "type": "ITEM_CATEGORY",
-    "name": { "str": "Integrated" },
+    "name_header": { "str": "Integrated" },
+    "name_noun": { "ctxt": "item_category", "str_sp": "integrated" },
     "sort_rank": -99
   },
   {
     "id": "BIONIC_FUEL_SOURCE",
     "type": "ITEM_CATEGORY",
-    "name": { "str": "Bionic fuel source" },
+    "name_header": { "str": "Bionic fuel source" },
+    "name_noun": { "ctxt": "item_category", "str": "bionic fuel source" },
     "sort_rank": -98
   },
   {
     "id": "WEAPON_HELD",
     "type": "ITEM_CATEGORY",
-    "name": { "str": "Weapon held" },
+    "name_header": { "str": "Weapon held" },
+    "name_noun": { "ctxt": "item_category", "str": "weapon held", "str_pl": "weapons held" },
     "sort_rank": -200
   }
 ]

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -1575,7 +1575,8 @@ When you sort your inventory by category, these are the categories that are disp
 | Identifier       | Description
 |---               |---
 | `id`             | Unique ID. Must be one continuous word, use underscores if necessary
-| `name`           | The name of the category. This is what shows up in-game when you open the inventory.
+| `name_header`    | The name of the category used for headers. This is what shows up in-game when you open the inventory.
+| `name_noun`      | The name of the category used for descriptive text, including singular and plural names.
 | `zone`           | The corresponding loot_zone (see loot_zones.json)
 | `sort_rank`      | Used to sort categories when displaying.  Lower values are shown first
 | `priority_zones` | When set, items in this category will be sorted to the priority zone if the conditions are met. If the user does not have the priority zone in the zone manager, the items get sorted into zone set in the 'zone' property. It is a list of objects. Each object has 3 properties: ID: The id of a LOOT_ZONE (see LOOT_ZONES.json), filthy: boolean. setting this means filthy items of this category will be sorted to the priority zone, flags: array of flags

--- a/lang/string_extractor/parsers/item_category.py
+++ b/lang/string_extractor/parsers/item_category.py
@@ -2,5 +2,10 @@ from ..write_text import write_text
 
 
 def parse_item_category(json, origin):
-    if "name" in json:
-        write_text(json["name"], origin, comment="Item category name")
+    if "name_header" in json:
+        write_text(json["name_header"], origin,
+                   comment="Item category name used for headers")
+    if "name_noun" in json:
+        write_text(json["name_noun"], origin,
+                   comment="Item category name used for descriptive text",
+                   plural=True)

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -413,9 +413,8 @@ void advanced_inventory::print_items( side p, bool active )
                 break;
             }
             // insert category header
-            mvwprintz( window, point( ( columns - utf8_width( sitem.cat->name() ) - 6 ) / 2, 6 + line ), c_cyan,
-                       "[%s]",
-                       sitem.cat->name() );
+            mvwprintz( window, point( ( columns - utf8_width( sitem.cat->name_header() ) - 6 ) / 2, 6 + line ),
+                       c_cyan, "[%s]", sitem.cat->name_header() );
             item_line = line + 1;
         }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8710,7 +8710,7 @@ game::vmenu_ret game::list_items( const std::vector<map_item_stack> &item_list )
             for( int i = std::max( 0, highPEnd );
                  i < std::min( lowPStart, static_cast<int>( filtered_items.size() ) ); i++ ) {
                 const std::string &cat_name =
-                    filtered_items[i].example->get_category_of_contents().name();
+                    filtered_items[i].example->get_category_of_contents().name_header();
                 if( cat_name != last_cat_name ) {
                     mSortCategory[i + iCatSortNum++] = cat_name;
                     last_cat_name = cat_name;

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -769,7 +769,7 @@ std::string inventory_selector_preset::get_cell_text( const inventory_entry &ent
     } else if( cell_index != 0 ) {
         return replace_colors( cells[cell_index].title );
     } else {
-        return entry.get_category_ptr()->name();
+        return entry.get_category_ptr()->name_header();
     }
 }
 
@@ -1784,7 +1784,7 @@ size_t inventory_column::visible_cells() const
 
 selection_column::selection_column( const std::string &id, const std::string &name ) :
     inventory_column( selection_preset ),
-    selected_cat( id, no_translation( name ), 0 )
+    selected_cat( id, no_translation( name ), translation(), 0 )
 {
     hide_entries_override = { false };
 }
@@ -1874,9 +1874,9 @@ const item_category *inventory_selector::naturalize_category( const item_categor
             return existing;
         }
 
-        const std::string name = string_format( "%s %s", category.name(), suffix.c_str() );
+        const std::string name = string_format( "%s %s", category.name_header(), suffix.c_str() );
         const int sort_rank = category.sort_rank() + dist;
-        const item_category new_category( id, no_translation( name ), sort_rank );
+        const item_category new_category( id, no_translation( name ), translation(), sort_rank );
 
         categories.push_back( new_category );
     } else {
@@ -2087,7 +2087,7 @@ void inventory_selector::add_map_items( const tripoint &target )
     if( here.accessible_items( target ) ) {
         map_stack items = here.i_at( target );
         const std::string name = to_upper_case( here.name( target ) );
-        const item_category map_cat( name, no_translation( name ), 100 );
+        const item_category map_cat( name, no_translation( name ), translation(), 100 );
         _add_map_items( target, map_cat, items, [target]( item & it ) {
             return item_location( map_cursor( target ), &it );
         } );
@@ -2103,7 +2103,7 @@ void inventory_selector::add_vehicle_items( const tripoint &target )
     vehicle_part &vp = ovp->part();
     vehicle_stack items = ovp->items();
     const std::string name = to_upper_case( remove_color_tags( vp.name() ) );
-    const item_category vehicle_cat( name, no_translation( name ), 200 );
+    const item_category vehicle_cat( name, no_translation( name ), translation(), 200 );
     const vehicle_cursor cursor( ovp->vehicle(), ovp->part_index() );
     _add_map_items( target, vehicle_cat, items, [&cursor]( item & it ) {
         return item_location( cursor, &it );
@@ -2151,7 +2151,7 @@ void inventory_selector::add_remote_map_items( tinymap *remote_map, const tripoi
 {
     map_stack items = remote_map->i_at( target );
     const std::string name = to_upper_case( remote_map->name( target ) );
-    const item_category map_cat( name, no_translation( name ), 100 );
+    const item_category map_cat( name, no_translation( name ), translation(), 100 );
     _add_map_items( target, map_cat, items, [target]( item & it ) {
         return item_location( map_cursor( target ), &it );
     } );
@@ -3141,7 +3141,7 @@ void inventory_selector::_uncategorize( inventory_column &col )
         const item_category *custom_category = nullptr;
         if( ancestor.where() != item_location::type::character ) {
             const std::string name = to_upper_case( remove_color_tags( ancestor.describe() ) );
-            const item_category map_cat( name, no_translation( name ), 100 );
+            const item_category map_cat( name, no_translation( name ), translation(), 100 );
             custom_category = naturalize_category( map_cat, ancestor.position() );
         } else {
             custom_category = wielded_worn_category( ancestor, u );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -2407,7 +2407,7 @@ void item::basic_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
     }
     if( parts->test( iteminfo_parts::BASE_CATEGORY ) ) {
         info.emplace_back( "BASE", _( "Category: " ),
-                           "<header>" + get_category_shallow().name() + "</header>" );
+                           "<header>" + get_category_shallow().name_header() + "</header>" );
     }
 
     if( parts->test( iteminfo_parts::DESCRIPTION ) ) {

--- a/src/item_category.cpp
+++ b/src/item_category.cpp
@@ -53,7 +53,9 @@ void item_category::reset()
 void item_category::load( const JsonObject &jo, const std::string_view )
 {
     mandatory( jo, was_loaded, "id", id );
-    mandatory( jo, was_loaded, "name", name_ );
+    mandatory( jo, was_loaded, "name_header", name_header_ );
+    name_noun_.make_plural();
+    mandatory( jo, was_loaded, "name_noun", name_noun_ );
     mandatory( jo, was_loaded, "sort_rank", sort_rank_ );
     optional( jo, was_loaded, "priority_zones", zone_priority_ );
     optional( jo, was_loaded, "zone", zone_, std::nullopt );
@@ -65,15 +67,16 @@ bool item_category::operator<( const item_category &rhs ) const
     if( sort_rank_ != rhs.sort_rank_ ) {
         return sort_rank_ < rhs.sort_rank_;
     }
-    if( name_.translated_ne( rhs.name_ ) ) {
-        return name_.translated_lt( rhs.name_ );
+    if( name_header_.translated_ne( rhs.name_header_ ) ) {
+        return name_header_.translated_lt( rhs.name_header_ );
     }
     return id < rhs.id;
 }
 
 bool item_category::operator==( const item_category &rhs ) const
 {
-    return sort_rank_ == rhs.sort_rank_ && name_.translated_eq( rhs.name_ ) && id == rhs.id;
+    return sort_rank_ == rhs.sort_rank_ && name_header_.translated_eq( rhs.name_header_ ) &&
+           id == rhs.id;
 }
 
 bool item_category::operator!=( const item_category &rhs ) const
@@ -81,9 +84,14 @@ bool item_category::operator!=( const item_category &rhs ) const
     return !operator==( rhs );
 }
 
-std::string item_category::name() const
+std::string item_category::name_header() const
 {
-    return name_.translated();
+    return name_header_.translated();
+}
+
+std::string item_category::name_noun( const int count ) const
+{
+    return name_noun_.translated( count );
 }
 
 item_category_id item_category::get_id() const

--- a/src/item_category.h
+++ b/src/item_category.h
@@ -35,7 +35,8 @@ class item_category
 {
     private:
         /** Name of category for displaying to the user */
-        translation name_;
+        translation name_header_; // in inventory UI headers etc
+        translation name_noun_; // in descriptive text
         /** Used to sort categories when displaying.  Lower values are shown first. */
         int sort_rank_ = 0;
         /** Global spawn rate for items from category */
@@ -52,15 +53,21 @@ class item_category
         item_category() = default;
         /**
          * @param id @ref id_
-         * @param name @ref name_
+         * @param name_header @ref name_header_
+         * @param name_noun @ref name_noun_
          * @param sort_rank @ref sort_rank_
          */
-        item_category( const item_category_id &id, const translation &name, int sort_rank )
-            : name_( name ), sort_rank_( sort_rank ), id( id ) {}
-        item_category( const std::string &id, const translation &name, int sort_rank )
-            : name_( name ), sort_rank_( sort_rank ), id( item_category_id( id ) ) {}
+        item_category( const item_category_id &id, const translation &name_header,
+                       const translation &name_noun, const int sort_rank )
+            : name_header_( name_header ), name_noun_( name_noun )
+            , sort_rank_( sort_rank ), id( id ) {}
+        item_category( const std::string &id, const translation &name_header,
+                       const translation &name_noun, const int sort_rank )
+            : name_header_( name_header ), name_noun_( name_noun )
+            , sort_rank_( sort_rank ), id( item_category_id( id ) ) {}
 
-        std::string name() const;
+        std::string name_header() const;
+        std::string name_noun( int count ) const;
         item_category_id get_id() const;
         std::optional<zone_type_id> priority_zone( const item &it ) const;
         std::optional<zone_type_id> zone() const;
@@ -70,7 +77,8 @@ class item_category
         /**
          * Comparison operators
          *
-         * Used for sorting.  Will result in sorting by @ref sort_rank, then by @ref name, then by @ref id.
+         * Used for sorting.  Will result in sorting by @ref sort_rank_, then by
+         * @ref name_header_, then by @ref id.
          */
         /*@{*/
         bool operator<( const item_category &rhs ) const;

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -391,14 +391,14 @@ bool pocket_favorite_callback::key( const input_context &ctxt, const input_event
             } else if( !lhs_in_list && rhs_in_list ) {
                 return false;
             }
-            return localized_compare( lhs.name(), rhs.name() );
+            return localized_compare( lhs.name_header(), rhs.name_header() );
         } );
 
         uilist selector_menu;
         for( const item_category &cat : all_cat ) {
             const bool in_list = listed_cat.count( cat.get_id() );
             const std::string &prefix = in_list ? remove_prefix : add_prefix;
-            selector_menu.addentry( prefix + cat.name() );
+            selector_menu.addentry( prefix + cat.name_header() );
         }
         selector_menu.query();
 

--- a/src/item_search.cpp
+++ b/src/item_search.cpp
@@ -28,7 +28,7 @@ std::function<bool( const item & )> basic_item_filter( std::string filter )
         // category
         case 'c':
             return [filter]( const item & i ) {
-                return lcmatch( i.get_category_of_contents().name(), filter );
+                return lcmatch( i.get_category_of_contents().name_header(), filter );
             };
         // material
         case 'm':

--- a/src/item_tname.cpp
+++ b/src/item_tname.cpp
@@ -508,13 +508,13 @@ std::string relic_charges( item const &it, unsigned int /* quantity */,
     return {};
 }
 
-std::string category( item const &it, unsigned int /* quantity */,
+std::string category( item const &it, unsigned int quantity,
                       segment_bitset const &segments )
 {
     nc_color const &color = segments[tname::segments::FOOD_PERISHABLE] && it.is_food()
                             ? it.color_in_inventory( &get_avatar() )
                             : c_magenta;
-    return colorize( it.get_category_of_contents().name(), color );
+    return colorize( it.get_category_of_contents().name_noun( quantity ), color );
 }
 
 // function type that prints an element of tname::segments

--- a/tests/item_tname_test.cpp
+++ b/tests/item_tname_test.cpp
@@ -693,7 +693,7 @@ TEST_CASE( "nested_items_tname", "[item][tname]" )
             backpack_hiking.put_in( rock2, pocket_type::CONTAINER );
             CHECK( backpack_hiking.tname( 1 ) ==
                    color_pref + "hiking backpack " + nesting_sym + " 2 " +
-                   colorize( rock.get_category_shallow().name(), c_magenta ) );
+                   colorize( rock.get_category_shallow().name_noun( 2 ), c_magenta ) );
         }
         SECTION( "several stacks of variants" ) {
             item rock_blue( itype_test_rock );
@@ -723,7 +723,7 @@ TEST_CASE( "nested_items_tname", "[item][tname]" )
             REQUIRE( backpack_hiking.put_in( purse, pocket_type::CONTAINER ).success() );
             CHECK( backpack_hiking.tname( 1 ) ==
                    color_pref + "hiking backpack " + nesting_sym + " 2 " +
-                   colorize( rock.get_category_shallow().name(), c_magenta ) + " / 3 items" );
+                   colorize( rock.get_category_shallow().name_noun( 2 ), c_magenta ) + " / 3 items" );
         }
         SECTION( "container has whitelist" ) {
             std::string const wlmark = "⁺";
@@ -788,7 +788,7 @@ TEST_CASE( "nested_items_tname", "[item][tname]" )
             REQUIRE( backpack_hiking.put_in( bag2, pocket_type::CONTAINER ).success() );
             CHECK( backpack_hiking.tname( 1 ) ==
                    color_pref + "hiking backpack " + nesting_sym + " 2 " +
-                   colorize( rock.get_category_shallow().name(), c_magenta ) + " / 3 items" );
+                   colorize( rock.get_category_shallow().name_noun( 2 ), c_magenta ) + " / 3 items" );
         }
     }
 
@@ -809,7 +809,7 @@ TEST_CASE( "nested_items_tname", "[item][tname]" )
     SECTION( "aggregated food stats" ) {
         avatar &u = get_avatar();
         item salt( "salt" );
-        std::string const cat_food_str = salt.get_category_shallow().name();
+        std::string const cat_food_str = salt.get_category_shallow().name_noun( 2 );
         item pepper( "pepper" );
         item juniper( "juniper" );
         item ration( "protein_bar_evac" );
@@ -914,7 +914,7 @@ TEST_CASE( "nested_items_tname", "[item][tname]" )
         bool both_unfit = unfit ? GENERATE( true, false ) : false;
         CAPTURE( same_item, damaged, both_damaged, unfit, both_unfit );
 
-        std::string const cat_cl_str = pants.get_category_shallow().name();
+        std::string const cat_cl_str = pants.get_category_shallow().name_noun( 2 );
         std::string const pants_tname = pants.tname( 2, type_only );
         std::string dura_str = pants.durability_indicator();
         std::string fit_str;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Currently the item category header is used as the name to describe item content, but it does not have consistent pluralization, and might not work for languages with different plurals for different numbers.

#### Describe the solution
Add new pluralized names for item categories to json, and use them in tname code. Update docs, string extraction script, and tname test.

#### Describe alternatives you've considered

#### Testing
Tested in game and containers showed the correct category names. The tname unit test also passed. The string extraction script correctly extracted the header and non-header names.

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/11890223/7b9a131b-6f43-4afd-a842-4b94c877322f)

#### Additional context
