### PR TITLE
Migrate EOC text to `translation_or_var`/`translation` and update string extraction script

### DIFF
--- a/data/json/effects_on_condition/example_eocs.json
+++ b/data/json/effects_on_condition/example_eocs.json
@@ -3,9 +3,9 @@
     "type": "effect_on_condition",
     "id": "EOC_selector_test",
     "effect": [
-      { "set_string_var": "EOC Selector Test", "target_var": { "context_val": "title" } },
+      { "set_string_var": "EOC Selector Test", "target_var": { "context_val": "title" }, "i18n": true },
       { "set_string_var": "name_3", "target_var": { "context_val": "name" } },
-      { "set_string_var": "option 3", "target_var": { "context_val": "description" } },
+      { "set_string_var": "option 3", "target_var": { "context_val": "description" }, "i18n": true },
       {
         "run_eoc_selector": [ "EOC_selector_test_1", "EOC_selector_test_2", "EOC_selector_test_3", "EOC_selector_test_4" ],
         "names": [ "name_1", "name_2", "<context_val:name>", "should_fail" ],

--- a/data/json/effects_on_condition/mutation_eocs/mutation_activation_eocs.json
+++ b/data/json/effects_on_condition/mutation_eocs/mutation_activation_eocs.json
@@ -39,8 +39,8 @@
         "variables": {
           "prep_time": "3",
           "spell_to_cast": "spell_spit_flare",
-          "message_success": "You launch a glob of bioluminescent material!",
-          "message_fail": "Your body is too starved to activate your bioluminescent flare."
+          "message_success": { "i18n": true, "str": "You launch a glob of bioluminescent material!" },
+          "message_fail": { "i18n": true, "str": "Your body is too starved to activate your bioluminescent flare." }
         }
       }
     ]
@@ -54,8 +54,8 @@
         "variables": {
           "prep_time": "1",
           "spell_to_cast": "spell_slime_spray",
-          "message_success": "You spit out some goo onto your enemies!",
-          "message_fail": "Your body is too starved to activate your slime spray."
+          "message_success": { "i18n": true, "str": "You spit out some goo onto your enemies!" },
+          "message_fail": { "i18n": true, "str": "Your body is too starved to activate your slime spray." }
         }
       }
     ]
@@ -70,8 +70,11 @@
           "energy_amount": "2000",
           "prep_time": "1",
           "spell_to_cast": "spell_feline_leap",
-          "message_success": "You squat down, build up tension in your legs, waggling your tail, then release, launching yourself quite a distance.",
-          "message_fail": "Your legs are too tired to perform a jump."
+          "message_success": {
+            "i18n": true,
+            "str": "You squat down, build up tension in your legs, waggling your tail, then release, launching yourself quite a distance."
+          },
+          "message_fail": { "i18n": true, "str": "Your legs are too tired to perform a jump." }
         }
       }
     ]
@@ -86,8 +89,11 @@
           "energy_amount": "2000",
           "prep_time": "2",
           "spell_to_cast": "spell_short_leap",
-          "message_success": "You squat down, build up tension in your legs and release, launching yourself quite a distance.",
-          "message_fail": "Your legs are too tired to perform a jump."
+          "message_success": {
+            "i18n": true,
+            "str": "You squat down, build up tension in your legs and release, launching yourself quite a distance."
+          },
+          "message_fail": { "i18n": true, "str": "Your legs are too tired to perform a jump." }
         }
       }
     ]
@@ -102,8 +108,8 @@
           "energy_amount": "6000",
           "prep_time": "3",
           "spell_to_cast": "spell_crushing_leap",
-          "message_success": "You squat down, build up tension in your legs and release.  Death from above.",
-          "message_fail": "Your legs are too tired to perform a jump."
+          "message_success": { "i18n": true, "str": "You squat down, build up tension in your legs and release.  Death from above." },
+          "message_fail": { "i18n": true, "str": "Your legs are too tired to perform a jump." }
         }
       }
     ]
@@ -118,8 +124,11 @@
           "energy_amount": "2500",
           "prep_time": "1",
           "spell_to_cast": "spell_avian_leap",
-          "message_success": "You jump at your target with your talons up front, attempting to deal devastating damage to your target.",
-          "message_fail": "Your legs are too tired to perform a jump."
+          "message_success": {
+            "i18n": true,
+            "str": "You jump at your target with your talons up front, attempting to deal devastating damage to your target."
+          },
+          "message_fail": { "i18n": true, "str": "Your legs are too tired to perform a jump." }
         }
       }
     ]

--- a/data/json/effects_on_condition/mutation_eocs/mutation_effect_eocs.json
+++ b/data/json/effects_on_condition/mutation_eocs/mutation_effect_eocs.json
@@ -61,7 +61,7 @@
       { "u_add_effect": "narcosis", "duration": "5 minutes" },
       { "u_add_effect": "sleep", "duration": "5 minutes" },
       {
-        "u_message": "Your exoskeleton grows steadily more rigid until you can no longer move. You strain against it for a few minutes, and it peels and cracks away in chunks like a plaster mold, revealing a soft and tender new layer beneath.",
+        "u_message": "Your exoskeleton grows steadily more rigid until you can no longer move.  You strain against it for a few minutes, and it peels and cracks away in chunks like a plaster mold, revealing a soft and tender new layer beneath.",
         "type": "bad"
       },
       { "u_lose_trait": "CHITIN2" },

--- a/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
@@ -861,7 +861,8 @@
       },
       {
         "set_string_var": [ "Somewhere", "Nowhere", "Everywhere", "Yesterday", "Tomorrow" ],
-        "target_var": { "global_val": "place_name" }
+        "target_var": { "global_val": "place_name" },
+        "i18n": true
       },
       {
         "place_override": { "global_val": "place_name", "default": "1 minutes" },
@@ -918,7 +919,8 @@
       { "revert_location": { "global_val": "dungeon_loc" }, "key": "portal_dungeon", "time_in_future": "infinite" },
       {
         "set_string_var": [ "Somewhere", "Nowhere", "Everywhere", "Yesterday", "Tomorrow" ],
-        "target_var": { "global_val": "place_name" }
+        "target_var": { "global_val": "place_name" },
+        "i18n": true
       },
       {
         "place_override": { "global_val": "place_name", "default_str": "Error" },

--- a/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
@@ -950,7 +950,7 @@
       { "u_teleport": { "global_val": "dungeon_start" }, "fail_message": "Something is very wrong!", "force": true },
       { "run_eocs": [ "EOC_PORTAL_STORM_DUNGEON_REFLECTION_SPAWN", "capture_generic_nre_anomaly" ] },
       { "mapgen_update": "portal_dungeon", "target_var": { "global_val": "dungeon_loc" } },
-      { "u_message": "Weren't you just here? It feels thicker somehow though." },
+      { "u_message": "Weren't you just here?  It feels thicker somehow though." },
       { "u_message": { "global_val": "portal_storm_voice_mood", "default_str": "none" }, "snippet": true }
     ]
   },

--- a/data/json/effects_on_condition/scenario_specific_eocs.json
+++ b/data/json/effects_on_condition/scenario_specific_eocs.json
@@ -145,7 +145,7 @@
     "eoc_type": "SCENARIO_SPECIFIC",
     "effect": [
       {
-        "u_message": "They are all dead. The group you were surviving with has been annihilated. Their bodies are still nearby. You are the last one left alive and their screams will haunt you.",
+        "u_message": "They are all dead.  The group you were surviving with has been annihilated.  Their bodies are still nearby.  You are the last one left alive and their screams will haunt you.",
         "type": "warning",
         "popup": true
       },

--- a/data/json/items/melee/swords_and_blades.json
+++ b/data/json/items/melee/swords_and_blades.json
@@ -2878,9 +2878,9 @@
             "variables": {
               "turn_cost": "0.6",
               "transform_target": "combatsaw_on",
-              "success_message": "With a snarl, the <npc_name> screams to life!",
+              "success_message": { "i18n": true, "str": "With a snarl, the <npc_name> screams to life!" },
               "volume": "30",
-              "failure_message": "You yank the cord, but nothing happens."
+              "failure_message": { "i18n": true, "str": "You yank the cord, but nothing happens." }
             }
           }
         }
@@ -2918,7 +2918,12 @@
           "id": "EOC_toolweapon_running__combatsaw",
           "effect": {
             "run_eoc_with": "EOC_toolweapon_running",
-            "variables": { "sound_chance": "12", "sound_message": "Your combat chainsaw growls.", "volume": "18", "revert_to": "combatsaw_off" }
+            "variables": {
+              "sound_chance": "12",
+              "sound_message": { "i18n": true, "str": "Your combat chainsaw growls." },
+              "volume": "18",
+              "revert_to": "combatsaw_off"
+            }
           }
         }
       ]
@@ -2954,9 +2959,9 @@
             "variables": {
               "turn_cost": "0.6",
               "transform_target": "e_combatsaw_on",
-              "success_message": "With a snarl, the <npc_name> screams to life!",
+              "success_message": { "i18n": true, "str": "With a snarl, the <npc_name> screams to life!" },
               "volume": "30",
-              "failure_message": "You flip the switch, but nothing happens."
+              "failure_message": { "i18n": true, "str": "You flip the switch, but nothing happens." }
             }
           }
         }
@@ -3004,7 +3009,7 @@
             "run_eoc_with": "EOC_toolweapon_running",
             "variables": {
               "sound_chance": "12",
-              "sound_message": "Your electric combat chainsaw growls.",
+              "sound_message": { "i18n": true, "str": "Your electric combat chainsaw growls." },
               "volume": "18",
               "revert_to": "e_combatsaw_off"
             }

--- a/data/json/items/tool/cooking.json
+++ b/data/json/items/tool/cooking.json
@@ -95,9 +95,9 @@
             "variables": {
               "turn_cost": "0.8",
               "transform_target": "carver_on",
-              "success_message": "The electric carver's serrated blades start buzzing!",
+              "success_message": { "i18n": true, "str": "The electric carver's serrated blades start buzzing!" },
               "volume": "20",
-              "failure_message": "You pull the trigger, but nothing happens."
+              "failure_message": { "i18n": true, "str": "You pull the trigger, but nothing happens." }
             }
           }
         }
@@ -142,7 +142,12 @@
           "id": "EOC_toolweapon_running__carver",
           "effect": {
             "run_eoc_with": "EOC_toolweapon_running",
-            "variables": { "sound_chance": "10", "sound_message": "Your electric carver buzzes.", "volume": "8", "revert_to": "carver_off" }
+            "variables": {
+              "sound_chance": "10",
+              "sound_message": { "i18n": true, "str": "Your electric carver buzzes." },
+              "volume": "8",
+              "revert_to": "carver_off"
+            }
           }
         }
       ]

--- a/data/json/items/tool/landscaping.json
+++ b/data/json/items/tool/landscaping.json
@@ -368,9 +368,9 @@
             "variables": {
               "turn_cost": "0.8",
               "transform_target": "trimmer_on",
-              "success_message": "With a roar, the hedge trimmer leaps to life!",
+              "success_message": { "i18n": true, "str": "With a roar, the hedge trimmer leaps to life!" },
               "volume": "15",
-              "failure_message": "You yank the cord, but nothing happens."
+              "failure_message": { "i18n": true, "str": "You yank the cord, but nothing happens." }
             }
           },
           "false_effect": { "u_message": "You yank the cord, but nothing happens." }
@@ -406,7 +406,12 @@
           "id": "EOC_toolweapon_running__trimmer",
           "effect": {
             "run_eoc_with": "EOC_toolweapon_running",
-            "variables": { "sound_chance": "15", "sound_message": "Your hedge trimmer rumbles.", "volume": "10", "revert_to": "trimmer_off" }
+            "variables": {
+              "sound_chance": "15",
+              "sound_message": { "i18n": true, "str": "Your hedge trimmer rumbles." },
+              "volume": "10",
+              "revert_to": "trimmer_off"
+            }
           }
         }
       ]

--- a/data/json/items/tool/masonry.json
+++ b/data/json/items/tool/masonry.json
@@ -29,9 +29,9 @@
             "variables": {
               "turn_cost": "0.8",
               "transform_target": "masonrysaw_on",
-              "success_message": "With a roar, the <npc_name> screams to life!",
+              "success_message": { "i18n": true, "str": "With a roar, the <npc_name> screams to life!" },
               "volume": "20",
-              "failure_message": "You yank the cord, but nothing happens."
+              "failure_message": { "i18n": true, "str": "You yank the cord, but nothing happens." }
             }
           },
           "false_effect": { "u_message": "You yank the cord, but nothing happens." }
@@ -70,7 +70,12 @@
           "id": "EOC_toolweapon_running__masonrysaw",
           "effect": {
             "run_eoc_with": "EOC_toolweapon_running",
-            "variables": { "sound_chance": "15", "sound_message": "Your masonry saw buzzes.", "volume": "7", "revert_to": "masonrysaw_off" }
+            "variables": {
+              "sound_chance": "15",
+              "sound_message": { "i18n": true, "str": "Your masonry saw buzzes." },
+              "volume": "7",
+              "revert_to": "masonrysaw_off"
+            }
           }
         }
       ]
@@ -151,7 +156,7 @@
             "run_eoc_with": "EOC_toolweapon_running",
             "variables": {
               "sound_chance": "15",
-              "sound_message": "Your electric masonry saw buzzes.",
+              "sound_message": { "i18n": true, "str": "Your electric masonry saw buzzes." },
               "volume": "7",
               "revert_to": "electric_masonrysaw_off"
             }

--- a/data/json/items/tool/woodworking.json
+++ b/data/json/items/tool/woodworking.json
@@ -109,7 +109,12 @@
           "id": "EOC_toolweapon_running__chainsaw",
           "effect": {
             "run_eoc_with": "EOC_toolweapon_running",
-            "variables": { "sound_chance": "15", "sound_message": "Your chainsaw rumbles.", "volume": "12", "revert_to": "chainsaw_off" }
+            "variables": {
+              "sound_chance": "15",
+              "sound_message": { "i18n": true, "str": "Your chainsaw rumbles." },
+              "volume": "12",
+              "revert_to": "chainsaw_off"
+            }
           }
         }
       ]
@@ -147,9 +152,9 @@
             "variables": {
               "turn_cost": "0.8",
               "transform_target": "polesaw_on",
-              "success_message": "With a roar, the pole saw screams to life!",
+              "success_message": { "i18n": true, "str": "With a roar, the pole saw screams to life!" },
               "volume": "15",
-              "failure_message": "You yank the cord, but nothing happens."
+              "failure_message": { "i18n": true, "str": "You yank the cord, but nothing happens." }
             }
           }
         }
@@ -187,7 +192,12 @@
           "id": "EOC_toolweapon_running__polesaw",
           "effect": {
             "run_eoc_with": "EOC_toolweapon_running",
-            "variables": { "sound_chance": "15", "sound_message": "Your pole saw rumbles.", "volume": "12", "revert_to": "polesaw_off" }
+            "variables": {
+              "sound_chance": "15",
+              "sound_message": { "i18n": true, "str": "Your pole saw rumbles." },
+              "volume": "12",
+              "revert_to": "polesaw_off"
+            }
           }
         }
       ]
