### PR TITLE
[Magiclysm] Boosts spell leveling by cast

### DIFF
--- a/data/mods/Magiclysm/eoc_spell_learn_boost.json
+++ b/data/mods/Magiclysm/eoc_spell_learn_boost.json
@@ -30,10 +30,6 @@
     "//": "Regular classes levels some faster and needs 2-10 spellcasts to level up depends on spell cost",
     "condition": {
       "or": [
-        {
-          "compare_string": [ "NONE", { "context_val": "school" } ],
-          "//todo": "Should we check somehow 0 mana cost (for stamina cost spells etc)?"
-        },
         { "compare_string": [ "MANA_CRYST_MANA", { "context_val": "school" } ] },
         { "compare_string": [ "MANA_SEEKER_BOLTS", { "context_val": "school" } ] },
         { "compare_string": [ "ANIMIST", { "context_val": "school" } ] },
@@ -135,6 +131,55 @@
           "mc_spell_exp_diff(u_spell_level(_spell)) * (_cost / 1000) * mc_spell_train_focus_factor(u_val('focus'),u_spell_level(_spell))"
         ]
       }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_MC_CASTED_A_SPELL_LEARN_BOOST_CLASSLESS",
+    "eoc_type": "EVENT",
+    "required_event": "character_casts_spell",
+    "//": "Classless every spell cuz a but when you lear debug spells",
+    "condition": {
+      "or": [
+        { "compare_string": [ "crystallize_mana", { "context_val": "spell" } ] },
+        { "compare_string": [ "dark_sight", { "context_val": "spell" } ] },
+        { "compare_string": [ "megablast", { "context_val": "spell" } ] },
+        { "compare_string": [ "create_atomic_light", { "context_val": "spell" } ] },
+        { "compare_string": [ "blinding_flash", { "context_val": "spell" } ] },
+        { "compare_string": [ "ethereal_grasp", { "context_val": "spell" } ] },
+        { "compare_string": [ "obfuscated_body", { "context_val": "spell" } ] },
+        { "compare_string": [ "obfuscated_body_plus", { "context_val": "spell" } ] },
+        { "compare_string": [ "protection_aura", { "context_val": "spell" } ] },
+        { "compare_string": [ "protection_aura_plus", { "context_val": "spell" } ] },
+        { "compare_string": [ "translocate_self", { "context_val": "spell" } ] },
+        { "compare_string": [ "acid_resistance", { "context_val": "spell" } ] },
+        { "compare_string": [ "acid_resistance_greater", { "context_val": "spell" } ] },
+        { "compare_string": [ "thought_shield", { "context_val": "spell" } ] },
+        { "compare_string": [ "thought_shield_plus", { "context_val": "spell" } ] },
+        { "compare_string": [ "sound_bomb", { "context_val": "spell" } ] },
+        { "compare_string": [ "classless_watch_spell", { "context_val": "spell" } ] },
+        { "compare_string": [ "classless_clean_clothing_and_self", { "context_val": "spell" } ] },
+        { "compare_string": [ "classless_easy_sleep_spell", { "context_val": "spell" } ] },
+        { "compare_string": [ "classless_dispel_magic", { "context_val": "spell" } ] },
+        { "compare_string": [ "classless_disjunction", { "context_val": "spell" } ] }
+      ]
+    },
+    "effect": [
+      {
+        "math": [
+          "u_spell_exp(_spell)",
+          "+=",
+          "mc_spell_exp_diff(u_spell_level(_spell)) / mc_spell_cost_train_factor(_cost, 2, 10) * mc_spell_train_focus_factor(u_val('focus'),u_spell_level(_spell))"
+        ]
+      },
+      {
+        "math": [
+          "debug_mc_additional_spell_xp",
+          "=",
+          "mc_spell_exp_diff(u_spell_level(_spell)) / mc_spell_cost_train_factor(_cost, 2, 10) * mc_spell_train_focus_factor(u_val('focus'),u_spell_level(_spell))"
+        ]
+      },
+      { "u_message": "debug_mc_additional_spell_xp: <global_val:debug_mc_additional_spell_xp>", "type": "debug" }
     ]
   }
 ]

