### PR TITLE
Fix crash when new achievement is completed when loading past game info in achievement UI

### DIFF
--- a/src/scores_ui.cpp
+++ b/src/scores_ui.cpp
@@ -15,6 +15,7 @@
 #include "localized_comparator.h"
 #include "kill_tracker.h"
 #include "output.h"
+#include "past_games_info.h"
 #include "point.h"
 #include "stats_tracker.h"
 #include "string_formatter.h"
@@ -25,6 +26,9 @@
 static std::string get_achievements_text( const achievements_tracker &achievements,
         bool use_conducts, int width )
 {
+    // Load past game info beforehand because otherwise it may erase an `achievement_tracker`
+    // within a call to its method when lazy-loaded, causing dangling pointer.
+    get_past_games();
     std::string thing_name = use_conducts ? _( "conducts" ) : _( "achievements" );
     std::string cap_thing_name = use_conducts ? _( "Conducts" ) : _( "Achievements" );
     if( !achievements.is_enabled() ) {


### PR DESCRIPTION
#### Summary
Bugfixes "Fix crash when new achievement is completed when loading past game info in achievement UI"

#### Purpose of change
Fixes #71508. Opening the achievement UI calls `achievement_tracker::ui_text` which cause `past_game_info` to be loaded, which seems to cause an achievement to be completed in the process, erasing the the `achievement_tracker`, causing dangling pointer.

#### Describe the solution
Load past game info beforehand so that any erasure of `achievement_tracker` happens before iterating through the list of trackers when generating the UI text.

#### Describe alternatives you've considered
Devise some smart infrastructure that avoids the use-after-free problem.

#### Testing
Followed the reproduction steps from #71508. Before this fix the game crashed, and after this fix the game no longer crashed.

#### Additional context