### PR TITLE
Fix UBSan error in calling cata_tiles::set_draw_cache_dirty() in test mode

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -6718,8 +6718,10 @@ void map::update_visibility_cache( const int zlev )
     }
 
 #if defined(TILES)
-    // Mark cata_tiles draw caches as dirty
-    tilecontext->set_draw_cache_dirty();
+    if( !test_mode ) {
+        // Mark cata_tiles draw caches as dirty
+        tilecontext->set_draw_cache_dirty();
+    }
 #endif
 
     visibility_variables_cache.last_pos = player_character.pos();
@@ -9432,8 +9434,10 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
         player_prev_range = sr;
         camera_cache_dirty = true;
 #if defined(TILES)
-        // Mark cata_tiles draw caches as dirty
-        tilecontext->set_draw_cache_dirty();
+        if( !test_mode ) {
+            // Mark cata_tiles draw caches as dirty
+            tilecontext->set_draw_cache_dirty();
+        }
 #endif
     }
     if( camera_cache_dirty ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
UndefinedBehaviorSanitizer reports two instances of the following error in running tests:
```
src/map.cpp:9436:22: runtime error: member call on null pointer of type 'cata_tiles'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior src/map.cpp:9436:22
(lldb) bt
* thread #1, queue = 'com.apple.main-thread', stop reason = Null pointer use
  * frame #0: 0x000000011fe2d314 libclang_rt.asan_osx_dynamic.dylib`__ubsan_on_report
    frame #1: 0x000000011fe2d3c8 libclang_rt.asan_osx_dynamic.dylib`__ubsan::UndefinedBehaviorReport::UndefinedBehaviorReport(char const*, __ubsan::Location&, __sanitizer::InternalScopedString&) + 176
    frame #2: 0x000000011fe29004 libclang_rt.asan_osx_dynamic.dylib`__ubsan::Diag::~Diag() + 244
    frame #3: 0x000000011fe2a56c libclang_rt.asan_osx_dynamic.dylib`handleTypeMismatchImpl(__ubsan::TypeMismatchData*, unsigned long, __ubsan::ReportOptions) + 580
    frame #4: 0x000000011fe2a708 libclang_rt.asan_osx_dynamic.dylib`__ubsan_handle_type_mismatch_v1_abort + 44
    frame #5: 0x00000001050fa494 cata_test`map::build_map_cache(this=0x000000012520c880, zlev=<unavailable>, skip_lightmap=<unavailable>) at map.cpp:9436:22 [opt]
    frame #6: 0x0000000100fe5d28 cata_test`wipe_map_terrain(target=<unavailable>) at map_helpers.cpp:68:10 [opt]
    frame #7: 0x0000000100fe715c cata_test`clear_map(zmin=-2, zmax=0) at map_helpers.cpp:131:5 [opt]
    frame #8: 0x00000001000124c4 cata_test`(anonymous namespace)::run_test_case(u=<unavailable>) at act_build_test.cpp:102:5 [opt]
    frame #9: 0x0000000101ac56a8 cata_test`Catch::RunContext::invokeActiveTestCase(this=0x000000016fdfd650) at catch.hpp:12997:27 [opt]
    frame #10: 0x0000000101abdd20 cata_test`Catch::RunContext::runCurrentTest(this=0x000000016fdfd650, redirectedCout=<unavailable>, redirectedCerr=<unavailable>) at catch.hpp:12970:17 [opt]
    frame #11: 0x0000000101abbcdc cata_test`Catch::RunContext::runTest(this=0x000000016fdfd650, testCase=<unavailable>) at catch.hpp:12731:13 [opt]
    frame #12: 0x0000000101acdda0 cata_test`Catch::Session::runInternal() at catch.hpp:13324:45 [opt]
    frame #13: 0x0000000101acd948 cata_test`Catch::Session::runInternal(this=<unavailable>) at catch.hpp:13530:39 [opt]
    frame #14: 0x0000000101acc5e4 cata_test`Catch::Session::run(this=0x000000016fdfde40) at catch.hpp:13486:24 [opt]
    frame #15: 0x0000000101b19888 cata_test`main(argc=<unavailable>, argv=<unavailable>) at test_main.cpp:420:26 [opt]
    frame #16: 0x0000000184a750e0 dyld`start + 2360
```
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Avoid calling `cata_tiles::set_draw_cache_dirty()` on nullptr tiles context.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
UBSan does not report the same error after the patch.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
