### PR TITLE
Fire in your eyes

### DIFF
--- a/data/json/obsoletion/blacklist_temperature_removal.json
+++ b/data/json/obsoletion/blacklist_temperature_removal.json
@@ -18,7 +18,9 @@
       "ammonia_liquid",
       "chem_sulphur",
       "insecticide",
-      "wax"
+      "wax",
+      "bifocal_contacts_weekly",
+      "bifocal_transition_contacts_weekly"
     ],
     "//1": "CAUTION: this list is for items that are safe for straightforward deactivation",
     "//2": "items that may be active for additional reasons other than temperature tracking should use separate special case handling"


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
fix #71523
#### Describe the solution
Add two lenses, that was migrated from comestible type, into temperature_removal_blacklist, to make them stop tracking said temperature