### PR TITLE
EoCify STARE monattack

### DIFF
--- a/data/json/monster_special_attacks/spells.json
+++ b/data/json/monster_special_attacks/spells.json
@@ -1092,5 +1092,111 @@
       { "turn_cost": "4 s" }
     ],
     "false_effect": { "u_message": "You manage to avoid staring at the horrendous <npc_name>." }
+  },
+  {
+    "id": "stare",
+    "type": "SPELL",
+    "name": "Stare",
+    "description": "Applies various effects when you see the creature.",
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_STARE",
+    "message": "",
+    "shape": "blast",
+    "valid_targets": [ "hostile" ],
+    "flags": [ "SILENT", "NO_EXPLOSION_SFX" ],
+    "min_range": 150,
+    "max_range": 150
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_STARE",
+    "//": "dimensional effects don't take against dimensionally anchored foes.",
+    "condition": { "or": [ { "u_has_worn_with_flag": "DIMENSIONAL_ANCHOR" }, { "npc_has_flag": "DIMENSIONAL_ANCHOR" } ] },
+    "effect": { "u_message": "You feel a strange reverberation across your body.", "type": "warning" },
+    "false_effect": { "run_eocs": [ "EOC_STARE2" ] }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_STARE2",
+    "condition": {
+      "and": [
+        { "u_has_trait": "SCHIZOPHRENIC" },
+        { "not": { "u_has_effect": "took_thorazine" } },
+        { "x_in_y_chance": { "x": 2, "y": 3 } }
+      ]
+    },
+    "effect": [
+      {
+        "if": "player_see_u",
+        "then": { "u_message": "The <npc_name> quickly looks away from you.", "type": "warning" },
+        "else": { "u_message": "A chorus of whispers chatter raucously around you.", "type": "warning" }
+      }
+    ],
+    "false_effect": { "run_eocs": [ "EOC_STARE3" ] }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_STARE3",
+    "condition": { "math": [ "rand(6) < u_effect_intensity('drunk')" ] },
+    "effect": [
+      { "u_message": "The world lurches drunkenly around you.", "type": "warning" },
+      { "u_add_effect": "stunned", "duration": 4 }
+    ],
+    "false_effect": { "run_eocs": [ "EOC_STARE4" ] }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_STARE4",
+    "condition": "player_see_npc",
+    "effect": [
+      { "u_message": "The <npc_name> stares at you, and you shudder.", "type": "bad" },
+      { "run_eocs": [ "EOC_STARE_EFF" ] }
+    ],
+    "false_effect": [
+      { "u_message": "You feel like you're being watched, it makes you sick.", "type": "bad" },
+      { "run_eocs": [ "EOC_STARE_EFF" ] }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_STARE_EFF",
+    "effect": [
+      {
+        "u_add_effect": "taint",
+        "intensity": { "math": [ "u_effect_intensity('taint') + 1" ] },
+        "duration": [ "2 m", "5 m" ]
+      },
+      { "run_eocs": [ "EOC_STARE_EFF2" ] },
+      { "run_eocs": [ "EOC_STARE_EFF3" ] },
+      { "run_eocs": [ "EOC_STARE_EFF4" ] }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_STARE_EFF2",
+    "//": "in case of fire, break glass, pull u_is_avatar",
+    "condition": { "and": [ { "math": [ "u_effect_intensity('taint') >= 2" ] }, { "one_in_chance": 2 } ] },
+    "effect": [
+      { "u_add_effect": "hallu", "duration": [ "25 m", "35 m" ] },
+      { "u_spawn_monster": "", "hallucination_count": 1, "target_range": 50, "lifespan": 60 }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_STARE_EFF3",
+    "condition": { "and": [ { "math": [ "u_effect_intensity('taint') >= 3" ] }, { "one_in_chance": 12 } ] },
+    "effect": [
+      { "u_add_effect": "blind", "duration": [ "4 m", "5 m" ] },
+      { "u_message": "Your sight darkens as the visions overtake you!", "type": "bad" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_STARE_EFF4",
+    "condition": { "and": [ { "math": [ "u_effect_intensity('taint') == 4" ] }, { "one_in_chance": 12 } ] },
+    "effect": [
+      { "u_add_effect": "tindrift", "duration": "1 s" },
+      { "u_message": "Your sight darkens as the visions overtake you!", "type": "bad" }
+    ]
   }
 ]

--- a/data/json/monsters/nether.json
+++ b/data/json/monsters/nether.json
@@ -487,7 +487,7 @@
     "weakpoint_sets": [ "wps_netherium_abomination" ],
     "harvest": "zombie_meatslug",
     "//": "Add a demihuman alien anatomy for things like flaming eye's and Mi-go, polyps and other lovecraftian horrors from other dimensions",
-    "special_attacks": [ [ "STARE", 12 ] ],
+    "special_attacks": [ { "type": "spell", "spell_data": { "id": "stare" }, "monster_message": "", "cooldown": 12 } ],
     "flags": [ "SEES", "WARM", "FLIES", "FIREY", "NO_BREATHE", "NOHEAD", "PACIFIST" ],
     "armor": { "bash": 4 }
   },

--- a/data/mods/MindOverMatter/effectoncondition/eoc_misc.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_misc.json
@@ -303,6 +303,23 @@
     "id": "EOC_FEAR_PARALYZE1",
     "condition": { "not": { "u_has_effect": "effect_telepathic_psi_armor" } },
     "effect": { "run_eocs": [ "EOC_FEAR_PARALYZE2" ] },
-    "false_effect": { "u_message": "Some <npc_name> tries to intrude into your thoughts, but your telepathic shield reflects it!" }
+    "false_effect": {
+      "u_message": "Some <npc_name> tries to intrude into your thoughts, but your telepathic shield reflects it!",
+      "type": "warning"
+    }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_STARE",
+    "condition": { "or": [ { "u_has_worn_with_flag": "DIMENSIONAL_ANCHOR" }, { "npc_has_flag": "DIMENSIONAL_ANCHOR" } ] },
+    "effect": { "u_message": "You feel a strange reverberation across your body.", "type": "warning" },
+    "false_effect": { "run_eocs": [ "EOC_STARE1" ] }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_STARE1",
+    "condition": { "u_has_effect": "effect_telepathic_psi_armor" },
+    "effect": { "u_message": "You sense some <npc_name> trying to enter your mind, but you repel!", "type": "warning" },
+    "false_effect": { "run_eocs": [ "EOC_STARE2" ] }
   }
 ]

--- a/data/mods/No_Hope/monsters.json
+++ b/data/mods/No_Hope/monsters.json
@@ -488,7 +488,7 @@
     "vision_night": 40,
     "luminance": 25,
     "harvest": "zombie_meatslug",
-    "special_attacks": [ [ "STARE", 12 ] ],
+    "special_attacks": [ { "type": "spell", "spell_data": { "id": "stare" }, "monster_message": "", "cooldown": 12 } ],
     "flags": [ "SEES", "WARM", "FLIES", "FIREY", "NO_BREATHE", "NOHEAD" ],
     "armor": { "bash": 4 }
   },

