### PR TITLE
[Magiclysm] Rebalance enchanted_combat_items

### DIFF
--- a/data/mods/Magiclysm/itemgroups/itemgroups.json
+++ b/data/mods/Magiclysm/itemgroups/itemgroups.json
@@ -695,6 +695,59 @@
     ]
   },
   {
+    "id": "enchanted_wands_disposable",
+    "type": "item_group",
+    "//": "disposable wands only",
+    "subtype": "distribution",
+    "items": [
+      { "group": "enchanted_wands_disposable_minor", "prob": 100 },
+      { "group": "enchanted_wands_disposable_lesser", "prob": 50 },
+      { "group": "enchanted_wands_disposable_greater", "prob": 10 }
+    ]
+  },
+  {
+    "id": "enchanted_wands_disposable_minor",
+    "type": "item_group",
+    "subtype": "distribution",
+    "items": [
+      { "item": "wand_disp_magic_missile_minor", "prob": 10, "charges-min": 3, "charges-max": 24 },
+      { "item": "wand_disp_fireball_minor", "prob": 5, "charges-min": 3, "charges-max": 24 },
+      { "item": "wand_disp_mana_beam_minor", "prob": 10, "charges-min": 3, "charges-max": 24 },
+      { "item": "wand_disp_point_flare_minor", "prob": 10, "charges-min": 3, "charges-max": 24 },
+      { "item": "wand_disp_hoaryblast_minor", "prob": 10, "charges-min": 3, "charges-max": 24 },
+      { "item": "wand_disp_cone_cold_minor", "prob": 10, "charges-min": 3, "charges-max": 24 },
+      { "item": "wand_disp_knock_minor", "prob": 10, "charges-min": 3, "charges-max": 24 }
+    ]
+  },
+  {
+    "id": "enchanted_wands_disposable_lesser",
+    "type": "item_group",
+    "subtype": "distribution",
+    "items": [
+      { "item": "wand_disp_magic_missile_lesser", "prob": 10, "charges-min": 3, "charges-max": 24 },
+      { "item": "wand_disp_fireball_lesser", "prob": 5, "charges-min": 3, "charges-max": 24 },
+      { "item": "wand_disp_mana_beam_lesser", "prob": 10, "charges-min": 3, "charges-max": 24 },
+      { "item": "wand_disp_point_flare_lesser", "prob": 10, "charges-min": 3, "charges-max": 24 },
+      { "item": "wand_disp_hoaryblast_lesser", "prob": 10, "charges-min": 3, "charges-max": 24 },
+      { "item": "wand_disp_cone_cold_lesser", "prob": 10, "charges-min": 3, "charges-max": 24 },
+      { "item": "wand_disp_knock_lesser", "prob": 10, "charges-min": 3, "charges-max": 24 }
+    ]
+  },
+  {
+    "id": "enchanted_wands_disposable_greater",
+    "type": "item_group",
+    "subtype": "distribution",
+    "items": [
+      { "item": "wand_disp_magic_missile_greater", "prob": 10, "charges-min": 3, "charges-max": 24 },
+      { "item": "wand_disp_fireball_greater", "prob": 5, "charges-min": 3, "charges-max": 24 },
+      { "item": "wand_disp_mana_beam_greater", "prob": 10, "charges-min": 3, "charges-max": 24 },
+      { "item": "wand_disp_point_flare_greater", "prob": 10, "charges-min": 3, "charges-max": 24 },
+      { "item": "wand_disp_hoaryblast_greater", "prob": 10, "charges-min": 3, "charges-max": 24 },
+      { "item": "wand_disp_cone_cold_greater", "prob": 10, "charges-min": 3, "charges-max": 24 },
+      { "item": "wand_disp_knock_greater", "prob": 10, "charges-min": 3, "charges-max": 24 }
+    ]
+  },
+  {
     "id": "enchanted_arrows",
     "type": "item_group",
     "//": "enchanted arrows in various quantities",
@@ -977,7 +1030,11 @@
     "subtype": "distribution",
     "items": [
       { "group": "enchanted_worn_items", "prob": 15 },
-      { "group": "enchanted_melee_weapons_plus1", "prob": 10 },
+      { "group": "enchanted_wands_disposable", "prob": 10 },
+      {
+        "distribution": [ { "group": "enchanted_melee_weapons_plus1", "prob": 95 }, { "group": "enchanted_melee_weapons_plus2", "prob": 5 } ],
+        "prob": 4
+      },
       { "group": "enchanted_small_items", "prob": 1 }
     ]
   },

