### PR TITLE
Make the ice axe resemble an ice axe instead of a strange hammer

### DIFF
--- a/data/json/items/tool/entry_tools.json
+++ b/data/json/items/tool/entry_tools.json
@@ -63,10 +63,7 @@
     "price": 5000,
     "price_postapoc": 500,
     "to_hit": { "grip": "weapon", "length": "short", "surface": "point", "balance": "neutral" },
-    "material": [
-      "steel",
-      "aluminum"
-    ],
+    "material": [ "steel", "aluminum" ],
     "symbol": ";",
     "color": "dark_gray",
     "techniques": [ "WBLOCK_1" ],

--- a/data/json/items/tool/entry_tools.json
+++ b/data/json/items/tool/entry_tools.json
@@ -56,22 +56,25 @@
     "id": "iceaxe",
     "type": "TOOL",
     "name": { "str": "ice axe" },
-    "description": "An ice axe with a hammer on its head, a multi-purpose hiking and climbing tool used by mountaineers.  It is sturdy enough to pry open closed doors or lift manhole covers.",
+    "description": "An ice axe with a hammer on the other end, a multi-purpose hiking and climbing tool used by mountaineers.  It is sturdy enough to lift manhole covers.",
     "weight": "300 g",
     "volume": "140 ml",
     "longest_side": "50 cm",
     "price": 5000,
     "price_postapoc": 500,
-    "to_hit": { "grip": "weapon", "length": "short", "surface": "point", "balance": "uneven" },
-    "material": [ "steel" ],
+    "to_hit": { "grip": "weapon", "length": "short", "surface": "point", "balance": "neutral" },
+    "material": [
+      "steel",
+      "aluminum"
+    ],
     "symbol": ";",
     "color": "dark_gray",
     "techniques": [ "WBLOCK_1" ],
-    "qualities": [ [ "HAMMER", 2 ], [ "HAMMER_FINE", 1 ], [ "PRY", 2 ] ],
+    "qualities": [ [ "HAMMER", 2 ], [ "HAMMER_FINE", 1 ], [ "PRY", 1 ] ],
     "use_action": [ "CROWBAR" ],
     "flags": [ "DURABLE_MELEE", "BELT_CLIP", "SHEATH_AXE" ],
     "weapon_category": [ "HAND_AXES" ],
-    "melee_damage": { "bash": 20, "cut": 8 }
+    "melee_damage": { "bash": 4, "stab": 15 }
   },
   {
     "id": "makeshift_crowbar",

--- a/data/json/recipes/tools/tools_hand.json
+++ b/data/json/recipes/tools/tools_hand.json
@@ -1506,14 +1506,14 @@
     "time": "240 m",
     "reversible": true,
     "autolearn": true,
-    "using": [ [ "blacksmithing_standard", 4 ], [ "steel_standard", 1 ], [ "material_aluminium_ingot", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 4 ], [ "steel_standard", 1 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },
       { "proficiency": "prof_toolsmithing" }
     ],
     "qualities": [ { "id": "GRIND", "level": 2 } ],
-    "components": [ [ [ "filament", 100, "LIST" ] ], [ [ "cotton_patchwork", 2 ], [ "felt_patch", 2 ], [ "leather", 2 ], [ "fur", 2 ] ] ]
+    "components": [ [ [ "material_aluminium_ingot", 1 ] ], [ [ "filament", 100, "LIST" ] ], [ [ "cotton_patchwork", 2 ], [ "felt_patch", 2 ], [ "leather", 2 ], [ "fur", 2 ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/tools/tools_hand.json
+++ b/data/json/recipes/tools/tools_hand.json
@@ -1506,7 +1506,7 @@
     "time": "240 m",
     "reversible": true,
     "autolearn": true,
-    "using": [ [ "blacksmithing_standard", 4 ], [ "steel_standard", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 4 ], [ "steel_standard", 1 ], [ "material_aluminium_ingot", 1 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },

--- a/data/json/recipes/tools/tools_hand.json
+++ b/data/json/recipes/tools/tools_hand.json
@@ -1513,7 +1513,11 @@
       { "proficiency": "prof_toolsmithing" }
     ],
     "qualities": [ { "id": "GRIND", "level": 2 } ],
-    "components": [ [ [ "material_aluminium_ingot", 1 ] ], [ [ "filament", 100, "LIST" ] ], [ [ "cotton_patchwork", 2 ], [ "felt_patch", 2 ], [ "leather", 2 ], [ "fur", 2 ] ] ]
+    "components": [
+      [ [ "material_aluminium_ingot", 1 ] ],
+      [ [ "filament", 100, "LIST" ] ],
+      [ [ "cotton_patchwork", 2 ], [ "felt_patch", 2 ], [ "leather", 2 ], [ "fur", 2 ] ]
+    ]
   },
   {
     "type": "recipe",

--- a/data/mods/TEST_DATA/expected_dps_data/axes_dps.json
+++ b/data/mods/TEST_DATA/expected_dps_data/axes_dps.json
@@ -8,7 +8,7 @@
     "expected_dps": {
       "hatchet": 18.0,
       "crash_axe": 18.0,
-      "iceaxe": 19.0,
+      "iceaxe": 12.5,
       "throwing_axe": 14.4,
       "carver_on": 22.5,
       "pickaxe": 10.5,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Bring ice axe in line with reality"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

Currently, the ice axe is busted. These are it's stats with 5 in relevant skills and 12 str, It's DPS is higher than combat machetes, maces, and hatchets, and it has a very high vs armoured DPS, thanks to it being bash damage for some reason. Its damage per stam is also the highest I've ever seen, able to clear entire screens of zombies without dropping past half stam. It is very compact, and has excellent utility qualities. The only downside is that it is -2 to hit.

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/12851666/8152d9a9-dcb2-4a5f-86f4-f73f48e252a1)


#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/12851666/54fb0969-ab6c-4643-af5b-e2d10d750a12)

This is roughly what I assume the ice axe is trying to resemble. You wouldn't swing this thing on the hammer side, so it's being changed to pierce damage with some bash. The pry values have been lowered since there's no way you're prying a door with it. The materials are updated to include aluminum since ice axes often use that and are very light. The to_hit has been increased by one by giving a neutral balance to bring it in line with hatchets.


#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

Checked values in game.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

This unfortunately a big nerf to the ice axe, but the weapon in it's current state just doesn't make any sense.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
