### PR TITLE
Fix display of inventory_multiselector denials and improve popup

### DIFF
--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -1677,9 +1677,13 @@ void inventory_column::draw( const catacurses::window &win, const point &p,
                                                   true ) ) );
 
             if( denial_width > 0 ) {
-                // Print from right rather than trim_and_print to avoid improper positioning of wide characters
-                right_print( win, yy, 1, c_red, trim_by_length( selected ? hilite_string( colorize( denial,
-                             c_red ) ) : denial, denial_width ) );
+                /* Need to determine exact point to start printing from the left, since just trimming produces
+                 * artifacts on languages with wide characters, and right_print expects only a second column */
+                std::string trimmed = trim_by_length( denial, denial_width );
+                const int x = p.x + get_width() - utf8_width( remove_color_tags( trimmed ) );
+                nc_color temp = c_red;
+                print_colored_text( win, point( x, yy ), temp, c_red,
+                                    selected ? hilite_string( colorize( trimmed, c_red ) ) : trimmed );
                 entry.cached_denial_space = denial_width;
             }
         }

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -3618,12 +3618,8 @@ void inventory_multiselector::toggle_entries( int &count, const toggle_mode mode
         if( !denial.empty() ) {
             const std::string assembled = highlighted_entry.any_item().get_item()->display_name() + ":\n"
                                           + colorize( denial, c_red );
-
             if( static_cast<size_t>( utf8_width( denial ) ) > highlighted_entry.cached_denial_space ) {
-                query_popup()
-                .message( "%s", assembled )
-                .option( "QUIT" )
-                .query();
+                popup( assembled, PF_GET_KEY );
             }
         }
         count = 0;

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -1680,6 +1680,7 @@ void inventory_column::draw( const catacurses::window &win, const point &p,
                 // Print from right rather than trim_and_print to avoid improper positioning of wide characters
                 right_print( win, yy, 1, c_red, trim_by_length( selected ? hilite_string( colorize( denial,
                              c_red ) ) : denial, denial_width ) );
+                entry.cached_denial_space = denial_width;
             }
         }
 
@@ -3613,10 +3614,13 @@ void inventory_multiselector::toggle_entries( int &count, const toggle_mode mode
         if( !denial.empty() ) {
             const std::string assembled = highlighted_entry.any_item().get_item()->display_name() + ":\n"
                                           + colorize( denial, c_red );
-            query_popup()
-            .message( "%s", assembled )
-            .option( "QUIT" )
-            .query();
+
+            if( static_cast<size_t>( utf8_width( denial ) ) > highlighted_entry.cached_denial_space ) {
+                query_popup()
+                .message( "%s", assembled )
+                .option( "QUIT" )
+                .query();
+            }
         }
         count = 0;
         return;

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -72,6 +72,7 @@ class inventory_entry
         std::string *cached_name = nullptr;
         std::string *cached_name_full = nullptr;
         unsigned int contents_count = 0;
+        size_t cached_denial_space = 0;
 
         inventory_entry() = default;
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
PR #61742 changed how inventory_multiselector denial messages were displayed, but introduced two new issues:
1. When the inventory_multiselector had multiple columns, the denial message would always print on the rightmost column (hat tip to KujiArgisia on the dev Discord)
![Multicolumn_issue](https://github.com/CleverRaven/Cataclysm-DDA/assets/89038572/36ff9818-4c1f-4393-80d4-b04114b1f408)

2. A popup was added to ensure people on small screens would know why an item/action was unavailable.  However, the popup would display even if the full message was already visible, which meant an extra keypress was required to get rid of it.
Fixes #71547 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
1. Instead of relying on right_print() to determine where to start printing the denial message, trim and calculate the position directly and use print_colored_text()
2a. Cache the available space for the denial message in inventory_entry and only display the popup with the full message if the message didn't fit.  This will still result in some false positives where only one or two characters were trimmed and the actual message is still obvious, but I don't think trying to programmatically figure out where additional context would be required is worthwhile.

https://github.com/CleverRaven/Cataclysm-DDA/assets/89038572/974db199-8543-494e-baec-654e6276ab16

2b. Change the popup to close on any key input rather than requiring `Esc`/`Enter`

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
1. Calculating the correct indent for right_print()
The first attempt failed miserably, and it wouldn't really simplify the logic any.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested various screens at various sizes in various languages, including:
The activation screen (`a`):
![Activation--English--WithDeadInfraredGoggles](https://github.com/CleverRaven/Cataclysm-DDA/assets/89038572/c7fdd9b4-61e3-4643-9da0-ba4b308db079)
![Activation--Polish--80x24](https://github.com/CleverRaven/Cataclysm-DDA/assets/89038572/5ac624e6-ae76-4e5f-bca4-be0cb0c9a4a9)
![Activation--SimplifiedChinese--3Columns](https://github.com/CleverRaven/Cataclysm-DDA/assets/89038572/2a569762-d72d-4bcc-8f47-79262235b80f)
(I didn't know 3 columns was possible in an inventory_multiselector, but it seems to work)

Diassembly( `(`):
![Diassembly](https://github.com/CleverRaven/Cataclysm-DDA/assets/89038572/99aefac9-b843-4533-8564-4e7b6f9b6245)

Pickup (`g`):
![Pickup--Denial--80x24](https://github.com/CleverRaven/Cataclysm-DDA/assets/89038572/d0bd1ec2-9678-4aae-822e-8b760c2322b1)
![Pickup--Polish--80x24](https://github.com/CleverRaven/Cataclysm-DDA/assets/89038572/a8dadea0-a699-4ca6-85fb-2d31aca01c9b)

Take Off (`T`):
![TakeOff--Denial](https://github.com/CleverRaven/Cataclysm-DDA/assets/89038572/3cf0b70b-c253-4c5b-a647-658466b81235)

Trade:
![TradeUI--Denial--80x24](https://github.com/CleverRaven/Cataclysm-DDA/assets/89038572/126a842b-be4f-4c7c-930a-c68b1be64d61)

Wear (`W`):
![Wear--Denial](https://github.com/CleverRaven/Cataclysm-DDA/assets/89038572/fc2abb6a-f026-409c-a036-0551ad7d1a1a)

If anyone else is aware of strange inventory_multiselector edge cases to test, please let me know.  There seem to be some that only occur at certain screen sizes, on certain languages, or with certain items.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
