### PR TITLE
Make barrel length affect bullet dispersion

### DIFF
--- a/data/json/items/ammo/223.json
+++ b/data/json/items/ammo/223.json
@@ -64,10 +64,7 @@
       ]
     },
     "dispersion": 30,
-    "dispersion_modifier":[
-      { "barrel_length": "368 mm", "dispersion": 30 },
-      { "barrel_length": "533 mm", "dispersion": 0 }
-    ],
+    "dispersion_modifier": [ { "barrel_length": "337 mm", "dispersion": 30 }, { "barrel_length": "533 mm", "dispersion": 0 } ],
     "recoil": 1500,
     "effects": [ "COOKOFF" ]
   },
@@ -105,11 +102,7 @@
     "price_postapoc": 900,
     "flags": [ "IRREPLACEABLE_CONSUMABLE" ],
     "relative": { "damage": { "damage_type": "bullet", "amount": -3, "armor_penetration": 10 }, "dispersion": 20 },
-    "dispersion_modifier":[
-      { "barrel_length": "368 mm", "dispersion": 120 },
-      { "barrel_length": "533 mm", "dispersion": 0 }
-
-    ],
+    "dispersion_modifier": [ { "barrel_length": "337 mm", "dispersion": 120 }, { "barrel_length": "533 mm", "dispersion": 0 } ],
     "proportional": { "recoil": 1.1 },
     "extend": { "effects": [ "NEVER_MISFIRES" ] }
   },

--- a/data/json/items/ammo/223.json
+++ b/data/json/items/ammo/223.json
@@ -64,6 +64,10 @@
       ]
     },
     "dispersion": 30,
+    "dispersion_modifier":[
+      { "barrel_length": "368 mm", "dispersion": 30 },
+      { "barrel_length": "533 mm", "dispersion": 0 }
+    ],
     "recoil": 1500,
     "effects": [ "COOKOFF" ]
   },
@@ -100,7 +104,12 @@
     "price": 290,
     "price_postapoc": 900,
     "flags": [ "IRREPLACEABLE_CONSUMABLE" ],
-    "relative": { "damage": { "damage_type": "bullet", "amount": -3, "armor_penetration": 10 }, "dispersion": 140 },
+    "relative": { "damage": { "damage_type": "bullet", "amount": -3, "armor_penetration": 10 }, "dispersion": 20 },
+    "dispersion_modifier":[
+      { "barrel_length": "368 mm", "dispersion": 120 },
+      { "barrel_length": "533 mm", "dispersion": 0 }
+
+    ],
     "proportional": { "recoil": 1.1 },
     "extend": { "effects": [ "NEVER_MISFIRES" ] }
   },

--- a/data/json/items/gun/223.json
+++ b/data/json/items/gun/223.json
@@ -530,7 +530,6 @@
     "material": [ "aluminum", "steel", "plastic" ],
     "ammo": [ "NULL" ],
     "default_mods": [ "adjustable_stock", "retool_ar15_223rem_extended" ],
-    "dispersion": 150,
     "durability": 7,
     "weapon_category": [ "AUTOMATIC_RIFLES" ],
     "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "BURST", "3 rd.", 3 ] ],

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -2993,20 +2993,33 @@ void item::ammo_info( std::vector<iteminfo> &info, const iteminfo_query *parts, 
                                           medium ).total_damage() );
             const int large_damage = static_cast<int>( ammo.damage.di_considering_length(
                                          large ).total_damage() );
-            if( small_damage != medium_damage || medium_damage != large_damage ) {
-                info.emplace_back( "AMMO", _( "Damage by barrel length: " ) );
+            const int small_dispersion = static_cast<int>( ammo.dispersion_considering_length( small ) );
+            const int medium_dispersion = static_cast<int>( ammo.dispersion_considering_length( medium ) );
+            const int large_dispersion = static_cast<int>( ammo.dispersion_considering_length( large ) );
+            if( small_damage != medium_damage || medium_damage != large_damage ||
+                small_dispersion != medium_dispersion || medium_damage != large_dispersion ) {
+                info.emplace_back( "AMMO", _( "Damage and dispersion by barrel length: " ) );
                 const std::string small_string = string_format( " <info>%d %s</info>: ",
                                                  convert_length( small ),
                                                  length_units( small ) );
-                info.emplace_back( "AMMO", small_string, small_damage );
+                info.emplace_back( "AMMO", small_string, _( " damage:  <num>" ), iteminfo::no_newline,
+                                   small_damage );
+                info.emplace_back( "AMMO", "", _( " dispersion:  <num>" ),
+                                   iteminfo::no_name | iteminfo::lower_is_better, small_dispersion );
                 const std::string medium_string = string_format( " <info>%d %s</info>: ",
                                                   convert_length( medium ),
                                                   length_units( medium ) );
-                info.emplace_back( "AMMO", medium_string, medium_damage );
+                info.emplace_back( "AMMO", medium_string, _( " damage:  <num>" ), iteminfo::no_newline,
+                                   medium_damage );
+                info.emplace_back( "AMMO", "", _( " dispersion:  <num>" ),
+                                   iteminfo::no_name  | iteminfo::lower_is_better, medium_dispersion );
                 const std::string large_string = string_format( " <info>%d %s</info>: ",
                                                  convert_length( large ),
                                                  length_units( large ) );
-                info.emplace_back( "AMMO", large_string, large_damage );
+                info.emplace_back( "AMMO", large_string, _( " damage:  <num>" ), iteminfo::no_newline,
+                                   large_damage );
+                info.emplace_back( "AMMO", "", _( " dispersion:  <num>" ),
+                                   iteminfo::no_name | iteminfo::lower_is_better, large_dispersion );
             }
         }
     }
