### PR TITLE
Improve variety of weapon mods dropped from soldiers

### DIFF
--- a/data/json/itemgroups/Weapons_Mods_Ammo/gunmod.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/gunmod.json
@@ -94,10 +94,16 @@
   },
   {
     "type": "item_group",
+    "id": "gunmod_army_potential_grip",
+    "//": "Not all soldiers would have a forward grip, but they're not uncommon.",
+    "items": [ [ "grip", 40 ], [ "null", 60 ] ]
+  },
+  {
+    "type": "item_group",
     "subtype": "collection",
     "id": "gunmod_army_loadout",
-    "//": "Weapon mod loadouts that represent the average US Army rifleman.",
-    "items": [ { "group": "firearm_slings" }, { "group": "gunmod_carbine_sights_army" } ]
+    "//": "Weapon mod loadouts that represent the average US Army carbine loadout.",
+    "items": [ { "group": "firearm_slings" }, { "group": "gunmod_carbine_sights_army" }, { "group": "gunmod_army_potential_grip" } ]
   },
   {
     "type": "item_group",

--- a/data/json/itemgroups/Weapons_Mods_Ammo/gunmod.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/gunmod.json
@@ -82,28 +82,34 @@
   },
   {
     "type": "item_group",
-    "id": "gunmod_carbine_sights_army",
+    "id": "issued_carbine_sights",
     "//": "Sights that are issued by the US Army for the M4 and similar firearms.",
-    "items": [ [ "acog_scope", 30 ], [ "hybrid_sight_4x", 10 ], [ "holo_sight", 20 ], [ "red_dot_sight", 40 ] ]
+    "items": [
+      [ "acog_scope", 15 ],
+      [ "hybrid_sight_4x", 5 ],
+      [ "holo_sight", 10 ],
+      [ "red_dot_sight", 20 ],
+      [ "improve_sights", 50 ]
+    ]
   },
   {
     "type": "item_group",
-    "id": "firearm_slings",
-    "//": "Slings that belong on a firearm.",
-    "items": [ [ "shoulder_strap_simple", 50 ], [ "shoulder_strap", 25 ] ]
+    "id": "issued_slings",
+    "//": "Slings that belong on a firearm, the 5% of soldiers who lost theirs are very unhappy right now.",
+    "items": [ [ "shoulder_strap_simple", 60 ], [ "shoulder_strap", 35 ], [ "null", 5 ] ]
   },
   {
     "type": "item_group",
-    "id": "gunmod_army_potential_grip",
-    "//": "Not all soldiers would have a forward grip, but they're not uncommon.",
+    "id": "issued_grip",
+    "//": "Not all soldiers would have a forward grip, but they're common accessories.",
     "items": [ [ "grip", 40 ], [ "null", 60 ] ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
-    "id": "gunmod_army_loadout",
+    "id": "issued_carbine_mods",
     "//": "Weapon mod loadouts that represent the average US Army carbine loadout.",
-    "items": [ { "group": "firearm_slings" }, { "group": "gunmod_carbine_sights_army" }, { "group": "gunmod_army_potential_grip" } ]
+    "items": [ { "group": "issued_slings" }, { "group": "issued_carbine_sights" }, { "group": "issued_grip" } ]
   },
   {
     "type": "item_group",

--- a/data/json/itemgroups/Weapons_Mods_Ammo/gunmod.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/gunmod.json
@@ -84,13 +84,7 @@
     "type": "item_group",
     "id": "issued_carbine_sights",
     "//": "Sights that are issued by the US Army for the M4 and similar firearms.",
-    "items": [
-      [ "acog_scope", 15 ],
-      [ "hybrid_sight_4x", 5 ],
-      [ "holo_sight", 10 ],
-      [ "red_dot_sight", 20 ],
-      [ "null", 50 ]
-    ]
+    "items": [ [ "acog_scope", 15 ], [ "hybrid_sight_4x", 5 ], [ "holo_sight", 10 ], [ "red_dot_sight", 20 ], [ "null", 50 ] ]
   },
   {
     "type": "item_group",

--- a/data/json/itemgroups/Weapons_Mods_Ammo/gunmod.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/gunmod.json
@@ -113,6 +113,13 @@
   },
   {
     "type": "item_group",
+    "subtype": "collection",
+    "id": "issued_grenadier_mods",
+    "//": "Weapon mod loadouts that represent the average US Army grenadier loadout.",
+    "items": [ { "group": "issued_slings" }, { "group": "issued_carbine_sights" }, { "group": "military_grenadier_mods" } ]
+  },
+  {
+    "type": "item_group",
     "id": "sights_rifle",
     "//": "Aftermarket sights that are for rifles.",
     "items": [

--- a/data/json/itemgroups/Weapons_Mods_Ammo/gunmod.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/gunmod.json
@@ -97,7 +97,7 @@
     "subtype": "collection",
     "id": "gunmod_army_loadout",
     "//": "Weapon mod loadouts that represent the average US Army rifleman.",
-    "entries": [ { "group": "firearm_slings" }, { "group": "gunmod_carbine_sights_army" } ]
+    "items": [ { "group": "firearm_slings" }, { "group": "gunmod_carbine_sights_army" } ]
   },
   {
     "type": "item_group",

--- a/data/json/itemgroups/Weapons_Mods_Ammo/gunmod.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/gunmod.json
@@ -89,7 +89,7 @@
       [ "hybrid_sight_4x", 5 ],
       [ "holo_sight", 10 ],
       [ "red_dot_sight", 20 ],
-      [ "improve_sights", 50 ]
+      [ "null", 50 ]
     ]
   },
   {
@@ -102,7 +102,7 @@
     "type": "item_group",
     "id": "issued_grip",
     "//": "Not all soldiers would have a forward grip, but they're common accessories.",
-    "items": [ [ "grip", 40 ], [ "null", 60 ] ]
+    "items": [ [ "grip", 33 ], [ "null", 67 ] ]
   },
   {
     "type": "item_group",

--- a/data/json/itemgroups/Weapons_Mods_Ammo/gunmod.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/gunmod.json
@@ -94,6 +94,13 @@
   },
   {
     "type": "item_group",
+    "subtype": "collection",
+    "id": "gunmod_army_loadout",
+    "//": "Weapon mod loadouts that represent the average US Army rifleman.",
+    "entries": [ { "group": "firearm_slings" }, { "group": "gunmod_carbine_sights_army" } ]
+  },
+  {
+    "type": "item_group",
     "id": "sights_rifle",
     "//": "Aftermarket sights that are for rifles.",
     "items": [

--- a/data/json/itemgroups/Weapons_Mods_Ammo/gunmod.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/gunmod.json
@@ -90,7 +90,7 @@
     "type": "item_group",
     "id": "firearm_slings",
     "//": "Slings that belong on a firearm.",
-    "items": [ [ "shoulder_strap_simple", 50 ], [ "single_sling", 25 ], [ "shoulder_strap", 25 ] ]
+    "items": [ [ "shoulder_strap_simple", 50 ], [ "shoulder_strap", 25 ] ]
   },
   {
     "type": "item_group",

--- a/data/json/itemgroups/Weapons_Mods_Ammo/gunmod.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/gunmod.json
@@ -69,6 +69,7 @@
     "items": [
       [ "acog_scope", 100 ],
       [ "holo_sight", 100 ],
+      [ "red_dot_sight", 100 ],
       [ "holo_magnifier", 80 ],
       [ "hybrid_sight_4x", 100 ],
       [ "m203", 30 ],
@@ -78,6 +79,18 @@
       [ "rm121aux", 10 ],
       [ "sword_bayonet", 10 ]
     ]
+  },
+  {
+    "type": "item_group",
+    "id": "gunmod_carbine_sights_army",
+    "//": "Sights that are issued by the US Army for the M4 and similar firearms.",
+    "items": [ [ "acog_scope", 30 ], [ "hybrid_sight_4x", 10 ], [ "holo_sight", 20 ], [ "red_dot_sight", 40 ] ]
+  },
+  {
+    "type": "item_group",
+    "id": "firearm_slings",
+    "//": "Slings that belong on a firearm.",
+    "items": [ [ "shoulder_strap_simple", 50 ], [ "single_sling", 25 ], [ "shoulder_strap", 25 ] ]
   },
   {
     "type": "item_group",

--- a/data/json/itemgroups/military.json
+++ b/data/json/itemgroups/military.json
@@ -9,14 +9,14 @@
         "variant": "modular_m4a1",
         "prob": 88,
         "charges": [ 0, 30 ],
-        "contents-group": "gunmod_army_loadout"
+        "contents-group": "issued_carbine_mods"
       },
       {
         "item": "modular_m27_assault_rifle",
         "variant": "modular_m27iar",
         "prob": 10,
         "charges": [ 0, 30 ],
-        "contents-group": "gunmod_army_loadout"
+        "contents-group": "issued_carbine_mods"
       },
       {
         "item": "modular_m27_assault_rifle",

--- a/data/json/itemgroups/military.json
+++ b/data/json/itemgroups/military.json
@@ -9,14 +9,14 @@
         "variant": "modular_m4a1",
         "prob": 88,
         "charges": [ 0, 30 ],
-        "contents-group": "firearm_slings"
+        "contents-group": "gunmod_army_loadout"
       },
       {
         "item": "modular_m27_assault_rifle",
         "variant": "modular_m27iar",
         "prob": 10,
         "charges": [ 0, 30 ],
-        "contents-group": "firearm_slings"
+        "contents-group": "gunmod_army_loadout"
       },
       {
         "item": "modular_m27_assault_rifle",
@@ -26,28 +26,6 @@
         "charges": [ 0, 30 ]
       },
       { "item": "modular_m16a4", "prob": 2, "charges": [ 0, 30 ], "contents-group": "firearm_slings" }
-    ]
-  },
-  {
-    "type": "item_group",
-    "id": "military_standard_assault_rifles_sighted",
-    "subtype": "distribution",
-    "entries": [
-      {
-        "item": "modular_m4_carbine",
-        "variant": "modular_m4a1",
-        "prob": 88,
-        "charges": [ 0, 30 ],
-        "contents-group": "gunmod_army_loadout"
-      },
-      {
-        "item": "modular_m27_assault_rifle",
-        "variant": "modular_m27iar",
-        "prob": 10,
-        "charges": [ 0, 30 ],
-        "contents-group": "gunmod_army_loadout"
-      },
-      { "item": "modular_m16a4", "prob": 2, "charges": [ 0, 30 ], "contents-group": "gunmod_army_loadout" }
     ]
   },
   {

--- a/data/json/itemgroups/military.json
+++ b/data/json/itemgroups/military.json
@@ -26,44 +26,55 @@
         "variant": "modular_m4a1",
         "prob": 40,
         "charges": [ 0, 30 ],
-        "contents-item": "acog_scope"
+        "contents-item": [ "acog_scope", "shoulder_strap_simple" ]
       },
       {
         "item": "modular_m4_carbine",
         "variant": "modular_m4a1",
         "prob": 40,
         "charges": [ 0, 30 ],
-        "contents-item": "red_dot_sight"
+        "contents-item": [ "red_dot_sight", "shoulder_strap_simple" ]
       },
       {
         "item": "modular_m4_carbine",
         "variant": "modular_m4a1",
         "prob": 10,
         "charges": [ 0, 30 ],
-        "contents-item": "holo_sight"
+        "contents-item": [ "holo_sight", "shoulder_strap_simple" ]
       },
       {
         "item": "modular_m27_assault_rifle",
         "variant": "modular_m27iar",
         "prob": 3,
         "charges": [ 0, 30 ],
-        "contents-item": "acog_scope"
+        "contents-item": [ "acog_scope", "shoulder_strap_simple" ]
       },
       {
         "item": "modular_m27_assault_rifle",
         "variant": "modular_m27iar",
         "prob": 3,
         "charges": [ 0, 30 ],
-        "contents-item": "red_dot_sight"
+        "contents-item": [ "red_dot_sight", "shoulder_strap_simple" ]
       },
       {
         "item": "modular_m27_assault_rifle",
         "variant": "modular_m27iar",
         "prob": 2,
         "charges": [ 0, 30 ],
-        "contents-item": "holo_sight"
+        "contents-item": [ "holo_sight", "shoulder_strap_simple" ]
       },
