### PR TITLE
Say which specials could not be placed.

### DIFF
--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -6848,8 +6848,8 @@ void overmap::place_specials( overmap_special_batch &enabled_specials )
                 "The following specials could not be placed, some missions may fail to initialize: ";
             int n = 0;
             for( auto iter = custom_overmap_specials.begin(); iter != custom_overmap_specials.end(); ) {
-                if (iter->instances_placed < iter->special_details->get_constraints().occurrences.min) {
-                    msg.append(iter->special_details->id.c_str()).append(", ");
+                if( iter->instances_placed < iter->special_details->get_constraints().occurrences.min ) {
+                    msg.append( iter->special_details->id.c_str() ).append( ", " );
                     n++;
                 }
                 ++iter;

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -6844,7 +6844,21 @@ void overmap::place_specials( overmap_special_batch &enabled_specials )
             point_abs_om new_om_addr = random_entry( nearest_candidates );
             overmap_buffer.create_custom_overmap( new_om_addr, custom_overmap_specials );
         } else {
-            add_msg( _( "Unable to place all configured specials, some missions may fail to initialize." ) );
+            std::string msg = "The following specials could not be placed, some missions may fail to initialize: ";
+            int n = 0;
+            for( auto iter = custom_overmap_specials.begin(); iter != custom_overmap_specials.end(); ) {
+                if (iter->instances_placed < iter->special_details->get_constraints().occurrences.min) {
+                    msg.append(iter->special_details->id.c_str()).append(", ");
+                    n++;
+                }
+                ++iter;
+            }
+            if (n > 0) {
+                msg = msg.substr(0, msg.length()-2);
+            } else {
+                msg = msg.append ("<unknown>");
+            }
+            add_msg( _( msg ) );
         }
     }
     // Then fill in non-mandatory specials.

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -6857,7 +6857,7 @@ void overmap::place_specials( overmap_special_batch &enabled_specials )
             if( n > 0 ) {
                 msg = msg.substr( 0, msg.length() - 2 );
             } else {
-                msg = msg.append ("<unknown>");
+                msg = msg.append( "<unknown>" );
             }
             add_msg( _( msg ) );
         }

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -6844,7 +6844,8 @@ void overmap::place_specials( overmap_special_batch &enabled_specials )
             point_abs_om new_om_addr = random_entry( nearest_candidates );
             overmap_buffer.create_custom_overmap( new_om_addr, custom_overmap_specials );
         } else {
-            std::string msg = "The following specials could not be placed, some missions may fail to initialize: ";
+            std::string msg =
+                "The following specials could not be placed, some missions may fail to initialize: ";
             int n = 0;
             for( auto iter = custom_overmap_specials.begin(); iter != custom_overmap_specials.end(); ) {
                 if (iter->instances_placed < iter->special_details->get_constraints().occurrences.min) {

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -6854,8 +6854,8 @@ void overmap::place_specials( overmap_special_batch &enabled_specials )
                 }
                 ++iter;
             }
-            if (n > 0) {
-                msg = msg.substr(0, msg.length()-2);
+            if( n > 0 ) {
+                msg = msg.substr( 0, msg.length() - 2 );
             } else {
                 msg = msg.append ("<unknown>");
             }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Say which specials could not be placed."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

When creating a new world, or if not then Debug menu > Reveal Map and scrolling around the map, this message is usually given:

`Unable to place all configured specials, some missions may fail to initialize.`

which is concerning as it means some game content is missing from the current map, but it doesn't say exactly what's missing.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

This change tries to find what couldn't be placed and prints it.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
NA
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Generated a few new maps, Debug menu > Reveal Map, then zoom out to max in the map viewer, and the error message now says what failed:


![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/42494548/8b662ae1-f002-415d-ab88-0729f3411383)

I haven't tested (and not sure how to) if the right error gets printed if multiple specials get printed, or if it couldn't find what's missing, and `<unknown>` should get printed)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

It's always `dm_office_cubical_phavian` that fails to generate, I haven't fully understood why but it has     

`"occurrences":` [ 100, 100 ],`

and I'm not sure if that's valid, changing it to 90,100 (similar to other specials) prevents the error (but haven't tested further if this actually gets properly generated now).

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
