### PR TITLE
group based molle accessories for zed soldiers

### DIFF
--- a/data/json/itemgroups/custom_lbvs.json
+++ b/data/json/itemgroups/custom_lbvs.json
@@ -12,22 +12,31 @@
   {
     "type": "item_group",
     "id": "molle_accessories",
-    "subtype": "distribution",
+    "subtype": "collection",
     "entries": [
-      { "item": "chestpouch", "prob": 40 },
-      { "item": "radio_pouch", "prob": 20 },
-      { "item": "gadget_pouch", "prob": 10 },
-      { "item": "h2o_pouch", "prob": 10 },
-      { "item": "tool_pouch", "prob": 10 },
-      { "item": "flashlight_pouch", "prob": 20 },
-      { "item": "tactical_holster", "prob": 20 },
-      { "item": "gas_mask_pouch", "prob": 10 },
-      { "item": "tactical_grenade_pouch", "prob": 40 },
-      { "item": "tactical_shotshell_pouch", "prob": 40 },
-      { "item": "grenade_pouch", "prob": 10 },
-      { "item": "triple_stacker_pouch", "prob": 10 },
-      { "item": "dump_pouch", "prob": 20 },
-      { "item": "canteen_pouch", "prob": 30 },
+      {
+        "distribution": [ { "item": "dump_pouch", "count": [ 1, 2 ] }, { "item": "gadget_pouch", "count": [ 1, 2 ] } ],
+        "prob": 40
+      },
+      { "distribution": [ { "item": "tool_pouch" }, { "item": "radio_pouch" } ], "prob": 70 },
+      {
+        "collection": [
+          { "item": "tactical_holster", "prob": 40 },
+          {
+            "distribution": [
+              { "item": "grenade_pouch" },
+              { "item": "tactical_shotshell_pouch" },
+              { "item": "tactical_grenade_pouch", "count": [ 1, 3 ] }
+            ],
+            "prob": 70
+          },
+          { "item": "flashlight_pouch", "prob": 40 }
+        ]
+      },
+      {
+        "distribution": [ { "item": "canteen_pouch" }, { "item": "h2o_pouch" }, { "item": "gas_mask_pouch" } ],
+        "prob": 80
+      },
       { "item": "deployment_bag", "prob": 10 }
     ]
   },
@@ -37,10 +46,8 @@
     "id": "custom_light_lbv",
     "subtype": "collection",
     "entries": [
-      { "item": "chestpouch" },
-      { "group": "molle_accessories" },
-      { "group": "molle_accessories", "prob": 60 },
-      { "group": "molle_accessories", "prob": 20 }
+      { "distribution": [ { "item": "chestpouch", "count": [ 1, 2 ] }, { "item": "triple_stacker_pouch" } ] },
+      { "group": "molle_accessories", "count": [ 1, 2 ] }
     ]
   },
   {
@@ -49,11 +56,8 @@
     "//": "generic spawns for a generic vest",
     "subtype": "collection",
     "entries": [
-      { "item": "chestpouch" },
-      { "item": "chestpouch" },
-      { "group": "molle_accessories" },
-      { "group": "molle_accessories", "prob": 60 },
-      { "group": "molle_accessories", "prob": 20 }
+      { "distribution": [ { "item": "chestpouch", "count": [ 1, 2 ] }, { "item": "triple_stacker_pouch" } ] },
+      { "group": "molle_accessories", "count": [ 1, 3 ] }
     ]
   },
   {
@@ -62,13 +66,10 @@
     "//": "generic spawns for a generic vest",
     "subtype": "collection",
     "entries": [
-      { "item": "chestpouch" },
-      { "item": "chestpouch" },
-      { "item": "chestpouch" },
-      { "group": "molle_accessories" },
-      { "group": "molle_accessories" },
-      { "group": "molle_accessories", "prob": 60 },
-      { "group": "molle_accessories", "prob": 20 }
+      {
+        "distribution": [ { "item": "chestpouch", "count": [ 1, 2 ] }, { "item": "triple_stacker_pouch", "count": [ 1, 2 ] } ]
+      },
+      { "group": "molle_accessories", "count": [ 1, 4 ] }
     ]
   },
   {
@@ -86,11 +87,6 @@
     "id": "molle_backpacks_contents",
     "//": "stuff that might be in a molle pack",
     "subtype": "collection",
-    "entries": [
-      { "item": "camelbak", "prob": 40 },
-      { "group": "molle_accessories" },
-      { "group": "molle_accessories", "prob": 60 },
-      { "group": "molle_accessories", "prob": 20 }
-    ]
+    "entries": [ { "item": "camelbak", "prob": 40 }, { "group": "molle_accessories", "count": [ 1, 2 ] } ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
fow a while now I've had the idea of moving molle accessories to a "loadout" system; really just move them from a list with probabilities that repeats itself to a manual groups of items a "loadout" in my mind

extend how molle accessories spawn, more stuff, more complex grouping and try to spawn them logically i.e. one of each category, containers/storage, utility and combat accessories


<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
some samples:
![Screenshot from 2024-02-04 17-38-01](https://github.com/CleverRaven/Cataclysm-DDA/assets/58050969/d49ff197-34e2-4296-9ff0-0b2c929c0eb5)
![Screenshot from 2024-02-04 17-38-17](https://github.com/CleverRaven/Cataclysm-DDA/assets/58050969/c2ebaa5b-2434-4e7d-976a-98f76da7bf1e)
![Screenshot from 2024-02-04 17-38-30](https://github.com/CleverRaven/Cataclysm-DDA/assets/58050969/c84454a5-7569-43c3-95f6-beb08fc8d112)
![Screenshot from 2024-02-04 17-39-24](https://github.com/CleverRaven/Cataclysm-DDA/assets/58050969/792a53a9-ac36-4e9d-8c4d-f1f72320fa4a)
![Screenshot from 2024-02-04 17-40-03](https://github.com/CleverRaven/Cataclysm-DDA/assets/58050969/76f731ec-3716-460e-8685-fa5d6ec95505)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
