### PR TITLE
Tweak one sentence in last delivery mission

### DIFF
--- a/data/json/starting_missions.json
+++ b/data/json/starting_missions.json
@@ -722,7 +722,7 @@
     "id": "MISSION_LAST_DELIVERY",
     "type": "mission_definition",
     "name": { "str": "Deliver Your Cargo" },
-    "description": "You're not sure who orders takeout when the world's ending, but that doesn't matter.  Evacuation doesn't matter.  Nothing, indeed, matters, save for safely delivering your precious cargo to its destination: a remote mansion.  May Foodperson watch over you, soldier.",
+    "description": "You're not sure who orders takeout when the world's ending, but that doesn't matter.  Evacuation doesn't matter.  Nothing, indeed, matters, save for safely delivering your precious cargo to its destination: a remote mansion.",
     "goal": "MGOAL_GO_TO_TYPE",
     "destination": "mansion_c3",
     "difficulty": 1,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None 

#### Purpose of change

Tweak one change from #71726
Remove the last sentence of the Last Delivery mission: you might be Foodperson yourself, and Foodperson is not a guardian entity, it's either a real hero for real, a colleague in a costume or yourself.
#### Describe the solution
Delete one sentence

#### Describe alternatives you've considered

#### Testing

Run in the linter for formatting and json error

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
