### PR TITLE
[Sky Island] Take NPCs on/back from raids

### DIFF
--- a/data/mods/Sky_Island/EOCs.json
+++ b/data/mods/Sky_Island/EOCs.json
@@ -19,6 +19,12 @@
     "effect": [
       { "u_location_variable": { "global_val": "OM_HQ_origin" } },
       {
+        "u_location_variable": { "global_val": "OM_HQ_origin_npc" },
+        "passable_only": true,
+        "min_radius": 1,
+        "max_radius": 3
+      },
+      {
         "u_add_effect": "warpcloak",
         "intensity": 1,
         "duration": { "global_val": "var", "var_name": "invistime", "default": "3 s" }
@@ -205,6 +211,18 @@
         "min_radius": 0,
         "max_radius": 10,
         "true_eocs": [ { "id": "EOC_map_item_run", "effect": [ { "npc_teleport": { "global_val": "OM_HQ_origin" } } ] } ]
+      },
+      {
+        "u_run_npc_eocs": [
+          {
+            "id": "EOC_return_OM_teleport_item_npc_nest",
+            "effect": [
+              { "u_teleport": { "global_val": "OM_HQ_origin_npc" } }
+            ]
+          }
+        ],
+        "npc_range":  10,
+        "local": true
       },
       { "queue_eocs": [ "EOC_return_OM_teleport" ], "time_in_future": "1 s" },
       { "u_message": "Now teleporting back home.  Please wait…" }

--- a/data/mods/Sky_Island/EOCs.json
+++ b/data/mods/Sky_Island/EOCs.json
@@ -48,7 +48,7 @@
             ]
           }
         ],
-        "npc_range":  10,
+        "npc_range": 10,
         "local": true
       },
       {
@@ -79,7 +79,7 @@
             ]
           }
         ],
-        "npc_range":  10,
+        "npc_range": 10,
         "local": true
       },
       { "u_teleport": { "global_val": "OM_HQ_origin" }, "force": true },

