### PR TITLE
Camp workers actually eat the food spent on them working

### DIFF
--- a/doc/FACTIONS.md
+++ b/doc/FACTIONS.md
@@ -66,7 +66,7 @@ Field                 | Meaning
 `"known_by_u"`        | boolean, whether the player has met members of the faction.  Can be changed in play.  Unknown factions will not be displayed in the faction menu.
 `"size"`              | integer, an approximate count of the members of the faction.  Has no effect in play currently.
 `"power"`             | integer, an approximation of the faction's power.  Has no effect in play currently.
-`"food_supply"`       | integer, the number of calories (not kilocalories!) available to the faction. Has no effect in play currently.
+`"fac_food_supply"`   | integer, the number of calories (not kilocalories!) available to the faction. Has no effect in play currently.
 `"vitamins"`          | array, *units* of vitamins available to this faction. This is not the same as RDA, see [the vitamins doc](VITAMIN.md) for more details. Has no effect in play currently.
 `"wealth"`            | integer, number of post-apocalyptic currency in cents that that faction has to purchase stuff. Serves as an upper limit on the amount of items restocked by a NPC of this faction with a defined shopkeeper_item_group (see NPCs.md)
 `"currency"`          | string, the item `"id"` of the faction's preferred currency.  Faction shopkeeps will trade faction current at 100% value, for both selling and buying.

--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -240,6 +240,7 @@ class basecamp
         void feed_workers( std::vector<shared_ptr_fast<npc>> workers, nutrients food );
         /// Helper, forwards to above
         void feed_workers( npc *worker, nutrients food );
+		void player_eats_meal();
         bool distribute_food();
         std::string name_display_of( const mission_id &miss_id );
         void handle_hide_mission( const point &dir );

--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -236,6 +236,10 @@ class basecamp
         nutrients camp_food_supply( int change = 0 );
         /// LEGACY FUNCTION. Calculates raw kcal cost from duration of work and exercise, then forwards it to above
         nutrients camp_food_supply( time_duration work, float exertion_level = NO_EXERCISE );
+        /// Evenly distributes the actual consumed food from a work project to the workers assigned to it
+        void feed_workers( std::vector<shared_ptr_fast<npc>> workers, nutrients food );
+        /// Helper, forwards to above
+        void feed_workers( npc *worker, nutrients food );
         bool distribute_food();
         std::string name_display_of( const mission_id &miss_id );
         void handle_hide_mission( const point &dir );

--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -237,9 +237,9 @@ class basecamp
         /// LEGACY FUNCTION. Calculates raw kcal cost from duration of work and exercise, then forwards it to above
         nutrients camp_food_supply( time_duration work, float exertion_level = NO_EXERCISE );
         /// Evenly distributes the actual consumed food from a work project to the workers assigned to it
-        void feed_workers( std::vector<shared_ptr_fast<npc>> workers, nutrients food );
+        void feed_workers( std::vector<npc_ptr> workers, nutrients food );
         /// Helper, forwards to above
-        void feed_workers( npc *worker, nutrients food );
+        void feed_workers( npc_ptr worker, nutrients food );
 		void player_eats_meal();
         bool distribute_food();
         std::string name_display_of( const mission_id &miss_id );

--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -226,15 +226,13 @@ class basecamp
         bool set_sort_points();
 
         // food utility
-        /// Takes all the food from the camp_food zone and increases the faction
-        /// food_supply
         /// Changes the faction food supply by @ref change, returns the amount of kcal+vitamins consumed, a negative
         /// total food supply hurts morale
         /// Handles vitamin consumption when only a kcal value is supplied
         nutrients camp_food_supply( nutrients &change );