--- a/data/mods/Magiclysm/itemgroups/itemgroups.json
+++ b/data/mods/Magiclysm/itemgroups/itemgroups.json
@@ -202,6 +202,42 @@
     }
   },
   {
+    "id": "mon_zombie_soldier_death_drops",
+    "type": "item_group",
+    "copy-from": "mon_zombie_soldier_death_drops",
+    "extend": { "items": [ { "group": "enchanted_combat_items", "prob": 2 } ] }
+  },
+  {
+    "id": "mon_zombie_heavy_soldier_death_drops",
+    "type": "item_group",
+    "copy-from": "mon_zombie_heavy_soldier_death_drops",
+    "extend": { "items": [ { "group": "enchanted_combat_items", "prob": 3 } ] }
+  },
+  {
+    "id": "mon_feral_prepper_death_drops",
+    "type": "item_group",
+    "copy-from": "mon_feral_prepper_death_drops",
+    "extend": { "items": [ { "group": "enchanted_combat_items", "prob": 15 } ] }
+  },
+  {
+    "id": "feral_sapien_death_drops_spear",
+    "type": "item_group",
+    "copy-from": "feral_sapien_death_drops_spear",
+    "extend": { "items": [ { "group": "enchanted_combat_items", "prob": 15 } ] }
+  },
+  {
+    "id": "mon_zombie_survivor_death_drops",
+    "type": "item_group",
+    "copy-from": "mon_zombie_survivor_death_drops",
+    "extend": { "items": [ { "group": "enchanted_combat_items", "prob": 15 } ] }
+  },
+  {
+    "id": "mon_zombie_survivor_elite_death_drops",
+    "type": "item_group",
+    "copy-from": "mon_zombie_survivor_elite_death_drops",
+    "extend": { "items": [ { "group": "enchanted_combat_items", "prob": 50 } ] }
+  },
+  {
     "type": "item_group",
     "id": "magic_shop_books",
     "items": [
@@ -915,7 +951,7 @@
       { "item": "retreat_map", "prob": 30 },
       { "item": "crystallized_mana", "prob": 50, "charges-min": 1, "charges-max": 10 },
       { "item": "small_mana_crystal", "prob": 40, "charges-min": 5, "charges-max": 50 },
-      { "item": "magic_knife_bag", "prob": 25 }
+      { "item": "magic_knife_bag", "prob": 10 }
     ]
   },
   {
@@ -940,9 +976,8 @@
     "type": "item_group",
     "subtype": "distribution",
     "items": [
-      { "group": "enchanted_bracers_lesser", "prob": 25 },
       { "group": "enchanted_worn_items", "prob": 15 },
-      { "group": "enchanted_melee_weapons_plus1", "prob": 3 },
+      { "group": "enchanted_melee_weapons_plus1", "prob": 10 },
       { "group": "enchanted_small_items", "prob": 1 }
     ]
   },

--- a/data/mods/Magiclysm/itemgroups/itemgroups.json
+++ b/data/mods/Magiclysm/itemgroups/itemgroups.json
@@ -204,12 +204,14 @@
   {
     "id": "mon_zombie_soldier_death_drops",
     "type": "item_group",
+    "subtype": "collection",
     "copy-from": "mon_zombie_soldier_death_drops",
     "extend": { "items": [ { "group": "enchanted_combat_items", "prob": 2 } ] }
   },
   {
     "id": "mon_zombie_heavy_soldier_death_drops",
     "type": "item_group",
+    "subtype": "collection",
     "copy-from": "mon_zombie_heavy_soldier_death_drops",
     "extend": { "items": [ { "group": "enchanted_combat_items", "prob": 3 } ] }
   },
