### PR TITLE
Fixed the amount of gunpowder in 338 Lapua ammunition and the mod locations of AXMC

### DIFF
--- a/data/json/items/gun/338lapua.json
+++ b/data/json/items/gun/338lapua.json
@@ -155,7 +155,7 @@
     "dispersion": 50,
     "durability": 10,
     "blackpowder_tolerance": 24,
-    "default_mods": [ "match_trigger", "high_end_folding_stock", "muzzle_brake" ],
+    "default_mods": [ "match_trigger", "high_end_folding_stock" ],
     "valid_mod_locations": [
       [ "grip", 1 ],
       [ "bore", 1 ],
@@ -164,6 +164,7 @@
       [ "sights", 1 ],
       [ "sling", 1 ],
       [ "stock accessory", 2 ],
+      [ "underbarrel", 1 ],
       [ "stock", 1 ]
     ],
     "flags": [ "NO_TURRET", "EASY_CLEAN" ],

--- a/data/json/recipes/ammo/rifle.json
+++ b/data/json/recipes/ammo/rifle.json
@@ -1816,7 +1816,7 @@
     "components": [
       [ [ "338lapua_casing", 1 ] ],
       [ [ "lgrifle_primer", 1 ] ],
-      [ [ "gunpowder", 26 ], [ "gunpowder_large_rifle", 26 ] ],
+      [ [ "gunpowder", 58 ], [ "gunpowder_large_rifle", 58 ] ],
       [ [ "lead", 5 ] ],
       [ [ "copper", 3 ] ]
     ]
@@ -1841,7 +1841,7 @@
     "components": [
       [ [ "338lapua_casing", 1 ] ],
       [ [ "lgrifle_primer", 1 ] ],
-      [ [ "gunpowder", 26 ], [ "gunpowder_large_rifle", 26 ] ],
+      [ [ "gunpowder", 58 ], [ "gunpowder_large_rifle", 58 ] ],
       [ [ "scrap", 1 ] ],
       [ [ "copper", 6 ] ]
     ]
@@ -1866,7 +1866,7 @@
     "components": [
       [ [ "338lapua_casing", 1 ] ],
       [ [ "lgrifle_primer", 1 ] ],
-      [ [ "gunpowder", 26 ], [ "gunpowder_large_rifle", 26 ] ],
+      [ [ "gunpowder", 58 ], [ "gunpowder_large_rifle", 58 ] ],
       [ [ "scrap", 1 ] ],
       [ [ "copper", 3 ] ],
       [ [ "incendiary", 6 ] ]
@@ -1892,7 +1892,7 @@
     "components": [
       [ [ "338lapua_casing", 1 ] ],
       [ [ "lgrifle_primer", 1 ] ],
-      [ [ "chem_black_powder", 26 ] ],
+      [ [ "chem_black_powder", 58 ] ],
       [ [ "lead", 5 ] ],
       [ [ "copper", 3 ] ]
     ]
@@ -1919,7 +1919,7 @@
       [ [ "lgrifle_primer", 1 ] ],
       [ [ "scrap", 1 ] ],
       [ [ "copper", 6 ] ],
-      [ [ "chem_black_powder", 29 ] ]
+      [ [ "chem_black_powder", 58 ] ]
     ]
   },
   {
@@ -1942,7 +1942,7 @@
     "components": [
       [ [ "338lapua_casing", 1 ] ],
       [ [ "lgrifle_primer", 1 ] ],
-      [ [ "chem_black_powder", 29 ] ],
+      [ [ "chem_black_powder", 58 ] ],
       [ [ "scrap", 1 ] ],
       [ [ "copper", 3 ] ],
       [ [ "incendiary", 6 ] ]

--- a/data/json/uncraft/ammo/338lapua.json
+++ b/data/json/uncraft/ammo/338lapua.json
@@ -10,7 +10,7 @@
       [ [ "lead", 5 ] ],
       [ [ "338lapua_casing", 1 ] ],
       [ [ "lgrifle_primer", 1 ] ],
-      [ [ "gunpowder_large_rifle", 26 ] ]
+      [ [ "gunpowder_large_rifle", 58 ] ]
     ]
   },
   {
@@ -23,7 +23,7 @@
       [ [ "copper", 6 ] ],
       [ [ "338lapua_casing", 1 ] ],
       [ [ "lgrifle_primer", 1 ] ],
-      [ [ "gunpowder_large_rifle", 29 ] ],
+      [ [ "gunpowder_large_rifle", 58 ] ],
       [ [ "scrap", 1 ] ]
     ]
   },
@@ -37,7 +37,7 @@
       [ [ "copper", 3 ] ],
       [ [ "338lapua_casing", 1 ] ],
       [ [ "lgrifle_primer", 1 ] ],
-      [ [ "gunpowder_large_rifle", 29 ] ],
+      [ [ "gunpowder_large_rifle", 58 ] ],
       [ [ "scrap", 1 ] ],
       [ [ "incendiary", 6 ] ]
     ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Although the 338 Lapua ammunition has high damage, the amount of powder in the game is similar to that of 7.62 × 51mm ammunition, which is obviously unreasonable.
In addition, the AXMC, a gun of this caliber, has the problem of not being able to attach a bipod and having a muzzle brake before the barrel is assembled.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
According to the data from this source（https://shootersreference.com/reloadingdata/338-lapua-magnum/）, the amount of its powder is usually between 80-100gr（avg 90gr）. If we assume that the powder amount of 7.62×51 and 5.56×45 is 45gr (26 units in game) and 27gr (17 units in game) respectively, we can find that this type of bullet should contain 58 units of powder.
In addition, a "under barrel" position was added to the AXMC, and the built-in muzzle brake was removed.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
