### PR TITLE
IR Vision can see through smoke

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10640,13 +10640,7 @@ bool Character::sees_with_infrared( const Creature &critter ) const
 
     map &here = get_map();
 
-    if( is_avatar() || critter.is_avatar() ) {
-        // Players should not use map::sees
-        // Likewise, players should not be "looked at" with map::sees, not to break symmetry
-        return here.pl_line_of_sight( critter.pos(), unimpaired_range() );
-    }
-
-    return here.sees( pos(), critter.pos(), unimpaired_range() );
+    return here.sees( pos(), critter.pos(), unimpaired_range(), false );
 }
 
 bool Character::is_visible_in_range( const Creature &critter, const int range ) const

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -803,25 +803,25 @@ bool map::pl_sees( const tripoint &t, const int max_range ) const
              map_cache.sm[t.x][t.y] > 0.0 );
 }
 
-bool map::pl_line_of_sight( const tripoint &t, const int max_range ) const
-{
-    if( !inbounds( t ) ) {
-        return false;
-    }
+//bool map::pl_line_of_sight( const tripoint &t, const int max_range ) const
+//{
+//    if( !inbounds( t ) ) {
+//        return false;
+//    }
 
-    const level_cache &map_cache = get_cache_ref( t.z );
-    if( map_cache.camera_cache[t.x][t.y] > 0.075f ) {
-        return true;
-    }
+//    const level_cache &map_cache = get_cache_ref( t.z );
+//    if( map_cache.camera_cache[t.x][t.y] > 0.075f ) {
+//        return true;
+//    }
 
-    if( max_range >= 0 && square_dist( t, get_player_character().pos() ) > max_range ) {
-        // Out of range!
-        return false;
-    }
+//    if( max_range >= 0 && square_dist( t, get_player_character().pos() ) > max_range ) {
+//        // Out of range!
+//        return false;
+//    }
 
-    // Any epsilon > 0 is fine - it means lightmap processing visited the point
-    return map_cache.seen_cache[t.x][t.y] > 0.0f;
-}
+//    // Any epsilon > 0 is fine - it means lightmap processing visited the point
+//    return map_cache.seen_cache[t.x][t.y] > 0.0f;
+//}
 
 // For a direction vector defined by x, y, return the quadrant that's the
 // source of that direction.  Assumes x != 0 && y != 0

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -803,26 +803,6 @@ bool map::pl_sees( const tripoint &t, const int max_range ) const
              map_cache.sm[t.x][t.y] > 0.0 );
 }
 
-//bool map::pl_line_of_sight( const tripoint &t, const int max_range ) const
-//{
-//    if( !inbounds( t ) ) {
-//        return false;
-//    }
-
-//    const level_cache &map_cache = get_cache_ref( t.z );
-//    if( map_cache.camera_cache[t.x][t.y] > 0.075f ) {
-//        return true;
-//    }
-
-//    if( max_range >= 0 && square_dist( t, get_player_character().pos() ) > max_range ) {
-//        // Out of range!
-//        return false;
-//    }
-
-//    // Any epsilon > 0 is fine - it means lightmap processing visited the point
-//    return map_cache.seen_cache[t.x][t.y] > 0.0f;
-//}
-
 // For a direction vector defined by x, y, return the quadrant that's the
 // source of that direction.  Assumes x != 0 && y != 0
 // NOLINTNEXTLINE(cata-xy)

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -7256,7 +7256,7 @@ point map::sees_cache_key( const tripoint &from, const tripoint &to ) const
  **/
 bool map::sees( const tripoint &F, const tripoint &T, const int range,
                 int &bresenham_slope, bool with_fields ) const
