### PR TITLE
NPCs can overeat, starve, and dehydrate to death

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -5324,7 +5324,7 @@ void Character::check_needs_extremes()
     }
 
     // check if we've starved
-    if( is_avatar() ) {
+    if( needs_food() ) {
         if( get_stored_kcal() <= 0 ) {
             add_msg_if_player( m_bad, _( "You have starved to death." ) );
             get_event_bus().send<event_type::dies_of_starvation>( getID() );
@@ -5363,7 +5363,7 @@ void Character::check_needs_extremes()
     }
 
     // Check if we're dying of thirst
-    if( is_avatar() && get_thirst() >= 600 && ( stomach.get_water() == 0_ml ||
+    if( needs_food() && get_thirst() >= 600 && ( stomach.get_water() == 0_ml ||
             guts.get_water() == 0_ml ) ) {
         if( get_thirst() >= 1200 ) {
             add_msg_if_player( m_bad, _( "You have died of dehydration." ) );

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -923,9 +923,7 @@ void Character::update_stomach( const time_point &from, const time_point &to )
     const needs_rates rates = calc_needs_rates();
     // No food/thirst/fatigue clock at all
     const bool debug_ls = has_trait( trait_DEBUG_LS );
-    // No food/thirst, capped fatigue clock (only up to tired)
-    const bool npc_no_food = !needs_food();
-    const bool foodless = debug_ls || npc_no_food;
+    const bool foodless = debug_ls || !needs_food();
     const bool no_thirst = has_flag( json_flag_NO_THIRST );
     const bool mycus = has_trait( trait_M_DEPENDENT );
     const float kcal_per_time = get_bmr() / ( 12.0f * 24.0f );
@@ -965,8 +963,8 @@ void Character::update_stomach( const time_point &from, const time_point &to )
             mod_stored_calories( -std::floor( five_mins * kcal_per_time * 1000 ) );
         }
     }
-    // if npc_no_food no need to calc hunger, and set hunger_effect
-    if( npc_no_food ) {
+    // if foodless no need to calc hunger, and set hunger_effect
+    if( foodless ) {
         return;
     }
     if( stomach.time_since_ate() > 10_minutes ) {


### PR DESCRIPTION
#### Summary
Bugfixes "NPCs can overeat, starve, and dehydrate to death"

#### Purpose of change
Only the player can ever starve to death, regardless of whether or not NPC needs are enabled.

#### Describe the solution
Let NPCs starve to death, too.

#### Describe alternatives you've considered

#### Testing
Debugged a NPC's stored kcal to -1, they died as soon as the function was called.

#### Additional context
Both the function name and the game boolean could do with a better name than "NO_NPC_FOOD" but it's what we've got and any effort to replace it is better spent paring down the places where it matters