### PR TITLE
item/tname: don't include contents count in sort keys

### DIFF
--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -649,7 +649,8 @@ struct advanced_inv_sorter {
         }
         // secondary sort by name and link length
         auto const sort_key = []( advanced_inv_listitem const & d ) {
-            return std::make_tuple( d.name_without_prefix, d.name, d.items.front()->link_sort_key() );
+            return std::make_tuple( d.name_without_prefix, d.contents_count, d.name,
+                                    d.items.front()->link_sort_key() );
         };
         return localized_compare( sort_key( d1 ), sort_key( d2 ) );
     }

--- a/src/advanced_inv_listitem.cpp
+++ b/src/advanced_inv_listitem.cpp
@@ -10,7 +10,8 @@ advanced_inv_listitem::advanced_inv_listitem( const item_location &an_item, int 
     , area( area )
     , id( an_item->typeId() )
     , name( an_item->tname( count ) )
-    , name_without_prefix( an_item->tname( 1, false ) )
+    , name_without_prefix( an_item->tname( 1, tname::tname_sort_key ) )
+    , contents_count( an_item->aggregated_contents().count )
     , autopickup( get_auto_pickup().has_rule( & * an_item ) )
     , stacks( count )
     , volume( an_item->volume() * stacks )
@@ -29,7 +30,8 @@ advanced_inv_listitem::advanced_inv_listitem( const std::vector<item_location> &
     id( list.front()->typeId() ),
     items( list ),
     name( list.front()->tname( 1 ) ),
-    name_without_prefix( list.front()->tname( 1, false ) ),
+    name_without_prefix( list.front()->tname( 1, tname::tname_sort_key ) ),
+    contents_count( list.front()->aggregated_contents().count ),
     autopickup( get_auto_pickup().has_rule( & * list.front() ) ),
     stacks( list.size() ),
     volume( list.front()->volume() * stacks ),

--- a/src/advanced_inv_listitem.h
+++ b/src/advanced_inv_listitem.h
@@ -40,6 +40,7 @@ class advanced_inv_listitem
          * Name of the item (singular) without damage (or similar) prefix, used for sorting.
          */
         std::string name_without_prefix;
+        unsigned int contents_count;
         /**
          * Whether auto pickup is enabled for this item (based on the name).
          */

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -71,6 +71,7 @@ class inventory_entry
         int custom_invlet = INT_MIN;
         std::string *cached_name = nullptr;
         std::string *cached_name_full = nullptr;
+        unsigned int contents_count = 0;
 
         inventory_entry() = default;
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1726,6 +1726,7 @@ stacking_info item::stacks_with( const item &rhs, bool check_components, bool co
     bits.set( tname::segments::CONTENTS, b_contents );
     bits.set( tname::segments::CONTENTS_FULL, b_contents );
     bits.set( tname::segments::CONTENTS_ABREV, b_contents );
+    bits.set( tname::segments::CONTENTS_COUNT, b_contents );
     return { bits };
 }
 

--- a/src/item_tname.cpp
+++ b/src/item_tname.cpp
@@ -223,11 +223,18 @@ std::string contents( item const &it, unsigned int /* quantity */,
         // (eg: quivers), as they format their own counts.
         if( total_count > 1 && it.ammo_types().empty() ) {
             if( total_count == aggi_count ) {
-                return string_format( " > %1$zd %2$s", total_count, ctnc );
+                return string_format(
+                           segments[tname::segments::CONTENTS_COUNT]
+                           //~ [container item name] " > [count] [type]"
+                           ? npgettext( "item name", " > %1$zd %2$s", " > %1$zd %2$s", total_count )
+                           : " > %2$s",
+                           total_count, ctnc );
             }
             return string_format(
+                       segments[tname::segments::CONTENTS_COUNT]
                        //~ [container item name] " > [count] [type] / [total] items"
-                       npgettext( "item name", " > %1$zd %2$s / %3$zd item", " > %1$zd %2$s / %3$zd items", total_count ),
+                       ? npgettext( "item name", " > %1$zd %2$s / %3$zd item", " > %1$zd %2$s / %3$zd items", total_count )
+                       : " > %2$s",
                        aggi_count, ctnc, total_count );
         }
         return string_format( " > %1$s", ctnc );
@@ -235,9 +242,11 @@ std::string contents( item const &it, unsigned int /* quantity */,
     } else if( segments[tname::segments::CONTENTS_ABREV] && !contents.empty_container() &&
                contents.num_item_stacks() != 0 ) {
         std::string const suffix =
-            npgettext( "item name",
-                       //~ [container item name] " > [count] item"
-                       " > %1$zd item", " > %1$zd items", contents.num_item_stacks() );
+            segments[tname::segments::CONTENTS_COUNT]
+            ? npgettext( "item name",
+                         //~ [container item name] " > [count] item"
+                         " > %1$zd item", " > %1$zd items", contents.num_item_stacks() )
+            : _( " > items" );
         return string_format( suffix, contents.num_item_stacks() );
     }
     return {};

--- a/src/item_tname.h
+++ b/src/item_tname.h
@@ -4,7 +4,6 @@
 
 #include <cstddef>
 #include <string>
-#include <unordered_map>
 
 #include "enum_bitset.h"
 #include "enum_traits.h"
@@ -63,6 +62,7 @@ enum class segments : std::size_t {
     // separate flags for CONTENTS
     CONTENTS_FULL,
     CONTENTS_ABREV,
+    CONTENTS_COUNT,
 
     // separate flags for CATEGORY
     FOOD_PERISHABLE,
@@ -94,16 +94,21 @@ constexpr uint64_t tname_prefix_bits =
     1ULL << static_cast<size_t>( tname::segments::FAVORITE_PRE ) |
     1ULL << static_cast<size_t>( tname::segments::DURABILITY ) |
     1ULL << static_cast<size_t>( tname::segments::BURN );
+constexpr uint64_t tname_unsortable_bits =
+    tname_prefix_bits |
+    ( 1ULL << static_cast<size_t>( tname::segments::CONTENTS_COUNT ) );
 constexpr uint64_t tname_contents_bits =
     1ULL << static_cast<size_t>( tname::segments::CONTENTS ) |
     1ULL << static_cast<size_t>( tname::segments::CONTENTS_FULL ) |
-    1ULL << static_cast<size_t>( tname::segments::CONTENTS_ABREV );
+    1ULL << static_cast<size_t>( tname::segments::CONTENTS_ABREV ) |
+    1ULL << static_cast<size_t>( tname::segments::CONTENTS_COUNT );
 constexpr uint64_t tname_conditional_bits =    // TODO: fine grain?
     1ULL << static_cast<size_t>( tname::segments::COMPONENTS ) |
     1ULL << static_cast<size_t>( tname::segments::TAGS ) |
     1ULL << static_cast<size_t>( tname::segments::VARS );
 constexpr segment_bitset default_tname( default_tname_bits );
 constexpr segment_bitset unprefixed_tname( default_tname_bits & ~tname_prefix_bits );
+constexpr segment_bitset tname_sort_key( default_tname_bits & ~tname_unsortable_bits );
 constexpr segment_bitset tname_contents( tname_contents_bits );
 constexpr segment_bitset tname_conditional( tname_conditional_bits );
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Items with contents are sorted in inventory UIs by contents count instead of type.

* Fixes: #71520

#### Describe the solution
Add a `COUNT` flag for the `CONTENTS` segment that makes it include the count in the name
Unset it when caching sort keys in inventory UIs
Cache contents count separately from name and include it in the sort key

#### Describe alternatives you've considered
N/A

#### Testing
<details>
<summary>inventory UI before</summary>
Contents are sorted by count, alphabetically

![0 - inv_ui before](https://github.com/CleverRaven/Cataclysm-DDA/assets/68240139/4adc2d42-0e13-48ca-a499-4c6031443bc3)

</details>

<details>
<summary>inventory UI after</summary>
Contents are sorted by type, alphabetically, then by count, numerically.

![Screenshot from 2024-02-05 12-00-39](https://github.com/CleverRaven/Cataclysm-DDA/assets/68240139/8edab9f7-75f9-476e-b8ff-3409a4478062)

</details>

<details>
<summary>AIM before</summary>

![2 - aim before](https://github.com/CleverRaven/Cataclysm-DDA/assets/68240139/7d4f5c2f-3e09-4780-b199-316b3e66a8f0)

</details>

<details>
<summary>AIM after</summary>

![Screenshot from 2024-02-05 12-00-28](https://github.com/CleverRaven/Cataclysm-DDA/assets/68240139/8aaa095a-baa8-4bd0-9fd7-e5fef4021aa6)

</details>

#### Additional context
N/A

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
