### PR TITLE
Add more trash to rolling trash cans & nestify them

### DIFF
--- a/data/json/itemgroups/trash_and_debris.json
+++ b/data/json/itemgroups/trash_and_debris.json
@@ -383,5 +383,17 @@
       { "item": "splinter", "count": [ 1, 2 ] },
       { "item": "nail", "charges": [ 0, 2 ] }
     ]
+  },
+  {
+    "id": "rolling_trash",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "bag_garbage",
+    "on_overflow": "spill",
+    "items": [
+      { "group": "trash_domestic", "count": [ 0, 35 ] },
+      { "group": "trash_cart", "count": [ 0, 10 ] },
+      { "group": "trash", "count": [ 0, 15 ] }
+    ]
   }
 ]

--- a/data/json/mapgen/house/2storymodern01.json
+++ b/data/json/mapgen/house/2storymodern01.json
@@ -229,10 +229,8 @@
       "furniture": { "!": "f_region_flower_decorative", "$": "f_table" },
       "items": { "$": { "item": "table_foyer", "chance": 30 } },
       "place_loot": [ { "item": "television", "x": 11, "y": 10, "chance": 100 } ],
-      "place_vehicles": [
-        { "vehicle": "suv", "x": 3, "y": 18, "chance": 20, "status": 50, "rotation": 270 },
-        { "vehicle": "rolling_trash_can", "x": 5, "y": 3, "chance": 80, "status": 0 }
-      ],
+      "place_vehicles": [ { "vehicle": "suv", "x": 3, "y": 18, "chance": 20, "status": 50, "rotation": 270 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 5, "y": 3 } ],
       "rotation": [ 2 ]
     }
   },
@@ -290,10 +288,8 @@
       },
       "furniture": { "$": "f_table", ",": "f_chair" },
       "items": { "$": { "item": "table_foyer", "chance": 30 } },
-      "place_vehicles": [
-        { "vehicle": "bicycle", "x": 21, "y": 3, "chance": 30, "status": 100, "rotation": 180 },
-        { "vehicle": "rolling_trash_can", "x": 17, "y": 3, "chance": 80, "status": 0 }
-      ],
+      "place_vehicles": [ { "vehicle": "bicycle", "x": 21, "y": 3, "chance": 30, "status": 100, "rotation": 180 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 17, "y": 3 } ],
       "rotation": [ 2 ]
     }
   },
@@ -346,7 +342,7 @@
       },
       "furniture": { "$": "f_table", ",": "f_chair", "(": "f_piano", "[": "f_region_flower_decorative" },
       "items": { "$": { "item": "table_foyer", "chance": 30 } },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 17, "y": 3, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 17, "y": 3 } ],
       "rotation": [ 2 ]
     }
   },

--- a/data/json/mapgen/house/2storymodern02.json
+++ b/data/json/mapgen/house/2storymodern02.json
@@ -110,7 +110,7 @@
         "$": "t_floor_noroof"
       },
       "furniture": { "$": "f_table" },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 8, "y": 1, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 8, "y": 1 } ],
       "place_loot": [ { "item": "television", "x": 15, "y": 2 } ]
     }
   },

--- a/data/json/mapgen/house/2storymodern03.json
+++ b/data/json/mapgen/house/2storymodern03.json
@@ -102,7 +102,7 @@
         "G": "t_sidewalk"
       },
       "furniture": { "≠": "f_piano", "$": "f_stool", "&": "f_table" },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 17, "y": 4, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 17, "y": 4 } ],
       "items": { "&": { "item": "table_foyer", "chance": 50 } }
     }
   },

--- a/data/json/mapgen/house/2storymodern04.json
+++ b/data/json/mapgen/house/2storymodern04.json
@@ -114,9 +114,9 @@
       "items": { "֎": { "item": "liquor_and_spirits", "chance": 30 } },
       "place_vehicles": [
         { "vehicle": "suburban_home", "x": 12, "y": 7, "chance": 20, "status": 80, "rotation": 90 },
-        { "vehicle": "suv_electric", "x": 6, "y": 8, "chance": 20, "status": 80, "rotation": 90 },
-        { "vehicle": "rolling_trash_can", "x": 17, "y": 4, "chance": 80, "status": 0 }
-      ]
+        { "vehicle": "suv_electric", "x": 6, "y": 8, "chance": 20, "status": 80, "rotation": 90 }
+      ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 17, "y": 4 } ]
     }
   },
   {

--- a/data/json/mapgen/house/bungalow01.json
+++ b/data/json/mapgen/house/bungalow01.json
@@ -52,7 +52,7 @@
         "w": "t_null",
         "q": "t_floor_noroof"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 17, "y": 4, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 17, "y": 3 } ],
       "place_loot": [ { "item": "television", "x": 20, "y": 10 } ]
     }
   },

--- a/data/json/mapgen/house/bungalow02.json
+++ b/data/json/mapgen/house/bungalow02.json
@@ -63,10 +63,8 @@
       "furniture": { "$": "f_rack", "&": "f_treadmill", "?": "f_exercise", "/": "f_region_flower", "¤": "f_table" },
       "items": { "$": { "item": "clothing_outdoor_shoes", "chance": 50 }, "¤": { "item": "nightstand", "chance": 30 } },
       "place_loot": [ { "item": "television", "x": 13, "y": 19 } ],
-      "place_vehicles": [
-        { "vehicle": "car", "x": 5, "y": 6, "chance": 20, "rotation": 90 },
-        { "vehicle": "rolling_trash_can", "x": 17, "y": 0, "chance": 80, "status": 0 }
-      ]
+      "place_vehicles": [ { "vehicle": "car", "x": 5, "y": 6, "chance": 20, "rotation": 90 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 17, "y": 0 } ]
     }
   },
   {

--- a/data/json/mapgen/house/bungalow03.json
+++ b/data/json/mapgen/house/bungalow03.json
@@ -50,7 +50,7 @@
       },
       "furniture": { "$": "f_rack", "&": "f_table" },
       "items": { "$": { "item": "clothing_outdoor_shoes", "chance": 50 }, "&": { "item": "table_foyer", "chance": 50 } },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 3, "y": 1, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 3, "y": 1 } ],
       "place_loot": [ { "item": "laptop", "x": 5, "y": 21, "chance": 50 } ]
     }
   },

--- a/data/json/mapgen/house/bungalow04.json
+++ b/data/json/mapgen/house/bungalow04.json
@@ -64,7 +64,7 @@
       },
       "furniture": { "!": [ "f_indoor_plant", "f_indoor_plant_y" ], "$": "f_table", "&": "f_region_flower" },
       "items": { "$": { "item": "table_foyer", "chance": 50 }, "/": { "item": "hydro", "chance": 40 } },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 7, "y": 1, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 7, "y": 1 } ],
       "place_loot": [
         { "item": "television", "x": 6, "y": 9 },
         { "group": "tools_earthworking", "x": [ 18, 20 ], "y": [ 10, 10 ], "chance": 50, "repeat": [ 1, 2 ] }

--- a/data/json/mapgen/house/bungalow05.json
+++ b/data/json/mapgen/house/bungalow05.json
@@ -54,7 +54,7 @@
         "&": { "item": "clothing_outdoor_shoes", "chance": 40, "repeat": [ 1, 2 ] },
         "$": [ { "item": "sports", "chance": 30 }, { "item": "camping", "chance": 30 } ]
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 7, "y": 1, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 7, "y": 1 } ],
       "place_loot": [ { "item": "television", "x": 12, "y": 11 } ]
     }
   },

--- a/data/json/mapgen/house/bungalow06.json
+++ b/data/json/mapgen/house/bungalow06.json
@@ -53,7 +53,7 @@
       },
       "furniture": { "$": "f_exercise", "&": "f_table" },
       "items": { "&": { "item": "table_foyer", "chance": 50 } },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 5, "y": 1, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 5, "y": 1 } ],
       "place_loot": [ { "item": "television", "x": 6, "y": 17 } ]
     }
   },

--- a/data/json/mapgen/house/bungalow07.json
+++ b/data/json/mapgen/house/bungalow07.json
@@ -42,7 +42,7 @@
         "$": "t_carpet_green"
       },
       "furniture": { ")": "f_treadmill", "$": "f_chair" },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 9, "y": 1, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 9, "y": 1 } ],
       "place_loot": [ { "item": "television", "x": 19, "y": 7 } ]
     }
   },

--- a/data/json/mapgen/house/bungalow08.json
+++ b/data/json/mapgen/house/bungalow08.json
@@ -49,7 +49,7 @@
       },
       "furniture": { "(": "f_table", "$": "f_piano", "&": "f_chair", "=": "f_rack" },
       "items": { "(": { "item": "table_foyer", "chance": 50 }, "=": { "item": "clothing_outdoor_shoes", "chance": 50 } },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 4, "y": 1, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 4, "y": 1 } ],
       "place_loot": [ { "item": "laptop", "x": 14, "y": 6 } ]
     }
   },

--- a/data/json/mapgen/house/bungalow09.json
+++ b/data/json/mapgen/house/bungalow09.json
@@ -50,7 +50,7 @@
         "l": "t_carpet_yellow",
         "s": "t_carpet_yellow"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 9, "y": 0, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 9, "y": 0 } ],
       "place_loot": [ { "item": "laptop", "x": 17, "y": 5, "chance": 100 }, { "item": "television", "x": 9, "y": 7, "chance": 100 } ]
     }
   },

--- a/data/json/mapgen/house/bungalow10.json
+++ b/data/json/mapgen/house/bungalow10.json
@@ -47,7 +47,7 @@
         ")": "t_dirtmound"
       },
       "furniture": { "?": "f_locker", "$": "f_treadmill", "&": "f_chair" },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 7, "y": 1, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 7, "y": 1 } ],
       "items": { ")": { "item": "hydro", "chance": 35 }, "?": { "item": "tools_earthworking", "chance": 30 } },
       "place_loot": [ { "item": "television", "x": 6, "y": 16 } ]
     }

--- a/data/json/mapgen/house/bungalow11.json
+++ b/data/json/mapgen/house/bungalow11.json
@@ -56,7 +56,7 @@
         "/": { "item": "clothing_outdoor_shoes", "chance": 40, "repeat": [ 1, 2 ] },
         "&": { "item": "table_foyer", "chance": 40 }
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 7, "y": 1, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 7, "y": 1 } ],
       "place_loot": [
         { "item": "television", "x": 18, "y": 5 },
         { "group": "child_items", "x": [ 2, 6 ], "y": [ 7, 8 ], "chance": 60, "repeat": [ 3, 4 ] }

--- a/data/json/mapgen/house/bungalow12.json
+++ b/data/json/mapgen/house/bungalow12.json
@@ -66,7 +66,7 @@
         { "item": "television", "x": 19, "y": 17, "chance": 100 },
         { "item": "television", "x": 11, "y": 15, "chance": 100 }
       ],
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 17, "y": 0, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 17, "y": 0 } ],
       "vehicles": { ")": { "vehicle": "swivel_chair", "chance": 100, "status": 1 } }
     }
   },

