### PR TITLE
Upgrade clang-tidy check to LLVM 17

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -25,6 +25,10 @@
 # We have lots of memory allocations in static variable declarations, and
 # that's fine.
 #
+# * clang-analyzer-core.{DivideZero,NonNullParamChecker}
+# * clang-analyzer-cplusplus.NewDelete
+# They report too many false positives.
+#
 # * modernize-use-auto
 # We prefer an almost-always-avoid-auto style.
 #
@@ -49,25 +53,37 @@ cert-*,\
 -cert-dcl51-cpp,\
 -cert-err58-cpp,\
 clang-diagnostic-*,\
+-clang-analyzer-core.CallAndMessage,\
+-clang-analyzer-core.DivideZero,\
+-clang-analyzer-core.NonNullParamChecker,\
+-clang-analyzer-cplusplus.NewDelete,\
 cppcoreguidelines-slicing,\
 google-explicit-constructor,\
 llvm-namespace-comment,\
 misc-*,\
 modernize-*,\
 -modernize-use-auto,\
+-modernize-use-emplace,\
 -modernize-use-trailing-return-type,\
 performance-*,\
+-performance-avoid-endl,\
+-performance-noexcept-swap,\
+-performance-no-automatic-move,\
 readability-*,\
 -readability-braces-around-statements,\
 -bugprone-assignment-in-if-condition,\
 -bugprone-easily-swappable-parameters,\
+-bugprone-empty-catch,\
 -bugprone-implicit-widening-of-multiplication-result,\
 -bugprone-narrowing-conversions,\
+-bugprone-switch-missing-default-case,\
 -bugprone-throw-keyword-missing,\
 -bugprone-unchecked-optional-access,\
 -bugprone-unhandled-exception-at-new,\
 -misc-confusable-identifiers,\
 -misc-const-correctness,\
+-misc-header-include-cycle,\
+-misc-include-cleaner,\
 -misc-no-recursion,\
 -misc-non-private-member-variables-in-classes,\
 -misc-use-anonymous-namespace,\
@@ -77,6 +93,7 @@ readability-*,\
 -modernize-return-braced-init-list,\
 -modernize-use-default-member-init,\
 -modernize-use-nodiscard,\
+-readability-avoid-unconditional-preprocessor-if,\
 -readability-container-data-pointer,\
 -readability-convert-member-functions-to-static,\
 -readability-duplicate-include,\

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,4 +1,4 @@
-name: Clang-tidy 16
+name: Clang-tidy 17
 
 on:
   push:
@@ -52,31 +52,31 @@ jobs:
     runs-on: ubuntu-22.04
     env:
         CMAKE: 1
-        CLANG: clang++-16
-        COMPILER: clang++-16
+        CLANG: clang++-17
+        COMPILER: clang++-17
         CATA_CLANG_TIDY: plugin
         CATA_CLANG_TIDY_SUBSET: ${{ matrix.subset }}
         TILES: 1
         SOUND: 1
         RELEASE: 1
     steps:
-    - name: install LLVM 16
+    - name: install LLVM 17
       run: |
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo apt-add-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main"
+          sudo apt-add-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main"
           sudo apt update
-          sudo apt install llvm-16 llvm-16-dev llvm-16-tools clang-16 clang-tidy-16 clang-tools-16 \
-            libclang-16-dev libflac-dev libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libsdl2-mixer-dev \
+          sudo apt install llvm-17 llvm-17-dev llvm-17-tools clang-17 clang-tidy-17 clang-tools-17 \
+            libclang-17-dev libflac-dev libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libsdl2-mixer-dev \
             libpulse-dev ccache gettext jq
     - name: install dependencies
       run: |
           sudo apt install python3-pip libncursesw5-dev ninja-build cmake gettext
           pip3 install --user lit
-    - name: ensure clang-tidy and FileCheck commands point to LLVM 16
+    - name: ensure clang-tidy and FileCheck commands point to LLVM 17
       run: |
           mkdir ~/llvm-command-override
-          ln -s /usr/bin/clang-tidy-16 ~/llvm-command-override/clang-tidy
-          ln -s /usr/bin/FileCheck-16 ~/llvm-command-override/FileCheck
+          ln -s /usr/bin/clang-tidy-17 ~/llvm-command-override/clang-tidy
+          ln -s /usr/bin/FileCheck-17 ~/llvm-command-override/FileCheck
           echo "$HOME/llvm-command-override" >> $GITHUB_PATH
     - name: checkout repository
       uses: actions/checkout@v4

--- a/build-scripts/clang-tidy.sh
+++ b/build-scripts/clang-tidy.sh
@@ -24,8 +24,8 @@ then
     cmake_extra_opts+=("-DCATA_CLANG_TIDY_PLUGIN=ON")
     # Need to specify the particular LLVM / Clang versions to use, lest it
     # use the older LLVM that comes by default on Ubuntu.
-    cmake_extra_opts+=("-DLLVM_DIR=/usr/lib/llvm-16/lib/cmake/llvm")
-    cmake_extra_opts+=("-DClang_DIR=/usr/lib/llvm-16/lib/cmake/clang")
+    cmake_extra_opts+=("-DLLVM_DIR=/usr/lib/llvm-17/lib/cmake/llvm")
+    cmake_extra_opts+=("-DClang_DIR=/usr/lib/llvm-17/lib/cmake/clang")
 fi
 
 mkdir -p build

--- a/tests/list_test.cpp
+++ b/tests/list_test.cpp
@@ -954,6 +954,7 @@ TEST_CASE( "list_emplace_move_copy_and_reverse_iterate", "[list]" )
 
     SECTION( "emplace post-moved list" ) {
         // Reuse the moved list will cause segmentation fault
+        // NOLINTNEXTLINE(clang-analyzer-cplusplus.Move)
         test_list.emplace_back( 3 );
         CHECK( test_list.size() == 1 );
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Apart from new static analysis checks, clang-tidy 17 also fixed a few bothering bugs in LLVM 16, notably
* clang-tidy freezes or crashes in `bugprone-unchecked-optional-access` that we had to disable the check (https://github.com/llvm/llvm-project/issues/62085)
* unable to disable individual static analyser checks so that we had to disable the entire clang static analyser in #71425
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Update the GitHub Actions CI workflow script to LLVM 17, and then temporarily disable a few new static analysis checks that are reporting too many violations. Will return to these checks to see if some of them warrant enabling later.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Good to merge if the clang-tidy CI check succeeds on this pull request.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
