### PR TITLE
Fix infinite looping in msvc builds in fragment test function

### DIFF
--- a/tests/explosion_balance_test.cpp
+++ b/tests/explosion_balance_test.cpp
@@ -141,7 +141,7 @@ static void check_lethality( const std::string &explosive_id, const int range, f
     const float fragment_velocity = explosion_handler::gurney_spherical( ex.power, shr.casing_mass );
     const float fragment_count = static_cast<float>( shr.casing_mass ) / shr.fragment_mass;
     const fragment_cloud cloud_at_target =
-        shrapnel_calc( { fragment_velocity, fragment_count }, { 1.2, 1.0 }, range );
+        shrapnel_calc( { fragment_velocity, fragment_count }, { 1.2, 1.0 }, std::max( 1, range ) );
     std::poisson_distribution<> d( cloud_at_target.density );
     int hits = d( rng_get_engine() );
     INFO( "Casing mass " << shr.casing_mass );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
My debug code in #71585 introduced a divide by zero, resulting in infinite fragmentation density.
It seems the msvc std::poisson_distribution constructor doesn't like infinite values.

#### Describe the solution
Floor the range passed to shrapnel_calc() by the debug code at 1 so it can't divide by zero.

#### Describe alternatives you've considered
Remove the debug code I guess?

#### Testing
I can't reproduce locally, so see if this fixes the infinite loop in the MSVC build.

#### Additional context
REALLY MSVC? REALLY?
