### PR TITLE
Cloak and Poncho fixes

### DIFF
--- a/data/json/items/armor/cloaks.json
+++ b/data/json/items/armor/cloaks.json
@@ -1627,7 +1627,7 @@
       {
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 95,
-        "encumbrance": [ 6 ],
+        "encumbrance": 6,
         "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
         "layers": [ "BELTED" ]
       }
@@ -1655,7 +1655,7 @@
       {
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 65,
-        "encumbrance": [ 4 ],
+        "encumbrance": 4,
         "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
         "layers": [ "BELTED" ]
       }
@@ -1675,20 +1675,20 @@
     "symbol": "[",
     "looks_like": "coat_rain",
     "color": "green",
-    "warmth": 30,
-    "material_thickness": 0.4,
-    "environmental_protection": 3,
-    "flags": [ "OVERSIZE", "HOOD", "BELTED" ],
     "armor": [
       { "encumbrance": 4, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r" ] },
       {
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 65,
-        "encumbrance": [ 4 ],
+        "encumbrance": 4,
         "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
         "layers": [ "BELTED" ]
       }
-    ]
+    ],
+    "warmth": 30,
+    "material_thickness": 0.4,
+    "environmental_protection": 3,
+    "flags": [ "OVERSIZE", "HOOD", "BELTED" ]
   },
   {
     "id": "cloak_denim",
@@ -1711,7 +1711,7 @@
       {
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 65,
-        "encumbrance": [ 8 ],
+        "encumbrance": 8,
         "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
         "layers": [ "BELTED" ]
       }
@@ -1742,7 +1742,7 @@
       {
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 65,
-        "encumbrance": [ 2 ],
+        "encumbrance": 2,
         "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
         "layers": [ "BELTED" ]
       }
@@ -1790,7 +1790,7 @@
       {
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 65,
-        "encumbrance": [ 2 ],
+        "encumbrance": 2,
         "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
         "layers": [ "BELTED" ]
       }
@@ -1819,7 +1819,7 @@
       {
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 65,
-        "encumbrance": [ 6 ],
+        "encumbrance": 6,
         "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
         "layers": [ "BELTED" ]
       }
@@ -1848,7 +1848,7 @@
       {
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 65,
-        "encumbrance": [ 6 ],
+        "encumbrance": 6,
         "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
         "layers": [ "BELTED" ]
       }
@@ -1877,7 +1877,7 @@
       {
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 65,
-        "encumbrance": [ 5 ],
+        "encumbrance": 5,
         "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
         "layers": [ "BELTED" ]
       }
@@ -1906,7 +1906,7 @@
       {
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 65,
-        "encumbrance": [ 3 ],
+        "encumbrance": 3,
         "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
         "layers": [ "BELTED" ]
       }
@@ -1944,7 +1944,7 @@
       {
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 65,
-        "encumbrance": [ 50 ],
+        "encumbrance": 50,
         "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
         "layers": [ "BELTED" ]
       }
@@ -1957,7 +1957,7 @@
     "type": "TOOL_ARMOR",
     "name": { "str": "FB51 optical cloak (on)", "str_pl": "FB51 optical cloaks (on)" },
     "description": "A plastic cloak embedded with cameras and LEDs that will render you fully invisible to normal vision when powered and worn.  It is turned on, and continually draining power from a UPS.  Use it to turn it off.",
-    "flags": [ "USE_UPS", "OVERSIZE", "HOOD", "STRAPPED", "ACTIVE_CLOAKING", "TRADER_AVOID", "SOFT", "NO_REPAIR" ],
+    "flags": [ "USE_UPS", "OVERSIZE", "HOOD", "BELTED", "ACTIVE_CLOAKING", "TRADER_AVOID", "SOFT", "NO_REPAIR" ],
     "power_draw": "20 kW",
     "revert_to": "optical_cloak",
     "use_action": {
@@ -1991,14 +1991,14 @@
       {
         "covers": [ "arm_l", "arm_r" ],
         "coverage": 100,
-        "encumbrance": [ 5 ],
+        "encumbrance": 5,
         "specifically_covers": [ "arm_shoulder_l", "arm_shoulder_r" ],
         "layers": [ "BELTED" ]
       },
       {
         "covers": [ "arm_l", "arm_r" ],
         "coverage": 85,
-        "encumbrance": [ 5 ],
+        "encumbrance": 5,
         "specifically_covers": [ "arm_upper_r", "arm_upper_l" ],
         "layers": [ "BELTED" ]
       }
@@ -2018,7 +2018,7 @@
     "weight": "30 g",
     "volume": "50 ml",
     "to_hit": -1,
-    "flags": [ "RAINPROOF", "OVERSIZE", "HOOD", "STRAPPED" ],
+    "flags": [ "RAINPROOF", "OVERSIZE", "HOOD", "BELTED" ],
     "environmental_protection": 1,
     "material_thickness": 0.1,
     "armor": [ { "coverage": 90, "covers": [ "torso" ] } ]
@@ -2038,7 +2038,7 @@
     "volume": "250 ml",
     "flags": [ "RAINPROOF", "HOOD", "OVERSIZE", "BELTED", "TRANSPARENT" ],
     "environmental_protection": 1,
-    "material_thickness": 0.1,
+    "material_thickness": 0.4,
     "variant_type": "generic",
     "armor": [
       { "covers": [ "torso" ], "specifically_covers": [ "torso_upper", "torso_lower" ], "coverage": 100 },
@@ -2095,7 +2095,7 @@
     "warmth": 50,
     "material_thickness": 2,
     "environmental_protection": 1,
-    "flags": [ "OVERSIZE", "OUTER" ],
+    "flags": [ "UNRESTRICTED", "OUTER" ],
     "armor": [ { "encumbrance": 20, "coverage": 85, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ] } ]
   }
 ]

--- a/data/json/items/armor/cloaks.json
+++ b/data/json/items/armor/cloaks.json
@@ -1938,7 +1938,7 @@
       "need_charges": 20,
       "need_charges_msg": "You don't have enough UPS charges to turn on the %s"
     },