--- a/data/json/mapgen/house/bungalow13.json
+++ b/data/json/mapgen/house/bungalow13.json
@@ -55,7 +55,7 @@
         "=": "f_counter",
         "/": "f_shredder"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 5, "y": 1, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 5, "y": 1 } ],
       "items": {
         "R": [
           { "item": "exotic_books", "chance": 10 },

--- a/data/json/mapgen/house/bungalow14.json
+++ b/data/json/mapgen/house/bungalow14.json
@@ -83,7 +83,7 @@
         "(": { "item": "table_foyer", "chance": 30 },
         "]": [ { "item": "SUS_wardrobe_mens", "chance": 50 }, { "item": "SUS_wardrobe_womens", "chance": 50 } ]
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 4, "y": 1, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 4, "y": 1 } ],
       "place_loot": [
         { "item": "television", "x": 5, "y": 17, "chance": 100 },
         { "item": "television", "x": 19, "y": 8, "chance": 100 },

--- a/data/json/mapgen/house/bungalow15.json
+++ b/data/json/mapgen/house/bungalow15.json
@@ -63,10 +63,8 @@
         "$": { "item": "clothing_outdoor_shoes", "chance": 100, "repeat": [ 1, 3 ] }
       },
       "place_loot": [ { "item": "lawnmower", "x": 3, "y": 21, "chance": 25 }, { "item": "television", "x": 10, "y": 9, "chance": 100 } ],
-      "place_vehicles": [
-        { "vehicle": "car", "x": 3, "y": 4, "chance": 30, "fuel": 80, "rotation": 90 },
-        { "vehicle": "rolling_trash_can", "x": 17, "y": 1, "chance": 80, "status": 0 }
-      ]
+      "place_vehicles": [ { "vehicle": "car", "x": 3, "y": 4, "chance": 30, "fuel": 80, "rotation": 90 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 17, "y": 1 } ]
     }
   },
   {

--- a/data/json/mapgen/house/bungalow16.json
+++ b/data/json/mapgen/house/bungalow16.json
@@ -82,7 +82,7 @@
         "c": { "item": "guns_pistol_common", "chance": 50 },
         "(": { "item": "table_foyer", "chance": 50, "repeat": [ 1, 2 ] }
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 5, "y": 1, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 5, "y": 1 } ],
       "place_loot": [ { "item": "television", "x": 4, "y": 6, "chance": 100 } ]
     }
   },

--- a/data/json/mapgen/house/bungalow17.json
+++ b/data/json/mapgen/house/bungalow17.json
@@ -46,7 +46,7 @@
         "&": "t_region_groundcover_urban",
         "Q": "t_floor_waxed"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 5, "y": 0, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 5, "y": 0 } ],
       "furniture": { "&": "f_boulder_large", "/": [ [ "f_null", 4 ], "f_ladder" ] }
     }
   },

--- a/data/json/mapgen/house/bungalow18.json
+++ b/data/json/mapgen/house/bungalow18.json
@@ -37,10 +37,8 @@
       "furniture": { "&": "f_bookcase", "?": "f_rack" },
       "items": { "?": { "item": "clothing_outdoor_shoes", "chance": 50, "repeat": [ 1, 3 ] } },
       "place_loot": [ { "item": "television", "x": [ 4, 5 ], "y": 18 }, { "group": "SUS_cooking_bookcase", "x": 17, "y": 18 } ],
-      "place_vehicles": [
-        { "vehicle": "car", "x": 18, "y": 2, "chance": 15, "rotation": 270 },
-        { "vehicle": "rolling_trash_can", "x": 5, "y": 1, "chance": 80, "status": 0 }
-      ]
+      "place_vehicles": [ { "vehicle": "car", "x": 18, "y": 2, "chance": 15, "rotation": 270 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 5, "y": 1 } ]
     }
   },
   {

--- a/data/json/mapgen/house/bungalow19.json
+++ b/data/json/mapgen/house/bungalow19.json
@@ -68,7 +68,7 @@
         "?": [ "f_indoor_plant", "f_indoor_plant_y" ],
         "/": "f_rack"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 4, "y": 0, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 4, "y": 0 } ],
       "items": {
         "$": { "item": "table_foyer", "chance": 50, "repeat": [ 2, 3 ] },
         "/": { "item": "clothing_outdoor_shoes", "chance": 50, "repeat": [ 2, 3 ] }

--- a/data/json/mapgen/house/bungalow20.json
+++ b/data/json/mapgen/house/bungalow20.json
@@ -50,7 +50,7 @@
         "=": "t_carpet_red",
         "L": "t_carpet_red"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 5, "y": 1, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 5, "y": 1 } ],
       "furniture": { "£": "f_exercise", "$": "f_treadmill", "?": "f_bookcase" },
       "place_loot": [ { "item": "television", "x": 10, "y": 3 }, { "group": "SUS_cooking_bookcase", "x": 16, "y": 8 } ]
     }

--- a/data/json/mapgen/house/bungalow21.json
+++ b/data/json/mapgen/house/bungalow21.json
@@ -55,10 +55,8 @@
         { "item": "backpack", "x": 7, "y": 5, "chance": 60 },
         { "item": "talking_doll", "x": 5, "y": 8, "chance": 60 }
       ],
-      "place_vehicles": [
-        { "vehicle": "car", "x": 19, "y": 7, "chance": 30, "rotation": 90 },
-        { "vehicle": "rolling_trash_can", "x": 8, "y": 1, "chance": 80, "status": 0 }
-      ]
+      "place_vehicles": [ { "vehicle": "car", "x": 19, "y": 7, "chance": 30, "rotation": 90 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 8, "y": 1 } ]
     }
   },
   {

--- a/data/json/mapgen/house/bungalow22.json
+++ b/data/json/mapgen/house/bungalow22.json
@@ -63,7 +63,7 @@
         "(": { "item": "clothing_outdoor_shoes", "chance": 50, "repeat": [ 1, 2 ] },
         "?": { "item": "table_foyer", "chance": 60 }
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 9, "y": 0, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 9, "y": 0 } ],
       "vehicles": { "&": { "vehicle": "swivel_chair", "chance": 100, "status": 1 } },
       "place_loot": [
         { "item": "2x4", "x": 5, "y": 10, "chance": 80, "repeat": [ 2, 3 ] },

--- a/data/json/mapgen/house/crack_house.json
+++ b/data/json/mapgen/house/crack_house.json
@@ -58,7 +58,7 @@
         "_": "t_region_soil",
         ";": "t_chainfence_posts"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 5, "y": 1, "chance": 50, "status": -1 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 5, "y": 1 } ],
       "furniture": { "&": "f_wreckage", "=": "f_toilet", "{": "f_dumpster", "?": "f_beaded_door", "!": "f_region_flower" },
       "place_items": [
         { "chance": 35, "item": "harddrugs", "x": 9, "y": 6 },

--- a/data/json/mapgen/house/garden_house_1.json
+++ b/data/json/mapgen/house/garden_house_1.json
@@ -72,7 +72,7 @@
         "7": "f_cupboard",
         "8": "f_counter"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 10, "y": 1, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 10, "y": 1 } ],
       "items": {
         "c": { "item": "kitchen_counters", "chance": 10 },
         "1": [ { "item": "SUS_dishes", "chance": 100 }, { "item": "SUS_silverware", "chance": 100 } ],

--- a/data/json/mapgen/house/house01.json
+++ b/data/json/mapgen/house/house01.json
@@ -43,7 +43,6 @@
         "A": "t_thconc_floor",
         "~": "t_thconc_floor"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 12, "y": 0, "chance": 80, "status": 0 } ],
       "place_loot": [ { "item": "television", "x": 11, "y": 9 }, { "item": "stereo", "x": 10, "y": 9 } ],
       "place_nested": [
         {
@@ -62,7 +61,8 @@
           ],
           "x": [ 4, 13 ],
           "y": 17
-        }
+        },
+        { "chunks": [ "rolling_trash_can_1x1" ], "x": 12, "y": 0 }
       ]
     }
   },

--- a/data/json/mapgen/house/house02.json
+++ b/data/json/mapgen/house/house02.json
@@ -42,14 +42,14 @@
         "K": "t_thconc_floor",
         "~": "t_thconc_floor"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 7, "y": 1, "chance": 80, "status": 0 } ],
       "place_loot": [ { "item": "television", "x": 3, "y": 18 }, { "item": "stereo", "x": 3, "y": 19 } ],
       "place_nested": [
         {
           "chunks": [ [ "playset_4x4_2", 25 ], [ "firepit_5x5_1", 25 ], [ "firepit_5x5_2", 25 ], [ "playset_4x4_1", 25 ] ],
           "x": 17,
           "y": 18
-        }
+        },
+        { "chunks": [ "rolling_trash_can_1x1" ], "x": 7, "y": 1 }
       ]
     }
   },

--- a/data/json/mapgen/house/house03.json
+++ b/data/json/mapgen/house/house03.json
@@ -35,14 +35,14 @@
       ],
       "palettes": [ "domestic_general_and_variant_palette", "standard_domestic_lino_bathroom", "standard_domestic_landscaping_palette" ],
       "terrain": { "G": "t_concrete", "-": "t_linoleum_gray", "k": "t_thconc_floor", "~": "t_thconc_floor" },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 3, "y": 1, "chance": 80, "status": 0 } ],
       "place_items": [ { "item": "stash_wood", "x": 12, "y": 11, "chance": 100, "repeat": [ 2, 6 ] } ],
       "place_nested": [
         {
           "chunks": [ [ "null", 25 ], [ "playset_4x4_2", 25 ], [ "firepit_5x5_1", 25 ], [ "firepit_5x5_2", 25 ], [ "playset_4x4_1", 25 ] ],
           "x": 3,
           "y": 19
-        }
+        },
+        { "chunks": [ "rolling_trash_can_1x1" ], "x": 3, "y": 1 }
       ]
     }
   },

--- a/data/json/mapgen/house/house04.json
+++ b/data/json/mapgen/house/house04.json
@@ -39,7 +39,7 @@
         { "point": "terrain", "id": "t_tree_young", "x": [ 0, 14 ], "y": 0, "chance": 5 },
         { "point": "terrain", "id": "t_tree_apple", "x": [ 0, 14 ], "y": 0, "chance": 10, "repeat": [ 1, 2 ] }
       ],
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 0, "y": 1, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 0, "y": 1 } ],
       "place_loot": [
         { "group": "cleaning", "x": 13, "y": 6, "chance": 90, "repeat": [ 1, 2 ] },
         { "group": "guns_pistol_common", "x": 2, "y": 13, "chance": 5, "ammo": 90, "magazine": 100 },

--- a/data/json/mapgen/house/house05.json
+++ b/data/json/mapgen/house/house05.json
@@ -79,7 +79,7 @@
         "...........^............"
       ],
       "palettes": [ "domestic_general_and_variant_palette" ],
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 5, "y": 0, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 5, "y": 0 } ],
       "place_loot": [
         { "group": "guns_pistol_common", "x": 2, "y": 13, "chance": 5, "ammo": 90, "magazine": 100 },
         { "item": "television", "x": 2, "y": 3, "chance": 85 },

--- a/data/json/mapgen/house/house06.json
+++ b/data/json/mapgen/house/house06.json
@@ -34,7 +34,7 @@
       ],
       "palettes": [ "domestic_general_and_variant_palette", "standard_domestic_landscaping_palette" ],
       "set": [ { "point": "terrain", "id": "t_tree_apple", "x": [ 0, 14 ], "y": [ 0, 0 ], "chance": 40, "repeat": [ 1, 2 ] } ],
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 5, "y": 0, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 5, "y": 0 } ],
       "place_loot": [
         { "group": "livingroom", "x": [ 1, 10 ], "y": [ 8, 13 ], "chance": 90, "repeat": [ 1, 5 ] },
         { "group": "consumer_electronics", "x": [ 1, 6 ], "y": [ 15, 21 ], "chance": 50, "repeat": [ 1, 3 ] },

--- a/data/json/mapgen/house/house07.json
+++ b/data/json/mapgen/house/house07.json
@@ -34,7 +34,7 @@
       ],
       "palettes": [ "domestic_general_and_variant_palette", "standard_domestic_landscaping_palette" ],
       "set": [ { "point": "terrain", "id": "t_tree_apple", "x": [ 0, 14 ], "y": [ 0, 0 ], "chance": 40, "repeat": [ 1, 2 ] } ],
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 2, "y": 0, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 2, "y": 0 } ],
       "place_loot": [ { "group": "livingroom", "x": [ 1, 10 ], "y": [ 1, 13 ], "chance": 90, "repeat": [ 1, 5 ] } ],
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "chance": 2 } ]
     }