-      { "item": "modular_m16a4", "prob": 2, "charges": [ 0, 30 ], "contents-item": "acog_scope" }
+      {
+        "item": "modular_m16a4",
+        "prob": 1,
+        "charges": [ 0, 30 ],
+        "contents-item": [ "red_dot_sight", "shoulder_strap_simple" ]
+      },
+      {
+        "item": "modular_m16a4",
+        "prob": 1,
+        "charges": [ 0, 30 ],
+        "contents-item": [ "acog_scope", "shoulder_strap_simple" ]
+      }
     ]
   },
   {

--- a/data/json/itemgroups/military.json
+++ b/data/json/itemgroups/military.json
@@ -32,14 +32,7 @@
     "type": "item_group",
     "id": "military_grenadier_assault_rifles",
     "subtype": "distribution",
-    "entries": [
-      {
-        "item": "modular_m4_carbine",
-        "contents-group": [ "military_grenadier_mods", "issued_slings" ],
-        "prob": 100,
-        "charges": [ 0, 30 ]
-      }
-    ]
+    "entries": [ { "item": "modular_m4_carbine", "contents-group": "issued_grenadier_mods", "prob": 100, "charges": [ 0, 30 ] } ]
   },
   {
     "id": "armor_plates",

--- a/data/json/itemgroups/military.json
+++ b/data/json/itemgroups/military.json
@@ -24,16 +24,44 @@
       {
         "item": "modular_m4_carbine",
         "variant": "modular_m4a1",
-        "prob": 88,
+        "prob": 40,
+        "charges": [ 0, 30 ],
+        "contents-item": "acog_scope"
+      },
+      {
+        "item": "modular_m4_carbine",
+        "variant": "modular_m4a1",
+        "prob": 40,
+        "charges": [ 0, 30 ],
+        "contents-item": "red_dot_sight"
+      },
+      {
+        "item": "modular_m4_carbine",
+        "variant": "modular_m4a1",
+        "prob": 10,
+        "charges": [ 0, 30 ],
+        "contents-item": "holo_sight"
+      },
+      {
+        "item": "modular_m27_assault_rifle",
+        "variant": "modular_m27iar",
+        "prob": 3,
         "charges": [ 0, 30 ],
         "contents-item": "acog_scope"
       },
       {
         "item": "modular_m27_assault_rifle",
         "variant": "modular_m27iar",
-        "prob": 10,
+        "prob": 3,
         "charges": [ 0, 30 ],
-        "contents-item": "acog_scope"
+        "contents-item": "red_dot_sight"
+      },
+      {
+        "item": "modular_m27_assault_rifle",
+        "variant": "modular_m27iar",
+        "prob": 2,
+        "charges": [ 0, 30 ],
+        "contents-item": "holo_sight"
       },
       { "item": "modular_m16a4", "prob": 2, "charges": [ 0, 30 ], "contents-item": "acog_scope" }
     ]