-    "flags": [ "USE_UPS", "OVERSIZE", "HOOD", "BELTED", "SOFT", "NO_REPAIR" ],
+    "flags": [ "USE_UPS", "OVERSIZE", "HOOD", "BELTED", "SOFT", "NO_REPAIR", "RAINPROOF" ],
     "armor": [
       { "encumbrance": 50, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r" ] },
       {
@@ -1957,7 +1957,7 @@
     "type": "TOOL_ARMOR",
     "name": { "str": "FB51 optical cloak (on)", "str_pl": "FB51 optical cloaks (on)" },
     "description": "A plastic cloak embedded with cameras and LEDs that will render you fully invisible to normal vision when powered and worn.  It is turned on, and continually draining power from a UPS.  Use it to turn it off.",
-    "flags": [ "USE_UPS", "OVERSIZE", "HOOD", "BELTED", "ACTIVE_CLOAKING", "TRADER_AVOID", "SOFT", "NO_REPAIR" ],
+    "flags": [ "USE_UPS", "OVERSIZE", "HOOD", "BELTED", "ACTIVE_CLOAKING", "TRADER_AVOID", "SOFT", "NO_REPAIR", "RAINPROOF" ],
     "power_draw": "20 kW",
     "revert_to": "optical_cloak",
     "use_action": {

--- a/data/json/items/armor/cloaks.json
+++ b/data/json/items/armor/cloaks.json
@@ -1892,7 +1892,7 @@
     "warmth": 35,
     "material_thickness": 1,
     "environmental_protection": 1,
-    "flags": [ "STRAPPED", "OVERSIZE" ],
+    "flags": [ "BELTED", "OVERSIZE" ],
     "armor": [ { "encumbrance": 5, "coverage": 85, "covers": [ "torso" ] } ]
   },
   {

--- a/data/json/items/armor/cloaks.json
+++ b/data/json/items/armor/cloaks.json
@@ -1759,7 +1759,7 @@
     "warmth": 60,
     "material_thickness": 0.6,
     "environmental_protection": 3,
-    "flags": [ "OVERSIZE", "HOOD", "BELTED", "WATERPROOF", "RAINPROOF" ],
+    "flags": [ "OVERSIZE", "HOOD", "BELTED", "RAINPROOF" ],
     "armor": [ { "encumbrance": 6, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ] } ]
   },
   {
@@ -1779,7 +1779,7 @@
     "warmth": 40,
     "material_thickness": 1.5,
     "environmental_protection": 3,
-    "flags": [ "OVERSIZE", "HOOD", "BELTED", "WATERPROOF", "RAINPROOF" ],
+    "flags": [ "OVERSIZE", "HOOD", "BELTED", "RAINPROOF" ],
     "armor": [ { "encumbrance": 6, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ] } ]
   },
   {
@@ -1854,7 +1854,7 @@
       "need_charges": 20,
       "need_charges_msg": "You don't have enough UPS charges to turn on the %s"
     },
-    "flags": [ "USE_UPS", "OVERSIZE", "HOOD", "WATERPROOF", "BELTED", "VARSIZE", "SOFT", "NO_REPAIR" ],
+    "flags": [ "USE_UPS", "OVERSIZE", "HOOD", "BELTED", "SOFT", "NO_REPAIR" ],
     "armor": [ { "encumbrance": 50, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ] } ]
   },
   {
@@ -1864,18 +1864,7 @@
     "type": "TOOL_ARMOR",
     "name": { "str": "FB51 optical cloak (on)", "str_pl": "FB51 optical cloaks (on)" },
     "description": "A plastic cloak embedded with cameras and LEDs that will render you fully invisible to normal vision when powered and worn.  It is turned on, and continually draining power from a UPS.  Use it to turn it off.",
-    "flags": [
-      "USE_UPS",
-      "OVERSIZE",
-      "HOOD",
-      "WATERPROOF",
-      "OUTER",
-      "VARSIZE",
-      "ACTIVE_CLOAKING",
-      "TRADER_AVOID",
-      "SOFT",
-      "NO_REPAIR"
-    ],
+    "flags": [ "USE_UPS", "OVERSIZE", "HOOD", "STRAPPED", "ACTIVE_CLOAKING", "TRADER_AVOID", "SOFT", "NO_REPAIR" ],
     "power_draw": "20 kW",
     "revert_to": "optical_cloak",
     "use_action": {
@@ -1903,7 +1892,7 @@
     "warmth": 35,
     "material_thickness": 1,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "OUTER" ],
+    "flags": [ "STRAPPED", "OVERSIZE" ],
     "armor": [ { "encumbrance": 5, "coverage": 85, "covers": [ "torso" ] } ]
   },
   {
@@ -1916,11 +1905,11 @@
     "description": "A large plastic trash bag with holes cut out for the head and arms.",
     "price": 0,
     "price_postapoc": 0,
-    "material": [ "plastic" ],
+    "material": [ "vinyl" ],
     "weight": "30 g",
     "volume": "50 ml",
     "to_hit": -1,
-    "flags": [ "WATERPROOF", "RAINPROOF", "OVERSIZE", "HOOD", "OUTER", "SOFT" ],
+    "flags": [ "RAINPROOF", "OVERSIZE", "HOOD", "STRAPPED" ],
     "environmental_protection": 1,
     "material_thickness": 0.1,
     "armor": [ { "coverage": 90, "covers": [ "torso" ] } ]

--- a/data/json/items/armor/cloaks.json
+++ b/data/json/items/armor/cloaks.json
@@ -1622,7 +1622,16 @@
     "warmth": 15,
     "material_thickness": 0.5,
     "flags": [ "OVERSIZE", "BELTED" ],
-    "armor": [ { "encumbrance": 6, "coverage": 95, "covers": [ "torso", "leg_r", "leg_l", "arm_r", "arm_l" ] } ]
+    "armor": [
+      { "encumbrance": 6, "coverage": 95, "covers": [ "torso", "arm_r", "arm_l" ] },
+      {
+        "covers": [ "leg_l", "leg_r" ],
+        "coverage": 95,
+        "encumbrance": [ 6 ],
+        "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
+        "layers": [ "BELTED" ]
+      }
+    ]
   },
   {
     "id": "grass_cloak",
@@ -1641,7 +1650,16 @@
     "warmth": 10,
     "material_thickness": 0.4,
     "flags": [ "OVERSIZE", "BELTED" ],
-    "armor": [ { "encumbrance": 4, "coverage": 65, "covers": [ "torso", "leg_l", "leg_r" ] } ]
+    "armor": [
+      { "encumbrance": 4, "coverage": 65, "covers": [ "torso" ] },
+      {
+        "covers": [ "leg_l", "leg_r" ],
+        "coverage": 65,
+        "encumbrance": [ 4 ],
+        "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
+        "layers": [ "BELTED" ]
+      }
+    ]
   },
   {
     "id": "cloak",
@@ -1661,7 +1679,16 @@
     "material_thickness": 0.4,
     "environmental_protection": 3,
     "flags": [ "OVERSIZE", "HOOD", "BELTED" ],
-    "armor": [ { "encumbrance": 4, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ] } ]
+    "armor": [
+      { "encumbrance": 4, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r" ] },
+      {
+        "covers": [ "leg_l", "leg_r" ],
+        "coverage": 65,
+        "encumbrance": [ 4 ],
+        "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
+        "layers": [ "BELTED" ]
+      }
+    ]
   },
   {
     "id": "cloak_denim",
@@ -1679,7 +1706,16 @@
     "symbol": "[",
     "color": "light_blue",
     "flags": [ "OVERSIZE", "HOOD", "BELTED", "STURDY" ],
-    "armor": [ { "encumbrance": 8, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ] } ],
+    "armor": [
+      { "encumbrance": 8, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r" ] },
+      {
+        "covers": [ "leg_l", "leg_r" ],
+        "coverage": 65,
+        "encumbrance": [ 8 ],
+        "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
+        "layers": [ "BELTED" ]
+      }
+    ],
     "warmth": 50,
     "material_thickness": 1.1
   },
