### PR TITLE
Added SMALL_HIDER flag

### DIFF
--- a/data/json/monsters/bird.json
+++ b/data/json/monsters/bird.json
@@ -566,7 +566,7 @@
     "special_attacks": [ [ "SHRIEK", 10 ], [ "EAT_CARRION", 40 ], [ "EAT_FOOD", 120 ] ],
     "biosignature": { "biosig_item": "feces_bird", "biosig_timer": 8 },
     "upgrades": { "half_life": 21, "into_group": "GROUP_CROW_MUTANT" },
-    "flags": [ "SEES", "HEARS", "SMELLS", "PATH_AVOID_DANGER_1", "WARM", "FLIES", "EATS", "SMALL_HIDER", "SMALL_HIDER" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "PATH_AVOID_DANGER_1", "WARM", "FLIES", "EATS", "SMALL_HIDER" ]
   },
   {
     "id": "mon_crow_mutant",

--- a/data/json/monsters/bird.json
+++ b/data/json/monsters/bird.json
@@ -35,7 +35,18 @@
       "feed": "The %s seems to like you!  It runs around your legs and seems friendly.",
       "pet": "The %s runs around your leg."
     },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "CANPLAY", "SWARMS", "CAN_BE_CULLED", "SMALL_HIDER" ]
+    "flags": [
+      "SEES",
+      "HEARS",
+      "SMELLS",
+      "ANIMAL",
+      "PATH_AVOID_DANGER_1",
+      "WARM",
+      "CANPLAY",
+      "SWARMS",
+      "CAN_BE_CULLED",
+      "SMALL_HIDER"
+    ]
   },
   {
     "id": "mon_grouse",
@@ -84,7 +95,19 @@
     "reproduction": { "baby_egg": "egg_crow", "baby_count": 4, "baby_timer": 18 },
     "baby_flags": [ "SPRING" ],
     "biosignature": { "biosig_item": "feces_bird", "biosig_timer": 8 },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "CANPLAY", "FLIES", "SWARMS", "EATS", "SMALL_HIDER" ]
+    "flags": [
+      "SEES",
+      "HEARS",
+      "SMELLS",
+      "ANIMAL",
+      "PATH_AVOID_DANGER_1",
+      "WARM",
+      "CANPLAY",
+      "FLIES",
+      "SWARMS",
+      "EATS",
+      "SMALL_HIDER"
+    ]
   },
   {
     "id": "mon_raven",
@@ -118,7 +141,19 @@
     "reproduction": { "baby_egg": "egg_raven", "baby_count": 5, "baby_timer": 18 },
     "baby_flags": [ "SPRING" ],
     "biosignature": { "biosig_item": "feces_bird", "biosig_timer": 8 },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "CANPLAY", "FLIES", "SWARMS", "EATS", "SMALL_HIDER" ]
+    "flags": [
+      "SEES",
+      "HEARS",
+      "SMELLS",
+      "ANIMAL",
+      "PATH_AVOID_DANGER_1",
+      "WARM",
+      "CANPLAY",
+      "FLIES",
+      "SWARMS",
+      "EATS",
+      "SMALL_HIDER"
+    ]
   },
   {
     "id": "mon_bluejay",
@@ -605,7 +640,19 @@
       "feed": "The %s seems to like you!  It runs around your legs and seems friendly.",
       "pet": "The %s runs around your leg."
     },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "FLIES", "SWARMS", "CANPLAY", "CAN_BE_CULLED", "SMALL_HIDER" ]
