### PR TITLE
Sky island fixes - quest completability

### DIFF
--- a/data/mods/Sky_Island/recipes.json
+++ b/data/mods/Sky_Island/recipes.json
@@ -167,7 +167,7 @@
     "reversible": false,
     "flags": [ "SECRET", "BLIND_EASY" ],
     "tools": [ [ [ "fakeitem_statue", -1 ] ] ],
-    "components": [ [ [ "warptoken", 15 ] ], [ [ "id_science", 1 ] ], [ [ "oxyacetylene", 60 ] ] ]
+    "components": [ [ [ "warptoken", 15 ] ], [ [ "id_science", 1 ] ], [ [ "microscope_dissecting", 1 ] ] ]
   },
   {
     "result": "warp_folded_infinitree",

--- a/data/mods/Sky_Island/upgrade_missions.json
+++ b/data/mods/Sky_Island/upgrade_missions.json
@@ -325,7 +325,7 @@
     "components": [
       [ [ "microscope_dissecting", 1 ] ],
       [ [ "sensor_module", 1 ] ],
-      [ [ "holybook_wicca1", 1 ] ],
+      [ [ "book_newage_witchcraftbeg", 1 ] ],
       [ [ "warptoken", 12 ] ],
       [ [ "platinum_small", 10 ] ],
       [ [ "battery_car", 1 ], [ "battery_motorbike", 1 ], [ "medium_storage_battery", 1 ] ],
@@ -860,7 +860,7 @@
       [ [ "geiger_off", 1 ] ],
       [ [ "scalpel", 1 ] ],
       [ [ "stethoscope", 1 ] ],
-      [ [ "meth", 10 ] ],
+      [ [ "pure_meth", 1 ] ],
       [ [ "transponder", 4 ] ],
       [ [ "receiver", 4 ] ],
       [
@@ -1398,7 +1398,7 @@
       [ [ "bat", 1 ], [ "bwirebat", 1 ], [ "nailbat", 1 ] ],
       [ [ "warptoken", 2 ] ],
       [ [ "bandages", 10 ] ],
-      [ [ "liq_bandage", 80 ] ],
+      [ [ "liq_bandage_spray", 1 ] ],
       [ [ "9mm", 50 ], [ "9mmfmj", 50 ], [ "9mmP", 30 ], [ "9mmP2", 20 ] ]
     ]
   },
@@ -1884,7 +1884,7 @@
       [ [ "feather", 40 ], [ "down_feather", 40 ] ],
       [ [ "eggs_any_shape", 6, "LIST" ] ],
       [ [ "golf_ball", 1 ] ],
-      [ [ "chair_folding", 1 ] ],
+      [ [ "camp_chair", 1 ] ],
       [ [ "tourist_table", 1 ] ],
       [ [ "stepladder", 1 ], [ "aluminum_stepladder", 1 ] ]
     ]
@@ -1913,6 +1913,7 @@
       "effect": [
         { "math": [ "labsunlocked", "=", "1" ] },
         { "u_forget_recipe": "upgradekey_labsunlock" },
+        { "u_learn_recipe": "warp_labs_catalyst" },
         {
           "u_message": "With this upgrade, you're guaranteed to begin your expedition at an underground lab.  Be aware that you will need to have a Labs Catalyst on you when activating the warp obelisk, and these will be consumed on leaving.",
           "type": "mixed"
@@ -1949,7 +1950,7 @@
       [ [ "id_science", 1 ] ],
       [ [ "plut_cell", 5 ] ],
       [ [ "oxy_torch", 1 ] ],
-      [ [ "oxyacetylene", 120 ] ],
+      [ [ "tinyweldtank", 1 ], [ "weldtank", 1 ] ],
       [ [ "mutagen", 2 ], [ "iv_mutagen", 1 ] ],
       [ [ "jackhammer", 1 ], [ "elec_jackhammer", 1 ] ]
     ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Sky Island quest & recipe fixes"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Some Sky Island quests were not completable, as there were charges from tanks among the ingredients. This fixes that. There were also a couple of small quest balance changes, trying to make the required quest items match the thematic nature of their unlocks or correcting for changes to holybook rarity elsewhere.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Updated recipe ingredients for island unlocks.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Not fixing the mod? TGWeaver stated that the higher tier unlocks were not particularly balanced, but I tried to avoid changing the difficulty in this pass. Rebalancing will be a different conversation.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Opened the game and confirmed that the recipes updated and that the missing recipe for the labs catalyst unlocked as appropriate.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