- {
+{
     bool ( map::*f_transparent )( const tripoint & p ) const =
         with_fields ? &map::is_transparent : &map::is_transparent_wo_fields;
     lru_cache_t &skew_cache = with_fields ? skew_vision_cache : skew_vision_wo_fields_cache;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -7231,10 +7231,10 @@ void map::draw_from_above( const catacurses::window &w, const tripoint &p,
     }
 }
 
-bool map::sees( const tripoint &F, const tripoint &T, const int range ) const
+bool map::sees( const tripoint &F, const tripoint &T, const int range, bool with_fields ) const
 {
     int dummy = 0;
-    return sees( F, T, range, dummy );
+    return sees( F, T, range, dummy, with_fields );
 }
 
 point map::sees_cache_key( const tripoint &from, const tripoint &to ) const
@@ -7255,8 +7255,11 @@ point map::sees_cache_key( const tripoint &from, const tripoint &to ) const
  * This one is internal-only, we don't want to expose the slope tweaking ickiness outside the map class.
  **/
 bool map::sees( const tripoint &F, const tripoint &T, const int range,
-                int &bresenham_slope ) const
-{
+                int &bresenham_slope, bool with_fields ) const
+ {
+    bool ( map::*f_transparent )( const tripoint & p ) const =
+        with_fields ? &map::is_transparent : &map::is_transparent_wo_fields;
+    lru_cache_t &skew_cache = with_fields ? skew_vision_cache : skew_vision_wo_fields_cache;
     if( std::abs( F.z - T.z ) > fov_3d_z_range ||
         ( range >= 0 && range < rl_dist( F, T ) ) ||
         !inbounds( T ) ) {
@@ -7264,7 +7267,7 @@ bool map::sees( const tripoint &F, const tripoint &T, const int range,
         return false; // Out of range!
     }
     const point key = sees_cache_key( F, T );
-    char cached = skew_vision_cache.get( key, -1 );
+    char cached = skew_cache.get( key, -1 );
     if( cached >= 0 ) {
         return cached > 0;
     }
@@ -7273,24 +7276,24 @@ bool map::sees( const tripoint &F, const tripoint &T, const int range,
     // Ugly `if` for now
     if( F.z == T.z ) {
         bresenham( F.xy(), T.xy(), bresenham_slope,
-        [this, &visible, &T]( const point & new_point ) {
+        [this, f_transparent, &visible, &T]( const point & new_point ) {
             // Exit before checking the last square, it's still visible even if opaque.
             if( new_point.x == T.x && new_point.y == T.y ) {
                 return false;
             }
-            if( !this->is_transparent( tripoint( new_point, T.z ) ) ) {
+            if( !( this->*f_transparent )( tripoint( new_point, T.z ) ) ) {
                 visible = false;
                 return false;
             }
             return true;
         } );
-        skew_vision_cache.insert( 100000, key, visible ? 1 : 0 );
+        skew_cache.insert( 100000, key, visible ? 1 : 0 );
         return visible;
     }
 
     tripoint last_point = F;
     bresenham( F, T, bresenham_slope, 0,
-    [this, &visible, &T, &last_point]( const tripoint & new_point ) {
+    [this, f_transparent, &visible, &T, &last_point]( const tripoint & new_point ) {
         // Exit before checking the last square if it's not a vertical transition,
         // it's still visible even if opaque.
         if( new_point == T && last_point.z == T.z ) {
@@ -7299,16 +7302,16 @@ bool map::sees( const tripoint &F, const tripoint &T, const int range,
 
         // TODO: Allow transparent floors (and cache them!)
         if( new_point.z == last_point.z ) {
-            if( !this->is_transparent( new_point ) ) {
+            if( !( this->*f_transparent )( new_point ) ) {
                 visible = false;
                 return false;
             }
         } else {
             const int max_z = std::max( new_point.z, last_point.z );
             if( ( has_floor_or_support( {new_point.xy(), max_z} ) ||
-                  !is_transparent( {new_point.xy(), last_point.z} ) ) &&
+                  !( this->*f_transparent )( {new_point.xy(), last_point.z} ) ) &&
                 ( has_floor_or_support( {last_point.xy(), max_z} ) ||
-                  !is_transparent( {last_point.xy(), new_point.z} ) ) ) {
+                  !( this->*f_transparent )( {last_point.xy(), new_point.z} ) ) ) {
                 visible = false;
                 return false;
             }
@@ -7317,7 +7320,7 @@ bool map::sees( const tripoint &F, const tripoint &T, const int range,
         last_point = new_point;
         return true;
     } );
-    skew_vision_cache.insert( 100000, key, visible ? 1 : 0 );
+    skew_cache.insert( 100000, key, visible ? 1 : 0 );
     return visible;
 }
 
@@ -9417,7 +9420,7 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
     seen_cache_dirty |= build_vision_transparency_cache( zlev );
 
     if( seen_cache_dirty ) {
-        skew_vision_cache.clear();
+        skew_vision_wo_fields_cache.clear();
     }
     avatar &u = get_avatar();
     Character::moncam_cache_t mcache = u.get_active_moncams();

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -9420,6 +9420,7 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
     seen_cache_dirty |= build_vision_transparency_cache( zlev );
 
     if( seen_cache_dirty ) {
+        skew_vision_cache.clear();
         skew_vision_wo_fields_cache.clear();
     }
     avatar &u = get_avatar();

--- a/src/map.h
+++ b/src/map.h
@@ -1827,12 +1827,7 @@ class map
          * Ignored if smaller than 0.
          */
         bool pl_sees( const tripoint &t, int max_range ) const;
-        /**
-         * Uses the map cache to tell if the player could see the given square.
-         * pl_sees implies pl_line_of_sight
-         * Used for infrared.
-         */
-        bool pl_line_of_sight( const tripoint &t, int max_range ) const;
+
         std::set<vehicle *> dirty_vehicle_list;
 
         /** return @ref abs_sub */

--- a/src/map.h
+++ b/src/map.h
@@ -602,7 +602,7 @@ class map
         /**
         * Returns whether `F` sees `T` with a view range of `range`.
         */
-        bool sees( const tripoint &F, const tripoint &T, int range ) const;
+        bool sees( const tripoint &F, const tripoint &T, int range, bool with_fields = true ) const;
     private:
         /**
          * Don't expose the slope adjust outside map functions.
@@ -614,7 +614,8 @@ class map
          * the two points, and may subsequently be used to form a path between them.
          * Set to zero if the function returns false.
         **/
-        bool sees( const tripoint &F, const tripoint &T, int range, int &bresenham_slope ) const;
+        bool sees( const tripoint &F, const tripoint &T, int range, int &bresenham_slope,
+                   bool with_fields = true ) const;
         point sees_cache_key( const tripoint &from, const tripoint &to ) const;
     public:
         /**
@@ -2264,7 +2265,9 @@ class map
         /**
          * Cache of coordinate pairs recently checked for visibility.
          */
-        mutable lru_cache<point, char> skew_vision_cache;
+        using lru_cache_t = lru_cache<point, char>;
+        mutable lru_cache_t skew_vision_cache;
+        mutable lru_cache_t skew_vision_wo_fields_cache;
 
         // Note: no bounds check
         level_cache &get_cache( int zlev ) const {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Allows Infrared vision to see through smoke"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
Fixes #54253 
Fixes #66948 
and probably others.

Infrared vision was using a simple calculation to determine line of sight. Because this was drawing on the same transparency cache that normal vision used, and because the map cache for performance reasons can't be drawn multiple times a second just for rare cases like IR, there wasn't a good way to make smoke block normal but not IR vision, because under our current model, both are active at the same time. This also caused some weirdness where having IR vision up slightly changed the way transparency behaved in some edge cases, but not in a way that was helpful or made any real sense.

This was a fairly major problem because the primary use case for infrared was seeing through fields. It wasn't particularly useful as a mode of darkvision because night vision is pretty forgiving in this game, and anyone with access to IR is either working with mutations or very powerful technology, both of which suggest that darkness is not a huge barrier.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Stops using pl_line_of_sight for IR vision. This function worked well enough normally, but was not able to deal with smoke's translucency code. Instead, we touch up map::sees to accept new conditions which can be run without drawing a new map cache. The result is that IR vision can see through smoke, but normal vision cannot.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
This method does not fix every possible use case. It's a step in the right direction but more could be done. Namely, it doesn't allow the use of remote IR cameras, which we don't have, but would be nice.

Some smoke, such as the higher-end smoke grenades now used by the military, contains particles which are intended to baffle IR vision. 99% of the smoke the player encounters is either coming from a zombie which probably isn't using such a sophisticated method, or it's coming from a fire. Regular fire smoke, while hot, does not impede IR vision this way - IR cameras are used by firefighters, for example. We also had several fields like poison gas and fog which were impeding IR even though they would be even less likely to do so. If we want IR-baffling smoke, it probably wouldn't be too hard to add a new field which acts like smoke but is flagged to block IR somehow.

I have left the pl_line_of_sight() function intact for now because it's still used for the echolocation in #70797 - once that PR is merged, I will move it over to this method and remove the obsolete function.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
- Spawned a character, gave them the IR vision mutation.
- Spawned Ashen Brawlers and some regular zombies to hang out with them. I was able to see their heat signatures through the smoke, but the smoke still obscured tiles otherwise.
- There was no noticeable performance dip, nor was one expected as we're not rebuilding the map cache.
- Hid behind a wall. Could not see through the wall. IR can see through thin stuff IRL but its previous behavior was that all wall tiles would block it and that's still the case.
- Hid in a roomy shell. Could not see through the shell. 👍 

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/94415528/7786adb0-682b-447b-85e5-7d4c96cfa7f3)

I can't take any credit for this fix as @andrei8l put it together for me. Thanks choom!

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