--- a/data/json/mapgen/house/house08.json
+++ b/data/json/mapgen/house/house08.json
@@ -39,7 +39,6 @@
         { "point": "terrain", "id": "t_tree", "x": [ 2, 11 ], "y": [ 16, 21 ], "repeat": [ 2, 6 ] },
         { "point": "terrain", "id": "t_tree_young", "x": [ 2, 11 ], "y": [ 16, 21 ], "repeat": [ 3, 5 ] }
       ],
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 5, "y": 0, "chance": 80, "status": 0 } ],
       "place_loot": [ { "group": "guns_pistol_common", "x": 4, "y": 10, "chance": 10, "ammo": 90, "magazine": 100 } ],
       "place_nested": [
         {
@@ -56,7 +55,8 @@
           ],
           "x": 15,
           "y": 15
-        }
+        },
+        { "chunks": [ "rolling_trash_can_1x1" ], "x": 5, "y": 0 }
       ],
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "chance": 2 } ]
     }

--- a/data/json/mapgen/house/house09.json
+++ b/data/json/mapgen/house/house09.json
@@ -34,7 +34,7 @@
         "...................^...."
       ],
       "palettes": [ "domestic_general_and_variant_palette", "standard_domestic_landscaping_palette" ],
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 12, "y": 1, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 17, "y": 0 } ],
       "place_monsters": [
         { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "chance": 2 },
         { "monster": "GROUP_PLAGUE_ROACH", "x": [ 2, 21 ], "y": [ 2, 21 ], "chance": 6 },

--- a/data/json/mapgen/house/house10.json
+++ b/data/json/mapgen/house/house10.json
@@ -37,7 +37,7 @@
         { "group": "guns_pistol_common", "x": [ 20, 20 ], "y": [ 8, 8 ], "chance": 4, "ammo": 90, "magazine": 100 },
         { "group": "guns_pistol_common", "x": [ 18, 18 ], "y": [ 20, 20 ], "chance": 3, "ammo": 90, "magazine": 100 }
       ],
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 5, "y": 1, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 5, "y": 1 } ],
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "chance": 2 } ]
     }
   },

--- a/data/json/mapgen/house/house11.json
+++ b/data/json/mapgen/house/house11.json
@@ -46,10 +46,8 @@
         { "group": "guns_pistol_common", "x": [ 3, 3 ], "y": [ 8, 8 ], "chance": 5, "ammo": 90, "magazine": 100 }
       ],
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "chance": 2 } ],
-      "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 5, "y": 1, "chance": 80, "status": 0 },
-        { "vehicle": "suburban_home", "x": 17, "y": 10, "chance": 15, "rotation": 270 }
-      ]
+      "place_vehicles": [ { "vehicle": "suburban_home", "x": 17, "y": 10, "chance": 15, "rotation": 270 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 5, "y": 1 } ]
     }
   },
   {

--- a/data/json/mapgen/house/house12.json
+++ b/data/json/mapgen/house/house12.json
@@ -33,7 +33,7 @@
         "........................"
       ],
       "palettes": [ "domestic_general_and_variant_palette", "standard_domestic_landscaping_palette" ],
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 5, "y": 1, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 5, "y": 1 } ],
       "place_loot": [ { "group": "livingroom", "x": [ 3, 7 ], "y": [ 13, 19 ], "chance": 90, "repeat": [ 1, 4 ] } ],
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "chance": 10 } ]
     }

--- a/data/json/mapgen/house/house13.json
+++ b/data/json/mapgen/house/house13.json
@@ -35,7 +35,7 @@
       "palettes": [ "domestic_general_and_variant_palette", "standard_domestic_landscaping_palette" ],
       "terrain": { "G": "t_concrete", "K": "t_concrete", "j": "t_concrete" },
       "place_loot": [ { "group": "livingroom", "x": [ 2, 8 ], "y": [ 10, 14 ], "chance": 90, "repeat": [ 1, 6 ] } ],
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 12, "y": 1, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 12, "y": 1 } ],
       "place_monsters": [
         { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "chance": 5 },
         { "monster": "GROUP_PLAGUE_ROACH", "x": [ 2, 21 ], "y": [ 2, 21 ], "chance": 5 },

--- a/data/json/mapgen/house/house14.json
+++ b/data/json/mapgen/house/house14.json
@@ -42,10 +42,8 @@
         "A": "t_thconc_floor"
       },
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "chance": 10 } ],
-      "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 12, "y": 1, "chance": 80, "status": 0 },
-        { "vehicle": "suburban_home", "x": 5, "y": 9, "chance": 10, "fuel": 30, "status": 0, "rotation": 90 }
-      ]
+      "place_vehicles": [ { "vehicle": "suburban_home", "x": 5, "y": 9, "chance": 10, "fuel": 30, "status": 0, "rotation": 90 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 12, "y": 1 } ]
     }
   },
   {

--- a/data/json/mapgen/house/house15.json
+++ b/data/json/mapgen/house/house15.json
@@ -36,7 +36,7 @@
       "terrain": { "%": "t_region_shrub_fruit" },
       "furniture": { "!": "f_bluebell", "$": [ "f_treadmill", "f_treadmill_mechanical" ] },
       "place_loot": [ { "group": "livingroom", "x": [ 7, 16 ], "y": [ 7, 9 ], "chance": 90, "repeat": [ 1, 6 ] } ],
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 5, "y": 0, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 5, "y": 0 } ],
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 1, 22 ], "y": [ 2, 21 ], "chance": 5 } ]
     }
   },

--- a/data/json/mapgen/house/house16.json
+++ b/data/json/mapgen/house/house16.json
@@ -33,7 +33,7 @@
         "........................"
       ],
       "palettes": [ "domestic_general_and_variant_palette", "standard_domestic_landscaping_palette" ],
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 8, "y": 1, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 8, "y": 1 } ],
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "chance": 5 } ]
     }
   },

--- a/data/json/mapgen/house/house17.json
+++ b/data/json/mapgen/house/house17.json
@@ -33,7 +33,7 @@
         "........................"
       ],
       "palettes": [ "domestic_general_and_variant_palette", "standard_domestic_landscaping_palette" ],
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 7, "y": 1, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 7, "y": 1 } ],
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "chance": 6 } ]
     }
   },

--- a/data/json/mapgen/house/house18.json
+++ b/data/json/mapgen/house/house18.json
@@ -35,7 +35,7 @@
       "palettes": [ "domestic_general_and_variant_palette", "standard_domestic_lino_bathroom" ],
       "terrain": { "p": "t_sidewalk", "X": "t_sidewalk", "~": "t_linoleum_gray" },
       "place_loot": [ { "item": "television", "x": 4, "y": 2, "chance": 70 }, { "item": "television", "x": 15, "y": 7, "chance": 70 } ],
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 5, "y": 0, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 5, "y": 0 } ],
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "chance": 8 } ]
     }
   },

--- a/data/json/mapgen/house/house19.json
+++ b/data/json/mapgen/house/house19.json
@@ -39,7 +39,7 @@
         { "group": "guns_pistol_common", "x": [ 15, 15 ], "y": [ 7, 8 ], "chance": 5, "ammo": 95, "magazine": 100 },
         { "item": "television", "x": [ 4, 4 ], "y": [ 16, 17 ], "chance": 75 }
       ],
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 5, "y": 2, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 5, "y": 2 } ],
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "chance": 6 } ]
     }
   },

--- a/data/json/mapgen/house/house20.json
+++ b/data/json/mapgen/house/house20.json
@@ -44,7 +44,7 @@
         "N": "t_thconc_floor",
         "~": "t_thconc_floor"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 2, "y": 1, "chance": 80, "status": 0 } ]
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 2, "y": 1 } ]
     }
   },
   {

--- a/data/json/mapgen/house/house21.json
+++ b/data/json/mapgen/house/house21.json
@@ -34,13 +34,13 @@
       "palettes": [ "domestic_general_and_variant_palette", "standard_domestic_lino_bathroom", "standard_domestic_landscaping_palette" ],
       "terrain": { "j": "t_concrete", "'": "t_linoleum_gray" },
       "place_item": [ { "item": "stereo", "x": 4, "y": 11, "chance": 100 } ],
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 5, "y": 1, "chance": 80, "status": 0 } ],
       "place_nested": [
         {
           "chunks": [ [ "null", 25 ], [ "playset_4x4_2", 25 ], [ "firepit_5x5_1", 25 ], [ "firepit_5x5_2", 25 ], [ "playset_4x4_1", 25 ] ],
           "x": [ 12, 15 ],
           "y": 19
-        }
+        },
+        { "chunks": [ "rolling_trash_can_1x1" ], "x": 5, "y": 1 }
       ]
     }
   },

--- a/data/json/mapgen/house/house22.json
+++ b/data/json/mapgen/house/house22.json
@@ -81,7 +81,7 @@
       ],
       "palettes": [ "domestic_general_and_variant_palette", "standard_domestic_landscaping_palette", "standard_domestic_lino_bathroom" ],
       "terrain": { "-": "t_linoleum_gray", "b": "t_linoleum_gray" },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 5, "y": 1, "chance": 80, "status": 0 } ]
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 5, "y": 1 } ]
     }
   },
   {

--- a/data/json/mapgen/house/house23.json
+++ b/data/json/mapgen/house/house23.json
@@ -33,7 +33,6 @@
       ],
       "palettes": [ "domestic_general_and_variant_palette", "standard_domestic_lino_bathroom", "standard_domestic_landscaping_palette" ],
       "terrain": { "'": "t_linoleum_gray", "$": "t_screened_porch_wall", "=": "t_screen_door_c" },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 5, "y": 1, "chance": 80, "status": 0 } ],
       "place_item": [ { "item": "stereo", "x": 4, "y": 10, "chance": 100 }, { "item": "television", "x": 5, "y": 10, "chance": 100 } ],
       "place_nested": [
         {
@@ -52,7 +51,8 @@
           ],
           "x": 1,
           "y": 17
-        }
+        },
+        { "chunks": [ "rolling_trash_can_1x1" ], "x": 5, "y": 1 }
       ]
     }
   },

