### PR TITLE
Camps are faction-agnostic (not just linked to player faction)

### DIFF
--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -804,6 +804,23 @@ void basecamp::unload_camp_map()
     }
 }
 
+void basecamp::set_owner( faction_id new_owner )
+{
+    for( const std::pair<faction_id, faction> fac : g->faction_manager_ptr->all() ) {
+        if( fac.first == new_owner ) {
+            owner = new_owner;
+            return;
+        }
+    }
+    //Fallthrough, id must be invalid
+    debugmsg( "Could not find matching faction for new owner's faction_id!" );
+}
+
+faction_id basecamp::get_owner()
+{
+    return owner;
+}
+
 void basecamp::form_crafting_inventory()
 {
     map &here = get_camp_map();

--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -249,6 +249,14 @@ class basecamp
         void handle_hide_mission( const point &dir );
         void handle_reveal_mission( const point &dir );
         bool has_water() const;
+        /// The number of days the current camp supplies lasts at the given exertion level.
+        int camp_food_supply_days( float exertion_level ) const;
+        /// Returns the total charges of food time_duration @ref work costs
+        int time_to_food( time_duration work, float exertion_level = NO_EXERCISE ) const;
+        /// Changes the faction respect for you by @ref change, returns respect
+        int camp_discipline( int change = 0 ) const;
+        /// Changes the faction opinion for you by @ref change, returns opinion
+        int camp_morale( int change = 0 ) const;
 
         // recipes, gathering, and craft support functions
         // from a direction

--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -453,6 +453,8 @@ class basecamp
     private:
         friend class basecamp_action_components;
 
+        // Which faction owns this camp?
+        mutable faction_id owner = faction_id::NULL_ID();
         // lazy re-evaluation of available camp resources
         void reset_camp_resources( map &here );
         void add_resource( const itype_id &camp_resource );

--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -460,6 +460,8 @@ class basecamp
         void form_storage_zones( map &here, const tripoint_abs_ms &abspos );
         map &get_camp_map();
         void unload_camp_map();
+        void set_owner( faction_id new_owner );
+        faction_id get_owner();
     private:
         friend class basecamp_action_components;
 

--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -33,6 +33,8 @@ enum class farm_ops : int;
 class item;
 class recipe;
 
+using faction_id = string_id<faction>;
+
 const int work_day_hours = 10;
 const int work_day_rest_hours = 8;
 const int work_day_idle_hours = 6;
@@ -455,6 +457,8 @@ class basecamp
 
         // Which faction owns this camp?
         mutable faction_id owner = faction_id::NULL_ID();
+        // Returns the actual faction object which owns this camp
+        faction *fac() const;
         // lazy re-evaluation of available camp resources
         void reset_camp_resources( map &here );
         void add_resource( const itype_id &camp_resource );

--- a/src/character.h
+++ b/src/character.h
@@ -2733,6 +2733,7 @@ class Character : public Creature, public visitable
         std::optional<tripoint> last_target_pos;
         // Save favorite ammo location
         item_location ammo_location;
+        // FIXME: The presence of camps should be global objects, this should only be knowledge of camps (at best)
         std::set<tripoint_abs_omt> camps;
 
         std::vector <addiction> addictions;

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -629,6 +629,7 @@ static std::optional<basecamp *> get_basecamp( npc &p,
         return std::nullopt;
     }
     basecamp *temp_camp = *bcp;
+    temp_camp->set_owner( p.get_fac_id() );
     temp_camp->define_camp( omt_pos, camp_type );
     return temp_camp;
 }

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -302,14 +302,6 @@ static std::string camp_trip_description( const time_duration &total_time,
         const time_duration &travel_time,
         int distance, int trips, int need_food );
 
