### PR TITLE
Add some mutation-specific fields to enchantments

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -753,6 +753,7 @@
     "occupied_bodyparts": [ [ "torso", 20 ] ],
     "vitamin_absorb_mod": 1.5,
     "flags": [ "BIONIC_NPC_USABLE", "BIONIC_SHOCKPROOF", "PARAIMMUNE", "IMMUNE_SPOIL" ],
+    "enchantments": [ { "values": [ { "value": "KCAL", "multiply": 0.5 } ] } ],
     "cant_remove_reason": "The CBM has replaced the patient's digestive organs and cannot be removed.",
     "canceled_mutations": [
       "WEAKSTOMACH",

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -4471,6 +4471,7 @@
     "description": "You seem to get full faster now, and food goes through you more rapidly as well.",
     "purifiable": false,
     "stomach_size_multiplier": 0.9,
+    "enchantments": [ { "values": [ { "value": "KCAL", "multiply": -0.4 } ] } ],
     "prereqs": [ "BEAK", "BEAK_PECK", "BEAK_HUM" ],
     "prereqs2": [ "LIGHTEATER" ],
     "threshreq": [ "THRESH_BIRD" ],

--- a/data/mods/Aftershock/player/bionics.json
+++ b/data/mods/Aftershock/player/bionics.json
@@ -57,6 +57,7 @@
     "type": "bionic",
     "name": { "str": "Linguistic Coprocessor" },
     "description": "The left hemisphere of your brain has been augmented with a microcomputer that moderately increases the speed that language and written words are processed, granting a 15% increase to reading speed.",
+    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "READING_SPEED_MULTIPLIER", "multiply": -0.15 } ] } ],
     "occupied_bodyparts": [ [ "head", 2 ] ]
   },
   {

--- a/doc/MAGIC.md
+++ b/doc/MAGIC.md
@@ -865,6 +865,18 @@ Character status value  | Description
 `REGEN_STAMINA`         | 
 `THIRST`                | 
 `WEAPON_DISPERSION`     | Positive value increase the dispersion, negative decrease one.
+`OVERMAP_SIGHT`         | Increases the amount of overmap tiles you can see around.
+`STEALTH_MODIFIER`      | Same as mutation `stealth_modifier` value, amount to be subtracted from player's visibility range, capped to 60.  Negative values work, but are not very effective due to the way vision ranges are capped.
+`MENDING_MODIFIER`      | Changes the speed of your limb mend. Since it's a percent, using `multiply` is recommended.
+`KCAL`                  | Same as bio_digestion effect, increases the amount of calories obrained from the food.
+`VITAMIN_ABSORB_MOD`    | Increases amount of vitamins obtained from the food
+`READING_SPEED_MULTIPLIER`  | Changes how fast you can read books; Lesser value means faster book reading, with cap of 1 second.
+`MELEE_STAMINA_CONSUMPTION` | Changes amount of stamina used when swing in melee; stamina consumption is a negative value, so `"add": 100` decreases amount of stamina consumed, when `"add": -100` increases it; `"multiply": 1` increases, `"multiply": -0.5` decreases it. Can't be bigger than -50.
+`OBTAIN_COST_MULTIPLIER`    | same as `obtain_cost_multiplier`, modifier for pulling an item from a container and storing it back, as a handling penalty. `"add": 100` add 100 additional moves to item wield (1 second)
+`STOMACH_SIZE_MULTIPLIER`   | Same as mutation `stomach_size_multiplier` field, changes how much food you can consume at once. `"add": 1000` adds 1 L to stomach size
+`CASTING_TIME_MULTIPLIER`   | Same as mutation `casting_time_multiplier` field, changes your casting speed. Since it's a percent, using `multiply` is recommended. `"multiply": 2"` triples the casting speed 
+`CRAFTING_SPEED_MULTIPLIER` | Same as mutation `crafting_speed_multiplier` field, changes your crafting speed. Since it's a percent, using `multiply` is recommended.
+`BIONIC_MANA_PENALTY`       | same as mutation `bionic_mana_penalty` field, changes how big the mana penalty for having bionic energy is (default ratio is 1 kj removes 1 mana point). better to use with `multiply`, using `add` just adds or removes flat amount of mana no matter of energy level. `"multiply": 1` double the ratio (1 kj removes 2 mana points), `"multiply": -0.5` halves it
 
 
 Melee-only enchantment values | Description

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -147,7 +147,6 @@ static const ammotype ammo_battery( "battery" );
 
 static const anatomy_id anatomy_human_anatomy( "human_anatomy" );
 
-static const bionic_id afs_bio_linguistic_coprocessor( "afs_bio_linguistic_coprocessor" );
 static const bionic_id bio_gills( "bio_gills" );
 static const bionic_id bio_ground_sonar( "bio_ground_sonar" );
 static const bionic_id bio_hydraulics( "bio_hydraulics" );
@@ -1304,6 +1303,8 @@ int Character::overmap_sight_range( float light_level ) const
     }
     // Mutations like Scout and Topographagnosia affect how far you can see.
     sight += mutation_value( "overmap_sight" );
