### PR TITLE
Remove odd .30-06 ammo spawn from radio_tower_2x2_map variant

### DIFF
--- a/data/json/mapgen/radio_tower.json
+++ b/data/json/mapgen/radio_tower.json
@@ -349,7 +349,7 @@
       "mapgensize": [ 2, 2 ],
       "place_loot": [
         { "item": "binoculars", "x": 1, "y": 0 },
-        { "item": "survivormap", "x": 1, "y": 0 },
+        { "item": "survivormap", "x": 1, "y": 0 }
       ]
     }
   }

--- a/data/json/mapgen/radio_tower.json
+++ b/data/json/mapgen/radio_tower.json
@@ -347,10 +347,7 @@
     "nested_mapgen_id": "radio_tower_2x2_map",
     "object": {
       "mapgensize": [ 2, 2 ],
-      "place_loot": [
-        { "item": "binoculars", "x": 1, "y": 0 },
-        { "item": "survivormap", "x": 1, "y": 0 }
-      ]
+      "place_loot": [ { "item": "binoculars", "x": 1, "y": 0 }, { "item": "survivormap", "x": 1, "y": 0 } ]
     }
   }
 ]

--- a/data/json/mapgen/radio_tower.json
+++ b/data/json/mapgen/radio_tower.json
@@ -350,7 +350,6 @@
       "place_loot": [
         { "item": "binoculars", "x": 1, "y": 0 },
         { "item": "survivormap", "x": 1, "y": 0 },
-        { "item": "3006", "x": 1, "y": 0, "chance": 40 }
       ]
     }
   }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Remove the odd .30-06 ammo from items that spawn in the map variant of the radio tower."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
It doesn't make sense that we just have thirty bullets up there with a map, binoculars, and no gun. We have a variant of the radio tower for sniper soldiers and they have ammo. That makes sense. This doesn't

#### Describe the solution
Remove the bullets from the map variant of the radio tower.

#### Describe alternatives you've considered
None

#### Testing
None. I deleted a line of JSON. If the auto tests say it's good, I'll believe them.

#### Additional context
If someone can give me a good reason this should stay, feel free to post it below.


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
