### PR TITLE
[Bombastic Perks] Add overwriting perkchain support

### DIFF
--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -24,7 +24,7 @@
         "topic": "TALK_PERK_MENU_SELECT"
       },
       {
-        "condition": { "and": [ { "u_has_trait": "perk_STR_UP" }, { "not": { "u_has_trait": "perk_STR_UP_2" } } ] },
+        "condition": { "not": { "u_has_trait": "perk_STR_UP_2" } },
         "text": "Gain [<trait_name:perk_STR_UP_2>]",
         "effect": [
           { "set_string_var": "<trait_name:perk_STR_UP_2>", "target_var": { "context_val": "trait_name" } },
@@ -61,7 +61,7 @@
         "topic": "TALK_PERK_MENU_SELECT"
       },
       {
-        "condition": { "and": [ { "u_has_trait": "perk_DEX_UP" }, { "not": { "u_has_trait": "perk_DEX_UP_2" } } ] },
+        "condition": { "not": { "u_has_trait": "perk_DEX_UP_2" } },
         "text": "Gain [<trait_name:perk_DEX_UP_2>]",
         "effect": [
           { "set_string_var": "<trait_name:perk_DEX_UP_2>", "target_var": { "context_val": "trait_name" } },
@@ -98,7 +98,7 @@
         "topic": "TALK_PERK_MENU_SELECT"
       },
       {
-        "condition": { "and": [ { "u_has_trait": "perk_INT_UP" }, { "not": { "u_has_trait": "perk_INT_UP_2" } } ] },
+        "condition": { "not": { "u_has_trait": "perk_INT_UP_2" } },
         "text": "Gain [<trait_name:perk_INT_UP_2>]",
         "effect": [
           { "set_string_var": "<trait_name:perk_INT_UP_2>", "target_var": { "context_val": "trait_name" } },
@@ -135,7 +135,7 @@
         "topic": "TALK_PERK_MENU_SELECT"
       },
       {
-        "condition": { "and": [ { "u_has_trait": "perk_PER_UP" }, { "not": { "u_has_trait": "perk_PER_UP_2" } } ] },
+        "condition": { "not": { "u_has_trait": "perk_PER_UP_2" } },
         "text": "Gain [<trait_name:perk_PER_UP_2>]",
         "effect": [
           { "set_string_var": "<trait_name:perk_PER_UP_2>", "target_var": { "context_val": "trait_name" } },

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -5,7 +5,7 @@
     "dynamic_line": "Lifestyle Perks:\nLevel <u_val:current_level>.\n<u_val:num_perks> perk points to spend.\nCurrent EXP: <u_val:available_exp>.\nEXP to next level: <u_val:exp_to_perk>.",
     "responses": [
       {
-        "condition": { "not": { "u_has_trait": "perk_STR_UP" } },
+        "condition": { "and": [ { "not": { "u_has_trait": "perk_STR_UP" } }, { "not": { "u_has_trait": "perk_STR_UP_2" } } ] },
         "text": "Gain [<trait_name:perk_STR_UP>]",
         "effect": [
           { "set_string_var": "<trait_name:perk_STR_UP>", "target_var": { "context_val": "trait_name" } },
@@ -19,12 +19,12 @@
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
+          { "set_condition": "perk_condition", "condition": { "not": { "u_has_trait": "perk_STR_UP_2" } } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },
       {
-        "condition": { "not": { "u_has_trait": "perk_STR_UP_2" } },
+        "condition": { "and": [ { "u_has_trait": "perk_STR_UP" }, { "not": { "u_has_trait": "perk_STR_UP_2" } } ] },
         "text": "Gain [<trait_name:perk_STR_UP_2>]",
         "effect": [
           { "set_string_var": "<trait_name:perk_STR_UP_2>", "target_var": { "context_val": "trait_name" } },
@@ -42,7 +42,7 @@
         "topic": "TALK_PERK_MENU_SELECT"
       },
       {
-        "condition": { "not": { "u_has_trait": "perk_DEX_UP" } },
+        "condition": { "and": [ { "not": { "u_has_trait": "perk_DEX_UP" } }, { "not": { "u_has_trait": "perk_DEX_UP_2" } } ] },
         "text": "Gain [<trait_name:perk_DEX_UP>]",
         "effect": [
           { "set_string_var": "<trait_name:perk_DEX_UP>", "target_var": { "context_val": "trait_name" } },
@@ -56,12 +56,12 @@
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
+          { "set_condition": "perk_condition", "condition": { "not": { "u_has_trait": "perk_DEX_UP_2" } } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },
       {
-        "condition": { "not": { "u_has_trait": "perk_DEX_UP_2" } },
+        "condition": { "and": [ { "u_has_trait": "perk_DEX_UP" }, { "not": { "u_has_trait": "perk_DEX_UP_2" } } ] },
         "text": "Gain [<trait_name:perk_DEX_UP_2>]",
         "effect": [
           { "set_string_var": "<trait_name:perk_DEX_UP_2>", "target_var": { "context_val": "trait_name" } },
@@ -79,7 +79,7 @@
         "topic": "TALK_PERK_MENU_SELECT"
       },
       {
-        "condition": { "not": { "u_has_trait": "perk_INT_UP" } },
+        "condition": { "and": [ { "not": { "u_has_trait": "perk_INT_UP" } }, { "not": { "u_has_trait": "perk_INT_UP_2" } } ] },
         "text": "Gain [<trait_name:perk_INT_UP>]",
         "effect": [
           { "set_string_var": "<trait_name:perk_INT_UP>", "target_var": { "context_val": "trait_name" } },
@@ -93,12 +93,12 @@
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
+          { "set_condition": "perk_condition", "condition": { "not": { "u_has_trait": "perk_INT_UP_2" } } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },
       {
-        "condition": { "not": { "u_has_trait": "perk_INT_UP_2" } },
+        "condition": { "and": [ { "u_has_trait": "perk_INT_UP" }, { "not": { "u_has_trait": "perk_INT_UP_2" } } ] },
         "text": "Gain [<trait_name:perk_INT_UP_2>]",
         "effect": [
           { "set_string_var": "<trait_name:perk_INT_UP_2>", "target_var": { "context_val": "trait_name" } },
@@ -116,7 +116,7 @@
         "topic": "TALK_PERK_MENU_SELECT"
       },
       {
-        "condition": { "not": { "u_has_trait": "perk_PER_UP" } },
+        "condition": { "and": [ { "not": { "u_has_trait": "perk_PER_UP" } }, { "not": { "u_has_trait": "perk_PER_UP_2" } } ] },
         "text": "Gain [<trait_name:perk_PER_UP>]",
         "effect": [
           { "set_string_var": "<trait_name:perk_PER_UP>", "target_var": { "context_val": "trait_name" } },
@@ -130,12 +130,12 @@
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
+          { "set_condition": "perk_condition", "condition": { "not": { "u_has_trait": "perk_PER_UP_2" } } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },
       {
-        "condition": { "not": { "u_has_trait": "perk_PER_UP_2" } },
+        "condition": { "and": [ { "u_has_trait": "perk_PER_UP" }, { "not": { "u_has_trait": "perk_PER_UP_2" } } ] },
         "text": "Gain [<trait_name:perk_PER_UP_2>]",
         "effect": [
           { "set_string_var": "<trait_name:perk_PER_UP_2>", "target_var": { "context_val": "trait_name" } },

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -24,6 +24,24 @@
         "topic": "TALK_PERK_MENU_SELECT"
       },
       {
+        "condition": { "not": { "u_has_trait": "perk_STR_UP_2" } },
+        "text": "Gain [<trait_name:perk_STR_UP_2>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_STR_UP_2>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:perk_STR_UP_2>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "perk_STR_UP_2", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Must have the Stronger perk.",
+            "target_var": { "context_val": "trait_requirement_description" }
+          },
+          { "set_condition": "perk_condition", "condition": { "u_has_trait": "perk_STR_UP" } }
+        ],
+        "topic": "TALK_PERK_MENU_SELECT"
+      },
+      {
         "condition": { "not": { "u_has_trait": "perk_DEX_UP" } },
         "text": "Gain [<trait_name:perk_DEX_UP>]",
         "effect": [
@@ -39,6 +57,24 @@
             "i18n": true
           },
           { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
+        ],
+        "topic": "TALK_PERK_MENU_SELECT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "perk_DEX_UP_2" } },
+        "text": "Gain [<trait_name:perk_DEX_UP_2>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_DEX_UP_2>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:perk_DEX_UP_2>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "perk_DEX_UP_2", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Must have the Faster perk",
+            "target_var": { "context_val": "trait_requirement_description" }
+          },
+          { "set_condition": "perk_condition", "condition": { "u_has_trait": "perk_DEX_UP" } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },
@@ -62,6 +98,24 @@
         "topic": "TALK_PERK_MENU_SELECT"
       },
       {
+        "condition": { "not": { "u_has_trait": "perk_INT_UP_2" } },
+        "text": "Gain [<trait_name:perk_INT_UP_2>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_INT_UP_2>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:perk_INT_UP_2>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "perk_INT_UP_2", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Must have the Smarter perk",
+            "target_var": { "context_val": "trait_requirement_description" }
+          },
+          { "set_condition": "perk_condition", "condition": { "u_has_trait": "perk_INT_UP" } }
+        ],
+        "topic": "TALK_PERK_MENU_SELECT"
+      },
+      {
         "condition": { "not": { "u_has_trait": "perk_PER_UP" } },
         "text": "Gain [<trait_name:perk_PER_UP>]",
         "effect": [
@@ -77,6 +131,24 @@
             "i18n": true
           },
           { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
+        ],
+        "topic": "TALK_PERK_MENU_SELECT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "perk_PER_UP_2" } },
+        "text": "Gain [<trait_name:perk_PER_UP_2>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_PER_UP_2>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:perk_PER_UP_2>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "perk_PER_UP_2", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Must have the Sharper perk",
+            "target_var": { "context_val": "trait_requirement_description" }
+          },
+          { "set_condition": "perk_condition", "condition": { "u_has_trait": "perk_PER_UP" } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },
@@ -1017,7 +1089,7 @@
         },
         "failure_explanation": "Requirements Not Met",
         "failure_topic": "TALK_PERK_MENU_FAIL",
-        "effect": [ { "u_add_trait": { "context_val": "trait_id" } }, { "math": [ "u_num_perks", "-=", "u_playstyle_cost + 1" ] } ]
+        "effect": [ { "u_mutate_towards": { "context_val": "trait_id" } }, { "math": [ "u_num_perks", "-=", "u_playstyle_cost + 1" ] } ]
       },
       {
         "text": "Go Back.",

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -1063,7 +1063,7 @@
         },
         "failure_explanation": "Requirements Not Met",
         "failure_topic": "TALK_PERK_MENU_FAIL",
-        "effect": [ { "u_add_trait": { "context_val": "trait_id" } }, { "math": [ "u_num_perks", "--" ] } ]
+        "effect": [ { "u_mutate_towards": { "context_val": "trait_id" } }, { "math": [ "u_num_perks", "--" ] } ]
       },
       {
         "text": "Go Back.",

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -19,8 +19,18 @@
     "name": { "str": "Stronger" },
     "points": 0,
     "description": "Have you been working out?  +1 Strength.",
+    "changes_to": [ "perk_STR_UP_2" ],
     "category": [ "perk" ],
     "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "STRENGTH", "add": 1 } ] } ]
+  },
+  {
+    "type": "mutation",
+    "id": "perk_STR_UP_2",
+    "name": { "str": "Even Stronger" },
+    "points": 2,
+    "description": "You HAVE been working out.  +2 Strength.",
+    "category": [ "perk" ],
+    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "STRENGTH", "add": 2 } ] } ]
   },
   {
     "type": "mutation",
@@ -28,8 +38,18 @@
     "name": { "str": "Faster" },
     "points": 0,
     "description": "Have you been doing cardio?  +1 Dexterity.",
+    "changes_to": [ "perk_DEX_UP_2" ],
     "category": [ "perk" ],
     "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "DEXTERITY", "add": 1 } ] } ]
+  },
+  {
+    "type": "mutation",
+    "id": "perk_DEX_UP_2",
+    "name": { "str": "Even Faster" },
+    "points": 2,
+    "description": "You HAVE been doing cardio.  +2 Dexterity.",
+    "category": [ "perk" ],
+    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "DEXTERITY", "add": 2 } ] } ]
   },
   {
     "type": "mutation",
@@ -37,8 +57,18 @@
     "name": { "str": "Smarter" },
     "points": 0,
     "description": "Have you been reading?  +1 Intelligence.",
+    "changes_to": [ "perk_INT_UP_2" ],
     "category": [ "perk" ],
     "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "INTELLIGENCE", "add": 1 } ] } ]
+  },
+  {
+    "type": "mutation",
+    "id": "perk_INT_UP_2",
+    "name": { "str": "Even Smarter" },
+    "points": 2,
+    "description": "You HAVE been reading.  +2 Intelligence.",
+    "category": [ "perk" ],
+    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "INTELLIGENCE", "add": 2 } ] } ]
   },
   {
     "type": "mutation",
@@ -46,8 +76,18 @@
     "name": { "str": "Sharper" },
     "points": 0,
     "description": "Have you been staring out into the middle distance?  +1 Perception.",
+    "changes_to": [ "perk_PER_UP_2" ],
     "category": [ "perk" ],
     "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "PERCEPTION", "add": 1 } ] } ]
+  },
+  {
+    "type": "mutation",
+    "id": "perk_PER_UP_2",
+    "name": { "str": "Even Sharper" },
+    "points": 2,
+    "description": "You HAVE been staring out into the middle distance.  +2 Perception.",
+    "category": [ "perk" ],
+    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "PERCEPTION", "add": 2 } ] } ]
   },
   {
     "type": "mutation",

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -27,8 +27,9 @@
     "type": "mutation",
     "id": "perk_STR_UP_2",
     "name": { "str": "Even Stronger" },
-    "points": 2,
+    "points": 0,
     "description": "You HAVE been working out.  +2 Strength.",
+    "prereqs": [ "perk_STR_UP" ],
     "category": [ "perk" ],
     "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "STRENGTH", "add": 2 } ] } ]
   },