+    "flags": [
+      "SEES",
+      "HEARS",
+      "SMELLS",
+      "ANIMAL",
+      "PATH_AVOID_DANGER_1",
+      "WARM",
+      "FLIES",
+      "SWARMS",
+      "CANPLAY",
+      "CAN_BE_CULLED",
+      "SMALL_HIDER"
+    ]
   },
   {
     "id": "mon_goose",

--- a/data/json/monsters/bird.json
+++ b/data/json/monsters/bird.json
@@ -35,7 +35,7 @@
       "feed": "The %s seems to like you!  It runs around your legs and seems friendly.",
       "pet": "The %s runs around your leg."
     },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "CANPLAY", "SWARMS", "CAN_BE_CULLED" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "CANPLAY", "SWARMS", "CAN_BE_CULLED", "SMALL_HIDER" ]
   },
   {
     "id": "mon_grouse",
@@ -84,7 +84,7 @@
     "reproduction": { "baby_egg": "egg_crow", "baby_count": 4, "baby_timer": 18 },
     "baby_flags": [ "SPRING" ],
     "biosignature": { "biosig_item": "feces_bird", "biosig_timer": 8 },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "CANPLAY", "FLIES", "SWARMS", "EATS" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "CANPLAY", "FLIES", "SWARMS", "EATS", "SMALL_HIDER" ]
   },
   {
     "id": "mon_raven",
@@ -118,7 +118,7 @@
     "reproduction": { "baby_egg": "egg_raven", "baby_count": 5, "baby_timer": 18 },
     "baby_flags": [ "SPRING" ],
     "biosignature": { "biosig_item": "feces_bird", "biosig_timer": 8 },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "CANPLAY", "FLIES", "SWARMS", "EATS" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "CANPLAY", "FLIES", "SWARMS", "EATS", "SMALL_HIDER" ]
   },
   {
     "id": "mon_bluejay",
@@ -150,7 +150,7 @@
     "reproduction": { "baby_egg": "egg_bluejay", "baby_count": 5, "baby_timer": 18 },
     "baby_flags": [ "SPRING" ],
     "biosignature": { "biosig_item": "feces_bird", "biosig_timer": 8 },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "CANPLAY", "FLIES", "SWARMS" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "CANPLAY", "FLIES", "SWARMS", "SMALL_HIDER" ]
   },
   {
     "id": "mon_cardinal",
@@ -182,7 +182,7 @@
     "reproduction": { "baby_egg": "egg_cardinal", "baby_count": 3, "baby_timer": 13 },
     "baby_flags": [ "SPRING" ],
     "biosignature": { "biosig_item": "feces_bird", "biosig_timer": 8 },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "FLIES", "SWARMS" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "FLIES", "SWARMS", "SMALL_HIDER" ]
   },
   {
     "id": "mon_robin",
@@ -214,7 +214,7 @@
     "reproduction": { "baby_egg": "egg_robin", "baby_count": 3, "baby_timer": 14 },
     "baby_flags": [ "SPRING" ],
     "biosignature": { "biosig_item": "feces_bird", "biosig_timer": 8 },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "FLIES", "SWARMS" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "FLIES", "SWARMS", "SMALL_HIDER" ]
   },
   {
     "id": "mon_sparrow",
@@ -246,7 +246,7 @@
     "reproduction": { "baby_egg": "egg_sparrow", "baby_count": 5, "baby_timer": 14 },
     "baby_flags": [ "SPRING" ],
     "biosignature": { "biosig_item": "feces_bird", "biosig_timer": 8 },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "FLIES", "SWARMS" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "FLIES", "SWARMS", "SMALL_HIDER" ]
   },
   {
     "id": "mon_duck",
@@ -278,7 +278,7 @@
     "reproduction": { "baby_egg": "egg_duck", "baby_count": 3, "baby_timer": 5 },
     "baby_flags": [ "SPRING" ],
     "biosignature": { "biosig_item": "feces_bird", "biosig_timer": 5 },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "FLIES", "SWARMS" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "FLIES", "SWARMS", "SMALL_HIDER" ]
   },
   {
     "id": "mon_goose_canadian",
@@ -331,7 +331,7 @@
     "reproduction": { "baby_egg": "egg_turkey", "baby_count": 3, "baby_timer": 12 },
     "baby_flags": [ "SPRING", "SUMMER" ],
     "biosignature": { "biosig_item": "feces_bird", "biosig_timer": 8 },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "FLIES" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "FLIES", "SMALL_HIDER" ]
   },
   {
     "id": "mon_pheasant",
@@ -378,7 +378,7 @@
     "harvest": "bird_tiny",
     "upgrades": { "age_grow": 14, "into": "mon_chicken" },
     "//": "Grows up into a standard chicken as a fallback",
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "SWARMS", "CAN_BE_CULLED" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "SWARMS", "CAN_BE_CULLED", "SMALL_HIDER" ]
   },
   {
     "id": "mon_chicken_chick",
@@ -531,7 +531,7 @@
     "special_attacks": [ [ "SHRIEK", 10 ], [ "EAT_CARRION", 40 ], [ "EAT_FOOD", 120 ] ],
     "biosignature": { "biosig_item": "feces_bird", "biosig_timer": 8 },
     "upgrades": { "half_life": 21, "into_group": "GROUP_CROW_MUTANT" },
-    "flags": [ "SEES", "HEARS", "SMELLS", "PATH_AVOID_DANGER_1", "WARM", "FLIES", "EATS" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "PATH_AVOID_DANGER_1", "WARM", "FLIES", "EATS", "SMALL_HIDER", "SMALL_HIDER" ]
   },
   {
     "id": "mon_crow_mutant",
@@ -605,7 +605,7 @@
       "feed": "The %s seems to like you!  It runs around your legs and seems friendly.",
       "pet": "The %s runs around your leg."
     },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "FLIES", "SWARMS", "CANPLAY", "CAN_BE_CULLED" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "FLIES", "SWARMS", "CANPLAY", "CAN_BE_CULLED", "SMALL_HIDER" ]
   },
   {
     "id": "mon_goose",
@@ -632,7 +632,7 @@
       "feed": "The %s seems to like you!  It runs around your legs and seems friendly.",
       "pet": "The %s runs around your leg."
     },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "CAN_BE_CULLED" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "CAN_BE_CULLED", "SMALL_HIDER" ]
   },
   {
     "id": "mon_goose_golden",
@@ -691,7 +691,7 @@
     "reproduction": { "baby_egg": "egg_hummingbird", "baby_count": 5, "baby_timer": 14 },
     "baby_flags": [ "SPRING" ],
     "biosignature": { "biosig_item": "feces_bird", "biosig_timer": 8 },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "FLIES" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "FLIES", "SMALL_HIDER" ]
   },
   {
     "id": "mon_woodpecker",
@@ -722,7 +722,7 @@
     "reproduction": { "baby_egg": "egg_woodpecker", "baby_count": 5, "baby_timer": 14 },
     "baby_flags": [ "SPRING" ],
     "biosignature": { "biosig_item": "feces_bird", "biosig_timer": 8 },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "FLIES" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "FLIES", "SMALL_HIDER" ]
   },
   {
     "id": "mon_hummingbird_chick",
@@ -769,7 +769,7 @@
     "reproduction": { "baby_egg": "egg_coot", "baby_count": 3, "baby_timer": 5 },
     "baby_flags": [ "SPRING" ],
     "biosignature": { "biosig_item": "feces_bird", "biosig_timer": 5 },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "FLIES", "SWARMS" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "FLIES", "SWARMS", "SMALL_HIDER" ]
   },
   {
     "id": "mon_cormorant",

--- a/data/json/monsters/insect_spider.json
+++ b/data/json/monsters/insect_spider.json
@@ -578,7 +578,7 @@
     ],
     "anger_triggers": [ "PLAYER_CLOSE" ],
     "armor": { "bash": 1, "cut": 2 },
-	"extend": { "flags": [ "SMALL_HIDER" ] }
+    "extend": { "flags": [ "SMALL_HIDER" ] }
   },
   {
     "id": "mon_centipede_mom",
@@ -877,7 +877,7 @@
     "dissect": "dissect_insect_sample_single",
     "upgrades": { "age_grow": 30, "into": "mon_firefly" },
     "armor": { "bash": 1, "cut": 2, "stab": 1 },
-	"extend": { "flags": [ "EATS", "SMALL_HIDER" ] }
+    "extend": { "flags": [ "EATS", "SMALL_HIDER" ] }
   },
   {
     "id": "mon_fly_small",
@@ -1374,7 +1374,7 @@
     "vision_day": 5,
     "vision_night": 5,
     "upgrades": { "age_grow": 30, "into": "mon_spider_jumping_giant" },
-	"extend": { "flags": [ "SMALL_HIDER" ] }
+    "extend": { "flags": [ "SMALL_HIDER" ] }
   },
   {
     "id": "mon_spider_jumping_mega",
@@ -1744,7 +1744,7 @@
     "vision_day": 5,
     "vision_night": 5,
     "upgrades": { "age_grow": 30, "into": "mon_spider_wolf_giant" },
-	"extend": { "flags": [ "SMALL_HIDER" ] }
+    "extend": { "flags": [ "SMALL_HIDER" ] }
   },
   {
     "id": "mon_spider_wolf_mega",
@@ -1856,7 +1856,19 @@
     "upgrades": { "half_life": 30, "into": "mon_wasp" },
     "zombify_into": "mon_meat_cocoon_tiny",
     "fungalize_into": "mon_wasp_small_fungus",
-    "flags": [ "SEES", "SMELLS", "HEARS", "FLIES", "SWARMS", "GROUP_MORALE", "CANPLAY", "PATH_AVOID_FIRE", "HARDTOSHOOT", "EATS", "SMALL_HIDER" ],
+    "flags": [
+      "SEES",
+      "SMELLS",
+      "HEARS",
+      "FLIES",
+      "SWARMS",
+      "GROUP_MORALE",
+      "CANPLAY",
+      "PATH_AVOID_FIRE",
+      "HARDTOSHOOT",
+      "EATS",
+      "SMALL_HIDER"
+    ],
     "armor": { "bash": 1, "cut": 6, "stab": 4 }
   },
   {
@@ -2626,7 +2638,7 @@
       [ "BROWSE", 60 ],
       [ "GRAZE", 800 ]
     ],
