### PR TITLE
NPCs are smarter in how they steal from the player

### DIFF
--- a/src/npc.h
+++ b/src/npc.h
@@ -1352,6 +1352,7 @@ class npc : public Character
         // Player orders a friendly NPC to move to this position
         std::optional<tripoint_abs_ms> goto_to_this_pos;
         int last_seen_player_turn = 0; // Timeout to forgetting
+        const item *wanted_item = nullptr;
         tripoint wanted_item_pos; // The square containing an item we want
         // These are the coordinates that a guard will return to inside of their goal tripoint
         std::optional<tripoint_abs_ms> guard_pos;

--- a/src/npc.h
+++ b/src/npc.h
@@ -1212,9 +1212,9 @@ class npc : public Character
         // Comment on item seen
         void see_item_say_smth( const itype_id &object, const std::string &smth );
         // Consider available storage
-        bool can_take_that( const item &it, const tripoint &p );
+        bool can_take_that( const item &it );
         // Consider hoarding
-        bool wants_take_that( const item &it, const tripoint &p );
+        bool wants_take_that( const item &it );
         // Consider a life of crime
         bool would_take_that( const item &it, const tripoint &p );
         // Look around and pick an item

--- a/src/npc.h
+++ b/src/npc.h
@@ -1211,9 +1211,13 @@ class npc : public Character
 
         // Comment on item seen
         void see_item_say_smth( const itype_id &object, const std::string &smth );
-		// Consider a life of crime
-        bool would_steal_that( const item &it, const tripoint &p );
-		// Look around and pick an item
+        // Consider available storage
+        bool can_take_that( const item &it, const tripoint &p );
+        // Consider hoarding
+        bool wants_take_that( const item &it, const tripoint &p );
+        // Consider a life of crime
+        bool would_take_that( const item &it, const tripoint &p );
+        // Look around and pick an item
         void find_item();
         // Move to, or grab, our targeted item
         void pick_up_item();

--- a/src/npc.h
+++ b/src/npc.h
@@ -1211,7 +1211,9 @@ class npc : public Character
 
         // Comment on item seen
         void see_item_say_smth( const itype_id &object, const std::string &smth );
-        // Look around and pick an item
+		// Consider a life of crime
+        bool would_steal_that( const item &it, const tripoint &p );
+		// Look around and pick an item
         void find_item();
         // Move to, or grab, our targeted item
         void pick_up_item();

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -3504,6 +3504,7 @@ void npc::find_item()
         if( ::good_for_pickup( it, *this, p ) ) {
             wanted_item_pos = p;
             wanted_item = &it;
+            wanted = wanted_item;
             best_value = has_item_whitelist() ? 1000 : value( it );
         }
     };

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -219,24 +219,11 @@ const std::vector<bionic_id> weapon_cbms = { {
 
 const int avoidance_vehicles_radius = 5;
 
-bool good_for_pickup( const item &it, npc &who, const tripoint &there )
+bool good_for_pickup( const item &it, npc &I, const tripoint &there )
 {
-    bool good = false;
-
-    const bool whitelisting = who.has_item_whitelist();
-    auto weight_allowed = who.weight_capacity() - who.weight_carried();
-    int min_value = who.minimum_item_value();
-
-    item &weap = who.get_wielded_item() ? *who.get_wielded_item() : null_item_reference();
-    if( ( !it.made_of_from_type( phase_id::LIQUID ) ) &&
-        ( ( !whitelisting && who.value( it ) > min_value ) || who.item_whitelisted( it ) ) &&
-        ( it.weight() <= weight_allowed ) &&
-        ( who.can_stash( it ) ||
-          who.weapon_value( it ) > who.weapon_value( weap ) ) ) {
-        good = true;
-    }
-
-    return good;
+    return I.can_take_that( it ) &&
+           I.wants_take_that( it ) &&
+           I.would_take_that( it, there );
 }
 
 } // namespace
@@ -3741,7 +3728,7 @@ std::list<item> npc_pickup_from_stack( npc &who, T &items )
 
     for( auto iter = items.begin(); iter != items.end(); ) {
         const item &it = *iter;
-        if( ::good_for_pickup( it, who ) ) {
+        if( who.can_take_that( it ) && who.wants_take_that( it ) ) {
             picked_up.push_back( it );
             iter = items.erase( iter );
         } else {
@@ -3752,7 +3739,7 @@ std::list<item> npc_pickup_from_stack( npc &who, T &items )
     return picked_up;
 }
 
-bool npc::can_take_that( const item &it, const tripoint &p )
+bool npc::can_take_that( const item &it )
 {
     bool good = false;
 
@@ -3766,7 +3753,7 @@ bool npc::can_take_that( const item &it, const tripoint &p )
     return good;
 }
 
-bool npc::wants_take_that( const item &it, const tripoint &p )
+bool npc::wants_take_that( const item &it )
 {
     bool good = false;
     int min_value = minimum_item_value();

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -219,11 +219,11 @@ const std::vector<bionic_id> weapon_cbms = { {
 
 const int avoidance_vehicles_radius = 5;
 
-bool good_for_pickup( const item &it, npc &I, const tripoint &there )
+bool good_for_pickup( const item &it, npc &who, const tripoint &there )
 {
-    return I.can_take_that( it ) &&
-           I.wants_take_that( it ) &&
-           I.would_take_that( it, there );
+    return who.can_take_that( it ) &&
+           who.wants_take_that( it ) &&
+           who.would_take_that( it, there );
 }
 
 } // namespace


### PR DESCRIPTION
#### Summary
Balance "NPCs wait to steal your stuff until you aren't looking"

#### Purpose of change
NPCs only considered whether you were guarding your stuff once - the moment they saw it and decided they wanted it. Even if you stepped out of the bushes right in front of them wielding a flaming minigun they'd happily ignore your presence and go on looting.

#### Describe the solution
Check every turn whether they're still unspotted, their pockets aren't full, that sort of thing.

Also expanded the check when taking from the player to take into account personalities - VERY aggressive NPCs will always consider taking your stuff, as will NPCs that hate your guts, even if you *can* see them. Whatcha gonna do about it, punk?
(For the players: Try scaring them off pre-emptively. No, that does not mean murder, although murder also works.)

#### Describe alternatives you've considered


#### Testing
~~It is difficult to test this properly, as NPCs are very temperamental about wanting to pick up items in the first place. I can confirm they properly go through the logic to the point where they start to want to steal, but they always change attitude on the next turn before even running into the once-per-turn check.~~ A bug of my own introduction! It works fine when you actually set the variables properly...

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/2dd35d98-236d-475d-8f6f-f9c154b9c573)


Reviewer/merger testing is greatly desired.

#### Additional context
