### PR TITLE
Extend clang-tidy unit overflow check to watt and kilowatt

### DIFF
--- a/src/units.cpp
+++ b/src/units.cpp
@@ -110,7 +110,7 @@ void power::deserialize( const JsonValue &jv )
 {
     if( jv.test_int() ) {
         // Compatibility with old 0.F saves
-        *this = from_watt( jv.get_int() );
+        *this = from_watt( static_cast<std::int64_t>( jv.get_int() ) );
         return;
     }
     *this = read_from_json_string( jv, units::power_units );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -5091,7 +5091,8 @@ units::power vehicle::active_reactor_epower() const
     // Only count as much power as will be drawn from the reactor to fill the batteries.
     const auto [bat_remaining, bat_capacity] = connected_battery_power_level();
     // max power flow into batteries for next turn
-    const units::power max_battery_flow = units::from_kilowatt( bat_capacity - bat_remaining );
+    const units::power max_battery_flow = units::from_kilowatt( static_cast<std::int64_t>
+                                          ( bat_capacity - bat_remaining ) );
     // power flow by all parts except reactors
     const units::power non_reactor_flow = net_battery_charge_rate( false );
 

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -211,8 +211,9 @@ void vehicle::smart_controller_handle_turn( const std::optional<float> &k_tracti
     if( max_battery_level == 0 || !discharge_forbidden_soft ) {
         target_charging_rate = 0_W;
     } else {
-        target_charging_rate = units::from_watt( ( max_battery_level * cfg.battery_hi / 100 -
-                               cur_battery_level ) * 10 / ( 6 * 3 ) );
+        target_charging_rate = units::from_watt( static_cast<std::int64_t>( ( max_battery_level *
+                               cfg.battery_hi / 100 -
+                               cur_battery_level ) * 10 / ( 6 * 3 ) ) );
     }
     //      ( max_battery_level * battery_hi / 100 - cur_battery_level )  * (1000 / (60 * 30))   // originally
     //                                ^ battery_hi%                  bat to W ^         ^ 30 minutes

--- a/tools/clang-tidy-plugin/UnitOverflowCheck.cpp
+++ b/tools/clang-tidy-plugin/UnitOverflowCheck.cpp
@@ -19,6 +19,8 @@ struct QuantityUnit {
 static const std::map<std::string_view, QuantityUnit> FunctionAndQuantityTypes {
     {"from_joule", {"energy", 1'000LL}},
     {"from_kilojoule", {"energy", 1'000'000LL}},
+    {"from_watt", {"power", 1'000LL}},
+    {"from_kilowatt", {"power", 1'000'000LL}},
 };
 
 void UnitOverflowCheck::registerMatchers( ast_matchers::MatchFinder *Finder )

--- a/tools/clang-tidy-plugin/test/unit-overflow.cpp
+++ b/tools/clang-tidy-plugin/test/unit-overflow.cpp
@@ -46,3 +46,48 @@ units::energy f_energy_6()
     // CHECK-MESSAGES: warning: constructing energy quantity from 'int' can overflow in 'from_kilojoule' in multiplying with the conversion factor [cata-unit-overflow]
     // CHECK-FIXES: return units::from_kilojoule( static_cast<std::int64_t>( kj ) );
 }
+
+units::power f_power_0()
+{
+    return units::from_milliwatt( 3'000 );
+}
+
+units::power f_power_1()
+{
+    return units::from_watt( 3'000 );
+}
+
+units::power f_power_2()
+{
+    return units::from_watt( 3'000'000 );
+    // CHECK-MESSAGES: warning: constructing power quantity from 'int' can overflow in 'from_watt' in multiplying with the conversion factor [cata-unit-overflow]
+    // CHECK-FIXES: return units::from_watt( 3'000'000LL );
+}
+
+units::power f_power_3()
+{
+    int watt = 3'000'000;
+    return units::from_watt( watt );
+    // CHECK-MESSAGES: warning: constructing power quantity from 'int' can overflow in 'from_watt' in multiplying with the conversion factor [cata-unit-overflow]
+    // CHECK-FIXES: return units::from_watt( static_cast<std::int64_t>( watt ) );
+}
+
+units::power f_power_4()
+{
+    return units::from_kilowatt( 2'000 );
+}
+
+units::power f_power_5()
+{
+    return units::from_kilowatt( 3'000 );
+    // CHECK-MESSAGES: warning: constructing power quantity from 'int' can overflow in 'from_kilowatt' in multiplying with the conversion factor [cata-unit-overflow]
+    // CHECK-FIXES: return units::from_kilowatt( 3'000LL );
+}
+
+units::power f_power_6()
+{
+    int kw = 3'000;
+    return units::from_kilowatt( kw );
+    // CHECK-MESSAGES: warning: constructing power quantity from 'int' can overflow in 'from_kilowatt' in multiplying with the conversion factor [cata-unit-overflow]
+    // CHECK-FIXES: return units::from_kilowatt( static_cast<std::int64_t>( kw ) );
+}


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
More static analysis to find potential overflows in converting kilowatt or watt to internal milliwatt representation in 32-bit integer.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Re-use the existing infra for energy overflow check and then apply auto code transformations.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