-	"extend": { "flags": [ "SMALL_HIDER" ] }
+    "extend": { "flags": [ "SMALL_HIDER" ] }
   },
   {
     "id": "mon_aphid_small",
@@ -2787,7 +2799,7 @@
     ],
     "anger_triggers": [ "PLAYER_CLOSE" ],
     "armor": { "bash": 1, "cut": 2, "bullet": 1 },
-	"extend": { "flags": [ "SMALL_HIDER" ] }
+    "extend": { "flags": [ "SMALL_HIDER" ] }
   },
   {
     "id": "mon_mantis_mega",
@@ -3015,7 +3027,7 @@
       "baby_flags": [ "SPRING", "SUMMER", "AUTUMN" ]
     },
     "upgrades": { "half_life": 35, "into": "mon_grasshopper_giant" },
-	"extend": { "flags": [ "SMALL_HIDER" ] }
+    "extend": { "flags": [ "SMALL_HIDER" ] }
   },
   {
     "id": "mon_grasshopper_giant",
@@ -3087,7 +3099,7 @@
       [ "GRAZE", 133 ],
       [ "BROWSE", 133 ]
     ],
-	"extend": { "flags": [ "SMALL_HIDER" ] }
+    "extend": { "flags": [ "SMALL_HIDER" ] }
   },
   {
     "id": "mon_stag_beetle_larva",
@@ -3744,7 +3756,7 @@
     "color": "white",
     "harvest": "mutant_shellfish",
     "upgrades": { "age_grow": 21, "into": "mon_woodlouse" },
-	"extend": { "flags": [ "SMALL_HIDER" ] }
+    "extend": { "flags": [ "SMALL_HIDER" ] }
   },
   {
     "id": "mon_diving_larva",
@@ -3776,7 +3788,7 @@
     "fear_triggers": [ "HURT" ],
     "flags": [ "AQUATIC", "SEES", "WATER_CAMOUFLAGE" ],
     "upgrades": { "age_grow": 21, "into": "mon_diving_beetle_small" },
-	"extend": { "flags": [ "SMALL_HIDER" ] }
+    "extend": { "flags": [ "SMALL_HIDER" ] }
   },
   {
     "id": "mon_diving_beetle_small",

--- a/data/json/monsters/insect_spider.json
+++ b/data/json/monsters/insect_spider.json
@@ -190,7 +190,7 @@
     "harvest": "mutant_meatslug",
     "dissect": "dissect_troglobite_sample_single",
     "upgrades": { "age_grow": 30, "into": "mon_worm" },
-    "extend": { "flags": [ "DIGS", "GOODHEARING" ] },
+    "extend": { "flags": [ "DIGS", "GOODHEARING", "SMALL_HIDER" ] },
     "delete": { "flags": [ "SEES", "SMELLS", "CLIMBS" ] }
   },
   {
@@ -577,7 +577,8 @@
       }
     ],
     "anger_triggers": [ "PLAYER_CLOSE" ],
