### PR TITLE
[XEDRA] Adjust Magnetic Holster Values

### DIFF
--- a/data/mods/Xedra_Evolved/items/inventor/armor.json
+++ b/data/mods/Xedra_Evolved/items/inventor/armor.json
@@ -654,7 +654,7 @@
         "rigid": true,
         "max_contains_volume": "20 L",
         "max_contains_weight": "15 kg",
-        "max_item_length": "500 cm",
+        "max_item_length": "300 cm",
         "moves": 50
       }
     ],

--- a/data/mods/Xedra_Evolved/items/inventor/armor.json
+++ b/data/mods/Xedra_Evolved/items/inventor/armor.json
@@ -639,7 +639,7 @@
     "type": "ARMOR",
     "name": { "str": "magnetic holster" },
     "looks_like": "shoulder_strap",
-    "description": "A long strap with small, powerful gravity pullers on the surface.  Allows one to strap and carry almost anything.",
+    "description": "A long strap with small, powerful gravity field emitters on the surface.  Allows one to strap and carry almost anything.",
     "weight": "250 g",
     "volume": "250 ml",
     "material": [ "plastic", "aluminum" ],
@@ -651,14 +651,15 @@
       {
         "pocket_type": "CONTAINER",
         "holster": true,
-        "max_contains_volume": "3 L",
-        "max_contains_weight": "5 kg",
-        "max_item_length": "200 cm",
+        "rigid": true,
+        "max_contains_volume": "50 L",
+        "max_contains_weight": "25 kg",
+        "max_item_length": "500 cm",
         "moves": 50
       }
     ],
     "use_action": { "type": "holster" },
-    "flags": [ "BELTED", "OVERSIZE", "MUNDANE", "INVENTOR_CRAFTED" ],
+    "flags": [ "BELTED", "OVERSIZE", "MUNDANE", "INVENTOR_CRAFTED", "TARDIS" ],
     "armor": [ { "encumbrance": 1, "coverage": 5, "covers": [ "torso" ], "specifically_covers": [ "torso_upper" ] } ]
   }
 ]

--- a/data/mods/Xedra_Evolved/items/inventor/armor.json
+++ b/data/mods/Xedra_Evolved/items/inventor/armor.json
@@ -653,7 +653,7 @@
         "holster": true,
         "rigid": true,
         "max_contains_volume": "20 L",
-        "max_contains_weight": "15 kg",
+        "max_contains_weight": "20 kg",
         "max_item_length": "300 cm",
         "moves": 50
       }

--- a/data/mods/Xedra_Evolved/items/inventor/armor.json
+++ b/data/mods/Xedra_Evolved/items/inventor/armor.json
@@ -653,7 +653,7 @@
         "holster": true,
         "rigid": true,
         "max_contains_volume": "20 L",
-        "max_contains_weight": "20 kg",
+        "max_contains_weight": "15 kg",
         "max_item_length": "300 cm",
         "moves": 50
       }

--- a/data/mods/Xedra_Evolved/items/inventor/armor.json
+++ b/data/mods/Xedra_Evolved/items/inventor/armor.json
@@ -652,8 +652,8 @@
         "pocket_type": "CONTAINER",
         "holster": true,
         "rigid": true,
-        "max_contains_volume": "50 L",
-        "max_contains_weight": "25 kg",
+        "max_contains_volume": "20 L",
+        "max_contains_weight": "15 kg",
         "max_item_length": "500 cm",
         "moves": 50
       }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[XEDRA] Adjust Magnetic Holster Values"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
After crafting a binary sword I crafted a magnetic holster to holster it, but realized that the binary sword actually cannot be stored within it.  I checked the item definitions and realized that a basic leather spear strap is better at holding items than using high tech gravity fields.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Weight Increase: 5 -> 15
Reasoning: Should allow almost every weapon in the game to be stored within, minus some extreme examples like the minigun. However, its not relatively that much weight, so there shouldn't be any 'put a fridge in the holster to carry a bunch of items within the fridge' strategies.

Volume Increase: 3 L -> 20 L
Reasoning: Relatively the biggest increase, at 5x a spear strap, but I feel it makes sense for technology like this.  Its not actually storing the item within it, instead using gravity fields to hold an item in place relative to it.  This offers a lot more room for larger items to be held as long as they do not exceed the weight limits.

Length Increase: 200 -> 300
Reasoning: Just a little bit more than a spear strap.  While conceptually the device could probably hold a very long object if it doesn't weight much, there's no way to model what happens if a character walks through an enclosed area with a 10 meter long stick.  300 cm enforced as a sanity check.

Rigid + TARDIS:
Reasoning: The magnetic holster doesn't actually hold items within it, instead using gravitational fields to hold items in place relative to its location.  This cannot be directly modeled by CDDA definitions, so these two do my best to get the closest we currently can.  Rigid prevents the magnetic holster from physically expanding when used to store an item, and TARDIS allows it to hold an item larger than itself without throwing an error.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Ooga Booga leather strap supremacy

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Binary Sword now storable. 
![holster with binary sword](https://github.com/CleverRaven/Cataclysm-DDA/assets/70666939/1f800722-dc37-40a2-81ad-224350b9172c)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