@@ -1701,7 +1737,16 @@
     "material_thickness": 0.2,
     "environmental_protection": 1,
     "flags": [ "OVERSIZE", "HOOD", "BELTED" ],
-    "armor": [ { "encumbrance": 2, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ] } ],
+    "armor": [
+      { "encumbrance": 2, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r" ] },
+      {
+        "covers": [ "leg_l", "leg_r" ],
+        "coverage": 65,
+        "encumbrance": [ 2 ],
+        "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
+        "layers": [ "BELTED" ]
+      }
+    ],
     "use_action": {
       "type": "transform",
       "msg": "Your cloak is now bathed in blood.",
@@ -1740,7 +1785,16 @@
     "warmth": 8,
     "material_thickness": 0.1,
     "flags": [ "OVERSIZE", "BELTED" ],
-    "armor": [ { "encumbrance": 2, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ] } ]
+    "armor": [
+      { "encumbrance": 2, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r" ] },
+      {
+        "covers": [ "leg_l", "leg_r" ],
+        "coverage": 65,
+        "encumbrance": [ 2 ],
+        "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
+        "layers": [ "BELTED" ]
+      }
+    ]
   },
   {
     "id": "cloak_fur",
@@ -1760,7 +1814,16 @@
     "material_thickness": 0.6,
     "environmental_protection": 3,
     "flags": [ "OVERSIZE", "HOOD", "BELTED", "RAINPROOF" ],
-    "armor": [ { "encumbrance": 6, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ] } ]
+    "armor": [
+      { "encumbrance": 6, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r" ] },
+      {
+        "covers": [ "leg_l", "leg_r" ],
+        "coverage": 65,
+        "encumbrance": [ 6 ],
+        "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
+        "layers": [ "BELTED" ]
+      }
+    ]
   },
   {
     "id": "cloak_leather",
@@ -1780,7 +1843,16 @@
     "material_thickness": 1.5,
     "environmental_protection": 3,
     "flags": [ "OVERSIZE", "HOOD", "BELTED", "RAINPROOF" ],
-    "armor": [ { "encumbrance": 6, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ] } ]
+    "armor": [
+      { "encumbrance": 6, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r" ] },
+      {
+        "covers": [ "leg_l", "leg_r" ],
+        "coverage": 65,
+        "encumbrance": [ 6 ],
+        "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
+        "layers": [ "BELTED" ]
+      }
+    ]
   },
   {
     "id": "cloak_wool",
@@ -1800,7 +1872,16 @@
     "material_thickness": 0.5,
     "environmental_protection": 3,
     "flags": [ "OVERSIZE", "HOOD", "BELTED" ],
-    "armor": [ { "encumbrance": 5, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ] } ]
+    "armor": [
+      { "encumbrance": 5, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r" ] },
+      {
+        "covers": [ "leg_l", "leg_r" ],
+        "coverage": 65,
+        "encumbrance": [ 5 ],
+        "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
+        "layers": [ "BELTED" ]
+      }
+    ]
   },
   {
     "id": "jedi_cloak",
@@ -1821,10 +1902,13 @@
     "environmental_protection": 5,
     "flags": [ "OVERSIZE", "BELTED" ],
     "armor": [
+      { "encumbrance": 3, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r", "head", "hand_l", "hand_r" ] },
       {
-        "encumbrance": 3,
+        "covers": [ "leg_l", "leg_r" ],
         "coverage": 65,
-        "covers": [ "leg_r", "leg_l", "torso", "arm_l", "arm_r", "head", "hand_l", "hand_r" ]
+        "encumbrance": [ 3 ],
+        "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
+        "layers": [ "BELTED" ]
       }
     ]
   },
@@ -1855,7 +1939,16 @@
       "need_charges_msg": "You don't have enough UPS charges to turn on the %s"
     },
     "flags": [ "USE_UPS", "OVERSIZE", "HOOD", "BELTED", "SOFT", "NO_REPAIR" ],
-    "armor": [ { "encumbrance": 50, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ] } ]
+    "armor": [
+      { "encumbrance": 50, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r" ] },
+      {
+        "covers": [ "leg_l", "leg_r" ],
+        "coverage": 65,
+        "encumbrance": [ 50 ],
+        "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
+        "layers": [ "BELTED" ]
+      }
+    ]
   },
   {
     "id": "optical_cloak_on",
@@ -1879,7 +1972,7 @@
     "id": "poncho",
     "type": "ARMOR",
     "name": { "str": "wool poncho" },
-    "description": "A simple wool garment worn over the torso.",
+    "description": "A simple wool garment worn over the torso and upper arms.",
     "weight": "907 g",
     "volume": "1250 ml",
     "price": 12000,
@@ -1893,7 +1986,23 @@
     "material_thickness": 1,
     "environmental_protection": 1,
     "flags": [ "BELTED", "OVERSIZE" ],
-    "armor": [ { "encumbrance": 5, "coverage": 85, "covers": [ "torso" ] } ]
+    "armor": [
+      { "encumbrance": 5, "coverage": 85, "covers": [ "torso" ] },
+      {
+        "covers": [ "arm_l", "arm_r" ],
+        "coverage": 100,
+        "encumbrance": [ 5 ],
+        "specifically_covers": [ "arm_shoulder_l", "arm_shoulder_r" ],
+        "layers": [ "BELTED" ]
+      },
+      {
+        "covers": [ "arm_l", "arm_r" ],
+        "coverage": 85,
+        "encumbrance": [ 5 ],
+        "specifically_covers": [ "arm_upper_r", "arm_upper_l" ],
+        "layers": [ "BELTED" ]
+      }
+    ]
   },
   {
     "id": "poncho_makeshift",
@@ -1913,6 +2022,61 @@
     "environmental_protection": 1,
     "material_thickness": 0.1,
     "armor": [ { "coverage": 90, "covers": [ "torso" ] } ]
+  },
+  {
+    "id": "folding_poncho",
+    "type": "ARMOR",
+    "category": "clothing",
+    "symbol": "[",
+    "color": "white",
+    "name": { "str": "rain poncho" },
+    "description": "A lightweight transparent plastic rain poncho with a hood.  It folds into a very compact form when not in use.",
+    "price": 5000,
+    "price_postapoc": 50,
+    "material": [ "vinyl" ],
+    "weight": "280 g",
+    "volume": "250 ml",
+    "flags": [ "RAINPROOF", "HOOD", "OVERSIZE", "BELTED", "TRANSPARENT" ],
+    "environmental_protection": 1,
+    "material_thickness": 0.1,
+    "variant_type": "generic",
+    "armor": [
+      { "covers": [ "torso" ], "specifically_covers": [ "torso_upper", "torso_lower" ], "coverage": 100 },
+      {
+        "covers": [ "arm_l", "arm_r" ],
+        "specifically_covers": [ "arm_shoulder_l", "arm_shoulder_r", "arm_upper_r", "arm_upper_l", "arm_elbow_r", "arm_elbow_l" ],
+        "coverage": 100
+      },
+      { "covers": [ "arm_l", "arm_r" ], "specifically_covers": [ "arm_lower_l", "arm_lower_r" ], "coverage": 90 }
+    ]
+  },
+  {
+    "id": "coat_straw",
+    "type": "ARMOR",
+    "name": { "str": "straw cape" },
+    "description": "A bulky traditional Japanese raincoat made from straw, which covers the entire body.  Also known as mino.",
+    "weight": "907 g",
+    "volume": "4 L",
+    "price": 9000,
+    "price_postapoc": 25,
+    "material": [ "dry_plant" ],
+    "symbol": "[",
+    "looks_like": "coat_winter",
+    "color": "yellow",
+    "armor": [
+      { "covers": [ "torso" ], "specifically_covers": [ "torso_upper" ], "coverage": 80, "encumbrance": 12 },
+      { "covers": [ "torso" ], "specifically_covers": [ "torso_lower" ], "coverage": 100 },
+      {
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_knee_r", "leg_knee_l", "leg_hip_r", "leg_hip_l" ],
+        "coverage": 100
+      },
+      { "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_lower_l", "leg_lower_r" ], "coverage": 10 },
+      { "covers": [ "arm_l", "arm_r" ], "coverage": 40, "encumbrance": 2 }
+    ],
+    "warmth": 15,
+    "material_thickness": 2,
+    "flags": [ "OVERSIZE", "RAINPROOF", "BELTED" ]
   },
   {
     "id": "snuggie",

--- a/data/json/items/armor/coats.json
+++ b/data/json/items/armor/coats.json
@@ -307,7 +307,7 @@
     "volume": "1750 ml",
     "price": 7900,
     "price_postapoc": 50,
-    "material": [ "vinyl", "cotton" ],
+    "material": [ { "type": "vinyl", "covered_by_mat": 100, "thickness": 0.4 } ],
     "symbol": "[",
     "looks_like": "coat_winter",
     "color": "yellow",
@@ -337,64 +337,8 @@
       }
     ],
     "warmth": 10,