-    "armor": { "bash": 1, "cut": 2 }
+    "armor": { "bash": 1, "cut": 2 },
+	"extend": { "flags": [ "SMALL_HIDER" ] }
   },
   {
     "id": "mon_centipede_mom",
@@ -861,7 +862,7 @@
     "reproduction": { "baby_egg": "egg_firefly", "baby_count": 3, "baby_timer": 15 },
     "baby_flags": [ "SPRING", "SUMMER" ],
     "fear_triggers": [ "HURT", "FIRE" ],
-    "flags": [ "SEES", "HEARS", "FLIES", "STUMBLES" ]
+    "flags": [ "SEES", "HEARS", "FLIES", "STUMBLES", "SMALL_HIDER" ]
   },
   {
     "id": "mon_firefly_larva",
@@ -875,7 +876,8 @@
     "color": "yellow",
     "dissect": "dissect_insect_sample_single",
     "upgrades": { "age_grow": 30, "into": "mon_firefly" },
-    "armor": { "bash": 1, "cut": 2, "stab": 1 }
+    "armor": { "bash": 1, "cut": 2, "stab": 1 },
+	"extend": { "flags": [ "EATS", "SMALL_HIDER" ] }
   },
   {
     "id": "mon_fly_small",
@@ -946,7 +948,7 @@
     "color": "light_green",
     "special_attacks": [ [ "EAT_CARRION", 100 ] ],
     "dissect": "dissect_insect_sample_single",
-    "extend": { "flags": [ "EATS" ] },
+    "extend": { "flags": [ "EATS", "SMALL_HIDER" ] },
     "upgrades": { "age_grow": 30, "into": "mon_fly" }
   },
   {
@@ -1033,7 +1035,7 @@
     "vision_day": 15,
     "upgrades": { "age_grow": 30, "into": "mon_mosquito_giant" },
     "fear_triggers": [ "HURT", "PLAYER_CLOSE", "SOUND" ],
-    "extend": { "flags": [ "SWIMS", "AQUATIC", "WATER_CAMOUFLAGE" ] }
+    "extend": { "flags": [ "SWIMS", "AQUATIC", "WATER_CAMOUFLAGE", "SMALL_HIDER" ] }
   },
   {
     "id": "mon_mosquito_mega",
@@ -1145,7 +1147,7 @@
     "vision_day": 5,
     "vision_night": 5,
     "upgrades": { "age_grow": 30, "into": "mon_spider_cellar_giant" },
-    "extend": { "flags": [ "WEBWALK" ] }
+    "extend": { "flags": [ "WEBWALK", "SMALL_HIDER" ] }
   },
   {
     "id": "mon_spider_cellar_mom",
@@ -1371,7 +1373,8 @@
     "families": [ "prof_intro_biology", "prof_physiology", "prof_wp_basic_bug", "prof_wp_spider" ],
     "vision_day": 5,
     "vision_night": 5,
-    "upgrades": { "age_grow": 30, "into": "mon_spider_jumping_giant" }
+    "upgrades": { "age_grow": 30, "into": "mon_spider_jumping_giant" },
+	"extend": { "flags": [ "SMALL_HIDER" ] }
   },
   {
     "id": "mon_spider_jumping_mega",
@@ -1463,7 +1466,7 @@
     "vision_day": 5,
     "vision_night": 5,
     "upgrades": { "age_grow": 30, "into": "mon_spider_trapdoor_giant" },
-    "extend": { "flags": [ "CAN_DIG", "WEBWALK" ] }
+    "extend": { "flags": [ "CAN_DIG", "WEBWALK", "SMALL_HIDER" ] }
   },
   {
     "id": "mon_spider_trapdoor_mega",
@@ -1573,7 +1576,7 @@
     "vision_day": 5,
     "vision_night": 5,
     "upgrades": { "age_grow": 30, "into": "mon_spider_web" },
-    "extend": { "flags": [ "WEBWALK" ] },
+    "extend": { "flags": [ "WEBWALK", "SMALL_HIDER" ] },
     "armor": { "bash": 2, "cut": 6, "bullet": 5 }
   },
   {
@@ -1664,7 +1667,7 @@
     "vision_day": 5,
     "vision_night": 5,
     "upgrades": { "age_grow": 30, "into": "mon_spider_widow_giant" },
-    "extend": { "flags": [ "WEBWALK" ] },
+    "extend": { "flags": [ "WEBWALK", "SMALL_HIDER" ] },
     "armor": { "bash": 2, "cut": 4, "bullet": 3 }
   },
   {
@@ -1740,7 +1743,8 @@
     "families": [ "prof_intro_biology", "prof_physiology", "prof_wp_basic_bug", "prof_wp_spider" ],
     "vision_day": 5,
     "vision_night": 5,
-    "upgrades": { "age_grow": 30, "into": "mon_spider_wolf_giant" }
+    "upgrades": { "age_grow": 30, "into": "mon_spider_wolf_giant" },
+	"extend": { "flags": [ "SMALL_HIDER" ] }
   },
   {
     "id": "mon_spider_wolf_mega",
@@ -1852,7 +1856,7 @@
     "upgrades": { "half_life": 30, "into": "mon_wasp" },
     "zombify_into": "mon_meat_cocoon_tiny",
     "fungalize_into": "mon_wasp_small_fungus",
-    "flags": [ "SEES", "SMELLS", "HEARS", "FLIES", "SWARMS", "GROUP_MORALE", "CANPLAY", "PATH_AVOID_FIRE", "HARDTOSHOOT", "EATS" ],
+    "flags": [ "SEES", "SMELLS", "HEARS", "FLIES", "SWARMS", "GROUP_MORALE", "CANPLAY", "PATH_AVOID_FIRE", "HARDTOSHOOT", "EATS", "SMALL_HIDER" ],
     "armor": { "bash": 1, "cut": 6, "stab": 4 }
   },
   {
@@ -2026,7 +2030,7 @@
     "melee_damage": [ { "damage_type": "cut", "amount": 1 } ],
     "dodge": 1,
     "upgrades": { "age_grow": 61, "into": "mon_dermatik" },
-    "extend": { "flags": [ "CAN_DIG" ] }
+    "extend": { "flags": [ "CAN_DIG", "SMALL_HIDER" ] }
   },
   {
     "id": "mon_dermatik",
@@ -2621,7 +2625,8 @@
       [ "EAT_CROP", 60 ],
       [ "BROWSE", 60 ],
       [ "GRAZE", 800 ]
-    ]
+    ],
+	"extend": { "flags": [ "SMALL_HIDER" ] }
   },
   {
     "id": "mon_aphid_small",
@@ -2677,7 +2682,7 @@
     "reproduction": { "baby_monster": "mon_aphid_small", "baby_count": 1, "baby_timer": 20 },
     "baby_flags": [ "SPRING", "SUMMER" ],
     "biosignature": { "biosig_item": "honeydew", "biosig_timer": 600 },
-    "flags": [ "SEES", "HEARS", "SMELLS", "CLIMBS", "PATH_AVOID_FIRE", "PATH_AVOID_FALL", "SWARMS" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "CLIMBS", "PATH_AVOID_FIRE", "PATH_AVOID_FALL", "SWARMS", "SMALL_HIDER" ],
     "armor": { "bash": 2, "cut": 5, "bullet": 3 }
   },
   {
@@ -2781,7 +2786,8 @@
       }
     ],
     "anger_triggers": [ "PLAYER_CLOSE" ],
-    "armor": { "bash": 1, "cut": 2, "bullet": 1 }
+    "armor": { "bash": 1, "cut": 2, "bullet": 1 },
+	"extend": { "flags": [ "SMALL_HIDER" ] }
   },
   {
     "id": "mon_mantis_mega",
@@ -3008,7 +3014,8 @@
       "reproduction": { "baby_egg": "egg_grasshopper", "baby_count": 3, "baby_timer": 15 },
       "baby_flags": [ "SPRING", "SUMMER", "AUTUMN" ]
     },
