### PR TITLE
[Magiclysm] Reduce mana cost of some of the spells I've written

### DIFF
--- a/data/mods/Magiclysm/Spells/biomancer.json
+++ b/data/mods/Magiclysm/Spells/biomancer.json
@@ -437,7 +437,7 @@
     "max_duration": 360000,
     "duration_increment": 24000,
     "energy_source": "MANA",
-    "base_energy_cost": 300,
+    "base_energy_cost": 200,
     "base_casting_time": 1000
   },
   {
@@ -457,7 +457,7 @@
     "max_duration": 90000,
     "duration_increment": 4000,
     "energy_source": "MANA",
-    "base_energy_cost": 550,
+    "base_energy_cost": 500,
     "base_casting_time": 100
   },
   {
@@ -586,7 +586,7 @@
     "min_range": 1,
     "max_range": 1,
     "energy_source": "MANA",
-    "base_energy_cost": 350,
+    "base_energy_cost": 500,
     "base_casting_time": 90000,
     "final_casting_time": 30000,
     "casting_time_increment": -6000
@@ -628,7 +628,7 @@
     "max_duration": 630000,
     "duration_increment": 36000,
     "energy_source": "MANA",
-    "base_energy_cost": 450,
+    "base_energy_cost": 250,
     "base_casting_time": 350
   },
   {
@@ -678,7 +678,7 @@
     "max_duration": 360000,
     "duration_increment": 24000,
     "energy_source": "MANA",
-    "base_energy_cost": 450,
+    "base_energy_cost": 300,
     "base_casting_time": 500
   },
   {
@@ -698,7 +698,7 @@
     "max_duration": 1380000,
     "duration_increment": 60000,
     "energy_source": "MANA",
-    "base_energy_cost": 750,
+    "base_energy_cost": 450,
     "base_casting_time": 600
   },
   {

--- a/data/mods/Magiclysm/Spells/classless.json
+++ b/data/mods/Magiclysm/Spells/classless.json
@@ -453,7 +453,7 @@
     "max_duration": 8640000,
     "duration_increment": 720000,
     "energy_source": "MANA",
-    "base_energy_cost": 150,
+    "base_energy_cost": 50,
     "base_casting_time": 6000
   },
   {
@@ -470,7 +470,7 @@
     "difficulty": 2,
     "max_level": 15,
     "energy_source": "MANA",
-    "base_energy_cost": 200,
+    "base_energy_cost": 75,
     "base_casting_time": 3000
   },
   {

--- a/data/mods/Magiclysm/Spells/druid.json
+++ b/data/mods/Magiclysm/Spells/druid.json
@@ -956,7 +956,7 @@
     "energy_source": "MANA",
     "difficulty": 5,
     "base_casting_time": 150,
-    "base_energy_cost": 550,
+    "base_energy_cost": 400,
     "max_level": 15
   },
   {
@@ -1187,7 +1187,7 @@
     "difficulty": 4,
     "max_level": 15,
     "energy_source": "MANA",
-    "base_energy_cost": 350,
+    "base_energy_cost": 200,
     "base_casting_time": 1000
   },
   {

--- a/data/mods/Magiclysm/Spells/kelvinist.json
+++ b/data/mods/Magiclysm/Spells/kelvinist.json
@@ -552,7 +552,7 @@
     "max_duration": 2160000,
     "duration_increment": 99000,
     "energy_source": "MANA",
-    "base_energy_cost": 450,
+    "base_energy_cost": 250,
     "base_casting_time": 1500
   },
   {
@@ -572,7 +572,7 @@
     "max_duration": 2160000,
     "duration_increment": 99000,
     "energy_source": "MANA",
-    "base_energy_cost": 450,
+    "base_energy_cost": 250,
     "base_casting_time": 1500
   },
   {
@@ -593,7 +593,7 @@
     "max_duration": 990000,
     "duration_increment": 45000,
     "energy_source": "MANA",
-    "base_energy_cost": 250,
+    "base_energy_cost": 350,
     "base_casting_time": 500
   },
   {
@@ -616,7 +616,7 @@
     "max_aoe": 10,
     "aoe_increment": 0.5,
     "energy_source": "MANA",
-    "base_energy_cost": 450,
+    "base_energy_cost": 250,
     "base_casting_time": 250
   },
   {
@@ -656,7 +656,7 @@
     "max_duration": 327240000,
     "duration_increment": 18360000,
     "energy_source": "MANA",
-    "base_energy_cost": 500,
+    "base_energy_cost": 400,
     "base_casting_time": 1500
   },
   {

--- a/data/mods/Magiclysm/Spells/magus.json
+++ b/data/mods/Magiclysm/Spells/magus.json
@@ -617,7 +617,7 @@
     "range_increment": 1,
     "energy_source": "MANA",
     "base_energy_cost": 200,
-    "final_energy_cost": 100,
+    "final_energy_cost": 50,
     "energy_increment": -10,
     "base_casting_time": 150,
     "final_casting_time": 50,

--- a/data/mods/Magiclysm/Spells/stormshaper.json
+++ b/data/mods/Magiclysm/Spells/stormshaper.json
@@ -1030,7 +1030,7 @@
     "max_duration": 90000,
     "duration_increment": 3750,
     "energy_source": "MANA",
-    "base_energy_cost": 650,
+    "base_energy_cost": 400,
     "base_casting_time": 1500
   },
   {

--- a/data/mods/Magiclysm/Spells/technomancer.json
+++ b/data/mods/Magiclysm/Spells/technomancer.json
@@ -658,7 +658,7 @@
     "max_damage": { "math": [ "( (u_spell_level('technomancer_robot_shutdown') * -25) - 400)" ] },
     "energy_source": "MANA",
     "base_casting_time": 150,
-    "base_energy_cost": 350,
+    "base_energy_cost": 250,
     "targeted_monster_species": [ "GOLEM", "ROBOT", "CYBORG" ]
   },
   {
@@ -679,7 +679,7 @@
     "duration_increment": 15000,
     "energy_source": "MANA",
     "base_casting_time": 6000,
-    "base_energy_cost": 450
+    "base_energy_cost": 300
   },
   {
     "id": "technomancer_conjure_ups",
@@ -700,9 +700,9 @@
     "//": "The Power Supply provides 1 kj per second and regenerates 1 kj per second, so the duration is the total power supplied.  Cost below increases but not as fast as power does.",
     "energy_source": "MANA",
     "base_casting_time": 3000,
-    "base_energy_cost": 600,
-    "final_energy_cost": 900,
-    "energy_increment": 15
+    "base_energy_cost": 300,
+    "final_energy_cost": 450,
+    "energy_increment": 7
   },
   {
     "id": "technomancer_welder",
@@ -723,7 +723,7 @@
     "max_duration": 720000,
     "duration_increment": 24000,
     "energy_source": "MANA",
-    "base_energy_cost": 500,
+    "base_energy_cost": 300,
     "base_casting_time": 3000
   },
   {
@@ -743,7 +743,7 @@
     "damage_increment": 2350,
     "min_range": 1,
     "energy_source": "MANA",
-    "base_energy_cost": 750,
+    "base_energy_cost": 500,
     "base_casting_time": 6000
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Magiclysm] Reduce mana cost of some of the spells I've written"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I went to start another spell PR but in looking at the spells, I think I overcosted some of the spells I wrote. And in the interest of not doing a "while I'm here..." I'll reduce them as a separate PR.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Reduce the mana cost of several spells. Mana takes 8 hours to regenerate to full, after all. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