-    "material_thickness": 0.2,
     "environmental_protection": 3,
     "flags": [ "VARSIZE", "POCKETS", "RAINPROOF", "HOOD", "OUTER" ]
-  },
-  {
-    "id": "folding_poncho",
-    "type": "ARMOR",
-    "category": "clothing",
-    "symbol": "[",
-    "color": "white",
-    "name": { "str": "rain poncho" },
-    "description": "A lightweight transparent plastic rain poncho with a hood.  It folds into a very compact form when not in use.",
-    "price": 5000,
-    "price_postapoc": 50,
-    "material": [ "vinyl" ],
-    "weight": "280 g",
-    "volume": "250 ml",
-    "flags": [ "RAINPROOF", "HOOD", "OVERSIZE", "BELTED", "TRANSPARENT" ],
-    "environmental_protection": 1,
-    "material_thickness": 0.1,
-    "variant_type": "generic",
-    "armor": [
-      { "covers": [ "torso" ], "specifically_covers": [ "torso_upper", "torso_lower" ], "coverage": 100 },
-      {
-        "covers": [ "arm_l", "arm_r" ],
-        "specifically_covers": [ "arm_shoulder_l", "arm_shoulder_r", "arm_upper_r", "arm_upper_l", "arm_elbow_r", "arm_elbow_l" ],
-        "coverage": 100
-      },
-      { "covers": [ "arm_l", "arm_r" ], "specifically_covers": [ "arm_lower_l", "arm_lower_r" ], "coverage": 90 }
-    ]
-  },
-  {
-    "id": "coat_straw",
-    "type": "ARMOR",
-    "name": { "str": "straw cape" },
-    "description": "A bulky traditional Japanese raincoat made from straw, which covers the entire body.  Also known as mino.",
-    "weight": "907 g",
-    "volume": "4 L",
-    "price": 9000,
-    "price_postapoc": 25,
-    "material": [ "dry_plant" ],
-    "symbol": "[",
-    "looks_like": "coat_winter",
-    "color": "yellow",
-    "armor": [
-      { "covers": [ "torso" ], "specifically_covers": [ "torso_upper" ], "coverage": 80, "encumbrance": 12 },
-      { "covers": [ "torso" ], "specifically_covers": [ "torso_lower" ], "coverage": 100 },
-      {
-        "covers": [ "leg_l", "leg_r" ],
-        "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_knee_r", "leg_knee_l", "leg_hip_r", "leg_hip_l" ],
-        "coverage": 100
-      },
-      { "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_lower_l", "leg_lower_r" ], "coverage": 10 },
-      { "covers": [ "arm_l", "arm_r" ], "coverage": 40, "encumbrance": 2 }
-    ],
-    "warmth": 15,
-    "material_thickness": 2,
-    "flags": [ "OVERSIZE", "RAINPROOF", "BELTED" ]
   },
   {
     "id": "coat_gut",
@@ -1171,7 +1115,10 @@
     "volume": "2250 ml",
     "price": 1000,
     "price_postapoc": 50,
-    "material": [ "vinyl", "nylon" ],
+    "material": [
+      { "type": "nylon", "covered_by_mat": 100, "thickness": 0.2 },
+      { "type": "vinyl", "covered_by_mat": 80, "thickness": 0.5 }
+    ],
     "symbol": "[",
     "looks_like": "jacket_leather",
     "color": "cyan",

--- a/data/json/items/armor/coats.json
+++ b/data/json/items/armor/coats.json
@@ -307,7 +307,6 @@
     "volume": "1750 ml",
     "price": 7900,
     "price_postapoc": 50,
-    "material": [ { "type": "vinyl", "covered_by_mat": 100, "thickness": 0.4 } ],
     "symbol": "[",
     "looks_like": "coat_winter",
     "color": "yellow",
@@ -316,9 +315,21 @@
         "covers": [ "torso" ],
         "specifically_covers": [ "torso_upper", "torso_lower" ],
         "coverage": 100,
-        "encumbrance": [ 7, 15 ]
+        "encumbrance": [ 7, 15 ],
+        "material": [
+          { "type": "vinyl", "covered_by_mat": 100, "thickness": 0.3 },
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.1 }
+        ]
       },
