### PR TITLE
Hub 01 Ancillae dialogue spelling/grammar fixes

### DIFF
--- a/data/json/npcs/robofac/robofac_ancilla_npcs/BAR_ENCOUNTER_MERCENARIES/BEM_anchor_seller.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/BAR_ENCOUNTER_MERCENARIES/BEM_anchor_seller.json
@@ -8,7 +8,7 @@
       "context": "BEM_ANCHOR_SELLER",
       "value": "yes",
       "yes": "Sorry I'd rather be left alone right now.",
-      "no": "&A grim expression and deep sunken eyes imply some malady that can't be simply drowned with alcohol alone.  They interrupt you just as you were about to introduce yourself.  \"This anchor im wearing, I don't think I will be needing it anymore.  I-I'm just looking for someone to rid me of it"
+      "no": "&A grim expression and deep sunken eyes imply some malady that can't be simply drowned with alcohol alone.  They interrupt you just as you were about to introduce yourself.  \"This anchor I'm wearing, I don't think I'll be needing it any more.  I-I'm just looking for someone to rid me of it"
     },
     "responses": [
       {

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/BAR_ENCOUNTER_MERCENARIES/BEM_chatting_veterans.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/BAR_ENCOUNTER_MERCENARIES/BEM_chatting_veterans.json
@@ -32,7 +32,7 @@
     ],
     "responses": [
       {
-        "text": "Bar… barshender!  we… we?",
+        "text": "Bar… barshender!  We… we?",
         "effect": [
           "end_conversation",
           { "queue_eocs": "EOC_BEM_BEM_CHATTING_VETERANS_DRUNK_MESSAGE", "time_in_future": [ "0s", "0s" ] }

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/BAR_ENCOUNTER_MERCENARIES/BEM_human_sample.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/BAR_ENCOUNTER_MERCENARIES/BEM_human_sample.json
@@ -5,7 +5,7 @@
     "name": { "str": "Fleshmonger" },
     "//": "This mission is assigned and completed using dialogue and EOCs. As such, we don't have any goal, which would make it auto-complete under certain circumstances.",
     "goal": "MGOAL_NULL",
-    "description": "Deposit a human sample in a pit within the dead drop location.  Pick your reward at The Terminal once that's done.",
+    "description": "Deposit a human sample in a pit within the dead drop location.  Pick up your reward at the Terminal once that's done.",
     "difficulty": 1,
     "value": 0,
     "start": {
@@ -74,7 +74,7 @@
   {
     "id": "BEM_HUMAN_SAMPLE2",
     "type": "talk_topic",
-    "dynamic_line": "Most I can give is two gold coins.  I have arranged a drop in the nearby woods, put the goods there and you can get your cash with the barkeep here.",
+    "dynamic_line": "Most I can give is two gold coins.  I've arranged a drop in the nearby woods, put the goods there and you can get your cash with the barkeep here.",
     "responses": [
       {
         "text": "It'll get done.",
@@ -109,7 +109,7 @@
   {
     "id": "BEM_HUMAN_SAMPLE_FINISH",
     "type": "talk_topic",
-    "dynamic_line": "&<mypronoun> quickly removes the offending piece of meat from your hand and places two golden coins on the table, apparently unshaken by the prospect of meeting someone who casually visits bars while carrying cuts of human flesh.  \"Now if you please, I have a meal to ger rid off.\" <mypronoun> says, between poorly masked bouts of nausea.",
+    "dynamic_line": "&<mypronoun> quickly removes the offending piece of meat from your hand and places two golden coins on the table, apparently unshaken by the prospect of meeting someone who casually visits bars while carrying cuts of human flesh.  \"Now if you please, I have a meal to get rid of.\" <mypronoun> says, between poorly masked bouts of nausea.",
     "speaker_effect": { "effect": [ { "u_sell_item": "human_sample", "count": 1 }, { "u_spawn_item": "RobofacCoin", "count": 2 } ] },
     "responses": [ { "text": "Leave.", "topic": "TALK_DONE", "effect": "end_conversation" } ]
   },

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/BAR_ENCOUNTER_MERCENARIES/BEM_template_seller.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/BAR_ENCOUNTER_MERCENARIES/BEM_template_seller.json
@@ -2,7 +2,7 @@
   {
     "id": [ "BEM_TEMPLATE_SELLER_1", "BEM_TEMPLATE_SELLER_ASK" ],
     "type": "talk_topic",
-    "dynamic_line": "&The mercenary seems uncharacteristically upbeat, or perhaps just drunk.  \"Found this neat gizmo in a bank run a few days ago.\"  <mypronoun> blurts while procuring a small cube of etched glass from <mypossesivepronoun> pocket.  \"Now, I have no use for such a thing, but perhaps you do.  What do you say?  Its yours for 3 coins.\"",
+    "dynamic_line": "&The mercenary seems uncharacteristically upbeat, or perhaps just drunk.  \"Found this neat gizmo in a bank run a few days ago.\"  <mypronoun> blurts while procuring a small cube of etched glass from <mypossesivepronoun> pocket.  \"Now, I have no use for such a thing, but perhaps you do.  What do you say?  It's yours for 3 coins.\"",
     "responses": [
       {
         "text": "[3 HGC] It's a deal.",
@@ -27,7 +27,7 @@
   {
     "id": "BEM_TEMPLATE_SELLER_DISCOUNT_BUY",
     "type": "talk_topic",
-    "dynamic_line": "Sure whatever, two coins and its all yours.",
+    "dynamic_line": "Sure whatever, two coins and it's all yours.",
     "responses": [
       {
         "text": "[2 HGC] It's a deal then.",
@@ -50,7 +50,7 @@
   {
     "id": "BEM_TEMPLATE_SELLER_ASK",
     "type": "talk_topic",
-    "dynamic_line": "A 'nanofabricator template', it seems, no idea what its good for, but it sure looks valuable.  Are you buying it or not?"
+    "dynamic_line": "A 'nanofabricator template', it seems, no idea what it's good for, but it sure looks valuable.  Are you buying it or not?"
   },
   {
     "id": "BEM_TEMPLATE_SELLER_NO_DEAL",

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/BAR_ENCOUNTER_MERCENARIES/NPC_BEMS.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/BAR_ENCOUNTER_MERCENARIES/NPC_BEMS.json
@@ -2,7 +2,7 @@
   {
     "type": "npc",
     "id": "BEM_gunrunner",
-    "//": "These are all random people you met in a bar once, the fact that they dont have names is meant to emphasize the transient nature of the conversations you have with them",
+    "//": "These are all random people you met in a bar once, the fact that they don't have names is meant to emphasize the transient nature of the conversations you have with them",
     "name_unique": "the enterprising gunrunner",
     "class": "NC_BEM_GUNRUNNER",
     "attitude": 0,

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/NPC_ANCILLA_BARKEEP.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/NPC_ANCILLA_BARKEEP.json
@@ -76,7 +76,7 @@
     "text": [
       "Ahh but if you want suggestions and are one for craft beers, I certainly suggest having some old world brew before it all goes flat or sour.",
       "Speaking off, Cranberry here brought me a whole cask of Cabernet a few days ago.  So if red wines are your thing I can offer that by the gallon.",
-      "Just bought some of this new \"Free Whiskey\" from the caravaneer up above.  Its vile if you ask me, but it packs a good punch.  A real drink of the apocalypse I suppose.",
+      "Just bought some of this new \"Free Whiskey\" from the caravaneer up above.  It's vile if you ask me, but it packs a good punch.  A real drink of the apocalypse I suppose.",
       "The water I boiled from a pool by the rails, so I don't suggest you get some.",
       "And you can also try chatting with some of the other patrons if networking is your thing.",
       "Also have some old world sodas if alcohol isn't your kind of thing.",
@@ -133,7 +133,7 @@
   {
     "id": "TALK_ANCILLA_BARKEEP_TAP",
     "type": "talk_topic",
-    "dynamic_line": "Just the best spirits the whole of New England has to offer.  Well the best we have managed to loot so far at least.\n\n <ANCILLA_barkeep_suggestion>",
+    "dynamic_line": "Just the best spirits the whole of New England has to offer.  Well the best we've managed to loot so far at least.\n\n <ANCILLA_barkeep_suggestion>",
     "responses": [
       {
         "//": "It is FREE? well just for regulars",

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/NPC_ANCILLA_DOCTOR.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/NPC_ANCILLA_DOCTOR.json
@@ -87,7 +87,7 @@
         "yes": [
           "Try not to touch anything.  Keeping this place clean is a full time job.",
           "I'm free at the moment if you need something.",
-          "Did you know you can loose a medical license over tax fraud?  Couldn't be me.",
+          "Did you know you can lose a medical license over tax fraud?  Couldn't be me.",
           "You try to use the autodoc alone and I'll let it carve you up.  I'm not kidding."
         ],
         "no": "Clinic is open, yes.  If you need medical assistance, I'm your man."


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Misc spelling fixes to Hub 01 Ancillae dialogue"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Just fixing some spelling and grammar issues that I noticed in the Hub 01 Ancillae dialogue files.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

I read through the Ancillae dialogue and fixed any issues I noticed. ¯\_(ツ)_/¯

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Not doing it?

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

None. If this breaks things I'm going to be _very_ surprised.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