--- a/data/mods/Magiclysm/eoc_spell_learn_boost.json
+++ b/data/mods/Magiclysm/eoc_spell_learn_boost.json
@@ -48,7 +48,13 @@
       ]
     },
     "effect": [
-      { "math": [ "u_spell_exp(_spell)", "+=", "mc_spell_exp_diff(u_spell_level(_spell)) / mc_spell_cost_train_factor(_cost, 2, 10) * mc_spell_train_focus_factor(u_val('focus'),u_spell_level(_spell))" ] }
+      {
+        "math": [
+          "u_spell_exp(_spell)",
+          "+=",
+          "mc_spell_exp_diff(u_spell_level(_spell)) / mc_spell_cost_train_factor(_cost, 2, 10) * mc_spell_train_focus_factor(u_val('focus'),u_spell_level(_spell))"
+        ]
+      }
     ]
   },
   {
@@ -59,7 +65,10 @@
     "//": "Attuned classes levels faster since they have no any books, and needs 1-5 spellcasts to level up depends on spell cost",
     "condition": {
       "or": [
-        { "compare_string": [ "NONE", { "context_val": "school" } ], "//todo": "Should we check somehow 0 mana cost (for stamina cost spells etc)?" },
+        {
+          "compare_string": [ "NONE", { "context_val": "school" } ],
+          "//todo": "Should we check somehow 0 mana cost (for stamina cost spells etc)?"
+        },
         { "compare_string": [ "MANA_CRYST_MANA", { "context_val": "school" } ] },
         { "compare_string": [ "MANA_SEEKER_BOLTS", { "context_val": "school" } ] },
         { "compare_string": [ "ANIMIST", { "context_val": "school" } ] },
@@ -102,7 +111,13 @@
       ]
     },
     "effect": [
-      { "math": [ "u_spell_exp(_spell)", "+=", "mc_spell_exp_diff(u_spell_level(_spell)) / mc_spell_cost_train_factor(_cost, 1, 5) * mc_spell_train_focus_factor(u_val('focus'),u_spell_level(_spell))" ] }
+      {
+        "math": [
+          "u_spell_exp(_spell)",
+          "+=",
+          "mc_spell_exp_diff(u_spell_level(_spell)) / mc_spell_cost_train_factor(_cost, 1, 5) * mc_spell_train_focus_factor(u_val('focus'),u_spell_level(_spell))"
+        ]
+      }
     ]
   },
   {
@@ -111,11 +126,15 @@
     "eoc_type": "EVENT",
     "required_event": "character_casts_spell",
     "//": "Biotek levels faster since it need an energy to cast, so factor is always is energy_cost/1000 * focus_factor",
-    "condition": {
-      "compare_string": [ "BIOTEK", { "context_val": "school" } ]
-    },
+    "condition": { "compare_string": [ "BIOTEK", { "context_val": "school" } ] },
     "effect": [
-      { "math": [ "u_spell_exp(_spell)", "+=", "mc_spell_exp_diff(u_spell_level(_spell)) * (_cost / 1000) * mc_spell_train_focus_factor(u_val('focus'),u_spell_level(_spell))" ] }
+      {
+        "math": [
+          "u_spell_exp(_spell)",
+          "+=",
+          "mc_spell_exp_diff(u_spell_level(_spell)) * (_cost / 1000) * mc_spell_train_focus_factor(u_val('focus'),u_spell_level(_spell))"
+        ]
+      }
     ]
   }
 ]

--- a/data/mods/Magiclysm/eoc_spell_learn_boost.json
+++ b/data/mods/Magiclysm/eoc_spell_learn_boost.json
@@ -27,7 +27,7 @@
     "id": "EOC_MC_CASTED_A_SPELL_LEARN_BOOST",
     "eoc_type": "EVENT",
     "required_event": "character_casts_spell",
