### PR TITLE
[MoM] Create Dimension-Lost Scenario, move Itzcuauhtli Corps Liaison to scenario-only

### DIFF
--- a/data/mods/MindOverMatter/professions.json
+++ b/data/mods/MindOverMatter/professions.json
@@ -328,7 +328,7 @@
     "type": "profession",
     "id": "psi_teleporter_slider",
     "name": "Itzcuauhtli Corps Liaison, Yohualli Èhecatl Division",
-    "description": "You don't understand what happened.  You were readying for a routine jump at the Far Hebrides transfer point when there was a power cascade in the drive and now you're here, on some other version of Tlalticpactli.  You need to find your way back home, but first you need to find a way to survive.",
+    "description": "The last thing you remember was inputting the jump coordinates into the tliltilhuicaātl drive and reaching out to initiate the transfer when there was a power surge and it felt like the entire ship was turning inside out.  Now, you have no idea where you are.",
     "points": 15,
     "skills": [
       { "level": 3, "name": "computer" },
@@ -374,7 +374,8 @@
       },
       "male": { "entries": [ { "item": "briefs" } ] },
       "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
-    }
+    },
+    "flags": [ "SCEN_ONLY" ]
   },
   {
     "type": "profession",

--- a/data/mods/MindOverMatter/scenarios.json
+++ b/data/mods/MindOverMatter/scenarios.json
@@ -10,5 +10,27 @@
     "type": "scenario",
     "extend": { "professions": [ "psi_new_psychic", "psi_telekinetic_testsubject", "psi_teleporter_slider" ] },
     "id": "portal_dependent"
+  },
+  {
+    "type": "scenario",
+    "id": "mutant",
+    "name": "Dimension-Lost",
+    "points": 0,
+    "description": "You don't understand what happened.  You were readying for a routine jump at the Far Hebrides transfer point when there was a power cascade in the drive and now you're here, on some other version of Tlalticpactli that may as well be one of the worse levels of Mictlān.  You need to find your way back home, but first you need to find a way to survive.",
+    "start_name": "???",
+    "allowed_locs": [
+      "sloc_forest",
+      "sloc_middle_of_nowhere",
+      "sloc_mine_finale",
+      "sloc_apartments_rooftop2",
+      "sloc_office_tower_rooftop",
+      "sloc_apartment_complex_roof",
+      "sloc_house",
+      "sloc_house_boarded",
+      "sloc_mall_food_court"
+    ],
+    "professions": [ "psi_teleporter_slider" ],
+    "reveal_locale": false,
+    "flags": [ "LONE_START" ]
   }
 ]

--- a/data/mods/MindOverMatter/scenarios.json
+++ b/data/mods/MindOverMatter/scenarios.json
@@ -13,7 +13,7 @@
   },
   {
     "type": "scenario",
-    "id": "mutant",
+    "id": "dimension_lost_fifth_sun",
     "name": "Dimension-Lost",
     "points": 0,
     "description": "You don't understand what happened.  You were readying for a routine jump at the Far Hebrides transfer point when there was a power cascade in the drive and now you're here, on some other version of Tlalticpactli that may as well be one of the worse levels of Mictlān.  You need to find your way back home, but first you need to find a way to survive.",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Create Dimension-Lost Scenario, move Itzcuauhtli Corps Liaison to scenario-only"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

It never did make much sense that the Itzcuauhtli Corps Liaison was in an evac shelter.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Make the Dimension-Lost scenario, make the Itzcuauhtli Corps Liaison scenario-only, and add a bunch of random possible start locations (rooftops, the wilderness, the mall, the bottom of a mine, etc), reflecting that they were dumped at a random destination when they arrived in this dimension. 

Name the drive system of their ship, providing a bit more Fifth Sun People lore. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Scenario exists in game, profession is not selectable otherwise. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