@@ -3228,7 +3241,7 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
                            mod->gun_dispersion( false, false ) );
     }
     if( mod->ammo_required() ) {
-        int ammo_dispersion = curammo->ammo->dispersion;
+        int ammo_dispersion = curammo->ammo->dispersion_considering_length( barrel_length() );
         // ammo_dispersion and sum_of_dispersion don't need to translate.
         if( parts->test( iteminfo_parts::GUN_DISPERSION_LOADEDAMMO ) ) {
             info.emplace_back( "GUN", "ammo_dispersion", "",
@@ -10346,7 +10359,7 @@ int item::gun_dispersion( bool with_ammo, bool with_scaling ) const
     dispersion_sum += damage_level() * dispPerDamage;
     dispersion_sum = std::max( dispersion_sum, 0 );
     if( with_ammo && ammo_data() ) {
-        dispersion_sum += ammo_data()->ammo->dispersion;
+        dispersion_sum += ammo_data()->ammo->dispersion_considering_length( barrel_length() );
     }
     if( !with_scaling ) {
         return dispersion_sum;
@@ -15075,4 +15088,11 @@ bool is_preferred_component( const item &component )
 bool is_preferred_crafting_component( const item &component )
 {
     return is_preferred_component( component ) && is_crafting_component( component );
+}
+
+disp_mod_by_barrel::disp_mod_by_barrel() = default;
+void disp_mod_by_barrel::deserialize( const JsonObject &jo )
+{
+    mandatory( jo, false, "barrel_length", barrel_length );
+    mandatory( jo, false, "dispersion", dispersion_modifier );
 }

--- a/src/item.h
+++ b/src/item.h
@@ -3278,3 +3278,13 @@ bool is_preferred_component( const item &component );
 bool is_preferred_crafting_component( const item &component );
 
 #endif // CATA_SRC_ITEM_H
+
+struct disp_mod_by_barrel {
+    units::length barrel_length;
+    int dispersion_modifier;
+
+    disp_mod_by_barrel();
+    disp_mod_by_barrel( units::length bl, int disp ) : barrel_length( bl ),
+        dispersion_modifier( disp ) {}
+    void deserialize( const JsonObject &jo );
+};

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2613,6 +2613,7 @@ void islot_ammo::load( const JsonObject &jo )
     assign( jo, "range", range, strict, 0 );
     assign( jo, "range_multiplier", range_multiplier, strict, 1.0f );
     assign( jo, "dispersion", dispersion, strict, 0 );
+    optional( jo, was_loaded, "dispersion_modifier", disp_mod_by_barrels, {} );
     assign( jo, "recoil", recoil, strict, 0 );
     assign( jo, "count", def_charges, strict, 1 );
     assign( jo, "loudness", loudness, strict, 0 );

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -420,3 +420,17 @@ const itype_id &itype::tool_slot_first_ammo() const
     }
     return itype_id::NULL_ID();
 }
+
+int islot_ammo::dispersion_considering_length( units::length barrel_length ) const
+{
+
+    if( disp_mod_by_barrels.empty() ) {
+        return  dispersion;
+    }
+    std::vector<std::pair<float, float>> lerp_points;
+    lerp_points.reserve( disp_mod_by_barrels.size() );
+    for( const disp_mod_by_barrel &b : disp_mod_by_barrels ) {
+        lerp_points.emplace_back( static_cast<float>( b.barrel_length.value() ), b.dispersion_modifier );
+    }
+    return multi_lerp( lerp_points, barrel_length.value() ) + dispersion;
+}

--- a/src/itype.h
+++ b/src/itype.h
@@ -1034,8 +1034,14 @@ struct islot_ammo : common_ranged_data {
      */
     bool force_stat_display;
 
+    /**
+    * Bullet dispersion affected by the length of the barrel
+    */
+    std::vector<disp_mod_by_barrel> disp_mod_by_barrels;
+
     bool was_loaded = false;
 
+    int dispersion_considering_length( units::length barrel_length ) const;
     void load( const JsonObject &jo );
     void deserialize( const JsonObject &jo );
 };


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The M855 was introduced in #51762.  This kind of bullet lacks sufficient accuracy when it cannot be accelerated in a sufficiently long barrel.  Therefore, in the past, its dispersion was simply set to a slightly exaggerated 170. Fortunately, we have clarified the barrel length of different guns, so that we can use a more reasonable way to reflect this characteristic.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Introduced a mechanism that affects the dispersion of bullets based on the length of the barrel, and configured and adjusted the dispersion of 223 caliber bullets. The current relationship between dispersion and barrel length is a rough linear relationship determined by the barrel length of the M249 (533mm) and the barrel length of the CQB receiver (368mm).  This numerical configuration ensures close proximity to current values. If necessary, more refined functional formulas may be considered in the future.
In addition, due to the higher shooting accuracy that can be achieved with a longer barrel, the base dispersion of the M16 equipped with a long barrel has been adjusted to 180, the same as that of the M4.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/92137695/32e638f3-fcb5-4407-8c06-a479b47b5c56)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/92137695/e9781725-4d91-466c-bb6b-b2a39cfa0bf7)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
