### PR TITLE
jsonify fear_paralyze

### DIFF
--- a/data/json/monster_special_attacks/spells.json
+++ b/data/json/monster_special_attacks/spells.json
@@ -1054,5 +1054,43 @@
       { "math": [ "portal_dungeon_carry_strength", "=", "max(portal_dungeon_carry_strength - 1, -75)" ] },
       { "u_add_effect": "strengthened_gravity", "duration": [ "4 hours", "6 hours" ] }
     ]
+  },
+  {
+    "id": "fear_paralyze",
+    "type": "SPELL",
+    "name": "Fear Paralyze",
+    "description": "Paralyzes you when you see the creature.",
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_FEAR_PARALYZE",
+    "message": "",
+    "shape": "blast",
+    "valid_targets": [ "hostile" ],
+    "flags": [ "SILENT", "NO_EXPLOSION_SFX" ],
+    "min_range": 10,
+    "max_range": 10
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_FEAR_PARALYZE",
+    "condition": { "not": { "u_has_effect": "fearparalyze" } },
+    "effect": { "run_eocs": [ "EOC_FEAR_PARALYZE2" ] }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_FEAR_PARALYZE2",
+    "condition": { "and": [ { "u_has_worn_with_flag": "PSYSHIELD_PARTIAL" }, { "one_in_chance": 4 } ] },
+    "effect": { "u_message": "The <npc_name> probes your mind, but is rebuffed!" },
+    "false_effect": { "run_eocs": [ "EOC_FEAR_PARALYZE3" ] }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_FEAR_PARALYZE3",
+    "condition": { "math": [ "rand(20) > u_val('intelligence')" ] },
+    "effect": [
+      { "u_message": "The terrifying visage of the <npc_name> paralyzes you.", "type": "bad" },
+      { "u_add_effect": "fearparalyze", "duration": 5 },
+      { "turn_cost": "4 s" }
+    ],
+    "false_effect": { "u_message": "You manage to avoid staring at the horrendous <npc_name>." }
   }
 ]

--- a/data/json/monsters/nether.json
+++ b/data/json/monsters/nether.json
@@ -60,7 +60,7 @@
     "harvest": "demihuman",
     "families": [ "prof_intro_biology", "prof_physiology" ],
     "weakpoint_sets": [ "wps_humanoid_body" ],
-    "special_attacks": [ [ "FEAR_PARALYZE", 0 ] ],
+    "special_attacks": [ { "type": "spell", "spell_data": { "id": "fear_paralyze" }, "monster_message": "" } ],
     "death_function": { "effect": { "id": "death_amigara" } },
     "dissect": "dissect_human_sample_single",
     "flags": [ "SMELLS", "HEARS", "SEES", "STUMBLES", "HARDTOSHOOT" ],
@@ -116,7 +116,10 @@
     "melee_damage": [ { "damage_type": "cut", "amount": 2 } ],
     "families": [ "prof_intro_biology", "prof_physiology" ],
     "harvest": "zombie",
-    "special_attacks": [ [ "FEAR_PARALYZE", 0 ], { "type": "bite", "cooldown": 5 } ],
+    "special_attacks": [
+      { "type": "spell", "spell_data": { "id": "fear_paralyze" }, "monster_message": "" },
+      { "type": "bite", "cooldown": 5 }
+    ],
     "death_function": { "effect": { "id": "death_guilt", "min_level": 6 } },
     "death_drops": "default_zombie_clothes",
     "flags": [ "SEES", "HEARS", "SMELLS", "WARM", "IMMOBILE", "POISON", "REVIVES", "FILTHY", "GUILT_OTHERS" ]
@@ -806,7 +809,7 @@
     "harvest": "gozu",
     "families": [ "prof_intro_biology", "prof_physiology", "prof_wp_demihuman" ],
     "weakpoint_sets": [ "wps_humanoid_body" ],
-    "special_attacks": [ [ "FEAR_PARALYZE", 20 ] ],
+    "special_attacks": [ { "type": "spell", "spell_data": { "id": "fear_paralyze" }, "monster_message": "", "cooldown": 20 } ],
     "flags": [ "SEES", "SMELLS", "HEARS", "HAS_MIND", "WARM", "BASHES", "GROUP_BASH", "ANIMAL", "NO_BREATHE", "PATH_AVOID_DANGER_1" ]
   },
   {

--- a/data/mods/MindOverMatter/effectoncondition/eoc_misc.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_misc.json
@@ -291,5 +291,18 @@
         "target_part": "eyes"
       }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_FEAR_PARALYZE",