-    "//": "Regular classes levels some faster and needs 2-10 spellcasts to level up depends on spell cost",
+    "//": "Regular classes levels some faster and needs 16-65 spellcasts to level up depends on spell cost",
     "condition": {
       "or": [
         { "compare_string": [ "MANA_CRYST_MANA", { "context_val": "school" } ] },
@@ -48,7 +48,7 @@
         "math": [
           "u_spell_exp(_spell)",
           "+=",
-          "mc_spell_exp_diff(u_spell_level(_spell)) / mc_spell_cost_train_factor(_cost, 2, 10) * mc_spell_train_focus_factor(u_val('focus'),u_spell_level(_spell))"
+          "mc_spell_exp_diff(u_spell_level(_spell)) / mc_spell_cost_train_factor(_cost, 16, 65) * mc_spell_train_focus_factor(u_val('focus'),u_spell_level(_spell))"
         ]
       }
     ]
@@ -58,7 +58,7 @@
     "id": "EOC_MC_CASTED_A_SPELL_LEARN_BOOST_ATTUNED",
     "eoc_type": "EVENT",
     "required_event": "character_casts_spell",
-    "//": "Attuned classes levels faster since they have no any books, and needs 1-5 spellcasts to level up depends on spell cost",
+    "//": "Attuned classes need 20 to 75 casts to level",
     "condition": {
       "or": [
         { "compare_string": [ "MANA_CRYST_MANA", { "context_val": "school" } ] },
@@ -107,7 +107,7 @@
         "math": [
           "u_spell_exp(_spell)",
           "+=",
-          "mc_spell_exp_diff(u_spell_level(_spell)) / mc_spell_cost_train_factor(_cost, 1, 5) * mc_spell_train_focus_factor(u_val('focus'),u_spell_level(_spell))"
+          "mc_spell_exp_diff(u_spell_level(_spell)) / mc_spell_cost_train_factor(_cost, 20, 75) * mc_spell_train_focus_factor(u_val('focus'),u_spell_level(_spell))"
         ]
       }
     ]
@@ -124,7 +124,7 @@
         "math": [
           "u_spell_exp(_spell)",
           "+=",
-          "mc_spell_exp_diff(u_spell_level(_spell)) * (_cost / 1000) * mc_spell_train_focus_factor(u_val('focus'),u_spell_level(_spell))"
+          "mc_spell_exp_diff(u_spell_level(_spell)) * (_cost / 5000) * mc_spell_train_focus_factor(u_val('focus'),u_spell_level(_spell))"
         ]
       }
     ]
@@ -165,14 +165,14 @@
         "math": [
           "u_spell_exp(_spell)",
           "+=",
-          "mc_spell_exp_diff(u_spell_level(_spell)) / mc_spell_cost_train_factor(_cost, 2, 10) * mc_spell_train_focus_factor(u_val('focus'),u_spell_level(_spell))"
+          "mc_spell_exp_diff(u_spell_level(_spell)) / mc_spell_cost_train_factor(_cost, 16, 65) * mc_spell_train_focus_factor(u_val('focus'),u_spell_level(_spell))"
         ]
       },
       {
         "math": [
           "debug_mc_additional_spell_xp",
           "=",
-          "mc_spell_exp_diff(u_spell_level(_spell)) / mc_spell_cost_train_factor(_cost, 2, 10) * mc_spell_train_focus_factor(u_val('focus'),u_spell_level(_spell))"
+          "mc_spell_exp_diff(u_spell_level(_spell)) / mc_spell_cost_train_factor(_cost, 16, 65) * mc_spell_train_focus_factor(u_val('focus'),u_spell_level(_spell))"
         ]
       },
       { "u_message": "debug_mc_additional_spell_xp: <global_val:debug_mc_additional_spell_xp>", "type": "debug" }

--- a/data/mods/Magiclysm/eoc_spell_learn_boost.json
+++ b/data/mods/Magiclysm/eoc_spell_learn_boost.json
@@ -22,7 +22,6 @@
     "//": "accept the spell _cost, return how much spellcasts required to level the spell; formula assumes 10 spellcasts at 100% manapool cost, and 2 spellcasts at 1% manapool cost",
     "return": "max(_1, min(_2, (_2 - (_1 * max(0, _0) / u_val('mana_max') * _2 / _1 ))))"
   },
