### PR TITLE
Made gates.h typed and the following adjustments

### DIFF
--- a/src/action.h
+++ b/src/action.h
@@ -9,9 +9,10 @@
 #include <string>
 #include <vector>
 
+#include "coordinates.h"
+
 struct input_event;
 struct point;
-struct tripoint;
 
 /**
  * Enumerates all discrete actions that can be performed by player
@@ -463,7 +464,11 @@ bool can_action_change_worldstate( action_id act );
  * @param[in] allow_vertical Allows player to select tiles above/below them if true
  */
 std::optional<tripoint> choose_adjacent( const std::string &message, bool allow_vertical = false );
+// TODO: Get rid of untyped overload.
 std::optional<tripoint> choose_adjacent( const tripoint &pos, const std::string &message,
+        bool allow_vertical = false );
+std::optional<tripoint_bub_ms> choose_adjacent( const tripoint_bub_ms &pos,
+        const std::string &message,
         bool allow_vertical = false );
 
 /**
@@ -477,7 +482,10 @@ std::optional<tripoint> choose_adjacent( const tripoint &pos, const std::string 
  * @param[in] message Message used in assembling the prompt to the player
  * @param[in] allow_vertical Allows direction vector to have vertical component if true
  */
+// TODO: Get rid of untyped version and typed name extension.
 std::optional<tripoint> choose_direction( const std::string &message,
+        bool allow_vertical = false );
+std::optional<tripoint_rel_ms> choose_direction_rel_ms( const std::string &message,
         bool allow_vertical = false );
 
 /**
@@ -496,7 +504,11 @@ std::optional<tripoint> choose_direction( const std::string &message,
  * @param[in] allow_vertical Allows direction vector to have vertical component if true
  * @param[in] allow_autoselect Automatically select location if there's only one valid option and the appropriate setting is enabled
  */
+// TODO: Get rid of untyped version and change name of typed one.
 std::optional<tripoint> choose_adjacent_highlight( const std::string &message,
+        const std::string &failure_message, action_id action,
+        bool allow_vertical = false, bool allow_autoselect = true );
+std::optional<tripoint_bub_ms> choose_adjacent_highlight_bub_ms( const std::string &message,
         const std::string &failure_message, action_id action,
         bool allow_vertical = false, bool allow_autoselect = true );
 