--- a/data/json/itemgroups/military.json
+++ b/data/json/itemgroups/military.json
@@ -26,21 +26,16 @@
         "variant": "modular_m4a1",
         "prob": 88,
         "charges": [ 0, 30 ],
-        "contents-group": [ "gunmod_carbine_sights_army", "firearm_slings" ]
+        "contents-group": "gunmod_army_loadout"
       },
       {
         "item": "modular_m27_assault_rifle",
         "variant": "modular_m27iar",
         "prob": 10,
         "charges": [ 0, 30 ],
-        "contents-group": [ "gunmod_carbine_sights_army", "firearm_slings" ]
+        "contents-group": "gunmod_army_loadout"
       },
-      {
-        "item": "modular_m16a4",
-        "prob": 2,
-        "charges": [ 0, 30 ],
-        "contents-group": [ "gunmod_carbine_sights_army", "firearm_slings" ]
-      }
+      { "item": "modular_m16a4", "prob": 2, "charges": [ 0, 30 ], "contents-group": "gunmod_army_loadout" }
     ]
   },
   {

--- a/data/json/itemgroups/military.json
+++ b/data/json/itemgroups/military.json
@@ -54,7 +54,14 @@
     "type": "item_group",
     "id": "military_grenadier_assault_rifles",
     "subtype": "distribution",
-    "entries": [ { "item": "modular_m4_carbine", "contents-group": [ "military_grenadier_mods", "firearm_slings" ], "prob": 100, "charges": [ 0, 30 ] } ]
+    "entries": [
+      {
+        "item": "modular_m4_carbine",
+        "contents-group": [ "military_grenadier_mods", "firearm_slings" ],
+        "prob": 100,
+        "charges": [ 0, 30 ]
+      }
+    ]
   },
   {
     "id": "armor_plates",

--- a/data/json/itemgroups/military.json
+++ b/data/json/itemgroups/military.json
@@ -4,8 +4,20 @@
     "id": "military_standard_assault_rifles",
     "subtype": "distribution",
     "entries": [
-      { "item": "modular_m4_carbine", "variant": "modular_m4a1", "prob": 88, "charges": [ 0, 30 ] },
-      { "item": "modular_m27_assault_rifle", "variant": "modular_m27iar", "prob": 10, "charges": [ 0, 30 ] },
+      {
+        "item": "modular_m4_carbine",
+        "variant": "modular_m4a1",
+        "prob": 88,
+        "charges": [ 0, 30 ],
+        "contents-group": "firearm_slings"
+      },
+      {
+        "item": "modular_m27_assault_rifle",
+        "variant": "modular_m27iar",
+        "prob": 10,
+        "charges": [ 0, 30 ],
+        "contents-group": "firearm_slings"
+      },
       {
         "item": "modular_m27_assault_rifle",
         "variant": "modular_m38dmr",
@@ -13,7 +25,7 @@
         "prob": 1,
         "charges": [ 0, 30 ]
       },
-      { "item": "modular_m16a4", "prob": 2, "charges": [ 0, 30 ] }
+      { "item": "modular_m16a4", "prob": 2, "charges": [ 0, 30 ], "contents-group": "firearm_slings" }
     ]
   },
   {
@@ -42,7 +54,7 @@
     "type": "item_group",
     "id": "military_grenadier_assault_rifles",
     "subtype": "distribution",
-    "entries": [ { "item": "modular_m4_carbine", "contents-group": "military_grenadier_mods", "prob": 100, "charges": [ 0, 30 ] } ]
+    "entries": [ { "item": "modular_m4_carbine", "contents-group": [ "military_grenadier_mods", "firearm_slings" ], "prob": 100, "charges": [ 0, 30 ] } ]
   },
   {
     "id": "armor_plates",

--- a/data/json/itemgroups/military.json
+++ b/data/json/itemgroups/military.json
@@ -25,7 +25,7 @@
         "prob": 1,
         "charges": [ 0, 30 ]
       },
