### PR TITLE
CMake: Add LLVM build for Windows and other linker fixes

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -30,10 +30,21 @@
       "cacheVariables": {
         "CMAKE_PROJECT_INCLUDE_BEFORE": "${sourceDir}/build-scripts/${presetName}.cmake",
         "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/build-scripts/MSVC.cmake",
+    {
+      "name": "windows-tiles-sounds-x64-llvm",
+      "binaryDir": "${sourceDir}/out/build/${presetName}",
+      "displayName": "Windows Tiles Sounds x64 LLVM",
+      "description": "Target Windows (64-bit) with the LLVM development environment.",
+      "inherits": "windows-tiles-sounds-x64",
+      "environment": {
+        "VCPKG_ROOT": "C:/vcpkg"
+      },
+      "cacheVariables": {
+        "LLVM_ROOT": "C:/Program Files/LLVM",
+        "CMAKE_PROJECT_INCLUDE_BEFORE": "${sourceDir}/build-scripts/windows-tiles-sounds-x64-msvc.cmake",
+        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/build-scripts/LLVM.cmake",
         "VCPKG_TARGET_TRIPLET": "x64-windows-static",
-        "DYNAMIC_LINKING": "False",
-        "CURSES": "False", "LOCALIZE": "True", "TILES": "True", "SOUND": "True", "TESTS": "True",
-        "CMAKE_INSTALL_MESSAGE": "NEVER"
+        "VCPKG_APPLOCAL_DEPS": "False"
       }
     },
     {
@@ -80,6 +91,10 @@
     {
       "name": "windows-tiles-sounds-x64-msvc",
       "configurePreset": "windows-tiles-sounds-x64-msvc"
+    },
+    {
+      "name": "windows-tiles-sounds-x64-llvm",
+      "configurePreset": "windows-tiles-sounds-x64-llvm"
     }
   ],
   "testPresets": [

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -24,12 +24,16 @@
       "displayName": "Windows Tiles Sounds x64 MSVC",
       "description": "Target Windows (64-bit) with the Visual Studio development environment.",
       "generator": "Visual Studio 16 2019",
+      "inherits": "windows-tiles-sounds-x64",
       "environment": {
         "VCPKG_ROOT": "C:/vcpkg"
       },
       "cacheVariables": {
         "CMAKE_PROJECT_INCLUDE_BEFORE": "${sourceDir}/build-scripts/${presetName}.cmake",
         "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/build-scripts/MSVC.cmake",
+        "VCPKG_TARGET_TRIPLET": "x64-windows-static"
+      }
+    },
     {
       "name": "windows-tiles-sounds-x64-llvm",
       "binaryDir": "${sourceDir}/out/build/${presetName}",

--- a/build-scripts/LLVM.cmake
+++ b/build-scripts/LLVM.cmake
@@ -1,0 +1,60 @@
+#[=======================================================================[
+
+LLVM
+----
+
+Toolchain file for LLVM CLANG on Windows
+
+Used by CMakePresets.json -> "toolchainFile".
+
+Using clang-cl.exe so we can copy MSVC.cmake flags over here.
+
+Refer to MSVC.cmake documentation
+
+#]=======================================================================]
+
+set(CMAKE_C_COMPILER   "${LLVM_ROOT}/bin/clang-cl.exe")
+set(CMAKE_CXX_COMPILER ${CMAKE_C_COMPILER})
+set(CMAKE_RC_COMPILER  "${LLVM_ROOT}/bin/llvm-rc.exe")
+set(CMAKE_MT "${LLVM_ROOT}/bin/llvm-mt.exe")
+set(CMAKE_OBJDUMP "${LLVM_ROOT}/bin/llvm-objdump.exe")
+
+set(CMAKE_CXX_FLAGS_INIT "\
+/utf-8 /bigobj /permissive- /sdl- /FC /Gd /GS- /Gy /GF \
+/wd4068 /wd4146 /wd4661 /wd4819 /wd6237 /wd6319 /wd26444 /wd26451 /wd26495 /WX- /W1 \
+/Zc:forScope /Zc:inline /Zc:wchar_t"
+)
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT
+"/Oi"
+)
+
+add_compile_definitions(
+    _SCL_SECURE_NO_WARNINGS
+    _CRT_SECURE_NO_WARNINGS
+    WIN32_LEAN_AND_MEAN
+    LOCALIZE
+    USE_VCPKG
+)
+
+add_link_options(
+    /OPT:REF
+    /OPT:ICF
+    /LTCG:OFF
+    /INCREMENTAL:NO
+    /DYNAMICBASE
+    /NXCOMPAT
+    "$<$<CONFIG:Debug>:/NODEFAULTLIB:LIBCMT>"
+    "$<$<CONFIG:RelWithDebInfo>:/NODEFAULTLIB:LIBCMTD>"
+)
+
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+ 
+# Where is vcpkg.json ?
+set(VCPKG_MANIFEST_DIR ${CMAKE_SOURCE_DIR}/msvc-full-features)
+
+set(VCPKG_ROOT "" CACHE PATH "Path to VCPKG installation")
+if (NOT $ENV{VCPKG_ROOT} STREQUAL "")
+    include($ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake)
+elseif(NOT $CACHE{VCPKG_ROOT} STREQUAL "")
+    include($CACHE{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake)
+endif()

--- a/build-scripts/MSVC.cmake
+++ b/build-scripts/MSVC.cmake
@@ -48,6 +48,21 @@ Linker flags used by all builds:
 /NXCOMPAT     same as above
 No need to force /TLBID:1 because is default
 
+CMake defaults seen in generators:
+CMAKE_CXX_FLAGS=/DWIN32 /D_WINDOWS /EHsc
+CMAKE_CXX_FLAGS_DEBUG=/Zi /Ob0 /Od /RTC1
+CMAKE_CXX_FLAGS_RELWITHDEBINFO=/Zi /O2 /Ob1 /DNDEBUG
+CMAKE_EXE_LINKER_FLAGS=/machine:x64
+CMAKE_EXE_LINKER_FLAGS_DEBUG=/debug /INCREMENTAL
+CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO=/debug /INCREMENTAL
+
+Use the following for Dr. Memory:
+/Zi or /ZI
+/DEBUG:FULL
+/Ob0    disable inlining
+/Oy-    don't omit frame pointers
+Remove /RTC1
+
 #]=======================================================================]
 
 # Path has changed, so this configure run will find cl.exe
@@ -61,6 +76,7 @@ set(CMAKE_CXX_FLAGS_INIT "\
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT
 "/Oi"
 )
+
 add_compile_definitions(
     _SCL_SECURE_NO_WARNINGS
     _CRT_SECURE_NO_WARNINGS
@@ -68,6 +84,7 @@ add_compile_definitions(
     LOCALIZE
     USE_VCPKG
 )
+
 add_link_options(
     /OPT:REF
     /OPT:ICF

--- a/build-scripts/MSVC.cmake
+++ b/build-scripts/MSVC.cmake
@@ -92,9 +92,11 @@ add_link_options(
     /INCREMENTAL:NO
     /DYNAMICBASE
     /NXCOMPAT
+    "$<$<CONFIG:Debug>:/NODEFAULTLIB:LIBCMT>"
+    "$<$<CONFIG:RelWithDebInfo>:/NODEFAULTLIB:LIBCMTD>"
 )
 
-set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded")
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
 # Where is vcpkg.json ?
 set(VCPKG_MANIFEST_DIR ${CMAKE_SOURCE_DIR}/msvc-full-features)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,7 +49,7 @@ if (TILES)
                 ${RESOURCE_RC})
         if(MSYS2)
             target_link_options(cataclysm-tiles PRIVATE
-                "LINKER:--strip-debug"
+                "$<$<CONFIG:Debug,RelWithDebInfo>:LINKER:--strip-debug>"
             )
         else()
             # Use only our RT_MANIFEST from resource.rc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,10 +51,9 @@ if (TILES)
             # /MANIFESTINPUT not supported by GNU linker
             # Defaul embed via `windres.exe` compiling `resource.rc` -> `resource.rc.obj`
         else()
-            # Embed manifest directly to avoid:
-            # "fatal error CVT1100: duplicate resource.  type:MANIFEST, name:1, language:0x0409"
+            # Use only our RT_MANIFEST from resource.rc
             target_link_options(cataclysm-tiles PRIVATE
-                "LINKER:/MANIFESTINPUT:${CMAKE_SOURCE_DIR}/data/application_manifest.xml"
+                "LINKER:/MANIFEST:NO"
             )
         endif()
     else ()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,8 +48,9 @@ if (TILES)
                 ${MESSAGES_CPP}
                 ${RESOURCE_RC})
         if(MSYS2)
-            # /MANIFESTINPUT not supported by GNU linker
-            # Defaul embed via `windres.exe` compiling `resource.rc` -> `resource.rc.obj`
+            target_link_options(cataclysm-tiles PRIVATE
+                "LINKER:--strip-debug"
+            )
         else()
             # Use only our RT_MANIFEST from resource.rc
             target_link_options(cataclysm-tiles PRIVATE

--- a/src/resource.rc
+++ b/src/resource.rc
@@ -3,10 +3,6 @@
 
 #include <windows.h>
 0  ICON  "../data/cataicon.ico"
-#if defined(CMAKE) && !defined(MSYS2)
-    // Will embed it with MSVC' linker /MANIFESTINPUT:
-#else
 1  RT_MANIFEST "../data/application_manifest.xml"
-#endif
 
 #endif // RESOURCE_RC_INCLUDED

--- a/src/version.cmake
+++ b/src/version.cmake
@@ -1,4 +1,6 @@
-file(TOUCH ${CMAKE_SOURCE_DIR}/src/version.h)
+if(NOT EXISTS ${CMAKE_SOURCE_DIR}/src/version.h)
+    file(TOUCH ${CMAKE_SOURCE_DIR}/src/version.h)
+endif()
 
 list(APPEND CMAKE_MODULE_PATH
     ${CMAKE_SOURCE_DIR}/CMakeModules)


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Build "CMake: Add LLVM build for Windows and other linker fixes"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
* Compile and link using LLVM v17 for Windows.
* Simplify logic for embedding the manifest.
* Fix MINGW executable not running right after the build.
* Fix `LNK4098` from MSVC
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
* Add a new CMake preset for using LLVM on Windows. Requires `LLVM_ROOT` to be defined. Default `C:\Program Files\LLVM`
* LLVM build uses `clang-cl.exe` so that we can reuse flags from `MSVC.cmake` toolchain file
* Removed a weird logic to handle manifest because it wasn't clear `/MANIFEST:NO` was about commanding the linker to **not automatically** generate and embed a manifest.
* Instead of manually stripping the MSYS/MINGW build manually, just add `--strip-debug` to `ld.exe` to make the executable run on native Windows.
* Handle `/NODEFAULTLIB:` and `CMAKE_MSVC_RUNTIME_LIBRARY` to fix MSVC's linker warning `LNK4098` about conflicting libraries.
* Do not always write `version.h` when configuring the build. Avoid `version.cpp` to be rebuilt when there is no need.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Split this PR in smaller ones.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
✅ Build and run LLVM, MSVC and UCRT64 executables
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
N/A
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
