### PR TITLE
Set new_game before loading JSON data

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -734,6 +734,7 @@ void game::reenter_fullscreen()
 void game::setup()
 {
     loading_ui ui( true );
+    new_game = true;
     {
         background_pane background;
         static_popup popup;
@@ -751,7 +752,6 @@ void game::setup()
 
     next_npc_id = character_id( 1 );
     next_mission_id = 1;
-    new_game = true;
     uquit = QUIT_NO;   // We haven't quit the game
     bVMonsterLookFire = true;
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Fixes #50493
* Resolves blocker for #71804

While loading core data, we do some adjustments to the (fake) map (yes before the game is started!). But we only set `new_game` *after* loading the json, but still before we actually start the game. The assumption being that loading json data is just loading json data, it doesn't modify the map or do anything besides moving data around. Well, it does. Camps generate a fake map, perform fake map updates to it, and in the process (about 20 functions down the callstack, in weather_manager::get_temperature) process any items with temperature that those fake updates generated. Since the real map isn't loaded and doesn't exist, it crashes.

#### Describe the solution
Before loading the JSON data, set `new_game`. This prevents the call in `weather_manager::get_temperature` and is what I personally would expect to be the case. `new_game` is still set to false at the same time(when the game is actually started), so this shouldn't impact gameplay. The only chance for unexpected interactions is if some function explicitly relied on `new_game` being false during loading(?!), which would be a baffling circumstance.

There are very few places where `new_game` is checked, so I am pretty confident this is a safe change.

#### Describe alternatives you've considered
I tried changing [the default parameters for mapgendata](https://github.com/CleverRaven/Cataclysm-DDA/blob/dd7a8369911d36bea19fb39b1cd1d713de31f4bd/src/mapgendata.cpp#L48) to use a terrain type which wouldn't generate any items, but this wasn't successful. The byproducts of the fake camp update were still being generated. I tried again, using a completely null terrain which couldn't be loaded, same issue.

#### Testing
All tests besides localization/overmap test passed locally, both before and after the changes. Game compiles, loads, does not crash even with the linked issue's JSON loaded.

#### Additional context