-        /// LEGACY FUNCTION. Constructs a new nutrients struct in place and forwards it
-        nutrients camp_food_supply( int change = 0 );
-        /// LEGACY FUNCTION. Calculates raw kcal cost from duration of work and exercise, then forwards it to above
+        /// Constructs a new nutrients struct in place and forwards it. Passed argument should be in kilocalories.
+        nutrients camp_food_supply( int change );
+        /// Calculates raw kcal cost from duration of work and exercise, then forwards it to above
         nutrients camp_food_supply( time_duration work, float exertion_level = NO_EXERCISE );
         /// Evenly distributes the actual consumed food from a work project to the workers assigned to it
         void feed_workers( std::vector<std::reference_wrapper <Character>> workers, nutrients food,
@@ -242,6 +240,8 @@ class basecamp
         /// Helper, forwards to above
         void feed_workers( Character &worker, nutrients food, bool is_player_meal = false );
         void player_eats_meal();
+        /// Takes all the food from the camp_food zone and increases the faction
+        /// food_supply
         bool distribute_food();
         std::string name_display_of( const mission_id &miss_id );
         void handle_hide_mission( const point &dir );

--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -237,9 +237,10 @@ class basecamp
         /// LEGACY FUNCTION. Calculates raw kcal cost from duration of work and exercise, then forwards it to above
         nutrients camp_food_supply( time_duration work, float exertion_level = NO_EXERCISE );
         /// Evenly distributes the actual consumed food from a work project to the workers assigned to it
-        void feed_workers( std::vector<std::reference_wrapper <Character>> workers, nutrients food );
+        void feed_workers( std::vector<std::reference_wrapper <Character>> workers, nutrients food,
+                           bool is_player_meal = false );
         /// Helper, forwards to above
-        void feed_workers( Character &worker, nutrients food );
+        void feed_workers( Character &worker, nutrients food, bool is_player_meal = false );
         void player_eats_meal();
         bool distribute_food();
         std::string name_display_of( const mission_id &miss_id );

--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -237,10 +237,10 @@ class basecamp
         /// LEGACY FUNCTION. Calculates raw kcal cost from duration of work and exercise, then forwards it to above
         nutrients camp_food_supply( time_duration work, float exertion_level = NO_EXERCISE );
         /// Evenly distributes the actual consumed food from a work project to the workers assigned to it
-        void feed_workers( std::vector<npc_ptr> workers, nutrients food );
+        void feed_workers( std::vector<std::reference_wrapper <Character>> workers, nutrients food );
         /// Helper, forwards to above
-        void feed_workers( npc_ptr worker, nutrients food );
-		void player_eats_meal();
+        void feed_workers( Character &worker, nutrients food );
+        void player_eats_meal();
         bool distribute_food();
         std::string name_display_of( const mission_id &miss_id );
         void handle_hide_mission( const point &dir );

--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -235,7 +235,7 @@ class basecamp
         /// Calculates raw kcal cost from duration of work and exercise, then forwards it to above
         nutrients camp_food_supply( time_duration work, float exertion_level = NO_EXERCISE );
         /// Evenly distributes the actual consumed food from a work project to the workers assigned to it
-        void feed_workers( std::vector<std::reference_wrapper <Character>> workers, nutrients food,
+        void feed_workers( const std::vector<std::reference_wrapper <Character>> &workers, nutrients food,
                            bool is_player_meal = false );
         /// Helper, forwards to above
         void feed_workers( Character &worker, nutrients food, bool is_player_meal = false );

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -368,7 +368,7 @@ std::pair<nc_color, std::string> faction::vitamin_stores( vitamin_type vit_type 
     // Iterate the map's content into a sortable container...
     for( auto &vit : stored_vits ) {
         int units_per_day = vit.first.obj().units_absorption_per_day();
-        double relative_intake = units_per_day / days_of_food;
+        double relative_intake = static_cast<double>( vit.second / units_per_day ) / days_of_food;
         // We use the inverse value for toxins, since they are bad.
         if( is_toxin ) {
             relative_intake = 1 / relative_intake;

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -348,6 +348,54 @@ nc_color faction::food_supply_color()
     }
 }
 
+std::pair<nc_color, std::string> faction::vitamin_stores( vitamin_type vit_type )
+{
+    bool is_toxin = ( vit_type == vitamin_type::TOXIN );
+    const double days_of_food = food_supply.kcal() / 3000.0;
+    std::map<vitamin_id, int> stored_vits = food_supply.vitamins();
+    // First, pare down our search to only the relevant type
+    for( auto it = stored_vits.cbegin(); it != stored_vits.cend(); ) {
+        if( it->first->type() != vit_type ) {
+            it = stored_vits.erase( it );
+        } else {
+            ++it;
+        }
+    }
+    if( stored_vits.empty() ) {
+        return std::pair<nc_color, std::string>( !is_toxin ? c_red : c_green, _( "None present (NONE)" ) );
+    }
+    std::vector<std::pair<vitamin_id, double>> vitamins;
+    // Iterate the map's content into a sortable container...
+    for( auto &vit : stored_vits ) {
+        int units_per_day = vit.first.obj().units_absorption_per_day();
+        double relative_intake = units_per_day / days_of_food;
+        // We use the inverse value for toxins, since they are bad.
+        if( is_toxin ) {
+            relative_intake = 1 / relative_intake;
+        }
+        vitamins.emplace_back( vit.first, relative_intake );
+    }
+    // Sort to find the worst-case scenario, lowest relative_intake is first
+    std::sort( vitamins.begin(), vitamins.end(), []( const auto & x, const auto & y ) {
+        return x.second > y.second;
+    } );
+    const double worst_intake = vitamins.at( 0 ).second;
+    std::string vit_name = vitamins.at( 0 ).first.obj().name();
+    std::string msg = is_toxin ? _( "(TRACE)" ) : _( "(PLENTY)" );
+    if( worst_intake <= 0.3 ) {
+        msg = is_toxin ? _( "(POISON)" ) : _( "(LACK)" );
+        return std::pair<nc_color, std::string>( c_red, string_format( _( "%1$s %2$s" ), vit_name,
+                msg ) );
+    }
+    if( worst_intake <= 1.0 ) {
+        msg = is_toxin ? _( "(DANGER)" ) : _( "(MEAGER)" );
+        return std::pair<nc_color, std::string>( c_yellow, string_format( _( "%1$s %2$s" ), vit_name,
+                msg ) );
+    }
+    return std::pair<nc_color, std::string>( c_green, string_format( _( "%1$s %2$s" ), vit_name,
+            msg ) );
+}
+
 faction_price_rule const *faction::get_price_rules( item const &it, npc const &guy ) const
 {
     auto const el = std::find_if(
@@ -519,6 +567,10 @@ void basecamp::faction_display( const catacurses::window &fac_w, const int width
                                            yours->food_supply_text(), yours->food_supply.kcal() );
     nc_color food_col = yours->food_supply_color();
     mvwprintz( fac_w, point( width, ++y ), food_col, food_text );
+    std::pair<nc_color, std::string> vitamins = yours->vitamin_stores( vitamin_type::VITAMIN );
+    mvwprintz( fac_w, point( width, ++y ), vitamins.first, _( "Worst vitamin:" ) + vitamins.second );
+    std::pair<nc_color, std::string> toxins = yours->vitamin_stores( vitamin_type::TOXIN );
+    mvwprintz( fac_w, point( width, ++y ), toxins.first, _( "Worst toxin:" ) + toxins.second );
     std::string bldg = next_upgrade( base_camps::base_dir, 1 );
     std::string bldg_full = _( "Next Upgrade: " ) + bldg;
     mvwprintz( fac_w, point( width, ++y ), col, bldg_full );

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -350,7 +350,7 @@ nc_color faction::food_supply_color()
 
 std::pair<nc_color, std::string> faction::vitamin_stores( vitamin_type vit_type )
 {
-    bool is_toxin = ( vit_type == vitamin_type::TOXIN );
+    bool is_toxin = vit_type == vitamin_type::TOXIN;
     const double days_of_food = food_supply.kcal() / 3000.0;
     std::map<vitamin_id, int> stored_vits = food_supply.vitamins();
     // First, pare down our search to only the relevant type
@@ -368,7 +368,8 @@ std::pair<nc_color, std::string> faction::vitamin_stores( vitamin_type vit_type 
     // Iterate the map's content into a sortable container...
     for( auto &vit : stored_vits ) {
         int units_per_day = vit.first.obj().units_absorption_per_day();
-        double relative_intake = static_cast<double>( vit.second / units_per_day ) / days_of_food;
+        double relative_intake = static_cast<double>( vit.second ) / static_cast<double>
+                                 ( units_per_day ) / days_of_food;
         // We use the inverse value for toxins, since they are bad.
         if( is_toxin ) {
             relative_intake = 1 / relative_intake;

--- a/src/faction.h
+++ b/src/faction.h
@@ -18,6 +18,7 @@
 #include "stomach.h"
 #include "translations.h"
 #include "type_id.h"
+#include "vitamin.h"
 
 namespace catacurses
 {
@@ -138,6 +139,8 @@ class faction : public faction_template
 
         std::string food_supply_text();
         nc_color food_supply_color();
+
+        std::pair<nc_color, std::string> vitamin_stores( vitamin_type vit );
 
         faction_price_rule const *get_price_rules( item const &it, npc const &guy ) const;
 

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -5535,6 +5535,10 @@ void basecamp::feed_workers( std::vector<shared_ptr_fast<npc>> workers, nutrient
         } );
         return;
     }
+    if( get_option<bool>( "NO_NPC_FOOD" ) ) {
+        return;
+    }
+
     // Split the food into equal sized portions.
     food /= num_workers;
     for( auto &worker : workers ) {

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -5489,6 +5489,35 @@ nutrients basecamp::camp_food_supply( time_duration work, float exertion_level )
     return camp_food_supply( -time_to_food( work, exertion_level ) );
 }
 
+void basecamp::feed_workers( std::vector<shared_ptr_fast<npc>> workers, nutrients food )
+{
+    const int num_workers = workers.size();
+    if( num_workers == 0 ) {
+        debugmsg( "feed_workers called without any workers to feed!" );
+        return;
+    }
+    // Split the food into equal sized portions.
+    food /= num_workers;
+    for( auto &worker : workers ) {
+        units::volume filling_vol = std::max( 0_ml,
+                                              worker->stomach.capacity( *worker ) / 2 - worker->stomach.contains() );
+        worker->stomach.ingest( food_summary{
+            0_ml,
+            filling_vol,
+            food
+        } );
+    }
+    return;
+}
+
+void basecamp::feed_workers( npc *worker, nutrients food )
+{
+    std::vector<shared_ptr_fast<npc>> work_party;
+    work_party.emplace_back( worker );
+    feed_workers( work_party, food );
+    return;
+}
+
 int time_to_food( time_duration work, float exertion_level )
 {
     const int days = to_hours<int>( work ) / 24;

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -5543,7 +5543,7 @@ void basecamp::feed_workers( const std::vector<std::reference_wrapper <Character
 
     // Split the food into equal sized portions.
     food /= num_workers;
-    for( auto &worker_reference : workers ) {
+    for( const auto &worker_reference : workers ) {
         Character &worker = worker_reference.get();
         worker.add_msg_if_player( _( "You grab a prepared meal from storage and chow down." ) );
         units::volume filling_vol = std::max( 0_ml,

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -1674,9 +1674,21 @@ void basecamp::choose_new_leader()
 
 void basecamp::player_eats_meal()
 {
-    // Make an empty vector, branch logic determines it must be the player
-    nutrients dinner = camp_food_supply( -3000 );
-    feed_workers( get_player_character(), dinner, true );
+    const int kcal_to_eat = 3000;
+    Character &you = get_player_character();
+    const int &food_available = you.get_faction()->food_supply.kcal();
+    if( you.stomach.contains() >= ( you.stomach.capacity( you ) / 2 ) ) {
+        popup( _( "You're way too full to eat a full meal right now." ) );
+        return;
+    }
+    if( food_available <= 0 ) {
+        popup( _( "You check storage for some food, but there is nothing but dust and cobwebs…" ) );
+        return;
+    } else if( food_available <= kcal_to_eat ) {
+        add_msg( _( "There's only one meal left.  Guess that's dinner!" ) );
+    }
+    nutrients dinner = camp_food_supply( -kcal_to_eat );
+    feed_workers( you, dinner, true );
 }
 
 bool basecamp::handle_mission( const ui_mission_id &miss_id )

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -5529,7 +5529,7 @@ nutrients basecamp::camp_food_supply( time_duration work, float exertion_level )
     return camp_food_supply( -time_to_food( work, exertion_level ) );
 }
 
-void basecamp::feed_workers( std::vector<std::reference_wrapper <Character>> workers,
+void basecamp::feed_workers( const std::vector<std::reference_wrapper <Character>> &workers,
                              nutrients food, bool is_player_meal )
 {
     const int num_workers = workers.size();
@@ -5554,15 +5554,13 @@ void basecamp::feed_workers( std::vector<std::reference_wrapper <Character>> wor
             food
         } );
     }
-    return;
 }
 
 void basecamp::feed_workers( Character &worker, nutrients food, bool is_player_meal )
 {
     std::vector<std::reference_wrapper <Character>> work_party;
     work_party.emplace_back( worker );
-    feed_workers( work_party, food, is_player_meal );
-    return;
+    feed_workers( work_party, std::move( food ), is_player_meal );
 }
 
 int time_to_food( time_duration work, float exertion_level )

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -1676,7 +1676,7 @@ void basecamp::player_eats_meal()
 {
     // Make an empty vector, branch logic determines it must be the player
     nutrients dinner = camp_food_supply( -3000 );
-    feed_workers( get_player_character(), dinner );
+    feed_workers( get_player_character(), dinner, true );
 }
 
 bool basecamp::handle_mission( const ui_mission_id &miss_id )
@@ -5523,14 +5523,14 @@ nutrients basecamp::camp_food_supply( time_duration work, float exertion_level )
 }
 
 void basecamp::feed_workers( std::vector<std::reference_wrapper <Character>> workers,
-                             nutrients food )
+                             nutrients food, bool is_player_meal )
 {
     const int num_workers = workers.size();
     if( num_workers == 0 ) {
         debugmsg( "feed_workers called without any workers to feed!" );
         return;
     }
-    if( get_option<bool>( "NO_NPC_FOOD" ) ) {
+    if( !is_player_meal && get_option<bool>( "NO_NPC_FOOD" ) ) {
         return;
     }
 
@@ -5538,6 +5538,7 @@ void basecamp::feed_workers( std::vector<std::reference_wrapper <Character>> wor
     food /= num_workers;
     for( auto &worker_reference : workers ) {
         Character &worker = worker_reference.get();
+        worker.add_msg_if_player( _( "You grab a prepared meal from storage and chow down." ) );
         units::volume filling_vol = std::max( 0_ml,
                                               worker.stomach.capacity( worker ) / 2 - worker.stomach.contains() );
         worker.stomach.ingest( food_summary{
@@ -5549,11 +5550,11 @@ void basecamp::feed_workers( std::vector<std::reference_wrapper <Character>> wor
     return;
 }
 
-void basecamp::feed_workers( Character &worker, nutrients food )
+void basecamp::feed_workers( Character &worker, nutrients food, bool is_player_meal )
 {
     std::vector<std::reference_wrapper <Character>> work_party;
     work_party.emplace_back( worker );
-    feed_workers( work_party, food );
+    feed_workers( work_party, food, is_player_meal );
     return;
 }
 

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -53,6 +53,7 @@
 #include "npc.h"
 #include "npctalk.h"
 #include "omdata.h"
+#include "options.h"
 #include "output.h"
 #include "overmap.h"
 #include "overmap_ui.h"

--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -150,6 +150,7 @@ std::string enum_to_string<mission_kind>( mission_kind data )
         case mission_kind::Caravan_Commune_Center_Job: return "Caravan_Commune_Center_Job";
         case mission_kind::Camp_Distribute_Food: return "Camp_Distribute_Food";
 		case mission_kind::Camp_Determine_Leadership: return "Camp_Determine_Leadership";
+		case mission_kind::Camp_Have_Meal: return "Camp_Have_Meal";
         case mission_kind::Camp_Hide_Mission: return "Camp_Hide_Mission";
         case mission_kind::Camp_Reveal_Mission: return "Camp_Reveal_Mission";
         case mission_kind::Camp_Assign_Jobs: return "Camp_Assign_Jobs";
@@ -228,6 +229,10 @@ static const std::array < miss_data, Camp_Harvest + 1 > miss_info = { {
         },
         {
             "Camp_Determine_Leadership",
+            no_translation( "" )
+        },
+        {
+            "Camp_Have_Meal",
             no_translation( "" )
         },
         {
@@ -1210,6 +1215,7 @@ bool talk_function::handle_outpost_mission( const mission_entry &cur_key, npc &p
 
         case Camp_Distribute_Food:
         case Camp_Determine_Leadership:
+        case Camp_Have_Meal:
         case Camp_Hide_Mission:
         case Camp_Reveal_Mission:
         case Camp_Assign_Jobs:

--- a/src/mission_companion.h
+++ b/src/mission_companion.h
@@ -47,10 +47,11 @@ enum mission_kind : int {
     Caravan_Commune_Center_Job,
 
     //  Faction camp tasks
-    Camp_Distribute_Food,  //  Direct action, not serialized
-    Camp_Determine_Leadership,
-    Camp_Hide_Mission,     //  Direct action, not serialized
-    Camp_Reveal_Mission,   //  Direct action, not serialized
+    Camp_Distribute_Food,        //  Direct action, not serialized
+    Camp_Determine_Leadership,   // Direct action, not serialized
+    Camp_Have_Meal,
+    Camp_Hide_Mission,           //  Direct action, not serialized
+    Camp_Reveal_Mission,         //  Direct action, not serialized
     Camp_Assign_Jobs,
     Camp_Assign_Workers,
     Camp_Abandon,

--- a/src/mission_companion.h
+++ b/src/mission_companion.h
@@ -48,8 +48,8 @@ enum mission_kind : int {
 
     //  Faction camp tasks
     Camp_Distribute_Food,        //  Direct action, not serialized
-    Camp_Determine_Leadership,   // Direct action, not serialized
-    Camp_Have_Meal,
+    Camp_Determine_Leadership,   //  Direct action, not serialized
+    Camp_Have_Meal,              //  Direct action, not serialized
     Camp_Hide_Mission,           //  Direct action, not serialized
     Camp_Reveal_Mission,         //  Direct action, not serialized
     Camp_Assign_Jobs,

--- a/src/vitamin.cpp
+++ b/src/vitamin.cpp
@@ -130,6 +130,11 @@ float vitamin::RDA_to_default( int percent ) const
     return ( 24_hours / rate_ ) * ( static_cast<float>( percent ) / 100.0f );
 }
 
+int vitamin::units_absorption_per_day() const
+{
+    return ( 24_hours / rate_ );
+}
+
 int vitamin::units_from_mass( vitamin_units::mass val ) const
 {
     if( !weight_per_unit.has_value() ) {

--- a/src/vitamin.h
+++ b/src/vitamin.h
@@ -110,6 +110,9 @@ class vitamin
          */
         float RDA_to_default( int percent ) const;
 
+        /** Returns how many of this vitamin (in units) can be absorbed in one day */
+        int units_absorption_per_day() const;
+
         int units_from_mass( vitamin_units::mass val ) const;
         // First is value, second is units (g, mg, etc)
         std::pair<std::string, std::string> mass_str_from_units( int units ) const;


### PR DESCRIPTION
#### Summary
Features "Player can eat from camp larder(always). Workers receive spent food from it when being assigned to work (requires NPC needs enabled)."

#### Purpose of change
Now it's possible to actually feed the workers. So, let's feed the workers.

#### Describe the solution
The workers receive all the food that is spent by working. All of it. Unless NPC needs are disabled with the default mod, in which case the food vanishes into the air.

Also the player can eat from the larder too. Same rules (you get a proportional amount of stored vitamins), but you always withdraw exactly 3000 calories at a time. This could be improved in a few ways, but I've always found it a bit odd that once the food is in there only the NPCs can eat from it.

There is a way to judge the **relative** amounts of vitamins you have stored. It is accessed through the faction info window and highlights any vitamins or toxins of concern, color-coding them appropriately (green if fine, red if bad). This can be done at any time, with no cost.

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/2a4b188f-d298-4dfa-b0f6-3c3f89455128)


#### Describe alternatives you've considered
Every time I do a new camp mission I grow more desirous of moving them to JSON....

#### Testing
Checked the CHECKME, got it to compile, played around with it a bit. I haven't found any problems.

#### Additional context