--- a/data/json/mapgen/house/house24.json
+++ b/data/json/mapgen/house/house24.json
@@ -43,7 +43,7 @@
         "A": "t_thconc_floor",
         "~": "t_thconc_floor"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 2, "y": 1, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 2, "y": 1 } ],
       "place_item": [ { "item": "stereo", "x": 15, "y": 20, "chance": 100 }, { "item": "television", "x": 10, "y": 15, "chance": 100 } ]
     }
   },

--- a/data/json/mapgen/house/house25.json
+++ b/data/json/mapgen/house/house25.json
@@ -34,7 +34,7 @@
       ],
       "palettes": [ "domestic_general_and_variant_palette", "standard_domestic_landscaping_palette" ],
       "terrain": { "~": "t_carpet_yellow", ",": "t_thconc_floor" },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 12, "y": 1, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 12, "y": 1 } ],
       "furniture": { "%": "f_safe_o" },
       "place_items": [
         { "chance": 10, "item": "ammo_rifle_common", "x": 9, "y": 17 },

--- a/data/json/mapgen/house/house26.json
+++ b/data/json/mapgen/house/house26.json
@@ -35,7 +35,7 @@
       ],
       "palettes": [ "domestic_general_and_variant_palette", "standard_domestic_landscaping_palette", "standard_domestic_lino_bathroom" ],
       "terrain": { "-": "t_linoleum_gray" },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 12, "y": 0, "chance": 80, "status": 0 } ]
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 12, "y": 0 } ]
     }
   },
   {

--- a/data/json/mapgen/house/house27.json
+++ b/data/json/mapgen/house/house27.json
@@ -35,7 +35,7 @@
       ],
       "palettes": [ "domestic_general_and_variant_palette", "standard_domestic_landscaping_palette", "standard_domestic_lino_bathroom" ],
       "terrain": { "-": "t_linoleum_gray" },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 7, "y": 1, "chance": 80, "status": 0 } ]
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 7, "y": 1 } ]
     }
   },
   {

--- a/data/json/mapgen/house/house28.json
+++ b/data/json/mapgen/house/house28.json
@@ -35,7 +35,7 @@
       ],
       "palettes": [ "domestic_general_and_variant_palette", "standard_domestic_landscaping_palette", "standard_domestic_lino_bathroom" ],
       "terrain": { "-": "t_linoleum_gray" },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 15, "y": 1, "chance": 80, "status": 0 } ]
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 15, "y": 1 } ]
     }
   },
   {

--- a/data/json/mapgen/house/house29.json
+++ b/data/json/mapgen/house/house29.json
@@ -35,7 +35,7 @@
       ],
       "palettes": [ "domestic_general_and_variant_palette", "standard_domestic_landscaping_palette", "standard_domestic_lino_bathroom" ],
       "terrain": { "-": "t_linoleum_gray" },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 8, "y": 1, "chance": 80, "status": 0 } ]
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 8, "y": 1 } ]
     }
   },
   {

--- a/data/json/mapgen/house/house30.json
+++ b/data/json/mapgen/house/house30.json
@@ -35,7 +35,7 @@
       ],
       "palettes": [ "domestic_general_and_variant_palette", "standard_domestic_landscaping_palette", "standard_domestic_lino_bathroom" ],
       "terrain": { "-": "t_linoleum_gray" },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 6, "y": 1, "chance": 80, "status": 0 } ]
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 6, "y": 1 } ]
     }
   },
   {

--- a/data/json/mapgen/house/house31.json
+++ b/data/json/mapgen/house/house31.json
@@ -43,7 +43,7 @@
         "N": "t_thconc_floor",
         "~": "t_thconc_floor"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 10, "y": 1, "chance": 80, "status": 0 } ]
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 11, "y": 1 } ]
     }
   },
   {

--- a/data/json/mapgen/house/house32.json
+++ b/data/json/mapgen/house/house32.json
@@ -42,7 +42,7 @@
         "N": "t_thconc_floor",
         "~": "t_thconc_floor"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 16, "y": 1, "chance": 80, "status": 0 } ]
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 16, "y": 1 } ]
     }
   },
   {

--- a/data/json/mapgen/house/house33.json
+++ b/data/json/mapgen/house/house33.json
@@ -56,9 +56,9 @@
       ],
       "place_vehicles": [
         { "vehicle": "car", "x": 4, "y": 4, "chance": 35, "rotation": 270 },
-        { "vehicle": "tricycle", "x": 6, "y": 22, "chance": 40, "status": 0 },
-        { "vehicle": "rolling_trash_can", "x": 22, "y": 1, "chance": 80, "status": 0 }
-      ]
+        { "vehicle": "tricycle", "x": 6, "y": 22, "chance": 40, "status": 0 }
+      ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 22, "y": 1 } ]
     }
   },
   {

--- a/data/json/mapgen/house/house34.json
+++ b/data/json/mapgen/house/house34.json
@@ -51,7 +51,7 @@
         "h": "t_linoleum_gray",
         "f": "t_linoleum_gray"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 5, "y": 1, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 4, "y": 1 } ],
       "place_loot": [
         { "item": "hose", "x": 10, "y": 1 },
         { "item": "television", "x": 16, "y": 3 },

--- a/data/json/mapgen/house/house35.json
+++ b/data/json/mapgen/house/house35.json
@@ -49,7 +49,7 @@
         "q": "t_thconc_floor",
         "'": "t_linoleum_gray"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 5, "y": 0, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 5, "y": 0 } ],
       "place_loot": [
         { "item": "hose", "x": 9, "y": 22 },
         { "item": "television", "x": 16, "y": 14 },

--- a/data/json/mapgen/house/house36.json
+++ b/data/json/mapgen/house/house36.json
@@ -56,9 +56,9 @@
       ],
       "place_vehicles": [
         { "vehicle": "car", "x": 3, "y": 14, "chance": 60, "rotation": 270 },
-        { "vehicle": "rolling_trash_can", "x": 11, "y": 1, "chance": 80, "status": 0 },
         { "vehicle": "tricycle", "x": 4, "y": 7, "chance": 40, "status": 0 }
-      ]
+      ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 11, "y": 1 } ]
     }
   },
   {

--- a/data/json/mapgen/house/house37.json
+++ b/data/json/mapgen/house/house37.json
@@ -56,10 +56,8 @@
         { "item": "television", "x": 12, "y": 18 },
         { "item": "stereo", "x": 13, "y": 18, "chance": 35 }
       ],
-      "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 11, "y": 0, "chance": 80, "status": 0 },
-        { "vehicle": "car", "x": 4, "y": 4, "chance": 35, "rotation": 270 }
-      ]
+      "place_vehicles": [ { "vehicle": "car", "x": 4, "y": 4, "chance": 35, "rotation": 270 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 11, "y": 0 } ]
     }
   },
   {

--- a/data/json/mapgen/house/house38.json
+++ b/data/json/mapgen/house/house38.json
@@ -57,10 +57,8 @@
         { "item": "television", "x": 14, "y": 16 },
         { "item": "stereo", "x": 14, "y": 18, "chance": 35 }
       ],
-      "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 5, "y": 0, "chance": 80, "status": 0 },
-        { "vehicle": "car", "x": 18, "y": 6, "chance": 35, "rotation": 270 }
-      ]
+      "place_vehicles": [ { "vehicle": "car", "x": 18, "y": 6, "chance": 35, "rotation": 270 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 5, "y": 0 } ]
     }
   },
   {

--- a/data/json/mapgen/house/house39.json
+++ b/data/json/mapgen/house/house39.json
@@ -53,10 +53,8 @@
         ";": "t_screen_door_c"
       },
       "place_loot": [ { "item": "hose", "x": 19, "y": 18, "chance": 35 } ],
-      "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 1, "y": 0, "chance": 80, "status": 0 },
-        { "vehicle": "car", "x": 4, "y": 6, "chance": 35, "rotation": 270 }
-      ]
+      "place_vehicles": [ { "vehicle": "car", "x": 4, "y": 6, "chance": 35, "rotation": 270 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 1, "y": 0 } ]
     }
   },
   {

--- a/data/json/mapgen/house/house40.json
+++ b/data/json/mapgen/house/house40.json
@@ -45,7 +45,7 @@
         "Z": "t_linoleum_gray",
         "W": "t_linoleum_gray"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 5, "y": 1, "chance": 80, "status": 0 } ]
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 5, "y": 1 } ]
     }
   },
   {

--- a/data/json/mapgen/house/house41.json
+++ b/data/json/mapgen/house/house41.json
@@ -48,10 +48,10 @@
       "furniture": { "!": "f_region_flower" },
       "place_loot": [ { "item": "television", "x": 10, "y": 9 }, { "item": "television", "x": 18, "y": 12 } ],
       "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 3, "y": 1, "chance": 80, "status": 0 },
         { "vehicle": "car", "x": 8, "y": 3, "chance": 35, "rotation": 270 },
         { "vehicle": "motorcycle_sidecart", "x": 14, "y": 2, "chance": 35, "rotation": 270 }
-      ]
+      ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 3, "y": 1 } ]
     }
   },
   {

--- a/data/json/mapgen/house/house42.json
+++ b/data/json/mapgen/house/house42.json
@@ -54,10 +54,8 @@
         { "item": "television", "x": 16, "y": 5, "chance": 35 },
         { "item": "stereo", "x": 16, "y": 6, "chance": 35 }
       ],
-      "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 5, "y": 1, "chance": 80, "status": 0 },
-        { "vehicle": "tricycle", "x": 13, "y": 14, "chance": 35, "rotation": 270 }
-      ]
+      "place_vehicles": [ { "vehicle": "tricycle", "x": 13, "y": 14, "chance": 35, "rotation": 270 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 5, "y": 1 } ]
     }
   },
   {

--- a/data/json/mapgen/house/house_2story.json
+++ b/data/json/mapgen/house/house_2story.json
@@ -48,7 +48,7 @@
         "]": "t_wall_glass",
         ")": "t_door_glass_c"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 12, "y": 1, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 12, "y": 1 } ],
       "furniture": { "!": "f_region_flower" },
       "place_loot": [ { "item": "stereo", "x": 12, "y": 19 } ]
     }

--- a/data/json/mapgen/house/house_detatched1.json
+++ b/data/json/mapgen/house/house_detatched1.json
@@ -80,10 +80,8 @@
         { "chance": 35, "item": "alcohol", "x": 10, "y": 13 }
       ],
       "place_monsters": [ { "chance": 5, "density": 1, "monster": "GROUP_ZOMBIE", "x": 7, "y": 10 } ],
-      "place_vehicles": [
-        { "vehicle": "bikeshop", "x": 19, "y": 14, "rotation": 270, "chance": 20 },
-        { "vehicle": "rolling_trash_can", "x": 15, "y": 0, "chance": 80, "status": 0 }
-      ]
+      "place_vehicles": [ { "vehicle": "bikeshop", "x": 19, "y": 14, "rotation": 270, "chance": 20 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 15, "y": 0 } ]
     }
   },
   {

--- a/data/json/mapgen/house/house_detatched10.json
+++ b/data/json/mapgen/house/house_detatched10.json
@@ -48,7 +48,7 @@
         "/": "t_door_boarded_damaged",
         "=": "t_window_boarded_noglass"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 7, "y": 1, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 7, "y": 1 } ],
       "furniture": { "?": "f_beaded_door", "!": "f_region_flower" },
       "place_item": [
         { "item": "splinter", "repeat": 1, "x": 2, "y": 4 },

--- a/data/json/mapgen/house/house_detatched2.json
+++ b/data/json/mapgen/house/house_detatched2.json
@@ -33,10 +33,8 @@
         "$$$$$$$$$$$$$$$$$$$$$$$$"
       ],
       "palettes": [ "domestic_general_and_variant_palette" ],
