### PR TITLE
Fix abnormal terrain generation in old version archives

### DIFF
--- a/data/json/effects_on_condition/mapgen_eocs/godco_mapgen_eocs.json
+++ b/data/json/effects_on_condition/mapgen_eocs/godco_mapgen_eocs.json
@@ -1,13 +1,13 @@
 [
   {
     "type": "effect_on_condition",
-    "id": "godco_place_coop",
+    "id": "godco_place_coop_new",
     "global": false,
     "effect": [ { "mapgen_update": "darryl_place_coop", "om_terrain": "godco_7" }, { "math": [ "darryl_building_coop", "=", "2" ] } ]
   },
   {
     "type": "effect_on_condition",
-    "id": "godco_place_herb_garden",
+    "id": "godco_place_herb_garden_new",
     "global": false,
     "effect": [
       { "mapgen_update": "place_herb_garden", "om_terrain": "godco_1_2" },
@@ -16,7 +16,7 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "godco_place_wall",
+    "id": "godco_place_wall_new",
     "global": false,
     "//": "4 hours 20 minutes per wall (from regular ground to full palisade) * 373 walls = ~1,567 hours.  Divided into 8-hour work shifts, thats ~196 days, or six and a half months for one person.  Presuming we have ~11 people working in a single shift, each building 1 wall, that should be ~18 days to build.  Please correct me if I messed up the math.",
     "effect": [
@@ -33,7 +33,7 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "godco_place_warehouse",
+    "id": "godco_place_warehouse_new",
     "global": false,
     "//": "1 hour 30 minutes per wood wall * 50 walls = 75 hours for walls. 132 wood floors * 1 hour 40 minutes a floor = 220 hours. 1 hour 30 minutes per shelf * 68 shelves = 102 hours. (397 so far)  2 hours per roof * 132 roof tiles (assume same as floors) = 264 hours.",
     "//2": "In total, this takes 661 labor hours to build. Assuming work is in 8-hour shifts, that's 83 days, or 2 months and 22 days for a single worker.  Assume we have ~6 people on the job (isn't as urgent as a wall), this takes us ~14 days to build, or two weeks.",

--- a/data/json/npcs/godco/godco_missions.json
+++ b/data/json/npcs/godco/godco_missions.json
@@ -174,7 +174,10 @@
       "failure": "Sorry, I had to find someone else since you didn't come through."
     },
     "end": {
-      "effect": [ { "queue_eocs": "godco_place_warehouse_new", "time_in_future": "336 hours" }, { "u_spawn_item": "icon", "count": 137 } ],
+      "effect": [
+        { "queue_eocs": "godco_place_warehouse_new", "time_in_future": "336 hours" },
+        { "u_spawn_item": "icon", "count": 137 }
+      ],
       "opinion": { "trust": 7, "value": 6, "anger": -3 }
     }
   },
@@ -930,7 +933,10 @@
     "difficulty": 5,
     "value": 0,
     "end": {
-      "effect": [ { "u_spawn_item": "icon", "count": 90 }, { "queue_eocs": "godco_place_herb_garden_new", "time_in_future": "72 hours" } ]
+      "effect": [
+        { "u_spawn_item": "icon", "count": 90 },
+        { "queue_eocs": "godco_place_herb_garden_new", "time_in_future": "72 hours" }
+      ]
     },
     "origins": [ "ORIGIN_SECONDARY" ],
     "followup": "MISSION_GODCO_KOSTAS_3",

--- a/data/json/npcs/godco/godco_missions.json
+++ b/data/json/npcs/godco/godco_missions.json
@@ -174,7 +174,7 @@
       "failure": "Sorry, I had to find someone else since you didn't come through."
     },
     "end": {
-      "effect": [ { "queue_eocs": "godco_place_warehouse", "time_in_future": "336 hours" }, { "u_spawn_item": "icon", "count": 137 } ],
+      "effect": [ { "queue_eocs": "godco_place_warehouse_new", "time_in_future": "336 hours" }, { "u_spawn_item": "icon", "count": 137 } ],
       "opinion": { "trust": 7, "value": 6, "anger": -3 }
     }
   },
@@ -303,7 +303,7 @@
     "end": {
       "effect": [
         { "math": [ "darryl_building_coop", "=", "1" ] },
-        { "queue_eocs": "godco_place_coop", "time_in_future": "168 hours" },
+        { "queue_eocs": "godco_place_coop_new", "time_in_future": "168 hours" },
         { "u_spawn_item": "icon", "count": 6 }
       ]
     }
@@ -930,7 +930,7 @@
     "difficulty": 5,
     "value": 0,
     "end": {
-      "effect": [ { "u_spawn_item": "icon", "count": 90 }, { "queue_eocs": "godco_place_herb_garden", "time_in_future": "72 hours" } ]
+      "effect": [ { "u_spawn_item": "icon", "count": 90 }, { "queue_eocs": "godco_place_herb_garden_new", "time_in_future": "72 hours" } ]
     },
     "origins": [ "ORIGIN_SECONDARY" ],
     "followup": "MISSION_GODCO_KOSTAS_3",
@@ -1191,7 +1191,7 @@
     "end": {
       "effect": [
         { "mapgen_update": "helena_planer", "om_terrain": "godco_8" },
-        { "queue_eocs": "godco_place_wall", "time_in_future": "432 hours" },
+        { "queue_eocs": "godco_place_wall_new", "time_in_future": "432 hours" },
         { "u_spawn_item": "icon", "count": 40 }
       ]
     },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
When the old archive is migrated to a version after 2024-02-16-0719, the EOC remaining in the archive will be triggered cyclically and generate terrain related to church retreat. This bug is caused by #71595.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Changing the ID of the relevant EOC automatically invalidates the EOC in the old archive, although this affects archives that triggered the relevant task chain after 2024-02-16-0719, it can at least save the vast majority of archives.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