-
   {
     "type": "effect_on_condition",
     "id": "EOC_MC_CASTED_A_SPELL_LEARN_BOOST",

--- a/data/mods/Magiclysm/eoc_spell_learn_boost.json
+++ b/data/mods/Magiclysm/eoc_spell_learn_boost.json
@@ -1,0 +1,121 @@
+[
+  {
+    "type": "jmath_function",
+    "id": "mc_spell_exp_diff",
+    "num_args": 1,
+    "//": "accept the spell level, return a difference in experience between spell's current level and the next level",
+    "return": "spell_exp(_0 + 1) - spell_exp(_0)"
+  },
+  {
+    "type": "jmath_function",
+    "id": "mc_spell_train_focus_factor",
+    "num_args": 2,
+    "//args": "_0=focus, _1=spell_level",
+    "//": "At level 15 focus factor is enabled, 50 focus = twice more spellcasts, 100 focus = same, 200 focus = twice less spellcasts",
+    "return": "_1 > 15 ? (max(20, _0) - 50) / 100 + 0.5 : 1"
+  },
+  {
+    "type": "jmath_function",
+    "id": "mc_spell_cost_train_factor",
+    "num_args": 3,
+    "//args": "_0=cost,_1=min_spellcasts,_2=max_spellcasts",
+    "//": "accept the spell _cost, return how much spellcasts required to level the spell; formula assumes 10 spellcasts at 100% manapool cost, and 2 spellcasts at 1% manapool cost",
+    "return": "max(_1, min(_2, (_2 - (_1 * max(0, _0) / u_val('mana_max') * _2 / _1 ))))"
+  },
+
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_MC_CASTED_A_SPELL_LEARN_BOOST",
+    "eoc_type": "EVENT",
+    "required_event": "character_casts_spell",
+    "//": "Regular classes levels some faster and needs 2-10 spellcasts to level up depends on spell cost",
+    "condition": {
+      "or": [
+        { "compare_string": [ "NONE", { "context_val": "school" } ], "//todo": "Should we check somehow 0 mana cost (for stamina cost spells etc)?" },
+        { "compare_string": [ "MANA_CRYST_MANA", { "context_val": "school" } ] },
+        { "compare_string": [ "MANA_SEEKER_BOLTS", { "context_val": "school" } ] },
+        { "compare_string": [ "ANIMIST", { "context_val": "school" } ] },
+        { "compare_string": [ "BIOMANCER", { "context_val": "school" } ] },
+        { "compare_string": [ "DRUID", { "context_val": "school" } ] },
+        { "compare_string": [ "EARTHSHAPER", { "context_val": "school" } ] },
+        { "compare_string": [ "KELVINIST", { "context_val": "school" } ] },
+        { "compare_string": [ "MAGUS", { "context_val": "school" } ] },
+        { "compare_string": [ "STORMSHAPER", { "context_val": "school" } ] },
+        { "compare_string": [ "TECHNOMANCER", { "context_val": "school" } ] },
+        { "compare_string": [ "ALCHEMIST", { "context_val": "school" } ] }
+      ]
+    },
+    "effect": [
+      { "math": [ "u_spell_exp(_spell)", "+=", "mc_spell_exp_diff(u_spell_level(_spell)) / mc_spell_cost_train_factor(_cost, 2, 10) * mc_spell_train_focus_factor(u_val('focus'),u_spell_level(_spell))" ] }
+    ]
+  },
+
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_MC_CASTED_A_SPELL_LEARN_BOOST_ATTUNED",
+    "eoc_type": "EVENT",
+    "required_event": "character_casts_spell",
+    "//": "Attuned classes levels faster since they have no any books, and needs 1-5 spellcasts to level up depends on spell cost",
+    "condition": {
+      "or": [
+        { "compare_string": [ "NONE", { "context_val": "school" } ], "//todo": "Should we check somehow 0 mana cost (for stamina cost spells etc)?" },
+        { "compare_string": [ "MANA_CRYST_MANA", { "context_val": "school" } ] },
+        { "compare_string": [ "MANA_SEEKER_BOLTS", { "context_val": "school" } ] },
+        { "compare_string": [ "ANIMIST", { "context_val": "school" } ] },
+        { "compare_string": [ "BIOMANCER", { "context_val": "school" } ] },
+        { "compare_string": [ "DRUID", { "context_val": "school" } ] },
+        { "compare_string": [ "EARTHSHAPER", { "context_val": "school" } ] },
+        { "compare_string": [ "KELVINIST", { "context_val": "school" } ] },
+        { "compare_string": [ "MAGUS", { "context_val": "school" } ] },
+        { "compare_string": [ "STORMSHAPER", { "context_val": "school" } ] },
+        { "compare_string": [ "TECHNOMANCER", { "context_val": "school" } ] },
+        { "compare_string": [ "ALCHEMIST", { "context_val": "school" } ] },
+        { "compare_string": [ "ARTIFICER", { "context_val": "school" } ] },
+        { "compare_string": [ "BLOOD_MAGE", { "context_val": "school" } ] },
+        { "compare_string": [ "BOREAL_MAGE", { "context_val": "school" } ] },
+        { "compare_string": [ "CLEANSING_FLAME", { "context_val": "school" } ] },
+        { "compare_string": [ "CRUSADER", { "context_val": "school" } ] },
+        { "compare_string": [ "EARTH_ELEMENTAL", { "context_val": "school" } ] },
+        { "compare_string": [ "FIRE_ELEMENTAL", { "context_val": "school" } ] },
+        { "compare_string": [ "FORCE_MAGE", { "context_val": "school" } ] },
+        { "compare_string": [ "GAIAS_CHOSEN", { "context_val": "school" } ] },
+        { "compare_string": [ "GLACIER_MAGE", { "context_val": "school" } ] },
+        { "compare_string": [ "GOLEMANCER", { "context_val": "school" } ] },
+        { "compare_string": [ "GRAVITY_MAGE", { "context_val": "school" } ] },
+        { "compare_string": [ "ICE_ELEMENTAL", { "context_val": "school" } ] },
+        { "compare_string": [ "ILLUSIONIST", { "context_val": "school" } ] },
+        { "compare_string": [ "MAGNETISM_MAGE", { "context_val": "school" } ] },
+        { "compare_string": [ "OVERCLOCKER", { "context_val": "school" } ] },
+        { "compare_string": [ "PERMAFROST_MAGE", { "context_val": "school" } ] },
+        { "compare_string": [ "RADIATION_MAGE", { "context_val": "school" } ] },
+        { "compare_string": [ "SHAMAN", { "context_val": "school" } ] },
+        { "compare_string": [ "SHAPESHIFTER", { "context_val": "school" } ] },
+        { "compare_string": [ "SOULFIRE", { "context_val": "school" } ] },
+        { "compare_string": [ "STORM_ELEMENTAL", { "context_val": "school" } ] },
+        { "compare_string": [ "STORMCALLER", { "context_val": "school" } ] },
+        { "compare_string": [ "SUN_MAGE", { "context_val": "school" } ] },
+        { "compare_string": [ "TUNDRA_MAGE", { "context_val": "school" } ] },
+        { "compare_string": [ "VOID_MAGE", { "context_val": "school" } ] },
+        { "compare_string": [ "VULCANIST", { "context_val": "school" } ] },
+        { "compare_string": [ "WITHER_MAGE", { "context_val": "school" } ] }
+      ]
+    },
+    "effect": [
+      { "math": [ "u_spell_exp(_spell)", "+=", "mc_spell_exp_diff(u_spell_level(_spell)) / mc_spell_cost_train_factor(_cost, 1, 5) * mc_spell_train_focus_factor(u_val('focus'),u_spell_level(_spell))" ] }
+    ]
+  },
+
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_MC_CASTED_A_SPELL_LEARN_BOOST_BIOTEK",
+    "eoc_type": "EVENT",
+    "required_event": "character_casts_spell",
+    "//": "Biotek levels faster since it need an energy to cast, so factor is always is energy_cost/1000 * focus_factor",
+    "condition": {
+      "compare_string": [ "BIOTEK", { "context_val": "school" } ]
+    },
+    "effect": [
+      { "math": [ "u_spell_exp(_spell)", "+=", "mc_spell_exp_diff(u_spell_level(_spell)) * (_cost / 1000) * mc_spell_train_focus_factor(u_val('focus'),u_spell_level(_spell))" ] }
+    ]
+  }
+]

