### PR TITLE
Add uncraft recipes for survivor masks

### DIFF
--- a/data/json/uncraft/armor.json
+++ b/data/json/uncraft/armor.json
@@ -152,7 +152,7 @@
     "components": [ [ [ "leather", 8 ] ], [ [ "plastic_chunk", 6 ] ] ]
   },
   {
-    "result": "mask_survivor_heavy",
+    "result": "mask_hsurvivor",
     "type": "uncraft",
     "activity_level": "LIGHT_EXERCISE",
     "time": "30 m",
@@ -160,7 +160,7 @@
     "components": [ [ [ "leather", 8 ] ], [ [ "plastic_chunk", 3 ] ], [ [ "sheet_metal_small", 1 ] ] ]
   },
   {
-    "result": "mask_survivor_fire",
+    "result": "mask_fsurvivor",
     "type": "uncraft",
     "activity_level": "LIGHT_EXERCISE",
     "time": "30 m",
@@ -168,7 +168,7 @@
     "components": [ [ [ "leather", 8 ] ], [ [ "plastic_chunk", 3 ] ], [ [ "nomex", 2 ] ] ]
   },
   {
-    "result": "mask_survivor_light",
+    "result": "mask_lsurvivor",
     "type": "uncraft",
     "activity_level": "LIGHT_EXERCISE",
     "time": "30 m",

--- a/data/json/uncraft/armor.json
+++ b/data/json/uncraft/armor.json
@@ -174,5 +174,69 @@
     "time": "30 m",
     "qualities": [ { "id": "CUT", "level": 2 } ],
     "components": [ [ [ "leather", 4 ] ], [ [ "plastic_chunk", 1 ] ] ]
+  },
+  {
+    "result": "mask_survivorxl",
+    "type": "uncraft",
+    "activity_level": "LIGHT_EXERCISE",
+    "time": "30 m",
+    "qualities": [ { "id": "CUT", "level": 2 } ],
+    "components": [ [ [ "leather", 10 ] ], [ [ "plastic_chunk", 8 ] ] ]
+  },
+  {
+    "result": "mask_hsurvivorxl",
+    "type": "uncraft",
+    "activity_level": "LIGHT_EXERCISE",
+    "time": "30 m",
+    "qualities": [ { "id": "CUT", "level": 2 } ],
+    "components": [ [ [ "leather", 10 ] ], [ [ "plastic_chunk", 4 ] ], [ [ "sheet_metal_small", 2 ] ] ]
+  },
+  {
+    "result": "mask_fsurvivorxl",
+    "type": "uncraft",
+    "activity_level": "LIGHT_EXERCISE",
+    "time": "30 m",
+    "qualities": [ { "id": "CUT", "level": 2 } ],
+    "components": [ [ [ "leather", 10 ] ], [ [ "plastic_chunk", 4 ] ], [ [ "nomex", 3 ] ] ]
+  },
+  {
+    "result": "mask_lsurvivorxl",
+    "type": "uncraft",
+    "activity_level": "LIGHT_EXERCISE",
+    "time": "30 m",
+    "qualities": [ { "id": "CUT", "level": 2 } ],
+    "components": [ [ [ "leather", 6 ] ], [ [ "plastic_chunk", 2 ] ] ]
+  },
+  {
+    "result": "mask_survivorxs",
+    "type": "uncraft",
+    "activity_level": "LIGHT_EXERCISE",
+    "time": "30 m",
+    "qualities": [ { "id": "CUT", "level": 2 } ],
+    "components": [ [ [ "leather", 4 ] ], [ [ "plastic_chunk", 3 ] ] ]
+  },
+  {
+    "result": "mask_hsurvivorxs",
+    "type": "uncraft",
+    "activity_level": "LIGHT_EXERCISE",
+    "time": "30 m",
+    "qualities": [ { "id": "CUT", "level": 2 } ],
+    "components": [ [ [ "leather", 4 ] ], [ [ "plastic_chunk", 2 ] ], [ [ "sheet_metal_small", 1 ] ] ]
+  },
+  {
+    "result": "mask_fsurvivorxs",
+    "type": "uncraft",
+    "activity_level": "LIGHT_EXERCISE",
+    "time": "30 m",
+    "qualities": [ { "id": "CUT", "level": 2 } ],
+    "components": [ [ [ "leather", 4 ] ], [ [ "plastic_chunk", 2 ] ], [ [ "nomex", 1 ] ] ]
+  },
+  {
+    "result": "mask_lsurvivorxs",
+    "type": "uncraft",
+    "activity_level": "LIGHT_EXERCISE",
+    "time": "30 m",
+    "qualities": [ { "id": "CUT", "level": 2 } ],
+    "components": [ [ [ "leather", 2 ] ], [ [ "plastic_chunk", 1 ] ] ]
   }
 ]

--- a/data/json/uncraft/armor.json
+++ b/data/json/uncraft/armor.json
@@ -142,5 +142,37 @@
     "time": "2 m",
     "qualities": [ { "id": "CUT", "level": 2 } ],
     "components": [ [ [ "cotton_patchwork", 2 ] ], [ [ "wire", 1 ] ], [ [ "button_plastic", 9 ] ] ]
+  },
+  {
+    "result": "mask_survivor",
+    "type": "uncraft",
+    "activity_level": "LIGHT_EXERCISE",
+    "time": "30 m",
+    "qualities": [ { "id": "CUT", "level": 2 } ],
+    "components": [ [ [ "leather", 8 ] ], [ [ "plastic_chunk", 6 ] ] ]
+  },
+  {
+    "result": "mask_survivor_heavy",
+    "type": "uncraft",
+    "activity_level": "LIGHT_EXERCISE",
+    "time": "30 m",
+    "qualities": [ { "id": "CUT", "level": 2 } ],
+    "components": [ [ [ "leather", 8 ] ], [ [ "plastic_chunk", 3 ] ], [ [ "sheet_metal_small", 1 ] ] ]
+  },
+  {
+    "result": "mask_survivor_fire",
+    "type": "uncraft",
+    "activity_level": "LIGHT_EXERCISE",
+    "time": "30 m",
+    "qualities": [ { "id": "CUT", "level": 2 } ],
+    "components": [ [ [ "leather", 8 ] ], [ [ "plastic_chunk", 3 ] ], [ [ "nomex", 2 ] ] ]
+  },
+  {
+    "result": "mask_survivor_light",
+    "type": "uncraft",
+    "activity_level": "LIGHT_EXERCISE",
+    "time": "30 m",
+    "qualities": [ { "id": "CUT", "level": 2 } ],
+    "components": [ [ [ "leather", 4 ] ], [ [ "plastic_chunk", 1 ] ] ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Add uncraft recipes for survivor masks"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
Survivor masks were giving wax back when uncrafted. The wax is used in treating the leather and shouldn't be returned when the item is cut up.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Create uncraft recipes that give sensible resources back if you disassemble any of the various survivor mask.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
N/A

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
Uncrafted each mask, saw normal stuff coming back.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
