### PR TITLE
[Magiclysm] Add chance of feral mages at magic cabins

### DIFF
--- a/data/mods/Magiclysm/worldgen/magic_cabin.json
+++ b/data/mods/Magiclysm/worldgen/magic_cabin.json
@@ -128,7 +128,8 @@
           { "item": "homebooks", "chance": 40, "repeat": [ 1, 4 ] },
           { "item": "games", "chance": 20, "repeat": [ 1, 2 ] }
         ]
-      }
+      },
+      "place_monster": [ { "group": "GROUP_FERAL_WIZARDS", "x": [ 2, 21 ], "y": [ 2, 21 ], "chance": 33, "repeat": [ 1, 2 ] } ]
     }
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Magiclysm] Add chance of feral mages at magic cabins"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

It always struck me as a little weird that the magic cabins never had anyone in them--they were always pristine and perfectly safe. Now that there are feral wizards, maybe someone is home.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add a chance there is a feral wizard or two at the cabin.  Currently that's it.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

The real way to solve this is different cabin variants for different wizard types--like, an earthshaper cabin that's made of stone with more earthshaper loot, maybe a golem or two, and maybe a feral earthshaper; or an animist cabin with a summoning circle out back, maybe some spirits or zombies roaming around; or a druid cabin with dirt floors, with some wild (or zombified) animals and maybe a feral druid and more natural loot; a kelvinist cabin with a bunch of braziers in it and a feral kelvinist, etc.

That requires a lot of work, though--not least that I still have six variants of feral mages to do--and while I do want to eventually do it, adding the chance of someone home to the grabbag cabin now helps close the gap.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Spawned a bunch of cabins, some of them had people in them. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Thought about this for wizard towers too, but the answer for that is "If there was anyone home, 50 golems smashed them to ribbons"
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
