### PR TITLE
Enable clang-tidy check modernize-use-emplace

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -60,7 +60,6 @@ llvm-namespace-comment,\
 misc-*,\
 modernize-*,\
 -modernize-use-auto,\
--modernize-use-emplace,\
 -modernize-use-trailing-return-type,\
 performance-*,\
 -performance-avoid-endl,\

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -2153,6 +2153,12 @@ struct mutable_overmap_phase_remainder {
         // so to aid that we provide a human-readable description here which is
         // only used in the event of a placement error.
         std::string description;
+
+        explicit satisfy_result( const tripoint_om_omt origin, const om_direction::type dir,
+                                 mutable_overmap_placement_rule_remainder *rule,
+                                 std::vector<om_pos_dir> suppressed_joins, std::string description ) :
+            origin( origin ), dir( dir ), rule( rule ),
+            suppressed_joins( std::move( suppressed_joins ) ), description( std::move( description ) ) {}
     };
 
     bool all_rules_exhausted() const {
@@ -2262,9 +2268,7 @@ struct mutable_overmap_phase_remainder {
                             best_result = *result;
                         }
                         if( *result == best_result ) {
-                            pos_dir_options.push_back(
-                                satisfy_result{ origin, dir, &rule, result.value().supressed_joins,
-                                                {} } );
+                            pos_dir_options.emplace_back( origin, dir, &rule, result.value().supressed_joins, std::string{} );
                         }
                     }
                 }
@@ -2311,7 +2315,7 @@ struct mutable_overmap_phase_remainder {
                     om.ter( pos + point_north ).id().str(), om.ter( pos + point_east ).id().str(),
                     om.ter( pos + point_south ).id().str(), om.ter( pos + point_west ).id().str(),
                     joins_s, rules_s );
-            return { {}, om_direction::type::invalid, nullptr, {}, std::move( message ) };
+            return satisfy_result{ {}, om_direction::type::invalid, nullptr, std::vector<om_pos_dir>{}, std::move( message ) };
         }
     }
 };

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -1079,15 +1079,14 @@ int worldfactory::show_worldgen_tab_modselection( const catacurses::window &win,
         std::string id;
         std::vector<mod_id> mods;
         std::vector<mod_id> mods_unfiltered;
+
+        explicit mod_tab( std::string id, std::vector<mod_id> mods, std::vector<mod_id> mods_unfiltered ) :
+            id( std::move( id ) ), mods( std::move( mods ) ), mods_unfiltered( std::move( mods_unfiltered ) ) {}
     };
     std::vector<mod_tab> all_tabs;
 
     for( const std::pair<std::string, translation> &tab : get_mod_list_tabs() ) {
-        all_tabs.push_back( {
-            tab.first,
-            std::vector<mod_id>(),
-            std::vector<mod_id>()
-        } );
+        all_tabs.emplace_back( tab.first, std::vector<mod_id> {}, std::vector<mod_id> {} );
     }
 
     const std::map<std::string, std::string> &cat_tab_map = get_mod_list_cat_tab();

--- a/tests/unseal_and_spill_test.cpp
+++ b/tests/unseal_and_spill_test.cpp
@@ -206,6 +206,11 @@ struct final_result {
     bool sealed;
     bool parent_pocket_sealed;
     std::vector<final_result> contents;
+
+    explicit final_result( const itype_id id, const bool sealed, const bool parent_pocket_sealed,
+                           std::vector<final_result> contents ) :
+        id( id ), sealed( sealed ), parent_pocket_sealed( parent_pocket_sealed ),
+        contents( std::move( contents ) ) {}
 };
 
 item *item_pointer( item *const it )
@@ -805,19 +810,19 @@ void test_scenario::run()
             break;
         case container_location::inventory:
             if( original_location ) {
-                worn_results.emplace_back( final_result {
+                worn_results.emplace_back(
                     itype_test_restricted_container_holder,
                     false,
                     false,
-                    { *original_location }
-                } );
+                    std::vector<final_result> { *original_location }
+                );
             } else {
-                worn_results.emplace_back( final_result {
+                worn_results.emplace_back(
                     itype_test_restricted_container_holder,
                     false,
                     false,
-                    {}
-                } );
+                    std::vector<final_result> {}
+                );
             }
             break;
         case container_location::worn:


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I temporarily disabled the check to get #71721 done. It's time to turn it back on.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Fix three places where it complains about constructing unnecessary temporaries in calling `emplace_back()` by adding custom constructors to allow direct initialization.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
clang-tidy passes locally and the unit tests also pass.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