-      "place_vehicles": [
-        { "vehicle": "bikeshop", "x": 3, "y": 16, "rotation": 270, "chance": 100 },
-        { "vehicle": "rolling_trash_can", "x": 12, "y": 1, "chance": 80, "status": 0 }
-      ],
+      "place_vehicles": [ { "vehicle": "bikeshop", "x": 3, "y": 16, "rotation": 270, "chance": 100 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 12, "y": 1 } ],
       "terrain": {
         "%": [ "t_region_shrub", "t_region_shrub_fruit", "t_region_shrub_decorative" ],
         "[": [ [ "t_region_tree_fruit", 2 ], [ "t_region_tree_nut", 2 ], "t_region_tree_shade" ],

--- a/data/json/mapgen/house/house_detatched3.json
+++ b/data/json/mapgen/house/house_detatched3.json
@@ -54,7 +54,7 @@
         ")": "t_wall_glass",
         "]": "t_door_glass_c"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 6, "y": 0, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 6, "y": 0 } ],
       "furniture": { "?": "f_beaded_door", "!": "f_region_flower", "(": "f_chair" },
       "place_item": [ { "item": "television", "repeat": 1, "x": 2, "y": 12 }, { "item": "lawnmower", "repeat": 1, "x": 7, "y": 20 } ],
       "place_items": [

--- a/data/json/mapgen/house/house_detatched4.json
+++ b/data/json/mapgen/house/house_detatched4.json
@@ -64,7 +64,7 @@
         "=": "t_water_pool_outdoors",
         "/": "t_water_pool_shallow_outdoors"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 2, "y": 0, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 1, "y": 0 } ],
       "furniture": { "?": "f_beaded_door", "!": "f_region_flower" },
       "place_item": [ { "item": "television", "repeat": 1, "x": 5, "y": 3 } ],
       "place_items": [

--- a/data/json/mapgen/house/house_detatched5.json
+++ b/data/json/mapgen/house/house_detatched5.json
@@ -70,7 +70,7 @@
         "]": "t_door_glass_c",
         "&": "t_sandbox"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 1, "y": 0, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 1, "y": 0 } ],
       "furniture": { "?": "f_beaded_door", "!": "f_region_flower", ",": "f_brazier", "(": "f_camp_chair" },
       "place_item": [ { "item": "television", "repeat": 1, "x": 14, "y": 7 }, { "item": "lawnmower", "repeat": 1, "x": 12, "y": 12 } ],
       "place_items": [

--- a/data/json/mapgen/house/house_detatched6.json
+++ b/data/json/mapgen/house/house_detatched6.json
@@ -54,7 +54,7 @@
         "*": "t_door_metal_pickable",
         "§": "t_region_groundcover_urban"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 2, "y": 0, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 2, "y": 0 } ],
       "furniture": { "?": "f_beaded_door", ",": "f_pinball_machine", "§": "f_wooden_flagpole" },
       "place_item": [
         { "item": "television", "repeat": 1, "x": 2, "y": 4 },

--- a/data/json/mapgen/house/house_detatched7.json
+++ b/data/json/mapgen/house/house_detatched7.json
@@ -54,7 +54,7 @@
         "=": "t_screen_door_c",
         "&": "t_sandbox"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 7, "y": 1, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 7, "y": 0 } ],
       "furniture": { "!": "f_region_flower" },
       "place_item": [
         { "item": "television", "repeat": 1, "x": 7, "y": 8 },

--- a/data/json/mapgen/house/house_detatched8.json
+++ b/data/json/mapgen/house/house_detatched8.json
@@ -52,7 +52,7 @@
         ",": "t_door_metal_corrugated_c",
         ";": "t_privacy_fencegate_c"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 11, "y": 1, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 11, "y": 1 } ],
       "furniture": { "!": "f_region_flower" },
       "place_item": [
         { "item": "television", "repeat": 1, "x": 13, "y": 8 },

--- a/data/json/mapgen/house/house_detatched9.json
+++ b/data/json/mapgen/house/house_detatched9.json
@@ -53,7 +53,7 @@
         ")": "t_wall_glass",
         "]": "t_door_glass_c"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 7, "y": 1, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 7, "y": 1 } ],
       "furniture": { "!": "f_region_flower" },
       "place_item": [
         { "item": "cig_butt", "repeat": 1, "x": 9, "y": 8 },

--- a/data/json/mapgen/house/house_dogs.json
+++ b/data/json/mapgen/house/house_dogs.json
@@ -47,7 +47,7 @@
         ".ŦŦŦŦŦŦŦŦŦŦŦŦŦŦŦŦŦŦŦŦŦŦ.",
         "........................"
       ],
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 6, "y": 0, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 6, "y": 0 } ],
       "palettes": [
         { "distribution": [ [ "standard_domestic_palette", 10 ], [ "standard_domestic_abandoned_palette", 2 ] ] },
         "standard_domestic_landscaping_palette"

--- a/data/json/mapgen/house/house_duplex.json
+++ b/data/json/mapgen/house/house_duplex.json
@@ -45,9 +45,9 @@
         "9": "t_linoleum_gray",
         "-": "t_linoleum_gray"
       },
-      "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 6, "y": 1, "chance": 80, "status": 0 },
-        { "vehicle": "rolling_trash_can", "x": 18, "y": 1, "chance": 80, "status": 0 }
+      "place_nested": [
+        { "chunks": [ "rolling_trash_can_1x1" ], "x": 6, "y": 1 },
+        { "chunks": [ "rolling_trash_can_1x1" ], "x": 18, "y": 1 }
       ],
       "furniture": { "!": "f_region_flower" },
       "place_item": [ { "item": "television", "x": 9, "y": 7 }, { "item": "stereo", "x": 12, "y": 8 } ],

--- a/data/json/mapgen/house/house_duplex10.json
+++ b/data/json/mapgen/house/house_duplex10.json
@@ -52,9 +52,11 @@
       "furniture": { "!": "f_region_flower" },
       "place_vehicles": [
         { "chance": 30, "fuel": 10, "rotation": 90, "status": -1, "vehicle": "car_sports", "x": 9, "y": 7 },
-        { "chance": 35, "fuel": 10, "rotation": 90, "status": -1, "vehicle": "car", "x": 16, "y": 7 },
-        { "vehicle": "rolling_trash_can", "x": 1, "y": 1, "chance": 80, "status": 0 },
-        { "vehicle": "rolling_trash_can", "x": 20, "y": 1, "chance": 80, "status": 0 }
+        { "chance": 35, "fuel": 10, "rotation": 90, "status": -1, "vehicle": "car", "x": 16, "y": 7 }
+      ],
+      "place_nested": [
+        { "chunks": [ "rolling_trash_can_1x1" ], "x": 1, "y": 1 },
+        { "chunks": [ "rolling_trash_can_1x1" ], "x": 20, "y": 1 }
       ]
     },
     "om_terrain": "house_duplex10",

--- a/data/json/mapgen/house/house_duplex11.json
+++ b/data/json/mapgen/house/house_duplex11.json
@@ -49,9 +49,9 @@
         "=": "t_screen_door_c",
         "/": "t_water_pool_shallow"
       },
-      "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 4, "y": 1, "chance": 80, "status": 0 },
-        { "vehicle": "rolling_trash_can", "x": 20, "y": 1, "chance": 80, "status": 0 }
+      "place_nested": [
+        { "chunks": [ "rolling_trash_can_1x1" ], "x": 4, "y": 1 },
+        { "chunks": [ "rolling_trash_can_1x1" ], "x": 20, "y": 1 }
       ],
       "furniture": { "!": "f_region_flower" },
       "place_loot": [

--- a/data/json/mapgen/house/house_duplex2.json
+++ b/data/json/mapgen/house/house_duplex2.json
@@ -45,9 +45,9 @@
         "9": "t_linoleum_gray",
         "-": "t_linoleum_gray"
       },
-      "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 6, "y": 0, "chance": 80, "status": 0 },
-        { "vehicle": "rolling_trash_can", "x": 16, "y": 0, "chance": 80, "status": 0 }
+      "place_nested": [
+        { "chunks": [ "rolling_trash_can_1x1" ], "x": 6, "y": 0 },
+        { "chunks": [ "rolling_trash_can_1x1" ], "x": 16, "y": 0 }
       ],
       "furniture": { "!": "f_region_flower" },
       "place_item": [

--- a/data/json/mapgen/house/house_duplex3.json
+++ b/data/json/mapgen/house/house_duplex3.json
@@ -45,9 +45,9 @@
         "9": "t_linoleum_gray",
         "-": "t_linoleum_gray"
       },
-      "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 5, "y": 1, "chance": 80, "status": 0 },
-        { "vehicle": "rolling_trash_can", "x": 13, "y": 1, "chance": 80, "status": 0 }
+      "place_nested": [
+        { "chunks": [ "rolling_trash_can_1x1" ], "x": 5, "y": 1 },
+        { "chunks": [ "rolling_trash_can_1x1" ], "x": 13, "y": 1 }
       ],
       "furniture": { "!": "f_region_flower" },
       "place_item": [ { "item": "television", "x": 10, "y": 7 }, { "item": "television", "x": 18, "y": 4 } ]

--- a/data/json/mapgen/house/house_duplex4.json
+++ b/data/json/mapgen/house/house_duplex4.json
@@ -45,9 +45,9 @@
         "9": "t_linoleum_gray",
         "-": "t_linoleum_gray"
       },
-      "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 6, "y": 0, "chance": 80, "status": 0 },
-        { "vehicle": "rolling_trash_can", "x": 12, "y": 0, "chance": 80, "status": 0 }
+      "place_nested": [
+        { "chunks": [ "rolling_trash_can_1x1" ], "x": 6, "y": 0 },
+        { "chunks": [ "rolling_trash_can_1x1" ], "x": 12, "y": 0 }
       ],
       "furniture": { "!": "f_region_flower" },
       "place_item": [ { "item": "television", "x": 11, "y": 13 }, { "item": "television", "x": 13, "y": 13 } ]

--- a/data/json/mapgen/house/house_duplex5.json
+++ b/data/json/mapgen/house/house_duplex5.json
@@ -47,9 +47,9 @@
         "9": "t_linoleum_gray",
         "-": "t_linoleum_gray"
       },
-      "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 3, "y": 1, "chance": 80, "status": 0 },
-        { "vehicle": "rolling_trash_can", "x": 12, "y": 1, "chance": 80, "status": 0 }
+      "place_nested": [
+        { "chunks": [ "rolling_trash_can_1x1" ], "x": 3, "y": 1 },
+        { "chunks": [ "rolling_trash_can_1x1" ], "x": 12, "y": 1 }
       ],
       "furniture": { "!": "f_region_flower" },
       "place_item": [

--- a/data/json/mapgen/house/house_duplex6.json
+++ b/data/json/mapgen/house/house_duplex6.json
@@ -59,9 +59,9 @@
         "A": "t_linoleum_gray",
         "-": "t_linoleum_gray"
       },