@@ -46,8 +47,9 @@
     "type": "mutation",
     "id": "perk_DEX_UP_2",
     "name": { "str": "Even Faster" },
-    "points": 2,
+    "points": 0,
     "description": "You HAVE been doing cardio.  +2 Dexterity.",
+    "prereqs": [ "perk_DEX_UP" ],
     "category": [ "perk" ],
     "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "DEXTERITY", "add": 2 } ] } ]
   },
@@ -65,8 +67,9 @@
     "type": "mutation",
     "id": "perk_INT_UP_2",
     "name": { "str": "Even Smarter" },
-    "points": 2,
+    "points": 0,
     "description": "You HAVE been reading.  +2 Intelligence.",
+    "prereqs": [ "perk_INT_UP" ],
     "category": [ "perk" ],
     "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "INTELLIGENCE", "add": 2 } ] } ]
   },
@@ -84,8 +87,9 @@
     "type": "mutation",
     "id": "perk_PER_UP_2",
     "name": { "str": "Even Sharper" },
-    "points": 2,
+    "points": 0,
     "description": "You HAVE been staring out into the middle distance.  +2 Perception.",
+    "prereqs": [ "perk_PER_UP" ],
     "category": [ "perk" ],
     "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "PERCEPTION", "add": 2 } ] } ]
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Bombastic Perks] Add overwriting perkchain support"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I wanted to add additional +1 stat perks to Bombastic Perks but not clutter up the mutation menu, but since the basic engine used `u_add_trait` there was no way to do that. However, swapping it over to `u_mutate_towards` should keep all basic behavior the same while allowing perks later in chains to overwrite perks earlier in chains, so that (for example) `Stronger` becomes `Even Stronger` and +1 STR becomes +2, rather than simply having `Even Stronger` give you another +1 and having both in your menu simultaneously.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Change  `u_add_trait` to `u_mutate_towards`. Add additional +1 stat perks that overwrite the previous perks in their chain, allowing +2 to all stats (at the cost of 8 perk points). 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Previous perks are properly selectable, new perks in the chain are not selectable unless previous perks are taken, previous perks in the chain cannot be selected a second time after taking the later perks, and part 2 of the chain properly overwrites part 1:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/120433252/aa96772e-1d33-46b4-a736-b11186f736ba)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

This should also allow adding otherwise-unselectable starting traits as perks, since `u_mutate_towards` respects the `cancels` field.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
