### PR TITLE
Tune up grenade fragments, fragment generation in general

### DIFF
--- a/data/json/items/tool/explosives.json
+++ b/data/json/items/tool/explosives.json
@@ -449,7 +449,7 @@
     "symbol": "*",
     "color": "green",
     "use_action": { "type": "message", "message": "You've already pulled the %s's pin, try throwing it instead.", "name": "Pull pin" },
-    "countdown_action": { "type": "explosion", "explosion": { "power": 240, "shrapnel": { "casing_mass": 217, "fragment_mass": 0.08 } } },
+    "countdown_action": { "type": "explosion", "explosion": { "power": 240, "shrapnel": { "casing_mass": 217, "fragment_mass": 0.02 } } },
     "flags": [ "BOMB", "TRADER_AVOID", "DANGEROUS" ],
     "melee_damage": { "bash": 6 }
   },

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -102,8 +102,8 @@ static float fragment_mass = 0.0001f;
 static float fragment_area = 0.00001f;
 // Minimum velocity resulting in skin perforation according to https://www.ncbi.nlg->m.nih.gov/pubmed/7304523
 static constexpr float MIN_EFFECTIVE_VELOCITY = 70.0f;
-// Pretty arbitrary minimum density.  1/1,000 change of a fragment passing through the given square.
-static constexpr float MIN_FRAGMENT_DENSITY = 0.0001f;
+// Pretty arbitrary minimum density.  1/100 chance of a fragment passing through the given square.
+static constexpr float MIN_FRAGMENT_DENSITY = 0.001f;
 
 explosion_data load_explosion_data( const JsonObject &jo )
 {
@@ -140,7 +140,7 @@ shrapnel_data load_shrapnel_data( const JsonObject &jo )
 namespace explosion_handler
 {
 
-static int ballistic_damage( float velocity, float mass )
+int ballistic_damage( float velocity, float mass )
 {
     // Damage is square root of Joules, dividing by 2000 because it's dividing by 2 and
     // converting mass from grams to kg. The initial term is simply a scaling factor.
@@ -159,7 +159,7 @@ static float mass_to_area( const float mass )
 // Approximate Gurney constant for Composition B and C (in m/s instead of the usual km/s).
 // Source: https://en.wikipedia.org/wiki/Gurney_equations#Gurney_constant_and_detonation_velocity
 static constexpr double TYPICAL_GURNEY_CONSTANT = 2700.0;
-static float gurney_spherical( const double charge, const double mass )
+float gurney_spherical( const double charge, const double mass )
 {
     return static_cast<float>( std::pow( ( mass / charge ) + ( 3.0 / 5.0 ),
                                          -0.5 ) * TYPICAL_GURNEY_CONSTANT );
@@ -415,7 +415,7 @@ static std::vector<tripoint> shrapnel( const Creature *source, const tripoint &s
     fragment_cloud initial_cloud = accumulate_fragment_cloud( obstacle_cache[src.x][src.y],
     { fragment_velocity, static_cast<float>( fragment_count ) }, 1 );
     visited_cache[src.x][src.y] = initial_cloud;
-    visited_cache[src.x][src.y].density = static_cast<float>( fragment_count );
+    visited_cache[src.x][src.y].density = static_cast<float>( fragment_count / 2.0 );
 
     castLightAll<fragment_cloud, fragment_cloud, shrapnel_calc, shrapnel_check,
                  update_fragment_cloud, accumulate_fragment_cloud>
@@ -938,14 +938,14 @@ fragment_cloud shrapnel_calc( const fragment_cloud &initial,
                               const int &distance )
 {
     // SWAG coefficient of drag.
-    constexpr float Cd = 0.5f;
+    constexpr float Cd = 1.5f;
     fragment_cloud new_cloud;
     new_cloud.velocity = initial.velocity * std::exp( -cloud.velocity * ( (
                              Cd * fragment_area * distance ) /
                          ( 2.0f * fragment_mass ) ) );
     // Two effects, the accumulated proportion of blocked fragments,
     // and the inverse-square dilution of fragments with distance.
-    new_cloud.density = ( initial.density * cloud.density ) / ( distance * distance / 2.5 );
+    new_cloud.density = ( initial.density * cloud.density ) / ( distance * distance );
     return new_cloud;
 }
 bool shrapnel_check( const fragment_cloud &cloud, const fragment_cloud &intensity )

--- a/src/explosion.h
+++ b/src/explosion.h
@@ -102,7 +102,7 @@ void draw_custom_explosion( const tripoint &p, const std::map<tripoint, nc_color
                             const std::optional<std::string> &tile_id = std::nullopt );
 
 int ballistic_damage( float velocity, float mass );
-float gurney_spherical( const double charge, const double mass );
+float gurney_spherical( double charge, double mass );
 void process_explosions();
 } // namespace explosion_handler
 

--- a/src/explosion.h
+++ b/src/explosion.h
@@ -101,6 +101,8 @@ void draw_explosion( const tripoint &p, int radius, const nc_color &col );
 void draw_custom_explosion( const tripoint &p, const std::map<tripoint, nc_color> &area,
                             const std::optional<std::string> &tile_id = std::nullopt );
 
+int ballistic_damage( float velocity, float mass );
+float gurney_spherical( const double charge, const double mass );
 void process_explosions();
 } // namespace explosion_handler
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -9045,7 +9045,7 @@ void map::build_obstacle_cache(
             continue;
         }
         // TODO: scale this with expected creature "thickness".
-        obstacle_cache[loc.x][loc.y].velocity = 1000.0f;
+        obstacle_cache[loc.x][loc.y].velocity = 1.2f;
         // ranged_target_size is "proportion of square that is blocked", and density needs to be
         // "transmissivity of square", so we need the reciprocal.
         obstacle_cache[loc.x][loc.y].density = 1.0 - critter.ranged_target_size();

--- a/tests/explosion_balance_test.cpp
+++ b/tests/explosion_balance_test.cpp
@@ -8,9 +8,11 @@
 #include "cata_catch.h"
 #include "creature.h"
 #include "explosion.h"
+#include "fragment_cloud.h"
 #include "game.h"
 #include "item.h"
 #include "itype.h"
+#include "iuse_actor.h"
 #include "line.h"
 #include "map.h"
 #include "map_helpers.h"
@@ -73,12 +75,28 @@ static void check_lethality( const std::string &explosive_id, const int range, f
     std::stringstream survivor_stats;
     int total_hp = 0;
     clear_map_and_put_player_underground();
+    tripoint origin( 30, 30, 0 );
+    std::map<int, std::vector<tripoint>> circles;
+    circles[0] = { origin };
+    circles[5] = {
+        { 25, 28, 0 }, { 25, 29, 0 }, { 25, 30, 0 }, { 25, 31, 0 }, { 25, 32, 0 },
+        { 26, 26, 0 }, { 26, 34, 0 },
+        { 27, 26, 0 }, { 27, 34, 0 },
+        { 28, 25, 0 }, { 28, 35, 0 },
+        { 29, 25, 0 }, { 29, 35, 0 },
+        { 30, 25, 0 }, { 30, 35, 0 },
+        { 31, 25, 0 }, { 31, 35, 0 },
+        { 32, 25, 0 }, { 32, 35, 0 },
+        { 33, 26, 0 }, { 33, 34, 0 },
+        { 34, 26, 0 }, { 34, 34, 0 },
+        { 35, 28, 0 }, { 35, 29, 0 }, { 35, 30, 0 }, { 35, 31, 0 }, { 35, 32, 0 }
+    };
+    circles[15] = closest_points_first( origin, range );
     do {
         clear_creatures();
         // Spawn some monsters in a circle.
-        tripoint origin( 30, 30, 0 );
         int num_subjects_this_time = 0;
-        for( const tripoint &monster_position : closest_points_first( origin, range ) ) {
+        for( const tripoint &monster_position : circles[range] ) {
             if( rl_dist( monster_position, origin ) != range ) {
                 continue;
             }
@@ -98,7 +116,7 @@ static void check_lethality( const std::string &explosive_id, const int range, f
         num_survivors += survivors.size();
         for( Creature *survivor : survivors ) {
             survivor_stats << survivor->pos() << " " << survivor->get_hp() << ", ";
-            bool wounded = survivor->get_hp() < survivor->get_hp_max();
+            bool wounded = survivor->get_hp() < survivor->get_hp_max() * 0.75;
             num_wounded += wounded ? 1 : 0;
             total_hp += survivor->get_hp();
             if( expected_outcome == outcome_type::Casualty && wounded ) {
@@ -116,6 +134,24 @@ static void check_lethality( const std::string &explosive_id, const int range, f
     } while( victims.uncertain_about( target_lethality ) );
     CAPTURE( margin );
     INFO( explosive_id );
+    item grenade( explosive_id );
+    const explosion_data &ex = dynamic_cast<const explosion_iuse *>
+                               ( grenade.type->countdown_action.get_actor_ptr() )->explosion;
+    const shrapnel_data &shr = ex.shrapnel;
+    const float fragment_velocity = explosion_handler::gurney_spherical( ex.power, shr.casing_mass );
+    const float fragment_count = static_cast<float>( shr.casing_mass ) / shr.fragment_mass;
+    const fragment_cloud cloud_at_target =
+        shrapnel_calc( { fragment_velocity, fragment_count }, { 1.2, 1.0 }, range );
+    std::poisson_distribution<> d( cloud_at_target.density );
+    int hits = d( rng_get_engine() );
+    INFO( "Casing mass " << shr.casing_mass );
+    INFO( "fragment mass " << shr.fragment_mass );
+    INFO( "Total fragments " << fragment_count );
+    INFO( "initial velocity " << fragment_velocity );
+    INFO( "damage per fragment " << explosion_handler::ballistic_damage( cloud_at_target.velocity,
+            shr.fragment_mass ) );
+    INFO( "fragments expected " << cloud_at_target.density );
+    INFO( "Sample fragment count " << hits );
     INFO( "range " << range );
     INFO( num_survivors << " survivors out of " << num_subjects << " targets." );
     INFO( survivor_stats.str() );


### PR DESCRIPTION
This also restores the ability of bomb fragments to pass through occupied tiles.

#### Summary
Balance "Retuned frag grenades to be less effective against ballistic armor and lose power over distance faster"

#### Purpose of change
Fixes #67162 
The inability of fragments to pass though a tile with a monster on it is definitely not intended, fixed that.
I went back and forth on whether the skeletal juggernaught dying to a frag grenade at extreme close range is a problem, but at the end of the day I went ahead and dialed down damage per fragment, and by the time I got balance shuffled around the way I wanted it they're now completely immune to grenades, but still get shredded by pipe bombs and other ordinance with larger fragments.

#### Describe the solution
See my comment in the diff for where the fix to fragments-through-an-occupied-tile happened.
Basically I shrunk the fragment size of the grenade, which means there are more fragments (about 10,000) that each do a much smaller amount of damage.  This is potentially a bit overboard but it meets my goals, and getting this code to work as intended continues to be surprisingly tricky so now that I have it stabilized again I don't want to keep tweaking it.
I also tuned some parts of the algorithm and beefed up feedback on the fragmentation lethality tests.

#### Testing
Adjusted tests pass with a large ish number of runs, need to keep an eye out for fragility.
Ran some manual tests like a grenade in a big horde of zombies or juggernaughts.
spawn a grenade, wield, arm, throw, wait 5 turns, spawn a pile of monsters on top of it, wait another turn.
Zombies: ~30 zombies nearest to the grenade died. Many more wounded.
Skeletal Juggernaughts: Negligible damage. They are wounded dlightly by the blast, but that's like 5 hp.
Frog Mother: The ones immediately adjacent to the grenade died, the rest were wounded heavily but of course started regenerating immediately. This is working as intended, anything without armor is going to have a bad time in close proximity to a fragmentation bomb.

#### Additional Context
If you're skeptical of that damage output, consider this, the official doctrine for the frag grenade this is based on is that an unarmored human within 5m of a detonation has a 95% casualty rate.  Then consider that being *adjacent* to a frag grenade detonation is roughly 16x as damaging, and standing in the same tile as a frag grenade is roughly 12x as damaging as that.  That is multiplicative, so same-tile-as-the-grenade has roughly 196x overkill vs a human.