-      { "covers": [ "arm_l", "arm_r" ], "coverage": 100, "encumbrance": [ 7, 7 ] }
+      {
+        "covers": [ "arm_l", "arm_r" ],
+        "coverage": 100,
+        "encumbrance": [ 7, 7 ],
+        "material": [
+          { "type": "vinyl", "covered_by_mat": 100, "thickness": 0.3 },
+          { "type": "vinyl", "covered_by_mat": 100, "thickness": 0.1 }
+        ]
+      }
     ],
     "pocket_data": [
       {
@@ -875,7 +886,7 @@
     "warmth": 20,
     "material_thickness": 0.8,
     "environmental_protection": 1,
-    "flags": [ "OUTER", "OVERSIZE" ]
+    "flags": [ "OUTER" ]
   },
   {
     "id": "jacket_army",
@@ -1115,16 +1126,28 @@
     "volume": "2250 ml",
     "price": 1000,
     "price_postapoc": 50,
-    "material": [
-      { "type": "nylon", "covered_by_mat": 100, "thickness": 0.2 },
-      { "type": "vinyl", "covered_by_mat": 80, "thickness": 0.5 }
-    ],
     "symbol": "[",
     "looks_like": "jacket_leather",
     "color": "cyan",
     "armor": [
-      { "covers": [ "torso" ], "coverage": 100, "encumbrance": [ 13, 15 ] },
-      { "covers": [ "arm_l", "arm_r" ], "coverage": 100, "encumbrance": [ 13, 13 ] }
+      {
+        "covers": [ "torso" ],
+        "coverage": 100,
+        "encumbrance": [ 13, 15 ],
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.1 },
+          { "type": "vinyl", "covered_by_mat": 60, "thickness": 0.2 }
+        ]
+      },
+      {
+        "covers": [ "arm_l", "arm_r" ],
+        "coverage": 100,
+        "encumbrance": [ 13, 13 ],
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.1 },
+          { "type": "vinyl", "covered_by_mat": 60, "thickness": 0.2 }
+        ]
+      }
     ],
     "pocket_data": [
       {
@@ -2187,7 +2210,7 @@
     ],
     "warmth": 8,
     "material_thickness": 0.1,
-    "flags": [ "OVERSIZE", "OUTER", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "UNRESTRICTED", "OUTER", "ALLOWS_NATURAL_ATTACKS" ]
   },
   {
     "id": "ghost_robe_sheet",
@@ -2268,7 +2291,7 @@
     },
     "warmth": 10,
     "material_thickness": 0.1,
-    "flags": [ "OVERSIZE", "OUTER", "ALLOWS_NATURAL_ATTACKS" ]
+    "flags": [ "UNRESTRICTED", "OUTER", "ALLOWS_NATURAL_ATTACKS" ]
   },
   {
     "id": "grim_reaper_robe_faceless",

--- a/data/json/items/armor/coats.json
+++ b/data/json/items/armor/coats.json
@@ -327,7 +327,7 @@
         "encumbrance": [ 7, 7 ],
         "material": [
           { "type": "vinyl", "covered_by_mat": 100, "thickness": 0.3 },
-          { "type": "vinyl", "covered_by_mat": 100, "thickness": 0.1 }
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.1 }
         ]
       }
     ],
@@ -1135,8 +1135,8 @@
         "coverage": 100,
         "encumbrance": [ 13, 15 ],
         "material": [
-          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.1 },
-          { "type": "vinyl", "covered_by_mat": 60, "thickness": 0.2 }
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.25 },
+          { "type": "vinyl", "covered_by_mat": 60, "thickness": 0.3 }
         ]
       },
       {
@@ -1144,8 +1144,8 @@
         "coverage": 100,
         "encumbrance": [ 13, 13 ],
         "material": [
-          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.1 },
-          { "type": "vinyl", "covered_by_mat": 60, "thickness": 0.2 }
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.25 },
+          { "type": "vinyl", "covered_by_mat": 60, "thickness": 0.3 }
         ]
       }
     ],
@@ -2527,7 +2527,8 @@
     "looks_like": "coat_winter",
     "color": "light_blue",
     "armor": [
-      { "covers": [ "torso" ], "coverage": 100, "encumbrance": [ 15, 22 ] },
+      { "covers": [ "torso" ], "coverage": 100, "encumbrance": [ 15, 22 ], "material": [ { "type": "cotton", "covered_by_mat": 100, "thickness": 1.2 },
+      { "type": "nylon", "covered_by_mat": 100, "thickness": 0.3 } ] },
       { "covers": [ "arm_l", "arm_r" ], "coverage": 100, "encumbrance": [ 15, 15 ] }
     ],
     "pocket_data": [
@@ -2561,7 +2562,6 @@
       }
     ],
     "warmth": 80,
