### PR TITLE
Revert "use ccache for emscripten builds (#71422)"

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -46,40 +46,8 @@ jobs:
     - name: Prepare web data
       run: ./build-scripts/prepare-web-data.sh
 
-    - name: Install ccache
-      run: |
-        sudo apt-get update
-        sudo apt-get install ccache
-
-    - name: Get ccache vars
-      id: get-vars
-      run: |
-        echo "datetime=$(/bin/date -u "+%Y%m%d%H%M")" >> $GITHUB_OUTPUT
-        echo "ccache-path=$(echo '~/.cache/ccache')" >> $GITHUB_OUTPUT
-
-    - name: ccache cache files
-      uses: actions/cache@v4
-      with:
-        path: ${{ steps.get-vars.outputs.ccache-path }}
-        # double-dash after compiler is not a typo, it is to disambiguate between g++-<date> and g++-11-<date> for restore key prefix matching
-        key: ccache-${{ github.ref_name }}-emscripten--${{ steps.get-vars.outputs.datetime }}
-        restore-keys: |
-          ccache-master-emscripten--
-
     - name: Build with emcc (emscripten)
       run: ./build-scripts/build-emscripten.sh
-
-    - name: post-build ccache manipulation
-      run: |
-        ccache --show-stats --verbose
-        ccache -M 4G
-        ccache -c
-        ccache --show-stats --verbose
-
-    - name: clear ccache on PRs
-      if: ${{ github.ref_name != 'master' && !failure() }}
-      run: |
-        ccache -C
 
     - name: Assemble web bundle
       run: ./build-scripts/prepare-web.sh

--- a/build-scripts/build-emscripten.sh
+++ b/build-scripts/build-emscripten.sh
@@ -4,9 +4,4 @@ set -exo pipefail
 emsdk install 3.1.51
 emsdk activate 3.1.51
 
-ccache --zero-stats
-# Increase cache size because debug builds generate large object files
-ccache -M 5G
-ccache --show-stats --verbose
-
-make -j`nproc` NATIVE=emscripten BACKTRACE=0 TILES=1 TESTS=0 RUNTESTS=0 RELEASE=1 CCACHE=1 LINTJSON=0 cataclysm-tiles.js
+make -j`nproc` NATIVE=emscripten BACKTRACE=0 TILES=1 TESTS=0 RUNTESTS=0 RELEASE=1 cataclysm-tiles.js


### PR DESCRIPTION
This reverts commit 03a693cd2672bd04563809b859483b8c5cd34027.

This was breaking the release builds of emscripten.

#### Summary
None