-      { "item": "modular_m16a4", "prob": 2, "charges": [ 0, 30 ], "contents-group": "firearm_slings" }
+      { "item": "modular_m16a4", "prob": 2, "charges": [ 0, 30 ], "contents-group": "issued_slings" }
     ]
   },
   {
@@ -35,7 +35,7 @@
     "entries": [
       {
         "item": "modular_m4_carbine",
-        "contents-group": [ "military_grenadier_mods", "firearm_slings" ],
+        "contents-group": [ "military_grenadier_mods", "issued_slings" ],
         "prob": 100,
         "charges": [ 0, 30 ]
       }

--- a/data/json/itemgroups/military.json
+++ b/data/json/itemgroups/military.json
@@ -24,56 +24,22 @@
       {
         "item": "modular_m4_carbine",
         "variant": "modular_m4a1",
-        "prob": 40,
+        "prob": 88,
         "charges": [ 0, 30 ],
-        "contents-item": [ "acog_scope", "shoulder_strap_simple" ]
+        "contents-group": [ "gunmod_carbine_sights_army", "firearm_slings" ]
       },
       {
-        "item": "modular_m4_carbine",
-        "variant": "modular_m4a1",
-        "prob": 40,
-        "charges": [ 0, 30 ],
-        "contents-item": [ "red_dot_sight", "shoulder_strap_simple" ]
-      },
-      {
-        "item": "modular_m4_carbine",
-        "variant": "modular_m4a1",
+        "item": "modular_m27_assault_rifle",
+        "variant": "modular_m27iar",
         "prob": 10,
         "charges": [ 0, 30 ],
-        "contents-item": [ "holo_sight", "shoulder_strap_simple" ]
+        "contents-group": [ "gunmod_carbine_sights_army", "firearm_slings" ]
       },
       {
-        "item": "modular_m27_assault_rifle",
-        "variant": "modular_m27iar",
-        "prob": 3,
-        "charges": [ 0, 30 ],
-        "contents-item": [ "acog_scope", "shoulder_strap_simple" ]
-      },
-      {
-        "item": "modular_m27_assault_rifle",
-        "variant": "modular_m27iar",
-        "prob": 3,
-        "charges": [ 0, 30 ],
-        "contents-item": [ "red_dot_sight", "shoulder_strap_simple" ]
-      },
-      {
-        "item": "modular_m27_assault_rifle",
-        "variant": "modular_m27iar",
+        "item": "modular_m16a4",
         "prob": 2,
         "charges": [ 0, 30 ],
-        "contents-item": [ "holo_sight", "shoulder_strap_simple" ]
-      },
-      {
-        "item": "modular_m16a4",
-        "prob": 1,
-        "charges": [ 0, 30 ],
-        "contents-item": [ "red_dot_sight", "shoulder_strap_simple" ]
-      },
-      {
-        "item": "modular_m16a4",
-        "prob": 1,
-        "charges": [ 0, 30 ],
-        "contents-item": [ "acog_scope", "shoulder_strap_simple" ]
+        "contents-group": [ "gunmod_carbine_sights_army", "firearm_slings" ]
       }
     ]
   },

