### PR TITLE
show note danger radius visually on map

### DIFF
--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -736,6 +736,9 @@ static void draw_ascii(
                 ter_sym = type->get_symbol();
             } else if( data.debug_scent && get_scent_glyph( omp, ter_color, ter_sym ) ) {
                 // get_scent_glyph has changed ter_color and ter_sym if omp has a scent
+            } else if( blink && overmap_buffer.is_marked_dangerous( omp ) ) {
+                ter_color = c_red;
+                ter_sym = "X";
             } else if( blink && has_target && omp.xy() == target.xy() ) {
                 // Mission target, display always, player should know where it is anyway.
                 ter_color = c_red;

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -1012,17 +1012,22 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
                 }
             }
 
-            if( blink && uistate.overmap_show_map_notes && overmap_buffer.has_note( omp ) ) {
+            if( blink && uistate.overmap_show_map_notes ) {
+                if( overmap_buffer.has_note( omp ) ) {
+                    nc_color ter_color = c_black;
+                    std::string ter_sym = " ";
+                    // Display notes in all situations, even when not seen
+                    std::tie( ter_sym, ter_color, std::ignore ) =
+                        overmap_ui::get_note_display_info( overmap_buffer.note( omp ) );
 
-                nc_color ter_color = c_black;
-                std::string ter_sym = " ";
-                // Display notes in all situations, even when not seen
-                std::tie( ter_sym, ter_color, std::ignore ) =
-                    overmap_ui::get_note_display_info( overmap_buffer.note( omp ) );
+                    std::string note_name = "note_" + ter_sym + "_" + string_from_color( ter_color );
+                    draw_from_id_string( note_name, TILE_CATEGORY::OVERMAP_NOTE, "overmap_note",
+                                         omp.raw(), 0, 0, lit_level::LIT, false );
+                } else if( overmap_buffer.is_marked_dangerous( omp ) ) {
+                    draw_from_id_string( "note_X_red", TILE_CATEGORY::OVERMAP_NOTE, "overmap_note",
+                                         omp.raw(), 0, 0, lit_level::LIT, false );
 
-                std::string note_name = "note_" + ter_sym + "_" + string_from_color( ter_color );
-                draw_from_id_string( note_name, TILE_CATEGORY::OVERMAP_NOTE, "overmap_note",
-                                     omp.raw(), 0, 0, lit_level::LIT, false );
+                }
             }
         }
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Show dangerous areas around notes visually on the map"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Along with #71628, this fixes #71577. It's nice to be able to visually see what
zones are marked dangerous. For instance, I had no idea that the danger zones
were square :)
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Rendered as if there were a red X note mark over every map tile that is
considered "dangerous". (Hidden when notes are hidden, and does not override
the note's own appearance).
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Perhaps a red X isn't the right character? Red ! might also be good, or ‼.
Further, I'm not totally sure if this approach allows a tileset to override the
danger icon? That ought to be possible!
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
<img width="752" alt="Screenshot 2024-02-09 at 17 28 23" src="https://github.com/CleverRaven/Cataclysm-DDA/assets/172800/926d3807-cf18-44d6-98f7-09a9957ab29f">

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
