### PR TITLE
Fix erroneous mapgen monster names in non-English games

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -8861,8 +8861,8 @@ void map::spawn_monsters_submap( const tripoint &gp, bool ignore_sight, bool spa
                     }
                 }
             }
-            if( i.name != "NONE" ) {
-                tmp.unique_name = i.name;
+            if( i.name.has_value() ) {
+                tmp.unique_name = i.name.value();
             }
             if( i.friendly ) {
                 tmp.friendly = -1;

--- a/src/map.h
+++ b/src/map.h
@@ -1780,9 +1780,9 @@ class map
         void apply_faction_ownership( const point &p1, const point &p2, const faction_id &id );
         void add_spawn( const mtype_id &type, int count, const tripoint &p,
                         bool friendly = false, int faction_id = -1, int mission_id = -1,
-                        const std::string &name = "NONE" );
+                        const std::optional<std::string> &name = std::nullopt );
         void add_spawn( const mtype_id &type, int count, const tripoint &p, bool friendly,
-                        int faction_id, int mission_id, const std::string &name,
+                        int faction_id, int mission_id, const std::optional<std::string> &name,
                         const spawn_data &data );
         void add_spawn( const MonsterGroupResult &spawn_details, const tripoint &p );
         void do_vehicle_caching( int z );

--- a/src/submap.h
+++ b/src/submap.h
@@ -43,11 +43,11 @@ struct spawn_point {
     int faction_id;
     int mission_id;
     bool friendly;
-    std::string name;
+    std::optional<std::string> name;
     spawn_data data;
     explicit spawn_point( const mtype_id &T = mtype_id::NULL_ID(), int C = 0, point P = point_zero,
                           int FAC = -1, int MIS = -1, bool F = false,
-                          const std::string &N = "NONE", const spawn_data &SD = spawn_data() ) :
+                          const std::optional<std::string> &N = std::nullopt, const spawn_data &SD = spawn_data() ) :
         pos( P ), count( C ), type( T ), faction_id( FAC ),
         mission_id( MIS ), friendly( F ), name( N ), data( SD ) {}
 };

--- a/tests/submap_load_test.cpp
+++ b/tests/submap_load_test.cpp
@@ -1323,36 +1323,36 @@ TEST_CASE( "submap_spawns_load", "[submap][load]" )
 
     // We placed a unique spawn in a couple of places. Check that those are correct
     INFO( string_format( "nw: [%d, %d] %d %s %s %s", nw.pos.x, nw.pos.y, nw.count, nw.type.str(),
-                         nw.friendly ? "friendly" : "hostile", nw.name ) );
+                         nw.friendly ? "friendly" : "hostile", nw.name.value_or( "NONE" ) ) );
     INFO( string_format( "ne: [%d, %d] %d %s %s %s", ne.pos.x, ne.pos.y, ne.count, ne.type.str(),
-                         ne.friendly ? "friendly" : "hostile", ne.name ) );
+                         ne.friendly ? "friendly" : "hostile", ne.name.value_or( "NONE" ) ) );
     INFO( string_format( "sw: [%d, %d] %d %s %s %s", sw.pos.x, sw.pos.y, sw.count, sw.type.str(),
-                         sw.friendly ? "friendly" : "hostile", sw.name ) );
+                         sw.friendly ? "friendly" : "hostile", sw.name.value_or( "NONE" ) ) );
     INFO( string_format( "se: [%d, %d] %d %s %s %s", se.pos.x, se.pos.y, se.count, se.type.str(),
-                         se.friendly ? "friendly" : "hostile", se.name ) );
+                         se.friendly ? "friendly" : "hostile", se.name.value_or( "NONE" ) ) );
     INFO( string_format( "ra: [%d, %d] %d %s %s %s", ra.pos.x, ra.pos.y, ra.count, ra.type.str(),
-                         ra.friendly ? "friendly" : "hostile", ra.name ) );
+                         ra.friendly ? "friendly" : "hostile", ra.name.value_or( "NONE" ) ) );
     // Require to prevent the lower CHECK from being spammy
     CHECK( nw.count == 3 );
     CHECK( nw.type.str() == "mon_fish_eel" );
     CHECK( !nw.friendly );
-    CHECK( nw.name == "Bob" );
+    CHECK( nw.name.value_or( "NONE" ) == "Bob" );
     CHECK( ne.count == 1 );
     CHECK( ne.type.str() == "mon_pheasant" );
     CHECK( !ne.friendly );
-    CHECK( ne.name == "NONE" );
+    CHECK( ne.name.value_or( "NONE" ) == "NONE" );
     CHECK( sw.count == 4 );
     CHECK( sw.type.str() == "mon_zombie_fungus" );
     CHECK( !sw.friendly );
-    CHECK( sw.name == "Hopper" );
+    CHECK( sw.name.value_or( "NONE" ) == "Hopper" );
     CHECK( se.count == 2 );
     CHECK( se.type.str() == "mon_mininuke_hack" );
     CHECK( se.friendly );
-    CHECK( se.name == "Tim" );
+    CHECK( se.name.value_or( "NONE" ) == "Tim" );
     CHECK( ra.count == 5 );
     CHECK( ra.type.str() == "mon_plague_vector" );
     CHECK( ra.friendly );
-    CHECK( ra.name == "Alice" );
+    CHECK( ra.name.value_or( "NONE" ) == "Alice" );
 
     // Also, check we have no other spawns
     CHECK( sm.spawns.size() == 5 );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix erroneous mapgen monster names in non-English games"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
* Fix #71634
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Following the analysis in https://github.com/CleverRaven/Cataclysm-DDA/issues/71634#issuecomment-1935661047, use `std::optional<std::string>` instead of a hardcoded `"NONE"` value to signify the absence of a custom monster name.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
1. Change game language to Chinese or Russian
2. Spawn an Island Prison in debug menu
3. Custom monsters like "The Chief", "The Doctor" have their custom names correct
4. General monsters like zombie cops do not have custom names as expected
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
