### PR TITLE
Fix guilt from killing hostile npcs

### DIFF
--- a/data/json/npcs/hells_raiders/npc.json
+++ b/data/json/npcs/hells_raiders/npc.json
@@ -14,7 +14,7 @@
     "type": "npc",
     "id": "bandit",
     "//": "Generic pistol/rifle focused guard for the Hell's Raiders faction.",
-    "name_suffix": "Bandit",
+    "name_suffix": "Bandit BONER",
     "class": "NC_SCAVENGER",
     "attitude": 0,
     "mission": 8,

--- a/data/json/npcs/hells_raiders/npc.json
+++ b/data/json/npcs/hells_raiders/npc.json
@@ -14,7 +14,7 @@
     "type": "npc",
     "id": "bandit",
     "//": "Generic pistol/rifle focused guard for the Hell's Raiders faction.",
-    "name_suffix": "Bandit BONER",
+    "name_suffix": "Bandit",
     "class": "NC_SCAVENGER",
     "attitude": 0,
     "mission": 8,

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -218,6 +218,7 @@ static const skill_id skill_computer( "computer" );
 static const skill_id skill_firstaid( "firstaid" );
 static const skill_id skill_survival( "survival" );
 
+static const species_id species_FERAL( "FERAL" );
 static const species_id species_HUMAN( "HUMAN" );
 static const species_id species_ZOMBIE( "ZOMBIE" );
 
@@ -532,7 +533,7 @@ static void set_up_butchery( player_activity &act, Character &you, butcher_type 
         }
     }
 
-    const bool is_human = corpse.id == mtype_id::NULL_ID() || ( corpse.in_species( species_HUMAN ) &&
+    const bool is_human = corpse.id == mtype_id::NULL_ID() || ( ( corpse.in_species( species_HUMAN ) || corpse.in_species( species_FERAL ) ) &&
                           !corpse.in_species( species_ZOMBIE ) );
 
     // applies to all butchery actions except for dissections

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -533,7 +533,8 @@ static void set_up_butchery( player_activity &act, Character &you, butcher_type 
         }
     }
 
