### PR TITLE
Improve menus of MRE

### DIFF
--- a/data/json/itemgroups/SUS/mre_packages.json
+++ b/data/json/itemgroups/SUS/mre_packages.json
@@ -49,12 +49,43 @@
   },
   {
     "type": "item_group",
+    "id": "mre_sides",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "mre_potato", "container-item": "null" },
+      { "item": "mre_fried_rice", "container-item": "null" },
+      { "item": "mre_zapplesauce", "container-item": "null" },
+      { "item": "mre_blackbeans", "container-item": "null" }
+    ]
+  },
+  {
+    "type": "item_group",
     "id": "mre_dessert_pack",
     "subtype": "collection",
     "entries": [
-      { "group": "candy2_wrapper_1" },
-      { "group": "cookies_wrapper_1" },
-      { "item": "dry_fruit", "container-item": "wrapper" }
+      {
+        "distribution": [
+          { "item": "mre_chocolate_cake", "container-item": "null" },
+          { "item": "mre_carrot_cake", "container-item": "null" },
+          { "item": "mre_poppyseed_cake", "container-item": "null" },
+          { "item": "mre_strawberry_cake", "container-item": "null" },
+          { "item": "mre_chocolate_pudding", "container-item": "null" }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "mre_bread_pack",
+    "subtype": "collection",
+    "container-item": "mre_bag_small",
+    "entries": [
+      {
+        "distribution": [
+          { "item": "crackers", "container-item": "null", "count": 2 },
+          { "item": "snack_bread", "container-item": "null", "count": 2 }
+        ]
+      }
     ]
   },
   {
@@ -72,13 +103,10 @@
       { "item": "spork" },
       {
         "distribution": [
-          { "item": "instant_coffee", "count": 2, "container-item": "bag_zipper" },
-          { "item": "herbal_tea_bag", "count": 2, "container-item": "bag_zipper" },
-          { "item": "tea_bag", "count": 2, "container-item": "bag_zipper" },
-          { "item": "tea_bag_chamomile", "count": 2, "container-item": "bag_zipper" },
-          { "item": "tea_bag_dandelion", "count": 2, "container-item": "bag_zipper" },
-          { "item": "tea_fruit_bag", "count": 2, "container-item": "bag_zipper" },
-          { "item": "tea_green_bag", "count": 2, "container-item": "bag_zipper" }
+          { "item": "instant_coffee", "count": 1, "container-item": "bag_zipper" },
+          { "item": "lemonade_powder", "count": 1, "container-item": "bag_zipper" },
+          { "item": "orangeade_powder", "count": 1, "container-item": "bag_zipper" },
+          { "item": "grapeade_powder", "count": 1, "container-item": "bag_zipper" }
         ]
       }
     ]
@@ -90,7 +118,7 @@
     "subtype": "collection",
     "entries": [
       { "group": "mre_entrees", "container-item": "mre_bag_small", "sealed": true },
-      { "item": "heatpack" },
+      { "group": "mre_sides", "container-item": "mre_bag_small", "sealed": true },
       {
         "distribution": [
           { "item": "can_cheese", "container-item": "null", "entry-wrapper": "mre_bag_spread", "sealed": true },
@@ -99,12 +127,20 @@
             "container-item": "null",
             "entry-wrapper": "mre_bag_spread",
             "sealed": true
+          },
+          {
+            "item": "jam_fruit",
+            "container-item": "null",
+            "entry-wrapper": "mre_bag_jam",
+            "sealed": true,
+            "charges": 1
           }
         ]
       },
-      { "group": "crackers_mre_bag_small_2", "sealed": true },
+      { "group": "mre_bread_pack", "sealed": true },
+      { "group": "mre_dessert_pack", "container-item": "mre_bag_dessert", "sealed": true },
       { "group": "mre_accessory_pack" },
-      { "item": "mre_bag_dessert", "contents-group": "mre_dessert_pack", "sealed": true }
+      { "item": "heatpack" }
     ]
   },
   {
@@ -118,9 +154,14 @@
     "id": "mre_used_dessert_pack",
     "subtype": "collection",
     "entries": [
-      { "count": [ 0, 1 ], "group": "candy2_wrapper_1" },
-      { "count": [ 0, 1 ], "group": "cookies_wrapper_1" },
-      { "item": "dry_fruit", "container-item": "wrapper" }
+      {
+        "distribution": [
+          { "item": "cookies", "count": [ 0, 1 ], "container-item": "null" },
+          { "item": "mre_carrot_cake", "count": [ 0, 1 ], "container-item": "null" },
+          { "item": "mre_poppyseed_cake", "count": [ 0, 1 ], "container-item": "null" },
+          { "item": "chocolate", "count": [ 0, 1 ], "container-item": "null" }
+        ]
+      }
     ]
   },
   {
@@ -129,16 +170,31 @@
     "subtype": "collection",
     "entries": [
       { "group": "mre_entrees", "container-item": "mre_bag_small", "sealed": false, "prob": 40 },
+      { "group": "mre_sides", "container-item": "mre_bag_small", "sealed": false, "prob": 40 },
       { "item": "heatpack", "prob": 40 },
       {
         "distribution": [
-          { "item": "can_cheese", "container-item": "mre_bag_spread", "prob": 40, "sealed": true },
-          { "item": "spread_peanutbutter", "container-item": "mre_bag_spread", "prob": 40, "sealed": true }
+          { "item": "can_cheese", "container-item": "null", "entry-wrapper": "mre_bag_spread", "prob": 40, "sealed": true },
+          {
+            "item": "spread_peanutbutter",
+            "container-item": "null",
+            "entry-wrapper": "mre_bag_spread",
+            "prob": 40,
+            "sealed": true
+          },
+          {
+            "item": "jam_fruit",
+            "container-item": "null",
+            "entry-wrapper": "mre_bag_jam",
+            "sealed": true,
+            "prob": 40,
+            "charges": 1
+          }
         ]
       },
-      { "sealed": false, "group": "crackers_mre_bag_small_0_2" },
+      { "group": "mre_bread_pack", "sealed": false, "prob": 40 },
       { "group": "mre_accessory_pack", "prob": 50 },
-      { "item": "mre_bag_dessert", "contents-group": "mre_used_dessert_pack", "sealed": false }
+      { "group": "mre_dessert_pack", "container-item": "mre_bag_dessert", "sealed": false, "prob": 40 }
     ]
   },
   {
@@ -177,7 +233,7 @@
     "subtype": "collection",
     "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_zipper",
-    "entries": [ { "item": "sugar", "container-item": "null", "count": 2 } ]
+    "entries": [ { "item": "sugar", "container-item": "null", "count": 10 } ]
   },
   {
     "type": "item_group",
@@ -201,7 +257,7 @@
     "subtype": "collection",
     "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_zipper",
-    "entries": [ { "item": "sugar", "container-item": "null", "count": [ 0, 2 ] } ]
+    "entries": [ { "item": "sugar", "container-item": "null", "count": [ 0, 10 ] } ]
   },
   {
     "type": "item_group",

--- a/data/json/items/comestibles/drink.json
+++ b/data/json/items/comestibles/drink.json
@@ -923,6 +923,20 @@
   },
   {
     "type": "COMESTIBLE",
+    "id": "orangeade",
+    "copy-from": "lemonade",
+    "name": { "str_sp": "orangeade" },
+    "description": "Cheap orange flavored beverage with limited vitamins."
+  },
+  {
+    "type": "COMESTIBLE",
+    "id": "grapeade",
+    "copy-from": "lemonade",
+    "name": { "str_sp": "grapeade" },
+    "description": "Cheap grape flavored beverage with limited vitamins."
+  },
+  {
+    "type": "COMESTIBLE",
     "id": "lemonlime",
     "looks_like": "lemonade",
     "name": { "str_sp": "lemon-lime soda" },

--- a/data/json/items/comestibles/fruit_dishes.json
+++ b/data/json/items/comestibles/fruit_dishes.json
@@ -159,6 +159,20 @@
   },
   {
     "type": "COMESTIBLE",
+    "id": "orangeade_powder",
+    "name": { "str_sp": "orangeade drink mix" },
+    "copy-from": "lemonade_powder",
+    "description": " Can be mixed with water to make orange juice."
+  },
+  {
+    "type": "COMESTIBLE",
+    "id": "grapeade_powder",
+    "name": { "str_sp": "orangeade drink mix" },
+    "copy-from": "lemonade_powder",
+    "description": " Can be mixed with water to make grape juice."
+  },
+  {
+    "type": "COMESTIBLE",
     "id": "fruit_cooked",
     "name": { "str_sp": "cooked fruit" },
     "conditional_names": [

--- a/data/json/items/comestibles/mre.json
+++ b/data/json/items/comestibles/mre.json
@@ -3,7 +3,7 @@
     "abstract": "mre_entree",
     "type": "COMESTIBLE",
     "name": { "str": "MRE entree" },
-    "weight": "125 g",
+    "weight": "227 g",
     "color": "brown",
     "spoils_in": "3 days 8 hours",
     "comestible_type": "FOOD",
@@ -314,5 +314,115 @@
     "description": "The pizza entree from an MRE, featuring pepperoni slices and cheese.",
     "material": [ "flesh", "wheat", "milk" ],
     "fun": 3
+  },
+  {
+    "abstract": "mre_side",
+    "type": "COMESTIBLE",
+    "name": { "str": "MRE side" },
+    "weight": "142 g",
+    "color": "brown",
+    "spoils_in": "3 days 8 hours",
+    "comestible_type": "FOOD",
+    "symbol": "%",
+    "calories": 220,
+    "description": "A generic MRE side, you shouldn't see this.",
+    "price": 1250,
+    "price_postapoc": 300,
+    "volume": "250 ml",
+    "flags": [ "EATEN_HOT", "RAD_STERILIZED", "DECAY_EXPOSED_ATMOSPHERE" ],
+    "looks_like": "mre_beef",
+    "fun": 2
+  },
+  {
+    "type": "COMESTIBLE",
+    "id": "mre_potato",
+    "copy-from": "mre_side",
+    "name": { "str": "potatoes, Au Gratin" },
+    "description": "Golden-fried potatoes.",
+    "material": [ "veggy" ]
+  },
+  {
+    "type": "COMESTIBLE",
+    "id": "mre_fried_rice",
+    "copy-from": "mre_side",
+    "name": { "str_sp": "fried rice(small portion)" },
+    "description": "Fried rice, a simple dish made by stir-frying rice with other ingredients.",
+    "material": [ "wheat" ]
+  },
+  {
+    "type": "COMESTIBLE",
+    "id": "mre_zapplesauce",
+    "copy-from": "mre_side",
+    "name": { "str": "zapplesauce" },
+    "description": "Golden, jelly-like food with the flavor of apples.",
+    "material": [ "fruit" ],
+    "fun": 5
+  },
+  {
+    "type": "COMESTIBLE",
+    "id": "mre_blackbeans",
+    "copy-from": "mre_side",
+    "name": { "str": "black beans in sauce" },
+    "description": "A savory and flavorful combination of black beans and sauce.",
+    "material": [ "bean" ],
+    "calories": 130
+  },
+  {
+    "abstract": "mre_dessert",
+    "type": "COMESTIBLE",
+    "name": { "str": "mre dessert" },
+    "weight": "52 g",
+    "color": "brown",
+    "spoils_in": "3 days 8 hours",
+    "comestible_type": "FOOD",
+    "symbol": "%",
+    "calories": 270,
+    "description": "A generic MRE dessert, you shouldn't see this.",
+    "price": 1250,
+    "price_postapoc": 300,
+    "volume": "125 ml",
+    "flags": [ "RAD_STERILIZED", "DECAY_EXPOSED_ATMOSPHERE" ],
+    "looks_like": "cookies",
+    "fun": 4
+  },
+  {
+    "type": "COMESTIBLE",
+    "id": "mre_carrot_cake",
+    "name": { "str_sp": "carrot pound cake" },
+    "copy-from": "mre_dessert",
+    "description": "Delicious cake with carrots blended seamlessly."
+  },
+  {
+    "type": "COMESTIBLE",
+    "id": "mre_poppyseed_cake",
+    "copy-from": "mre_carrot_cake",
+    "name": { "str_sp": "lemon poppy seed pound cake" },
+    "calories": 290,
+    "description": "Cake filled with the goodness of lemon and poppy seeds."
+  },
+  {
+    "type": "COMESTIBLE",
+    "id": "mre_chocolate_pudding",
+    "copy-from": "mre_dessert",
+    "name": { "str_sp": "chocolate pudding" },
+    "calories": 300,
+    "weight": "75 g",
+    "description": "Pudding made with chocolate.  Yummy!"
+  },
+  {
+    "type": "COMESTIBLE",
+    "id": "mre_chocolate_cake",
+    "copy-from": "mre_dessert",
+    "name": { "str_sp": "chocolate chip toaster pastry" },
+    "calories": 210,
+    "description": "Pastry with chocolate chips."
+  },
+  {
+    "type": "COMESTIBLE",
+    "id": "mre_strawberry_cake",
+    "copy-from": "mre_dessert",
+    "name": { "str_sp": "strawberry toaster pastry" },
+    "calories": 210,
+    "description": "Strawberry-flavor pastry."
   }
 ]

--- a/data/json/items/comestibles/wheat.json
+++ b/data/json/items/comestibles/wheat.json
@@ -401,6 +401,14 @@
   },
   {
     "type": "COMESTIBLE",
+    "id": "snack_bread",
+    "name": { "str": "wheat snack bread" },
+    "copy-from": "crackers",
+    "description": "Wheat Snack Bread, a delicious snack made from wheat.",
+    "quench": 0
+  },
+  {
+    "type": "COMESTIBLE",
     "id": "oyster_crackers",
     "name": { "str": "oyster cracker" },
     "copy-from": "crackers",

--- a/data/json/items/containers/containers.json
+++ b/data/json/items/containers/containers.json
@@ -3829,7 +3829,7 @@
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
-        "max_contains_volume": "1255 ml",
+        "max_contains_volume": "1600 ml",
         "max_contains_weight": "4 kg",
         "airtight": true,
         "moves": 50,
@@ -3858,7 +3858,7 @@
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
-        "max_contains_volume": "157 ml",
+        "max_contains_volume": "125 ml",
         "max_contains_weight": "750 g",
         "airtight": true,
         "moves": 50,
@@ -3887,6 +3887,34 @@
       {
         "pocket_type": "CONTAINER",
         "max_contains_volume": "31 ml",
+        "max_contains_weight": "180 g",
+        "airtight": true,
+        "moves": 50,
+        "sealed_data": { "spoil_multiplier": 0.0 },
+        "watertight": true
+      }
+    ],
+    "material": [ "plastic", "aluminum" ],
+    "symbol": ")",
+    "color": "light_gray"
+  },
+  {
+    "id": "mre_bag_jam",
+    "type": "GENERIC",
+    "category": "container",
+    "name": { "str": "MRE jam bag" },
+    "looks_like": "mre_beef_box",
+    "description": "A small, sturdy, plastic and aluminum container of multi-layered construction, with detailed nutritional information about its contents.",
+    "ascii_picture": "mre_bag_spread",
+    "weight": "10 g",
+    "volume": "12 ml",
+    "price": 0,
+    "price_postapoc": 0,
+    "to_hit": -1,
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "32 ml",
         "max_contains_weight": "180 g",
         "airtight": true,
         "moves": 50,

--- a/data/json/recipes/recipe_food.json
+++ b/data/json/recipes/recipe_food.json
@@ -3218,6 +3218,30 @@
   {
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
+    "result": "orangeade",
+    "id_suffix": "from_mix",
+    "category": "CC_FOOD",
+    "subcategory": "CSC_FOOD_DRINKS",
+    "skill_used": "cooking",
+    "time": "30 s",
+    "autolearn": true,
+    "components": [ [ [ "orangeade_powder", 1 ] ], [ [ "water_clean", 1 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "result": "grapeade",
+    "id_suffix": "from_mix",
+    "category": "CC_FOOD",
+    "subcategory": "CSC_FOOD_DRINKS",
+    "skill_used": "cooking",
+    "time": "30 s",
+    "autolearn": true,
+    "components": [ [ [ "grapeade_powder", 1 ] ], [ [ "water_clean", 1 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
     "result": "spezi",
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_DRINKS",

--- a/data/json/requirements/cooking_components.json
+++ b/data/json/requirements/cooking_components.json
@@ -34,7 +34,8 @@
         [ "sourdough_bread", 1 ],
         [ "brioche", 1 ],
         [ "brown_bread", 1 ],
-        [ "hallula", 1 ]
+        [ "hallula", 1 ],
+        [ "snack_bread", 1 ]
       ]
     ]
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Although the entrée of MRE in the current game has a rich menu and a relatively complete setting, the settings of other parts of MRE are quite rough, and even include various non-ready-to-eat tea bags. Therefore, these settings need to be improved.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Although the entrée of MRE in the game is different from the current menu, I don't think it needs to be changed too much. The detailed menu of 2016 can be found (https://www.mreinfo.com/wp-content/uploads/2016/01/US.12.3.Nutritionals.11.15.pdf), so the modification of this PR is mainly based on this data, and also refers to the 2021 one. MRE will be divided into six parts, and each part will randomly generate one of the items.
Entrée: Keep original settings.
Side: "potatoes, Au Gratin", "fried rice(small portion)", "zapplesauce", "black beans in sauce"
Dessert: "carrot pound cake", "lemon poppy seed pound cake", "chocolate pudding", "chocolate chip toaster pastry","strawberry toaster pastry"
Bread: "crackers", "wheat snack bread"
Spread: "cheese spread"，"peanut butter spread"，“fruit jam”
Beverage:"lemonade drink mix","orangeade drink mix","grapeade drink mix","instant coffee mix"

In order to make the total value of MRE reasonable, the unusually high transaction value of peanut butter spread was reduced.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