-    "material_thickness": 2,
     "environmental_protection": 3,
     "flags": [ "VARSIZE", "POCKETS", "HOOD", "COLLAR", "OUTER", "SOFT" ]
   },

--- a/data/json/items/armor/coats.json
+++ b/data/json/items/armor/coats.json
@@ -44,7 +44,7 @@
     "warmth": 30,
     "material_thickness": 2,
     "environmental_protection": 6,
-    "flags": [ "VARSIZE", "POCKETS", "STURDY", "WATERPROOF", "RAINPROOF", "OUTER" ]
+    "flags": [ "VARSIZE", "POCKETS", "STURDY", "RAINPROOF", "OUTER" ]
   },
   {
     "id": "cassock",
@@ -302,12 +302,12 @@
     "id": "coat_rain",
     "type": "ARMOR",
     "name": { "str": "rain coat" },
-    "description": "A plastic coat with a hood and two very large pockets, meant to provide protection from rain.",
+    "description": "A vinyl coat with a hood and two very large pockets, meant to provide protection from rain.",
     "weight": "960 g",
     "volume": "1750 ml",
     "price": 7900,
     "price_postapoc": 50,
-    "material": [ "plastic", "cotton" ],
+    "material": [ "vinyl", "cotton" ],
     "symbol": "[",
     "looks_like": "coat_winter",
     "color": "yellow",
@@ -339,7 +339,7 @@
     "warmth": 10,
     "material_thickness": 0.2,
     "environmental_protection": 3,
-    "flags": [ "VARSIZE", "POCKETS", "WATERPROOF", "RAINPROOF", "HOOD", "OUTER", "SOFT" ]
+    "flags": [ "VARSIZE", "POCKETS", "RAINPROOF", "HOOD", "OUTER" ]
   },
   {
     "id": "folding_poncho",
@@ -351,10 +351,10 @@
     "description": "A lightweight transparent plastic rain poncho with a hood.  It folds into a very compact form when not in use.",
     "price": 5000,
     "price_postapoc": 50,
-    "material": [ "plastic" ],
+    "material": [ "vinyl" ],
     "weight": "280 g",
     "volume": "250 ml",
-    "flags": [ "WATERPROOF", "RAINPROOF", "HOOD", "OVERSIZE", "OUTER", "SOFT", "TRANSPARENT" ],
+    "flags": [ "RAINPROOF", "HOOD", "OVERSIZE", "BELTED", "TRANSPARENT" ],
     "environmental_protection": 1,
     "material_thickness": 0.1,
     "variant_type": "generic",
@@ -394,7 +394,7 @@
     ],
     "warmth": 15,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "WATERPROOF", "OUTER" ]
+    "flags": [ "OVERSIZE", "RAINPROOF", "BELTED" ]
   },
   {
     "id": "coat_gut",
@@ -412,7 +412,7 @@
     "warmth": 10,
     "material_thickness": 0.2,
     "environmental_protection": 3,
-    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "HOOD", "OUTER" ],
+    "flags": [ "VARSIZE", "RAINPROOF", "HOOD", "OUTER" ],
     "armor": [
       { "covers": [ "torso" ], "specifically_covers": [ "torso_upper", "torso_lower" ], "coverage": 100, "encumbrance": 12 },
       {
@@ -548,7 +548,7 @@
     "warmth": 15,
     "material_thickness": 1.5,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "WATERPROOF", "RAINPROOF" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "RAINPROOF" ]
   },
   {
     "id": "duster_fur",
@@ -622,7 +622,7 @@
     "warmth": 50,
     "material_thickness": 3,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "WATERPROOF", "RAINPROOF" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "RAINPROOF" ]
   },
   {
     "id": "xl_duster_fur",
@@ -755,7 +755,7 @@
     "warmth": 30,
     "material_thickness": 1.5,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "WATERPROOF", "RAINPROOF" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "RAINPROOF" ]
   },
   {
     "id": "xl_duster_leather",
@@ -996,7 +996,7 @@
     ],
     "warmth": 20,
     "material_thickness": 0.3,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "SOFT" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER" ]
   },
   {
     "id": "jacket_army_modern",
@@ -1171,7 +1171,7 @@
     "volume": "2250 ml",
     "price": 1000,
     "price_postapoc": 50,
-    "material": [ "plastic", "cotton" ],
+    "material": [ "vinyl", "nylon" ],
     "symbol": "[",
     "looks_like": "jacket_leather",
     "color": "cyan",
@@ -1197,7 +1197,7 @@
     ],
     "warmth": 25,
     "material_thickness": 0.15,
-    "flags": [ "POCKETS", "HOOD", "OUTER", "WATERPROOF", "RAINPROOF", "SOFT" ]
+    "flags": [ "POCKETS", "HOOD", "OUTER", "RAINPROOF" ]
   },
   {
     "id": "jacket_flannel",
@@ -1530,7 +1530,7 @@
     "warmth": 15,
     "material_thickness": 0.8,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "SOFT" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER" ]
   },
   {
     "id": "jacket_light",
@@ -1612,7 +1612,7 @@
     "warmth": 10,
     "material_thickness": 0.25,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "POCKETS", "HOOD", "OUTER", "WATERPROOF", "RAINPROOF" ]
+    "flags": [ "VARSIZE", "POCKETS", "HOOD", "OUTER", "RAINPROOF" ]
   },
   {
     "id": "jacket_varsity",
@@ -2552,7 +2552,7 @@
     "volume": "5 L",
     "price": 18000,
     "price_postapoc": 500,
-    "material": [ "cotton", "plastic" ],
+    "material": [ "nylon", "cotton" ],
     "symbol": "[",
     "looks_like": "coat_winter",
     "color": "light_blue",
@@ -2673,7 +2673,7 @@
     "warmth": 15,
     "material_thickness": 1.5,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "WATERPROOF", "RAINPROOF" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "RAINPROOF" ]
   },
   {
     "id": "sleeveless_duster_fur",
@@ -2753,7 +2753,7 @@
     "warmth": 50,
     "material_thickness": 3,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "WATERPROOF", "RAINPROOF" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "RAINPROOF" ]
   },
   {
     "id": "sleeveless_duster_faux_fur",
@@ -2843,7 +2843,7 @@
     "warmth": 30,
     "material_thickness": 1.5,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "WATERPROOF", "RAINPROOF" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "RAINPROOF" ]
   },
   {
     "id": "sleeveless_trenchcoat",
@@ -2871,7 +2871,7 @@
     "warmth": 15,
     "material_thickness": 1.5,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "WATERPROOF", "RAINPROOF" ],
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "RAINPROOF" ],
     "armor": [
       { "covers": [ "torso" ], "coverage": 100, "encumbrance": [ 7, 15 ] },
       {
@@ -3096,7 +3096,7 @@
     "warmth": 15,
     "material_thickness": 1.5,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "WATERPROOF", "RAINPROOF" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "RAINPROOF" ]
   },
   {
     "id": "trenchcoat_fur",
@@ -3431,7 +3431,7 @@
     ],
     "warmth": 50,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "POCKETS", "HOOD", "OUTER", "WATERPROOF", "SOFT" ]