+
+    sight = enchantment_cache->modify_value( enchant_vals::mod::OVERMAP_SIGHT, sight );
 
     float multiplier = mutation_value( "overmap_multiplier" );
     // If sight is change due to overmap_sight, process the rest of the modifiers, otherwise skip them
@@ -3530,12 +3531,9 @@ int Character::read_speed() const
     /** @EFFECT_INT affects reading speed by an decreasing amount the higher intelligence goes, intially about 9% per point at 4 int to lower than 4% at 20+ int */
     time_duration ret = 180_seconds / intel;
 
-    if( has_bionic( afs_bio_linguistic_coprocessor ) ) { // Aftershock
-        ret *= .85;
-    }
-
     ret *= mutation_value( "reading_speed_multiplier" );
 
+    ret = enchantment_cache->modify_value( enchant_vals::mod::READING_SPEED_MULTIPLIER, ret );
     if( ret < 1_seconds ) {
         ret = 1_seconds;
     }
@@ -6057,6 +6055,8 @@ int Character::visibility( bool, int ) const
     // TODO:
     // if ( dark_clothing() && light check ...
     int stealth_modifier = std::floor( mutation_value( "stealth_modifier" ) );
+    stealth_modifier = enchantment_cache->modify_value( enchant_vals::mod::STEALTH_MODIFIER,
+                       stealth_modifier );
     return clamp( 100 - stealth_modifier, 40, 160 );
 }
 

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -57,7 +57,6 @@
 static const std::string comesttype_DRINK( "DRINK" );
 static const std::string comesttype_FOOD( "FOOD" );
 
-static const bionic_id bio_digestion( "bio_digestion" );
 static const bionic_id bio_faulty_grossfood( "bio_faulty_grossfood" );
 static const bionic_id bio_syringe( "bio_syringe" );
 static const bionic_id bio_taste_blocker( "bio_taste_blocker" );
@@ -129,7 +128,6 @@ static const trait_id trait_ANTIWHEAT( "ANTIWHEAT" );
 static const trait_id trait_CARNIVORE( "CARNIVORE" );
 static const trait_id trait_EATDEAD( "EATDEAD" );
 static const trait_id trait_EATHEALTH( "EATHEALTH" );
-static const trait_id trait_GIZZARD( "GIZZARD" );
 static const trait_id trait_GOURMAND( "GOURMAND" );
 static const trait_id trait_HERBIVORE( "HERBIVORE" );
 static const trait_id trait_HIBERNATE( "HIBERNATE" );
@@ -192,10 +190,6 @@ static int compute_default_effective_kcal( const item &comest, const Character &
         kcal *= 0.75f;
     }
 
