### PR TITLE
Shocker brute rebalancing

### DIFF
--- a/data/json/monsters/zed_electric.json
+++ b/data/json/monsters/zed_electric.json
@@ -10,7 +10,7 @@
     "diff": 10,
     "volume": "62500 ml",
     "weight": "81500 g",
-    "hp": 275,
+    "hp": 145,
     "speed": 110,
     "material": [ "flesh" ],
     "symbol": "Z",
@@ -21,7 +21,7 @@
     "melee_dice": 3,
     "melee_dice_sides": 4,
     "melee_damage": [ { "damage_type": "electric", "amount": 4 }, { "damage_type": "cut", "amount": 2 } ],
-    "weakpoint_sets": [ "wps_humanoid_body", "wps_natural_armor", "wps_humanoid_head_small" ],
+    "weakpoint_sets": [ "wps_humanoid_body", "wps_humanoid_head_small" ],
     "families": [ "prof_intro_biology", "prof_physiology", "prof_wp_zombie", "prof_electromagnetics" ],
     "bleed_rate": 0,
     "vision_night": 3,
@@ -42,10 +42,12 @@
       "ELECTRIC",
       "NO_BREATHE",
       "REVIVES",
+      "PUSH_MON",
+      "PUSH_VEH",
       "FILTHY",
       "RANGED_ATTACKER"
     ],
-    "armor": { "bash": 3, "cut": 8, "bullet": 6 }
+    "armor": { "bash": 4, "cut": 6, "bullet": 5 }
   },
   {
     "id": "mon_zombie_electric",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Shocker Brute has been ridiculously more tanky than a normal brute, and it appears the stats have not been changed in years.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Lowered the health from 275 to 145 - that's the biggest change here. It was horrendously high compared to other brute variants, even going above the wrestler's stats
- Changed the armor values to be the same as brute's - shockers use similar armor values as normal zombies, so a shocker brute should likely have similar values to a normal brute
- Added ``PUSH_MON`` and ``PUSH_VEH`` flags. This is the reason why these guys would often get stuck behind other zombies around hordes - I noticed this a lot during gameplay, never figured why unless I looked at the JSON - this is actually a *buff*
- Removed their natural armor weakpoint set as they don't actually have any more natural armor than normal brutes
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
