### PR TITLE
Utility Tool Additions

### DIFF
--- a/data/json/itemgroups/activities_hobbies.json
+++ b/data/json/itemgroups/activities_hobbies.json
@@ -448,7 +448,9 @@
       { "group": "premium_contents", "prob": 3 },
       { "item": "ar_glasses_basic", "prob": 1, "charges-min": 0 },
       { "item": "ar_glasses_advanced", "prob": 1, "charges-min": 0 },
-      [ "light_snare_kit", 5 ]
+      [ "light_snare_kit", 5 ],
+      [ "camping_multitool", 5 ],
+      [ "utility_knife_folding", 5 ]
     ]
   },
   {

--- a/data/json/itemgroups/tools.json
+++ b/data/json/itemgroups/tools.json
@@ -263,7 +263,9 @@
       { "item": "esbit_stove", "prob": 15, "charges": [ 0, 50 ] },
       { "item": "teargas_sprayer", "prob": 15, "charges": 10 },
       { "group": "book_mag_surv", "prob": 10 },
-      { "group": "vfw_books", "prob": 20 }
+      { "group": "vfw_books", "prob": 20 },
+      [ "camping_multitool", 2 ],
+      [ "utility_knife_folding", 2 ]
     ]
   },
   {
@@ -682,7 +684,9 @@
       [ "lifestraw", 3 ],
       [ "light_snare_kit", 3 ],
       { "item": "propane_lantern", "prob": 15, "charges": [ 2000, 3000 ] },
-      { "item": "propane_cooker", "prob": 15, "charges": [ 2000, 3000 ] }
+      { "item": "propane_cooker", "prob": 15, "charges": [ 2000, 3000 ] },
+      [ "camping_multitool", 2 ],
+      [ "utility_knife_folding", 2 ]
     ]
   },
   {

--- a/data/json/items/melee/swords_and_blades.json
+++ b/data/json/items/melee/swords_and_blades.json
@@ -277,6 +277,26 @@
     "melee_damage": { "stab": 12 }
   },
   {
+    "id": "utility_knife_folding",
+    "type": "TOOL",
+    "name": { "str": "utility folding knife", "str_pl": "utility folding knives" },
+    "description": "A 'Hideman' brand folding knife, this model includes extra utility options such as a screwdriver, Awl, and small pry bar.",
+    "looks_like": "knife_folding",
+    "weight": "155 g",
+    "volume": "40 ml",
+    "longest_side": "10 cm",
+    "price": 2500,
+    "price_postapoc": 150,
+    "to_hit": { "grip": "weapon", "length": "hand", "surface": "point", "balance": "neutral" },
+    "material": [ "steel", "plastic" ],
+    "symbol": ";",
+    "color": "light_gray",
+    "qualities": [ [ "CUT", 2 ], [ "CUT_FINE", 1 ], [ "BUTCHER", 12 ], [ "SCREW", 1 ], [ "PRYING_NAIL", 1 ], [ "LEATHER_AWL", 2 ] ],
+    "flags": [ "BELT_CLIP", "ALLOWS_BODY_BLOCK", "CONDUCTIVE" ],
+    "weapon_category": [ "KNIVES" ],
+    "melee_damage": { "stab": 12 }
+  },
+  {
     "id": "knife_combat_marine",
     "type": "TOOL",
     "category": "weapons",

--- a/data/json/items/melee/swords_and_blades.json
+++ b/data/json/items/melee/swords_and_blades.json
@@ -280,7 +280,7 @@
     "id": "utility_knife_folding",
     "type": "TOOL",
     "name": { "str": "utility folding knife", "str_pl": "utility folding knives" },
-    "description": "A 'Hideman' brand folding knife, this model includes extra utility options such as a screwdriver, Awl, and small pry bar.",
+    "description": "A 'Hideman' brand folding knife, this model includes extra utility options such as a screwdriver, awl, and small pry bar.",
     "looks_like": "knife_folding",
     "weight": "155 g",
     "volume": "40 ml",

--- a/data/json/items/tool/workshop.json
+++ b/data/json/items/tool/workshop.json
@@ -789,6 +789,52 @@
     "weapon_category": [ "SHIVS" ]
   },
   {
+    "id": "camping_multitool",
+    "type": "TOOL",
+    "name": { "str": "camping multitool" },
+    "//": "The multitool is a bit more of a toolkit than a knife.",
+    "description": "A 'Hideman' brand multi-tool.  This model includes extra options for outdoors use such as a firestarting rod, awl, rescue whistle and a hammering surface.",
+    "looks_like": "multitool",
+    "weight": "212 g",
+    "volume": "70 ml",
+    "longest_side": "12 cm",
+    "price": 4000,
+    "price_postapoc": 700,
+    "to_hit": -4,
+    "material": [ "steel" ],
+    "symbol": ";",
+    "color": "light_gray",
+    "initial_charges": 2000,
+    "max_charges": 2000,
+    "charges_per_use": 1,
+    "use_action": [
+      {
+        "type": "manualnoise",
+        "moves": 100,
+        "noise": 28,
+        "noise_message": "FWEEEET!",
+        "noise_id": "misc",
+        "noise_variant": "whistle",
+        "use_message": "You blow the whistle.",
+        "//": "Moderatly lower than the proper whistle."
+      },
+      { "type": "firestarter", "moves": 1000, "moves_slow": 5000 }
+    ],
+    "qualities": [
+      [ "CUT", 2 ],
+      [ "SAW_W", 1 ],
+      [ "SAW_M", 1 ],
+      [ "WRENCH", 1 ],
+      [ "SCREW", 1 ],
+      [ "BUTCHER", 7 ],
+      [ "HAMMER", 1 ],
+      [ "LEATHER_AWL", 2 ]
+    ],
+    "flags": [ "SHEATH_KNIFE", "ALLOWS_BODY_BLOCK", "FIRESTARTER", "REQUIRES_TINDER" ],
+    "melee_damage": { "bash": 1, "stab": 4 },
+    "weapon_category": [ "SHIVS" ]
+  },
+  {
     "id": "oxy_torch",
     "type": "TOOL",
     "name": { "str": "acetylene torch", "str_pl": "acetylene torches" },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "New Utility Tools"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Multi-Tools and folding knives are a dime a dozen. But real life examples of specialized multi-tools for camping exist and should be made available in game.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Created a "Camping" Multitool and Utility folding knife.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Debug spawned items and confirmed their functions were working. Then teleported around and until I found an instance of the item spawned naturally.
![Utility Knife](https://github.com/CleverRaven/Cataclysm-DDA/assets/14862800/7ff855ad-b7d6-40ba-aa27-ff4620df4cc4)
![Camping multitool](https://github.com/CleverRaven/Cataclysm-DDA/assets/14862800/589ef582-43cd-49d8-8be0-fee1f7785a99)


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Real life references to "Deluxe" multitools:
https://www.leatherman.com/signal-832262.html
https://www.leatherman.com/free-k4x-591.html

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