+    "condition": { "not": { "u_has_effect": "fearparalyze" } },
+    "effect": { "run_eocs": [ "EOC_FEAR_PARALYZE1" ] }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_FEAR_PARALYZE1",
+    "condition": { "not": { "u_has_effect": "effect_telepathic_psi_armor" } },
+    "effect": { "run_eocs": [ "EOC_FEAR_PARALYZE2" ] },
+    "false_effect": { "u_message": "Some <npc_name> tries to intrude into your thoughts, but your telepathic shield reflects it!" }
   }
 ]

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -118,7 +118,6 @@ static const efftype_id effect_downed( "downed" );
 static const efftype_id effect_dragging( "dragging" );
 static const efftype_id effect_eyebot_assisted( "eyebot_assisted" );
 static const efftype_id effect_eyebot_depleted( "eyebot_depleted" );
-static const efftype_id effect_fearparalyze( "fearparalyze" );
 static const efftype_id effect_fungus( "fungus" );
 static const efftype_id effect_glowing( "glowing" );
 static const efftype_id effect_got_checked( "got_checked" );
@@ -2913,33 +2912,6 @@ bool mattack::stare( monster *z )
     return true;
 }
 
-bool mattack::fear_paralyze( monster *z )
-{
-    if( z->friendly ) {
-        // TODO: handle friendly monsters
-        return false;
-    }
-
-    if( !within_visual_range( z, 10 ) ) {
-        return false;
-    }
-
-    Character &player_character = get_player_character();
-    if( player_character.sees( *z ) && !player_character.has_effect( effect_fearparalyze ) ) {
-        if( player_character.worn_with_flag( flag_PSYSHIELD_PARTIAL ) && one_in( 4 ) ) {
-            add_msg( _( "The %s probes your mind, but is rebuffed!" ), z->name() );
-            ///\EFFECT_INT decreases chance of being paralyzed by fear attack
-        } else if( rng( 0, 20 ) > player_character.get_int() ) {
-            add_msg( m_bad, _( "The terrifying visage of the %s paralyzes you." ), z->name() );
-            player_character.add_effect( effect_fearparalyze, 5_turns );
-            player_character.moves -= 4 * player_character.get_speed();
-        } else {
-            add_msg( _( "You manage to avoid staring at the horrendous %s." ), z->name() );
-        }
-    }
-
-    return true;
-}
 bool mattack::nurse_check_up( monster *z )
 {
     bool found_target = false;

--- a/src/monattack.h
+++ b/src/monattack.h
@@ -63,7 +63,6 @@ bool gene_sting( monster *z );
 bool para_sting( monster *z );
 bool triffid_growth( monster *z );
 bool stare( monster *z );
-bool fear_paralyze( monster *z );
 bool nurse_check_up( monster *z );
 bool nurse_assist( monster *z );
 bool nurse_operate( monster *z );

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -631,7 +631,6 @@ void MonsterGenerator::init_attack()
     add_hardcoded_attack( "PARA_STING", mattack::para_sting );
     add_hardcoded_attack( "TRIFFID_GROWTH", mattack::triffid_growth );
     add_hardcoded_attack( "STARE", mattack::stare );
-    add_hardcoded_attack( "FEAR_PARALYZE", mattack::fear_paralyze );
     add_hardcoded_attack( "PHOTOGRAPH", mattack::photograph );
     add_hardcoded_attack( "TAZER", mattack::tazer );
     add_hardcoded_attack( "SEARCHLIGHT", mattack::searchlight );


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Nice little project for EoC
#### Describe the solution
jsonify fear_paralyze monster attack, remove old code
add MoM overwritten version, that uses protection from effect_telepathic_psi_armor
#### Testing
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/67688115/e1c20316-63c7-4550-b611-a73ade6419a4)
#### Additional context
The only issue is that original implementation has not flat 4 seconds of move subtraction, but `4 * player_character.get_speed()`, and math can't return character speed at this moment. I failed to implement such for myself