### PR TITLE
Tweak shadow lieutenant warnings to remove excessive repeat popups

### DIFF
--- a/data/json/monsters/zed_lieutenant.json
+++ b/data/json/monsters/zed_lieutenant.json
@@ -364,6 +364,15 @@
         {
           "or": [ { "math": [ "Shadow_Lurking", ">", "0" ] }, { "not": { "math": [ "time_since('cataclysm', 'unit':'days') >= 7" ] } } ]
         },
+        {
+          "or": [
+            { "math": [ "Shadow_Warnings", "<", "2" ] },
+            { "not": { "math": [ "time_since('cataclysm', 'unit':'days') >= 7" ] } }
+          ]
+        },
+        {
+          "or": [ { "math": [ "Shadow_Warnings", "<", "1" ] }, { "math": [ "time_since('cataclysm', 'unit':'days') >= 7" ] } ]
+        },
         "u_is_outside",
         {
           "or": [ { "u_at_om_location": "field" }, { "u_at_om_location": "forest" }, { "u_at_om_location": "forest_thick" } ]

--- a/data/json/monsters/zed_lieutenant.json
+++ b/data/json/monsters/zed_lieutenant.json
@@ -364,7 +364,6 @@
         {
           "or": [ { "math": [ "Shadow_Lurking", ">", "0" ] }, { "not": { "math": [ "time_since('cataclysm', 'unit':'days') >= 7" ] } } ]
         },
-        { "math": [ "Shadow_Warnings", "<", "2" ] },
         {
           "or": [ { "math": [ "Shadow_Warnings", "<", "1" ] }, { "math": [ "time_since('cataclysm', 'unit':'days') >= 7" ] } ]
         },

--- a/data/json/monsters/zed_lieutenant.json
+++ b/data/json/monsters/zed_lieutenant.json
@@ -364,6 +364,7 @@
         {
           "or": [ { "math": [ "Shadow_Lurking", ">", "0" ] }, { "not": { "math": [ "time_since('cataclysm', 'unit':'days') >= 7" ] } } ]
         },
+        { "math": [ "Shadow_Warnings", "<", "2" ] },
         {
           "or": [ { "math": [ "Shadow_Warnings", "<", "1" ] }, { "math": [ "time_since('cataclysm', 'unit':'days') >= 7" ] } ]
         },
@@ -379,6 +380,38 @@
         "if": { "math": [ "time_since('cataclysm', 'unit':'days') >= 7" ] },
         "then": { "u_message": "Shadow_Warnings_Snippets_late", "snippet": true, "popup": true },
         "else": { "u_message": "Shadow_Warnings_Snippets_early", "snippet": true, "popup": true }
+      }
+    ],
+    "false_effect": [ { "run_eocs": [ "EOC_LIEUTENANT_SHADOW_WARN_LITE" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_LIEUTENANT_SHADOW_WARN_LITE",
+    "eoc_type": "ACTIVATION",
+    "//1": "Same conditions as EOC_LIEUTENANT_SPAWN_SHADOW, minus the RNG check and the warnings check.",
+    "//2": "This doesn't put a popup message in front of you.",
+    "condition": {
+      "and": [
+        { "not": "is_day" },
+        { "not": { "u_has_effect": "sleep" } },
+        {
+          "or": [ { "math": [ "Shadow_Lurking", ">", "0" ] }, { "not": { "math": [ "time_since('cataclysm', 'unit':'days') >= 7" ] } } ]
+        },
+        {
+          "or": [ { "math": [ "Shadow_Warnings", "<", "1" ] }, { "math": [ "time_since('cataclysm', 'unit':'days') >= 7" ] } ]
+        },
+        "u_is_outside",
+        {
+          "or": [ { "u_at_om_location": "field" }, { "u_at_om_location": "forest" }, { "u_at_om_location": "forest_thick" } ]
+        }
+      ]
+    },
+    "effect": [
+      { "math": [ "Shadow_Warnings", "+=", "1" ] },
+      {
+        "if": { "math": [ "time_since('cataclysm', 'unit':'days') >= 7" ] },
+        "then": { "u_message": "Shadow_Warnings_Snippets_late", "snippet": true, "popup": false },
+        "else": { "u_message": "Shadow_Warnings_Snippets_early", "snippet": true, "popup": false }
       }
     ]
   },

--- a/data/json/monsters/zed_lieutenant.json
+++ b/data/json/monsters/zed_lieutenant.json
@@ -364,12 +364,7 @@
         {
           "or": [ { "math": [ "Shadow_Lurking", ">", "0" ] }, { "not": { "math": [ "time_since('cataclysm', 'unit':'days') >= 7" ] } } ]
         },
-        {
-          "or": [
-            { "math": [ "Shadow_Warnings", "<", "2" ] },
-            { "not": { "math": [ "time_since('cataclysm', 'unit':'days') >= 7" ] } }
-          ]
-        },
+        { "math": [ "Shadow_Warnings", "<", "2" ] },
         {
           "or": [ { "math": [ "Shadow_Warnings", "<", "1" ] }, { "math": [ "time_since('cataclysm', 'unit':'days') >= 7" ] } ]
         },

--- a/data/json/monsters/zed_lieutenant.json
+++ b/data/json/monsters/zed_lieutenant.json
@@ -364,7 +364,6 @@
         {
           "or": [ { "math": [ "Shadow_Lurking", ">", "0" ] }, { "not": { "math": [ "time_since('cataclysm', 'unit':'days') >= 7" ] } } ]
         },
-        { "math": [ "Shadow_Warnings", "<", "2" ] },
         {
           "or": [ { "math": [ "Shadow_Warnings", "<", "1" ] }, { "math": [ "time_since('cataclysm', 'unit':'days') >= 7" ] } ]
         },
@@ -378,40 +377,16 @@
       { "math": [ "Shadow_Warnings", "+=", "1" ] },
       {
         "if": { "math": [ "time_since('cataclysm', 'unit':'days') >= 7" ] },
-        "then": { "u_message": "Shadow_Warnings_Snippets_late", "snippet": true, "popup": true },
-        "else": { "u_message": "Shadow_Warnings_Snippets_early", "snippet": true, "popup": true }
-      }
-    ],
-    "false_effect": [ { "run_eocs": [ "EOC_LIEUTENANT_SHADOW_WARN_LITE" ] } ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_LIEUTENANT_SHADOW_WARN_LITE",
-    "eoc_type": "ACTIVATION",
-    "//1": "Same conditions as EOC_LIEUTENANT_SPAWN_SHADOW, minus the RNG check and the warnings check.",
-    "//2": "This doesn't put a popup message in front of you.",
-    "condition": {
-      "and": [
-        { "not": "is_day" },
-        { "not": { "u_has_effect": "sleep" } },
-        {
-          "or": [ { "math": [ "Shadow_Lurking", ">", "0" ] }, { "not": { "math": [ "time_since('cataclysm', 'unit':'days') >= 7" ] } } ]
+        "then": {
+          "if": { "math": [ "Shadow_Warnings", "<", "2" ] },
+          "then": { "u_message": "Shadow_Warnings_Snippets_late", "snippet": true, "popup": true },
+          "else": { "u_message": "Shadow_Warnings_Snippets_late", "snippet": true, "popup": false }
         },
-        {
-          "or": [ { "math": [ "Shadow_Warnings", "<", "1" ] }, { "math": [ "time_since('cataclysm', 'unit':'days') >= 7" ] } ]
-        },
-        "u_is_outside",
-        {
-          "or": [ { "u_at_om_location": "field" }, { "u_at_om_location": "forest" }, { "u_at_om_location": "forest_thick" } ]
+        "else": {
+          "if": { "math": [ "Shadow_Warnings", "<", "2" ] },
+          "then": { "u_message": "Shadow_Warnings_Snippets_early", "snippet": true, "popup": true },
+          "else": { "u_message": "Shadow_Warnings_Snippets_early", "snippet": true, "popup": false }
         }
-      ]
-    },
-    "effect": [
-      { "math": [ "Shadow_Warnings", "+=", "1" ] },
-      {
-        "if": { "math": [ "time_since('cataclysm', 'unit':'days') >= 7" ] },
-        "then": { "u_message": "Shadow_Warnings_Snippets_late", "snippet": true, "popup": false },
-        "else": { "u_message": "Shadow_Warnings_Snippets_early", "snippet": true, "popup": false }
       }
     ]
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fixes excessive shadow lieutenant warnings"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #71672 

#### Describe the solution
You get a maximum of one warning before the 7 day mark (before when the monster can actually spawn), and after that, warnings will fire when it fails to spawn. The first time it doesn't spawn, you will get a popup warning. After that, warnings just go into the logs.

#### Describe alternatives you've considered
None

#### Testing
Created a character and had them stand around a field for a week and change. The shadow lieutenant EOCs fired as I expected

#### Additional context
Pinging @RenechCDDA as this is their baby. This okay?


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