-    "upgrades": { "half_life": 35, "into": "mon_grasshopper_giant" }
+    "upgrades": { "half_life": 35, "into": "mon_grasshopper_giant" },
+	"extend": { "flags": [ "SMALL_HIDER" ] }
   },
   {
     "id": "mon_grasshopper_giant",
@@ -3079,7 +3086,8 @@
       [ "EAT_CROP", 100 ],
       [ "GRAZE", 133 ],
       [ "BROWSE", 133 ]
-    ]
+    ],
+	"extend": { "flags": [ "SMALL_HIDER" ] }
   },
   {
     "id": "mon_stag_beetle_larva",
@@ -3402,7 +3410,7 @@
     "baby_flags": [ "SPRING", "SUMMER", "AUTUMN" ],
     "anger_triggers": [ "PLAYER_WEAK" ],
     "fear_triggers": [ "FIRE", "PLAYER_CLOSE" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "SWIMS" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "SWIMS", "SMALL_HIDER" ],
     "armor": { "bash": 1, "cut": 3, "bullet": 2 }
   },
   {
@@ -3415,7 +3423,7 @@
     "symbol": "s",
     "color": "light_gray",
     "upgrades": { "age_grow": 30, "into": "mon_strider_giant" },
-    "extend": { "flags": [ "SWIMS" ] }
+    "extend": { "flags": [ "SWIMS", "SMALL_HIDER" ] }
   },
   {
     "id": "mon_butterfly",
@@ -3735,7 +3743,8 @@
     "stomach_size": 60,
     "color": "white",
     "harvest": "mutant_shellfish",
-    "upgrades": { "age_grow": 21, "into": "mon_woodlouse" }
+    "upgrades": { "age_grow": 21, "into": "mon_woodlouse" },
+	"extend": { "flags": [ "SMALL_HIDER" ] }
   },
   {
     "id": "mon_diving_larva",
@@ -3766,7 +3775,8 @@
     "anger_triggers": [ "PLAYER_CLOSE" ],
     "fear_triggers": [ "HURT" ],
     "flags": [ "AQUATIC", "SEES", "WATER_CAMOUFLAGE" ],
-    "upgrades": { "age_grow": 21, "into": "mon_diving_beetle_small" }
+    "upgrades": { "age_grow": 21, "into": "mon_diving_beetle_small" },
+	"extend": { "flags": [ "SMALL_HIDER" ] }
   },
   {
     "id": "mon_diving_beetle_small",

--- a/data/json/monsters/mammal.json
+++ b/data/json/monsters/mammal.json
@@ -2373,7 +2373,18 @@
     "families": [ "prof_intro_biology", "prof_physiology" ],
     "anger_triggers": [ "FRIEND_ATTACKED", "FRIEND_DIED" ],
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "HIT_AND_RUN", "KEENNOSE", "SWIMS", "SMALL_HIDER" ]
+    "flags": [
+      "SEES",
+      "HEARS",
+      "SMELLS",
+      "ANIMAL",
+      "PATH_AVOID_DANGER_1",
+      "WARM",
+      "HIT_AND_RUN",
+      "KEENNOSE",
+      "SWIMS",
+      "SMALL_HIDER"
+    ]
   },
   {
     "id": "mon_moose",
@@ -3214,7 +3225,7 @@
     "dissect": "dissect_cattle_sample_single",
     "special_attacks": [ [ "EAT_CROP", 60 ], [ "GRAZE", 60 ] ],
     "upgrades": { "age_grow": 500, "into": "mon_reindeer" },
-	"extend": { "flags": [ "SMALL_HIDER" ] }
+    "extend": { "flags": [ "SMALL_HIDER" ] }
   },
   {
     "id": "mon_llama_calf",
@@ -3332,7 +3343,18 @@
     "families": [ "prof_intro_biology", "prof_physiology" ],
     "reproduction": { "baby_monster": "mon_ferret_kit", "baby_count": 5, "baby_timer": 100 },
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "SWIMS", "WARM", "CANPLAY", "CAN_BE_CULLED", "SMALL_HIDER" ]
+    "flags": [
+      "SEES",
+      "HEARS",
+      "SMELLS",
+      "ANIMAL",
+      "PATH_AVOID_DANGER_1",
+      "SWIMS",
+      "WARM",
+      "CANPLAY",
+      "CAN_BE_CULLED",
+      "SMALL_HIDER"
+    ]
   },
   {
     "id": "mon_ferret_kit",

--- a/data/json/monsters/mammal.json
+++ b/data/json/monsters/mammal.json
@@ -63,7 +63,7 @@
     "vision_night": 20,
     "special_attacks": [ { "type": "bite", "cooldown": 15 } ],
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE" ],
-    "flags": [ "SEES", "SMELLS", "HEARS", "GOODHEARING", "WARM", "FLIES", "ANIMAL", "PATH_AVOID_DANGER_1" ]
+    "flags": [ "SEES", "SMELLS", "HEARS", "GOODHEARING", "WARM", "FLIES", "ANIMAL", "PATH_AVOID_DANGER_1", "SMALL_HIDER" ]
   },
   {
     "id": "mon_bear_cub",
@@ -195,7 +195,7 @@
     "anger_triggers": [ "PLAYER_WEAK" ],
     "fear_triggers": [ "PLAYER_CLOSE" ],
     "special_attacks": [ [ "EAT_FOOD", 120 ], [ "BROWSE", 120 ] ],
-    "flags": [ "SEES", "SMELLS", "HEARS", "WARM", "SWIMS", "ANIMAL", "STUMBLES", "PATH_AVOID_DANGER_1", "EATS" ]
+    "flags": [ "SEES", "SMELLS", "HEARS", "WARM", "SWIMS", "ANIMAL", "STUMBLES", "PATH_AVOID_DANGER_1", "EATS", "SMALL_HIDER" ]
   },
   {
     "id": "mon_lab_rat",
@@ -246,7 +246,8 @@
       "ANIMAL",
       "PATH_AVOID_DANGER_1",
       "CAN_BE_CULLED",
-      "EATS"
+      "EATS",
+	  "SMALL_HIDER"
     ]
   },
   {
@@ -282,7 +283,7 @@
     "upgrades": { "age_grow": 38, "into": "mon_boar_wild" },
     "biosignature": { "biosig_item": "feces_manure", "biosig_timer": 7 },
     "special_attacks": [ [ "EAT_FOOD", 40 ], [ "EAT_CARRION", 60 ] ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "KEENNOSE", "EATS" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "KEENNOSE", "EATS", "SMALL_HIDER" ]
   },
   {
     "id": "mon_boar_wild",
@@ -363,7 +364,7 @@
     "harvest": "cat_medium_with_skull",
     "families": [ "prof_intro_biology", "prof_physiology" ],
     "dissect": "dissect_feline_sample_single",
-    "flags": [ "SEES", "HEARS", "GOODHEARING", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "HIT_AND_RUN" ]
+    "flags": [ "SEES", "HEARS", "GOODHEARING", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "HIT_AND_RUN", "SMALL_HIDER" ]
   },
   {
     "id": "mon_cat_kitten",
@@ -677,7 +678,7 @@
     "dissect": "dissect_mouse_sample_single",
     "families": [ "prof_intro_biology", "prof_physiology" ],
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE" ],
-    "flags": [ "SEES", "SMELLS", "HEARS", "WARM", "ANIMAL", "PATH_AVOID_DANGER_1" ]
+    "flags": [ "SEES", "SMELLS", "HEARS", "WARM", "ANIMAL", "PATH_AVOID_DANGER_1", "SMALL_HIDER" ]
   },
   {
     "id": "mon_cougar",
@@ -1049,7 +1050,7 @@
     "vision_night": 4,
     "harvest": "dog_small_with_skull",
     "upgrades": { "age_grow": 42, "into": "mon_dog" },
-    "extend": { "flags": [ "NO_BREED" ] },
+    "extend": { "flags": [ "NO_BREED", "SMALL_HIDER" ] },
     "delete": { "flags": [ "CORNERED_FIGHTER" ] }
   },
   {
@@ -1138,7 +1139,8 @@
       "SEES",
       "SMELLS",
       "WARM",
-      "EATS"
+      "EATS",
+	  "SMALL_HIDER"
     ]
   },
   {
@@ -1228,7 +1230,8 @@
       "SEES",
       "SMELLS",
       "WARM",
-      "EATS"
+      "EATS",
+	  "SMALL_HIDER"
     ]
   },
   {
@@ -1272,7 +1275,8 @@
       "SWARMS",
       "WARM",
       "CORNERED_FIGHTER",
-      "EATS"
+      "EATS",
+	  "SMALL_HIDER"
     ]
   },
   {
@@ -1325,7 +1329,8 @@
       "SMELLS",
       "SWARMS",
       "WARM",
-      "EATS"
+      "EATS",
+	  "SMALL_HIDER"
     ]
   },
   {
@@ -1415,7 +1420,8 @@
       "SEES",
       "SMELLS",
       "WARM",
-      "EATS"
+      "EATS",
+	  "SMALL_HIDER"
     ]
   },
   {
@@ -1489,7 +1495,8 @@
       "SMELLS",
       "SWARMS",
       "WARM",
-      "EATS"
+      "EATS",
+	  "SMALL_HIDER"
     ]
   },
   {
@@ -1532,7 +1539,8 @@
       "SEES",
       "SMELLS",
       "WARM",
-      "EATS"
+      "EATS",
+	  "SMALL_HIDER"
     ]
   },
   {
@@ -1584,7 +1592,8 @@
       "SEES",
       "SMELLS",
       "WARM",
-      "EATS"
+      "EATS",
+	  "SMALL_HIDER"
     ]
   },
   {
@@ -1627,7 +1636,8 @@
       "SMELLS",
       "STUMBLES",
       "WARM",
-      "EATS"
+      "EATS",
+	  "SMALL_HIDER"
     ]
   },
   {
@@ -1680,7 +1690,8 @@
       "SMELLS",
       "STUMBLES",
       "WARM",
-      "EATS"
+      "EATS",
+	  "SMALL_HIDER"
     ]
   },
   {
@@ -1768,7 +1779,8 @@
       "SEES",
       "SMELLS",
       "WARM",
-      "EATS"
+      "EATS",
+	  "SMALL_HIDER"
     ]
   },
   {
@@ -1864,7 +1876,8 @@
       "SEES",
       "SMELLS",
       "WARM",
-      "EATS"
+      "EATS",
+	  "SMALL_HIDER"
     ]
   },
   {
@@ -1959,7 +1972,8 @@
       "SEES",
       "SMELLS",
       "WARM",
-      "EATS"
+      "EATS",
+	  "SMALL_HIDER"
     ]
   },
   {
@@ -2051,7 +2065,8 @@
       "SEES",
       "SMELLS",
       "WARM",
-      "EATS"
+      "EATS",
+	  "SMALL_HIDER"
     ]
   },
   {
@@ -2110,7 +2125,7 @@
     "families": [ "prof_intro_biology", "prof_physiology" ],
     "anger_triggers": [ "FRIEND_ATTACKED", "FRIEND_DIED" ],
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "HIT_AND_RUN", "KEENNOSE", "CLIMBS" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "HIT_AND_RUN", "KEENNOSE", "CLIMBS", "SMALL_HIDER" ]
   },
   {
     "id": "mon_fox_red",
@@ -2142,7 +2157,7 @@
     "families": [ "prof_intro_biology", "prof_physiology" ],
     "anger_triggers": [ "FRIEND_ATTACKED", "FRIEND_DIED" ],
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "HIT_AND_RUN", "KEENNOSE" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "HIT_AND_RUN", "KEENNOSE", "SMALL_HIDER" ]
   },
   {
     "id": "mon_groundhog",
@@ -2172,7 +2187,7 @@
     "stomach_size": 30,
     "special_attacks": [ [ "GRAZE", 100 ] ],
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE" ],
-    "flags": [ "SEES", "HEARS", "GOODHEARING", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "EATS" ]
+    "flags": [ "SEES", "HEARS", "GOODHEARING", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "EATS", "SMALL_HIDER" ]
   },
   {
     "id": "mon_hare",
@@ -2358,7 +2373,7 @@
     "families": [ "prof_intro_biology", "prof_physiology" ],
     "anger_triggers": [ "FRIEND_ATTACKED", "FRIEND_DIED" ],
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "HIT_AND_RUN", "KEENNOSE", "SWIMS" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "HIT_AND_RUN", "KEENNOSE", "SWIMS", "SMALL_HIDER" ]
   },
   {
     "id": "mon_moose",
@@ -2543,7 +2558,7 @@
     "dissect": "dissect_rat_sample_single",
     "families": [ "prof_intro_biology", "prof_physiology" ],
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE" ],
-    "flags": [ "SEES", "SMELLS", "HEARS", "WARM", "SWIMS", "ANIMAL", "PATH_AVOID_DANGER_1" ]
+    "flags": [ "SEES", "SMELLS", "HEARS", "WARM", "SWIMS", "ANIMAL", "PATH_AVOID_DANGER_1", "SMALL_HIDER" ]
   },
   {
     "id": "mon_opossum",
@@ -2574,7 +2589,7 @@
     "families": [ "prof_intro_biology", "prof_physiology" ],
     "anger_triggers": [ "FRIEND_ATTACKED", "HURT" ],
     "fear_triggers": [ "PLAYER_CLOSE" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "CLIMBS", "PATH_AVOID_DANGER_1", "WARM", "KEENNOSE", "EATS" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "CLIMBS", "PATH_AVOID_DANGER_1", "WARM", "KEENNOSE", "EATS", "SMALL_HIDER" ]
   },
   {
     "id": "mon_otter",
@@ -2601,7 +2616,7 @@
     "harvest": "mammal_small_fur",
     "families": [ "prof_intro_biology", "prof_physiology" ],
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "SWIMS", "WARM", "WATER_CAMOUFLAGE" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "SWIMS", "WARM", "WATER_CAMOUFLAGE", "SMALL_HIDER" ]
   },
   {
     "id": "mon_pig_piglet",
@@ -2646,7 +2661,8 @@
       "WARM",
       "KEENNOSE",
       "CAN_BE_CULLED",
-      "EATS"
+      "EATS",
+	  "SMALL_HIDER"
     ]
   },
   {
@@ -2736,7 +2752,8 @@
       "WARM",
       "CAN_BE_CULLED",
       "GOODHEARING",
-      "EATS"
+      "EATS",
+	  "SMALL_HIDER"
     ]
   },
   {
@@ -2820,7 +2837,7 @@
     "upgrades": { "half_life": 30, "into": "mon_raccoon_mutant" },
     "special_attacks": [ [ "EAT_FOOD", 60 ], [ "BROWSE", 50 ], [ "EAT_CARRION", 60 ] ],
     "anger_triggers": [ "FRIEND_ATTACKED", "HURT" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "CLIMBS", "PATH_AVOID_DANGER_1", "WARM", "KEENNOSE", "EATS" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "CLIMBS", "PATH_AVOID_DANGER_1", "WARM", "KEENNOSE", "EATS", "SMALL_HIDER" ]
   },
   {
     "id": "mon_sewer_rat",
@@ -2856,7 +2873,7 @@
     "upgrades": { "half_life": 42, "into_group": "GROUP_RATKIN_EVOLVED" },
     "path_settings": { "max_dist": 10 },
     "anger_triggers": [ "PLAYER_WEAK", "FRIEND_ATTACKED", "FRIEND_DIED" ],
-    "flags": [ "SEES", "SMELLS", "HEARS", "WARM", "SWIMS", "ANIMAL", "PATH_AVOID_DANGER_1", "STUMBLES", "EATS" ]
+    "flags": [ "SEES", "SMELLS", "HEARS", "WARM", "SWIMS", "ANIMAL", "PATH_AVOID_DANGER_1", "STUMBLES", "EATS", "SMALL_HIDER" ]
   },
   {
     "id": "mon_sheep_lamb",
@@ -3015,7 +3032,7 @@
     "families": [ "prof_intro_biology", "prof_physiology" ],
     "special_attacks": [ [ "BROWSE", 120 ] ],
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "STUMBLES", "WARM", "EATS" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "STUMBLES", "WARM", "EATS", "SMALL_HIDER" ]
   },
   {
     "id": "mon_squirrel_red",
@@ -3046,7 +3063,7 @@
     "dissect": "dissect_mouse_sample_single",
     "families": [ "prof_intro_biology", "prof_physiology" ],
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "STUMBLES", "WARM", "EATS" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "STUMBLES", "WARM", "EATS", "SMALL_HIDER" ]
   },
   {
     "id": "mon_weasel",
@@ -3073,7 +3090,7 @@
     "harvest": "mammal_tiny",
     "families": [ "prof_intro_biology", "prof_physiology" ],
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "SWIMS", "WARM" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "SWIMS", "WARM", "SMALL_HIDER" ]
   },
   {
     "id": "mon_wolf",
@@ -3196,7 +3213,8 @@
     "harvest": "mammal_fur",
     "dissect": "dissect_cattle_sample_single",
     "special_attacks": [ [ "EAT_CROP", 60 ], [ "GRAZE", 60 ] ],
-    "upgrades": { "age_grow": 500, "into": "mon_reindeer" }
+    "upgrades": { "age_grow": 500, "into": "mon_reindeer" },
+	"extend": { "flags": [ "SMALL_HIDER" ] }
   },
   {
     "id": "mon_llama_calf",
@@ -3314,7 +3332,7 @@
     "families": [ "prof_intro_biology", "prof_physiology" ],
     "reproduction": { "baby_monster": "mon_ferret_kit", "baby_count": 5, "baby_timer": 100 },
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "SWIMS", "WARM", "CANPLAY", "CAN_BE_CULLED" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "SWIMS", "WARM", "CANPLAY", "CAN_BE_CULLED", "SMALL_HIDER" ]
   },
   {
     "id": "mon_ferret_kit",

--- a/data/json/monsters/mammal.json
+++ b/data/json/monsters/mammal.json
@@ -2125,7 +2125,18 @@
     "families": [ "prof_intro_biology", "prof_physiology" ],
     "anger_triggers": [ "FRIEND_ATTACKED", "FRIEND_DIED" ],
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "HIT_AND_RUN", "KEENNOSE", "CLIMBS", "SMALL_HIDER" ]
+    "flags": [
+      "SEES",
+      "HEARS",
+      "SMELLS",
+      "ANIMAL",
+      "PATH_AVOID_DANGER_1",
+      "WARM",
+      "HIT_AND_RUN",
+      "KEENNOSE",
+      "CLIMBS",
+      "SMALL_HIDER"
+    ]
   },
   {
     "id": "mon_fox_red",
@@ -2673,7 +2684,7 @@
       "KEENNOSE",
       "CAN_BE_CULLED",
       "EATS",
-	  "SMALL_HIDER"
+      "SMALL_HIDER"
     ]
   },
   {
@@ -2764,7 +2775,7 @@
       "CAN_BE_CULLED",
       "GOODHEARING",
       "EATS",
-	  "SMALL_HIDER"
+      "SMALL_HIDER"
     ]
   },
   {

--- a/data/json/monsters/mammal.json
+++ b/data/json/monsters/mammal.json
@@ -247,7 +247,7 @@
       "PATH_AVOID_DANGER_1",
       "CAN_BE_CULLED",
       "EATS",
-	  "SMALL_HIDER"
+      "SMALL_HIDER"
     ]
   },
   {
@@ -1140,7 +1140,7 @@
       "SMELLS",
       "WARM",
       "EATS",
-	  "SMALL_HIDER"
+      "SMALL_HIDER"
     ]
   },
   {
@@ -1231,7 +1231,7 @@
       "SMELLS",
       "WARM",
       "EATS",
-	  "SMALL_HIDER"
+      "SMALL_HIDER"
     ]
   },
   {
@@ -1276,7 +1276,7 @@
       "WARM",
       "CORNERED_FIGHTER",
       "EATS",
-	  "SMALL_HIDER"
+      "SMALL_HIDER"
     ]
   },
   {
@@ -1330,7 +1330,7 @@
       "SWARMS",
       "WARM",
       "EATS",
-	  "SMALL_HIDER"
+      "SMALL_HIDER"
     ]
   },
   {
@@ -1421,7 +1421,7 @@
       "SMELLS",
       "WARM",
       "EATS",
-	  "SMALL_HIDER"
+      "SMALL_HIDER"
     ]
   },
   {
@@ -1496,7 +1496,7 @@
       "SWARMS",
       "WARM",
       "EATS",
-	  "SMALL_HIDER"
+      "SMALL_HIDER"
     ]
   },
   {
@@ -1540,7 +1540,7 @@
       "SMELLS",
       "WARM",
       "EATS",
-	  "SMALL_HIDER"
+      "SMALL_HIDER"
     ]
   },
   {
@@ -1593,7 +1593,7 @@
       "SMELLS",
       "WARM",
       "EATS",
-	  "SMALL_HIDER"
+      "SMALL_HIDER"
     ]
   },
   {
@@ -1637,7 +1637,7 @@
       "STUMBLES",
       "WARM",
       "EATS",
-	  "SMALL_HIDER"
+      "SMALL_HIDER"
     ]
   },
   {
@@ -1691,7 +1691,7 @@
       "STUMBLES",
       "WARM",
       "EATS",
-	  "SMALL_HIDER"
+      "SMALL_HIDER"
     ]
   },
   {
@@ -1780,7 +1780,7 @@
       "SMELLS",
       "WARM",
       "EATS",
-	  "SMALL_HIDER"
+      "SMALL_HIDER"
     ]
   },
   {
@@ -1877,7 +1877,7 @@
       "SMELLS",
       "WARM",
       "EATS",
-	  "SMALL_HIDER"
+      "SMALL_HIDER"
     ]
   },
   {
@@ -1973,7 +1973,7 @@
       "SMELLS",
       "WARM",
       "EATS",
-	  "SMALL_HIDER"
+      "SMALL_HIDER"
     ]
   },
   {
@@ -2066,7 +2066,7 @@
       "SMELLS",
       "WARM",
       "EATS",
-	  "SMALL_HIDER"
+      "SMALL_HIDER"
     ]
   },
   {

--- a/data/json/monsters/rodentkin.json
+++ b/data/json/monsters/rodentkin.json
@@ -43,7 +43,19 @@
     "stomach_size": 30,
     "fear_triggers": [ "PLAYER_CLOSE", "SOUND" ],
     "special_attacks": [ [ "EAT_FOOD", 120 ] ],
-    "flags": [ "SEES", "SMELLS", "HEARS", "KEENNOSE", "CANPLAY", "WARM", "SWIMS", "ANIMAL", "PATH_AVOID_DANGER_1", "EATS", "SMALL_HIDER" ]
+    "flags": [
+      "SEES",
+      "SMELLS",
+      "HEARS",
+      "KEENNOSE",
+      "CANPLAY",
+      "WARM",
+      "SWIMS",
+      "ANIMAL",
+      "PATH_AVOID_DANGER_1",
+      "EATS",
+      "SMALL_HIDER"
+    ]
   },
   {
     "id": "mon_big_rat",

--- a/data/json/monsters/rodentkin.json
+++ b/data/json/monsters/rodentkin.json
@@ -43,7 +43,7 @@
     "stomach_size": 30,
     "fear_triggers": [ "PLAYER_CLOSE", "SOUND" ],
     "special_attacks": [ [ "EAT_FOOD", 120 ] ],
-    "flags": [ "SEES", "SMELLS", "HEARS", "KEENNOSE", "CANPLAY", "WARM", "SWIMS", "ANIMAL", "PATH_AVOID_DANGER_1", "EATS" ]
+    "flags": [ "SEES", "SMELLS", "HEARS", "KEENNOSE", "CANPLAY", "WARM", "SWIMS", "ANIMAL", "PATH_AVOID_DANGER_1", "EATS", "SMALL_HIDER" ]
   },
   {
     "id": "mon_big_rat",
@@ -87,7 +87,7 @@
       [ "EAT_CARRION", 120 ]
     ],
     "attack_effs": [ { "id": "rat_bite_fever", "duration": 400, "chance": 10 } ],