--- a/data/mods/Magiclysm/eoc_spell_learn_boost.json
+++ b/data/mods/Magiclysm/eoc_spell_learn_boost.json
@@ -30,7 +30,10 @@
     "//": "Regular classes levels some faster and needs 2-10 spellcasts to level up depends on spell cost",
     "condition": {
       "or": [
-        { "compare_string": [ "NONE", { "context_val": "school" } ], "//todo": "Should we check somehow 0 mana cost (for stamina cost spells etc)?" },
+        {
+          "compare_string": [ "NONE", { "context_val": "school" } ],
+          "//todo": "Should we check somehow 0 mana cost (for stamina cost spells etc)?"
+        },
         { "compare_string": [ "MANA_CRYST_MANA", { "context_val": "school" } ] },
         { "compare_string": [ "MANA_SEEKER_BOLTS", { "context_val": "school" } ] },
         { "compare_string": [ "ANIMIST", { "context_val": "school" } ] },

--- a/data/mods/Magiclysm/eoc_spell_learn_boost.json
+++ b/data/mods/Magiclysm/eoc_spell_learn_boost.json
@@ -19,7 +19,7 @@
     "id": "mc_spell_cost_train_factor",
     "num_args": 3,
     "//args": "_0=cost,_1=min_spellcasts,_2=max_spellcasts",
-    "//": "accept the spell _cost, return how much spellcasts required to level the spell; formula assumes 10 spellcasts at 100% manapool cost, and 2 spellcasts at 1% manapool cost",
+    "//": "accept the spell _cost, return how many spellcasts are required to level the spell; formula assumes 10 spellcasts at 100% manapool cost, and 2 spellcasts at 1% manapool cost",
     "return": "max(_1, min(_2, (_2 - (_1 * max(0, _0) / u_val('mana_max') * _2 / _1 ))))"
   },
   {

--- a/data/mods/Magiclysm/eoc_spell_learn_boost.json
+++ b/data/mods/Magiclysm/eoc_spell_learn_boost.json
@@ -19,7 +19,7 @@
     "id": "mc_spell_cost_train_factor",
     "num_args": 3,
     "//args": "_0=cost,_1=min_spellcasts,_2=max_spellcasts",
-    "//": "accept the spell _cost, return how many spellcasts are required to level the spell; formula assumes 2 spellcasts at 100% manapool cost, and 10 spellcasts at 1% manapool cost",
+    "//": "accept the spell _cost, return how many spellcasts are required to level the spell; formula assumes 16 spellcasts at 100% manapool cost, and 65 spellcasts at 1% manapool cost",
     "return": "max(_1, min(_2, (_2 - (_1 * max(0, _0) / u_val('mana_max') * _2 / _1 ))))"
   },
   {
@@ -117,7 +117,7 @@
     "id": "EOC_MC_CASTED_A_SPELL_LEARN_BOOST_BIOTEK",
     "eoc_type": "EVENT",
     "required_event": "character_casts_spell",
-    "//": "Biotek levels faster since it need an energy to cast, so factor is always is energy_cost/1000 * focus_factor",
+    "//": "Biotek levels faster since it need an energy to cast, so factor is always is energy_cost/5000 * focus_factor",
     "condition": { "compare_string": [ "BIOTEK", { "context_val": "school" } ] },
     "effect": [
       {

--- a/data/mods/Magiclysm/eoc_spell_learn_boost.json
+++ b/data/mods/Magiclysm/eoc_spell_learn_boost.json
@@ -61,10 +61,6 @@
     "//": "Attuned classes levels faster since they have no any books, and needs 1-5 spellcasts to level up depends on spell cost",
     "condition": {
       "or": [
-        {
-          "compare_string": [ "NONE", { "context_val": "school" } ],
-          "//todo": "Should we check somehow 0 mana cost (for stamina cost spells etc)?"
-        },
         { "compare_string": [ "MANA_CRYST_MANA", { "context_val": "school" } ] },
         { "compare_string": [ "MANA_SEEKER_BOLTS", { "context_val": "school" } ] },
         { "compare_string": [ "ANIMIST", { "context_val": "school" } ] },

--- a/data/mods/Magiclysm/eoc_spell_learn_boost.json
+++ b/data/mods/Magiclysm/eoc_spell_learn_boost.json
@@ -19,7 +19,7 @@
     "id": "mc_spell_cost_train_factor",
     "num_args": 3,
     "//args": "_0=cost,_1=min_spellcasts,_2=max_spellcasts",
-    "//": "accept the spell _cost, return how much spellcasts required to level the spell; formula assumes 10 spellcasts at 100% manapool cost, and 2 spellcasts at 1% manapool cost",
+    "//": "accept the spell _cost, return how much spellcasts required to level the spell; formula assumes 2 spellcasts at 100% manapool cost, and 10 spellcasts at 1% manapool cost",
     "return": "max(_1, min(_2, (_2 - (_1 * max(0, _0) / u_val('mana_max') * _2 / _1 ))))"
   },
   {

--- a/data/mods/Magiclysm/eoc_spell_learn_boost.json
+++ b/data/mods/Magiclysm/eoc_spell_learn_boost.json
@@ -105,7 +105,6 @@
       { "math": [ "u_spell_exp(_spell)", "+=", "mc_spell_exp_diff(u_spell_level(_spell)) / mc_spell_cost_train_factor(_cost, 1, 5) * mc_spell_train_focus_factor(u_val('focus'),u_spell_level(_spell))" ] }
     ]
   },
-
   {
     "type": "effect_on_condition",
     "id": "EOC_MC_CASTED_A_SPELL_LEARN_BOOST_BIOTEK",

--- a/data/mods/Magiclysm/eoc_spell_learn_boost.json
+++ b/data/mods/Magiclysm/eoc_spell_learn_boost.json
@@ -51,7 +51,6 @@
       { "math": [ "u_spell_exp(_spell)", "+=", "mc_spell_exp_diff(u_spell_level(_spell)) / mc_spell_cost_train_factor(_cost, 2, 10) * mc_spell_train_focus_factor(u_val('focus'),u_spell_level(_spell))" ] }
     ]
   },
-
   {
     "type": "effect_on_condition",
     "id": "EOC_MC_CASTED_A_SPELL_LEARN_BOOST_ATTUNED",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Added EOC that boosts spell leveling on cast depends on mana cost"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
At the moment, training spells requires a lot of time. It takes 4 spells of level 15 to attunement, and it takes more than a month to level them through reading books. After discussing with @GuardianDll, we came to an agreement that we need to speed up the pumping in the same way as it was done in Xedra Evolved. Link to the discussion: https://discord.com/channels/699895400253095956/699896121027461137/1210699395801022584

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

This fix ports EOC from Xedra Evolved, but I've made some adjustments.
1. For spells of ordinary classes, I made a linear formula for the dependence of gaining experience on the cost of the spell. At the moment, it takes 10 spellcasts to raise the level of a spell that requires 1% mana pool, and only 2 for spells that require 100% mana pool.
2. After reaching level 15, the `focus` factor is activated. At 100 focus, a multiplier of 1 is used, at 50 focus, a multiplier of 0.5, and at 200 focus - 2. The focus consumption for this adjustment is not currently implemented.
3. For attunement classes, the formula works twice as effectively (1-5 spellcasts, depending on the cost), since there are no books and scrolls for these spells, which makes their leveling even longer (two eternities, haha).
4. For the `BIOTECH` class, the formula has been changed to depend on battery power consumption. At the moment, it is equal to the `cost / 1000` - this is the number of spellcasts to reach the next level. The focus factor works similarly.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Using a new random character, and focusing only on leveling spells and meeting natural needs, I managed to complete the attunement in just over a week. During the mana regeneration, I read the relevant scrolls, drank coffee by the liter to sleep less often. In a normal game, this is rarely possible, so the average leveling will take a little longer. Plus, don't forget, first you need to get scrolls, plenty of food, and a safe place to study. After the experiment, it seemed to me that this rate of spell level increase is very suitable to "stop players grinding and play the game".

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
