### PR TITLE
show danger radius in overmap note list

### DIFF
--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -3196,6 +3196,20 @@ void overmap::mark_note_dangerous( const tripoint_om_omt &p, int radius, bool is
     }
 }
 
+int overmap::note_danger_radius( const tripoint_om_omt &p ) const
+{
+    if( p.z() < -OVERMAP_DEPTH || p.z() > OVERMAP_HEIGHT ) {
+        return -1;
+    }
+
+    const auto &notes = layer[p.z() + OVERMAP_DEPTH].notes;
+    const auto it = std::find_if( begin( notes ), end( notes ), [&]( const om_note & n ) {
+        return n.p == p.xy();
+    } );
+
+    return ( it != std::end( notes ) ) && it->dangerous ? it->danger_radius : -1;
+}
+
 void overmap::delete_note( const tripoint_om_omt &p )
 {
     add_note( p, std::string{} );

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -245,6 +245,7 @@ class overmap
         void add_note( const tripoint_om_omt &p, std::string message );
         void delete_note( const tripoint_om_omt &p );
         void mark_note_dangerous( const tripoint_om_omt &p, int radius, bool is_dangerous );
+        int note_danger_radius( const tripoint_om_omt &p ) const;
 
         bool has_extra( const tripoint_om_omt &p ) const;
         const map_extra_id &extra( const tripoint_om_omt &p ) const;

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -482,13 +482,16 @@ static point_abs_omt draw_notes( const tripoint_abs_omt &origin )
                 overmap_buffer.get_description_at( tripoint_abs_sm( sm_pos, origin.z() ) );
             const bool is_dangerous =
                 overmap_buffer.is_marked_dangerous( tripoint_abs_omt( p, origin.z() ) );
+            const int note_danger_radius = overmap_buffer.note_danger_radius( tripoint_abs_omt( p, origin.z() ) );
+            nc_color bracket_color = note_danger_radius >= 0 ? c_red : c_light_gray;
+            std::string danger_desc_text = note_danger_radius >= 0 ? string_format( _( "DANGEROUS AREA! (R=%d)" ), note_danger_radius ) : is_dangerous ? _( "IN DANGEROUS AREA!" ) : "";
             nmenu.addentry_desc(
-                string_format( _( "[%s] %s" ), colorize( note_symbol, note_color ), note_text ),
+                string_format( colorize(_( "[%s] %s" ), bracket_color), colorize( note_symbol, note_color ), note_text ),
                 string_format(
                     _( "<color_red>LEVEL %i, %d'%d, %d'%d</color>: %s "
                        "(Distance: <color_white>%d</color>) <color_red>%s</color>" ),
                     origin.z(), p_om.x(), p_omt.x(), p_om.y(), p_omt.y(), location_desc,
-                    distance_player, is_dangerous ? "DANGEROUS AREA!" : "" ) );
+                    distance_player, danger_desc_text ) );
             nmenu.entries[row].ctxt =
                 string_format( _( "<color_light_gray>Distance: </color><color_white>%d</color>" ),
                                distance_player );

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -482,11 +482,14 @@ static point_abs_omt draw_notes( const tripoint_abs_omt &origin )
                 overmap_buffer.get_description_at( tripoint_abs_sm( sm_pos, origin.z() ) );
             const bool is_dangerous =
                 overmap_buffer.is_marked_dangerous( tripoint_abs_omt( p, origin.z() ) );
-            const int note_danger_radius = overmap_buffer.note_danger_radius( tripoint_abs_omt( p, origin.z() ) );
+            const int note_danger_radius = overmap_buffer.note_danger_radius( tripoint_abs_omt( p,
+                                           origin.z() ) );
             nc_color bracket_color = note_danger_radius >= 0 ? c_red : c_light_gray;
-            std::string danger_desc_text = note_danger_radius >= 0 ? string_format( _( "DANGEROUS AREA! (R=%d)" ), note_danger_radius ) : is_dangerous ? _( "IN DANGEROUS AREA!" ) : "";
+            std::string danger_desc_text = note_danger_radius >= 0 ? string_format(
+                                               _( "DANGEROUS AREA! (R=%d)" ), note_danger_radius ) : is_dangerous ? _( "IN DANGEROUS AREA!" ) : "";
             nmenu.addentry_desc(
-                string_format( colorize(_( "[%s] %s" ), bracket_color), colorize( note_symbol, note_color ), note_text ),
+                string_format( colorize( _( "[%s] %s" ), bracket_color ), colorize( note_symbol, note_color ),
+                               note_text ),
                 string_format(
                     _( "<color_red>LEVEL %i, %d'%d, %d'%d</color>: %s "
                        "(Distance: <color_white>%d</color>) <color_red>%s</color>" ),

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -387,6 +387,14 @@ const std::string &overmapbuffer::note( const tripoint_abs_omt &p )
     return empty_string;
 }
 
+int overmapbuffer::note_danger_radius( const tripoint_abs_omt &p )
+{
+    if( const overmap_with_local_coords om_loc = get_existing_om_global( p ) ) {
+        return om_loc.om->note_danger_radius( om_loc.local );
+    }
+    return -1;
+}
+
 bool overmapbuffer::has_extra( const tripoint_abs_omt &p )
 {
     if( const overmap_with_local_coords om_loc = get_existing_om_global( p ) ) {

--- a/src/overmapbuffer.h
+++ b/src/overmapbuffer.h
@@ -176,6 +176,7 @@ class overmapbuffer
         bool has_note( const tripoint_abs_omt &p );
         bool is_marked_dangerous( const tripoint_abs_omt &p );
         const std::string &note( const tripoint_abs_omt &p );
+        int note_danger_radius( const tripoint_abs_omt &p );
         void add_note( const tripoint_abs_omt &, const std::string &message );
         void delete_note( const tripoint_abs_omt &p );
         void mark_note_dangerous( const tripoint_abs_omt &p, int radius, bool is_dangerous );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Show danger radius in note list"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Ref #71577. This adds some indication in the note list UI that a particular
note has a danger radius associated with it.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Added a new `note_danger_radius` method, because this information wasn't
previously exposed by the overmap interface.

Also makes the "DANGEROUS AREA" text translated, and changes it to "IN DANGEROUS AREA" for notes that are not themselves marked dangerous (but which fall inside a danger zone).
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Perhaps the whole `om_note` struct ought to be exposed..?
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Tested locally.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
<img width="634" alt="Screenshot 2024-02-08 at 21 06 02" src="https://github.com/CleverRaven/Cataclysm-DDA/assets/172800/f1e3eb18-9a5e-424c-b07e-9f3fb76eb724">
<img width="634" alt="Screenshot 2024-02-08 at 21 06 12" src="https://github.com/CleverRaven/Cataclysm-DDA/assets/172800/86058fe2-e3fb-485e-b350-483565266645">
<img width="634" alt="Screenshot 2024-02-08 at 21 06 20" src="https://github.com/CleverRaven/Cataclysm-DDA/assets/172800/c24db826-4213-45a1-8431-16576e3a07fb">

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

NB there is a bug in trim_by_length which messes up the color when the note name is very long. I'll attempt to address this separately:

<img width="634" alt="Screenshot 2024-02-08 at 21 07 22" src="https://github.com/CleverRaven/Cataclysm-DDA/assets/172800/7b4815d0-ce74-4d65-8788-8ed72563b3de">



<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