-      "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 3, "y": 1, "chance": 80, "status": 0 },
-        { "vehicle": "rolling_trash_can", "x": 12, "y": 1, "chance": 80, "status": 0 }
+      "place_nested": [
+        { "chunks": [ "rolling_trash_can_1x1" ], "x": 3, "y": 1 },
+        { "chunks": [ "rolling_trash_can_1x1" ], "x": 12, "y": 1 }
       ],
       "furniture": { "!": "f_region_flower" },
       "place_items": [ { "chance": 40, "item": "bags_trip", "x": 6, "y": 20 } ],

--- a/data/json/mapgen/house/house_duplex7.json
+++ b/data/json/mapgen/house/house_duplex7.json
@@ -58,9 +58,9 @@
         "h": "t_linoleum_gray",
         "-": "t_linoleum_gray"
       },
-      "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 4, "y": 1, "chance": 80, "status": 0 },
-        { "vehicle": "rolling_trash_can", "x": 12, "y": 1, "chance": 80, "status": 0 }
+      "place_nested": [
+        { "chunks": [ "rolling_trash_can_1x1" ], "x": 4, "y": 1 },
+        { "chunks": [ "rolling_trash_can_1x1" ], "x": 12, "y": 1 }
       ],
       "furniture": { "?": "f_beaded_door", "!": "f_region_flower" },
       "place_item": [

--- a/data/json/mapgen/house/house_duplex8.json
+++ b/data/json/mapgen/house/house_duplex8.json
@@ -47,9 +47,9 @@
         "$": "t_screened_porch_wall",
         "=": "t_screen_door_c"
       },
-      "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 4, "y": 1, "chance": 80, "status": 0 },
-        { "vehicle": "rolling_trash_can", "x": 12, "y": 0, "chance": 80, "status": 0 }
+      "place_nested": [
+        { "chunks": [ "rolling_trash_can_1x1" ], "x": 4, "y": 1 },
+        { "chunks": [ "rolling_trash_can_1x1" ], "x": 12, "y": 0 }
       ],
       "furniture": { "!": "f_region_flower" }
     }

--- a/data/json/mapgen/house/house_duplex9.json
+++ b/data/json/mapgen/house/house_duplex9.json
@@ -57,9 +57,11 @@
       ],
       "place_vehicles": [
         { "chance": 35, "fuel": 10, "rotation": 90, "status": -1, "vehicle": "car", "x": 8, "y": 7 },
-        { "chance": 30, "fuel": 10, "rotation": 90, "status": -1, "vehicle": "car_sports", "x": 16, "y": 7 },
-        { "vehicle": "rolling_trash_can", "x": 1, "y": 0, "chance": 80, "status": 0 },
-        { "vehicle": "rolling_trash_can", "x": 22, "y": 1, "chance": 80, "status": 0 }
+        { "chance": 30, "fuel": 10, "rotation": 90, "status": -1, "vehicle": "car_sports", "x": 16, "y": 7 }
+      ],
+      "place_nested": [
+        { "chunks": [ "rolling_trash_can_1x1" ], "x": 1, "y": 0 },
+        { "chunks": [ "rolling_trash_can_1x1" ], "x": 22, "y": 1 }
       ]
     }
   },

--- a/data/json/mapgen/house/house_fortified.json
+++ b/data/json/mapgen/house/house_fortified.json
@@ -49,7 +49,7 @@
         "$": "t_window_boarded",
         "=": "t_door_locked"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 2, "y": 1, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 2, "y": 1 } ],
       "furniture": { "!": "f_region_flower" },
       "set": [
         { "point": "trap", "id": "tr_funnel", "x": [ 3, 9 ], "y": 19, "repeat": [ 1, 2 ] },

--- a/data/json/mapgen/house/house_garage.json
+++ b/data/json/mapgen/house/house_garage.json
@@ -51,10 +51,8 @@
         { "item": "television", "x": 10, "y": 19, "chance": 100 }
       ],
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "chance": 2 } ],
-      "place_vehicles": [
-        { "vehicle": "suburban_home", "x": 17, "y": 6, "chance": 15, "fuel": 70, "status": 0, "rotation": 90 },
-        { "vehicle": "rolling_trash_can", "x": 2, "y": 0, "chance": 80, "status": 0 }
-      ]
+      "place_vehicles": [ { "vehicle": "suburban_home", "x": 17, "y": 6, "chance": 15, "fuel": 70, "status": 0, "rotation": 90 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 2, "y": 0 } ]
     }
   },
   {

--- a/data/json/mapgen/house/house_garage2.json
+++ b/data/json/mapgen/house/house_garage2.json
@@ -60,10 +60,8 @@
         { "group": "home_hw", "x": [ 21, 21 ], "y": [ 9, 11 ], "chance": 85, "repeat": [ 1, 2 ] }
       ],
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "chance": 2 } ],
-      "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 3, "y": 3, "chance": 80, "status": 0 },
-        { "vehicle": "suburban_home", "x": 17, "y": 6, "chance": 15, "fuel": 80, "status": 0, "rotation": 90 }
-      ]
+      "place_vehicles": [ { "vehicle": "suburban_home", "x": 17, "y": 6, "chance": 15, "fuel": 80, "status": 0, "rotation": 90 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 3, "y": 0 } ]
     }
   },
   {

--- a/data/json/mapgen/house/house_garage3.json
+++ b/data/json/mapgen/house/house_garage3.json
@@ -51,10 +51,8 @@
         { "item": "american_flag", "x": [ 4, 4 ], "y": [ 5, 5 ], "chance": 2 }
       ],
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "chance": 2 } ],
-      "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 2, "y": 1, "chance": 80, "status": 0 },
-        { "vehicle": "suburban_home", "x": 17, "y": 6, "chance": 10, "rotation": 270 }
-      ]
+      "place_vehicles": [ { "vehicle": "suburban_home", "x": 17, "y": 6, "chance": 10, "rotation": 270 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 2, "y": 1 } ]
     }
   },
   {

--- a/data/json/mapgen/house/house_garage4.json
+++ b/data/json/mapgen/house/house_garage4.json
@@ -47,10 +47,8 @@
       "furniture": { "!": "f_region_flower" },
       "place_loot": [ { "group": "guns_pistol_common", "x": [ 21, 21 ], "y": [ 21, 21 ], "chance": 5, "ammo": 90, "magazine": 100 } ],
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "chance": 2 } ],
-      "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 4, "y": 3, "chance": 80, "status": 0 },
-        { "vehicle": "suburban_home", "x": 11, "y": 8, "chance": 10, "rotation": 0 }
-      ]
+      "place_vehicles": [ { "vehicle": "suburban_home", "x": 11, "y": 8, "chance": 10, "rotation": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 4, "y": 3 } ]
     }
   },
   {

--- a/data/json/mapgen/house/house_garage5.json
+++ b/data/json/mapgen/house/house_garage5.json
@@ -44,10 +44,8 @@
       },
       "furniture": { "!": "f_region_flower" },
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "chance": 2 } ],
-      "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 2, "y": 1, "chance": 80, "status": 0 },
-        { "vehicle": "suburban_home", "x": 5, "y": 5, "chance": 10, "rotation": 270 }
-      ]
+      "place_vehicles": [ { "vehicle": "suburban_home", "x": 5, "y": 5, "chance": 10, "rotation": 270 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 2, "y": 1 } ]
     }
   },
   {

--- a/data/json/mapgen/house/house_garage6.json
+++ b/data/json/mapgen/house/house_garage6.json
@@ -79,10 +79,8 @@
         { "item": "hose", "x": [ 12, 12 ], "y": [ 22, 22 ], "chance": 75 }
       ],
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "chance": 2 } ],
-      "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 3, "y": 0, "chance": 80, "status": 0 },
-        { "vehicle": "suburban_home", "x": 17, "y": 7, "chance": 10, "rotation": 90 }
-      ]
+      "place_vehicles": [ { "vehicle": "suburban_home", "x": 17, "y": 7, "chance": 10, "rotation": 90 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 3, "y": 0 } ]
     }
   },
   {

--- a/data/json/mapgen/house/house_garage7.json
+++ b/data/json/mapgen/house/house_garage7.json
@@ -57,10 +57,8 @@
         { "item": "television", "x": 13, "y": 7, "chance": 75 }
       ],
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "chance": 6 } ],
-      "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 12, "y": 1, "chance": 80, "status": 0 },
-        { "vehicle": "suburban_home", "x": 4, "y": 4, "chance": 15, "fuel": 80, "status": 50, "rotation": 270 }
-      ]
+      "place_vehicles": [ { "vehicle": "suburban_home", "x": 4, "y": 4, "chance": 15, "fuel": 80, "status": 50, "rotation": 270 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 12, "y": 1 } ]
     }
   },
   {

--- a/data/json/mapgen/house/house_garage8.json
+++ b/data/json/mapgen/house/house_garage8.json
@@ -73,18 +73,8 @@
         "♣": { "item": { "item": "seed_carrot", "chance": 100 }, "furniture": "f_plant_seedling" }
       },
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 4, 5 ], "y": [ 12, 13 ], "chance": 6 } ],
-      "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 12, "y": 1, "chance": 80, "status": 0 },
-        {
-          "vehicle": "suburban_home_compact",
-          "x": 4,
-          "y": 2,
-          "chance": 15,
-          "fuel": 80,
-          "status": 50,
-          "rotation": 270
-        }
-      ]
+      "place_vehicles": [ { "vehicle": "suburban_home_compact", "x": 4, "y": 2, "chance": 15, "fuel": 80, "status": 50, "rotation": 270 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 12, "y": 1 } ]
     }
   },
   {

--- a/data/json/mapgen/house/house_garage_prepper.json
+++ b/data/json/mapgen/house/house_garage_prepper.json
@@ -64,7 +64,7 @@
         ",": "t_door_boarded",
         "(": "t_door_metal_pickable"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 2, "y": 0, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 1, "y": 0 } ],
       "furniture": { "!": "f_region_flower", ";": "f_console_broken", "{": "f_table", "}": "f_chair", ")": "f_locker" },
       "set": [
         { "point": "trap", "id": "tr_beartrap", "x": [ 10, 11 ], "y": 2, "repeat": [ 1, 2 ] },

--- a/data/json/mapgen/house/house_gardener.json
+++ b/data/json/mapgen/house/house_gardener.json
@@ -47,7 +47,7 @@
         { "group": "farming_tools", "x": [ 16, 20 ], "y": 11, "chance": 65, "repeat": [ 1, 2 ] },
         { "group": "farming_seeds", "x": [ 16, 20 ], "y": 13, "chance": 85, "repeat": [ 1, 5 ] }
       ],
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 10, "y": 1, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 10, "y": 1 } ],
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "chance": 2 } ]
     }
   },