@@ -517,11 +529,20 @@ std::optional<tripoint> choose_adjacent_highlight( const std::string &message,
  * @param[in] allow_vertical Allows direction vector to have vertical component if true
  * @param[in] allow_autoselect Automatically select location if there's only one valid option and the appropriate setting is enabled
  */
+// TODO: Get rid of untyped overload.
 std::optional<tripoint> choose_adjacent_highlight( const std::string &message,
         const std::string &failure_message, const std::function<bool( const tripoint & )> &allowed,
         bool allow_vertical = false, bool allow_autoselect = true );
+std::optional<tripoint_bub_ms> choose_adjacent_highlight( const std::string &message,
+        const std::string &failure_message, const std::function<bool( const tripoint_bub_ms & )> &allowed,
+        bool allow_vertical = false, bool allow_autoselect = true );
+// TODO: Get rid of untyped overload.
 std::optional<tripoint> choose_adjacent_highlight( const tripoint &pos, const std::string &message,
         const std::string &failure_message, const std::function<bool( const tripoint & )> &allowed,
+        bool allow_vertical = false, bool allow_autoselect = true );
+std::optional<tripoint_bub_ms> choose_adjacent_highlight( const tripoint_bub_ms &pos,
+        const std::string &message,
+        const std::string &failure_message, const std::function<bool( const tripoint_bub_ms & )> &allowed,
         bool allow_vertical = false, bool allow_autoselect = true );
 
 // (Press X (or Y)|Try) to Z
@@ -598,7 +619,9 @@ action_id handle_main_menu();
  * @param p Point to perform test at
  * @returns true if movement is possible in the indicated direction
  */
+// TODO: Get rid of untyped overload.
 bool can_interact_at( action_id action, const tripoint &p );
+bool can_interact_at( action_id action, const tripoint_bub_ms &p );
 
 /**
  * Test whether it is possible to perform butcher action

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3095,7 +3095,7 @@ void open_gate_activity_actor::serialize( JsonOut &jsout ) const
 
 std::unique_ptr<activity_actor> open_gate_activity_actor::deserialize( JsonValue &jsin )
 {
-    open_gate_activity_actor actor( 0, tripoint_zero );
+    open_gate_activity_actor actor( 0, tripoint_bub_ms( tripoint_zero ) );
 
     JsonObject data = jsin.get_object();
 

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -745,7 +745,7 @@ class open_gate_activity_actor : public activity_actor
 {
     private:
         int moves_total;
-        tripoint placement;
+        tripoint_bub_ms placement;
 
         /**
          * @pre @p other is a open_gate_activity_actor
@@ -756,7 +756,7 @@ class open_gate_activity_actor : public activity_actor
         }
 
     public:
-        open_gate_activity_actor( int gate_moves, const tripoint &gate_placement ) :
+        open_gate_activity_actor( int gate_moves, const tripoint_bub_ms &gate_placement ) :
             moves_total( gate_moves ), placement( gate_placement ) {}
 
         activity_id get_type() const override {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5753,7 +5753,17 @@ bool game::forced_door_closing( const tripoint &p, const ter_id &door_type, int 
     return true;
 }
 
+bool game::forced_door_closing( const tripoint_bub_ms &p, const ter_id &door_type, int bash_dmg )
+{
+    return forced_door_closing( p.raw(), door_type, bash_dmg );
+}
+
 void game::open_gate( const tripoint &p )
+{
+    open_gate( tripoint_bub_ms( p ) );
+}
+
+void game::open_gate( const tripoint_bub_ms &p )
 {
     gates::open_gate( p, u );
 }

--- a/src/game.h
+++ b/src/game.h
@@ -744,7 +744,9 @@ class game
 
         /**@}*/
 
+        // TODO: Get rid of untyped overload.
         void open_gate( const tripoint &p );
+        void open_gate( const tripoint_bub_ms &p );
 
         // Knockback functions: knock target at t along a line, either calculated
         // from source position s using force parameter or passed as an argument;
@@ -824,7 +826,9 @@ class game
         // will do so, if bash_dmg is greater than 0, items won't stop the door
         // from closing at all.
         // If the door gets closed the items on the door tile get moved away or destroyed.
+        // TODO: Get rid of untyped overload.
         bool forced_door_closing( const tripoint &p, const ter_id &door_type, int bash_dmg );
+        bool forced_door_closing( const tripoint_bub_ms &p, const ter_id &door_type, int bash_dmg );
 
         /** Attempt to load first valid save (if any) in world */
         bool load( const std::string &world );

--- a/src/gates.cpp
+++ b/src/gates.cpp
@@ -70,10 +70,10 @@ struct gate_data {
     void load( const JsonObject &jo, std::string_view src );
     void check() const;
 
-    bool is_suitable_wall( const tripoint &pos ) const;
+    bool is_suitable_wall( const tripoint_bub_ms &pos ) const;
 };
 
-gate_id get_gate_id( const tripoint &pos )
+gate_id get_gate_id( const tripoint_bub_ms &pos )
 {
     return gate_id( get_map().ter( pos ).id().str() );
 }
@@ -129,7 +129,7 @@ void gate_data::check() const
     }
 }
 
