### PR TITLE
[Magiclysm] Add wizard version of LMOE

### DIFF
--- a/data/mods/Magiclysm/worldgen/last_mage_on_earth.json
+++ b/data/mods/Magiclysm/worldgen/last_mage_on_earth.json
@@ -1,0 +1,153 @@
+[
+  {
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": [ "lmoe_under_empty" ],
+    "//": "Empty LMOE shelter built for a wizard.",
+    "weight": 40,
+    "object": {
+      "fill_ter": "t_carpet_metal_purple",
+      "rows": [
+        "##|||||########||||||###",
+        "##|,,<|||||||##|β🜍🜍β|###",
+        "##|Y,<|w,BBd|##|_ØØ_|###",
+        "||||+||},BB,||||_ØØ_|###",
+        "|A,,,E|,,,,,:__+__X_|###",
+        "|f,,,,|+|||||||||||+||||",
+        "|f,,,e|,,,,b|_____|,☿,Ƀ|",
+        "|f,,,,|,,h,,|_____|,,,Ƀ|",
+        "|Dh,,P|,hLh,|_____|M,,Ƀ|",
+        "|☿,,,,|,hLh,|_____|,,,Ƀ|",
+        "|,,,,,+,,h,,|_____|ɃɃ,Ƀ|",
+        "|,|||||~,,,☿|_____|||+||",
+        "|,+,,B|K,,,u:_____||y_y|",
+        "|,|d,B|COC,u|_____||y_y|",
+        "|,||||||||+||_____||y_y|",
+        "|,+,,B|t,,,K|_____||y_y|",
+        "|}|d,B|WAv,s|_____||y_y|",
+        "|;|||||||||:|||+|||||:||",
+        "|__|_____|__|_______=__|",
+        "|__|_____||+|_______*__|",
+        "|__|________|_______=__|",
+        "|__|________+_______=__|",
+        "|__+________|_______=__|",
+        "||||||||||||||||||||||||"
+      ],
+      "palettes": [ "bunker", "empty_bunker_items" ],
+      "terrain": {
+        "M": "t_carpet_metal_purple",
+        "y": "t_metal_floor",
+        "X": "t_metal_floor",
+        "β": "t_metal_floor",
+        "Ø": "t_metal_floor",
+        "🜍": "t_metal_floor"
+      },
+      "furniture": {
+        "M": "f_armchair",
+        "y": "f_utility_shelf",
+        "Ƀ": "f_bookcase",
+        "☿": "f_everburning_torch_candelabra",
+        "🜍": "f_everburning_torch_candelabra",
+        "β": "f_magic_bench",
+        "Ø": "f_magic_circle"
+      },
+      "items": {
+        "Ƀ": [
+          { "item": "magic_shop_books", "chance": 40, "repeat": [ 1, 4 ] },
+          { "item": "spellbook_loot_0", "chance": 25, "repeat": [ 1, 2 ] },
+          { "item": "homebooks", "chance": 80, "repeat": [ 1, 3 ] },
+          { "item": "novels", "chance": 100, "repeat": [ 1, 3 ] }
+        ],
+        "β": [
+          { "item": "potions_common", "chance": 75, "repeat": [ 3, 6 ] },
+          { "item": "enchanted_small_items", "chance": 50, "repeat": [ 1, 4 ] },
+          { "item": "magical_reagents", "chance": 80, "repeat": [ 1, 2 ] }
+        ],
+        "y": [
+          { "item": "magical_reagents", "chance": 80, "repeat": [ 2, 3 ] },
+          { "item": "magic_plants_common", "chance": 85, "repeat": [ 2, 4 ] },
+          { "item": "magic_plants_uncommon", "chance": 35, "repeat": [ 2, 3 ] },
+          { "item": "magic_plants_rare", "chance": 5, "repeat": [ 1, 3 ] },
+          { "item": "potions_common", "chance": 80, "repeat": [ 1, 3 ] },
+          { "item": "potions_uncommon", "chance": 40, "repeat": [ 1, 3 ] }
+        ],
+        "w": [
+          { "item": "allclothes", "chance": 80, "repeat": [ 2, 4 ] },
+          { "item": "enchanted_worn_items", "chance": 50, "repeat": [ 1, 3 ] },
+          { "item": "enchanted_rings_common", "chance": 20 },
+          { "item": "enchanted_rings_uncommon", "chance": 5 },
+          { "item": "enchanted_masks", "chance": 2 }
+        ]
+      },
+      "place_item": [
+        { "item": "crystallized_mana", "x": 20, "y": 12, "chance": 10 },
+        { "item": "crystallized_mana", "x": 22, "y": 12, "chance": 10 },
+        { "item": "crystallized_mana", "x": 20, "y": 13, "chance": 10 },
+        { "item": "crystallized_mana", "x": 22, "y": 13, "chance": 10 },
+        { "item": "crystallized_mana", "x": 20, "y": 14, "chance": 10 },
+        { "item": "crystallized_mana", "x": 22, "y": 14, "chance": 10 },
+        { "item": "crystallized_mana", "x": 20, "y": 15, "chance": 10 },
+        { "item": "crystallized_mana", "x": 22, "y": 15, "chance": 10 },
+        { "item": "crystallized_mana", "x": 20, "y": 16, "chance": 10 },
+        { "item": "crystallized_mana", "x": 22, "y": 16, "chance": 10 }
+      ],
+      "place_items": [
+        { "item": "enchanted_wands_disposable_combat", "x": 2, "y": 18, "chance": 40 },
+        { "item": "enchanted_wands_disposable_combat", "x": 2, "y": 19, "chance": 40 },
+        { "item": "enchanted_wands_disposable_combat", "x": 2, "y": 20, "chance": 40 },
+        { "item": "enchanted_wands_disposable_combat", "x": 2, "y": 21, "chance": 40 }
+      ],
+      "nested": { "X": { "chunks": [ [ "lmoe_dead_mage", 1 ], [ "null", 5 ] ] } },
+      "place_nested": [
+        { "chunks": [ "lmoe3_storage_mage_11x11" ], "x": 13, "y": 6 },
+        { "chunks": [ "lmoe3_tankroom_11x11" ], "x": 1, "y": 18 },
+        { "chunks": [ "lmoe3_crafting_11x11" ], "x": 13, "y": 18 }
+      ],
+      "place_monster": [
+        { "monster": "mon_irongolem", "x": [ 2, 11 ], "y": [ 4, 16 ], "chance": 20, "repeat": [ 1, 3 ] },
+        { "monster": "mon_darkman", "x": [ 2, 11 ], "y": [ 4, 16 ], "chance": 10, "repeat": [ 1, 3 ] }
+      ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "lmoe3_storage_mage_11x11",
+    "//": "This is done in a nested map to make the flooring under the furniture look right, nothing much else.",
+    "object": {
+      "mapgensize": [ 11, 11 ],
+      "rows": [
+        "lllll|     ",
+        "u___U|     ",
+        "u_u_U|     ",
+        "u_u_U|     ",
+        "u_u_U|     ",
+        "u_u_U|     ",
+        "__v_U|     ",
+        "u_v_U|     ",
+        "u_v_U|     ",
+        "u___U|     ",
+        "AV_VU|     "
+      ],
+      "palettes": [ "bunker", "empty_bunker_items" ],
+      "place_monster": [ { "monster": "mon_irongolem", "x": 0, "y": 6, "chance": 50 } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "lmoe_dead_mage",
+    "//": "lore: a dead mage.  Maybe killed in some kind of magical ritual that the portal storms messed up, maybe they went feral and their defense golems killed them.",
+    "object": {
+      "mapgensize": [ 1, 1 ],
+      "rows": [ "X" ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "terrain": { "X": "t_metal_floor" },
+      "place_fields": [
+        { "field": "fd_blood", "x": 0, "y": 0, "intensity": 2, "age": 0 },
+        { "field": "fd_gibs_flesh", "x": 0, "y": 0, "intensity": 3, "age": 0 }
+      ],
+      "place_items": [ { "item": "corpse_bloody", "x": 0, "y": 0 } ]
+    }
+  }
+]

--- a/data/mods/Magiclysm/worldgen/last_mage_on_earth.json
+++ b/data/mods/Magiclysm/worldgen/last_mage_on_earth.json
@@ -100,7 +100,7 @@
       "nested": { "X": { "chunks": [ [ "lmoe_dead_mage", 1 ], [ "null", 5 ] ] } },
       "place_nested": [
         { "chunks": [ "lmoe3_storage_mage_11x11" ], "x": 13, "y": 6 },
-        { "chunks": [ "lmoe3_tankroom_11x11" ], "x": 1, "y": 18 },
+        { "chunks": [ "lmoe3_tankroom_mage_11x11" ], "x": 1, "y": 18 },
         { "chunks": [ "lmoe3_crafting_11x11" ], "x": 13, "y": 18 }
       ],
       "place_monster": [
@@ -150,6 +150,60 @@
       ],
       "place_monster": [ { "monster": "mon_star_vampire", "x": 0, "y": 0, "chance": 50 } ],
       "place_items": [ { "item": "corpse_bloody", "x": 0, "y": 0 } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "lmoe3_tankroom_mage_11x11",
+    "//": "This is done in a nested map to make the flooring under the furniture look right, nothing much else.",
+    "object": {
+      "mapgensize": [ 11, 11 ],
+      "rows": [
+        "_{|l__aa|{_",
+        "_{|l__aa||+",
+        "_{|l____ll_",
+        "_{|l_______",
+        "__+________",
+        "|||||||||||",
+        "           ",
+        "           ",
+        "           ",
+        "           ",
+        "           "
+      ],
+      "palettes": [ "bunker", "empty_bunker_items" ],
+      "place_monster": [ { "monster": "mon_krabgek", "x": [ 4, 10 ], "y": [ 0, 4 ], "chance": 40, "repeat": [ 1, 3 ] } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "lmoe3_tankroom_mage_11x11",
+    "weight": 650,
+    "//": "Translocator gate variant.",
+    "object": {
+      "mapgensize": [ 11, 11 ],
+      "rows": [
+        "_{|l__aa|M_",
+        "_{|l__aa||+",
+        "_{|l____ll_",
+        "_{|l_______",
+        "__+________",
+        "|||||||||||",
+        "           ",
+        "           ",
+        "           ",
+        "           ",
+        "           "
+      ],
+      "palettes": [ "bunker", "empty_bunker_items" ],
+      "terrain": { "M": "t_metal_floor" },
+      "furniture": { "M": "f_magiclysm_translocator_gate" },
+      "place_monster": [
+        { "monster": "mon_krabgek", "x": 10, "y": 0, "chance": 100 },
+        { "monster": "mon_krabgek", "x": [ 4, 10 ], "y": [ 0, 4 ], "chance": 40, "repeat": [ 1, 2 ] }
+      ]
     }
   }
 ]

--- a/data/mods/Magiclysm/worldgen/last_mage_on_earth.json
+++ b/data/mods/Magiclysm/worldgen/last_mage_on_earth.json
@@ -105,7 +105,8 @@
       ],
       "place_monster": [
         { "monster": "mon_irongolem", "x": [ 2, 11 ], "y": [ 4, 16 ], "chance": 20, "repeat": [ 1, 3 ] },
-        { "monster": "mon_darkman", "x": [ 2, 11 ], "y": [ 4, 16 ], "chance": 10, "repeat": [ 1, 3 ] }
+        { "monster": "mon_darkman", "x": [ 2, 11 ], "y": [ 4, 16 ], "chance": 10, "repeat": [ 1, 3 ] },
+        { "monster": "mon_star_vampire", "x": [ 2, 11 ], "y": [ 4, 16 ], "chance": 15, "repeat": [ 1, 3 ] }
       ]
     }
   },

--- a/data/mods/Magiclysm/worldgen/last_mage_on_earth.json
+++ b/data/mods/Magiclysm/worldgen/last_mage_on_earth.json
@@ -138,7 +138,7 @@
     "type": "mapgen",
     "method": "json",
     "nested_mapgen_id": "lmoe_dead_mage",
-    "//": "lore: a dead mage.  Maybe killed in some kind of magical ritual that the portal storms messed up, maybe they went feral and their defense golems killed them.",
+    "//": "lore: a dead mage.  Maybe killed in some kind of magical ritual that the portal storms messed up, maybe they went feral and their defense golems killed them, maybe they tried to summon a star vampire and it went out of control.",
     "object": {
       "mapgensize": [ 1, 1 ],
       "rows": [ "X" ],
@@ -148,6 +148,7 @@
         { "field": "fd_blood", "x": 0, "y": 0, "intensity": 2, "age": 0 },
         { "field": "fd_gibs_flesh", "x": 0, "y": 0, "intensity": 3, "age": 0 }
       ],
+      "place_monster": [ { "monster": "mon_star_vampire", "x": 0, "y": 0, "chance": 50 } ],
       "place_items": [ { "item": "corpse_bloody", "x": 0, "y": 0 } ]
     }
   }

--- a/data/mods/Magiclysm/worldgen/last_mage_on_earth.json
+++ b/data/mods/Magiclysm/worldgen/last_mage_on_earth.json
@@ -10,9 +10,9 @@
       "rows": [
         "##|||||########||||||###",
         "##|,,<|||||||##|β🜍🜍β|###",
-        "##|Y,<|w,BBd|##|_ØØ_|###",
-        "||||+||},BB,||||_ØØ_|###",
-        "|A,,,E|,,,,,:__+__X_|###",
+        "##|Y,<|w,BBd|##|/ØØ/|###",
+        "||||+||},BB,||||/ØØ/|###",
+        "|A,,,E|,,,,,:__+//X/|###",
         "|f,,,,|+|||||||||||+||||",
         "|f,,,e|,,,,b|_____|,☿,Ƀ|",
         "|f,,,,|,,h,,|_____|,,,Ƀ|",
@@ -37,10 +37,11 @@
       "terrain": {
         "M": "t_carpet_metal_purple",
         "y": "t_metal_floor",
-        "X": "t_metal_floor",
-        "β": "t_metal_floor",
-        "Ø": "t_metal_floor",
-        "🜍": "t_metal_floor"
+        "X": "t_magiconc_floor",
+        "β": "t_magiconc_floor",
+        "Ø": "t_magiconc_floor",
+        "🜍": "t_magiconc_floor",
+        "/": "t_magiconc_floor"
       },
       "furniture": {
         "M": "f_armchair",
@@ -143,7 +144,7 @@
       "mapgensize": [ 1, 1 ],
       "rows": [ "X" ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
-      "terrain": { "X": "t_metal_floor" },
+      "terrain": { "X": "t_magiconc_floor" },
       "place_fields": [
         { "field": "fd_blood", "x": 0, "y": 0, "intensity": 2, "age": 0 },
         { "field": "fd_gibs_flesh", "x": 0, "y": 0, "intensity": 3, "age": 0 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Magiclysm] Add wizard version of LMOE"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Thought about the phrase "Last Mage on Earth shelter" and here we are.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add a rare version of the LMOE for a paranoid mage.  It has the standard setup, as well as a ritual room, a library, and potion and materials storage.

However, mages have access to unliving and unsleeping guardians as well and a mage rich enough and paranoid enough to build an LMOE would definitely put guardians in it, so if you're unlucky, there might be arcane defenses even if there's no mage left in there...
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered


<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Spawned 9 LMOEs, one of them was the wizard variant:

<details>
<summary>Layout</summary>

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/120433252/02fbdcd8-6731-455a-8ce9-4511ec7cfb4e)

Featuring cool ritual room and translocation gate! Just don't get killed by the guardians...

[Translocation gate is nested, not all of them will have it]
</details>
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Probably going to do a starting scenario for this once it gets merged.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
