### PR TITLE
Faction camps store, track, and consume vitamins

### DIFF
--- a/data/json/npcs/factions.json
+++ b/data/json/npcs/factions.json
@@ -8,7 +8,7 @@
     "known_by_u": true,
     "size": 1,
     "power": 100,
-    "food_supply": 0,
+    "fac_food_supply": { "calories": 0, "vitamins": {  } },
     "wealth": 0,
     "relations": {
       "your_followers": {
@@ -34,7 +34,7 @@
     "known_by_u": false,
     "size": 1,
     "power": 100,
-    "food_supply": 0,
+    "fac_food_supply": { "calories": 0, "vitamins": {  } },
     "wealth": 0,
     "relations": {
       "your_followers": { "kill on sight": true, "knows your voice": true },
@@ -60,7 +60,7 @@
     "known_by_u": false,
     "size": 100,
     "power": 100,
-    "food_supply": 115200,
+    "fac_food_supply": { "calories": 115200, "vitamins": { "iron": 800, "calcium": 800, "vitC": 600 } },
     "wealth": 100000000,
     "currency": "RobofacCoin",
     "price_rules": [ { "group": "NC_ROBOFAC_gear", "markup": 2 } ],
@@ -91,7 +91,7 @@
     "known_by_u": false,
     "size": 70,
     "power": 100,
-    "food_supply": 115200,
+    "fac_food_supply": { "calories": 115200, "vitamins": {  } },
     "wealth": 75000,
     "currency": "RobofacCoin",
     "relations": {
@@ -117,7 +117,7 @@
     "known_by_u": false,
     "size": 100,
     "power": 100,
-    "food_supply": 201600,
+    "fac_food_supply": { "calories": 201600, "vitamins": {  } },
     "wealth": 100000000,
     "relations": {
       "old_guard": {
@@ -155,7 +155,7 @@
     "known_by_u": false,
     "size": 100,
     "power": 100,
-    "food_supply": 115200,
+    "fac_food_supply": { "calories": 115200, "vitamins": {  } },
     "wealth": 75000000,
     "currency": "FMCNote",
     "price_rules": [
@@ -241,7 +241,7 @@
     "known_by_u": false,
     "size": 5,
     "power": 0,
-    "food_supply": 1152,
+    "fac_food_supply": { "calories": 1152, "vitamins": {  } },
     "wealth": 100,
     "relations": {
       "lobby_beggars": {
@@ -301,7 +301,7 @@
     "known_by_u": false,
     "size": 100,
     "power": 100,
-    "food_supply": 115200,
+    "fac_food_supply": { "calories": 115200, "vitamins": {  } },
     "wealth": 10000000,
     "currency": "FMCNote",
     "price_rules": [ { "item": "money_strap_FMCNote", "fixed_adj": 0 }, { "item": "money_bundle_FMCNote", "fixed_adj": 0 } ],
@@ -331,7 +331,7 @@
     "known_by_u": false,
     "size": 2,
     "power": 5,
-    "food_supply": 4000,
+    "fac_food_supply": { "calories": 4000, "vitamins": {  } },
     "wealth": 100000,
     "currency": "FMCNote",
     "price_rules": [ { "item": "money_strap_FMCNote", "fixed_adj": 0 }, { "item": "money_bundle_FMCNote", "fixed_adj": 0 } ],
@@ -361,7 +361,7 @@
     "known_by_u": false,
     "size": 100,
     "power": 100,
-    "food_supply": 172800,
+    "fac_food_supply": { "calories": 172800, "vitamins": {  } },
     "wealth": 25000,
     "relations": {
       "marloss": {
@@ -385,7 +385,7 @@
     "known_by_u": false,
     "size": 1,
     "power": 1,
-    "food_supply": 1,
+    "fac_food_supply": { "calories": 1, "vitamins": {  } },
     "lone_wolf_faction": true,
     "wealth": 1,
     "relations": {
@@ -406,7 +406,7 @@
     "known_by_u": false,
     "size": 100,
     "power": 100,
-    "food_supply": 172800,
+    "fac_food_supply": { "calories": 172800, "vitamins": {  } },
     "wealth": 2500000,
     "relations": {
       "lobby_beggars": { "knows your voice": true },
@@ -430,7 +430,7 @@
     "known_by_u": false,
     "size": 100,
     "power": 100,
-    "food_supply": 230400,
+    "fac_food_supply": { "calories": 230400, "vitamins": {  } },
     "wealth": 45000000,
     "relations": {
       "hells_raiders": {
@@ -470,7 +470,7 @@
     "known_by_u": false,
     "size": 1,
     "power": 1,
-    "food_supply": 1,
+    "fac_food_supply": { "calories": 1, "vitamins": {  } },
     "wealth": 1,
     "relations": {
       "slaves": {
@@ -506,7 +506,7 @@
     "known_by_u": false,
     "size": 100,
     "power": 100,
-    "food_supply": 172800,
+    "fac_food_supply": { "calories": 172800, "vitamins": {  } },
     "wealth": 25000,
     "currency": "signed_chit",
     "relations": {
@@ -546,7 +546,7 @@
     "known_by_u": false,
     "size": 1,
     "power": 10,
-    "food_supply": 2304,
+    "fac_food_supply": { "calories": 2304, "vitamins": {  } },
     "wealth": 0,
     "relations": {
       "apis_hive": {
@@ -574,7 +574,7 @@
     "size": 7,
     "power": 10,
     "currency": "signed_chit",
-    "food_supply": 115200,
+    "fac_food_supply": { "calories": 115200, "vitamins": {  } },
     "wealth": 75000,
     "relations": {
       "free_merchants": {
@@ -647,7 +647,7 @@
     "size": 25,
     "power": 20,
     "currency": "icon",
-    "food_supply": 87500,
+    "fac_food_supply": { "calories": 87500, "vitamins": {  } },
     "wealth": 82500,
     "relations": {
       "gods_community": {
@@ -739,7 +739,7 @@
     "size": 1,
     "power": 1,
     "currency": "fur",
-    "food_supply": 87500,
+    "fac_food_supply": { "calories": 87500, "vitamins": {  } },
     "wealth": 82500,
     "relations": {
       "free_merchants": {
@@ -821,7 +821,7 @@
     "known_by_u": false,
     "size": 3,
     "power": 3,
-    "food_supply": 100,
+    "fac_food_supply": { "calories": 100, "vitamins": {  } },
     "wealth": 20000,
     "relations": {
       "free_merchants": { "knows your voice": true },
@@ -840,7 +840,7 @@
     "known_by_u": true,
     "size": 100,
     "power": 100,
-    "food_supply": 230400,
+    "fac_food_supply": { "calories": 230400, "vitamins": {  } },
     "wealth": 45000000,
     "relations": {
       "hells_raiders": {
@@ -872,7 +872,7 @@
     "mon_faction": "exodii",
     "size": 100,
     "power": 100,
-    "food_supply": 115200,
+    "fac_food_supply": { "calories": 115200, "vitamins": {  } },
     "wealth": 75000000,
     "price_rules": [ { "group": "games_board_all", "premium": 2.5 } ],
     "relations": {
@@ -955,7 +955,7 @@
     "known_by_u": false,
     "size": 100,
     "power": 100,
-    "food_supply": 115200,
+    "fac_food_supply": { "calories": 115200, "vitamins": {  } },
     "wealth": 25000000,
     "currency": "FlatCoin",
     "price_rules": [

--- a/data/mods/Aftershock/npcs/factions.json
+++ b/data/mods/Aftershock/npcs/factions.json
@@ -10,7 +10,7 @@
     "size": 15,
     "power": 20,
     "currency": "crypto_coin",
-    "food_supply": 115200,
+    "fac_food_supply": { "calories": 115200, "vitamins": {  } },
     "wealth": 75000,
     "relations": {
       "free_merchants": {
@@ -91,7 +91,7 @@
       { "item": "UICA_1000d", "fixed_adj": 0 },
       { "item": "UICA_10000d", "fixed_adj": 0 }
     ],
-    "food_supply": 115200,
+    "fac_food_supply": { "calories": 115200, "vitamins": {  } },
     "wealth": 75000,
     "relations": {
       "free_merchants": {
@@ -172,7 +172,7 @@
     "size": 100,
     "power": 100,
     "currency": "",
-    "food_supply": 115200,
+    "fac_food_supply": { "calories": 115200, "vitamins": {  } },
     "wealth": 75000,
     "relations": {
       "free_merchants": {
@@ -252,7 +252,7 @@
     "known_by_u": false,
     "size": 15,
     "power": 20,
-    "food_supply": 1200,
+    "fac_food_supply": { "calories": 1200, "vitamins": {  } },
     "wealth": 7500,
     "relations": {
       "free_merchants": {

--- a/data/mods/DinoMod/NPC/NC_BO_BARONYX.json
+++ b/data/mods/DinoMod/NPC/NC_BO_BARONYX.json
@@ -290,7 +290,7 @@
     "size": 25,
     "power": 20,
     "currency": "icon",
-    "food_supply": 87500,
+    "fac_food_supply": { "calories": 87500, "vitamins": {  } },
     "wealth": 82500,
     "relations": {
       "free_merchants": {

--- a/data/mods/Magiclysm/npc/factions.json
+++ b/data/mods/Magiclysm/npc/factions.json
@@ -8,7 +8,7 @@
     "known_by_u": false,
     "size": 5,
     "power": 100,
-    "food_supply": 115200,
+    "fac_food_supply": { "calories": 115200, "vitamins": {  } },
     "wealth": 100000,
     "currency": "embued_coin",
     "relations": {
@@ -69,7 +69,7 @@
     "known_by_u": false,
     "size": 50,
     "power": 50,
-    "food_supply": 11520,
+    "fac_food_supply": { "calories": 11520, "vitamins": {  } },
     "wealth": 1000,
     "relations": {
       "lobby_beggars": {
@@ -130,7 +130,7 @@
     "known_by_u": false,
     "size": 5,
     "power": 100,
-    "food_supply": 115200,
+    "fac_food_supply": { "calories": 115200, "vitamins": {  } },
     "wealth": 75000000,
     "currency": "denarius",
     "relations": {

--- a/data/mods/TEST_DATA/factions.json
+++ b/data/mods/TEST_DATA/factions.json
@@ -8,7 +8,7 @@
     "known_by_u": true,
     "size": 5,
     "power": 9001,
-    "food_supply": 1,
+    "fac_food_supply": { "calories": 1, "vitamins": {  } },
     "wealth": 0,
     "currency": "FMCNote",
     "price_rules": [

--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -4838,5 +4838,25 @@
     "volume": "250 ml",
     "to_hit": -3,
     "melee_damage": { "bash": 1 }
+  },
+  {
+    "type": "COMESTIBLE",
+    "comestible_type": "FOOD",
+    "id": "test_500_kcal",
+    "category": "spare_parts",
+    "symbol": ",",
+    "color": "light_gray",
+    "name": { "str": "TEST 500kcal" },
+    "description": "This one's 500kcal, and some vitamins.",
+    "price": 0,
+    "spoils_in": 0,
+    "calories": 500,
+    "material": [ "stone" ],
+    "weight": "100 g",
+    "volume": "250 ml",
+    "to_hit": -3,
+    "//": "Do not use calcium, iron or vitamin C! Those are calculated as RDAs, and you only get 96% of the listed value! No, that doesn't make any sense! But that's how it is. So use a normal vitamin. This is for a camp test, not a vitamin test...",
+    "vitamins": [ [ "mutant_toxin", 100 ], [ "mutagen", 200 ] ],
+    "melee_damage": { "bash": 1 }
   }
 ]

--- a/doc/FACTIONS.md
+++ b/doc/FACTIONS.md
@@ -13,7 +13,7 @@ An NPC faction looks like this:
     "known_by_u": false,
     "size": 100,
     "power": 100,
-    "food_supply": 115200,
+    "fac_food_supply": { "calories": 115200, "vitamins": { "iron": 800, "calcium": 800, "vitC": 600 } },
     "lone_wolf_faction": true,
     "wealth": 75000000,
     "currency": "FMCNote",
@@ -66,7 +66,8 @@ Field                 | Meaning
 `"known_by_u"`        | boolean, whether the player has met members of the faction.  Can be changed in play.  Unknown factions will not be displayed in the faction menu.
 `"size"`              | integer, an approximate count of the members of the faction.  Has no effect in play currently.
 `"power"`             | integer, an approximation of the faction's power.  Has no effect in play currently.
-`"food_supply"`       | integer, the number of calories available to the faction.  Has no effect in play currently.
+`"food_supply"`       | integer, the number of calories (not kilocalories!) available to the faction. Has no effect in play currently.
+`"vitamins"`          | array, *units* of vitamins available to this faction. This is not the same as RDA, see [the vitamins doc](VITAMIN.md) for more details. Has no effect in play currently.
 `"wealth"`            | integer, number of post-apocalyptic currency in cents that that faction has to purchase stuff. Serves as an upper limit on the amount of items restocked by a NPC of this faction with a defined shopkeeper_item_group (see NPCs.md)
 `"currency"`          | string, the item `"id"` of the faction's preferred currency.  Faction shopkeeps will trade faction current at 100% value, for both selling and buying.
 `"price_rules"`       | array, allows defining `premium`, `markup`, `price` and/or `fixed_adj` for an `item`/`category`/`group`.<br/><br/>`premium` is a price multiplier that applies to both sides.<br/> `markup` is only used when an NPC is selling to the avatar and defaults to `1`.<br/>`price` replaces the item's `price_postapoc`.<br/>`fixed_adj` is used instead of adjustment based on social skill and intelligence stat and can be used to define secondary currencies.<br/><br/>Lower entries override higher ones. For conditionals, the avatar is used as alpha and the evaluating npc as beta

--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -231,7 +231,7 @@ class basecamp
         /// Changes the faction food supply by @ref change, returns the amount of kcal+vitamins consumed, a negative
         /// total food supply hurts morale
         /// Handles vitamin consumption when only a kcal value is supplied
-        nutrients camp_food_supply( nutrients change );
+        nutrients camp_food_supply( nutrients &change );
         /// LEGACY FUNCTION. Constructs a new nutrients struct in place and forwards it
         nutrients camp_food_supply( int change = 0 );
         /// LEGACY FUNCTION. Calculates raw kcal cost from duration of work and exercise, then forwards it to above

--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -13,12 +13,14 @@
 
 #include "coordinates.h"
 #include "craft_command.h"
+#include "game_constants.h"
 #include "game_inventory.h"
 #include "inventory.h"
 #include "map.h"
 #include "mission_companion.h"
 #include "point.h"
 #include "requirements.h"
+#include "stomach.h"
 #include "type_id.h"
 
 class JsonObject;
@@ -226,6 +228,14 @@ class basecamp
         // food utility
         /// Takes all the food from the camp_food zone and increases the faction
         /// food_supply
+        /// Changes the faction food supply by @ref change, returns the amount of kcal+vitamins consumed, a negative
+        /// total food supply hurts morale
+        /// Handles vitamin consumption when only a kcal value is supplied
+        nutrients camp_food_supply( nutrients change );
+        /// LEGACY FUNCTION. Constructs a new nutrients struct in place and forwards it
+        nutrients camp_food_supply( int change = 0 );
+        /// LEGACY FUNCTION. Calculates raw kcal cost from duration of work and exercise, then forwards it to above
+        nutrients camp_food_supply( time_duration work, float exertion_level = NO_EXERCISE );
         bool distribute_food();
         std::string name_display_of( const mission_id &miss_id );
         void handle_hide_mission( const point &dir );

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -2309,7 +2309,7 @@ static void faction_edit_menu()
          << string_format( _( "Currency: %s" ), fac->currency.obj().nname( fac->wealth ) ) << std::endl;
     data << string_format( _( "Size: %d" ), fac->size ) << " | "
          << string_format( _( "Power: %d" ), fac->power ) << " | "
-         << string_format( _( "Food Supply: %d" ), fac->food_supply ) << std::endl;
+         << string_format( _( "Food Supply: %d" ), fac->food_supply.kcal() ) << std::endl;
     data << string_format( _( "Like: %d" ), fac->likes_u ) << " | "
          << string_format( _( "Respect: %d" ), fac->respects_u ) << " | "
          << string_format( _( "Trust: %d" ), fac->trusts_u ) << std::endl;
@@ -2348,8 +2348,8 @@ static void faction_edit_menu()
             }
             break;
         case D_FOOD:
-            if( query_int( value, _( "Change food from %d to: " ), fac->food_supply ) ) {
-                fac->food_supply = value;
+            if( query_int( value, _( "Change food from %d to: " ), fac->food_supply.kcal() ) ) {
+                fac->food_supply.calories = ( value * 1000 ) ;
             }
             break;
         case D_OPINION:

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -2290,6 +2290,35 @@ static void faction_edit_opinion_menu( faction *fac )
     }
 }
 
+static void faction_edit_larder_menu( faction *fac )
+{
+    uilist smenu;
+    smenu.addentry( 0, true, 'l', _( "kcal: have stored %i" ), fac->food_supply.kcal() );
+    const auto &vits = vitamin::all();
+    for( const auto &v : vits ) {
+        smenu.addentry( -1, true, 0, _( "%s: have stored %d" ), v.second.name(),
+                        fac->food_supply.get_vitamin( v.first ) );
+    }
+
+    smenu.query();
+    int value;
+    switch( smenu.ret ) {
+        case 0:
+            if( query_int( value, _( "Change food from %d to: " ), fac->food_supply.kcal() ) ) {
+                fac->food_supply.calories = ( value * 1000 );
+            }
+            break;
+        default:
+            if( smenu.ret >= 1 && smenu.ret < static_cast<int>( vits.size() + 1 ) ) {
+                auto iter = std::next( vits.begin(), smenu.ret - 1 );
+                if( query_int( value, _( "Set %s to?  Currently: %d" ),
+                               iter->second.name(), fac->food_supply.get_vitamin( iter->first ) ) ) {
+                    fac->food_supply.set_vitamin( iter->first, value );
+                }
+            }
+    }
+}
+
 static void faction_edit_menu()
 {
 
@@ -2348,9 +2377,7 @@ static void faction_edit_menu()
             }
             break;
         case D_FOOD:
-            if( query_int( value, _( "Change food from %d to: " ), fac->food_supply.kcal() ) ) {
-                fac->food_supply.calories = ( value * 1000 ) ;
-            }
+            faction_edit_larder_menu( fac );
             break;
         case D_OPINION:
             faction_edit_opinion_menu( fac );

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -121,7 +121,7 @@ faction_template::faction_template( const JsonObject &jsobj )
     , id( faction_id( jsobj.get_string( "id" ) ) )
     , size( jsobj.get_int( "size" ) )
     , power( jsobj.get_int( "power" ) )
-	, food_supply(jsobj.get_int("food_supply"))
+    , food_supply()
     , wealth( jsobj.get_int( "wealth" ) )
 {
     jsobj.get_member( "description" ).read( desc );

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -126,6 +126,7 @@ faction_template::faction_template( const JsonObject &jsobj )
 {
     jsobj.get_member( "description" ).read( desc );
     optional( jsobj, false, "price_rules", price_rules, faction_price_rules_reader {} );
+    jsobj.read( "food_supply", food_supply.calories, true );
     if( jsobj.has_string( "currency" ) ) {
         jsobj.read( "currency", currency, true );
         price_rules.emplace_back( currency, 1, 0 );

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -53,7 +53,7 @@ faction_template::faction_template()
     respects_u = 0;
     trusts_u = 0;
     known_by_u = true;
-    food_supply = 0;
+    food_supply.calories = 0;
     wealth = 0;
     size = 0;
     power = 0;
@@ -121,7 +121,7 @@ faction_template::faction_template( const JsonObject &jsobj )
     , id( faction_id( jsobj.get_string( "id" ) ) )
     , size( jsobj.get_int( "size" ) )
     , power( jsobj.get_int( "power" ) )
-    , food_supply( jsobj.get_int( "food_supply" ) )
+	, food_supply(jsobj.get_int("food_supply"))
     , wealth( jsobj.get_int( "wealth" ) )
 {
     jsobj.get_member( "description" ).read( desc );
@@ -315,7 +315,7 @@ std::string fac_wealth_text( int val, int size )
 std::string faction::food_supply_text()
 {
     //Convert to how many days you can support the population
-    int val = food_supply / ( size * 288 );
+    int val = food_supply.kcal() / ( size * 288 );
     if( val >= 30 ) {
         return pgettext( "Faction food", "Overflowing" );
     }
@@ -333,7 +333,7 @@ std::string faction::food_supply_text()
 
 nc_color faction::food_supply_color()
 {
-    int val = food_supply / ( size * 288 );
+    int val = food_supply.kcal() / ( size * 288 );
     if( val >= 30 ) {
         return c_green;
     } else if( val >= 14 ) {
@@ -514,8 +514,8 @@ void basecamp::faction_display( const catacurses::window &fac_w, const int width
     }
     mvwprintz( fac_w, point( width, ++y ), col, _( "Location: %s" ), camp_pos.to_string() );
     faction *yours = player_character.get_faction();
-    std::string food_text = string_format( _( "Food Supply: %s %d calories" ),
-                                           yours->food_supply_text(), yours->food_supply );
+    std::string food_text = string_format( _( "Food Supply: %s %d kilocalories" ),
+                                           yours->food_supply_text(), yours->food_supply.kcal() );
     nc_color food_col = yours->food_supply_color();
     mvwprintz( fac_w, point( width, ++y ), food_col, food_text );
     std::string bldg = next_upgrade( base_camps::base_dir, 1 );

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -126,7 +126,7 @@ faction_template::faction_template( const JsonObject &jsobj )
 {
     jsobj.get_member( "description" ).read( desc );
     optional( jsobj, false, "price_rules", price_rules, faction_price_rules_reader {} );
-    jsobj.read( "food_supply", food_supply.calories, true );
+    jsobj.read( "fac_food_supply", food_supply, true );
     if( jsobj.has_string( "currency" ) ) {
         jsobj.read( "currency", currency, true );
         price_rules.emplace_back( currency, 1, 0 );

--- a/src/faction.h
+++ b/src/faction.h
@@ -15,6 +15,7 @@
 #include "character_id.h"
 #include "color.h"
 #include "shop_cons_rate.h"
+#include "stomach.h"
 #include "translations.h"
 #include "type_id.h"
 
@@ -112,7 +113,7 @@ class faction_template
         translation desc;
         int size; // How big is our sphere of influence?
         int power; // General measure of our power
-        nutrients food_supply;  //Total nutritional value held
+        nutrients food_supply; //Total nutritional value held
         int wealth;  //Total trade currency
         bool lone_wolf_faction; // is this a faction for just one person?
         itype_id currency; // id of the faction currency

--- a/src/faction.h
+++ b/src/faction.h
@@ -112,7 +112,7 @@ class faction_template
         translation desc;
         int size; // How big is our sphere of influence?
         int power; // General measure of our power
-        int food_supply;  //Total nutritional value held
+        nutrients food_supply;  //Total nutritional value held
         int wealth;  //Total trade currency
         bool lone_wolf_faction; // is this a faction for just one person?
         itype_id currency; // id of the faction currency

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -29,7 +29,6 @@
 #include "faction.h"
 #include "flag.h"
 #include "game.h"
-#include "game_constants.h"
 #include "game_inventory.h"
 #include "iexamine.h"
 #include "input_context.h"
@@ -65,7 +64,6 @@
 #include "requirements.h"
 #include "rng.h"
 #include "skill.h"
-#include "stomach.h"
 #include "string_formatter.h"
 #include "string_input_popup.h"
 #include "translations.h"
@@ -305,14 +303,6 @@ static std::string camp_trip_description( const time_duration &total_time,
 
 /// The number of days the current camp supplies lasts at the given exertion level.
 static int camp_food_supply_days( float exertion_level );
-/// Changes the faction food supply by @ref change, returns the amount of kcal+vitamins consumed, a negative
-/// total food supply hurts morale
-/// Handles vitamin consumption when only a kcal value is supplied
-static nutrients camp_food_supply( nutrients change );
-/// LEGACY FUNCTION. Constructs a new nutrients struct in place and forwards it
-static nutrients camp_food_supply( int change = 0 );
-/// LEGACY FUNCTION. Calculates raw kcal cost from duration of work and exercise, then forwards it to above
-static nutrients camp_food_supply( time_duration work, float exertion_level = NO_EXERCISE );
 /// Returns the total charges of food time_duration @ref work costs
 static int time_to_food( time_duration work, float exertion_level = NO_EXERCISE );
 /// Changes the faction respect for you by @ref change, returns respect

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -305,12 +305,14 @@ static std::string camp_trip_description( const time_duration &total_time,
 
 /// The number of days the current camp supplies lasts at the given exertion level.
 static int camp_food_supply_days( float exertion_level );
-/// Changes the faction food supply by @ref change, 0 returns total food supply, a negative
+/// Changes the faction food supply by @ref change, returns the amount of kcal+vitamins consumed, a negative
 /// total food supply hurts morale
-static int camp_food_supply( int change = 0 );
-/// Same as above but takes a time_duration and consumes from faction food supply for that
-/// duration of work
-static int camp_food_supply( time_duration work, float exertion_level = NO_EXERCISE );
+/// Handles vitamin consumption when only a kcal value is supplied
+static nutrients camp_food_supply( nutrients change );
+/// LEGACY FUNCTION. Constructs a new nutrients struct in place and forwards it
+static nutrients camp_food_supply( int change = 0 );
+/// LEGACY FUNCTION. Calculates raw kcal cost from duration of work and exercise, then forwards it to above
+static nutrients camp_food_supply( time_duration work, float exertion_level = NO_EXERCISE );
 /// Returns the total charges of food time_duration @ref work costs
 static int time_to_food( time_duration work, float exertion_level = NO_EXERCISE );
 /// Changes the faction respect for you by @ref change, returns respect
@@ -766,6 +768,7 @@ void basecamp::add_available_recipes( mission_data &mission_key, mission_kind ki
 void basecamp::get_available_missions_by_dir( mission_data &mission_key, const point &dir )
 {
     std::string entry;
+    faction *yours = get_player_character().get_faction();
 
     const std::string dir_id = base_camps::all_directions.at( dir ).id;
     const std::string dir_abbr = base_camps::all_directions.at( dir ).bracket_abbr.translated();
@@ -801,7 +804,7 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, const p
                 const int foodcost = time_to_food( base_camps::to_workdays( time_duration::from_moves(
                                                        making.blueprint_build_reqs().reqs_by_parameters.find( miss_id.mapgen_args )->second.time ) ),
                                                    making.exertion_level() );
-                const int available_calories = camp_food_supply( );
+                const int available_calories = yours->food_supply.kcal();
                 bool can_upgrade = upgrade.avail;
                 entry = om_upgrade_description( upgrade.bldg, upgrade.args );
                 if( foodcost > available_calories ) {
@@ -1372,6 +1375,7 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, const p
 void basecamp::get_available_missions( mission_data &mission_key, map &here )
 {
     std::string entry;
+    faction *yours = get_player_character().get_faction();
 
     const point &base_dir = base_camps::base_dir;
     const base_camps::direction_data &base_data = base_camps::all_directions.at( base_dir );
@@ -1486,7 +1490,7 @@ void basecamp::get_available_missions( mission_data &mission_key, map &here )
                                       "> Rots in < 5 days: 80%%\n\n"
                                       "Total faction food stock: %d kcal\nor %d / %d / %d day's rations\n"
                                       "where the days is measured for Extra / Moderate / No exercise levels" ),
-                                   camp_food_supply(), camp_food_supply_days( EXTRA_EXERCISE ),
+                                   yours->food_supply.kcal(), camp_food_supply_days( EXTRA_EXERCISE ),
                                    camp_food_supply_days( MODERATE_EXERCISE ), camp_food_supply_days( NO_EXERCISE ) );
             mission_key.add( { miss_id, false }, name_display_of( miss_id ),
                              entry );
@@ -1924,7 +1928,8 @@ npc_ptr basecamp::start_mission( const mission_id &miss_id, time_duration durati
                                  const std::vector<item *> &equipment, float exertion_level,
                                  const std::map<skill_id, int> &required_skills )
 {
-    if( must_feed && camp_food_supply() < time_to_food( duration, exertion_level ) ) {
+    faction *yours = get_player_character().get_faction();
+    if( must_feed && yours->food_supply.kcal() < time_to_food( duration, exertion_level ) ) {
         popup( _( "You don't have enough food stored to feed your companion." ) );
         return nullptr;
     }
@@ -1976,6 +1981,7 @@ comp_list basecamp::start_multi_mission( const mission_id &miss_id,
     cata_assert( req_it != making.blueprint_build_reqs().reqs_by_parameters.end() );
     const build_reqs &bld_reqs = req_it->second;
     time_duration base_time = time_duration::from_moves( bld_reqs.time );
+    faction *yours = get_player_character().get_faction();
 
     comp_list result;
 
@@ -1985,7 +1991,8 @@ comp_list basecamp::start_multi_mission( const mission_id &miss_id,
         work_days = base_camps::to_workdays( base_time / ( result.size() + 1 ) );
 
         if( must_feed &&
-            camp_food_supply() < time_to_food( work_days * ( result.size() + 1 ), making.exertion_level() ) ) {
+            yours->food_supply.kcal() < time_to_food( work_days * ( result.size() + 1 ),
+                    making.exertion_level() ) ) {
             if( result.empty() ) {
                 popup( _( "You don't have enough food stored to feed your companion for this task." ) );
                 return result;
@@ -2409,7 +2416,8 @@ void basecamp::job_assignment_ui()
 
 void basecamp::start_menial_labor()
 {
-    if( camp_food_supply() < time_to_food( 3_hours ) ) {
+    faction *yours = get_player_character().get_faction();
+    if( yours->food_supply.kcal() < time_to_food( 3_hours ) ) {
         popup( _( "You don't have enough food stored to feed your companion." ) );
         return;
     }
@@ -3727,10 +3735,11 @@ void basecamp::finish_return( npc &comp, const bool fixed_time, const std::strin
     // companions subtracted food when they started the mission, but didn't mod their hunger for
     // that food.  so add it back in.
     int need_food = time_to_food( mission_time - reserve_time );
-    if( camp_food_supply() < need_food ) {
+    faction *yours = get_player_character().get_faction();
+    if( yours->food_supply.kcal() < need_food ) {
         popup( _( "Your companion seems disappointed that your pantry is empty…" ) );
     }
-    int avail_food = std::min( need_food, camp_food_supply() ) + time_to_food( reserve_time );
+    int avail_food = std::min( need_food, yours->food_supply.kcal() ) + time_to_food( reserve_time );
     // movng all the logic from talk_function::companion return here instead of polluting
     // mission_companion
     comp.reset_companion_mission();
@@ -4622,6 +4631,7 @@ std::string talk_function::name_mission_tabs(
 // recipes and craft support functions
 int basecamp::recipe_batch_max( const recipe &making ) const
 {
+    faction *yours = get_player_character().get_faction();
     int max_batch = 0;
     const int max_checks = 9;
     for( size_t batch_size = 1000; batch_size > 0; batch_size /= 10 ) {
@@ -4631,7 +4641,7 @@ int basecamp::recipe_batch_max( const recipe &making ) const
             int food_req = time_to_food( work_days );
             bool can_make = making.deduped_requirements().can_make_with_inventory(
                                 _inv, making.get_component_filter(), max_batch + batch_size );
-            if( can_make && camp_food_supply() > food_req ) {
+            if( can_make && yours->food_supply.kcal() > food_req ) {
                 max_batch += batch_size;
             } else {
                 break;
@@ -5331,7 +5341,8 @@ int basecamp::recruit_evaluation( int &sbase, int &sexpansions, int &sfaction, i
             farm++;
         }
     }
-    sfaction = std::min( camp_food_supply() / 10000, 10 );
+    faction *yours = get_player_character().get_faction();
+    sfaction = std::min( yours->food_supply.kcal() / 10000, 10 );
     sfaction += std::min( camp_discipline() / 10, 5 );
     sfaction += std::min( camp_morale() / 10, 5 );
 
@@ -5444,23 +5455,46 @@ int camp_food_supply_days( float exertion_level )
     return yours->food_supply.kcal() / time_to_food( 24_hours, exertion_level );
 }
 
-int camp_food_supply( int change )
+nutrients camp_food_supply( nutrients change )
 {
+    nutrients consumed;
     faction *yours = get_player_character().get_faction();
-    yours->food_supply.calories += ( change * 1000 );
-    if( yours->food_supply.calories < 0 ) {
+    if( change.calories < 0 && change.vitamins().empty() && yours->food_supply.calories > 0 ) {
+        // We've been passed a raw kcal value, we should also consume a proportional amount of vitamins
+        // Kcals are used as a proxy to consume vitamins.
+        // e.g. if you have a larder with 10k kcal, 100 vitamin A, 200 vitamin B then consuming 1000 kcal will
+        // consume 10 vitamin A and *20* vitamin B. In other words, we assume the vitamins are uniformly distributed with the kcals
+        // This isn't a perfect assumption but it's a necessary one to abstract away the food items themselves
+        double percent_consumed = std::abs( static_cast<double>( change.calories ) ) /
+                                  yours->food_supply.calories;
+        consumed = yours->food_supply;
+        consumed *= percent_consumed;
+        // Subtraction since we use the absolute value of change's calories to get the percent
+        yours->food_supply -= consumed;
+        return consumed;
+    }
+    yours->food_supply += change;
+    if( yours->food_supply.kcal() < 0 ) {
         yours->likes_u += yours->food_supply.kcal() / 1250;
         yours->respects_u += yours->food_supply.kcal() / 625;
         yours->trusts_u += yours->food_supply.kcal() / 625;
         yours->food_supply.calories = 0;
     }
 
-    //TODO: These nutrients should actually be consumed by the workers
-
-    return yours->food_supply.kcal();
+    consumed = change;
+    //TODO: This return value is so that nutrients can actually be consumed by the workers instead of vanishing.
+    return consumed;
 }
 
-int camp_food_supply( time_duration work, float exertion_level )
+nutrients camp_food_supply( int change )
+{
+    nutrients added;
+    // Kcal to calories
+    added.calories = ( change * 1000 );
+    return camp_food_supply( added );
+}
+
+nutrients camp_food_supply( time_duration work, float exertion_level )
 {
     return camp_food_supply( -time_to_food( work, exertion_level ) );
 }

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -5441,21 +5441,21 @@ int camp_food_supply_days( float exertion_level )
 {
     faction *yours = get_player_character().get_faction();
 
-    return yours->food_supply / time_to_food( 24_hours, exertion_level );
+    return yours->food_supply.kcal() / time_to_food( 24_hours, exertion_level );
 }
 
 int camp_food_supply( int change )
 {
     faction *yours = get_player_character().get_faction();
-    yours->food_supply += change;
-    if( yours->food_supply < 0 ) {
-        yours->likes_u += yours->food_supply / 1250;
-        yours->respects_u += yours->food_supply / 625;
-        yours->trusts_u += yours->food_supply / 625;
-        yours->food_supply = 0;
+    yours->food_supply.calories += ( change * 1000 );
+    if( yours->food_supply.calories < 0 ) {
+        yours->likes_u += yours->food_supply.kcal() / 1250;
+        yours->respects_u += yours->food_supply.kcal() / 625;
+        yours->trusts_u += yours->food_supply.kcal() / 625;
+        yours->food_supply.calories = 0;
     }
 
-    return yours->food_supply;
+    return yours->food_supply.kcal();
 }
 
 int camp_food_supply( time_duration work, float exertion_level )

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -5445,7 +5445,7 @@ int camp_food_supply_days( float exertion_level )
     return yours->food_supply.kcal() / time_to_food( 24_hours, exertion_level );
 }
 
-nutrients camp_food_supply( nutrients change )
+nutrients basecamp::camp_food_supply( nutrients change )
 {
     nutrients consumed;
     faction *yours = get_player_character().get_faction();
@@ -5476,7 +5476,7 @@ nutrients camp_food_supply( nutrients change )
     return consumed;
 }
 
-nutrients camp_food_supply( int change )
+nutrients basecamp::camp_food_supply( int change )
 {
     nutrients added;
     // Kcal to calories
@@ -5484,7 +5484,7 @@ nutrients camp_food_supply( int change )
     return camp_food_supply( added );
 }
 
-nutrients camp_food_supply( time_duration work, float exertion_level )
+nutrients basecamp::camp_food_supply( time_duration work, float exertion_level )
 {
     return camp_food_supply( -time_to_food( work, exertion_level ) );
 }

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -5544,13 +5544,9 @@ bool basecamp::distribute_food()
             return false;
         }
         nutrients from_it = getAverageJoe().compute_effective_nutrients( it ) * it.count();
-        // Do this multiplication separately so we don't null out the entire struct for rot_multip < 1
-        from_it.calories *= rot_multip( it, container );
-        nutrients_to_add.calories += from_it.calories;
-        auto vits = from_it.vitamins();
-        for( auto &vit : vits ) {
-            nutrients_to_add.add_vitamin( vit.first, ( vit.second * rot_multip( it, container ) ) );
-        }
+        // Do this multiplication separately to make sure we're using the *= operator with double argument..
+        from_it *= rot_multip( it, container );
+        nutrients_to_add += from_it;
         if( from_it.kcal() <= 0 ) {
             // can happen if calories is low and rot is high.
             return false;
@@ -5600,11 +5596,7 @@ bool basecamp::distribute_food()
 
     popup( _( "You distribute %d kcal worth of food to your companions." ), nutrients_to_add.kcal() );
     faction *yours = get_player_character().get_faction();
-    yours->food_supply.calories += nutrients_to_add.calories;
-    auto vits = nutrients_to_add.vitamins();
-    for( auto &vit : vits ) {
-        yours->food_supply.add_vitamin( vit.first, vit.second );
-    }
+    yours->food_supply += nutrients_to_add;
     return true;
 }
 

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -5619,8 +5619,7 @@ bool basecamp::distribute_food()
     }
 
     popup( _( "You distribute %d kcal worth of food to your companions." ), nutrients_to_add.kcal() );
-    faction *yours = get_player_character().get_faction();
-    yours->food_supply += nutrients_to_add;
+    camp_food_supply( nutrients_to_add );
     return true;
 }
 

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -5445,7 +5445,7 @@ int camp_food_supply_days( float exertion_level )
     return yours->food_supply.kcal() / time_to_food( 24_hours, exertion_level );
 }
 
-nutrients basecamp::camp_food_supply( nutrients change )
+nutrients basecamp::camp_food_supply( nutrients &change )
 {
     nutrients consumed;
     faction *yours = get_player_character().get_faction();

--- a/src/npc.h
+++ b/src/npc.h
@@ -21,6 +21,7 @@
 
 #include "activity_type.h"
 #include "auto_pickup.h"
+#include "basecamp.h"
 #include "calendar.h"
 #include "character.h"
 #include "color.h"

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -4434,7 +4434,7 @@ bool npc::consume_food_from_camp()
         // but also don't try to eat a week's worth of food in one sitting
         int desired_kcals = std::min( static_cast<int>( base_metabolic_rate ), std::max( 0,
                                       kcal_threshold + 100 - current_kcals ) );
-        int kcals_to_eat = std::min( desired_kcals, yours->food_supply );
+        int kcals_to_eat = std::min( desired_kcals, yours->food_supply.kcal() );
 
         if( kcals_to_eat > 0 ) {
             // We need food and there's some available, so let's eat it
@@ -4460,7 +4460,7 @@ bool npc::consume_food_from_camp()
             // update_stomach() usually takes care of that but it's only called once every 10 seconds for NPCs
             set_hunger( -1 );
 
-            yours->food_supply -= kcals_to_eat;
+            yours->food_supply.calories -= ( kcals_to_eat * 1000 );
             return true;
         } else {
             // We need food but there's none to eat :(

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -4422,6 +4422,7 @@ bool npc::consume_food_from_camp()
     basecamp *bcp = *potential_bc;
     if( get_thirst() > 40 && bcp->has_water() ) {
         complain_about( "camp_water_thanks", 1_hours, chatbin.snip_camp_water_thanks, false );
+        // TODO: Stop skipping the stomach for this, actually put the water in there.
         set_thirst( 0 );
         return true;
     }
@@ -4448,8 +4449,7 @@ bool npc::consume_food_from_camp()
 
             // TODO: At the moment, vitamins are not tracked by the faction camp, so this does *not* give
             // the NPC any vitamins. That will need to be added once vitamin deficiencies start mattering
-            nutrients nutr{};
-            nutr.calories = kcals_to_eat * 1000;
+            nutrients nutr = bcp->camp_food_supply( kcals_to_eat );
 
             stomach.ingest( food_summary{
                 0_ml,

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -4447,9 +4447,8 @@ bool npc::consume_food_from_camp()
             // or becoming engorged
             units::volume filling_vol = std::max( 0_ml, stomach.capacity( *this ) / 2 - stomach.contains() );
 
-            // TODO: At the moment, vitamins are not tracked by the faction camp, so this does *not* give
-            // the NPC any vitamins. That will need to be added once vitamin deficiencies start mattering
-            nutrients nutr = bcp->camp_food_supply( kcals_to_eat );
+            // Returns the actual amount of calories and vitamins taken from the camp's larder.
+            nutrients nutr = bcp->camp_food_supply( -kcals_to_eat );
 
             stomach.ingest( food_summary{
                 0_ml,
@@ -4460,7 +4459,6 @@ bool npc::consume_food_from_camp()
             // update_stomach() usually takes care of that but it's only called once every 10 seconds for NPCs
             set_hunger( -1 );
 
-            yours->food_supply.calories -= ( kcals_to_eat * 1000 );
             return true;
         } else {
             // We need food but there's none to eat :(

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3811,9 +3811,10 @@ void faction::deserialize( const JsonObject &jo )
     jo.read( "known_by_u", known_by_u );
     jo.read( "size", size );
     jo.read( "power", power );
-    if( !jo.read( "food_supply", food_supply ) ) {
+    /*if( !jo.read( "food_supply", food_supply ) ) {
         food_supply.calories = 100000;
     }
+	*/
     if( !jo.read( "wealth", wealth ) ) {
         wealth = 100;
     }
@@ -3835,7 +3836,7 @@ void faction::serialize( JsonOut &json ) const
     json.member( "known_by_u", known_by_u );
     json.member( "size", size );
     json.member( "power", power );
-    json.member( "food_supply", food_supply );
+    //json.member( "food_supply", food_supply );
     json.member( "wealth", wealth );
     json.member( "opinion_of", opinion_of );
     json.member( "relations" );

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3812,7 +3812,7 @@ void faction::deserialize( const JsonObject &jo )
     jo.read( "size", size );
     jo.read( "power", power );
     if( !jo.read( "food_supply", food_supply ) ) {
-        food_supply = 100;
+        food_supply.calories = 100000;
     }
     if( !jo.read( "wealth", wealth ) ) {
         wealth = 100;

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3811,10 +3811,12 @@ void faction::deserialize( const JsonObject &jo )
     jo.read( "known_by_u", known_by_u );
     jo.read( "size", size );
     jo.read( "power", power );
-    /*if( !jo.read( "food_supply", food_supply ) ) {
-        food_supply.calories = 100000;
+    if( jo.has_int( "food_supply" ) ) {
+        // Legacy kcal value found, migrate to calories
+        food_supply.calories = ( jo.read( "food_supply", food_supply.calories ) * 1000 );
+    } else {
+        jo.read( "calories", food_supply.calories );
     }
-	*/
     if( !jo.read( "wealth", wealth ) ) {
         wealth = 100;
     }
@@ -3836,7 +3838,9 @@ void faction::serialize( JsonOut &json ) const
     json.member( "known_by_u", known_by_u );
     json.member( "size", size );
     json.member( "power", power );
-    //json.member( "food_supply", food_supply );
+    json.member( "calories", food_supply.calories );
+    json.member( "finalized", food_supply.finalized );
+    json.member( "vitamins_", food_supply.vitamins() );
     json.member( "wealth", wealth );
     json.member( "opinion_of", opinion_of );
     json.member( "relations" );

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3813,9 +3813,10 @@ void faction::deserialize( const JsonObject &jo )
     jo.read( "power", power );
     if( jo.has_int( "food_supply" ) ) {
         // Legacy kcal value found, migrate to calories
-        food_supply.calories = ( jo.read( "food_supply", food_supply.calories ) * 1000 );
+        jo.read( "food_supply", food_supply.calories );
+        food_supply.calories *= 1000;
     } else {
-        jo.read( "calories", food_supply.calories );
+        jo.read( "fac_food_supply", food_supply );
     }
     if( !jo.read( "wealth", wealth ) ) {
         wealth = 100;
@@ -3838,9 +3839,7 @@ void faction::serialize( JsonOut &json ) const
     json.member( "known_by_u", known_by_u );
     json.member( "size", size );
     json.member( "power", power );
-    json.member( "calories", food_supply.calories );
-    json.member( "finalized", food_supply.finalized );
-    json.member( "vitamins_", food_supply.vitamins() );
+    json.member( "fac_food_supply", food_supply );
     json.member( "wealth", wealth );
     json.member( "opinion_of", opinion_of );
     json.member( "relations" );

--- a/src/stomach.cpp
+++ b/src/stomach.cpp
@@ -191,6 +191,19 @@ nutrients &nutrients::operator*=( int r )
     return *this;
 }
 
+nutrients &nutrients::operator*=( double r )
+{
+    if( !finalized ) {
+        debugmsg( "Nutrients not finalized when *= called!" );
+    }
+    calories *= r;
+    for( const std::pair<const vitamin_id, std::variant<int, vitamin_units::mass>> &vit : vitamins_ ) {
+        std::variant<int, vitamin_units::mass> &here = vitamins_[vit.first];
+        here = std::get<int>( here ) * r;
+    }
+    return *this;
+}
+
 nutrients &nutrients::operator/=( int r )
 {
     if( !finalized ) {

--- a/src/stomach.cpp
+++ b/src/stomach.cpp
@@ -217,6 +217,25 @@ nutrients &nutrients::operator/=( int r )
     return *this;
 }
 
+void nutrients::serialize( JsonOut &jsout ) const
+{
+    jsout.start_object();
+    jsout.member( "calories", calories );
+    jsout.member( "vitamins", vitamins() );
+    jsout.end_object();
+}
+
+void nutrients::deserialize( const JsonObject &jo )
+{
+    jo.read( "calories", calories );
+    std::map<vitamin_id, int> vit_map;
+    jo.read( "vitamins", vit_map );
+    for( auto &vit : vit_map ) {
+        set_vitamin( vit.first, vit.second );
+    }
+	debugmsg("testest");
+}
+
 stomach_contents::stomach_contents() = default;
 
 stomach_contents::stomach_contents( units::volume max_vol, bool is_stomach )

--- a/src/stomach.cpp
+++ b/src/stomach.cpp
@@ -199,7 +199,8 @@ nutrients &nutrients::operator*=( double r )
     calories *= r;
     for( const std::pair<const vitamin_id, std::variant<int, vitamin_units::mass>> &vit : vitamins_ ) {
         std::variant<int, vitamin_units::mass> &here = vitamins_[vit.first];
-        here = std::get<int>( here ) * r;
+        // Note well: This truncates the result!
+        here = static_cast<int>( std::get<int>( here ) * r );
     }
     return *this;
 }
@@ -233,7 +234,7 @@ void nutrients::deserialize( const JsonObject &jo )
     for( auto &vit : vit_map ) {
         set_vitamin( vit.first, vit.second );
     }
-	debugmsg("testest");
+    debugmsg( "testest" );
 }
 
 stomach_contents::stomach_contents() = default;

--- a/src/stomach.cpp
+++ b/src/stomach.cpp
@@ -234,7 +234,6 @@ void nutrients::deserialize( const JsonObject &jo )
     for( auto &vit : vit_map ) {
         set_vitamin( vit.first, vit.second );
     }
-    debugmsg( "testest" );
 }
 
 stomach_contents::stomach_contents() = default;

--- a/src/stomach.cpp
+++ b/src/stomach.cpp
@@ -232,6 +232,7 @@ void nutrients::deserialize( const JsonObject &jo )
     std::map<vitamin_id, int> vit_map;
     jo.read( "vitamins", vit_map );
     for( auto &vit : vit_map ) {
+        //rebuild vitamins_
         set_vitamin( vit.first, vit.second );
     }
 }

--- a/src/stomach.h
+++ b/src/stomach.h
@@ -70,6 +70,7 @@ struct nutrients {
         nutrients &operator+=( const nutrients &r );
         nutrients &operator-=( const nutrients &r );
         nutrients &operator*=( int r );
+        nutrients &operator*=( double r );
         nutrients &operator/=( int r );
 
         friend nutrients operator*( nutrients l, int r ) {

--- a/src/stomach.h
+++ b/src/stomach.h
@@ -86,14 +86,14 @@ struct nutrients {
         // All vitamins are in vitamin units, not units::mass (e.g. all JSON has been loaded)
         // defaults to true because this is only false when nutrients are loaded from JSON,
         // where it is set explicitly to false
-        bool finalized = true;
+        bool finalized = true; // NOLINT(cata-serialize)
 
         void serialize( JsonOut & ) const;
         void deserialize( const JsonObject &jo );
 
     private:
         /** vitamins potentially provided by this comestible (if any) */
-        std::map<vitamin_id, std::variant<int, vitamin_units::mass>> vitamins_;
+        std::map<vitamin_id, std::variant<int, vitamin_units::mass>> vitamins_; // NOLINT(cata-serialize)
 };
 
 // Contains all information that can pass out of (or into) a stomach

--- a/src/stomach.h
+++ b/src/stomach.h
@@ -88,6 +88,9 @@ struct nutrients {
         // where it is set explicitly to false
         bool finalized = true;
 
+        void serialize( JsonOut & ) const;
+        void deserialize( const JsonObject &jo );
+
     private:
         /** vitamins potentially provided by this comestible (if any) */
         std::map<vitamin_id, std::variant<int, vitamin_units::mass>> vitamins_;

--- a/tests/faction_camp_test.cpp
+++ b/tests/faction_camp_test.cpp
@@ -33,18 +33,18 @@ TEST_CASE( "camp_calorie_counting", "[camp]" )
     std::optional<basecamp *> bcp = overmap_buffer.find_camp( this_omt.xy() );
     basecamp *test_camp = *bcp;
     WHEN( "a base item is added to larder" ) {
-        camp_faction->food_supply = 0;
+        camp_faction->food_supply.calories = 0;
         item test_100_kcal( "test_100_kcal" );
         tripoint_bub_ms zone_local = m.bub_from_abs( zone_loc );
         m.i_clear( zone_local.raw() );
         m.add_item_or_charges( zone_local, test_100_kcal );
         REQUIRE( m.has_items( zone_local ) );
         test_camp->distribute_food();
-        CHECK( camp_faction->food_supply == 100 );
+        CHECK( camp_faction->food_supply.kcal() == 100 );
     }
 
     WHEN( "an item with inherited components is added to larder" ) {
-        camp_faction->food_supply = 0;
+        camp_faction->food_supply.calories = 0;
         item test_100_kcal( "test_100_kcal" );
         item test_200_kcal( "test_200_kcal" );
         item_components made_of;
@@ -56,7 +56,7 @@ TEST_CASE( "camp_calorie_counting", "[camp]" )
         m.i_clear( zone_local.raw() );
         m.add_item_or_charges( zone_local, test_200_kcal );
         test_camp->distribute_food();
-        CHECK( camp_faction->food_supply == 200 );
+        CHECK( camp_faction->food_supply.kcal() == 200 );
     }
 }
 // TODO: Tests for: Check calorie display at various activity levels, camp crafting works as expected (consumes inputs, returns outputs+byproducts, costs calories)

--- a/tests/faction_camp_test.cpp
+++ b/tests/faction_camp_test.cpp
@@ -14,6 +14,9 @@
 #include "overmapbuffer.h"
 #include "player_helpers.h"
 
+static const vitamin_id vitamin_mutagen( "mutagen" );
+static const vitamin_id vitamin_mutant_toxin( "mutant_toxin" );
+
 static const zone_type_id zone_type_CAMP_FOOD( "CAMP_FOOD" );
 static const zone_type_id zone_type_CAMP_STORAGE( "CAMP_STORAGE" );
 
@@ -32,19 +35,20 @@ TEST_CASE( "camp_calorie_counting", "[camp]" )
     m.add_camp( this_omt, "faction_camp" );
     std::optional<basecamp *> bcp = overmap_buffer.find_camp( this_omt.xy() );
     basecamp *test_camp = *bcp;
+    nutrients &food_supply = camp_faction->food_supply;
     WHEN( "a base item is added to larder" ) {
-        camp_faction->food_supply.calories = 0;
+        food_supply *= 0;
         item test_100_kcal( "test_100_kcal" );
         tripoint_bub_ms zone_local = m.bub_from_abs( zone_loc );
         m.i_clear( zone_local.raw() );
         m.add_item_or_charges( zone_local, test_100_kcal );
         REQUIRE( m.has_items( zone_local ) );
         test_camp->distribute_food();
-        CHECK( camp_faction->food_supply.kcal() == 100 );
+        CHECK( food_supply.kcal() == 100 );
     }
 
     WHEN( "an item with inherited components is added to larder" ) {
-        camp_faction->food_supply.calories = 0;
+        food_supply *= 0;
         item test_100_kcal( "test_100_kcal" );
         item test_200_kcal( "test_200_kcal" );
         item_components made_of;
@@ -56,7 +60,34 @@ TEST_CASE( "camp_calorie_counting", "[camp]" )
         m.i_clear( zone_local.raw() );
         m.add_item_or_charges( zone_local, test_200_kcal );
         test_camp->distribute_food();
-        CHECK( camp_faction->food_supply.kcal() == 200 );
+        CHECK( food_supply.kcal() == 200 );
+    }
+
+    WHEN( "an item with vitamins is added to larder" ) {
+        food_supply *= 0;
+        item test_500_kcal( "test_500_kcal" );
+        tripoint_bub_ms zone_local = m.bub_from_abs( zone_loc );
+        m.i_clear( zone_local.raw() );
+        m.add_item_or_charges( zone_local, test_500_kcal );
+        test_camp->distribute_food();
+        REQUIRE( food_supply.kcal() == 500 );
+        REQUIRE( food_supply.get_vitamin( vitamin_mutant_toxin ) == 100 );
+        REQUIRE( food_supply.get_vitamin( vitamin_mutagen ) == 200 );
+    }
+
+    WHEN( "a larder with stored calories and vitamins has food withdrawn" ) {
+        food_supply *= 0;
+        food_supply.calories += 100000;
+        food_supply.set_vitamin( vitamin_mutant_toxin, 100 );
+        food_supply.set_vitamin( vitamin_mutagen, 200 );
+        CHECK( food_supply.kcal() == 100 );
+        CHECK( food_supply.get_vitamin( vitamin_mutant_toxin ) == 100 );
+        CHECK( food_supply.get_vitamin( vitamin_mutagen ) == 200 );
+        // Now withdraw 15% of the total calories, this should also draw out 15% of the stored vitamins.
+        test_camp->camp_food_supply( -15 );
+        REQUIRE( food_supply.kcal() == 85 );
+        REQUIRE( food_supply.get_vitamin( vitamin_mutant_toxin ) == 85 );
+        REQUIRE( food_supply.get_vitamin( vitamin_mutagen ) == 170 );
     }
 }
 // TODO: Tests for: Check calorie display at various activity levels, camp crafting works as expected (consumes inputs, returns outputs+byproducts, costs calories)


### PR DESCRIPTION
#### Summary
Features "Faction camps store, track, and consume vitamins"

#### Purpose of change
Despite the introduction of vitamins and their deficiencies several years ago, NPCs have been languishing without attention. Camps use calories to pay for construction and crafting but they just vanish. You can stuff all sorts of weird things into the larder and it just ignores all the downsides of e.g. an all-alcohol diet.

#### Describe the solution
This is not a full solution, as calories spent on *work projects* still vanish into the ether.  This PR is just a huge infrastructure change before I can even start to do that. Things this DOES do:

-Adds vitamins appropriately when food is distributed

-Retains those vitamins over save/load and as new food is added to/removed from the larder.

-Removes a proportional amount of vitamins when kcal are deducted from the larder.

-*Returns that value* as a nutrients struct. Right now this is only used in one place but the infrastructure is there for your workers to eat properly

-Because the drain of vitamins is proportional to consumed kilocalories this means that if you stuff your larder full of toxins you'll be pulling toxins right back out whenever you eat from it. With all the appropriate effects. You still can stuff mutant meat in the larder... but you'll be paying for it just like if you shoved it down your own throat.

-As of this PR the only time vitamins are actually pulled from the larder and put into a character's stomach is when a hungry NPC eats from the larder by being near it. This is not the same thing as NPCs consuming(vanishing) calories when they are assigned to work.

There is not currently a non-debug way to view the vitamin contents of the larder.

#### Describe alternatives you've considered
We could just delete the larder entirely but I think it's a necessary *and good* abstraction, although it needs even more work than this.

#### Testing
In a completely empty field I stripped an NPC of all their belongings, debugged them to starving, and then magic'd up some protein rations and put the rations into the larder. Then I waited until they ate from the larder.

Some time later, after their body was able to start absorbing the food...
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/94b035df-8016-49b9-81e1-b31981193069)


#### Additional context
That default mod is going away sooner or later. Prepare your salt

Known issues:
`calories` in the nutrients struct is a 32-bit integer, and can be overflowed. After this PR camps have a practical limit of ~2.1 million kcal (about 178 worker-days worth of food at EXTRA_EXERCISE). Changing that to a 64-bit integer will take some careful work as the nutrients struct is more widely used outside of camps.

`calories` as defined by a faction template is now actually calories. Previously it was **kilocalories**. This means that factions have 1000x less food available to them. However the docs already indicate that it's supposed to be calories and this has no current ingame effect, so nothing further has been done for this. In the future as we add basecamp support for NPC factions they will need to have this looked at.