--- a/data/mods/Sky_Island/EOCs.json
+++ b/data/mods/Sky_Island/EOCs.json
@@ -15,19 +15,41 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_initiate_randomport",
-    "//": "The actual EOC that teleports the player to the ground.  If this fails, it will be checked and corrected in the following EOC_safely_landed event, which is also where most values are initialized.  A target location must already be stored when this is called.  When this begins, it also memorizes the player's exact position on leaving, which is where they'll return to when the mission ends or they die.  Note that this also gives a bit of warpcloak before the teleport even happens, so if the player spawns over a pit or hole they will not be injured.",
+    "//": "The actual EOC that teleports the player and NPCs that follow to the ground.  If this fails, it will be checked and corrected in the following EOC_safely_landed event, which is also where most values are initialized.  A target location must already be stored when this is called.  When this begins, it also memorizes the player's exact position on leaving, which is where they'll return to when the mission ends or they die.  Note that this also gives a bit of warpcloak before the teleport even happens, so if the player spawns over a pit or hole they will not be injured.",
     "effect": [
       { "u_location_variable": { "global_val": "OM_HQ_origin" } },
       {
         "u_location_variable": { "global_val": "OM_HQ_origin_npc" },
         "passable_only": true,
-        "min_radius": 1,
-        "max_radius": 3
+        "min_radius": 2,
+        "max_radius": 10
       },
       {
         "u_add_effect": "warpcloak",
         "intensity": 1,
         "duration": { "global_val": "var", "var_name": "invistime", "default": "3 s" }
+      },
+      {
+        "u_run_npc_eocs": [
+          {
+            "id": "EOC_initiate_randomport_npc_follower",
+            "condition": "u_following",
+            "effect": [
+              {
+                "u_teleport": { "global_val": "OM_missionspot" },
+                "fail_message": "It seems some of your followers couldn't teleport with you.",
+                "force": true
+              },
+              {
+                "location_variable_adjust": { "global_val": "OM_missionspot" },
+                "x_adjust": [ -2, -1, 1, 2 ],
+                "y_adjust": [ -2, -1, 1, 2 ]
+              }
+            ]
+          }
+        ],
+        "npc_range":  10,
+        "local": true
       },
       {
         "u_teleport": { "global_val": "OM_missionspot" },
@@ -42,6 +64,24 @@
     "id": "EOC_return_OM_teleport",
     "//": "This is the EOC which actually returns you home.  It brings you home and removes all warp-related effects including warp sickness.  It heals you enough to fix broken limbs.  It also resets the awayfromhome counter to 0 so warp sickness can be tracked properly next time you're out.",
     "effect": [
+      {
+        "u_run_npc_eocs": [
+          {
+            "id": "EOC_return_OM_teleport_followers",
+            "condition": "u_following",
+            "effect": [
+              { "u_teleport": { "global_val": "OM_HQ_origin_npc" }, "force": true },
+              {
+                "location_variable_adjust": { "global_val": "OM_HQ_origin_npc" },
+                "x_adjust": [ -2, -1, 1, 2 ],
+                "y_adjust": [ -2, -1, 1, 2 ]
+              }
+            ]
+          }
+        ],
+        "npc_range":  10,
+        "local": true
+      },
       { "u_teleport": { "global_val": "OM_HQ_origin" }, "force": true },
       { "u_remove_item_with": "warphome" },
       { "math": [ "raidstotal", "++" ] },
@@ -211,18 +251,6 @@
         "min_radius": 0,
         "max_radius": 10,
         "true_eocs": [ { "id": "EOC_map_item_run", "effect": [ { "npc_teleport": { "global_val": "OM_HQ_origin" } } ] } ]
-      },
-      {
-        "u_run_npc_eocs": [
-          {
-            "id": "EOC_return_OM_teleport_item_npc_nest",
-            "effect": [
-              { "u_teleport": { "global_val": "OM_HQ_origin_npc" } }
-            ]
-          }
-        ],
-        "npc_range":  10,
-        "local": true
       },
       { "queue_eocs": [ "EOC_return_OM_teleport" ], "time_in_future": "1 s" },
       { "u_message": "Now teleporting back home.  Please wait…" }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Sky Island] Take NPCs on/back from raids"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change. Having NPCs means potential faction camps, upgrades, trading, etc.

If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

There is currently no way to include NPCs into your Sky Island, except debug.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
NPCs can be teleported both ways - *in* and *out* of the island.
NPCs will only be teleported if they are currently actively following you, allowing you to keep NPCs on watch at the island.


#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
Balancing this could be tricky, as NPCs can act as essentially free storage space. I think that adding a limiter (e.g. only 1 NPC follower at a time, both in and out) could bring an interesting challenge: if you want to bring a new NPC back, you'll need to head out alone, but if you bring a follower with you to a raid (making the raid easier), you can't recruit anyone new.
Currently, this PR **does not** limit the NPC count at teleportation time, though the logic for selecting NPC teleport locations is random, meaning "more NPCs = more chance of teleportation mishaps".

Aftershock has an implementation of "teleport with a following companion" feature, which is much simpler, and teleports both player and NPC to the same location. In my testing, I found that this works if you have *only* a single NPC follower, and does not allow stacking multiple NPCs on a single tile. If the above "limiting" gets implemented, this simpler teleportation approach might be viable. 

I initially made NPCs only return (raid -> island) when you use the "teleport with items in the room" option (paid or free), but that would mean people without this difficulty option on will not be able to return with NPCs that they *initially* brought earthside with them, which does not make sense to me. 

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

On a fresh world, created a few NPC followers, started a quick expedition, got teleported together with NPCs.
Walked to the exit, activated the return obelisk, got teleported back to the island with NPCs.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Things that could be added:
- save `OM_HQ_origin` per NPC (as a `u_val`), so that NPCs you bring into raids return into the exact same spots they teleported from (this is the logic currently used for the player); would mean additional logic for picking teleport locations for new (found in raid and recruited) NPCs
- less randomness with teleport location selection; if anybody knows how to find a suitable location (passable, without other NPCs) around `OM_HQ_origin` *per NPC*, please let me know!

Thanks to @GuardianDll for their assistance.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
