### PR TITLE
Fix typo in adv solar panels vehicle part

### DIFF
--- a/data/json/items/vehicle/solar.json
+++ b/data/json/items/vehicle/solar.json
@@ -126,7 +126,7 @@
     "type": "GENERIC",
     "id": "ground_solar_panel_v2",
     "name": { "str": "advanced solar panel array" },
-    "description": "A collection of four smaller solar panels, read to convert solar radiation into electric power.  These panels are high-performance, made with monocrystalline silicon cells.",
+    "description": "A collection of four smaller solar panels, ready to convert solar radiation into electric power.  These panels are high-performance, made with monocrystalline silicon cells.",
     "copy-from": "solar_panel_v2",
     "proportional": { "price": 4, "price_postapoc": 4, "weight": 4, "volume": 4, "longest_side": 2 }
   },


### PR DESCRIPTION
#### Summary

Bugfixes "Fixed typos in advanced solar panel vehicle part"

#### Purpose of change

Solar panels were "read to convert" sunlight into electricity.

They're now "ready to covert".

#### Describe the solution

JSON edit

#### Describe alternatives you've considered

None

#### Testing

None. Sorry, I'm on a train.

#### Additional context

None