@@ -222,9 +232,9 @@
             "variables": {
               "turn_cost": "0.6",
               "transform_target": "circsaw_on",
-              "success_message": "With a loud buzz, the <npc_name> roars to life!",
+              "success_message": { "i18n": true, "str": "With a loud buzz, the <npc_name> roars to life!" },
               "volume": "15",
-              "failure_message": "You flip the switch, but nothing happens."
+              "failure_message": { "i18n": true, "str": "You flip the switch, but nothing happens." }
             }
           }
         }
@@ -269,7 +279,12 @@
           "id": "EOC_toolweapon_running__circsaw",
           "effect": {
             "run_eoc_with": "EOC_toolweapon_running",
-            "variables": { "sound_chance": "15", "sound_message": "Your circular saw buzzes.", "volume": "7", "revert_to": "circsaw_off" }
+            "variables": {
+              "sound_chance": "15",
+              "sound_message": { "i18n": true, "str": "Your circular saw buzzes." },
+              "volume": "7",
+              "revert_to": "circsaw_off"
+            }
           }
         }
       ]
@@ -367,9 +382,9 @@
             "variables": {
               "turn_cost": "0.6",
               "transform_target": "elec_chainsaw_on",
-              "success_message": "With a roar, the electric chainsaw screams to life!",
+              "success_message": { "i18n": true, "str": "With a roar, the electric chainsaw screams to life!" },
               "volume": "20",
-              "failure_message": "You flip the switch, but nothing happens."
+              "failure_message": { "i18n": true, "str": "You flip the switch, but nothing happens." }
             }
           },
           "false_effect": { "u_message": "You flip the switch, but nothing happens." }
@@ -417,7 +432,7 @@
             "run_eoc_with": "EOC_toolweapon_running",
             "variables": {
               "sound_chance": "5",
-              "sound_message": "Your electric chainsaw rumbles.",
+              "sound_message": { "i18n": true, "str": "Your electric chainsaw rumbles." },
               "volume": "12",
               "revert_to": "elec_chainsaw_off"
             }
@@ -449,9 +464,9 @@
               "variables": {
                 "turn_cost": "0.6",
                 "transform_target": "elec_chainsaw_cord_on",
-                "success_message": "With a roar, the corded electric chainsaw screams to life!",
+                "success_message": { "i18n": true, "str": "With a roar, the corded electric chainsaw screams to life!" },
                 "volume": "20",
-                "failure_message": "You flip the switch, but nothing happens."
+                "failure_message": { "i18n": true, "str": "You flip the switch, but nothing happens." }
               }
             },
             "false_effect": { "u_message": "You flip the switch, but nothing happens." }
@@ -490,7 +505,7 @@
             "run_eoc_with": "EOC_toolweapon_running",
             "variables": {
               "sound_chance": "5",
-              "sound_message": "Your corded electric chainsaw rumbles.",
+              "sound_message": { "i18n": true, "str": "Your corded electric chainsaw rumbles." },
               "volume": "12",
               "revert_to": "elec_chainsaw_cord_off"
             }

--- a/data/json/npcs/isolated_road/isolated_road_jay_convert.json
+++ b/data/json/npcs/isolated_road/isolated_road_jay_convert.json
@@ -57,35 +57,35 @@
           {
             "case": 300,
             "effect": [
-              { "set_string_var": "300 BLK", "target_var": { "u_val": "artisans_gunsmith_ammo_source_name" } },
+              { "set_string_var": "300 BLK", "target_var": { "u_val": "artisans_gunsmith_ammo_source_name" }, "i18n": true },
               { "set_string_var": "300blk", "target_var": { "u_val": "artisans_gunsmith_ammo_source_item" } }
             ]
           },
           {
             "case": 545,
             "effect": [
-              { "set_string_var": "5.45x39", "target_var": { "u_val": "artisans_gunsmith_ammo_source_name" } },
+              { "set_string_var": "5.45x39", "target_var": { "u_val": "artisans_gunsmith_ammo_source_name" }, "i18n": true },
               { "set_string_var": "545", "target_var": { "u_val": "artisans_gunsmith_ammo_source_item" } }
             ]
           },
           {
             "case": 556,
             "effect": [
-              { "set_string_var": "5.56x45", "target_var": { "u_val": "artisans_gunsmith_ammo_source_name" } },
+              { "set_string_var": "5.56x45", "target_var": { "u_val": "artisans_gunsmith_ammo_source_name" }, "i18n": true },
               { "set_string_var": "556", "target_var": { "u_val": "artisans_gunsmith_ammo_source_item" } }
             ]
           },
           {
             "case": 76239,
             "effect": [
-              { "set_string_var": "7.62x39", "target_var": { "u_val": "artisans_gunsmith_ammo_source_name" } },
+              { "set_string_var": "7.62x39", "target_var": { "u_val": "artisans_gunsmith_ammo_source_name" }, "i18n": true },
               { "set_string_var": "762_m87", "target_var": { "u_val": "artisans_gunsmith_ammo_source_item" } }
             ]
           },
           {
             "case": 76251,
             "effect": [
-              { "set_string_var": "7.62x51", "target_var": { "u_val": "artisans_gunsmith_ammo_source_name" } },
+              { "set_string_var": "7.62x51", "target_var": { "u_val": "artisans_gunsmith_ammo_source_name" }, "i18n": true },
               { "set_string_var": "762_51", "target_var": { "u_val": "artisans_gunsmith_ammo_source_item" } }
             ]
           }

--- a/data/json/npcs/missiondef.json
+++ b/data/json/npcs/missiondef.json
@@ -1017,7 +1017,7 @@
     "effect": [
       { "remove_active_mission": "MISSION_CAMP_LEADERSHIP_CHANGE" },
       {
-        "u_message": "You've been badly wounded.  It might be better to rest for a while and let someone else scavenge. (Changing characters is now available at any camp board.)",
+        "u_message": "You've been badly wounded.  It might be better to rest for a while and let someone else scavenge.  (Changing characters is now available at any camp board.)",
         "type": "mixed"
       },
       { "math": [ "u_timer_time_of_last_succession", "-=", "time_between_succession" ] }

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -14,7 +14,11 @@
             "target_var": { "context_val": "trait_description" }
           },
           { "set_string_var": "perk_STR_UP", "target_var": { "context_val": "trait_id" } },