--- a/data/json/mapgen/house/house_inner_garden.json
+++ b/data/json/mapgen/house/house_inner_garden.json
@@ -43,10 +43,10 @@
       },
       "furniture": { "a": "f_displaycase" },
       "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 3, "y": 1, "chance": 80, "status": 0 },
         { "vehicle": "showroom_small_vehicles", "x": 17, "y": 5, "rotation": 270, "chance": 20, "status": 0 },
         { "vehicle": "showroom_small_vehicles", "x": 19, "y": 5, "rotation": 270, "chance": 20, "status": 0 }
       ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 3, "y": 1 } ],
       "items": {
         "E": { "item": "coat_rack", "chance": 30, "repeat": [ 1, 4 ] },
         "G": { "item": "mail", "chance": 30, "repeat": [ 2, 5 ] },

--- a/data/json/mapgen/house/house_library.json
+++ b/data/json/mapgen/house/house_library.json
@@ -41,7 +41,7 @@
         "S": "t_linoleum_gray",
         "Q": "t_linoleum_gray"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 2, "y": 0, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 2, "y": 0 } ],
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "chance": 2 } ]
     }
   }

--- a/data/json/mapgen/house/house_modern_lx.json
+++ b/data/json/mapgen/house/house_modern_lx.json
@@ -59,7 +59,7 @@
         { "item": "katana_inferior", "x": [ 12, 12 ], "y": [ 10, 10 ], "chance": 8 },
         { "item": "spiral_stone", "x": [ 12, 12 ], "y": [ 10, 10 ], "chance": 25 }
       ],
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 13, "y": 1, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 13, "y": 1 } ],
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "chance": 2 } ]
     }
   },

--- a/data/json/mapgen/house/house_patio.json
+++ b/data/json/mapgen/house/house_patio.json
@@ -74,12 +74,10 @@
           ],
           "x": 1,
           "y": 17
-        }
+        },
+        { "chunks": [ "rolling_trash_can_1x1" ], "x": 15, "y": 0 }
       ],
-      "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 15, "y": 0, "chance": 80, "status": 0 },
-        { "vehicle": "suburban_home", "x": 5, "y": 4, "chance": 10, "rotation": 90 }
-      ]
+      "place_vehicles": [ { "vehicle": "suburban_home", "x": 5, "y": 4, "chance": 10, "rotation": 90 } ]
     }
   },
   {

--- a/data/json/mapgen/house/house_porch.json
+++ b/data/json/mapgen/house/house_porch.json
@@ -51,7 +51,7 @@
         "f": "t_carpet_red",
         "h": "t_carpet_red"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 4, "y": 1, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 4, "y": 1 } ],
       "furniture": { "%": "f_region_flower" },
       "place_loot": [
         { "group": "alcohol", "x": [ 2, 2 ], "y": [ 8, 8 ], "chance": 15 },

--- a/data/json/mapgen/house/house_prepper.json
+++ b/data/json/mapgen/house/house_prepper.json
@@ -50,7 +50,7 @@
         "=": "t_door_locked",
         "/": "t_door_metal_pickable"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 2, "y": 0, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 2, "y": 0 } ],
       "furniture": { "!": "f_region_flower" },
       "place_loot": [ { "item": "television", "x": 5, "y": 6 }, { "item": "stereo", "x": 6, "y": 6 } ],
       "place_items": [
@@ -105,7 +105,7 @@
         ".######################.",
         "............^..........."
       ],
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 2, "y": 0, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 2, "y": 0 } ],
       "palettes": [ "standard_domestic_palette" ],
       "place_npcs": [ { "class": "prepper_survivor", "x": 13, "y": 20 } ],
       "place_zones": [ { "type": "LOOT_UNSORTED", "faction": "no_faction", "x": [ 11, 15 ], "y": 21 } ],

--- a/data/json/mapgen/house/house_quiverfull.json
+++ b/data/json/mapgen/house/house_quiverfull.json
@@ -62,11 +62,10 @@
         { "monster": "GROUP_QUIVERFULL", "x": [ 2, 14 ], "y": [ 15, 21 ], "chance": 1 }
       ],
       "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 2, "y": 0, "chance": 80, "status": 0 },
-        { "vehicle": "rolling_trash_can", "x": 3, "y": 0, "chance": 80, "status": 0 },
         { "vehicle": "tricycle", "x": 10, "y": 8, "chance": 50, "status": 0 },
         { "vehicle": "tricycle", "x": 4, "y": 21, "chance": 50, "status": 0 }
-      ]
+      ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 2, "y": 0 }, { "chunks": [ "rolling_trash_can_1x1" ], "x": 3, "y": 0 } ]
     }
   }
 ]

--- a/data/json/mapgen/house/house_suicide.json
+++ b/data/json/mapgen/house/house_suicide.json
@@ -39,8 +39,10 @@
         "#": "t_rock_wall",
         "!": "t_door_locked_interior"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 3, "y": 1, "chance": 80, "status": 0 } ],
-      "place_nested": [ { "chunks": [ [ "bathroom_suicide", 100 ] ], "x": 18, "y": 13 } ]
+      "place_nested": [
+        { "chunks": [ [ "bathroom_suicide", 100 ] ], "x": 18, "y": 13 },
+        { "chunks": [ "rolling_trash_can_1x1" ], "x": 3, "y": 1 }
+      ]
     }
   },
   {

--- a/data/json/mapgen/house/house_tool_shed.json
+++ b/data/json/mapgen/house/house_tool_shed.json
@@ -44,7 +44,7 @@
         "q": "t_thconc_floor",
         "!": "t_thconc_floor"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 6, "y": 0, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 6, "y": 0 } ],
       "set": [
         { "point": "terrain", "id": "t_tree_apple", "x": [ 0, 14 ], "y": [ 0, 0 ], "repeat": [ 1, 2 ] },
         { "point": "terrain", "id": "t_tree", "x": [ 2, 14 ], "y": [ 17, 21 ], "repeat": [ 1, 3 ] },

--- a/data/json/mapgen/house/house_wooded.json
+++ b/data/json/mapgen/house/house_wooded.json
@@ -54,7 +54,7 @@
         ")": "t_wall_glass",
         "]": "t_door_glass_c"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 1, "y": 0, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 1, "y": 0 } ],
       "furniture": { "!": "f_region_flower", "}": [ "f_indoor_plant", "f_indoor_plant_y" ] },
       "place_loot": [ { "item": "television", "x": 3, "y": 18 }, { "item": "stereo", "x": 5, "y": 15 } ]
     }

--- a/data/json/mapgen/house/multi_unit_housing.json
+++ b/data/json/mapgen/house/multi_unit_housing.json
@@ -32,14 +32,14 @@
         "..............=======..."
       ],
       "palettes": [ "domestic_general_and_variant_palette", "apt_complex_ground" ],
-      "place_nested": [ { "chunks": [ "multi_unit_home" ], "x": 2, "y": 2 } ],
-      "terrain": { "-": "t_concrete" },
-      "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 10, "y": 1, "chance": 80, "status": 0 },
-        { "vehicle": "rolling_trash_can", "x": 11, "y": 1, "chance": 80, "status": 0 },
-        { "vehicle": "rolling_trash_can", "x": 12, "y": 1, "chance": 80, "status": 0 },
-        { "vehicle": "rolling_trash_can", "x": 13, "y": 1, "chance": 80, "status": 0 }
-      ]
+      "place_nested": [
+        { "chunks": [ "multi_unit_home" ], "x": 2, "y": 2 },
+        { "chunks": [ "rolling_trash_can_1x1" ], "x": 10, "y": 1 },
+        { "chunks": [ "rolling_trash_can_1x1" ], "x": 11, "y": 1 },
+        { "chunks": [ "rolling_trash_can_1x1" ], "x": 12, "y": 1 },
+        { "chunks": [ "rolling_trash_can_1x1" ], "x": 13, "y": 1 }
+      ],
+      "terrain": { "-": "t_concrete" }
     }
   },
   {

--- a/data/json/mapgen/house/urban_10_house_brick_pool.json
+++ b/data/json/mapgen/house/urban_10_house_brick_pool.json
@@ -47,7 +47,7 @@
         "~": "t_water_pool_outdoors",
         "ƃ": "t_privacy_fencegate_c"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 12, "y": 1, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 12, "y": 1 } ],
       "place_loot": [ { "item": "television", "x": 39, "y": 7, "chance": 100 }, { "item": "stereo", "x": 39, "y": 8, "chance": 50 } ]
     }
   },

--- a/data/json/mapgen/house/urban_11_house_brick.json
+++ b/data/json/mapgen/house/urban_11_house_brick.json
@@ -52,10 +52,8 @@
         "Y": "t_linoleum_gray"
       },
       "place_loot": [ { "item": "television", "x": 12, "y": 11, "chance": 100 }, { "item": "stereo", "x": 12, "y": 12, "chance": 50 } ],
-      "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 12, "y": 1, "chance": 80, "status": 0 },
-        { "vehicle": "suburban_home", "x": 35, "y": 13, "chance": 100, "rotation": 270 }
-      ]
+      "place_vehicles": [ { "vehicle": "suburban_home", "x": 35, "y": 13, "chance": 100, "rotation": 270 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 12, "y": 1 } ]
     }
   },
   {

--- a/data/json/mapgen/house/urban_12_house.json
+++ b/data/json/mapgen/house/urban_12_house.json
@@ -59,10 +59,8 @@
         "Y": "t_linoleum_gray"
       },
       "place_loot": [ { "item": "television", "x": 40, "y": 5, "chance": 100 }, { "item": "stereo", "x": 41, "y": 5, "chance": 50 } ],
-      "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 7, "y": 1, "chance": 80, "status": 0 },
-        { "vehicle": "suburban_home", "x": 11, "y": 9, "chance": 100, "rotation": 270 }
-      ]
+      "place_vehicles": [ { "vehicle": "suburban_home", "x": 11, "y": 9, "chance": 100, "rotation": 270 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 7, "y": 1 } ]
     }
   },
   {

--- a/data/json/mapgen/house/urban_15_house.json
+++ b/data/json/mapgen/house/urban_15_house.json
@@ -53,10 +53,8 @@
       },
       "furniture": { "0": "f_counter" },
       "place_loot": [ { "item": "television", "x": 16, "y": 14, "chance": 100 }, { "item": "stereo", "x": 16, "y": 15, "chance": 50 } ],
-      "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 34, "y": 1, "chance": 80, "status": 0 },
-        { "vehicle": "suburban_home_compact", "x": 37, "y": 9, "chance": 50, "rotation": 270 }
-      ]
+      "place_vehicles": [ { "vehicle": "suburban_home_compact", "x": 37, "y": 9, "chance": 50, "rotation": 270 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 34, "y": 1 } ]
     }
   },
   {

--- a/data/json/mapgen/house/urban_1_house.json
+++ b/data/json/mapgen/house/urban_1_house.json
@@ -72,10 +72,8 @@
       },
       "furniture": { "!": "f_region_flower", "$": "f_sofa", "0": "f_stool", ")": "f_table" },
       "place_loot": [ { "item": "television", "x": 14, "y": 9, "chance": 100 }, { "item": "stereo", "x": 14, "y": 10, "chance": 60 } ],