-/// The number of days the current camp supplies lasts at the given exertion level.
-static int camp_food_supply_days( float exertion_level );
-/// Returns the total charges of food time_duration @ref work costs
-static int time_to_food( time_duration work, float exertion_level = NO_EXERCISE );
-/// Changes the faction respect for you by @ref change, returns respect
-static int camp_discipline( int change = 0 );
-/// Changes the faction opinion for you by @ref change, returns opinion
-static int camp_morale( int change = 0 );
 /*
  * check if a companion survives a random encounter
  * @param comp the companion
@@ -5479,11 +5471,9 @@ std::string basecamp::farm_description( const tripoint_abs_omt &farm_pos, size_t
 
 // food supply
 
-int camp_food_supply_days( float exertion_level )
+int basecamp::camp_food_supply_days( float exertion_level ) const
 {
-    faction *yours = get_player_character().get_faction();
-    // FIXME: Hardcoded to player faction!
-    return yours->food_supply.kcal() / time_to_food( 24_hours, exertion_level );
+    return fac()->food_supply.kcal() / time_to_food( 24_hours, exertion_level );
 }
 
 nutrients basecamp::camp_food_supply( nutrients &change )
@@ -5567,7 +5557,7 @@ void basecamp::feed_workers( Character &worker, nutrients food, bool is_player_m
     feed_workers( work_party, std::move( food ), is_player_meal );
 }
 
-int time_to_food( time_duration work, float exertion_level )
+int basecamp::time_to_food( time_duration work, float exertion_level ) const
 {
     const int days = to_hours<int>( work ) / 24;
     const int work_time = days * work_day_hours + to_hours<int>( work ) - days * 24;
@@ -5859,20 +5849,16 @@ void basecamp::handle_hide_mission( const point &dir )
 }
 
 // morale
-int camp_discipline( int change )
+int basecamp::camp_discipline( int change ) const
 {
-    faction *yours = get_player_character().get_faction();
-    // FIXME: Hardcoded to player faction!
-    yours->respects_u += change;
-    return yours->respects_u;
+    fac()->respects_u += change;
+    return fac()->respects_u;
 }
 
-int camp_morale( int change )
+int basecamp::camp_morale( int change ) const
 {
-    faction *yours = get_player_character().get_faction();
-    yours->likes_u += change;
-    // FIXME: Hardcoded to player faction!
-    return yours->likes_u;
+    fac()->likes_u += change;
+    return fac()->likes_u;
 }
 
 void basecamp::place_results( const item &result )

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -634,6 +634,8 @@ static std::optional<basecamp *> get_basecamp( npc &p,
     return temp_camp;
 }
 
+/** @relates string_id */
+template<>
 const faction &string_id<faction>::obj() const
 {
     return *g->faction_manager_ptr->get( *this );

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -4271,6 +4271,7 @@ void basecamp::serialize( JsonOut &json ) const
 {
     if( omt_pos != tripoint_abs_omt() ) {
         json.start_object();
+        json.member( "owner", owner );
         json.member( "name", name );
         json.member( "pos", omt_pos );
         json.member( "bb_pos", bb_pos );
@@ -4356,6 +4357,10 @@ void basecamp::serialize( JsonOut &json ) const
 void basecamp::deserialize( const JsonObject &data )
 {
     data.allow_omitted_members();
+    if( !data.read( "owner", owner ) ) {
+        faction_id your_fac( "your_followers" );
+        owner = your_fac;
+    }
     data.read( "name", name );
     data.read( "pos", omt_pos );
     data.read( "bb_pos", bb_pos );

--- a/tests/faction_camp_test.cpp
+++ b/tests/faction_camp_test.cpp
@@ -35,6 +35,7 @@ TEST_CASE( "camp_calorie_counting", "[camp]" )
     m.add_camp( this_omt, "faction_camp" );
     std::optional<basecamp *> bcp = overmap_buffer.find_camp( this_omt.xy() );
     basecamp *test_camp = *bcp;
+    test_camp->set_owner( your_fac );
     nutrients &food_supply = camp_faction->food_supply;
     WHEN( "a base item is added to larder" ) {
         food_supply *= 0;


### PR DESCRIPTION
#### Summary
Infrastructure "Camps are faction-agnostic (not just linked to player faction)"

#### Purpose of change
It is intended that one day, NPC factions can also use camps. However, they are locked in to only working for the player's faction("your followers").

#### Describe the solution
Add new member `owner` which stores the faction_id of the faction which controls this camp.

Replace all the code referring solely to the player's faction with generic handling of the owner. (like 90% of this PR)

Save and load all future camps with a faction_id listing their `owner` (camps without any owner listed will be assigned to the player's faction on next load)

For new camps at the time of construction: assign owner's faction_id via the NPC used to construct the camp.

#### Describe alternatives you've considered
I would have liked to have played some helldivers 2 today but instead you got a PR, I hope you're happy

#### Testing
Compiles, loads. Smacked the camp board around a few times, confirmed that calories were subtracted as expected and nothing unexpected happened.

#### Additional context
This is an infrastructure-only change. Players should not notice any changes.