@@ -238,12 +240,28 @@
     "extend": { "items": [ { "group": "enchanted_combat_items", "prob": 50 } ] }
   },
   {
-    "id": "milspec_arsenal_weapon&ammo_collection",
+    "id": "milspec_arsenal_group_only_guns",
     "type": "item_group",
-    "copy-from": "milspec_arsenal_weapon&ammo_collection",
-    "extend": {
-      "items": [ { "group": "enchanted_wands_disposable", "prob": 10 }, { "group": "enchanted_melee_weapons_plus1", "prob": 4 } ]
-    }
+    "copy-from": "milspec_arsenal_group_only_guns",
+    "extend": { "items": [ { "group": "enchanted_wands_disposable", "prob": 10 } ] }
+  },
+  {
+    "id": "army_personal_locker",
+    "type": "item_group",
+    "copy-from": "army_personal_locker",
+    "extend": { "items": [ { "group": "enchanted_worn_items", "prob": 20 } ] }
+  },
+  {
+    "id": "lmoe_guns",
+    "type": "item_group",
+    "copy-from": "lmoe_guns",
+    "extend": { "items": [ { "group": "enchanted_wands_disposable", "prob": 20 } ] }
+  },
+  {
+    "id": "homeguns",
+    "type": "item_group",
+    "copy-from": "homeguns",
+    "extend": { "items": [ { "group": "enchanted_wands_disposable", "prob": 5 } ] }
   },
   {
     "type": "item_group",

--- a/data/mods/Magiclysm/itemgroups/itemgroups.json
+++ b/data/mods/Magiclysm/itemgroups/itemgroups.json
@@ -238,6 +238,12 @@
     "extend": { "items": [ { "group": "enchanted_combat_items", "prob": 50 } ] }
   },
   {
+    "id": "arsenal_mics_group",
+    "type": "item_group",
+    "copy-from": "arsenal_mics_group",
+    "extend": { "items": [ { "group": "enchanted_combat_items", "prob": 5 } ] }
+  },
+  {
     "type": "item_group",
     "id": "magic_shop_books",
     "items": [

--- a/data/mods/Magiclysm/itemgroups/itemgroups.json
+++ b/data/mods/Magiclysm/itemgroups/itemgroups.json
@@ -238,10 +238,12 @@
     "extend": { "items": [ { "group": "enchanted_combat_items", "prob": 50 } ] }
   },
   {
-    "id": "arsenal_mics_group",
+    "id": "milspec_arsenal_weapon&ammo_collection",
     "type": "item_group",
-    "copy-from": "arsenal_mics_group",
-    "extend": { "items": [ { "group": "enchanted_combat_items", "prob": 5 } ] }
+    "copy-from": "milspec_arsenal_weapon&ammo_collection",
+    "extend": {
+      "items": [ { "group": "enchanted_wands_disposable", "prob": 10 }, { "group": "enchanted_melee_weapons_plus1", "prob": 4 } ]
+    }
   },
   {
     "type": "item_group",

--- a/data/mods/Magiclysm/itemgroups/itemgroups.json
+++ b/data/mods/Magiclysm/itemgroups/itemgroups.json
@@ -218,24 +218,28 @@
   {
     "id": "mon_feral_prepper_death_drops",
     "type": "item_group",
+    "subtype": "collection",
     "copy-from": "mon_feral_prepper_death_drops",
     "extend": { "items": [ { "group": "enchanted_combat_items", "prob": 15 } ] }
   },
   {
     "id": "feral_sapien_death_drops_spear",
     "type": "item_group",
+    "subtype": "collection",
     "copy-from": "feral_sapien_death_drops_spear",
     "extend": { "items": [ { "group": "enchanted_combat_items", "prob": 15 } ] }
   },
   {
     "id": "mon_zombie_survivor_death_drops",
     "type": "item_group",
+    "subtype": "collection",
     "copy-from": "mon_zombie_survivor_death_drops",
     "extend": { "items": [ { "group": "enchanted_combat_items", "prob": 15 } ] }
   },
   {
     "id": "mon_zombie_survivor_elite_death_drops",
     "type": "item_group",
+    "subtype": "collection",
     "copy-from": "mon_zombie_survivor_elite_death_drops",
     "extend": { "items": [ { "group": "enchanted_combat_items", "prob": 50 } ] }
   },

--- a/data/mods/Magiclysm/itemgroups/itemgroups.json
+++ b/data/mods/Magiclysm/itemgroups/itemgroups.json
@@ -247,7 +247,7 @@
     "id": "milspec_arsenal_group_only_guns",
     "type": "item_group",
     "copy-from": "milspec_arsenal_group_only_guns",
-    "extend": { "items": [ { "group": "enchanted_wands_disposable", "prob": 10 } ] }
+    "extend": { "items": [ { "group": "enchanted_wands_disposable_combat", "prob": 10 } ] }
   },
   {
     "id": "army_personal_locker",
@@ -259,13 +259,13 @@
     "id": "lmoe_guns",
     "type": "item_group",
     "copy-from": "lmoe_guns",
-    "extend": { "items": [ { "group": "enchanted_wands_disposable", "prob": 20 } ] }
+    "extend": { "items": [ { "group": "enchanted_wands_disposable_combat", "prob": 20 } ] }
   },
   {
     "id": "homeguns",
     "type": "item_group",
     "copy-from": "homeguns",
-    "extend": { "items": [ { "group": "enchanted_wands_disposable", "prob": 5 } ] }
+    "extend": { "items": [ { "group": "enchanted_wands_disposable_combat", "prob": 5 } ] }
   },
   {
     "type": "item_group",
@@ -725,18 +725,18 @@
     ]
   },
   {
-    "id": "enchanted_wands_disposable",
+    "id": "enchanted_wands_disposable_combat",
     "type": "item_group",
     "//": "disposable wands only",
     "subtype": "distribution",
     "items": [
-      { "group": "enchanted_wands_disposable_minor", "prob": 100 },
-      { "group": "enchanted_wands_disposable_lesser", "prob": 50 },
-      { "group": "enchanted_wands_disposable_greater", "prob": 10 }
+      { "group": "enchanted_wands_disposable_minor_combat", "prob": 100 },
+      { "group": "enchanted_wands_disposable_lesser_combat", "prob": 50 },
+      { "group": "enchanted_wands_disposable_greater_combat", "prob": 10 }
     ]
   },
   {
-    "id": "enchanted_wands_disposable_minor",
+    "id": "enchanted_wands_disposable_minor_combat",
     "type": "item_group",
     "subtype": "distribution",
     "items": [
@@ -750,7 +750,7 @@
     ]
   },
   {
-    "id": "enchanted_wands_disposable_lesser",
+    "id": "enchanted_wands_disposable_lesser_combat",
     "type": "item_group",
     "subtype": "distribution",
     "items": [
@@ -764,7 +764,7 @@
     ]
   },
   {
-    "id": "enchanted_wands_disposable_greater",
+    "id": "enchanted_wands_disposable_greater_combat",
     "type": "item_group",
     "subtype": "distribution",
     "items": [
@@ -1060,7 +1060,7 @@
     "subtype": "distribution",
     "items": [
       { "group": "enchanted_worn_items", "prob": 15 },
-      { "group": "enchanted_wands_disposable", "prob": 10 },
+      { "group": "enchanted_wands_disposable_combat", "prob": 10 },
       {
         "distribution": [ { "group": "enchanted_melee_weapons_plus1", "prob": 95 }, { "group": "enchanted_melee_weapons_plus2", "prob": 5 } ],
         "prob": 4

--- a/data/mods/Magiclysm/monsters/goblin.json
+++ b/data/mods/Magiclysm/monsters/goblin.json
@@ -96,7 +96,10 @@
         { "item": "boots_scrap", "prob": 40 },
         { "item": "armguard_scrap", "prob": 40 },
         { "item": "cuirass_scrap", "prob": 40 },
-        { "group": "enchanted_melee_weapons_plus1", "prob": 100 }
+        {
+          "distribution": [ { "group": "survivor_melee", "prob": 90 }, { "group": "enchanted_melee_weapons_plus1", "prob": 10 } ],
+          "prob": 100
+        }
       ]
     }
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Magiclysm] Rebalance enchanted combat loot"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

It's kind of weird that the `enchanted_combat_items` itemgroup only shows up in the lairs of magical beasts or in goblin camps. Presumably the military had access to some of this gear since there are actual Magiclysm use-cases that require enchanted melee weapons (creatures that are immune to mundane weaponry), so they'd have some around in case the sealed tomb of an ancient evil in the Rocky Mountains opens and the army has to deploy outside Denver to repel an unholy legion of wraiths, or they need to conduct a military exercise outside the green dragon territories in what would be upstate New York in the real world to remind them that just because magic means they're immune to air-to-air missile fire doesn't mean dragons are invincible, or something. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Rework the `enchanted_combat_items` itemgroup and place it in a bunch of new relevant areas:

For `enchanted_combat_items`, it had bracers as a separate category even though the most common result of that itemgroup was the group `enchanted_worn_items`, for which bracers were _also_ the most common result. So remove bracers from enchanted_combat_items. Create an item group for disposable wands, which seems like they should be more common as self-defense tool, and add it. Add enchanted_combat_items as possible loot for feral and zombie soldiers (at a low chance), feral preppers and zombie survivors (higher chance) and zombie elite survivors (very high chance). Add enchanted wands to `milspec_arsenal_group_only_guns` so they'll show up in military outposts and areas and add them to `homeguns` at a low chance, and add `enchanted_worn_items` to `army_personal_locker` (also at a low chance).  

Also, make it so goblin chieftans only have magical weapons 10% of the time, pending my rework of goblins (it's coming post-ogres, get ready for bugbears). 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

An example of the new `enchanted_combat_items`:

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/120433252/b1ec4080-002e-4c8c-bef8-fa69e1889dfd)

Get ready to make some decisions about when to use your disposable wands.

Looks like the military base uses mostly place_loot so there's no easy way to add these there., unfortunately.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Probably going to add more disposable non-combat wands, for civilian use, in another PR
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