-bool gate_data::is_suitable_wall( const tripoint &pos ) const
+bool gate_data::is_suitable_wall( const tripoint_bub_ms &pos ) const
 {
     const ter_id wid = get_map().ter( pos );
     const auto iter = std::find_if( walls.begin(), walls.end(), [ wid ]( const ter_str_id & wall ) {
@@ -165,7 +165,7 @@ void gates::reset()
 //  !|   |!        !   |
 //
 
-void gates::open_gate( const tripoint &pos )
+void gates::open_gate( const tripoint_bub_ms &pos )
 {
     const gate_id gid = get_gate_id( pos );
 
@@ -181,21 +181,21 @@ void gates::open_gate( const tripoint &pos )
 
     map &here = get_map();
     for( const point &wall_offset : four_adjacent_offsets ) {
-        const tripoint wall_pos = pos + wall_offset;
+        const tripoint_bub_ms wall_pos = pos + wall_offset;
 
         if( !gate.is_suitable_wall( wall_pos ) ) {
             continue;
         }
 
         for( const point &gate_offset : four_adjacent_offsets ) {
-            const tripoint gate_pos = wall_pos + gate_offset;
+            const tripoint_bub_ms gate_pos = wall_pos + gate_offset;
 
             if( gate_pos == pos ) {
                 continue; // Never comes back
             }
 
             if( !open ) { // Closing the gate...
-                tripoint cur_pos = gate_pos;
+                tripoint_bub_ms cur_pos = gate_pos;
                 while( here.ter( cur_pos ) == gate.floor.id() ) {
                     fail = !g->forced_door_closing( cur_pos, gate.door.id(), gate.bash_dmg ) || fail;
                     close = !fail;
@@ -204,7 +204,7 @@ void gates::open_gate( const tripoint &pos )
             }
 
             if( !close ) { // Opening the gate...
-                tripoint cur_pos = gate_pos;
+                tripoint_bub_ms cur_pos = gate_pos;
                 while( true ) {
                     const ter_id ter = here.ter( cur_pos );
 
@@ -233,7 +233,7 @@ void gates::open_gate( const tripoint &pos )
     }
 }
 
-void gates::open_gate( const tripoint &pos, Character &p )
+void gates::open_gate( const tripoint_bub_ms &pos, Character &p )
 {
     const gate_id gid = get_gate_id( pos );
 
@@ -251,7 +251,7 @@ void gates::open_gate( const tripoint &pos, Character &p )
 // Doors namespace
 // TODO: move door functions from maps namespace here, or vice versa.
 
-void doors::close_door( map &m, Creature &who, const tripoint &closep )
+void doors::close_door( map &m, Creature &who, const tripoint_bub_ms &closep )
 {
     bool didit = false;
     const bool inside = !m.is_outside( who.pos() );
@@ -353,7 +353,7 @@ void doors::close_door( map &m, Creature &who, const tripoint &closep )
 }
 
 // If you update this, look at doors::can_lock_door too.
-bool doors::lock_door( map &m, Creature &who, const tripoint &lockp )
+bool doors::lock_door( map &m, Creature &who, const tripoint_bub_ms &lockp )
 {
     bool didit = false;
 
@@ -392,7 +392,7 @@ bool doors::lock_door( map &m, Creature &who, const tripoint &lockp )
     return didit;
 }
 
-bool doors::can_lock_door( const map &m, const Creature &who, const tripoint &lockp )
+bool doors::can_lock_door( const map &m, const Creature &who, const tripoint_bub_ms &lockp )
 {
     int lockable = -1;
     if( const optional_vpart_position vp = m.veh_at( lockp ) ) {
@@ -406,7 +406,7 @@ bool doors::can_lock_door( const map &m, const Creature &who, const tripoint &lo
 }
 
 // If you update this, look at doors::can_unlock_door too.
-bool doors::unlock_door( map &m, Creature &who, const tripoint &lockp )
+bool doors::unlock_door( map &m, Creature &who, const tripoint_bub_ms &lockp )
 {
     bool didit = false;
 
@@ -446,7 +446,7 @@ bool doors::unlock_door( map &m, Creature &who, const tripoint &lockp )
     return didit;
 }
 
-bool doors::can_unlock_door( const map &m, const Creature &who, const tripoint &lockp )
+bool doors::can_unlock_door( const map &m, const Creature &who, const tripoint_bub_ms &lockp )
 {
     int unlockable = -1;
     if( const optional_vpart_position vp = m.veh_at( lockp ) ) {

--- a/src/gates.h
+++ b/src/gates.h
@@ -4,11 +4,12 @@
 
 #include <string>
 
+#include "coordinates.h"
+
 class Character;
 class Creature;
 class JsonObject;
 class map;
-struct tripoint;
 
 namespace gates
 {
@@ -18,9 +19,9 @@ void check();
 void reset();
 
 /** opens the gate via player's activity */
-void open_gate( const tripoint &pos, Character &p );
+void open_gate( const tripoint_bub_ms &pos, Character &p );
 /** opens the gate immediately */
-void open_gate( const tripoint &pos );
+void open_gate( const tripoint_bub_ms &pos );
 
 } // namespace gates
 
@@ -31,7 +32,7 @@ namespace doors
  * Handles deducting moves, printing messages (only non-NPCs cause messages), actually closing it,
  * checking if it can be closed, etc.
 */
-void close_door( map &m, Creature &who, const tripoint &closep );
+void close_door( map &m, Creature &who, const tripoint_bub_ms &closep );
 /**
  * Locks a door at "lockp" as "who."
  *
@@ -41,7 +42,7 @@ void close_door( map &m, Creature &who, const tripoint &closep );
  *
  * @returns whether a door was actually locked
  */
-bool lock_door( map &m, Creature &who, const tripoint &lockp );
+bool lock_door( map &m, Creature &who, const tripoint_bub_ms &lockp );
 
 /**
  * Unlocks a door at "lockp" as "who."
@@ -51,16 +52,16 @@ bool lock_door( map &m, Creature &who, const tripoint &lockp );
  *
  * @returns whether a door was actually unlocked
  */
-bool unlock_door( map &m, Creature &who, const tripoint &lockp );
+bool unlock_door( map &m, Creature &who, const tripoint_bub_ms &lockp );
 
 /**
 * Whether a door at "lockp" can be locked by "who."
 */
-bool can_lock_door( const map &m, const Creature &who, const tripoint &lockp );
+bool can_lock_door( const map &m, const Creature &who, const tripoint_bub_ms &lockp );
 /**
 * Whether a door at "lockp" can be unlocked by "who."
 */
-bool can_unlock_door( const map &m, const Creature &who, const tripoint &lockp );
+bool can_unlock_door( const map &m, const Creature &who, const tripoint_bub_ms &lockp );
 
 } // namespace doors
 

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -650,9 +650,10 @@ static void open()
 
 static void close()
 {
-    if( const std::optional<tripoint> pnt = choose_adjacent_highlight( _( "Close where?" ),
-                                            pgettext( "no door, gate, etc.", "There is nothing that can be closed nearby." ),
-                                            ACTION_CLOSE, false ) ) {
+    if( const std::optional<tripoint_bub_ms> pnt = choose_adjacent_highlight_bub_ms(
+                _( "Close where?" ),
+                pgettext( "no door, gate, etc.", "There is nothing that can be closed nearby." ),
+                ACTION_CLOSE, false ) ) {
         doors::close_door( get_map(), get_player_character(), *pnt );
     }
 }
@@ -2292,7 +2293,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
                     add_msg( m_info, _( "You can't close things while you're riding." ) );
                 }
             } else if( mouse_target ) {
-                doors::close_door( m, player_character, *mouse_target );
+                doors::close_door( m, player_character, tripoint_bub_ms( *mouse_target ) );
             } else {
                 close();
             }

--- a/src/input_context.cpp
+++ b/src/input_context.cpp
@@ -498,6 +498,41 @@ std::optional<tripoint> input_context::get_direction( const std::string &action 
     }
 }
 
+std::optional<tripoint_rel_ms> input_context::get_direction_rel_ms( const std::string &action )
+const
+{
+    static const auto noop = static_cast<tripoint_rel_ms( * )( tripoint_rel_ms )>( [](
+    tripoint_rel_ms p ) {
+        return p;
+    } );
+    static const auto rotate = static_cast<tripoint_rel_ms( * )( tripoint_rel_ms )>( [](
+    tripoint_rel_ms p ) {
+        rotate_direction_cw( p.x(), p.y() );
+        return p;
+    } );
+    const auto transform = iso_mode && g->is_tileset_isometric() ? rotate : noop;
+
+    if( action == "UP" ) {
+        return transform( tripoint_rel_ms( tripoint_north ) );
+    } else if( action == "DOWN" ) {
+        return transform( tripoint_rel_ms( tripoint_south ) );
+    } else if( action == "LEFT" ) {
+        return transform( tripoint_rel_ms( tripoint_west ) );
+    } else if( action == "RIGHT" ) {
+        return transform( tripoint_rel_ms( tripoint_east ) );
+    } else if( action == "LEFTUP" ) {
+        return transform( tripoint_rel_ms( tripoint_north_west ) );
+    } else if( action == "RIGHTUP" ) {
+        return transform( tripoint_rel_ms( tripoint_north_east ) );
+    } else if( action == "LEFTDOWN" ) {
+        return transform( tripoint_rel_ms( tripoint_south_west ) );
+    } else if( action == "RIGHTDOWN" ) {
+        return transform( tripoint_rel_ms( tripoint_south_east ) );
+    } else {
+        return std::nullopt;
+    }
+}
+
 // Custom set of hotkeys that explicitly don't include the hardcoded
 // alternative hotkeys, which mustn't be included so that the hardcoded
 // hotkeys do not show up beside entries within the window.

--- a/src/input_context.h
+++ b/src/input_context.h
@@ -273,7 +273,9 @@ class input_context
          * the delta vector associated with it. Otherwise returns an empty value.
          * The returned vector will always have a z component of 0.
          */
+        // TODO: Get rid of untyped version and change name of the typed one.
         std::optional<tripoint> get_direction( const std::string &action ) const;
+        std::optional<tripoint_rel_ms> get_direction_rel_ms( const std::string &action ) const;
 
         /**
          * Get the coordinates associated with the last mouse click (if any).

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1653,6 +1653,11 @@ std::string map::obstacle_name( const tripoint &p )
     return name( p );
 }
 
+std::string map::obstacle_name( const tripoint_bub_ms &p )
+{
+    return obstacle_name( p.raw() );
+}
+
 bool map::has_furn( const tripoint &p ) const
 {
     return furn( p ) != f_null;
@@ -4924,6 +4929,11 @@ void map::i_clear( const tripoint &p )
     current_submap->get_items( l ).clear();
 }
 
+void map::i_clear( const tripoint_bub_ms &p )
+{
+    i_clear( p.raw() );
+}
+
 std::vector<item *> map::spawn_items( const tripoint &p, const std::vector<item> &new_items )
 {
     std::vector<item *> ret;
@@ -6949,6 +6959,12 @@ void map::drawsq( const catacurses::window &w, const tripoint &p,
     tripoint below( p.xy(), p.z - 1 );
     const const_maptile tile_below = maptile_at( below );
     draw_from_above( w, below, tile_below, params );
+}
+
+void map::drawsq( const catacurses::window &w, const tripoint_bub_ms &p,
+                  const drawsq_params &params ) const
+{
+    map::drawsq( w, p.raw(), params );
 }
 
 // a check to see if the lower floor needs to be rendered in tiles

--- a/src/map.h
+++ b/src/map.h
@@ -460,7 +460,10 @@ class map
          * @param p The tile on this map to draw.
          * @param params Draw parameters.
          */
+        // TODO: Get rid of untyped overload,
         void drawsq( const catacurses::window &w, const tripoint &p, const drawsq_params &params ) const;
+        void drawsq( const catacurses::window &w, const tripoint_bub_ms &p,
+                     const drawsq_params &params ) const;
 
         /**
          * Add currently loaded submaps (in @ref grid) to the @ref mapbuffer.
@@ -797,7 +800,9 @@ class map
         * Returns the name of the obstacle at p that might be blocking movement/projectiles/etc.
         * Note that this only accounts for vehicles, terrain, and furniture.
         */
+        // TODO: Get rid of untyped overload.
         std::string obstacle_name( const tripoint &p );
+        std::string obstacle_name( const tripoint_bub_ms &p );
         bool has_furn( const tripoint &p ) const;
         // TODO: fix point types (remove the first overload)
         bool has_furn( const tripoint_bub_ms &p ) const;
@@ -1270,7 +1275,9 @@ class map
             return i_at( tripoint( p, abs_sub.z() ) );
         }
         item water_from( const tripoint &p );
+        // TODO: Get rid of untyped overload.
         void i_clear( const tripoint &p );
+        void i_clear( const tripoint_bub_ms &p );
         void i_clear( const point &p ) {
             i_clear( tripoint( p, abs_sub.z() ) );
         }

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -3279,7 +3279,7 @@ std::unordered_set<tripoint> npc::get_path_avoid() const
     }
     if( rules.has_flag( ally_rule::avoid_locks ) ) {
         for( const tripoint &p : here.points_in_radius( pos(), 30 ) ) {
-            if( doors::can_unlock_door( here, *this, p ) ) {
+            if( doors::can_unlock_door( here, *this, tripoint_bub_ms( p ) ) ) {
                 ret.insert( p );
             }
         }

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -3047,9 +3047,9 @@ void npc::move_to( const tripoint &pt, bool no_bashing, std::set<tripoint> *nomo
             moves -= 100;
             moved = true;
         }
-    } else if( doors::can_unlock_door( here, *this, pt ) ) {
+    } else if( doors::can_unlock_door( here, *this, tripoint_bub_ms( pt ) ) ) {
         if( !is_hallucination() ) {
-            doors::unlock_door( here, *this, pt );
+            doors::unlock_door( here, *this, tripoint_bub_ms( pt ) );
         } else {
             mod_moves( -100 );
             moved = true;
@@ -3117,11 +3117,11 @@ void npc::move_to( const tripoint &pt, bool no_bashing, std::set<tripoint> *nomo
 
         // Close doors behind self (if you can)
         if( ( rules.has_flag( ally_rule::close_doors ) && is_player_ally() ) && !is_hallucination() ) {
-            doors::close_door( here, *this, old_pos );
+            doors::close_door( here, *this, tripoint_bub_ms( old_pos ) );
         }
         // Lock doors as well
         if( ( rules.has_flag( ally_rule::lock_doors ) && is_player_ally() ) && !is_hallucination() ) {
-            doors::lock_door( here, *this, old_pos );
+            doors::lock_door( here, *this, tripoint_bub_ms( old_pos ) );
         }
 
         if( here.veh_at( p ).part_with_feature( VPFLAG_BOARDABLE, true ) ) {

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -332,10 +332,24 @@ void sounds::sound( const tripoint &p, int vol, sound_t category, const std::str
                                                  false, id, variant, seas_str } );
 }
 
+void sounds::sound( const tripoint_bub_ms &p, int vol, sound_t category,
+                    const std::string &description,
+                    bool ambient, const std::string &id, const std::string &variant )
+{
+    sounds::sound( p.raw(), vol, category, description, ambient, id, variant );
+}
+
 void sounds::sound( const tripoint &p, int vol, sound_t category, const translation &description,
                     bool ambient, const std::string &id, const std::string &variant )
 {
     sounds::sound( p, vol, category, description.translated(), ambient, id, variant );
+}
+
+void sounds::sound( const tripoint_bub_ms &p, int vol, sound_t category,
+                    const translation &description,
+                    bool ambient, const std::string &id, const std::string &variant )
+{
+    sounds::sound( p.raw(), vol, category, description, ambient, id, variant );
 }
 
 void sounds::add_footstep( const tripoint &p, int volume, int, monster *,

--- a/src/sounds.h
+++ b/src/sounds.h
@@ -7,6 +7,7 @@
 #include <utility>
 #include <vector>
 
+#include "coordinates.h"
 #include "units_fwd.h"
 
 class Character;
@@ -15,7 +16,6 @@ class JsonObject;
 class item;
 class monster;
 class translation;
-struct tripoint;
 template <typename E> struct enum_traits;
 
 namespace sounds
@@ -52,10 +52,18 @@ enum class sound_t : int {
  * @param variant Variant of sound effect given in id
  * @returns true if the player could hear the sound.
  */
+// TODO: Get rid of untyped overload.
 void sound( const tripoint &p, int vol, sound_t category, const std::string &description,
             bool ambient = false, const std::string &id = "",
             const std::string &variant = "default" );
+void sound( const tripoint_bub_ms &p, int vol, sound_t category, const std::string &description,
+            bool ambient = false, const std::string &id = "",
+            const std::string &variant = "default" );
+// TODO: Get rid of untyped overload.
 void sound( const tripoint &p, int vol, sound_t category, const translation &description,
+            bool ambient = false, const std::string &id = "",
+            const std::string &variant = "default" );
+void sound( const tripoint_bub_ms &p, int vol, sound_t category, const translation &description,
             bool ambient = false, const std::string &id = "",
             const std::string &variant = "default" );
 /** Functions identical to sound(..., true). */

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -2385,13 +2385,13 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint &p, bool with_
             menu.add( string_format( _( "Lock %s" ), vp_lockable_door->part().name() ) )
             .hotkey( "LOCK_DOOR" )
             .on_submit( [p] {
-                doors::lock_door( get_map(), get_player_character(), p );
+                doors::lock_door( get_map(), get_player_character(), tripoint_bub_ms( p ) );
             } );
         } else if( player_inside && vp_lockable_door->part().locked ) {
             menu.add( string_format( _( "Unlock %s" ), vp_lockable_door->part().name() ) )
             .hotkey( "UNLOCK_DOOR" )
             .on_submit( [p] {
-                doors::unlock_door( get_map(), get_player_character(), p );
+                doors::unlock_door( get_map(), get_player_character(), tripoint_bub_ms( p ) );
             } );
         } else if( vp_lockable_door->part().locked ) {
             menu.add( string_format( _( "Check the lock on %s" ), vp_lockable_door->part().name() ) )

--- a/tests/active_item_cache_test.cpp
+++ b/tests/active_item_cache_test.cpp
@@ -35,7 +35,7 @@ TEST_CASE( "place_active_item_at_various_coordinates", "[item]" )
             REQUIRE( here.get_submaps_with_active_items().find( abs_loc ) !=
                      here.get_submaps_with_active_items().end() );
             REQUIRE_FALSE( here.i_at( tripoint{ x, y, z } ).empty() );
-            here.i_clear( { x, y, z } );
+            here.i_clear( tripoint_bub_ms{ x, y, z } );
             here.process_items();
         }
     }

--- a/tests/map_helpers.cpp
+++ b/tests/map_helpers.cpp
@@ -108,7 +108,7 @@ void clear_items( const int zlevel )
     const int mapsize = here.getmapsize() * SEEX;
     for( int x = 0; x < mapsize; ++x ) {
         for( int y = 0; y < mapsize; ++y ) {
-            here.i_clear( { x, y, zlevel } );
+            here.i_clear( tripoint_bub_ms{ x, y, zlevel } );
         }
     }
 }

--- a/tests/player_activities_test.cpp
+++ b/tests/player_activities_test.cpp
@@ -1708,7 +1708,7 @@ static const std::vector<std::function<player_activity()>> test_activities {
     [] { return player_activity( mop_activity_actor( 1 ) ); },
     //player_activity( move_furniture_activity_actor( p, false ) ),
     [] { return player_activity( move_items_activity_actor( {}, {}, false, get_avatar().pos() + tripoint_north ) ); },
-    [] { return player_activity( open_gate_activity_actor( 1, get_avatar().pos() ) ); },
+    [] { return player_activity( open_gate_activity_actor( 1, get_avatar().pos_bub() ) ); },
     //player_activity( oxytorch_activity_actor( p, loc ) ),
     [] { return player_activity( pickup_activity_actor( {}, {}, std::nullopt, false ) ); },
     [] { return player_activity( play_with_pet_activity_actor() ); },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary

None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Slowly turn coordinate use typed. This time dealing with gates.h.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

- Changed all the appropriate operations in gates.h to use tripoint_bub_ms instead of the generic tripoint.
- Dealt with all the things that won't compile. This includes the introduction of typed versions of untyped operations in various other headers, plus, of course, code adjustments.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Collective procrastination.

A number of headers had forward declarations of the tripoint struct, presumably in order to avoid getting a whole lot of C header copying. Well, that forward declaration had to go and be replaced by inclusion of coordinates.h in a few places. That might be changed if there's a way to make a forward declaration of the classes derived from tripoint,, in particular tripoint_bub_ms.

There were a number of type conversions of untyped constants such as tripoint_north into tripoint_rel_ms. This indicates it might be a better idea to define such constants in a suitable header file (coordinates.h?). That could be changed if there is advice to do so, and where it would be best to place it.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Started the game. Note that the changes are not supposed to change anything functionally.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