+    "flags": [ "VARSIZE", "POCKETS", "HOOD", "OUTER" ]
   },
   {
     "id": "trenchcoat_steampunk",
@@ -3579,7 +3579,7 @@
     ],
     "warmth": 15,
     "material_thickness": 0.5,
-    "flags": [ "VARSIZE", "POCKETS", "WATERPROOF", "HOOD", "OUTER" ],
+    "flags": [ "VARSIZE", "POCKETS", "RAINPROOF", "HOOD", "OUTER" ],
     "variant_type": "generic",
     "variants": [
       {

--- a/data/json/items/armor/coats.json
+++ b/data/json/items/armor/coats.json
@@ -2527,8 +2527,15 @@
     "looks_like": "coat_winter",
     "color": "light_blue",
     "armor": [
-      { "covers": [ "torso" ], "coverage": 100, "encumbrance": [ 15, 22 ], "material": [ { "type": "cotton", "covered_by_mat": 100, "thickness": 1.2 },
-      { "type": "nylon", "covered_by_mat": 100, "thickness": 0.3 } ] },
+      {
+        "covers": [ "torso" ],
+        "coverage": 100,
+        "encumbrance": [ 15, 22 ],
+        "material": [
+          { "type": "cotton", "covered_by_mat": 100, "thickness": 1.2 },
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.3 }
+        ]
+      },
       { "covers": [ "arm_l", "arm_r" ], "coverage": 100, "encumbrance": [ 15, 15 ] }
     ],
     "pocket_data": [

--- a/data/json/items/armor/hoods.json
+++ b/data/json/items/armor/hoods.json
@@ -193,14 +193,14 @@
     "volume": "750 ml",
     "price": 2000,
     "price_postapoc": 250,
-    "material": [ "plastic", "cotton" ],
+    "material": [ "vinyl" ],
     "symbol": "[",
     "looks_like": "hat_cotton",
     "color": "yellow",
     "warmth": 8,
     "material_thickness": 0.3,
     "environmental_protection": 2,
-    "flags": [ "WATERPROOF", "OUTER", "SOFT" ],
+    "flags": [ "RAINPROOF", "OUTER" ],
     "armor": [ { "encumbrance_modifiers": [ "NONE" ], "coverage": 100, "covers": [ "head" ] } ]
   },
   {
@@ -239,7 +239,7 @@
     "warmth": 10,
     "material_thickness": 0.1,
     "environmental_protection": 1,
-    "flags": [ "WATERPROOF", "RAINPROOF", "OUTER" ],
+    "flags": [ "RAINPROOF", "OUTER" ],
     "armor": [ { "encumbrance_modifiers": [ "NONE" ], "coverage": 95, "covers": [ "head" ] } ]
   },
   {

--- a/data/json/items/armor/hoods.json
+++ b/data/json/items/armor/hoods.json
@@ -193,7 +193,7 @@
     "volume": "750 ml",
     "price": 2000,
     "price_postapoc": 250,
-    "material": [ "vinyl" ],
+    "material": [ { "type": "vinyl", "covered_by_mat": 100, "thickness": 0.4 } ],
     "symbol": "[",
     "looks_like": "hat_cotton",
     "color": "yellow",

--- a/data/json/items/armor/hoods.json
+++ b/data/json/items/armor/hoods.json
@@ -193,7 +193,7 @@
     "volume": "750 ml",
     "price": 2000,
     "price_postapoc": 250,
-    "material": [ { "type": "vinyl", "covered_by_mat": 100, "thickness": 0.4 } ],
+    "material": [ "vinyl" ],
     "symbol": "[",
     "looks_like": "hat_cotton",
     "color": "yellow",

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -700,12 +700,19 @@
     "use_action": [ "DIRECTIONAL_HOLOGRAM" ],
     "flags": [ "OVERSIZE", "HOOD", "WATERPROOF", "BELTED", "SOFT" ],
     "armor": [
-      { "encumbrance": 10, "coverage": 70, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ] },
+      { "encumbrance": 10, "coverage": 70, "covers": [ "torso", "arm_l", "arm_r" ] },
       {
+        "covers": [ "head" ],
         "encumbrance": 10,
         "coverage": 100,
-        "covers": [ "head" ],
         "specifically_covers": [ "head_crown", "head_forehead", "head_nape" ]
+      },
+      {
+        "covers": [ "leg_l", "leg_r" ],
+        "coverage": 70,
+        "encumbrance": 10,
+        "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
+        "layers": [ "BELTED" ]
       }
     ]
   },

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -698,7 +698,7 @@
     "material_thickness": 0.5,
     "environmental_protection": 2,
     "use_action": [ "DIRECTIONAL_HOLOGRAM" ],
-    "flags": [ "OVERSIZE", "HOOD", "WATERPROOF", "OUTER", "SOFT" ],
+    "flags": [ "OVERSIZE", "HOOD", "WATERPROOF", "BELTED", "SOFT" ],
     "armor": [
       { "encumbrance": 10, "coverage": 70, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ] },
       {

--- a/data/mods/Magiclysm/items/enchanted_cloaks.json
+++ b/data/mods/Magiclysm/items/enchanted_cloaks.json
@@ -18,7 +18,7 @@
     "symbol": "w",
     "color": "blue",
     "material": [ "magical_material" ],
-    "flags": [ "OUTER", "OVERSIZE", "NONCONDUCTIVE", "WATER_FRIENDLY", "RAINPROOF" ],
+    "flags": [ "BELTED", "OVERSIZE", "NONCONDUCTIVE", "WATER_FRIENDLY", "RAINPROOF" ],
     "relic_data": { "passive_effects": [ { "id": "ench_fishform" } ] },
     "armor": [ { "encumbrance": 0, "coverage": 0, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ] } ]
   },