-          { "set_string_var": "No Requirements", "target_var": { "context_val": "trait_requirement_description" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
           { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
@@ -29,7 +33,11 @@
             "target_var": { "context_val": "trait_description" }
           },
           { "set_string_var": "perk_DEX_UP", "target_var": { "context_val": "trait_id" } },
-          { "set_string_var": "No Requirements", "target_var": { "context_val": "trait_requirement_description" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
           { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
@@ -44,7 +52,11 @@
             "target_var": { "context_val": "trait_description" }
           },
           { "set_string_var": "perk_INT_UP", "target_var": { "context_val": "trait_id" } },
-          { "set_string_var": "No Requirements", "target_var": { "context_val": "trait_requirement_description" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
           { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
@@ -59,7 +71,11 @@
             "target_var": { "context_val": "trait_description" }
           },
           { "set_string_var": "perk_PER_UP", "target_var": { "context_val": "trait_id" } },
-          { "set_string_var": "No Requirements", "target_var": { "context_val": "trait_requirement_description" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
           { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
@@ -74,7 +90,11 @@
             "target_var": { "context_val": "trait_description" }
           },
           { "set_string_var": "perk_holdout_pocket", "target_var": { "context_val": "trait_id" } },
-          { "set_string_var": "No Requirements", "target_var": { "context_val": "trait_requirement_description" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
           { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
@@ -89,7 +109,11 @@
             "target_var": { "context_val": "trait_description" }
           },
           { "set_string_var": "perk_built_tough", "target_var": { "context_val": "trait_id" } },
-          { "set_string_var": "No Requirements", "target_var": { "context_val": "trait_requirement_description" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
           { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
@@ -104,7 +128,11 @@
             "target_var": { "context_val": "trait_description" }
           },
           { "set_string_var": "perk_hauler", "target_var": { "context_val": "trait_id" } },
-          { "set_string_var": "No Requirements", "target_var": { "context_val": "trait_requirement_description" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
           { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
@@ -119,7 +147,11 @@
             "target_var": { "context_val": "trait_description" }
           },
           { "set_string_var": "perk_vacationer", "target_var": { "context_val": "trait_id" } },
-          { "set_string_var": "No Requirements", "target_var": { "context_val": "trait_requirement_description" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
           { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
@@ -136,7 +168,8 @@
           { "set_string_var": "perk_gymrat", "target_var": { "context_val": "trait_id" } },
           {
             "set_string_var": "Requires athletics 3",
-            "target_var": { "context_val": "trait_requirement_description" }
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
           },
           { "set_condition": "perk_condition", "condition": { "math": [ "u_skill('swimming')", ">=", "3" ] } }
         ],
@@ -152,7 +185,11 @@
             "target_var": { "context_val": "trait_description" }
           },
           { "set_string_var": "perk_safety_net", "target_var": { "context_val": "trait_id" } },
-          { "set_string_var": "No Requirements", "target_var": { "context_val": "trait_requirement_description" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
           { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
@@ -167,7 +204,11 @@
             "target_var": { "context_val": "trait_description" }
           },
           { "set_string_var": "perk_lucky_dodge", "target_var": { "context_val": "trait_id" } },
-          { "set_string_var": "No Requirements", "target_var": { "context_val": "trait_requirement_description" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
           { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
@@ -182,7 +223,11 @@
             "target_var": { "context_val": "trait_description" }
           },
           { "set_string_var": "perk_thick_skull", "target_var": { "context_val": "trait_id" } },
-          { "set_string_var": "No Requirements", "target_var": { "context_val": "trait_requirement_description" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
           { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
@@ -199,7 +244,8 @@
           { "set_string_var": "perk_way_openpalm", "target_var": { "context_val": "trait_id" } },
           {
             "set_string_var": "Must not have <trait_name:perk_way_closedfist>, <trait_name:perk_way_pinchedfingers>.  Requires unarmed 2 and cutting 1",
-            "target_var": { "context_val": "trait_requirement_description" }
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
           },
           {
             "set_condition": "perk_condition",
@@ -214,7 +260,8 @@
           },
           {
             "set_string_var": "Taking this means you can't take <trait_name:perk_way_closedfist> or <trait_name:perk_way_pinchedfingers>",
-            "target_var": { "context_val": "trait_additional_details" }
+            "target_var": { "context_val": "trait_additional_details" },
+            "i18n": true
           }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
@@ -231,7 +278,8 @@
           { "set_string_var": "perk_way_closedfist", "target_var": { "context_val": "trait_id" } },
           {
             "set_string_var": "Must not have <trait_name:perk_way_openpalm>, <trait_name:perk_way_pinchedfingers>.  Requires unarmed 2 and bashing 1",
-            "target_var": { "context_val": "trait_requirement_description" }
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
           },
           {
             "set_condition": "perk_condition",
@@ -246,7 +294,8 @@
           },
           {
             "set_string_var": "Taking this means you can't take <trait_name:perk_way_openpalm> or <trait_name:perk_way_pinchedfingers>",
-            "target_var": { "context_val": "trait_additional_details" }
+            "target_var": { "context_val": "trait_additional_details" },
+            "i18n": true
           }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
@@ -263,7 +312,8 @@
           { "set_string_var": "perk_way_pinchedfingers", "target_var": { "context_val": "trait_id" } },
           {
             "set_string_var": "Must not have <trait_name:perk_way_closedfist>, <trait_name:perk_way_openpalm>.  Requires unarmed 2 and piercing 1",
-            "target_var": { "context_val": "trait_requirement_description" }
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
           },
           {
             "set_condition": "perk_condition",
@@ -278,7 +328,8 @@
           },
           {
             "set_string_var": "Taking this means you can't take <trait_name:perk_way_closedfist> or <trait_name:perk_way_openpalm>",
-            "target_var": { "context_val": "trait_additional_details" }
+            "target_var": { "context_val": "trait_additional_details" },
+            "i18n": true
           }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
@@ -295,12 +346,14 @@
           { "set_string_var": "perk_bloody_mess", "target_var": { "context_val": "trait_id" } },
           {
             "set_string_var": "Must not have <trait_name:perk_surgical_strikes>",
-            "target_var": { "context_val": "trait_requirement_description" }
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
           },
           { "set_condition": "perk_condition", "condition": { "not": { "u_has_trait": "perk_surgical_strikes" } } },
           {
             "set_string_var": "Taking this means you can't take <trait_name:perk_surgical_strikes>",
-            "target_var": { "context_val": "trait_additional_details" }
+            "target_var": { "context_val": "trait_additional_details" },
+            "i18n": true
           }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
@@ -317,7 +370,8 @@
           { "set_string_var": "perk_surgical_strikes", "target_var": { "context_val": "trait_id" } },
           {
             "set_string_var": "Must not have <trait_name:perk_bloody_mess>.  Melee or guns 2",
-            "target_var": { "context_val": "trait_requirement_description" }
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
           },
           {
             "set_condition": "perk_condition",
@@ -332,7 +386,8 @@
           },
           {
             "set_string_var": "Taking this means you can't take <trait_name:perk_bloody_mess>",
-            "target_var": { "context_val": "trait_additional_details" }
+            "target_var": { "context_val": "trait_additional_details" },
+            "i18n": true
           }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
@@ -349,7 +404,8 @@
           { "set_string_var": "perk_quickdraw", "target_var": { "context_val": "trait_id" } },
           {
             "set_string_var": "Requires handguns 2",
-            "target_var": { "context_val": "trait_requirement_description" }
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
           },
           { "set_condition": "perk_condition", "condition": { "math": [ "u_skill('pistol')", ">=", "2" ] } }
         ],
@@ -365,7 +421,11 @@
             "target_var": { "context_val": "trait_description" }
           },
           { "set_string_var": "perk_vengeful", "target_var": { "context_val": "trait_id" } },
-          { "set_string_var": "No requirements", "target_var": { "context_val": "trait_requirement_description" } },
+          {
+            "set_string_var": "No requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
           { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
@@ -380,7 +440,11 @@
             "target_var": { "context_val": "trait_description" }
           },
           { "set_string_var": "perk_tuck_and_roll", "target_var": { "context_val": "trait_id" } },
-          { "set_string_var": "No Requirements", "target_var": { "context_val": "trait_requirement_description" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
           { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
@@ -397,7 +461,8 @@
           { "set_string_var": "perk_recycler", "target_var": { "context_val": "trait_id" } },
           {
             "set_string_var": "Requires survival 4",
-            "target_var": { "context_val": "trait_requirement_description" }
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
           },
           { "set_condition": "perk_condition", "condition": { "math": [ "u_skill('survival')", ">=", "4" ] } }
         ],
@@ -413,7 +478,11 @@
             "target_var": { "context_val": "trait_description" }
           },
           { "set_string_var": "perk_tingly", "target_var": { "context_val": "trait_id" } },
-          { "set_string_var": "No Requirements", "target_var": { "context_val": "trait_requirement_description" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
           { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
@@ -425,7 +494,11 @@
           { "set_string_var": "<trait_name:perk_jumpy>", "target_var": { "context_val": "trait_name" } },
           { "set_string_var": "<trait_description:perk_jumpy>", "target_var": { "context_val": "trait_description" } },
           { "set_string_var": "perk_jumpy", "target_var": { "context_val": "trait_id" } },
-          { "set_string_var": "No Requirements", "target_var": { "context_val": "trait_requirement_description" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
           { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
@@ -442,7 +515,8 @@
           { "set_string_var": "perk_quick_recovery", "target_var": { "context_val": "trait_id" } },
           {
             "set_string_var": "Requires dexterity 10",
-            "target_var": { "context_val": "trait_requirement_description" }
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
           },
           { "set_condition": "perk_condition", "condition": { "math": [ "u_val('dexterity_base')", ">=", "10" ] } }
         ],
@@ -458,7 +532,11 @@
             "target_var": { "context_val": "trait_description" }
           },
           { "set_string_var": "perk_hobbyist", "target_var": { "context_val": "trait_id" } },
-          { "set_string_var": "No Requirements", "target_var": { "context_val": "trait_requirement_description" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
           { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
@@ -473,7 +551,11 @@
             "target_var": { "context_val": "trait_description" }
           },
           { "set_string_var": "perk_troubleseeker", "target_var": { "context_val": "trait_id" } },
-          { "set_string_var": "No Requirements", "target_var": { "context_val": "trait_requirement_description" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
           { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
@@ -490,7 +572,8 @@
           { "set_string_var": "perk_long_shot", "target_var": { "context_val": "trait_id" } },
           {
             "set_string_var": "Requires perception 10",
-            "target_var": { "context_val": "trait_requirement_description" }
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
           },
           { "set_condition": "perk_condition", "condition": { "math": [ "u_val('perception_base')", ">=", "10" ] } }
         ],
@@ -506,7 +589,11 @@
             "target_var": { "context_val": "trait_description" }
           },
           { "set_string_var": "perk_popeye", "target_var": { "context_val": "trait_id" } },
-          { "set_string_var": "No Requirements", "target_var": { "context_val": "trait_requirement_description" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
           { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
@@ -521,7 +608,11 @@
             "target_var": { "context_val": "trait_description" }
           },
           { "set_string_var": "perk_crafty_hands", "target_var": { "context_val": "trait_id" } },
-          { "set_string_var": "No Requirements", "target_var": { "context_val": "trait_requirement_description" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
           { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
@@ -536,7 +627,11 @@
             "target_var": { "context_val": "trait_description" }
           },
           { "set_string_var": "perk_sleepy", "target_var": { "context_val": "trait_id" } },
-          { "set_string_var": "No Requirements", "target_var": { "context_val": "trait_requirement_description" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
           { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
@@ -551,7 +646,11 @@
             "target_var": { "context_val": "trait_description" }
           },
           { "set_string_var": "perk_chainsmoker", "target_var": { "context_val": "trait_id" } },
-          { "set_string_var": "No Requirements", "target_var": { "context_val": "trait_requirement_description" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
           { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
@@ -566,7 +665,11 @@
             "target_var": { "context_val": "trait_description" }
           },
           { "set_string_var": "perk_praise", "target_var": { "context_val": "trait_id" } },
-          { "set_string_var": "No Requirements", "target_var": { "context_val": "trait_requirement_description" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
           { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
@@ -604,7 +707,8 @@
           { "set_string_var": "perk_frakenstein", "target_var": { "context_val": "trait_id" } },
           {
             "set_string_var": "Requires electronics 4, and health care 4",
-            "target_var": { "context_val": "trait_requirement_description" }
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
           },
           {
             "set_condition": "perk_condition",
@@ -620,7 +724,11 @@
           { "set_string_var": "<trait_name:perk_jugg>", "target_var": { "context_val": "trait_name" } },
           { "set_string_var": "<trait_description:perk_jugg>", "target_var": { "context_val": "trait_description" } },
           { "set_string_var": "perk_jugg", "target_var": { "context_val": "trait_id" } },
-          { "set_string_var": "No Requirements", "target_var": { "context_val": "trait_requirement_description" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
           { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
@@ -635,7 +743,11 @@
             "target_var": { "context_val": "trait_description" }
           },
           { "set_string_var": "perk_olde_guns", "target_var": { "context_val": "trait_id" } },
-          { "set_string_var": "No Requirements", "target_var": { "context_val": "trait_requirement_description" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
           { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
@@ -650,7 +762,11 @@
             "target_var": { "context_val": "trait_description" }
           },
           { "set_string_var": "perk_empath", "target_var": { "context_val": "trait_id" } },
-          { "set_string_var": "No Requirements", "target_var": { "context_val": "trait_requirement_description" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
           { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
@@ -665,7 +781,11 @@
             "target_var": { "context_val": "trait_description" }
           },
           { "set_string_var": "perk_chainsaw", "target_var": { "context_val": "trait_id" } },
-          { "set_string_var": "No Requirements", "target_var": { "context_val": "trait_requirement_description" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
           { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
@@ -680,7 +800,11 @@
             "target_var": { "context_val": "trait_description" }
           },
           { "set_string_var": "perk_skeleton", "target_var": { "context_val": "trait_id" } },
-          { "set_string_var": "No Requirements", "target_var": { "context_val": "trait_requirement_description" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
           { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
@@ -707,7 +831,8 @@
           { "set_string_var": "perk_metamagic_quicken", "target_var": { "context_val": "trait_id" } },
           {
             "set_string_var": "Requires a spell known of level 2 or above",
-            "target_var": { "context_val": "trait_requirement_description" }
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
           },
           { "set_condition": "perk_condition", "condition": { "math": [ "u_spell_level('null')", ">=", "2" ] } }
         ],
@@ -725,7 +850,8 @@
           { "set_string_var": "perk_metamagic_widen", "target_var": { "context_val": "trait_id" } },
           {
             "set_string_var": "Requires a spell known of level 2 or above",
-            "target_var": { "context_val": "trait_requirement_description" }
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
           },
           { "set_condition": "perk_condition", "condition": { "math": [ "u_spell_level('null')", ">=", "2" ] } }
         ],
@@ -743,7 +869,8 @@
           { "set_string_var": "perk_metamagic_reach", "target_var": { "context_val": "trait_id" } },
           {
             "set_string_var": "Requires a spell known of level 2 or above",
-            "target_var": { "context_val": "trait_requirement_description" }
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
           },
           { "set_condition": "perk_condition", "condition": { "math": [ "u_spell_level('null')", ">=", "2" ] } }
         ],
@@ -767,7 +894,8 @@
           { "set_string_var": "perk_metamagic_silent", "target_var": { "context_val": "trait_id" } },
           {
             "set_string_var": "Requires a spell known of level 2 or above",
-            "target_var": { "context_val": "trait_requirement_description" }
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
           },
           { "set_condition": "perk_condition", "condition": { "math": [ "u_spell_level('null')", ">=", "2" ] } }
         ],
@@ -791,7 +919,8 @@
           { "set_string_var": "perk_metamagic_still", "target_var": { "context_val": "trait_id" } },
           {
             "set_string_var": "Requires a spell known of level 2 or above",
-            "target_var": { "context_val": "trait_requirement_description" }
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
           },
           { "set_condition": "perk_condition", "condition": { "math": [ "u_spell_level('null')", ">=", "2" ] } }
         ],
@@ -809,7 +938,8 @@
           { "set_string_var": "perk_metamagic_careful", "target_var": { "context_val": "trait_id" } },
           {
             "set_string_var": "Requires a spell known",
-            "target_var": { "context_val": "trait_requirement_description" }
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
           },
           { "set_condition": "perk_condition", "condition": { "math": [ "u_spell_level('null')", ">=", "0" ] } }
         ],
@@ -827,7 +957,8 @@
           { "set_string_var": "perk_metamagic_intuitive", "target_var": { "context_val": "trait_id" } },
           {
             "set_string_var": "Requires a spell known of level 8 or above",
-            "target_var": { "context_val": "trait_requirement_description" }
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
           },
           { "set_condition": "perk_condition", "condition": { "math": [ "u_spell_level('null')", ">=", "8" ] } }
         ],

--- a/data/mods/Defense_Mode/mod_interactions/BombasticPerks/perkmenu.json
+++ b/data/mods/Defense_Mode/mod_interactions/BombasticPerks/perkmenu.json
@@ -15,7 +15,8 @@
           { "set_string_var": "perk_money_maker_merc", "target_var": { "context_val": "trait_id" } },
           {
             "set_string_var": "Must have completed a wave",
-            "target_var": { "context_val": "trait_requirement_description" }
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
           },
           { "set_condition": "perk_condition", "condition": { "math": [ "wave_number", ">=", "1" ] } }
         ],
@@ -31,7 +32,11 @@
             "target_var": { "context_val": "trait_description" }
           },
           { "set_string_var": "perk_slice&dice", "target_var": { "context_val": "trait_id" } },
-          { "set_string_var": "No Requirements", "target_var": { "context_val": "trait_requirement_description" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
           { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
@@ -46,7 +51,11 @@
             "target_var": { "context_val": "trait_description" }
           },
           { "set_string_var": "perk_bash&mash", "target_var": { "context_val": "trait_id" } },
-          { "set_string_var": "No Requirements", "target_var": { "context_val": "trait_requirement_description" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
           { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
@@ -61,7 +70,11 @@
             "target_var": { "context_val": "trait_description" }
           },
           { "set_string_var": "perk_knifey", "target_var": { "context_val": "trait_id" } },
-          { "set_string_var": "No Requirements", "target_var": { "context_val": "trait_requirement_description" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
           { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
@@ -78,7 +91,8 @@
           { "set_string_var": "perk_melee_master", "target_var": { "context_val": "trait_id" } },
           {
             "set_string_var": "Requires Slice & Dice, Bash & Mash, and Knifey",
-            "target_var": { "context_val": "trait_requirement_description" }
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
           },
           {
             "set_condition": "perk_condition",
@@ -101,7 +115,8 @@
           { "set_string_var": "perk_gymrat_king", "target_var": { "context_val": "trait_id" } },
           {
             "set_string_var": "Requires athletics 5 and Gym Rat",
-            "target_var": { "context_val": "trait_requirement_description" }
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
           },
           {
             "set_condition": "perk_condition",
@@ -120,7 +135,11 @@
             "target_var": { "context_val": "trait_description" }
           },
           { "set_string_var": "perk_extra_life", "target_var": { "context_val": "trait_id" } },
-          { "set_string_var": "No Requirements", "target_var": { "context_val": "trait_requirement_description" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
           { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
@@ -135,7 +154,11 @@
             "target_var": { "context_val": "trait_description" }
           },
           { "set_string_var": "perk_mysterious_stranger", "target_var": { "context_val": "trait_id" } },
-          { "set_string_var": "No Requirements", "target_var": { "context_val": "trait_requirement_description" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
           { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"

--- a/data/mods/MindOverMatter/effectoncondition/eoc_awakening.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_awakening.json
@@ -351,7 +351,7 @@
     "id": "EOC_TELEKIN_MATRIX_AWAKENING_SUCCESS",
     "effect": [
       {
-        "u_message": "You gaze into the strange crystal and the light slowly grows brighter.  You release your grasp on the crystal but it doesn't fall.  It floats, supported on nothingness, and as you watch it you become aware of the connections between objects. Gravity, attraction and repulsion, reveal themselves--you can see the weakened influence of gravity on the crystal, and with a thought you nudge it slightly.  The crystal floats up in the air, stretching the connections between it at the ground, before they adjust to its new place.  You tug on the connections, rotating the crystal, moving it from left to right, and as the light within it slowly fades away, you let go and the crystal drops back to your hand.",
+        "u_message": "You gaze into the strange crystal and the light slowly grows brighter.  You release your grasp on the crystal but it doesn't fall.  It floats, supported on nothingness, and as you watch it you become aware of the connections between objects.  Gravity, attraction and repulsion, reveal themselves--you can see the weakened influence of gravity on the crystal, and with a thought you nudge it slightly.  The crystal floats up in the air, stretching the connections between it at the ground, before they adjust to its new place.  You tug on the connections, rotating the crystal, moving it from left to right, and as the light within it slowly fades away, you let go and the crystal drops back to your hand.",
         "popup": true
       },
       { "u_add_trait": "TELEKINETIC" },
@@ -774,7 +774,7 @@
     },
     "effect": [
       {
-        "u_message": "A roar fills your mind, louder even than the screaming madness of the portal storm.  Multi-colored lightning flashes across the sky and then freezes.  The lightning expands in your sight, until you can see individual electrons tracing their paths through the air. You reach out a hand and some of the electrons change their path, and as the world restarts its motion the lightning crashes into you and through you to the ground.  A few sparks remain, dancing across your hand, and as you flex your fingers lightning crackles between them.",
+        "u_message": "A roar fills your mind, louder even than the screaming madness of the portal storm.  Multi-colored lightning flashes across the sky and then freezes.  The lightning expands in your sight, until you can see individual electrons tracing their paths through the air.  You reach out a hand and some of the electrons change their path, and as the world restarts its motion the lightning crashes into you and through you to the ground.  A few sparks remain, dancing across your hand, and as you flex your fingers lightning crackles between them.",
         "popup": true
       },
       { "u_add_trait": "ELECTROKINETIC" },
@@ -939,7 +939,7 @@
     },
     "effect": [
       {
-        "u_message": "A roar fills your mind, louder even than the screaming madness of the portal storm.  Reality grows thin--you can see the ground beneath your hand. You can see the spaces between molecules, larger by far than the distances at a macro scale.  You see the paths you could take to slip between them, to traverse space in an instant without any obstacles in your path.  As the distances collapse back and reality grows solid once again, that knowledge remains with you.",
+        "u_message": "A roar fills your mind, louder even than the screaming madness of the portal storm.  Reality grows thin--you can see the ground beneath your hand.  You can see the spaces between molecules, larger by far than the distances at a macro scale.  You see the paths you could take to slip between them, to traverse space in an instant without any obstacles in your path.  As the distances collapse back and reality grows solid once again, that knowledge remains with you.",
         "popup": true
       },
       { "u_add_trait": "TELEPORTER" },

--- a/data/mods/Sky_Island/EOCs.json
+++ b/data/mods/Sky_Island/EOCs.json
@@ -639,7 +639,7 @@
       { "math": [ "totalstarts", "=", "1 + basementsunlocked + roofsunlocked + labsunlocked" ] },
       { "math": [ "totalexits", "=", "1 + bonusexits" ] },
       {
-        "u_message": "Island Rank: <global_val:islandrank_readable> of 2 \nExpedition Lengths: <global_val:longerraids> of 2 \nExpedition Starts: <global_val:totalstarts> of 5 \nBonus Pulses: <global_val:bonuspulses> of 4 \nTarget reveal distance: <global_val:scoutingdistancetargets> of 10 \nLanding reveal distance: <global_val:scoutingdistancelanding> of 24 \nWarpcloak duration in seconds: <global_val:invistime> of 120 \nSlaughter missions unlocked: <global_val:slaughterunlocked> of 1 \nExits per expedition: <global_val:totalexits> of 3 \nMissions per expedition: <global_val:bonusmissions> of 3 \nMission tiers unlocked: <global_val:hardmissions_readable> of 3",
+        "u_message": "Island Rank: <global_val:islandrank_readable> of 2\nExpedition Lengths: <global_val:longerraids> of 2\nExpedition Starts: <global_val:totalstarts> of 5\nBonus Pulses: <global_val:bonuspulses> of 4\nTarget reveal distance: <global_val:scoutingdistancetargets> of 10\nLanding reveal distance: <global_val:scoutingdistancelanding> of 24\nWarpcloak duration in seconds: <global_val:invistime> of 120\nSlaughter missions unlocked: <global_val:slaughterunlocked> of 1\nExits per expedition: <global_val:totalexits> of 3\nMissions per expedition: <global_val:bonusmissions> of 3\nMission tiers unlocked: <global_val:hardmissions_readable> of 3",
         "popup": true
       }
     ]
@@ -652,7 +652,7 @@
       { "math": [ "readablepulselimit", "=", "8 + bonuspulses" ] },
       { "math": [ "readabledisintegrationlimit", "=", "12 + bonuspulses" ] },
       {
-        "u_message": "Total expeditions: <global_val:raidstotal> \nWins: <global_val:raidswon> \nLosses: <global_val:raidslost> \nMissions complete: <u_val:missionswon> \nSlaughter missions complete: <global_val:slaughterswon>\n\nCurrent difficulty settings:\nWarpsickness at: <global_val:readablepulselimit> pulses.\nDisintegration at: <global_val:readabledisintegrationlimit> pulses.\nDefault pulse length: <global_val:readablesicknessintervals> minutes.",
+        "u_message": "Total expeditions: <global_val:raidstotal>\nWins: <global_val:raidswon>\nLosses: <global_val:raidslost>\nMissions complete: <u_val:missionswon>\nSlaughter missions complete: <global_val:slaughterswon>\n\nCurrent difficulty settings:\nWarpsickness at: <global_val:readablepulselimit> pulses.\nDisintegration at: <global_val:readabledisintegrationlimit> pulses.\nDefault pulse length: <global_val:readablesicknessintervals> minutes.",
         "popup": true
       }
     ]
@@ -663,7 +663,7 @@
     "//": "Displays the player's current constructions.",
     "effect": [
       {
-        "u_message": "Entrance: <global_val:skyisland_build_base> of 1 \nMain Room: <global_val:skyisland_build_bigroom> of 4",
+        "u_message": "Entrance: <global_val:skyisland_build_base> of 1\nMain Room: <global_val:skyisland_build_bigroom> of 4",
         "popup": true
       }
     ]

--- a/data/mods/Sky_Island/sickness_checks.json
+++ b/data/mods/Sky_Island/sickness_checks.json
@@ -114,7 +114,7 @@
       { "u_add_effect": "warpsickness", "intensity": 1, "duration": "PERMANENT" },
       { "u_add_effect": "warpdisintegration", "intensity": 1, "duration": "PERMANENT" },
       {
-        "u_message": "As the warp pulse hits, you realize there are no words to describe how much trouble you're in.  Your body is crumbling to wet paste and your blood is twisting into a viny tangle.  All you know is pain.  \nYou're not just dying, you're dying horribly.  \nIf escape is already near you may survive against all odds, but oblivion is only moments away.",
+        "u_message": "As the warp pulse hits, you realize there are no words to describe how much trouble you're in.  Your body is crumbling to wet paste and your blood is twisting into a viny tangle.  All you know is pain.\nYou're not just dying, you're dying horribly.\nIf escape is already near you may survive against all odds, but oblivion is only moments away.",
         "popup": true,
         "type": "mixed"
       }

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_eocs.json
@@ -228,8 +228,8 @@
         "variables": {
           "prep_time": "1",
           "spell_to_cast": "arvore_vine_drag_spell",
-          "message_success": "Vines lash out and drag your target in!",
-          "message_fail": "You are too parched to lash out with any vines."
+          "message_success": { "i18n": true, "str": "Vines lash out and drag your target in!" },
+          "message_fail": { "i18n": true, "str": "You are too parched to lash out with any vines." }
         }
       }
     ]

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/ierde_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/ierde_eocs.json
@@ -109,7 +109,7 @@
         "variables": {
           "prep_time": "2",
           "spell_to_cast": "ierde_smashing_punch_spell",
-          "message_success": "You gather yourself for a moment and strike.",
+          "message_success": { "i18n": true, "str": "You gather yourself for a moment and strike." },
           "message_fail": ""
         }
       }
@@ -125,7 +125,7 @@
         "variables": {
           "prep_time": "1",
           "spell_to_cast": "ierde_no_sleep_meditate_spell",
-          "message_success": "You settle down, feeling the ground beneath you, and begin your vigil",
+          "message_success": { "i18n": true, "str": "You settle down, feeling the ground beneath you, and begin your vigil" },
           "message_fail": ""
         }
       }

--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -1541,7 +1541,7 @@ Same as `run_eocs`, but runs the specific EoC with provided variables as context
 | "alpha_loc","beta_loc" | optional | string, [variable object](#variable-object) | `u_location_variable`, where the EoC should be run. Set the alpha/beta talker to the creature at the location. |
 | "alpha_talker","beta_talker" | optional (If you use both "alpha_loc" and "alpha_talker", "alpha_talker" will be ignored.) | string, [variable object](#variable-object) | Set alpha/beta talker. This can be either a `character_id` (you can get from [EOC event](#event-eocs) or [u_set_talker](#u_set_talkernpc_set_talker) ) or some hard-coded values: <br> `""`: null talker <br> `"u"/"npc": the alpha/beta talker of the EOC`(Should be Avatar/Character/NPC/Monster) <br> `"avatar"`: your avatar|
 | "false_eocs" | optional | string, [variable object](#variable-object), inline EoC, or range of all of them | false EOCs will run if<br>1. there is no creature at "alpha_loc"/"beta_loc",or<br>2. "alpha_talker" or "beta_talker" doesn't exist in the game (eg. dead NPC),or<br>3. alpha and beta talker are both null |
-| "variables" | optional | pair of `"variable_name": "varialbe"` | variables, that would be passed to the EoC;  all variables should be strings, even if it's int; `expects_vars` condition can be used to ensure every variable exist before the EoC is run | 
+| "variables" | optional | pair of `"variable_name": "variable"` | variables, that would be passed to the EoC; numeric values should be specified as strings; when a variable is an object and has the `i18n` member set to true, the variable will be localized; `expects_vars` condition can be used to ensure every variable exist before the EoC is run | 
 
 ##### Valid talkers:
 
@@ -1680,7 +1680,7 @@ Combination of `run_eoc_with` and `queue_eocs` - Put EoC into queue and run into
 | --- | --- | --- | --- | 
 | "queue_eoc_with" | **mandatory** | string (eoc id or inline eoc) | EoC, that would be added into queue; Could be an inline EoC |
 | "time_in_future" | optional | int, duration, [variable object](#variable-object) or value between two | When in the future EoC would be run; default 0 |
-| "variables" | optional | pair of `"variable_name": "varialbe"` | variables, that would be passed to the EoC; `expects_vars` condition can be used to ensure every variable exist before the EoC is run | 
+| "variables" | optional | pair of `"variable_name": "variable"` | variables, that would be passed to the EoC; numeric values should be specified as strings; when a variable is an object and has the `i18n` member set to true, the variable will be localized; `expects_vars` condition can be used to ensure every variable exist before the EoC is run | 
 
 ##### Valid talkers:
 
@@ -2107,7 +2107,7 @@ Open a menu, that allow to select one of multiple options
 | "title" | optional | string | Text, that would be shown as the name of the list; Default `Select an option.` | 
 | "hide_failing" | optional | boolean | if true, the options, that fail their check, would be completely removed from the list, instead of being grayed out | 
 | "allow_cancel" | optional | boolean | if true, you can quit the menu without selecting an option, no effect will occur | 
-| "variables" | optional | pair of `"variable_name": "varialbe"` | variables, that would be passed to the EoCs; `expects_vars` condition can be used to ensure every variable exist before the EoC is run | 
+| "variables" | optional | pair of `"variable_name": "variable"` | variables, that would be passed to the EoCs; numeric values should be specified as strings; when a variable is an object and has the `i18n` member set to true, the variable will be localized; `expects_vars` condition can be used to ensure every variable exist before the EoC is run | 
 ##### Valid talkers:
 
 | Avatar | Character | NPC | Monster |  Furniture | Item |

--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -2638,6 +2638,7 @@ Store string from `set_string_var` in the variable object `target_var`
 | "set_string_var" | **mandatory** | string, [variable object](##variable-object), or array of both | value, that would be put into `target_var` |
 | "target_var" | **mandatory** | [variable object](##variable-object) | variable, that accept the value; usually `context_val` | 
 | "parse_tags" | optional | boolean | Allo if parse [custom entries](NPCs.md#customizing-npc-speech) in string before storing | 
+| "i18n"       | optional | boolean | Whether the string values should be localized | 
 
 
 ##### Valid talkers:

--- a/lang/string_extractor/parse.py
+++ b/lang/string_extractor/parse.py
@@ -35,5 +35,4 @@ def parse_json_file(file_path):
     except Exception as E:
         print("Error in JSON object\n'{0}'\nfrom file: '{1}'".format(
             json.dumps(json_object, indent=2), file_path))
-        print(E)
-        exit(1)
+        raise

--- a/lang/string_extractor/parse.py
+++ b/lang/string_extractor/parse.py
@@ -32,7 +32,7 @@ def parse_json_file(file_path):
         json_objects = json_data if type(json_data) is list else [json_data]
         for json_object in json_objects:
             parse_json_object(json_object, file_path)
-    except Exception as E:
+    except Exception:
         print("Error in JSON object\n'{0}'\nfrom file: '{1}'".format(
             json.dumps(json_object, indent=2), file_path))
         raise

--- a/lang/string_extractor/parsers/condition.py
+++ b/lang/string_extractor/parsers/condition.py
@@ -9,10 +9,12 @@ def parse_condition(conditions, origin):
             # if *_query is an object, the message is taken from elsewhere
             if "u_query" in cond and type(cond["u_query"]) is str:
                 write_translation_or_var(cond["u_query"], origin,
-                                         comment="Query message shown in a popup")
+                                         comment="Query message shown in a "
+                                         "popup")
             if "npc_query" in cond and type(cond["npc_query"]) is str:
                 write_translation_or_var(cond["npc_query"], origin,
-                                         comment="Query message shown in a popup")
+                                         comment="Query message shown in a "
+                                         "popup")
             if "and" in cond:
                 parse_condition(cond["and"], origin)
             if "or" in cond:

--- a/lang/string_extractor/parsers/condition.py
+++ b/lang/string_extractor/parsers/condition.py
@@ -1,4 +1,4 @@
-from ..write_text import write_text
+from ..write_text import write_translation_or_var
 
 
 def parse_condition(conditions, origin):
@@ -8,11 +8,11 @@ def parse_condition(conditions, origin):
         if type(cond) is dict:
             # if *_query is an object, the message is taken from elsewhere
             if "u_query" in cond and type(cond["u_query"]) is str:
-                write_text(cond["u_query"], origin,
-                           comment="Query message shown in a popup")
+                write_translation_or_var(cond["u_query"], origin,
+                                         comment="Query message shown in a popup")
             if "npc_query" in cond and type(cond["npc_query"]) is str:
-                write_text(cond["npc_query"], origin,
-                           comment="Query message shown in a popup")
+                write_translation_or_var(cond["npc_query"], origin,
+                                         comment="Query message shown in a popup")
             if "and" in cond:
                 parse_condition(cond["and"], origin)
             if "or" in cond:

--- a/lang/string_extractor/parsers/effect.py
+++ b/lang/string_extractor/parsers/effect.py
@@ -72,6 +72,18 @@ def parse_effect(effects, origin, comment=""):
                             parse_effect_on_condition(eoc, origin,
                                                       comment="nested EOCs in {}"
                                                       .format(comment))
+            if "run_eoc_selector" in eff:
+                for name in eff.get("names", []):
+                    write_text(name, origin,
+                               comment="EOC option name in {}".format(comment))
+                for desc in eff.get("descriptions", []):
+                    write_text(desc, origin,
+                               comment="EOC option description in {}"
+                               .format(comment))
+                if "title" in eff:
+                    write_text(eff["title"], origin,
+                               comment="EOC selection title in {}"
+                               .format(comment))
             if "weighted_list_eocs" in eff:
                 for e in eff["weighted_list_eocs"]:
                     if type(e[0]) is dict:

--- a/lang/string_extractor/parsers/effect.py
+++ b/lang/string_extractor/parsers/effect.py
@@ -53,19 +53,6 @@ def parse_effect(effects, origin, comment=""):
                     write_translation_or_var(eff["message"], origin,
                                              comment="{} roll message in {}"
                                              .format(roll_type, comment))
-                for key in ["true_eocs", "false_eocs"]:
-                    if key not in eff:
-                        continue
-                    eoc_list = eff[key]
-                    if type(eoc_list) is not list:
-                        eoc_list = [eoc_list]
-                    for eoc in eoc_list:
-                        if type(eoc) is not dict:
-                            continue
-                        parse_effect_on_condition(
-                            eoc, origin,
-                            comment="{} roll nested EOCs in {}"
-                            .format(roll_type, comment))
             for cast_spell_key in ["u_cast_spell", "npc_cast_spell"]:
                 if cast_spell_key not in eff:
                     continue
@@ -105,15 +92,6 @@ def parse_effect(effects, origin, comment=""):
                                .format(comment))
             if "variables" in eff:
                 parse_effect_variables(eff["variables"], origin, comment)
-            if "run_eocs" in eff:
-                eoc_list = eff["run_eocs"]
-                if type(eoc_list) is not list:
-                    eoc_list = [eoc_list]
-                for eoc in eoc_list:
-                    if type(eoc) is dict:
-                        parse_effect_on_condition(eoc, origin,
-                                                  comment="nested EOCs in {}"
-                                                  .format(comment))
             if "run_eoc_selector" in eff:
                 for name in eff.get("names", []):
                     write_translation_or_var(name, origin,
@@ -136,6 +114,11 @@ def parse_effect(effects, origin, comment=""):
                     write_translation_or_var(eff["title"], origin,
                                              comment="NPC inventory menu "
                                              "title in {}".format(comment))
+            if "place_override" in eff:
+                write_translation_or_var(eff["place_override"], origin,
+                                         comment="place name in {}"
+                                         .format(comment))
+            # Nested effects
             if "weighted_list_eocs" in eff:
                 for e in eff["weighted_list_eocs"]:
                     if type(e[0]) is dict:
@@ -143,15 +126,34 @@ def parse_effect(effects, origin, comment=""):
                             parse_effect(e[0]["effect"], origin,
                                          comment="nested effect in {}"
                                          .format(comment))
+            if "run_eocs" in eff:
+                eoc_list = eff["run_eocs"]
+                if type(eoc_list) is not list:
+                    eoc_list = [eoc_list]
+                for eoc in eoc_list:
+                    if type(eoc) is dict:
+                        parse_effect_on_condition(eoc, origin,
+                                                  comment="nested EOCs in {}"
+                                                  .format(comment))
+            for key, cond_type in [("true_eocs", "true"),
+                                   ("false_eocs", "false")]:
+                if key not in eff:
+                    continue
+                eoc_list = eff[key]
+                if type(eoc_list) is not list:
+                    eoc_list = [eoc_list]
+                for eoc in eoc_list:
+                    if type(eoc) is not dict:
+                        continue
+                    parse_effect_on_condition(
+                        eoc, origin,
+                        comment="nested EOCs on {} condition in {}"
+                        .format(cond_type, comment))
             if "switch" in eff:
                 for e in eff["cases"]:
                     parse_effect(e["effect"], origin,
                                  comment="nested effect in switch statement in {}"
                                  .format(comment))
-            if "place_override" in eff:
-                write_translation_or_var(eff["place_override"], origin,
-                                         comment="place name in {}"
-                                         .format(comment))
 
 
 def parse_effect_on_condition(json, origin, comment=""):

--- a/lang/string_extractor/parsers/effect.py
+++ b/lang/string_extractor/parsers/effect.py
@@ -104,11 +104,11 @@ def parse_effect(effects, origin, comment=""):
                                comment="EOC selection title in {}"
                                .format(comment))
             if "title" in eff:
-                if "u_run_inv_eocs" in eff:
+                if "u_run_inv_eocs" in eff or "u_map_run_item_eocs" in eff:
                     write_translation_or_var(eff["title"], origin,
                                              comment="Player inventory menu "
                                              "title in {}".format(comment))
-                if "npc_run_inv_eocs" in eff:
+                if "npc_run_inv_eocs" in eff or "npc_map_run_item_eocs" in eff:
                     write_translation_or_var(eff["title"], origin,
                                              comment="NPC inventory menu "
                                              "title in {}".format(comment))

--- a/lang/string_extractor/parsers/effect.py
+++ b/lang/string_extractor/parsers/effect.py
@@ -83,13 +83,15 @@ def parse_effect(effects, origin, comment=""):
                            .format(comment))
             if "u_teleport" in eff or "npc_teleport" in eff:
                 if "success_message" in eff:
-                    write_text(eff["success_message"], origin,
-                               comment="Success message in teleportation in {}"
-                               .format(comment))
+                    write_translation_or_var(eff["success_message"], origin,
+                                             comment="Success message in "
+                                             "teleportation in {}"
+                                             .format(comment))
                 if "fail_message" in eff:
-                    write_text(eff["fail_message"], origin,
-                               comment="Fail message in teleportation in {}"
-                               .format(comment))
+                    write_translation_or_var(eff["fail_message"], origin,
+                                             comment="Fail message in "
+                                             "teleportation in {}"
+                                             .format(comment))
             if "variables" in eff:
                 parse_effect_variables(eff["variables"], origin, comment)
             if "run_eoc_selector" in eff:

--- a/lang/string_extractor/parsers/effect.py
+++ b/lang/string_extractor/parsers/effect.py
@@ -73,14 +73,20 @@ def parse_effect(effects, origin, comment=""):
                     write_translation_or_var(val, origin,
                                              comment="Text variable value in {}"
                                              .format(comment))
-            if "spawn_message" in eff:
-                write_text(eff["spawn_message"], origin,
-                           comment="Player sees monster spawns in {}"
-                           .format(comment))
-            if "spawn_message_plural" in eff:
-                write_text(eff["spawn_message_plural"], origin,
-                           comment="Player sees monsters spawn in {}"
-                           .format(comment))
+            if ("u_spawn_monster" in eff or "npc_spawn_monster" in eff
+                or "u_spawn_npc" in eff or "npc_spawn_npc" in eff):
+                if "u_spawn_monster" in eff or "npc_spawn_monster" in eff:
+                    spawn_type = "monster"
+                else:
+                    spawn_type = "NPC"
+                if "spawn_message" in eff:
+                    write_text(eff["spawn_message"], origin,
+                               comment="Player sees {} spawns in {}"
+                               .format(spawn_type, comment))
+                if "spawn_message_plural" in eff:
+                    write_text(eff["spawn_message_plural"], origin,
+                               comment="Player sees {}s spawn in {}"
+                               .format(spawn_type, comment))
             if "u_teleport" in eff or "npc_teleport" in eff:
                 if "success_message" in eff:
                     write_translation_or_var(eff["success_message"], origin,

--- a/lang/string_extractor/parsers/effect.py
+++ b/lang/string_extractor/parsers/effect.py
@@ -187,17 +187,11 @@ def parse_effect_on_condition(json, origin, comment=""):
 
 
 def parse_effect_variables(json, origin, comment):
-    if "message_success" in json:
-        write_text(json["message_success"], origin,
-                   comment="Success message casting spell \"{}\" in {}"
-                   .format(json["spell_to_cast"], comment))
-    if "message_fail" in json:
-        write_text(json["message_fail"], origin,
-                   comment="Fail message casting spell \"{}\" in {}"
-                   .format(json["spell_to_cast"], comment))
-    if "success_message" in json:
-        write_text(json["success_message"], origin,
-                   comment="Success message in {}".format(comment))
-    if "failure_message" in json:
-        write_text(json["failure_message"], origin,
-                   comment="Failure message in {}".format(comment))
+    if type(json) is dict:
+        json = [json]
+    for jsobj in json:
+        for key, val in jsobj.items():
+            if type(val) is dict and val.get("i18n", False):
+                write_translation_or_var(val, origin,
+                                         comment="value of variable '{}' in {}"
+                                         .format(key, comment))

--- a/lang/string_extractor/parsers/effect.py
+++ b/lang/string_extractor/parsers/effect.py
@@ -19,9 +19,10 @@ def parse_effect(effects, origin, comment=""):
                 write_text(eff["message_npc"], origin,
                            comment="NPC message in {}".format(comment))
             if "u_buy_monster" in eff and "name" in eff:
-                write_text(eff["name"], origin,
-                           comment="Nickname for creature '{}' in {}".
-                           format(eff["u_buy_monster"], comment))
+                write_translation_or_var(eff["name"], origin,
+                                         comment="Nickname for creature '{}' "
+                                         "in {}"
+                                         .format(eff["u_buy_monster"], comment))
             if "snippet" not in eff or eff["snippet"] is False:
                 if "message" in eff:
                     write_translation_or_var(eff["message"], origin,

--- a/lang/string_extractor/parsers/effect.py
+++ b/lang/string_extractor/parsers/effect.py
@@ -44,6 +44,28 @@ def parse_effect(effects, origin, comment=""):
                     write_translation_or_var(eff["npc_make_sound"], origin,
                                              comment="NPC makes sound in {}"
                                              .format(comment))
+            if "u_roll_remainder" in eff or "npc_roll_remainder" in eff:
+                if "u_roll_remainder" in eff:
+                    roll_type = "player"
+                else:
+                    roll_type = "NPC"
+                if "message" in eff:
+                    write_translation_or_var(eff["message"], origin,
+                                             comment="{} roll message in {}"
+                                             .format(roll_type, comment))
+                for key in ["true_eocs", "false_eocs"]:
+                    if key not in eff:
+                        continue
+                    eoc_list = eff[key]
+                    if type(eoc_list) is not list:
+                        eoc_list = [eoc_list]
+                    for eoc in eoc_list:
+                        if type(eoc) is not dict:
+                            continue
+                        parse_effect_on_condition(
+                            eoc, origin,
+                            comment="{} roll nested EOCs in {}"
+                            .format(roll_type, comment))
             for cast_spell_key in ["u_cast_spell", "npc_cast_spell"]:
                 if cast_spell_key not in eff:
                     continue
@@ -84,12 +106,14 @@ def parse_effect(effects, origin, comment=""):
             if "variables" in eff:
                 parse_effect_variables(eff["variables"], origin, comment)
             if "run_eocs" in eff:
-                if type(eff["run_eocs"]) is list:
-                    for eoc in eff["run_eocs"]:
-                        if type(eoc) is dict:
-                            parse_effect_on_condition(eoc, origin,
-                                                      comment="nested EOCs in {}"
-                                                      .format(comment))
+                eoc_list = eff["run_eocs"]
+                if type(eoc_list) is not list:
+                    eoc_list = [eoc_list]
+                for eoc in eoc_list:
+                    if type(eoc) is dict:
+                        parse_effect_on_condition(eoc, origin,
+                                                  comment="nested EOCs in {}"
+                                                  .format(comment))
             if "run_eoc_selector" in eff:
                 for name in eff.get("names", []):
                     write_translation_or_var(name, origin,

--- a/lang/string_extractor/parsers/effect.py
+++ b/lang/string_extractor/parsers/effect.py
@@ -36,14 +36,14 @@ def parse_effect(effects, origin, comment=""):
                     write_translation_or_var(eff["npc_message"], origin,
                                              comment="NPC message in {}"
                                              .format(comment))
-                if "u_make_sound" in eff and type(eff["u_make_sound"]) is str:
-                    write_text(eff["u_make_sound"], origin,
-                               comment="Player makes sound in {}".
-                               format(comment))
-                if "npc_make_sound" in eff and \
-                        type(eff["npc_make_sound"]) is str:
-                    write_text(eff["npc_make_sound"], origin,
-                               comment="NPC makes sound in {}".format(comment))
+                if "u_make_sound" in eff:
+                    write_translation_or_var(eff["u_make_sound"], origin,
+                                             comment="Player makes sound in {}"
+                                             .format(comment))
+                if "npc_make_sound" in eff:
+                    write_translation_or_var(eff["npc_make_sound"], origin,
+                                             comment="NPC makes sound in {}"
+                                             .format(comment))
             for cast_spell_key in ["u_cast_spell", "npc_cast_spell"]:
                 if cast_spell_key not in eff:
                     continue

--- a/lang/string_extractor/parsers/effect.py
+++ b/lang/string_extractor/parsers/effect.py
@@ -157,11 +157,23 @@ def parse_effect(effects, origin, comment=""):
                         eoc, origin,
                         comment="nested EOCs on {} condition in {}"
                         .format(cond_type, comment))
+            if "if" in eff:
+                parse_effect(eff["then"], origin,
+                             comment="nested effect in then statement in {}"
+                             .format(comment))
+                if "else" in eff:
+                    parse_effect(eff["else"], origin,
+                                 comment="nested effect in else statement in {}"
+                                 .format(comment))
             if "switch" in eff:
                 for e in eff["cases"]:
                     parse_effect(e["effect"], origin,
                                  comment="nested effect in switch statement in {}"
                                  .format(comment))
+            if "foreach" in eff:
+                parse_effect(eff["effect"], origin,
+                             comment="nested effect in foreach statement in {}"
+                             .format(comment))
 
 
 def parse_effect_on_condition(json, origin, comment=""):

--- a/lang/string_extractor/parsers/effect.py
+++ b/lang/string_extractor/parsers/effect.py
@@ -39,6 +39,13 @@ def parse_effect(effects, origin, comment=""):
                         type(eff["npc_make_sound"]) is str:
                     write_text(eff["npc_make_sound"], origin,
                                comment="NPC makes sound in {}".format(comment))
+            if "set_string_var" in eff and "i18n" in eff and eff["i18n"] is True:
+                str_vals = eff["set_string_var"]
+                if type(str_vals) is not list:
+                    str_vals = [str_vals]
+                for val in str_vals:
+                    write_text(val, origin,
+                               comment="Text variable value in {}".format(comment))
             if "spawn_message" in eff:
                 write_text(eff["spawn_message"], origin,
                            comment="Player sees monster spawns in {}"
@@ -62,7 +69,9 @@ def parse_effect(effects, origin, comment=""):
                 if type(eff["run_eocs"]) is list:
                     for eoc in eff["run_eocs"]:
                         if type(eoc) is dict:
-                            parse_effect_on_condition(eoc, origin)
+                            parse_effect_on_condition(eoc, origin,
+                                                      comment="nested EOCs in {}"
+                                                      .format(comment))
             if "weighted_list_eocs" in eff:
                 for e in eff["weighted_list_eocs"]:
                     if type(e[0]) is dict:
@@ -70,16 +79,23 @@ def parse_effect(effects, origin, comment=""):
                             parse_effect(e[0]["effect"], origin,
                                          comment="nested effect in {}"
                                          .format(comment))
+            if "switch" in eff:
+                for e in eff["cases"]:
+                    parse_effect(e["effect"], origin,
+                                 comment="nested effect in switch statement in {}"
+                                 .format(comment))
 
 
 def parse_effect_on_condition(json, origin, comment=""):
     id = json["id"]
-    if comment:
-        parse_effect(json["effect"], origin,
-                     comment="effect in EoC \"{}\" in {}".format(id, comment))
-    else:
-        parse_effect(json["effect"], origin,
-                     comment="effect in EoC \"{}\"".format(id))
+    if "effect" in json:
+        if comment:
+            parse_effect(json["effect"], origin,
+                         comment="effect in EoC \"{}\" in {}"
+                         .format(id, comment))
+        else:
+            parse_effect(json["effect"], origin,
+                         comment="effect in EoC \"{}\"".format(id))
     if "false_effect" in json:
         if comment:
             parse_effect(json["false_effect"], origin,

--- a/lang/string_extractor/parsers/effect.py
+++ b/lang/string_extractor/parsers/effect.py
@@ -96,6 +96,9 @@ def parse_effect(effects, origin, comment=""):
                     parse_effect(e["effect"], origin,
                                  comment="nested effect in switch statement in {}"
                                  .format(comment))
+            if "place_override" in eff:
+                write_text(eff["place_override"], origin,
+                           comment="place name in {}".format(comment))
 
 
 def parse_effect_on_condition(json, origin, comment=""):

--- a/lang/string_extractor/parsers/effect.py
+++ b/lang/string_extractor/parsers/effect.py
@@ -44,6 +44,18 @@ def parse_effect(effects, origin, comment=""):
                         type(eff["npc_make_sound"]) is str:
                     write_text(eff["npc_make_sound"], origin,
                                comment="NPC makes sound in {}".format(comment))
+            for cast_spell_key in ["u_cast_spell", "npc_cast_spell"]:
+                if cast_spell_key not in eff:
+                    continue
+                spell_obj = eff[cast_spell_key]
+                if "message" in spell_obj:
+                    write_translation_or_var(spell_obj["message"], origin,
+                                             comment="Player spell casting "
+                                             "message in {}".format(comment))
+                if "npc_message" in spell_obj:
+                    write_translation_or_var(spell_obj["npc_message"], origin,
+                                             comment="NPC spell casting "
+                                             "message in {}".format(comment))
             if "set_string_var" in eff and "i18n" in eff and eff["i18n"] is True:
                 str_vals = eff["set_string_var"]
                 if type(str_vals) is not list:

--- a/lang/string_extractor/parsers/effect.py
+++ b/lang/string_extractor/parsers/effect.py
@@ -62,7 +62,8 @@ def parse_effect(effects, origin, comment=""):
                     write_translation_or_var(spell_obj["npc_message"], origin,
                                              comment="NPC spell casting "
                                              "message in {}".format(comment))
-            if "set_string_var" in eff and "i18n" in eff and eff["i18n"] is True:
+            if ("set_string_var" in eff
+                and "i18n" in eff and eff["i18n"] is True):
                 str_vals = eff["set_string_var"]
                 if type(str_vals) is not list:
                     str_vals = [str_vals]
@@ -165,8 +166,8 @@ def parse_effect(effects, origin, comment=""):
             if "switch" in eff:
                 for e in eff["cases"]:
                     parse_effect(e["effect"], origin,
-                                 comment="nested effect in switch statement in {}"
-                                 .format(comment))
+                                 comment="nested effect in switch statement in "
+                                 "{}".format(comment))
             if "foreach" in eff:
                 parse_effect(eff["effect"], origin,
                              comment="nested effect in foreach statement in {}"

--- a/lang/string_extractor/parsers/effect.py
+++ b/lang/string_extractor/parsers/effect.py
@@ -103,6 +103,15 @@ def parse_effect(effects, origin, comment=""):
                     write_text(eff["title"], origin,
                                comment="EOC selection title in {}"
                                .format(comment))
+            if "title" in eff:
+                if "u_run_inv_eocs" in eff:
+                    write_translation_or_var(eff["title"], origin,
+                                             comment="Player inventory menu "
+                                             "title in {}".format(comment))
+                if "npc_run_inv_eocs" in eff:
+                    write_translation_or_var(eff["title"], origin,
+                                             comment="NPC inventory menu "
+                                             "title in {}".format(comment))
             if "weighted_list_eocs" in eff:
                 for e in eff["weighted_list_eocs"]:
                     if type(e[0]) is dict:

--- a/lang/string_extractor/parsers/effect.py
+++ b/lang/string_extractor/parsers/effect.py
@@ -18,8 +18,8 @@ def parse_effect(effects, origin, comment=""):
             if "u_buy_monster" in eff and "name" in eff:
                 write_translation_or_var(eff["name"], origin,
                                          comment="Nickname for creature '{}' "
-                                         "in {}"
-                                         .format(eff["u_buy_monster"], comment))
+                                         "in {}".format(eff["u_buy_monster"],
+                                                        comment))
             if "snippet" not in eff or eff["snippet"] is False:
                 if "message" in eff:
                     write_translation_or_var(eff["message"], origin,
@@ -62,17 +62,17 @@ def parse_effect(effects, origin, comment=""):
                     write_translation_or_var(spell_obj["npc_message"], origin,
                                              comment="NPC spell casting "
                                              "message in {}".format(comment))
-            if ("set_string_var" in eff
-                and "i18n" in eff and eff["i18n"] is True):
+            if ("set_string_var" in eff and
+                    "i18n" in eff and eff["i18n"] is True):
                 str_vals = eff["set_string_var"]
                 if type(str_vals) is not list:
                     str_vals = [str_vals]
                 for val in str_vals:
                     write_translation_or_var(val, origin,
-                                             comment="Text variable value in {}"
-                                             .format(comment))
-            if ("u_spawn_monster" in eff or "npc_spawn_monster" in eff
-                or "u_spawn_npc" in eff or "npc_spawn_npc" in eff):
+                                             comment="Text variable value in "
+                                             "{}".format(comment))
+            if ("u_spawn_monster" in eff or "npc_spawn_monster" in eff or
+                    "u_spawn_npc" in eff or "npc_spawn_npc" in eff):
                 if "u_spawn_monster" in eff or "npc_spawn_monster" in eff:
                     spawn_type = "monster"
                 else:
@@ -161,13 +161,13 @@ def parse_effect(effects, origin, comment=""):
                              .format(comment))
                 if "else" in eff:
                     parse_effect(eff["else"], origin,
-                                 comment="nested effect in else statement in {}"
-                                 .format(comment))
+                                 comment="nested effect in else statement in "
+                                 "{}".format(comment))
             if "switch" in eff:
                 for e in eff["cases"]:
                     parse_effect(e["effect"], origin,
-                                 comment="nested effect in switch statement in "
-                                 "{}".format(comment))
+                                 comment="nested effect in switch statement "
+                                 "in {}".format(comment))
             if "foreach" in eff:
                 parse_effect(eff["effect"], origin,
                              comment="nested effect in foreach statement in {}"

--- a/lang/string_extractor/parsers/effect.py
+++ b/lang/string_extractor/parsers/effect.py
@@ -15,9 +15,6 @@ def parse_effect(effects, origin, comment=""):
                     comment = "effect \"{}\"".format(eff["effect_id"])
                 else:
                     comment = "an effect"
-            if "message_npc" in eff:
-                write_text(eff["message_npc"], origin,
-                           comment="NPC message in {}".format(comment))
             if "u_buy_monster" in eff and "name" in eff:
                 write_translation_or_var(eff["name"], origin,
                                          comment="Nickname for creature '{}' "

--- a/lang/string_extractor/parsers/effect.py
+++ b/lang/string_extractor/parsers/effect.py
@@ -1,5 +1,6 @@
 from .condition import parse_condition
 from ..write_text import write_text
+from ..write_text import write_translation_or_var
 
 
 def parse_effect(effects, origin, comment=""):
@@ -14,9 +15,6 @@ def parse_effect(effects, origin, comment=""):
                     comment = "effect \"{}\"".format(eff["effect_id"])
                 else:
                     comment = "an effect"
-            if "message" in eff:
-                write_text(eff["message"], origin,
-                           comment="Message in {}".format(comment))
             if "message_npc" in eff:
                 write_text(eff["message_npc"], origin,
                            comment="NPC message in {}".format(comment))
@@ -25,12 +23,18 @@ def parse_effect(effects, origin, comment=""):
                            comment="Nickname for creature '{}' in {}".
                            format(eff["u_buy_monster"], comment))
             if "snippet" not in eff or eff["snippet"] is False:
+                if "message" in eff:
+                    write_translation_or_var(eff["message"], origin,
+                                             comment="Message in {}"
+                                             .format(comment))
                 if "u_message" in eff:
-                    write_text(eff["u_message"], origin,
-                               comment="Player message in {}".format(comment))
+                    write_translation_or_var(eff["u_message"], origin,
+                                             comment="Player message in {}"
+                                             .format(comment))
                 if "npc_message" in eff:
-                    write_text(eff["npc_message"], origin,
-                               comment="NPC message in {}".format(comment))
+                    write_translation_or_var(eff["npc_message"], origin,
+                                             comment="NPC message in {}"
+                                             .format(comment))
                 if "u_make_sound" in eff and type(eff["u_make_sound"]) is str:
                     write_text(eff["u_make_sound"], origin,
                                comment="Player makes sound in {}".
@@ -44,8 +48,9 @@ def parse_effect(effects, origin, comment=""):
                 if type(str_vals) is not list:
                     str_vals = [str_vals]
                 for val in str_vals:
-                    write_text(val, origin,
-                               comment="Text variable value in {}".format(comment))
+                    write_translation_or_var(val, origin,
+                                             comment="Text variable value in {}"
+                                             .format(comment))
             if "spawn_message" in eff:
                 write_text(eff["spawn_message"], origin,
                            comment="Player sees monster spawns in {}"
@@ -74,12 +79,13 @@ def parse_effect(effects, origin, comment=""):
                                                       .format(comment))
             if "run_eoc_selector" in eff:
                 for name in eff.get("names", []):
-                    write_text(name, origin,
-                               comment="EOC option name in {}".format(comment))
+                    write_translation_or_var(name, origin,
+                                             comment="EOC option name in {}"
+                                             .format(comment))
                 for desc in eff.get("descriptions", []):
-                    write_text(desc, origin,
-                               comment="EOC option description in {}"
-                               .format(comment))
+                    write_translation_or_var(desc, origin,
+                                             comment="EOC option description "
+                                             "in {}".format(comment))
                 if "title" in eff:
                     write_text(eff["title"], origin,
                                comment="EOC selection title in {}"
@@ -97,8 +103,9 @@ def parse_effect(effects, origin, comment=""):
                                  comment="nested effect in switch statement in {}"
                                  .format(comment))
             if "place_override" in eff:
-                write_text(eff["place_override"], origin,
-                           comment="place name in {}".format(comment))
+                write_translation_or_var(eff["place_override"], origin,
+                                         comment="place name in {}"
+                                         .format(comment))
 
 
 def parse_effect_on_condition(json, origin, comment=""):

--- a/lang/string_extractor/parsers/field_type.py
+++ b/lang/string_extractor/parsers/field_type.py
@@ -6,10 +6,18 @@ def parse_field_type(json, origin):
     for fd in json.get("intensity_levels", []):
         if "name" in fd:
             write_text(fd["name"], origin, comment="Field intensity level")
-        if "effects" in fd:
-            parse_effect(fd["effects"], origin,
-                         comment="effect in field {}".format(fd["name"])
-                         if "name" in fd else "")
+            id_or_name = fd["name"]
+        else:
+            id_or_name = json["id"]
+        for eff in fd.get("effects", []):
+            if "message" in eff:
+                write_text(eff["message"], origin,
+                           comment="Player message on effect of field {}"
+                           .format(id_or_name))
+            if "message_npc" in eff:
+                write_text(eff["message_npc"], origin,
+                           comment="NPC message on effect of field {}"
+                           .format(id_or_name))
     if "npc_complain" in json:
         write_text(json["npc_complain"]["speech"], origin,
                    comment="Field NPC complaint")

--- a/lang/string_extractor/parsers/field_type.py
+++ b/lang/string_extractor/parsers/field_type.py
@@ -1,5 +1,4 @@
 from ..write_text import write_text
-from .effect import parse_effect
 
 
 def parse_field_type(json, origin):

--- a/lang/string_extractor/parsers/generic.py
+++ b/lang/string_extractor/parsers/generic.py
@@ -22,6 +22,8 @@ def parse_generic(json, origin):
 
     if "use_action" in json:
         parse_use_action(json["use_action"], origin, name)
+    if "tick_action" in json:
+        parse_use_action(json["tick_action"], origin, name)
 
     for cname in json.get("conditional_names", []):
         write_text(cname["name"], origin,

--- a/lang/string_extractor/parsers/use_action.py
+++ b/lang/string_extractor/parsers/use_action.py
@@ -46,9 +46,12 @@ def parse_use_action(json, origin, item_name):
                 write_text(json[msg_key], origin,
                            comment="\"{0}\" action message of item \"{1}\""
                            .format(msg_key, item_name))
-        for json_key in json:
-            parse_use_action(json[json_key], origin, item_name)
-        if "effect_on_conditions" in json:
+        if json["type"] == "place_trap" and "bury" in json:
+            write_text(json["bury"]["done_message"], origin,
+                       comment="bury trap message of item \"{}\""
+                       .format(item_name))
+        if (json["type"] == "effect_on_conditions"
+            and "effect_on_conditions" in json):
             for e in json["effect_on_conditions"]:
                 if type(e) is dict:
                     parse_effect_on_condition(e, origin,

--- a/lang/string_extractor/parsers/use_action.py
+++ b/lang/string_extractor/parsers/use_action.py
@@ -50,8 +50,8 @@ def parse_use_action(json, origin, item_name):
             write_text(json["bury"]["done_message"], origin,
                        comment="bury trap message of item \"{}\""
                        .format(item_name))
-        if (json["type"] == "effect_on_conditions"
-            and "effect_on_conditions" in json):
+        if (json["type"] == "effect_on_conditions" and
+                "effect_on_conditions" in json):
             for e in json["effect_on_conditions"]:
                 if type(e) is dict:
                     parse_effect_on_condition(e, origin,

--- a/lang/string_extractor/write_text.py
+++ b/lang/string_extractor/write_text.py
@@ -69,3 +69,15 @@ def write_text(json, origin, context="", comment="",
     messages[(context, text)].append(
         Message(comments, origin, format_tag, context, text, text_plural))
     occurrences.append((context, text))
+
+
+# Used in parse_effect and parse_condition
+def write_translation_or_var(json, origin, context="", comment="",
+                             plural=False, c_format=True):
+    if type(json) is dict and "default_str" in json:
+        write_text(json["default_str"], origin, context=context,
+                   comment="default value for {}".format(comment),
+                   plural=plural, c_format=c_format)
+    else:
+        write_text(json, origin, context=context, comment=comment,
+                   plural=plural, c_format=c_format)

--- a/src/condition.h
+++ b/src/condition.h
@@ -47,6 +47,7 @@ duration_or_var_part get_duration_or_var_part( const JsonValue &jv, const std::s
         time_duration default_val = 0_seconds );
 tripoint_abs_ms get_tripoint_from_var( std::optional<var_info> var, dialogue const &d );
 var_info read_var_info( const JsonObject &jo );
+translation_var_info read_translation_var_info( const JsonObject &jo );
 void write_var_value( var_type type, const std::string &name, talker *talk, dialogue *d,
                       const std::string &value );
 void write_var_value( var_type type, const std::string &name, talker *talk, dialogue *d,

--- a/src/condition.h
+++ b/src/condition.h
@@ -32,8 +32,15 @@ struct enum_traits<jarg> {
 
 str_or_var get_str_or_var( const JsonValue &jv, std::string_view member, bool required = true,
                            std::string_view default_val = "" );
+str_or_var get_str_or_var( const JsonObject &jv, std::string_view member,
+                           std::string_view default_val = "" );
 translation_or_var get_translation_or_var( const JsonValue &jv, std::string_view member,
         bool required = true, const translation &default_val = {} );
+translation_or_var get_translation_or_var( const JsonObject &jv, std::string_view member,
+        const translation &default_val = {} );
+str_translation_or_var get_str_translation_or_var(
+    const JsonValue &jv, std::string_view member, bool required = true,
+    std::string_view str_default_val = "", const translation &translation_default_val = {} );
 dbl_or_var get_dbl_or_var( const JsonObject &jo, std::string_view member, bool required = true,
                            double default_val = 0.0 );
 dbl_or_var_part get_dbl_or_var_part( const JsonValue &jv, std::string_view member,

--- a/src/condition.h
+++ b/src/condition.h
@@ -32,11 +32,11 @@ struct enum_traits<jarg> {
 
 str_or_var get_str_or_var( const JsonValue &jv, std::string_view member, bool required = true,
                            std::string_view default_val = "" );
-str_or_var get_str_or_var( const JsonObject &jv, std::string_view member,
+str_or_var get_str_or_var( const JsonObject &jo, std::string_view member,
                            std::string_view default_val = "" );
 translation_or_var get_translation_or_var( const JsonValue &jv, std::string_view member,
         bool required = true, const translation &default_val = {} );
-translation_or_var get_translation_or_var( const JsonObject &jv, std::string_view member,
+translation_or_var get_translation_or_var( const JsonObject &jo, std::string_view member,
         const translation &default_val = {} );
 str_translation_or_var get_str_translation_or_var(
     const JsonValue &jv, std::string_view member, bool required = true,

--- a/src/dialogue_helpers.cpp
+++ b/src/dialogue_helpers.cpp
@@ -138,6 +138,13 @@ std::string translation_or_var::evaluate( dialogue const &d ) const
     return "";
 }
 
+std::string str_translation_or_var::evaluate( dialogue const &d ) const
+{
+    return std::visit( [&d]( auto &&val ) {
+        return val.evaluate( d );
+    }, val );
+}
+
 double dbl_or_var_part::evaluate( dialogue &d ) const
 {
     if( dbl_val.has_value() ) {

--- a/src/dialogue_helpers.cpp
+++ b/src/dialogue_helpers.cpp
@@ -4,7 +4,9 @@
 
 #include "dialogue.h"
 
-std::optional<std::string> maybe_read_var_value( const var_info &info, const dialogue &d )
+template<class T>
+std::optional<std::string> maybe_read_var_value(
+    const abstract_var_info<T> &info, const dialogue &d )
 {
     global_variables &globvars = get_globals();
     switch( info.type ) {
@@ -28,9 +30,21 @@ std::optional<std::string> maybe_read_var_value( const var_info &info, const dia
     return std::nullopt;
 }
 
+template
+std::optional<std::string> maybe_read_var_value( const var_info &, const dialogue & );
+template
+std::optional<std::string> maybe_read_var_value( const translation_var_info &, const dialogue & );
+
+template<>
 std::string read_var_value( const var_info &info, const dialogue &d )
 {
     return maybe_read_var_value( info, d ).value_or( info.default_val );
+}
+
+template<>
+std::string read_var_value( const translation_var_info &info, const dialogue &d )
+{
+    return maybe_read_var_value( info, d ).value_or( info.default_val.translated() );
 }
 
 var_info process_variable( const std::string &type )

--- a/src/dialogue_helpers.h
+++ b/src/dialogue_helpers.h
@@ -3,6 +3,7 @@
 #define CATA_SRC_DIALOGUE_HELPERS_H
 
 #include <optional>
+#include <variant>
 
 #include "calendar.h"
 #include "global_vars.h"
@@ -45,6 +46,12 @@ struct abstract_str_or_var {
 };
 
 using str_or_var = abstract_str_or_var<std::string>;
+using translation_or_var = abstract_str_or_var<translation>;
+
+struct str_translation_or_var {
+    std::variant<str_or_var, translation_or_var> val;
+    std::string evaluate( dialogue const & ) const;
+};
 
 struct talk_effect_fun_t {
     public:
@@ -79,8 +86,6 @@ std::optional<std::string> maybe_read_var_value(
     const abstract_var_info<T> &info, const dialogue &d );
 
 var_info process_variable( const std::string &type );
-
-using translation_or_var = abstract_str_or_var<translation>;
 
 struct eoc_math {
     enum class oper : int {

--- a/src/dialogue_helpers.h
+++ b/src/dialogue_helpers.h
@@ -20,21 +20,25 @@ using dialogue_fun_ptr = std::add_pointer_t<void( npc & )>;
 using trial_mod = std::pair<std::string, int>;
 struct dbl_or_var;
 
-struct var_info {
-    var_info( var_type in_type, std::string in_name ): type( in_type ),
+template<class T>
+struct abstract_var_info {
+    abstract_var_info( var_type in_type, std::string in_name ): type( in_type ),
         name( std::move( in_name ) ) {}
-    var_info( var_type in_type, std::string in_name, std::string in_default_val ): type( in_type ),
+    abstract_var_info( var_type in_type, std::string in_name, T in_default_val ): type( in_type ),
         name( std::move( in_name ) ), default_val( std::move( in_default_val ) ) {}
-    var_info() : type( var_type::global ) {}
+    abstract_var_info() : type( var_type::global ) {}
     var_type type;
     std::string name;
-    std::string default_val;
+    T default_val;
 };
+
+using var_info = abstract_var_info<std::string>;
+using translation_var_info = abstract_var_info<translation>;
 
 template<class T>
 struct abstract_str_or_var {
     std::optional<T> str_val;
-    std::optional<var_info> var_val;
+    std::optional<abstract_var_info<T>> var_val;
     std::optional<T> default_val;
     std::optional<std::function<T( const dialogue & )>> function;
     std::string evaluate( dialogue const & ) const;
@@ -68,8 +72,11 @@ struct talk_effect_fun_t {
         }
 };
 
-std::string read_var_value( const var_info &info, const dialogue &d );
-std::optional<std::string> maybe_read_var_value( const var_info &info, const dialogue &d );
+template<class T>
+std::string read_var_value( const abstract_var_info<T> &info, const dialogue &d );
+template<class T>
+std::optional<std::string> maybe_read_var_value(
+    const abstract_var_info<T> &info, const dialogue &d );
 
 var_info process_variable( const std::string &type );
 

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1204,7 +1204,7 @@ std::string display::overmap_position_text( const tripoint_abs_omt &loc )
 std::string display::current_position_text( const tripoint_abs_omt &loc )
 {
     if( const timed_event *e = get_timed_events().get( timed_event_type::OVERRIDE_PLACE ) ) {
-        return _( e->string_id );
+        return e->string_id;
     }
     return overmap_buffer.ter( loc )->get_name();
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6534,7 +6534,7 @@ void game::print_terrain_info( const tripoint &lp, const catacurses::window &w_l
     std::string tile = uppercase_first_letter( m.tername( lp ) );
     std::string area = uppercase_first_letter( area_name );
     if( const timed_event *e = get_timed_events().get( timed_event_type::OVERRIDE_PLACE ) ) {
-        area = _( e->string_id );
+        area = e->string_id;
     }
     mvwprintz( w_look, point( column, line++ ), c_yellow, area );
     mvwprintz( w_look, point( column, line++ ), c_white, tile );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -5573,11 +5573,11 @@ talk_effect_fun_t::func f_roll_remainder( const JsonObject &jo,
         list.emplace_back( get_str_or_var( jv, member ) );
     }
     str_or_var type = get_str_or_var( jo.get_member( "type" ), "type", true );
-    str_or_var message;
+    translation_or_var message;
     if( jo.has_member( "message" ) ) {
-        message = get_str_or_var( jo.get_member( "message" ), "message", true );
+        message = get_translation_or_var( jo.get_member( "message" ), "message", true );
     } else {
-        message.str_val = "";
+        message.str_val = translation();
     }
     std::vector<effect_on_condition_id> true_eocs = load_eoc_vector( jo, "true_eocs" );
     std::vector<effect_on_condition_id> false_eocs = load_eoc_vector( jo, "false_eocs" );
@@ -5632,7 +5632,7 @@ talk_effect_fun_t::func f_roll_remainder( const JsonObject &jo,
             if( !cur_message.empty() ) {
                 Character *target = d.actor( is_npc )->get_character();
                 if( target ) {
-                    target->add_msg_if_player( _( cur_message ), name );
+                    target->add_msg_if_player( cur_message, name );
                 }
             }
             run_eoc_vector( true_eocs, d );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -5246,11 +5246,11 @@ talk_effect_fun_t::func f_run_inv_eocs( const JsonObject &jo,
     for( const JsonValue &search_data_jo : jo.get_array( "search_data" ) ) {
         data.emplace_back( search_data_jo );
     }
-    str_or_var title;
+    translation_or_var title;
     if( jo.has_member( "title" ) ) {
-        title = get_str_or_var( jo.get_member( "title" ), "title", true );
+        title = get_translation_or_var( jo.get_member( "title" ), "title", true );
     } else {
-        title.str_val = "";
+        title.str_val = translation();
     }
 
     return [option, true_eocs, false_eocs, data, is_npc, title]( dialogue & d ) {

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -4964,14 +4964,13 @@ talk_effect_fun_t::func f_run_eoc_selector( const JsonObject &jo, std::string_vi
         jo.throw_error( "Invalid input for run_eoc_selector, size of eocs and keys needs to be identical, or keys need to be empty." );
     }
 
-    std::vector<std::unordered_map<std::string, str_or_var>> context;
+    std::vector<std::unordered_map<std::string, str_translation_or_var>> context;
     if( jo.has_array( "variables" ) ) {
         for( const JsonValue &member : jo.get_array( "variables" ) ) {
             const JsonObject &variables = member.get_object();
-            std::unordered_map<std::string, str_or_var> temp_context;
+            std::unordered_map<std::string, str_translation_or_var> temp_context;
             for( const JsonMember &jv : variables ) {
-                temp_context["npctalk_var_" + jv.name()] =
-                    get_str_or_var( variables.get_member( jv.name() ), jv.name(), true );
+                temp_context["npctalk_var_" + jv.name()] = get_str_translation_or_var( jv, jv.name(), true );
             }
             context.emplace_back( temp_context );
         }
@@ -5079,12 +5078,11 @@ talk_effect_fun_t::func f_run_eoc_with( const JsonObject &jo, std::string_view m
 {
     effect_on_condition_id eoc = effect_on_conditions::load_inline_eoc( jo.get_member( member ), "" );
 
-    std::unordered_map<std::string, str_or_var> context;
+    std::unordered_map<std::string, str_translation_or_var> context;
     if( jo.has_object( "variables" ) ) {
         const JsonObject &variables = jo.get_object( "variables" );
         for( const JsonMember &jv : variables ) {
-            context["npctalk_var_" + jv.name()] = get_str_or_var( variables.get_member( jv.name() ), jv.name(),
-                                                  true );
+            context["npctalk_var_" + jv.name()] = get_str_translation_or_var( jv, jv.name(), true );
         }
     }
 
@@ -5401,12 +5399,11 @@ talk_effect_fun_t::func f_queue_eoc_with( const JsonObject &jo, std::string_view
 {
     effect_on_condition_id eoc = effect_on_conditions::load_inline_eoc( jo.get_member( member ), "" );
 
-    std::unordered_map<std::string, str_or_var> context;
+    std::unordered_map<std::string, str_translation_or_var> context;
     if( jo.has_object( "variables" ) ) {
         const JsonObject &variables = jo.get_object( "variables" );
         for( const JsonMember &jv : variables ) {
-            context["npctalk_var_" + jv.name()] = get_str_or_var( variables.get_member( jv.name() ), jv.name(),
-                                                  true );
+            context["npctalk_var_" + jv.name()] = get_str_translation_or_var( jv, jv.name(), true );
         }
     }
 

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -5762,8 +5762,10 @@ talk_effect_fun_t::func f_spawn_monster( const JsonObject &jo, std::string_view 
     if( jo.has_member( "target_var" ) ) {
         target_var = read_var_info( jo.get_object( "target_var" ) );
     }
-    std::string spawn_message = jo.get_string( "spawn_message", "" );
-    std::string spawn_message_plural = jo.get_string( "spawn_message_plural", "" );
+    translation spawn_message;
+    jo.read( "spawn_message", spawn_message );
+    translation spawn_message_plural;
+    jo.read( "spawn_message_plural", spawn_message_plural );
     std::vector<effect_on_condition_id> true_eocs = load_eoc_vector( jo, "true_eocs" );
     std::vector<effect_on_condition_id> false_eocs = load_eoc_vector( jo, "false_eocs" );
     return [monster_id, dov_target_range, dov_hallucination_count, dov_real_count, dov_min_radius,
@@ -5944,8 +5946,10 @@ talk_effect_fun_t::func f_spawn_npc( const JsonObject &jo, std::string_view memb
     if( jo.has_member( "target_var" ) ) {
         target_var = read_var_info( jo.get_object( "target_var" ) );
     }
-    std::string spawn_message = jo.get_string( "spawn_message", "" );
-    std::string spawn_message_plural = jo.get_string( "spawn_message_plural", "" );
+    translation spawn_message;
+    jo.read( "spawn_message", spawn_message );
+    translation spawn_message_plural;
+    jo.read( "spawn_message_plural", spawn_message_plural );
     std::vector<effect_on_condition_id> true_eocs = load_eoc_vector( jo, "true_eocs" );
     std::vector<effect_on_condition_id> false_eocs = load_eoc_vector( jo, "false_eocs" );
     return [sov_npc_class, unique_id, traits, dov_hallucination_count, dov_real_count,

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -6064,18 +6064,19 @@ talk_effect_fun_t::func f_teleport( const JsonObject &jo, std::string_view membe
                                     bool is_npc )
 {
     std::optional<var_info> target_var = read_var_info( jo.get_object( member ) );
-    str_or_var fail_message;
+    translation_or_var fail_message;
     if( jo.has_member( "fail_message" ) ) {
-        fail_message = get_str_or_var( jo.get_member( "fail_message" ), "fail_message", false, "" );
+        fail_message = get_translation_or_var( jo.get_member( "fail_message" ), "fail_message",
+                                               false, translation() );
     } else {
-        fail_message.str_val = "";
+        fail_message.str_val = translation();
     }
-    str_or_var success_message;
+    translation_or_var success_message;
     if( jo.has_member( "success_message" ) ) {
-        success_message = get_str_or_var( jo.get_member( "success_message" ), "success_message", false,
-                                          "" );
+        success_message = get_translation_or_var( jo.get_member( "success_message" ), "success_message",
+                          false, translation() );
     } else {
-        success_message.str_val = "";
+        success_message.str_val = translation();
     }
     bool force = jo.get_bool( "force", false );
     return [is_npc, target_var, fail_message, success_message, force]( dialogue const & d ) {
@@ -6084,15 +6085,15 @@ talk_effect_fun_t::func f_teleport( const JsonObject &jo, std::string_view membe
         if( teleporter ) {
             if( teleport::teleport_to_point( *teleporter, get_map().getlocal( target_pos ), true, false,
                                              false, force ) ) {
-                teleporter->add_msg_if_player( _( success_message.evaluate( d ) ) );
+                teleporter->add_msg_if_player( success_message.evaluate( d ) );
             } else {
-                teleporter->add_msg_if_player( _( fail_message.evaluate( d ) ) );
+                teleporter->add_msg_if_player( fail_message.evaluate( d ) );
             }
         }
         item_location *it = d.actor( is_npc )->get_item();
         if( it && it->get_item() ) {
             map_add_item( *it->get_item(), target_pos );
-            add_msg( _( success_message.evaluate( d ) ) );
+            add_msg( success_message.evaluate( d ) );
             it->remove_item();
         }
     };

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -4920,17 +4920,17 @@ talk_effect_fun_t::func f_run_eoc_selector( const JsonObject &jo, std::string_vi
         jo.throw_error( "Invalid input for run_eocs" );
     }
 
-    std::vector<str_or_var> eoc_names;
+    std::vector<translation_or_var> eoc_names;
     if( jo.has_array( "names" ) ) {
         for( const JsonValue &jv : jo.get_array( "names" ) ) {
-            eoc_names.push_back( get_str_or_var( jv, "names", true ) );
+            eoc_names.emplace_back( get_translation_or_var( jv, "names", true ) );
         }
     }
 
-    std::vector<str_or_var> eoc_descriptions;
+    std::vector<translation_or_var> eoc_descriptions;
     if( jo.has_array( "descriptions" ) ) {
         for( const JsonValue &jv : jo.get_array( "descriptions" ) ) {
-            eoc_descriptions.push_back( get_str_or_var( jv, "descriptions", true ) );
+            eoc_descriptions.emplace_back( get_translation_or_var( jv, "descriptions", true ) );
         }
     }
 
@@ -4987,7 +4987,8 @@ talk_effect_fun_t::func f_run_eoc_selector( const JsonObject &jo, std::string_vi
         allow_cancel = jo.get_bool( "allow_cancel" );
     }
 
-    std::string title = jo.get_string( "title", _( "Select an option." ) );
+    translation title = to_translation( "Select an option." );
+    jo.read( "title", title );
 
     return [eocs, context, title, eoc_names, eoc_keys, eoc_descriptions,
           hide_failing, allow_cancel]( dialogue & d ) {
@@ -4998,7 +4999,7 @@ talk_effect_fun_t::func f_run_eoc_selector( const JsonObject &jo, std::string_vi
         talker &beta = d.has_beta ? *d.actor( true ) : *default_talker;
 
 
-        eoc_list.text = title;
+        eoc_list.text = title.translated();
         eoc_list.allow_cancel = allow_cancel;
         eoc_list.desc_enabled = !eoc_descriptions.empty();
         parse_tags( eoc_list.text, alpha, beta, d );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -4086,18 +4086,18 @@ talk_effect_fun_t::func f_u_buy_monster( const JsonObject &jo, std::string_view 
     dbl_or_var cost = get_dbl_or_var( jo, "cost", false, 0 );
     dbl_or_var count = get_dbl_or_var( jo, "count", false, 1 );
     const bool pacified = jo.get_bool( "pacified", false );
-    str_or_var name;
+    translation_or_var name;
     if( jo.has_member( "name" ) ) {
-        name = get_str_or_var( jo.get_member( "name" ), "name", true );
+        name = get_translation_or_var( jo.get_member( "name" ), "name", true );
     } else {
-        name.str_val = "";
+        name.str_val = translation();
     }
     std::vector<effect_on_condition_id> true_eocs = load_eoc_vector( jo, "true_eocs" );
     std::vector<effect_on_condition_id> false_eocs = load_eoc_vector( jo, "false_eocs" );
     return [monster_type_id, cost, count, pacified, name, true_eocs,
                      false_eocs]( dialogue & d ) {
         const mtype_id mtype( monster_type_id.evaluate( d ) );
-        translation translated_name = to_translation( name.evaluate( d ) );
+        translation translated_name = no_translation( name.evaluate( d ) );
         if( d.actor( false )->buy_monster( *d.actor( true ), mtype, cost.evaluate( d ), count.evaluate( d ),
                                            pacified, translated_name ) ) {
             run_eoc_vector( true_eocs, d );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -5278,11 +5278,11 @@ talk_effect_fun_t::func f_map_run_item_eocs( const JsonObject &jo, std::string_v
     for( const JsonValue &search_data_jo : jo.get_array( "search_data" ) ) {
         data.emplace_back( search_data_jo );
     }
-    str_or_var title;
+    translation_or_var title;
     if( jo.has_member( "title" ) ) {
-        title = get_str_or_var( jo.get_member( "title" ), "title", true );
+        title = get_translation_or_var( jo.get_member( "title" ), "title", true );
     } else {
-        title.str_val = "";
+        title.str_val = translation();
     }
     std::optional<var_info> loc_var;
     if( jo.has_object( "loc" ) ) {

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -3826,7 +3826,7 @@ talk_effect_fun_t::func f_transform_line( const JsonObject &jo, std::string_view
 
 talk_effect_fun_t::func f_place_override( const JsonObject &jo, std::string_view member )
 {
-    str_or_var new_place = get_str_or_var( jo.get_member( member ), member );
+    translation_or_var new_place = get_translation_or_var( jo.get_member( member ), member );
     duration_or_var dov_length = get_duration_or_var( jo, "length", true );
     str_or_var key;
     if( jo.has_member( "key" ) ) {

--- a/src/translation.cpp
+++ b/src/translation.cpp
@@ -121,12 +121,12 @@ static std::pair<bool, std::string> possible_plural_of( const std::string &raw )
 
 void translation::deserialize( const JsonValue &jsin )
 {
-    // reset the cache
-    cached_language_version = INVALID_LANGUAGE_VERSION;
-    cached_num = 0;
-    cached_translation = nullptr;
-
     if( jsin.test_string() ) {
+        // reset the cache
+        cached_language_version = INVALID_LANGUAGE_VERSION;
+        cached_num = 0;
+        cached_translation = nullptr;
+
         ctxt = nullptr;
 #ifndef CATA_IN_TOOL
         const bool check_style = test_mode;
@@ -161,115 +161,7 @@ void translation::deserialize( const JsonValue &jsin )
         }
         needs_translation = true;
     } else {
-        JsonObject jsobj = jsin.get_object();
-        if( std::optional<JsonValue> comments = jsobj.get_member_opt( "//~" );
-            comments.has_value() && !comments->test_string() ) {
-            // Ensure we have a string and mark the member as visited in the process
-            try {
-                jsobj.throw_error_at( "//~", "\"//~\" should be a string that contains comments for translators." );
-            } catch( const JsonError &e ) {
-                debugmsg( "(json-error)\n%s", e.what() );
-            }
-        }
-        if( jsobj.has_member( "ctxt" ) ) {
-            ctxt = cata::make_value<std::string>( jsobj.get_string( "ctxt" ) );
-        } else {
-            ctxt = nullptr;
-        }
-#ifndef CATA_IN_TOOL
-        const bool check_style = test_mode && !jsobj.has_member( "//NOLINT(cata-text-style)" );
-#else
-        const bool check_style = false;
-#endif
-        if( jsobj.has_member( "str_sp" ) ) {
-            // same singular and plural forms
-            // strings with plural forms are currently only simple names, and
-            // need no text style check.
-            raw = jsobj.get_string( "str_sp" );
-            // if plural form is enabled
-            if( raw_pl ) {
-                raw_pl = cata::make_value<std::string>( raw );
-#ifndef CATA_IN_TOOL
-                if( check_style ) {
-                    try {
-                        const std::pair<bool, std::string> suggested_pl = possible_plural_of( raw );
-                        if( suggested_pl.first && *raw_pl == suggested_pl.second ) {
-                            jsobj.throw_error_at(
-                                "str_sp",
-                                "\"str_sp\" is not necessary here since the plural form can be "
-                                "automatically generated." );
-                        }
-                    } catch( const JsonError &e ) {
-                        debugmsg( "(json-error)\n%s", e.what() );
-                    }
-                }
-#endif
-            } else {
-                try {
-                    jsobj.throw_error_at( "str_sp", "str_sp not supported here" );
-                } catch( const JsonError &e ) {
-                    debugmsg( "(json-error)\n%s", e.what() );
-                }
-            }
-        } else {
-            if( raw_pl || !check_style ) {
-                // strings with plural forms are currently only simple names, and
-                // need no text style check.
-                raw = jsobj.get_string( "str" );
-            } else {
-                raw = text_style_check_reader( text_style_check_reader::allow_object::no )
-                      .get_next( jsobj.get_member( "str" ) );
-            }
-            // if plural form is enabled
-            if( raw_pl ) {
-                if( jsobj.has_member( "str_pl" ) ) {
-                    raw_pl = cata::make_value<std::string>( jsobj.get_string( "str_pl" ) );
-#ifndef CATA_IN_TOOL
-                    if( check_style ) {
-                        try {
-                            const std::pair<bool, std::string> suggested_pl = possible_plural_of( raw );
-                            if( suggested_pl.first && *raw_pl == suggested_pl.second ) {
-                                jsobj.throw_error_at(
-                                    "str_pl",
-                                    "\"str_pl\" is not necessary here since the plural form can "
-                                    "be automatically generated." );
-                            } else if( *raw_pl == raw ) {
-                                jsobj.throw_error_at(
-                                    "str_pl",
-                                    "Please use \"str_sp\" instead of \"str\" and \"str_pl\" "
-                                    "for text with identical singular and plural forms" );
-                            }
-                        } catch( const JsonError &e ) {
-                            debugmsg( "(json-error)\n%s", e.what() );
-                        }
-                    }
-#endif
-                } else {
-                    const std::pair<bool, std::string> suggested_pl = possible_plural_of( raw );
-                    raw_pl = cata::make_value<std::string>( suggested_pl.second );
-#ifndef CATA_IN_TOOL
-                    if( !suggested_pl.first && check_style ) {
-                        try {
-                            jsobj.throw_error_at(
-                                "str",
-                                "Cannot autogenerate plural form.  Please specify the plural "
-                                "form explicitly using 'str' and 'str_pl', or 'str_sp' if the "
-                                "singular and plural forms are the same." );
-                        } catch( const JsonError &e ) {
-                            debugmsg( "(json-error)\n%s", e.what() );
-                        }
-                    }
-#endif
-                }
-            } else if( jsobj.has_member( "str_pl" ) ) {
-                try {
-                    jsobj.throw_error_at( "str_pl", "str_pl not supported here" );
-                } catch( const JsonError &e ) {
-                    debugmsg( "(json-error)\n%s", e.what() );
-                }
-            }
-        }
-        needs_translation = true;
+        deserialize( jsin.get_object() );
     }
 
     // Reset the underlying jsonin stream because errors leave it in an undefined state.
@@ -280,6 +172,123 @@ void translation::deserialize( const JsonValue &jsin )
     } else if( jsin.test_object() ) {
         jsin.get_object().allow_omitted_members();
     }
+}
+
+void translation::deserialize( const JsonObject &jsobj )
+{
+    // reset the cache
+    cached_language_version = INVALID_LANGUAGE_VERSION;
+    cached_num = 0;
+    cached_translation = nullptr;
+
+    if( std::optional<JsonValue> comments = jsobj.get_member_opt( "//~" );
+        comments.has_value() && !comments->test_string() ) {
+        // Ensure we have a string and mark the member as visited in the process
+        try {
+            jsobj.throw_error_at( "//~", "\"//~\" should be a string that contains comments for translators." );
+        } catch( const JsonError &e ) {
+            debugmsg( "(json-error)\n%s", e.what() );
+        }
+    }
+    if( jsobj.has_member( "ctxt" ) ) {
+        ctxt = cata::make_value<std::string>( jsobj.get_string( "ctxt" ) );
+    } else {
+        ctxt = nullptr;
+    }
+#ifndef CATA_IN_TOOL
+    const bool check_style = test_mode && !jsobj.has_member( "//NOLINT(cata-text-style)" );
+#else
+    const bool check_style = false;
+#endif
+    if( jsobj.has_member( "str_sp" ) ) {
+        // same singular and plural forms
+        // strings with plural forms are currently only simple names, and
+        // need no text style check.
+        raw = jsobj.get_string( "str_sp" );
+        // if plural form is enabled
+        if( raw_pl ) {
+            raw_pl = cata::make_value<std::string>( raw );
+#ifndef CATA_IN_TOOL
+            if( check_style ) {
+                try {
+                    const std::pair<bool, std::string> suggested_pl = possible_plural_of( raw );
+                    if( suggested_pl.first && *raw_pl == suggested_pl.second ) {
+                        jsobj.throw_error_at(
+                            "str_sp",
+                            "\"str_sp\" is not necessary here since the plural form can be "
+                            "automatically generated." );
+                    }
+                } catch( const JsonError &e ) {
+                    debugmsg( "(json-error)\n%s", e.what() );
+                }
+            }
+#endif
+        } else {
+            try {
+                jsobj.throw_error_at( "str_sp", "str_sp not supported here" );
+            } catch( const JsonError &e ) {
+                debugmsg( "(json-error)\n%s", e.what() );
+            }
+        }
+    } else {
+        if( raw_pl || !check_style ) {
+            // strings with plural forms are currently only simple names, and
+            // need no text style check.
+            raw = jsobj.get_string( "str" );
+        } else {
+            raw = text_style_check_reader( text_style_check_reader::allow_object::no )
+                  .get_next( jsobj.get_member( "str" ) );
+        }
+        // if plural form is enabled
+        if( raw_pl ) {
+            if( jsobj.has_member( "str_pl" ) ) {
+                raw_pl = cata::make_value<std::string>( jsobj.get_string( "str_pl" ) );
+#ifndef CATA_IN_TOOL
+                if( check_style ) {
+                    try {
+                        const std::pair<bool, std::string> suggested_pl = possible_plural_of( raw );
+                        if( suggested_pl.first && *raw_pl == suggested_pl.second ) {
+                            jsobj.throw_error_at(
+                                "str_pl",
+                                "\"str_pl\" is not necessary here since the plural form can "
+                                "be automatically generated." );
+                        } else if( *raw_pl == raw ) {
+                            jsobj.throw_error_at(
+                                "str_pl",
+                                "Please use \"str_sp\" instead of \"str\" and \"str_pl\" "
+                                "for text with identical singular and plural forms" );
+                        }
+                    } catch( const JsonError &e ) {
+                        debugmsg( "(json-error)\n%s", e.what() );
+                    }
+                }
+#endif
+            } else {
+                const std::pair<bool, std::string> suggested_pl = possible_plural_of( raw );
+                raw_pl = cata::make_value<std::string>( suggested_pl.second );
+#ifndef CATA_IN_TOOL
+                if( !suggested_pl.first && check_style ) {
+                    try {
+                        jsobj.throw_error_at(
+                            "str",
+                            "Cannot autogenerate plural form.  Please specify the plural "
+                            "form explicitly using 'str' and 'str_pl', or 'str_sp' if the "
+                            "singular and plural forms are the same." );
+                    } catch( const JsonError &e ) {
+                        debugmsg( "(json-error)\n%s", e.what() );
+                    }
+                }
+#endif
+            }
+        } else if( jsobj.has_member( "str_pl" ) ) {
+            try {
+                jsobj.throw_error_at( "str_pl", "str_pl not supported here" );
+            } catch( const JsonError &e ) {
+                debugmsg( "(json-error)\n%s", e.what() );
+            }
+        }
+    }
+    needs_translation = true;
 }
 
 std::string translation::translated( const int num ) const

--- a/src/translation.h
+++ b/src/translation.h
@@ -8,6 +8,7 @@
 #include "translation_cache.h"
 #include "value_ptr.h"
 
+class JsonObject;
 class JsonValue;
 
 /**
@@ -62,6 +63,7 @@ class translation
          * or converted using `make_plural()`.
          **/
         void deserialize( const JsonValue &jsin );
+        void deserialize( const JsonObject &jsobj );
 
         /**
          * Returns raw string if no translation is needed, otherwise returns


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Load EOC text with `translation_or_var` or `translation` to check text style and allow specifying translation context and comment for translators. Update the string extraction script to extract the EOC text.

#### Describe the solution
The PR is split into commits migrating EOCs and a few other supplementary commits so it might be easier to review it commit by commit. Here's a brief overview of the combined changes:

1. Update C++ code to load EOC text with `translation_or_var` or `translation`
1.1. Default values for variable access are loaded using `class translation`.
1.2. The code now translates EOC text by evaluating `translation_or_var` or `translation` instead of calling `_()`.
1.3. Values for `set_string_var`'s string and several EOC types' `variables` member can be either messages or ids, and the previous method of extracting `variables` values according to their keys won't work for new EOC calls that use different sets of keys, so a `i18n` member is added to specify whether a value should be localized in these cases instead. The values are then loaded as `std::variant` of `str_or_var` and `translation_or_var` and evaluated to strings when the EOCs are run.
2. Updated string extraction script to match the JSON EOC syntax.
2.1. Constant string values and default string values for variable access are both extracted.
2.2. Nested EOCs including `if`, `switch`, and `foreach` statements are properly extracted.
2.3. Extract `tick_action` in item definitions which contains EOC.
2.4. Replace recursive catch-all extraction of use action message with proper code, to avoid duplicate extraction of EOC text.
2.5. Move extraction of field effect to the field type extraction code because it it not actually EOC.
3. Updated JSON code
3.1 Marked localizable strings in `set_string_var` EOC and EOCs with `variables` with the `i18n` flag.
3.2 Fixed reported text style issues.
4. Updated EOC documentation to reflect the changes of JSON syntax.

#### Describe alternatives you've considered
Some `translation` can probably be further converted to `translation_or_var` but that is out of the scope of this PR. There might be more strings to migrate to `translation_or_var` but this PR was aleady getting huge so I stopped after migrating the obvious ones.

#### Testing
Each commit was tested by compiling, running the string extraction script, loading the game in the unit test, and sometimes in-game test. The string extraction script extracted previously unextracted strings, and game loading did not report any errors. Tested a few EOCs of various types and formats related to the more non-straightforward changes and they worked as expected.

#### Additional context