-    if( you.has_trait( trait_GIZZARD ) ) {
-        kcal *= 0.6f;
-    }
-
     if( you.has_trait( trait_CARNIVORE ) && comest.has_flag( flag_CARNIVORE_OK ) &&
         comest.has_any_flag( carnivore_blacklist ) ) {
         // TODO: Comment pizza scrapping
@@ -211,10 +205,7 @@ static int compute_default_effective_kcal( const item &comest, const Character &
         kcal *= ( 1.0f - rottedness );
     }
 
-    // Bionic digestion gives extra nutrition
-    if( you.has_bionic( bio_digestion ) ) {
-        kcal *= 1.5f;
-    }
+    kcal = you.enchantment_cache->modify_value( enchant_vals::mod::KCAL, kcal );
 
     return static_cast<int>( kcal );
 }
@@ -262,6 +253,10 @@ static std::map<vitamin_id, int> compute_default_effective_vitamins(
         for( std::pair<const vitamin_id, int> &vit : res ) {
             vit.second *= bid->vitamin_absorb_mod;
         }
+    }
+    for( std::pair<const vitamin_id, int> &vit : res ) {
+        vit.second = you.enchantment_cache->modify_value( enchant_vals::mod::VITAMIN_ABSORB_MOD,
+                     vit.second );
     }
     return res;
 }

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -281,9 +281,13 @@ float Character::workbench_crafting_speed_multiplier( const item &craft,
 
 float Character::crafting_speed_multiplier( const recipe &rec ) const
 {
-    const float result = morale_crafting_speed_multiplier( rec ) *
-                         lighting_craft_speed_multiplier( rec ) *
-                         get_limb_score( limb_score_manip );
+    float crafting_speed = morale_crafting_speed_multiplier( rec ) *
+                           lighting_craft_speed_multiplier( rec ) *
+                           get_limb_score( limb_score_manip );
+
+    const float result = enchantment_cache->modify_value( enchant_vals::mod::CRAFTING_SPEED_MULTIPLIER,
+                         crafting_speed );
+
     add_msg_debug( debugmode::DF_CHARACTER, "Limb score multiplier %.1f, crafting speed multiplier %1f",
                    get_limb_score( limb_score_manip ), result );
 

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -719,6 +719,8 @@ class item_location::impl::item_in_container : public item_location::impl
 
             int primary_cost = ch.mutation_value( "obtain_cost_multiplier" ) * ch.item_handling_cost( *target(),
                                true, container_mv );
+            primary_cost = ch.enchantment_cache->modify_value( enchant_vals::mod::OBTAIN_COST_MULTIPLIER,
+                           primary_cost );
             int parent_obtain_cost = container.obtain_cost( ch, qty );
             if( container->get_use( "holster" ) ) {
                 if( ch.is_worn( *container ) ) {

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1177,6 +1177,9 @@ int spell::casting_time( const Character &guy, bool ignore_encumb ) const
 
     casting_time *= guy.mutation_value( "casting_time_multiplier" );
 
+    casting_time = guy.enchantment_cache->modify_value( enchant_vals::mod::CASTING_TIME_MULTIPLIER,
+                   casting_time );
+
     if( !ignore_encumb && temp_somatic_difficulty_multiplyer > 0 ) {
         if( !has_flag( spell_flag::NO_LEGS ) ) {
             // the first 20 points of encumbrance combined is ignored
@@ -2151,9 +2154,13 @@ void known_magic::mod_mana( const Character &guy, int add_mana )
 int known_magic::max_mana( const Character &guy ) const
 {
     const float int_bonus = ( ( 0.2f + guy.get_int() * 0.1f ) - 1.0f ) * mana_base;
-    const int bionic_penalty = std::round( std::max( 0.0f,
-                                           units::to_kilojoule( guy.get_power_level() ) *
-                                           guy.mutation_value( "bionic_mana_penalty" ) ) );
+    int penalty_calc = std::round( std::max( 0.0f,
+                                   units::to_kilojoule( guy.get_power_level() ) *
+                                   guy.mutation_value( "bionic_mana_penalty" ) ) );
+
+    const int bionic_penalty = guy.enchantment_cache->modify_value(
+                                   enchant_vals::mod::BIONIC_MANA_PENALTY, penalty_calc );
+
     const float unaugmented_mana = std::max( 0.0f,
                                    ( ( mana_base + int_bonus ) * guy.mutation_value( "mana_multiplier" ) ) +
                                    guy.mutation_value( "mana_modifier" ) - bionic_penalty );

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -99,6 +99,18 @@ namespace io
             case enchant_vals::mod::MOD_HEALTH_CAP: return "MOD_HEALTH_CAP";
             case enchant_vals::mod::READING_EXP: return "READING_EXP";
             case enchant_vals::mod::SKILL_RUST_RESIST: return "SKILL_RUST_RESIST";
+            case enchant_vals::mod::OVERMAP_SIGHT: return "OVERMAP_SIGHT";
+            case enchant_vals::mod::READING_SPEED_MULTIPLIER: return "READING_SPEED_MULTIPLIER";
+            case enchant_vals::mod::KCAL: return "KCAL";
+            case enchant_vals::mod::VITAMIN_ABSORB_MOD: return "VITAMIN_ABSORB_MOD";
+            case enchant_vals::mod::MELEE_STAMINA_CONSUMPTION: return "MELEE_STAMINA_CONSUMPTION";
+            case enchant_vals::mod::OBTAIN_COST_MULTIPLIER: return "OBTAIN_COST_MULTIPLIER";
+            case enchant_vals::mod::CASTING_TIME_MULTIPLIER: return "CASTING_TIME_MULTIPLIER";
+            case enchant_vals::mod::CRAFTING_SPEED_MULTIPLIER: return "CRAFTING_SPEED_MULTIPLIER";
+            case enchant_vals::mod::BIONIC_MANA_PENALTY: return "BIONIC_MANA_PENALTY";
+            case enchant_vals::mod::STEALTH_MODIFIER: return "STEALTH_MODIFIER";
+            case enchant_vals::mod::MENDING_MODIFIER: return "MENDING_MODIFIER";
+            case enchant_vals::mod::STOMACH_SIZE_MULTIPLIER: return "STOMACH_SIZE_MULTIPLIER";
             case enchant_vals::mod::LEARNING_FOCUS: return "LEARNING_FOCUS";
             case enchant_vals::mod::RECOIL_MODIFIER: return "RECOIL_MODIFIER";
             case enchant_vals::mod::ARMOR_ACID: return "ARMOR_ACID";
@@ -840,6 +852,22 @@ units::mass enchant_cache::modify_value( const enchant_vals::mod mod_val,
         units::mass value ) const
 {
     value += units::from_gram<double>( get_value_add( mod_val ) );
+    value *= 1.0 + get_value_multiply( mod_val );
+    return value;
+}
+
+units::volume enchant_cache::modify_value( const enchant_vals::mod mod_val,
+        units::volume value ) const
+{
+    value += units::from_milliliter<double>( get_value_add( mod_val ) );
+    value *= 1.0 + get_value_multiply( mod_val );
+    return value;
+}
+
+time_duration enchant_cache::modify_value( const enchant_vals::mod mod_val,
+        time_duration value ) const
+{
+    value += time_duration::from_seconds<double>( get_value_add( mod_val ) );
     value *= 1.0 + get_value_multiply( mod_val );
     return value;
 }

--- a/src/magic_enchantment.h
+++ b/src/magic_enchantment.h
@@ -76,6 +76,18 @@ enum class mod : int {
     MOD_HEALTH_CAP,
     READING_EXP,
     SKILL_RUST_RESIST,
+    READING_SPEED_MULTIPLIER,
+    OVERMAP_SIGHT,
+    KCAL,
+    VITAMIN_ABSORB_MOD,
+    MELEE_STAMINA_CONSUMPTION,
+    OBTAIN_COST_MULTIPLIER,
+    CASTING_TIME_MULTIPLIER,
+    CRAFTING_SPEED_MULTIPLIER,
+    BIONIC_MANA_PENALTY,
+    STEALTH_MODIFIER,
+    MENDING_MODIFIER,
+    STOMACH_SIZE_MULTIPLIER,
     LEARNING_FOCUS,
     ARMOR_BASH,
     ARMOR_CUT,
@@ -242,6 +254,8 @@ class enchant_cache : public enchantment
         double modify_value( const skill_id &mod_val, double value ) const;
         units::energy modify_value( enchant_vals::mod mod_val, units::energy value ) const;
         units::mass modify_value( enchant_vals::mod mod_val, units::mass value ) const;
+        units::volume modify_value( enchant_vals::mod mod_val, units::volume value ) const;
+        time_duration modify_value( enchant_vals::mod mod_val, time_duration value ) const;
         // adds two enchantments together and ignores their conditions
         void force_add( const enchantment &rhs, const Character &guy );
         void force_add( const enchantment &rhs );

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -921,7 +921,9 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
     /** @EFFECT_MELEE reduces stamina cost of melee attacks */
     const int deft_bonus = !hits && has_trait( trait_DEFT ) ? 50 : 0;
     const int base_stam = get_base_melee_stamina_cost();
-    const int total_stam = get_total_melee_stamina_cost();
+    const int total_stam = enchantment_cache->modify_value(
+                               enchant_vals::mod::MELEE_STAMINA_CONSUMPTION,
+                               get_total_melee_stamina_cost() );
 
     burn_energy_arms( std::min( -50, total_stam + deft_bonus ) );
     add_msg_debug( debugmode::DF_MELEE, "Stamina burn base/total (capped at -50): %d/%d", base_stam,

--- a/src/stomach.cpp
+++ b/src/stomach.cpp
@@ -304,7 +304,8 @@ void stomach_contents::deserialize( const JsonObject &jo )
 
 units::volume stomach_contents::capacity( const Character &owner ) const
 {
-    return max_volume * owner.mutation_value( "stomach_size_multiplier" );
+    return owner.enchantment_cache->modify_value( enchant_vals::mod::STOMACH_SIZE_MULTIPLIER,
+            max_volume * owner.mutation_value( "stomach_size_multiplier" ) );
 }
 
 units::volume stomach_contents::stomach_remaining( const Character &owner ) const

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -1958,6 +1958,9 @@ void Character::mend( int rate_multiplier )
 
     healing_factor *= mutation_value( "mending_modifier" );
 
+    healing_factor = enchantment_cache->modify_value( enchant_vals::mod::MENDING_MODIFIER,
+                     healing_factor );
+
     add_msg_debug( debugmode::DF_CHAR_HEALTH, "Limb mend healing factor: %.2f", healing_factor );
     if( healing_factor <= 0.0f ) {
         // The section below assumes positive healing rate


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Inspired by #71920
#### Describe the solution
port some mutation fields to be used by enchantments, specifically `"OVERMAP_SIGHT", "STEALTH_MODIFIER", "MENDING_MODIFIER", "STOMACH_SIZE_MULTIPLIER", "CASTING_TIME_MULTIPLIER", "CRAFTING_SPEED_MULTIPLIER", "BIONIC_MANA_PENALTY", "MELEE_STAMINA_CONSUMPTION", "KCAL", "VITAMIN_ABSORB_MOD", "OBTAIN_COST_MULTIPLIER", "READING_SPEED_MULTIPLIER"` 
#### Testing
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/67688115/cb419f2e-c36b-4fd8-b0c0-9e1fda54ea96)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/67688115/81439682-4944-4590-8a06-7c6a8f8a93e8)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/67688115/3e4ea44c-1e06-4d73-ba1f-d44a1b343d36)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/67688115/aeeab87a-ee64-4199-a04f-2863c2faba06)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/67688115/e3f87cce-dc0a-4474-9553-e218cd44e774)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/67688115/203a4f54-cc4b-47e5-a484-c5b2e397ca3b)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/67688115/71c32572-0b3e-4661-b4a3-af4c492e0ca6)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/67688115/c2de84b2-3708-41aa-b93a-162ceb8093f5)