@@ -55,7 +55,7 @@
     "symbol": "w",
     "color": "brown",
     "material": [ "magical_material" ],
-    "flags": [ "OUTER", "OVERSIZE", "NONCONDUCTIVE", "WATER_FRIENDLY", "RAINPROOF" ],
+    "flags": [ "BELTED", "OVERSIZE", "NONCONDUCTIVE", "WATER_FRIENDLY", "RAINPROOF" ],
     "relic_data": { "passive_effects": [ { "id": "ench_bearform" } ] },
     "armor": [ { "encumbrance": 0, "coverage": 0, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ] } ]
   },
@@ -90,7 +90,7 @@
     "symbol": "w",
     "color": "green",
     "material": [ "magical_material" ],
-    "flags": [ "OUTER", "OVERSIZE", "NONCONDUCTIVE", "WATER_FRIENDLY", "RAINPROOF" ],
+    "flags": [ "BELTED", "OVERSIZE", "NONCONDUCTIVE", "WATER_FRIENDLY", "RAINPROOF" ],
     "relic_data": { "passive_effects": [ { "id": "ench_deerform" } ] },
     "armor": [ { "encumbrance": 0, "coverage": 0, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ] } ]
   }

--- a/data/mods/TEST_DATA/known_bad_density.json
+++ b/data/mods/TEST_DATA/known_bad_density.json
@@ -219,7 +219,6 @@
       "nailgun",
       "cocaine_topical",
       "feces_dog",
-      "folding_poncho",
       "tortilla_corn",
       "broken_gasbomb_hack",
       "meal_bone_tainted",

--- a/data/mods/Xedra_Evolved/items/armor/armor.json
+++ b/data/mods/Xedra_Evolved/items/armor/armor.json
@@ -134,7 +134,7 @@
     "price_postapoc": 2750,
     "material": [ "fae_fur" ],
     "color": "brown_red",
-    "flags": [ "OVERSIZE", "HOOD", "OUTER", "WATERPROOF", "RAINPROOF", "FANCY" ],
+    "flags": [ "OVERSIZE", "HOOD", "BELTED", "RAINPROOF", "FANCY" ],
     "armor": [ { "encumbrance": 6, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ] } ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Ponchos are BELTED and OVERSIZE, like cloaks. Updates materials and removes WATERPROOF from some outerwear"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
#65629 moved cloaks to the BELTED layer, which makes sense, as they are sleeveless and worn over other stuff. Ponchos and a few cape-type items were left out, which is likely unintentional as they're all sorta the same thing.

While working on this, I noticed a lot of inconsistencies and leftover old stuff in jsons, as well as some materials that could use updating now that the world isn't made entirely out of plastic and cotton.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
- All cloaks, ponchos, capes, and anything like that are BELTED and OVERSIZE. This means they fit everybody except mice and can be worn over armor. If something has sleeves or fits very close to the body, it does not get this treatment.
- All of the above which reach the legs now use the leg_draped bodyparts, so that characters can comfortably wear scabbards and holsters under cloaks, as with dusters.
- Removed WATERPROOF from all coats and ponchos. This was applied a long time ago and was no longer appropriate, as it provides complete immunity from wetness even if you're underwater, which is obviously not true of a trenchcoat.
- Added RAINPROOF in cases where the item had WATERPROOF and was clearly meant to be resistant to rain. I think this might not be necessary in some cases thanks to materials, but better safe than sorry for now.
- Changed nearly all SOFT items in outerwear.json, hoods.json, and cloaks.json which were made of plastic to vinyl and removed the SOFT flag. I did not do this with the optical cloak, as it has a bunch of embedded cameras and stuff and may be better represented some other way. Also removed SOFT from some items which did not need it because they were already made of soft materials.
- Swapped some materials over e.g. cotton to nylon in a few cases where this was due for an update.
- Gave the wool poncho some upper arm coverage.
- Rain coats now have a tiny bit of protection due to their materials, which I tried to pin to real-life raincoats - https://www.tasco-safety.com/products/pvc-industrial-rain-coats-35-mil-all-sizes.html is 3.5mm, I made ours 3mm because not every raincoat is this heavy-duty. This will help with the acid updates in #71584
- Emergency jackets also have a tiny bit of protection. They're slightly thinner than standard windbreakers, but have vinyl hi-visibility markers on them. It's still a really bad idea to wear one, but they do _something_ now.
- Also updated the rain hood and gutskin hood, and updated the Magiclysm and XEDRA evolved cloaks.
- Moved the straw cape and folding poncho from coats.json to cloaks.json.
- Changed the snuggie and the halloween robes (except ghost_robe_sheet) from OVERSIZE to UNRESTRICTED. They can be worn by mutants, but not cow-sized guys, because they have sleeves and aren't just a draped piece of cloth.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
I didn't touch pride/nation/state flags. These items are not quite the same thing a a cloak since per the json you're like fully cocooning yourself in it like you would with a blanket.

I need to do some updates to materials, specifically rubber, treated leather, and vinyl, before #71584 drops. That'll be a different PR.

We could stand to add arm_draped bodyparts akin to the leg ones, but that's out of scope for now. Not sure about torso-draped. That would let people wear cloaks over the huge snail shell growing out of their back without penalty. Is that fine?

I didn't touch the Hub-01 Modular Defense System, despite the fact that it's described as a poncho. Its WATERPROOF flag appears to be for its waterproof pockets. Its armor "pockets" are hooks and straps that allow armor pieces to be fitted over it, and those are mostly items which would be most appropriate on the OUTER layer. Switching the whole kit and kaboodle to BELTED would allow you to wear a full suit of heavy plate armor under it (lol no). Switching just the MDS to BELTED and leaving the pieces as OUTER wouldn't appropriately represent the item as described either, as as far as I can tell, it fits _over_ the poncho, not under. Those items have weight and would hold the garment to the body, so it makes sense as it is.

#### Testing

- [x] Checked the following items for mutation compatibility, holster compatibility:
Hologram Cloak, Jedi Cloak, Denim Cloak, Cloak, Leather Cloak, Sinister Cloak, Dark Cloak, Fur Cloak, Grass Cloak, FB51 Optical Cloak.
- [x] Makeshift Poncho, Rain Poncho, Wool Poncho.
- [x] Check the above items for weird armor or other values.
- [x] Checked the ski jacket, emergency jacket, and rain coat for weird armor values.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