--- a/data/json/mapgen/map_extras/military.json
+++ b/data/json/mapgen/map_extras/military.json
@@ -15,7 +15,8 @@
     "id": "military_squad_guns",
     "subtype": "distribution",
     "groups": [
-      [ "military_standard_assault_rifles", 80 ],
+      [ "military_standard_assault_rifles", 30 ],
+      [ "military_standard_assault_rifles_sighted", 50 ],
       [ "military_standard_lmgs", 10 ],
       [ "military_standard_sniper_rifles", 5 ],
       [ "military_standard_shotguns", 5 ]

--- a/data/json/mapgen/map_extras/military.json
+++ b/data/json/mapgen/map_extras/military.json
@@ -15,8 +15,7 @@
     "id": "military_squad_guns",
     "subtype": "distribution",
     "groups": [
-      [ "military_standard_assault_rifles", 30 ],
-      [ "military_standard_assault_rifles_sighted", 50 ],
+      [ "military_standard_assault_rifles", 80 ],
       [ "military_standard_lmgs", 10 ],
       [ "military_standard_sniper_rifles", 5 ],
       [ "military_standard_shotguns", 5 ]

--- a/data/json/monsterdrops/zombie_soldier.json
+++ b/data/json/monsterdrops/zombie_soldier.json
@@ -18,16 +18,7 @@
           {
             "collection": [
               {
-                "distribution": [
-                  { "group": "military_grenadier_assault_rifles", "prob": 4, "damage": [ 0, 4 ], "dirt": [ 0, 6000 ] },
-                  {
-                    "group": "military_grenadier_assault_rifles",
-                    "contents-item": [ "shoulder_strap", "acog_scope" ],
-                    "prob": 6,
-                    "damage": [ 0, 4 ],
-                    "dirt": [ 0, 6000 ]
-                  }
-                ]
+                "distribution": [ { "group": "military_grenadier_assault_rifles", "prob": 4, "damage": [ 0, 4 ], "dirt": [ 0, 6000 ] } ]
               },
               { "item": "40x46mm_m433", "charges": [ 1, 3 ], "prob": 50 }
             ]
@@ -79,13 +70,6 @@
             "group": "military_standard_assault_rifles",
             "contents-item": "shoulder_strap",
             "prob": 25,
-            "damage": [ 0, 4 ],
-            "dirt": [ 0, 6000 ]
-          },
-          {
-            "group": "military_standard_assault_rifles_sighted",
-            "contents-item": [ "shoulder_strap", "acog_scope" ],
-            "prob": 40,
             "damage": [ 0, 4 ],
             "dirt": [ 0, 6000 ]
           },

--- a/data/json/monsterdrops/zombie_soldier.json
+++ b/data/json/monsterdrops/zombie_soldier.json
@@ -14,31 +14,12 @@
       },
       {
         "distribution": [
-          {
-            "group": "military_standard_assault_rifles",
-            "contents-item": "shoulder_strap",
-            "prob": 25,
-            "damage": [ 0, 4 ],
-            "dirt": [ 0, 6000 ]
-          },
-          {
-            "group": "military_standard_assault_rifles_sighted",
-            "contents-item": "shoulder_strap",
-            "prob": 40,
-            "damage": [ 0, 4 ],
-            "dirt": [ 0, 6000 ]
-          },
+          { "group": "military_standard_assault_rifles", "prob": 65, "damage": [ 0, 4 ], "dirt": [ 0, 6000 ] },
           {
             "collection": [
               {
                 "distribution": [
-                  {
-                    "group": "military_grenadier_assault_rifles",
-                    "contents-item": "shoulder_strap",
-                    "prob": 4,
-                    "damage": [ 0, 4 ],
-                    "dirt": [ 0, 6000 ]
-                  },
+                  { "group": "military_grenadier_assault_rifles", "prob": 4, "damage": [ 0, 4 ], "dirt": [ 0, 6000 ] },
                   {
                     "group": "military_grenadier_assault_rifles",
                     "contents-item": [ "shoulder_strap", "acog_scope" ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Soldiers' rifles have more/various weapon mods"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Dead soldiers (reanimated and otherwise) were dropping completely barebones assault rifles.  There is a variety of standard issue weapon modifications available to US soldiers, this PR reflects that.

#### Describe the solution

Remove the "military_standard_assault_rifles_sighted" group, it only included the ACOG scope and was only present in a single file, the zombie soldier drops.  The other group "military_standard_assault_rifles" was changed to pull mods from "issued_carbine_mods" which includes a variety of possible modifications with the following chances:

### Sights
No Optic: 50%
Red Dot Sight: 20%
ACOG: 15%
Hybrid ACOG: 5%
Holographic Sight: 10%

### Slings
Two Point Sling: 60%
Adjustable Sling: 35%
No Sling: 5%

### Foregrip
No Foregrip: 67%
Forward Grip: 33%

"military_grenadier_mods" got a similar treatment with the metagroup addition of "issued_grenadier_mods" (obviously minus the foregrip)

#### Describe alternatives you've considered

I could have left it to assign mods individually to enemy drops, but this is a more elegant and future-proof solution.

#### Testing

Loaded the game, spawned and killed excessive amounts of zombie soldiers, looked in other locations where the itemgroup spawns.  Everything checks out locally, no errors.

#### Additional context

This PR is mostly a proof-of-concept and a demonstration.
I'd like to do more of this for other weapons, but I just want to get this approved first.

![cataclysm-tiles_ccM6Q10Ds3](https://github.com/CleverRaven/Cataclysm-DDA/assets/52714184/42e50b62-4745-4e02-892d-89b580df765d)

![cataclysm-tiles_d7JuP0oQiZ](https://github.com/CleverRaven/Cataclysm-DDA/assets/52714184/db53e13f-38ac-4ca4-b848-88fb7b10a017)

![cataclysm-tiles_rTXSaCfFL5](https://github.com/CleverRaven/Cataclysm-DDA/assets/52714184/1c071fb7-aa74-44dd-9ac4-c67aa63df39d)


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