--- a/data/mods/Xedra_Evolved/monsters/monster.json
+++ b/data/mods/Xedra_Evolved/monsters/monster.json
@@ -235,9 +235,10 @@
     "type": "MONSTER",
     "name": { "str": "flaming eye" },
     "special_attacks": [
-      [ "STARE", 12 ],
+      { "type": "spell", "id": "stare_att", "spell_data": { "id": "stare" }, "monster_message": "", "cooldown": 12 },
       {
         "type": "spell",
+        "id": "evil_att",
         "spell_data": { "id": "mon_flaming_eye_evil_spell", "min_level": 1 },
         "cooldown": 20,
         "monster_message": "%1$s stares at you and you feel a sense of doom!"

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -116,7 +116,6 @@ static const efftype_id effect_deaf( "deaf" );
 static const efftype_id effect_dermatik( "dermatik" );
 static const efftype_id effect_downed( "downed" );
 static const efftype_id effect_dragging( "dragging" );
-static const efftype_id effect_drunk( "drunk" );
 static const efftype_id effect_eyebot_assisted( "eyebot_assisted" );
 static const efftype_id effect_eyebot_depleted( "eyebot_depleted" );
 static const efftype_id effect_fungus( "fungus" );
@@ -125,7 +124,6 @@ static const efftype_id effect_got_checked( "got_checked" );
 static const efftype_id effect_grabbed( "grabbed" );
 static const efftype_id effect_grabbing( "grabbing" );
 static const efftype_id effect_grown_of_fuse( "grown_of_fuse" );
-static const efftype_id effect_hallu( "hallu" );
 static const efftype_id effect_has_bag( "has_bag" );
 static const efftype_id effect_infected( "infected" );
 static const efftype_id effect_laserlocked( "laserlocked" );
@@ -139,10 +137,7 @@ static const efftype_id effect_rat( "rat" );
 static const efftype_id effect_shrieking( "shrieking" );
 static const efftype_id effect_slimed( "slimed" );
 static const efftype_id effect_stunned( "stunned" );
-static const efftype_id effect_taint( "taint" );
 static const efftype_id effect_targeted( "targeted" );
-static const efftype_id effect_tindrift( "tindrift" );
-static const efftype_id effect_took_thorazine( "took_thorazine" );
 
 static const gun_mode_id gun_mode_AUTO( "AUTO" );
 
@@ -234,7 +229,6 @@ static const trait_id trait_PROF_FED( "PROF_FED" );
 static const trait_id trait_PROF_PD_DET( "PROF_PD_DET" );
 static const trait_id trait_PROF_POLICE( "PROF_POLICE" );
 static const trait_id trait_PROF_SWAT( "PROF_SWAT" );
-static const trait_id trait_SCHIZOPHRENIC( "SCHIZOPHRENIC" );
 static const trait_id trait_TAIL_CATTLE( "TAIL_CATTLE" );
 static const trait_id trait_THRESH_MARLOSS( "THRESH_MARLOSS" );
 static const trait_id trait_THRESH_MYCUS( "THRESH_MYCUS" );
@@ -2873,63 +2867,6 @@ bool mattack::triffid_growth( monster *z )
     z->poly( mon_triffid );
 
     return false;
-}
-
-bool mattack::stare( monster *z )
-{
-    if( z->friendly ) {
-        // TODO: handle friendly monsters
-        return false;
-    }
-    z->moves -= 200;
-    Character &player_character = get_player_character();
-    if( z->sees( player_character ) ) {
-        //dimensional effects don't take against dimensionally anchored foes.
-        if( player_character.worn_with_flag( flag_DIMENSIONAL_ANCHOR ) ||
-            player_character.has_flag( flag_DIMENSIONAL_ANCHOR ) ) {
-            add_msg( m_warning, _( "You feel a strange reverberation across your body." ) );
-            return true;
-        }//Does the eye fear what it sees in the fractured mind, or is it simply unable to get a good look at it?
-        if( player_character.has_trait( trait_SCHIZOPHRENIC ) &&
-            !player_character.has_effect( effect_took_thorazine ) && x_in_y( 2.0, 3.0 ) ) {
-            if( player_character.sees( *z ) ) {
-                add_msg( m_warning, _( "The %s quickly looks away from you." ), z->name() );
-                return true;
-            } else {
-                add_msg( m_warning, _( "A chorus of whispers chatter raucously around you." ) );
-                return true;
-            }
-        }
-        //Being drunk can protect you from The Horrors
-        if( player_character.has_effect( effect_drunk ) &&
-            ( rng( 1, 6 ) < player_character.get_effect_int( effect_drunk ) ) ) {
-            add_msg( m_warning, _( "The world lurches drunkenly around you." ) );
-            player_character.add_effect( effect_stunned, 4_seconds );
-            return true;
-        }
-        if( player_character.sees( *z ) ) {
-            add_msg( m_bad, _( "The %s stares at you, and you shudder." ), z->name() );
-        } else {
-            add_msg( m_bad, _( "You feel like you're being watched, it makes you sick." ) );
-        }
-        player_character.add_effect( effect_taint, rng( 2_minutes, 5_minutes ) );
-        //Check severity before adding more debuffs
-        if( player_character.get_effect_int( effect_taint ) > 2 ) {
-            player_character.add_effect( effect_hallu, 30_minutes );
-            //Check if target is a player before spawning hallucinations
-            if( player_character.is_avatar() && one_in( 2 ) ) {
-                g->spawn_hallucination( player_character.pos() + tripoint( rng( -10, 10 ), rng( -10, 10 ), 0 ) );
-            }
-            if( one_in( 12 ) ) {
-                player_character.add_effect( effect_blind, 5_minutes );
-                add_msg( m_bad, _( "Your sight darkens as the visions overtake you!" ) );
-            }
-        }
-        if( player_character.get_effect_int( effect_taint ) >= 3 && one_in( 12 ) ) {
-            player_character.add_effect( effect_tindrift, 1_turns );
-        }
-    }
-    return true;
 }
 
 bool mattack::nurse_check_up( monster *z )

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -630,7 +630,6 @@ void MonsterGenerator::init_attack()
     add_hardcoded_attack( "GENE_STING", mattack::gene_sting );
     add_hardcoded_attack( "PARA_STING", mattack::para_sting );
     add_hardcoded_attack( "TRIFFID_GROWTH", mattack::triffid_growth );
-    add_hardcoded_attack( "STARE", mattack::stare );
     add_hardcoded_attack( "PHOTOGRAPH", mattack::photograph );
     add_hardcoded_attack( "TAZER", mattack::tazer );
     add_hardcoded_attack( "SEARCHLIGHT", mattack::searchlight );


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
🤷 
#### Describe the solution
EoCify STARE, add telepathic defence against it in MoM
things changed:
- removed avatar check when applied hallucinations - it was confirmed they work properly with NPCs now, so i don't see the reason they should be immune
- change bad effects being applied gradually if you have tainted mind effect of intensity 2, 3 and 4 for all three bad effects it has, comparing to previous "only effect intensity 3 or bigger". one in x checks are still presented
- replaced the code hallucination type, where hallucination is generated out of all monsters in the game, to EoC hallucination type, where random creature is picked from around and it's hallu copy is created
- small variation in effect length, like hallucinations are applied for 25-35 minutes now instead of being 30 minutes
#### Testing
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/67688115/40364e2a-cf31-4289-8561-69818bc1dc8f)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/67688115/476a8fcc-f3a3-46a1-a41f-300cc65969eb)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/67688115/316f8d55-b3e6-4bb2-b411-720f066de964)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/67688115/4e4af391-2cf4-4c38-933c-b1af4488e884)
#### Additional context
~~i think i messed up a bit in EOC_STARE4, because even if character is blind, check still return "true"~~ fixed