### PR TITLE
[Xedra Evolved] Fix blocky pistol recipe

### DIFF
--- a/data/mods/Xedra_Evolved/recipes/inventor/gun.json
+++ b/data/mods/Xedra_Evolved/recipes/inventor/gun.json
@@ -786,7 +786,7 @@
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
     "result": "inventor_pistol",
-    "qualities": [ { "id": "SAW_M_FINE", "level": 1 }, { "id": "SCREW", "level": 1 }, { "id": "SCREW_FINE", "level": 1 } ],
+    "qualities": [ { "id": "SAW_M_FINE", "level": 1 }, { "id": "WRENCH", "level": 1 }, { "id": "WRENCH_FINE", "level": 1 } ],
     "proficiencies": [
       { "proficiency": "prof_gunsmithing_improv", "time_multiplier": 3, "skill_penalty": 0, "learning_time_multiplier": 0.3 }
     ],


### PR DESCRIPTION


#### Summary
Mods "Change screw driving and fine screw driving qualities to bolt turning and fine bolt turning for XE's blocky pistol."


#### Purpose of change

I noticed that the blocky pistol recipe uses screw driving and fine screw driving tool qualities, which is wrong cuz there's nuts and bolts in the component list.

#### Describe the solution

Change screw driving and fine screw driving to bolt turning and fine bolt turning.

#### Describe alternatives you've considered

Suspend your disbelief of how the heck fastening a nut and bolt with screw driver works.
#### Testing

![Screenshot_2024-02-19_03-48-55_1](https://github.com/CleverRaven/Cataclysm-DDA/assets/78019001/17c38ad9-89ab-47fa-a90a-c211a230c2b0)


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