-      "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 23, "y": 23, "chance": 80, "status": 0 },
-        { "vehicle": "suburban_home", "x": 39, "y": 12, "chance": 30, "rotation": 270 }
-      ]
+      "place_vehicles": [ { "vehicle": "suburban_home", "x": 39, "y": 12, "chance": 30, "rotation": 270 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 23, "y": 23 } ]
     }
   },
   {

--- a/data/json/mapgen/house/urban_20_house.json
+++ b/data/json/mapgen/house/urban_20_house.json
@@ -74,10 +74,8 @@
         "Z": "f_floor_lamp"
       },
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 1, 22 ], "y": [ 1, 22 ], "density": 0.03 } ],
-      "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 12, "y": 0, "chance": 80, "status": 0 },
-        { "vehicle": "suburban_home", "x": 15, "y": 14, "chance": 40, "rotation": 0 }
-      ],
+      "place_vehicles": [ { "vehicle": "suburban_home", "x": 15, "y": 14, "chance": 40, "rotation": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 12, "y": 0 } ],
       "place_item": [ { "item": "television", "x": 18, "y": 3 } ]
     }
   },

--- a/data/json/mapgen/house/urban_2_house.json
+++ b/data/json/mapgen/house/urban_2_house.json
@@ -73,10 +73,10 @@
         { "item": "stepladder", "x": 10, "y": 7, "chance": 100 }
       ],
       "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 23, "y": 23, "chance": 80, "status": 0 },
         { "vehicle": "suburban_home", "x": 33, "y": 11, "chance": 30, "rotation": 270 },
         { "vehicle": "suburban_home", "x": 40, "y": 11, "chance": 30, "rotation": 270 }
-      ]
+      ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 23, "y": 23 } ]
     }
   },
   {

--- a/data/json/mapgen/house/urban_2_house_dd.json
+++ b/data/json/mapgen/house/urban_2_house_dd.json
@@ -78,10 +78,10 @@
       ],
       "place_fields": [ { "field": "fd_blood", "x": 24, "y": 3, "intensity": 2, "age": 20 } ],
       "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 23, "y": 23, "chance": 80, "status": 0 },
         { "vehicle": "suburban_home", "x": 33, "y": 11, "chance": 30, "rotation": 270 },
         { "vehicle": "suburban_home", "x": 40, "y": 11, "chance": 30, "rotation": 270 }
-      ]
+      ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 23, "y": 23 } ]
     }
   },
   {

--- a/data/json/mapgen/house/urban_3_house.json
+++ b/data/json/mapgen/house/urban_3_house.json
@@ -74,10 +74,8 @@
         { "item": "lawnmower", "x": 41, "y": 14, "chance": 100 },
         { "item": "stepladder", "x": 41, "y": 15, "chance": 100 }
       ],
-      "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 23, "y": 23, "chance": 80, "status": 0 },
-        { "vehicle": "suburban_home", "x": 36, "y": 11, "chance": 30, "rotation": 270 }
-      ]
+      "place_vehicles": [ { "vehicle": "suburban_home", "x": 36, "y": 11, "chance": 30, "rotation": 270 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 23, "y": 23 } ]
     }
   },
   {

--- a/data/json/mapgen/house/urban_4_house_basement.json
+++ b/data/json/mapgen/house/urban_4_house_basement.json
@@ -119,10 +119,8 @@
       },
       "furniture": { "!": "f_region_flower", "0": "f_stool", "]": "f_sofa", "}": "f_table" },
       "place_loot": [ { "item": "television", "x": 8, "y": 5, "chance": 100 }, { "item": "stereo", "x": 9, "y": 5, "chance": 100 } ],
-      "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 16, "y": 22, "chance": 80, "status": 0 },
-        { "vehicle": "suburban_home", "x": 36, "y": 12, "chance": 30, "rotation": 270 }
-      ]
+      "place_vehicles": [ { "vehicle": "suburban_home", "x": 36, "y": 12, "chance": 30, "rotation": 270 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 16, "y": 22 } ]
     }
   },
   {

--- a/data/json/mapgen/house/urban_5_house.json
+++ b/data/json/mapgen/house/urban_5_house.json
@@ -71,10 +71,8 @@
       },
       "furniture": { "!": "f_region_flower", "0": "f_stool", "]": "f_sofa", "}": "f_table" },
       "place_loot": [ { "item": "television", "x": 28, "y": 14, "chance": 100 }, { "item": "stereo", "x": 28, "y": 15, "chance": 100 } ],
-      "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 17, "y": 22, "chance": 80, "status": 0 },
-        { "vehicle": "suburban_home", "x": 37, "y": 12, "chance": 30, "rotation": 270 }
-      ]
+      "place_vehicles": [ { "vehicle": "suburban_home", "x": 37, "y": 12, "chance": 30, "rotation": 270 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 17, "y": 22 } ]
     }
   },
   {

--- a/data/json/mapgen/house/urban_6_house.json
+++ b/data/json/mapgen/house/urban_6_house.json
@@ -72,10 +72,10 @@
         { "item": "lawnmower", "x": 38, "y": 5, "chance": 100 }
       ],
       "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 16, "y": 23, "chance": 80, "status": 0 },
         { "vehicle": "suburban_home", "x": 31, "y": 12, "chance": 30, "rotation": 270 },
         { "vehicle": "suburban_home", "x": 39, "y": 12, "chance": 30, "rotation": 270 }
-      ]
+      ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 16, "y": 23 } ]
     }
   },
   {

--- a/data/json/mapgen/house/urban_7_house_garden.json
+++ b/data/json/mapgen/house/urban_7_house_garden.json
@@ -68,7 +68,7 @@
         "t": "t_linoleum_gray"
       },
       "furniture": { "!": "f_region_flower", "0": "f_stool", "}": "f_counter" },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 12, "y": 22, "chance": 80, "status": 0 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 12, "y": 22 } ],
       "place_loot": [
         { "item": "television", "x": 15, "y": 18, "chance": 100 },
         { "item": "stereo", "x": 16, "y": 18, "chance": 100 },

--- a/data/json/mapgen/house/urban_8_house_brick_garden.json
+++ b/data/json/mapgen/house/urban_8_house_brick_garden.json
@@ -57,9 +57,9 @@
       "sealed_item": { "0": { "items": { "item": "farming_seeds", "chance": 100 }, "furniture": "f_plant_seedling", "chance": 70 } },
       "place_nested": [
         { "chunks": [ [ "greenhouse_6x6_herbal", 100 ] ], "x": 8, "y": 8 },
-        { "chunks": [ [ "greenhouse_6x6_vegetable", 100 ] ], "x": 8, "y": 15 }
+        { "chunks": [ [ "greenhouse_6x6_vegetable", 100 ] ], "x": 8, "y": 15 },
+        { "chunks": [ "rolling_trash_can_1x1" ], "x": 31, "y": 0 }
       ],
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 31, "y": 0, "chance": 80, "status": 0 } ],
       "place_loot": [
         { "item": "television", "x": 29, "y": 6, "chance": 100 },
         { "item": "stereo", "x": 29, "y": 7, "chance": 50 },

--- a/data/json/mapgen/house/urban_9_house_garage_loft.json
+++ b/data/json/mapgen/house/urban_9_house_garage_loft.json
@@ -80,10 +80,8 @@
         { "item": "lawnmower", "x": 33, "y": 18, "chance": 100 },
         { "item": "basket_laundry", "x": 31, "y": 18, "chance": 100 }
       ],
-      "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 9, "y": 1, "chance": 80, "status": 0 },
-        { "vehicle": "suburban_home_compact", "x": 39, "y": 19, "chance": 100, "rotation": 270 }
-      ]
+      "place_vehicles": [ { "vehicle": "suburban_home_compact", "x": 39, "y": 19, "chance": 100, "rotation": 270 } ],
+      "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 9, "y": 1 } ]
     }
   },
   {

--- a/data/json/mapgen/nested/aux_nested.json
+++ b/data/json/mapgen/nested/aux_nested.json
@@ -418,6 +418,17 @@
   {
     "type": "mapgen",
     "method": "json",
+    "//": "trash can that can be quite full, or empty",
+    "nested_mapgen_id": "rolling_trash_can_1x1",
+    "object": {
+      "mapgensize": [ 1, 1 ],
+      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 0, "y": 0, "chance": 80, "status": 0 } ],
+      "place_items": [ { "item": "trash", "x": 0, "y": 0, "repeat": [ 0, 10 ] } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
     "update_mapgen_id": "amigara_death",
     "object": { "place_items": [ { "item": "amigara_drops", "x": 11, "y": 12, "chance": 100 } ] }
   },

--- a/data/json/mapgen/nested/aux_nested.json
+++ b/data/json/mapgen/nested/aux_nested.json
@@ -418,12 +418,10 @@
   {
     "type": "mapgen",
     "method": "json",
-    "//": "trash can that can be quite full, or empty",
     "nested_mapgen_id": "rolling_trash_can_1x1",
     "object": {
       "mapgensize": [ 1, 1 ],
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 0, "y": 0, "chance": 80, "status": 0 } ],
-      "place_items": [ { "item": "trash", "x": 0, "y": 0, "repeat": [ 0, 10 ] } ]
+      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 0, "y": 0, "chance": 80, "status": 0 } ]
     }
   },
   {

--- a/data/json/vehicles/carts.json
+++ b/data/json/vehicles/carts.json
@@ -138,7 +138,12 @@
     "type": "vehicle",
     "name": "Rolling Trash Can",
     "blueprint": [ [ "o" ] ],
-    "parts": [ { "x": 0, "y": 0, "parts": [ "xlframe", "wheel_caster", "integrated_trashcan" ] } ]
+    "parts": [ { "x": 0, "y": 0, "parts": [ "xlframe", "wheel_caster", "integrated_trashcan" ] } ],
+    "items": [
+      { "x": 0, "y": 0, "chance": 20, "item_groups": [ "rolling_trash" ] },
+      { "x": 0, "y": 0, "chance": 20, "item_groups": [ "rolling_trash" ] },
+      { "x": 0, "y": 0, "chance": 20, "item_groups": [ "rolling_trash" ] }
+    ]
   },
   {
     "id": "grocery_cart",

--- a/data/json/vehicles/carts.json
+++ b/data/json/vehicles/carts.json
@@ -138,8 +138,7 @@
     "type": "vehicle",
     "name": "Rolling Trash Can",
     "blueprint": [ [ "o" ] ],
-    "parts": [ { "x": 0, "y": 0, "parts": [ "xlframe", "wheel_caster", "integrated_trashcan" ] } ],
-    "items": [ { "x": 0, "y": 0, "chance": 75, "item_groups": [ "trash" ] } ]
+    "parts": [ { "x": 0, "y": 0, "parts": [ "xlframe", "wheel_caster", "integrated_trashcan" ] } ]
   },
   {
     "id": "grocery_cart",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "More trash in rolling trash cans"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I found the amount of trash in the rolling trash cans to be... low? They also weren't in a garbage bag which they normally are. It felt very off, so I decided to add bags and more trash into them while also making them nests so it's a bit easier to do.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Change the way rolling trash cans are spawned from being vehicles directly spawned to a nest that has the vehicle in it.
I also increased the amount of trash that can spawn in trash cans, and made them able to be empty or pretty filled using an item group which spawns items in garbage bags.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Make the amount of trash vary per block in the city i.e. blocks that just had trash day would have basically no trash and blocks that had it a longer time ago would have more trash but afaik it's not possible to do that in json.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Houses spawn with more or less trash in the trash cans, in bags if it fits, outside them if it doesn't.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I'm planning on making every house use the `domestic_general_and_variant_palette` eventually, and maybe I could add the trash can as a symbol in there, but I'm unsure if you can attach a nest to a symbol like that.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
