### PR TITLE
clean up danger mark ui in overmap notes

### DIFF
--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -3196,6 +3196,20 @@ void overmap::mark_note_dangerous( const tripoint_om_omt &p, int radius, bool is
     }
 }
 
+int overmap::note_danger_radius( const tripoint_om_omt &p ) const
+{
+    if( p.z() < -OVERMAP_DEPTH || p.z() > OVERMAP_HEIGHT ) {
+        return -1;
+    }
+
+    const auto &notes = layer[p.z() + OVERMAP_DEPTH].notes;
+    const auto it = std::find_if( begin( notes ), end( notes ), [&]( const om_note & n ) {
+        return n.p == p.xy();
+    } );
+
+    return ( it != std::end( notes ) ) && it->dangerous ? it->danger_radius : -1;
+}
+
 void overmap::delete_note( const tripoint_om_omt &p )
 {
     add_note( p, std::string{} );

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -245,6 +245,7 @@ class overmap
         void add_note( const tripoint_om_omt &p, std::string message );
         void delete_note( const tripoint_om_omt &p );
         void mark_note_dangerous( const tripoint_om_omt &p, int radius, bool is_dangerous );
+        int note_danger_radius( const tripoint_om_omt &p ) const;
 
         bool has_extra( const tripoint_om_omt &p ) const;
         const map_extra_id &extra( const tripoint_om_omt &p ) const;

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1912,6 +1912,7 @@ static tripoint_abs_omt display( const tripoint_abs_omt &orig,
                         create_note( curs );
                     }
                     const int max_amount = 20;
+                    // NOLINTNEXTLINE(cata-text-style): No need for two whitespaces
                     const std::string popupmsg = _( "Danger radius in overmap squares? (0-20)" );
                     int amount = string_input_popup()
                                  .title( popupmsg )

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -401,29 +401,33 @@ class map_notes_callback : public uilist_callback
                     return true;
                 }
                 if( action == "MARK_DANGER" ) {
-                    if( overmap_buffer.is_marked_dangerous( note_location() ) &&
+                    if( overmap_buffer.note_danger_radius( note_location() ) >= 0 &&
                         query_yn( _( "Remove dangerous mark?" ) ) ) {
                         overmap_buffer.mark_note_dangerous( note_location(), 0, false );
-                    }
-                    // NOLINTNEXTLINE(cata-text-style): No need for two whitespaces
-                    else if( ( overmap_buffer.is_marked_dangerous( note_location() ) &&
-                               query_yn( _( "Edit dangerous mark?" ) ) ) ||
-                             ( !overmap_buffer.is_marked_dangerous( note_location() ) &&
-                               // NOLINTNEXTLINE(cata-text-style): No need for two whitespaces
-                               query_yn( _( "Mark area as dangerous ( to avoid on auto move paths?  This will create a note if none exists already )" ) ) ) ) {
-                        const int max_amount = 20;
-                        // NOLINTNEXTLINE(cata-text-style): No need for two whitespaces
-                        const std::string popupmsg = _( "Danger radius in overmap squares? ( 0-20 )" );
-                        int amount = string_input_popup()
-                                     .title( popupmsg )
-                                     .width( 20 )
-                                     .text( "0" )
-                                     .only_digits( true )
-                                     .query_int();
-                        if( amount > -1 && amount <= max_amount ) {
-                            overmap_buffer.mark_note_dangerous( note_location(), amount, true );
-                            menu->ret = UILIST_MAP_NOTE_EDITED;
-                            return true;
+                    } else {
+                        bool has_mark = overmap_buffer.note_danger_radius( note_location() ) >= 0;
+                        bool has_note = overmap_buffer.has_note( note_location() );
+                        std::string query_text = has_mark ?  _( "Edit dangerous mark?" )  : has_note ?
+                                                 _( "Mark area as dangerous (to avoid on auto move paths)?" ) :
+                                                 _( "Create note and mark area as dangerous (to avoid on auto move paths)?" );
+                        if( query_yn( query_text ) ) {
+                            if( !has_note ) {
+                                create_note( note_location() );
+                            }
+                            const int max_amount = 20;
+                            // NOLINTNEXTLINE(cata-text-style): No need for two whitespaces
+                            const std::string popupmsg = _( "Danger radius in overmap squares? (0-20)" );
+                            int amount = string_input_popup()
+                                         .title( popupmsg )
+                                         .width( 20 )
+                                         .text( "0" )
+                                         .only_digits( true )
+                                         .query_int();
+                            if( amount >= 0 && amount <= max_amount ) {
+                                overmap_buffer.mark_note_dangerous( note_location(), amount, true );
+                                menu->ret = UILIST_MAP_NOTE_EDITED;
+                                return true;
+                            }
                         }
                     }
                 }
@@ -1897,24 +1901,27 @@ static tripoint_abs_omt display( const tripoint_abs_omt &orig,
                 query_yn( _( "Remove dangerous mark?" ) ) ) {
                 overmap_buffer.mark_note_dangerous( curs, 0,
                                                     false );
-            } else if( ( overmap_buffer.is_marked_dangerous( curs ) &&
-                         query_yn( _( "Edit dangerous mark?" ) ) ) || ( !overmap_buffer.is_marked_dangerous( curs ) &&
-                                 // NOLINTNEXTLINE(cata-text-style): No need for two whitespaces
-                                 query_yn( _( "Mark area as dangerous ( to avoid on auto move paths?  This will create a note if none exists already )" ) ) ) ) {
-                if( !overmap_buffer.has_note( curs ) ) {
-                    create_note( curs );
-                }
-                const int max_amount = 20;
-                // NOLINTNEXTLINE(cata-text-style): No need for two whitespaces
-                const std::string popupmsg = _( "Danger radius in overmap squares? ( 0-20 )" );
-                int amount = string_input_popup()
-                             .title( popupmsg )
-                             .width( 20 )
-                             .text( "0" )
-                             .only_digits( true )
-                             .query_int();
-                if( amount > -1 && amount <= max_amount ) {
-                    overmap_buffer.mark_note_dangerous( curs, amount, true );
+            } else {
+                bool has_mark = overmap_buffer.note_danger_radius( curs ) >= 0;
+                bool has_note = overmap_buffer.has_note( curs );
+                std::string query_text = has_mark ?  _( "Edit dangerous mark?" )  : has_note ?
+                                         _( "Mark area as dangerous (to avoid on auto move paths)?" ) :
+                                         _( "Create note and mark area as dangerous (to avoid on auto move paths)?" );
+                if( query_yn( query_text ) ) {
+                    if( !has_note ) {
+                        create_note( curs );
+                    }
+                    const int max_amount = 20;
+                    const std::string popupmsg = _( "Danger radius in overmap squares? (0-20)" );
+                    int amount = string_input_popup()
+                                 .title( popupmsg )
+                                 .width( 20 )
+                                 .text( "0" )
+                                 .only_digits( true )
+                                 .query_int();
+                    if( amount >= 0 && amount <= max_amount ) {
+                        overmap_buffer.mark_note_dangerous( curs, amount, true );
+                    }
                 }
             }
         } else if( action == "LIST_NOTES" ) {

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -387,6 +387,14 @@ const std::string &overmapbuffer::note( const tripoint_abs_omt &p )
     return empty_string;
 }
 
+int overmapbuffer::note_danger_radius( const tripoint_abs_omt &p )
+{
+    if( const overmap_with_local_coords om_loc = get_existing_om_global( p ) ) {
+        return om_loc.om->note_danger_radius( om_loc.local );
+    }
+    return -1;
+}
+
 bool overmapbuffer::has_extra( const tripoint_abs_omt &p )
 {
     if( const overmap_with_local_coords om_loc = get_existing_om_global( p ) ) {

--- a/src/overmapbuffer.h
+++ b/src/overmapbuffer.h
@@ -176,6 +176,7 @@ class overmapbuffer
         bool has_note( const tripoint_abs_omt &p );
         bool is_marked_dangerous( const tripoint_abs_omt &p );
         const std::string &note( const tripoint_abs_omt &p );
+        int note_danger_radius( const tripoint_abs_omt &p );
         void add_note( const tripoint_abs_omt &, const std::string &message );
         void delete_note( const tripoint_abs_omt &p );
         void mark_note_dangerous( const tripoint_abs_omt &p, int radius, bool is_dangerous );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Clean up some confusing and incorrect flows in the "mark danger" overmap UI.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Firstly, this change cleans up some of the strings from the danger mark UI to
have more sensible spacing and simpler language.

Secondly, the UI code was confused about the possibility that a note could be
_inside_ a danger area but _not itself be a danger mark_. This is presumably
because of the confusingly named `is_marked_dangerous` function, which actually
returns whether a given location is within a danger area. (Renaming that
function can be a task for a followup PR :))

For instance, if a note was inside a danger area but not itself dangerous,
pressing <kbd>M</kbd> on it in the note list screen would ask if you wanted to
remove the danger mark (even though there wasn't one). Answering "yes" would
have no effect. With this change, the UI now correctly asks if you want to
_add_ a danger mark.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