-    const bool is_human = corpse.id == mtype_id::NULL_ID() || ( ( corpse.in_species( species_HUMAN ) || corpse.in_species( species_FERAL ) ) &&
+    const bool is_human = corpse.id == mtype_id::NULL_ID() || ( ( corpse.in_species( species_HUMAN ) ||
+                          corpse.in_species( species_FERAL ) ) &&
                           !corpse.in_species( species_ZOMBIE ) );
 
     // applies to all butchery actions except for dissections

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -3062,7 +3062,7 @@ void npc::die( Creature *nkiller )
                 // No morale effect
             } else if( morale_effect <= -50 ) {
                 player_character.add_morale( MORALE_KILLED_INNOCENT, morale_effect, 0, 2_days, 3_hours );
-            } else if( morale_effect > -50 && morale_effect < 0 ){
+            } else if( morale_effect > -50 && morale_effect < 0 ) {
                 player_character.add_morale( MORALE_KILLED_INNOCENT, morale_effect, 0, 1_days, 1_hours );
             } else {
                 player_character.add_morale( MORALE_KILLED_INNOCENT, morale_effect, 0, 3_hours, 7_minutes );

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1861,7 +1861,7 @@ void npc::on_attacked( const Creature &attacker )
     if( attacker.is_avatar() && !is_enemy() && !is_dead() ) {
         make_angry();
         if( !guaranteed_hostile() ) {
-        hit_by_player = true;
+            hit_by_player = true;
         }
     }
 }

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -3056,7 +3056,7 @@ void npc::die( Creature *nkiller )
                 if( morale_effect > 0 ) {
                     add_msg( _( "You feel a sense of righteous purpose." ) );
                     morale_effect += 5;
-                    }
+                }
             }
             if( morale_effect == 0 ) {
                 // No morale effect

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -154,6 +154,7 @@ static const trait_id trait_HALLUCINATION( "HALLUCINATION" );
 static const trait_id trait_KILLER( "KILLER" );
 static const trait_id trait_MUTE( "MUTE" );
 static const trait_id trait_NO_BASH( "NO_BASH" );
+static const trait_id trait_PACIFIST( "PACIFIST" );
 static const trait_id trait_PROF_DICEMASTER( "PROF_DICEMASTER" );
 static const trait_id trait_SQUEAMISH( "SQUEAMISH" );
 static const trait_id trait_TERRIFYING( "TERRIFYING" );

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -3045,7 +3045,10 @@ void npc::die( Creature *nkiller )
             if( player_character.has_trait( trait_KILLER ) ) {
                 morale_effect += 5;
             } // only god can juge me
-            if( player_character.has_flag( json_flag_SPIRITUAL ) && ( !player_character.has_flag( json_flag_PSYCHOPATH ) && !player_character.has_trait( trait_KILLER ) ) && !player_character.has_flag( json_flag_SAPIOVORE ) ) {
+            if( player_character.has_flag( json_flag_SPIRITUAL ) &&
+                ( !player_character.has_flag( json_flag_PSYCHOPATH ) &&
+                  !player_character.has_trait( trait_KILLER ) ) &&
+                !player_character.has_flag( json_flag_SAPIOVORE ) ) {
                 if( morale_effect < 0 ) {
                     add_msg( _( "You feel ashamed of your actions." ) );
                     morale_effect -= 10;

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -3025,10 +3025,10 @@ void npc::die( Creature *nkiller )
     }
     Character &player_character = get_player_character();
     if( killer == &player_character ) {
-            if( player_character.has_trait( trait_PACIFIST ) ) {
-                add_msg_if_player_sees( _( "A cold shock of guilt washes over you." ) );
-                player_character.add_morale( MORALE_KILLER_HAS_KILLED, -15, 0, 1_days, 1_hours );
-            } 
+        if( player_character.has_trait( trait_PACIFIST ) ) {
+            add_msg_if_player_sees( _( "A cold shock of guilt washes over you." ) );
+            player_character.add_morale( MORALE_KILLER_HAS_KILLED, -15, 0, 1_days, 1_hours );
+        }
         if( !badguy ) {
             int morale_effect = -90;
             // Just because you like eating people doesn't mean you love killing innocents

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -3027,7 +3027,7 @@ void npc::die( Creature *nkiller )
     Character &player_character = get_player_character();
     if( killer == &player_character ) {
         if( player_character.has_trait( trait_PACIFIST ) ) {
-            add_msg_if_player_sees( _( "A cold shock of guilt washes over you." ) );
+            add_msg( _( "A cold shock of guilt washes over you." ) );
             player_character.add_morale( MORALE_KILLER_HAS_KILLED, -15, 0, 1_days, 1_hours );
         }
         if( !badguy ) {

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -3045,9 +3045,9 @@ void npc::die( Creature *nkiller )
                 morale_effect += 5;
             } // only god can juge me
             if( player_character.has_flag( json_flag_SPIRITUAL ) &&
-              ( !player_character.has_flag( json_flag_PSYCHOPATH ) ||
-                ( player_character.has_flag( json_flag_PSYCHOPATH ) &&
-                  player_character.has_trait( trait_KILLER ) ) ) &&
+                ( !player_character.has_flag( json_flag_PSYCHOPATH ) ||
+                  ( player_character.has_flag( json_flag_PSYCHOPATH ) &&
+                    player_character.has_trait( trait_KILLER ) ) ) &&
                 !player_character.has_flag( json_flag_SAPIOVORE ) ) {
                 if( morale_effect < 0 ) {
                     add_msg( _( "You feel ashamed of your actions." ) );

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -3037,8 +3037,9 @@ void npc::die( Creature *nkiller )
             } // Pacifists double dip on penalties if they kill an innocent
             if( player_character.has_trait( trait_PACIFIST ) ) {
                 morale_effect = std::min( 0, morale_effect - 15 );
-            } 
-            if( player_character.has_flag( json_flag_PSYCHOPATH ) || player_character.has_flag( json_flag_SAPIOVORE ) ) {
+            }
+            if( player_character.has_flag( json_flag_PSYCHOPATH ) ||
+                player_character.has_flag( json_flag_SAPIOVORE ) ) {
                 morale_effect = 0;
             } // Killer has the psychopath flag, so we're at +5 total. Whee!
             if( player_character.has_trait( trait_KILLER ) ) {

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1859,7 +1859,7 @@ void npc::on_attacked( const Creature &attacker )
     if( is_hallucination() ) {
         die( nullptr );
     }
-    if( attacker.is_avatar() && !is_enemy() && !is_dead() ) {
+    if( attacker.is_avatar() && !is_enemy() && !is_dead() && !guaranteed_hostile() ) {
         make_angry();
         hit_by_player = true;
     }
@@ -2959,7 +2959,6 @@ void npc::die( Creature *nkiller )
         // *only* set to true in this function!
         return;
     }
-    bool was_enemy = guaranteed_hostile();
     prevent_death_reminder = false;
     dialogue d( get_talker_for( this ), nkiller == nullptr ? nullptr : get_talker_for( nkiller ) );
     for( effect_on_condition_id &eoc : death_eocs ) {
@@ -3028,7 +3027,7 @@ void npc::die( Creature *nkiller )
             add_msg( _( "A cold shock of guilt washes over you." ) );
             player_character.add_morale( MORALE_KILLER_HAS_KILLED, -15, 0, 1_days, 1_hours );
         }
-        if( !was_enemy ) {
+        if( hit_by_player ) {
             int morale_effect = -90;
             // Just because you like eating people doesn't mean you love killing innocents
             if( player_character.has_flag( json_flag_CANNIBAL ) && morale_effect < 0 ) {

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -3052,7 +3052,7 @@ void npc::die( Creature *nkiller )
                 if( morale_effect < 0 ) {
                     add_msg( _( "You feel ashamed of your actions." ) );
                     morale_effect -= 10;
-                    } // skulls for the skull throne
+                } // skulls for the skull throne
                 if( morale_effect > 0 ) {
                     add_msg( _( "You feel a sense of righteous purpose." ) );
                     morale_effect += 5;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Killing unaware hostile NPCs no longer debuffs morale. Killing innocents has better interaction with traits. Butchering ferals causes guilt again."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
There was a check in npc::die that was supposed to look for guaranteed_hostile(), but it was always failing because all faction information for the dead NPC was unloaded by then. This meant that if the player could be hit with a -100 morale penalty for multiple days because they shot first at a bandit with a red hostility string who would always attack them if they saw them. This was even happening if you took out an assassin before they saw you, which was especially silly.

@IdleSol noticed a bug with guilt on butchering/dissecting ferals. The check was looking for species_HUMAN but ferals use a different species entry for some reason.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
- Adds a bool to the beginning of npc::die that stores the status of guaranteed_hostile() so that it can be properly checked at the end of the function.
- Moves trait checks to flag checks, which will fix some weirdness with Killer Drive and probably some other traits.
- Makes the morale penalty a bit more granular. Cannibals feel less bad (but not better) about killing people. Uncaring/Sapiovore types don't get a penalty at all, but have no particular bonus. Killer Drive has the PSYCHOPATH flag, so it sets your penalty to 0, then gives you a +5 bonus on top of that. Spiritual gives you a -10 penalty if you wind up feeling bad about the kill, or a +5 bonus if you wind up feeling good. There's a small message accompanying either result.
- Pacifists now get a -15 mood penalty whenever they kill any NPC, innocent or not. There's a message that comes with this about being horrified at having taken a life.
- Pacifists get an additional -15 to their total morale modifier for killing an innocent.
- Adds ferals to the guilt check when dissecting or butchering bodies, as they are humans too. This can be ignored with autopsy proficiency, Cannibal, Uncaring, or Sapiovore traits as before.

The bonuses Killer Drive gets for killing NPCs aren't a strong motivator to do that kind of thing, they're mostly there for flavor, and because they fit logically.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
If we ever have the ability to talk hostile NPCs down, we may want to revisit this.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
- Got the bandit cabin mission from the old guard.
- Went down to the cabin while debug invisible. Shot a bandit. Didn't get a debuff.
- Shot a bandit with pacifist. Got a smaller debuff and a little message.
- Went back to the refugee center and shot the doctor. Got a debuff.
- Shot an innocent NPC with Pacifist. Got a much bigger debuff and a little message.
- Shot an innocent NPC with Spiritual. Got a bigger debuff and a little message.
- Shot innocent NPCs with Uncaring and Sapiovore. No debuff.
- Spiritual and Uncaring/Sapiovore. No buff or debuff. No message.
- Shot an innocent person with killer drive. Got a small buff.
- Shot an innocent person with killer drive and spiritual. Got a slightly larger buff.
- Butchered an NPC with Uncaring, butchered one without. Uncaring gave no debuff, but the other way gave one.
- Repeated the process with a feral human and got the same result.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
