### PR TITLE
properly migrate ammo

### DIFF
--- a/data/json/obsoletion_and_migration_0.I/migration_items.json
+++ b/data/json/obsoletion_and_migration_0.I/migration_items.json
@@ -438,22 +438,22 @@
   {
     "id": "8mm_civilian",
     "type": "MIGRATION",
-    "replace": "9mm"
+    "replace": "8mm_caseless"
   },
   {
     "id": "8mm_fmj",
     "type": "MIGRATION",
-    "replace": "9mm"
+    "replace": "8mm_caseless"
   },
   {
     "id": "8mm_hvp",
     "type": "MIGRATION",
-    "replace": "9mm"
+    "replace": "8mm_caseless"
   },
   {
     "id": "8mm_inc",
     "type": "MIGRATION",
-    "replace": "9mm"
+    "replace": "8mm_caseless"
   },
   {
     "id": "rm298",


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fix #71778
#### Describe the solution
Replace migration of 8mm to 9mm to migration of 8mm to another 8mm