### PR TITLE
Draw SDL ASCII lines by default

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2355,7 +2355,7 @@ void options_manager::add_options_graphics()
 
         add( "USE_DRAW_ASCII_LINES_ROUTINE", page_id, to_translation( "SDL ASCII lines" ),
              to_translation( "If true, use SDL ASCII line drawing routine instead of Unicode Line Drawing characters.  Use this option when your selected font doesn't contain necessary glyphs." ),
-             false, COPT_CURSES_HIDE
+             true, COPT_CURSES_HIDE
            );
     } );
 #endif // TILES


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fixes #71568
