### PR TITLE
Ignore MGOAL_FIND_ITEM Check If Player Is Busy

### DIFF
--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -507,6 +507,9 @@ bool mission::is_complete( const character_id &_npc_id ) const
             if( npc_id.is_valid() && npc_id != _npc_id ) {
                 return false;
             }
+            if( player_character.activity ) {
+                return false;
+            }
             item item_sought( type->item_id );
             map &here = get_map();
             int found_quantity = 0;


### PR DESCRIPTION
Ignore mission find item if character is busy

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Performance "Skip MGOAL_Find_Item if the player is busy."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
When the player has a quest with MGOAL_FIND_ITEM as the objective, the game will check every single turn to see if that item exists within the players field of vision. Seeing as items don't tend to magically appear out of nowhere, there's no reason to do this if the player is busy and it causes a massive performance hit. In my testing on my Sky Island home base, with around 5 related quests active, the speed of 5 minute increments when crafting or waiting went from around 8 seconds per 5 minute chunk to 3 or 4 chunks per second. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Simply adds a check in the mission processing for MGOAL_FIND_ITEM that returns false if the player is doing an activity.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Adding a new quest type like MGOAL_CRAFT_ITEM that triggers on crafting an item, but thats a bit beyond my current code base knowledge, and would only help with Sky Island content.

Continuing to check every turn in the hope the item has magically appeared, but it never has...
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Spawned a related quest item, both waiting and moving immediately trigger find item properly.
Crafted the quest item, the mission completion triggered immediately afterwards without issue.

As mentioned earlier, this changed the rate of 5 minute time intervals from 0.12 per second to 3.50 or so per second.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