-    "flags": [ "SEES", "SMELLS", "HEARS", "WARM", "SWIMS", "ANIMAL", "PATH_AVOID_DANGER_1", "EATS" ],
+    "flags": [ "SEES", "SMELLS", "HEARS", "WARM", "SWIMS", "ANIMAL", "PATH_AVOID_DANGER_1", "EATS", "SMALL_HIDER" ],
     "families": [ "prof_intro_biology", "prof_physiology" ],
     "harvest": "mutant_mammal_small_fur",
     "dissect": "dissect_rat_sample_single"
@@ -109,7 +109,7 @@
     "special_attacks": [ [ "EAT_FOOD", 120 ], [ "EAT_CARRION", 120 ] ],
     "families": [ "prof_intro_biology", "prof_physiology", "prof_electromagnetics" ],
     "upgrades": { "half_life": 42, "into_group": "GROUP_RATKIN_EVOLVED" },
-    "flags": [ "SEES", "SMELLS", "HEARS", "WARM", "SWIMS", "ELECTRIC", "ANIMAL", "PATH_AVOID_DANGER_1", "EATS" ],
+    "flags": [ "SEES", "SMELLS", "HEARS", "WARM", "SWIMS", "ELECTRIC", "ANIMAL", "PATH_AVOID_DANGER_1", "EATS", "SMALL_HIDER" ],
     "emit_fields": [ { "emit_id": "emit_shock_burst_rat", "delay": "5 s" } ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "Added SMALL_HIDER flag to various monsters."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Addressing issue #71671. Added SMALL_HIDER flag so small monsters can hide under small furniture and bushes and things.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
In four files rodentkin.json, bird.json, insect_spider.json, and mammal.json, I parsed through by weight. If monster was less then 7 kg, automatically added the flag. If it was between 7-11 kg, considered on case by case basis.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I considered adding the flag based on body dimensions instead of weight but no suitable method of determining that was found.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
No testing was done.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
Average cat is 7 – 11 kg so anything at or below 7 kg is considered valid for tag. Between 7-11 kg is considered on case-by-case basis and listed under each file. Changes indexed by file.

- Rodentkin.json
- bird.json
- insect_spider.json
  - Did not change the mon_larva_abstract but rather extended each instance child of mon_larva_abstract to include this flag.
  - Over 7kg given flag:
    - mon_mantis_nymph
    - mon_strider_giant
      - Was described as being as big as cat
- mammal.json
  - Over 7kg given flag
    - mon_otter
    - mon_pig_piglet


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
