### PR TITLE
Item faults

### DIFF
--- a/data/json/faults/faults_electronic.json
+++ b/data/json/faults/faults_electronic.json
@@ -1,0 +1,71 @@
+[
+  {
+    "type": "fault",
+    "id": "fault_electronic_blown_fuse",
+    "fault_type": "shorted",
+    "name": { "str": "Blown fuse" },
+    "description": "Required for closing a protected electronic circuit.",
+    "item_prefix": "shorted",
+    "flags": [ "ITEM_BROKEN" ]
+  },
+  {
+    "type": "fault_fix",
+    "id": "mend_fault_electronic_blown_fuse",
+    "name": "Replace blown fuse",
+    "success_msg": "You replace the blown fuse of the %s.",
+    "time": "5 m",
+    "faults_removed": [ "fault_electronic_blown_fuse" ],
+    "skills": { "electronics": 3 },
+    "requirements": [ { "qualities": [ { "id": "SCREW", "level": 1 } ], "components": [ [ [ "e_scrap", 1 ], [ "copper_wire", 1 ] ] ] } ]
+  },
+  {
+    "type": "fault",
+    "id": "fault_electronic_blown_capacitor",
+    "fault_type": "shorted",
+    "name": { "str": "Blown capacitor" },
+    "description": "Required for storing charge in an electronic circuit.",
+    "item_prefix": "shorted",
+    "flags": [ "ITEM_BROKEN" ]
+  },
+  {
+    "type": "fault_fix",
+    "id": "mend_fault_electronic_blown_capacitor",
+    "name": "Replace blown fuse",
+    "success_msg": "You replace the blow capacitor of the %s.",
+    "time": "10 m",
+    "faults_removed": [ "fault_electronic_blown_capacitor" ],
+    "skills": { "electronics": 4 },
+    "requirements": [
+      {
+        "qualities": [ { "id": "SCREW", "level": 1 } ],
+        "tools": [ [ "soldering_iron" ], [ "soldering_iron_portable" ] ],
+        "components": [ [ [ "e_scrap", 1 ] ] ]
+      }
+    ]
+  },
+  {
+    "type": "fault",
+    "id": "fault_electronic_shorted_circuit",
+    "fault_type": "shorted",
+    "name": { "str": "Shorted electronic circuit" },
+    "description": "An electronic circuit has been destroyed by overvoltage.",
+    "item_prefix": "shorted",
+    "flags": [ "ITEM_BROKEN" ]
+  },
+  {
+    "type": "fault_fix",
+    "id": "mend_fault_electronic_shorted_circuit",
+    "name": "Replace shorted circuit",
+    "success_msg": "You replace the shorted circuit of the %s.",
+    "time": "70 m",
+    "faults_removed": [ "fault_electronic_shorted_circuit" ],
+    "skills": { "electronics": 5 },
+    "requirements": [
+      {
+        "qualities": [ { "id": "SCREW", "level": 1 } ],
+        "tools": [ [ "soldering_iron" ], [ "soldering_iron_portable" ] ],
+        "components": [ [ [ "circuit", 1 ] ] ]
+      }
+    ]
+  }
+]

--- a/data/json/faults/faults_water.json
+++ b/data/json/faults/faults_water.json
@@ -1,0 +1,45 @@
+[
+  {
+    "id": "fault_wet",
+    "type": "fault",
+    "fault_type": "wet",
+    "name": { "str": "Wet" },
+    "description": "Item is too wet to use and has to be dried.",
+    "item_prefix": "waterlogged",
+    "flags": [ "ITEM_BROKEN" ]
+  },
+  {
+    "type": "fault_fix",
+    "id": "mend_fault_wet",
+    "name": "Passively dry",
+    "success_msg": "You dry the %s.",
+    "time": "120 m",
+    "faults_removed": [ "fault_wet" ],
+    "skills": { "fabrication": 2 },
+    "requirements": [
+      {
+        "qualities": [ { "id": "CONTAIN", "level": 1 } ],
+        "components": [ [ [ "flour", 10 ], [ "dry_rice", 10 ], [ "dry_beans", 10 ], [ "dry_lentils", 10 ] ] ]
+      }
+    ]
+  },
+  {
+    "type": "fault_fix",
+    "id": "mend_fault_wet_oven",
+    "name": "Dry with hot air in an oven.  Requires good temperature control.",
+    "success_msg": "You heat up and dry the %s.",
+    "time": "60 m",
+    "faults_removed": [ "fault_wet" ],
+    "skills": { "cooking": 4 },
+    "requirements": [ { "qualities": [ { "id": "OVEN", "level": 3 } ] } ]
+  },
+  {
+    "type": "fault_fix",
+    "id": "mend_fault_wet_hot_air",
+    "name": "Dry with hot air.",
+    "success_msg": "You dry the %s with hot air.",
+    "time": "10 m",
+    "faults_removed": [ "fault_wet" ],
+    "requirements": [ { "qualities": [ { "id": "BLOW_HOT_AIR", "level": 1 } ] } ]
+  }
+]

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -23,6 +23,7 @@
 #include "creature_tracker.h"
 #include "debug.h"
 #include "enums.h"
+#include "fault.h"
 #include "flag.h"
 #include "game.h"
 #include "game_constants.h"
@@ -1115,7 +1116,11 @@ void avatar_action::use_item( avatar &you, item_location &loc, std::string const
     if( loc->wetness && loc->has_flag( flag_WATER_BREAK_ACTIVE ) ) {
         if( query_yn( _( "This item is still wet and it will break if you turn it on. Proceed?" ) ) ) {
             loc->deactivate();
-            loc->set_flag( flag_ITEM_BROKEN );
+            loc.get_item()->set_fault( random_entry( fault::get_by_type( std::string( "wet" ) ) ) );
+            // An electronic item in water is also shorted.
+            if( loc->has_flag( flag_ELECTRONIC ) ) {
+                loc.get_item()->set_fault( random_entry( fault::get_by_type( std::string( "shorted" ) ) ) );
+            }
         } else {
             return;
         }

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -28,6 +28,7 @@
 #include "damage.h"
 #include "debug.h"
 #include "enums.h"
+#include "fault.h"
 #include "field_type.h"
 #include "flag.h"
 #include "game.h"
@@ -772,7 +773,7 @@ void emp_blast( const tripoint &p )
                 !player_character.has_flag( json_flag_EMP_IMMUNE ) ) {
                 add_msg( m_bad, _( "The EMP blast fries your %s!" ), it->tname() );
                 it->deactivate();
-                it->set_flag( flag_ITEM_BROKEN );
+                it->faults.insert( random_entry( fault::get_by_type( "shorted" ) ) );
             }
         }
     }
@@ -785,7 +786,7 @@ void emp_blast( const tripoint &p )
                 add_msg( _( "The EMP blast fries the %s!" ), it.tname() );
             }
             it.deactivate();
-            it.set_flag( flag_ITEM_BROKEN );
+            it.set_fault( random_entry( fault::get_by_type( "shorted" ) ) );
         }
     }
     // TODO: Drain NPC energy reserves

--- a/src/fault.h
+++ b/src/fault.h
@@ -3,6 +3,7 @@
 #define CATA_SRC_FAULT_H
 
 #include <iosfwd>
+#include <list>
 #include <map>
 #include <new>
 #include <optional>
@@ -52,6 +53,7 @@ class fault
     public:
         const fault_id &id() const;
         std::string name() const;
+        std::string type() const; // use a set of types?
         std::string description() const;
         std::string item_prefix() const;
         bool has_flag( const std::string &flag ) const;
@@ -59,6 +61,7 @@ class fault
         const std::set<fault_fix_id> &get_fixes() const;
 
         static const std::map<fault_id, fault> &all();
+        static const std::list<fault_id> &get_by_type( const std::string &type );
         static void load( const JsonObject &jo );
         static void reset();
         static void check_consistency();
@@ -66,6 +69,7 @@ class fault
     private:
         friend class fault_fix;
         fault_id id_ = fault_id::NULL_ID();
+        std::string type_;
         translation name_;
         translation description_;
         translation item_prefix_; // prefix added to affected item's name

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -7600,6 +7600,12 @@ item &item::set_flag( const flag_id &flag )
     return *this;
 }
 
+item &item::set_fault( const fault_id &fault_id )
+{
+    faults.insert( fault_id );
+    return *this;
+}
+
 item &item::unset_flag( const flag_id &flag )
 {
     item_tags.erase( flag );
@@ -9748,12 +9754,14 @@ bool item::is_irremovable() const
 
 bool item::is_broken() const
 {
-    return has_flag( flag_ITEM_BROKEN );
+    return has_flag( flag_ITEM_BROKEN ) || has_fault_flag( std::string( "ITEM_BROKEN" ) );
 }
 
 bool item::is_broken_on_active() const
 {
-    return has_flag( flag_ITEM_BROKEN ) || ( wetness && has_flag( flag_WATER_BREAK_ACTIVE ) );
+    return has_flag( flag_ITEM_BROKEN ) ||
+           has_fault_flag( std::string( "ITEM_BROKEN" ) ) ||
+           ( wetness && has_flag( flag_WATER_BREAK_ACTIVE ) );
 }
 
 int item::wind_resist() const
@@ -14020,7 +14028,10 @@ bool item::process_internal( map &here, Character *carrier, const tripoint &pos,
 
         if( wetness && has_flag( flag_WATER_BREAK ) ) {
             deactivate();
-            set_flag( flag_ITEM_BROKEN );
+            set_fault( random_entry( fault::get_by_type( std::string( "wet" ) ) ) );
+            if( has_flag( flag_ELECTRONIC ) ) {
+                set_fault( random_entry( fault::get_by_type( std::string( "shorted" ) ) ) );
+            }
         }
 
         if( !is_food() && item_counter > 0 ) {

--- a/src/item.h
+++ b/src/item.h
@@ -1970,6 +1970,9 @@ class item : public visitable
         /** Idempotent filter setting an item specific flag. */
         item &set_flag( const flag_id &flag );
 
+        /** Idempotent filter setting an item specific fault. */
+        item &set_fault( const fault_id &fault_id );
+
         /** Idempotent filter removing an item specific flag */
         item &unset_flag( const flag_id &flag );
 

--- a/tests/item_test.cpp
+++ b/tests/item_test.cpp
@@ -434,10 +434,13 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
             item smart_phone( itype_test_smart_phone );
 
             REQUIRE( guy.wield( smart_phone ) );
+            item *test_item = guy.get_wielded_item().get_item();
 
             THEN( "should be broken by water" ) {
                 g->water_affect_items( guy );
-                CHECK( guy.has_item_with_flag( flag_ITEM_BROKEN ) );
+
+                CHECK_FALSE( test_item->faults.empty() );
+                CHECK( test_item->is_broken() );
             }
         }
 
@@ -451,10 +454,12 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
             backpack.put_in( smart_phone, pocket_type::CONTAINER );
 
             REQUIRE( guy.wield( backpack ) );
+            item *test_item = &guy.get_wielded_item()->only_item();
 
             THEN( "should be broken by water" ) {
                 g->water_affect_items( guy );
-                CHECK( guy.has_item_with_flag( flag_ITEM_BROKEN ) );
+                CHECK_FALSE( test_item->faults.empty() );
+                CHECK( test_item->is_broken() );
             }
         }
 
@@ -468,10 +473,12 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
             body_bag.put_in( smart_phone, pocket_type::CONTAINER );
 
             REQUIRE( guy.wield( body_bag ) );
+            item *test_item = &guy.get_wielded_item()->only_item();
 
             THEN( "should not be broken by water" ) {
                 g->water_affect_items( guy );
-                CHECK_FALSE( guy.has_item_with_flag( flag_ITEM_BROKEN ) );
+                CHECK( test_item->faults.empty() );
+                CHECK_FALSE( test_item->is_broken() );
             }
         }
 
@@ -487,10 +494,12 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
             duffelbag.put_in( backpack, pocket_type::CONTAINER );
 
             REQUIRE( guy.wield( duffelbag ) );
+            item *test_item = &guy.get_wielded_item()->only_item().only_item();
 
             THEN( "should be broken by water" ) {
                 g->water_affect_items( guy );
-                CHECK( guy.has_item_with_flag( flag_ITEM_BROKEN ) );
+                CHECK_FALSE( test_item->faults.empty() );
+                CHECK( test_item->is_broken() );
             }
         }
 
@@ -506,10 +515,12 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
             body_bag.put_in( backpack, pocket_type::CONTAINER );
 
             REQUIRE( guy.wield( body_bag ) );
+            item *test_item = &guy.get_wielded_item()->only_item().only_item();
 
             THEN( "should not be broken by water" ) {
                 g->water_affect_items( guy );
-                CHECK_FALSE( guy.has_item_with_flag( flag_ITEM_BROKEN ) );
+                CHECK( test_item->faults.empty() );
+                CHECK_FALSE( test_item->is_broken() );
             }
         }
     }

--- a/tools/spell_checker/dictionary.txt
+++ b/tools/spell_checker/dictionary.txt
@@ -2189,6 +2189,7 @@ overbore
 overbuilt
 overclock
 overclocks
+overcurrent
 overdosage
 overdrinking
 overengineered
@@ -2197,6 +2198,7 @@ overgloves
 overgrowth
 overhood
 overhoods
+overload
 overmap
 overmaps
 overpenetration


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Replace ITEM_BROKEN flag with a nuanced but simple system that uses faults following the system used for vehicle parts"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The current system of items becoming permanently disabled by water and electricity, while necessary for balance and providing a challenge, lacks nuance and complexity. Instead, use the system of mending and repair used for vehicle parts and guns. Also see issue https://github.com/CleverRaven/Cataclysm-DDA/issues/64528

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

For now, create a number of faults that can be applied to items with the ELECTRONIC or WATER_BREAK or WATER_BREAK_ACTIVE flags when these items are damaged by water or EMP-like effects.

When an item with a WATER_BREAK or WATER_BREAK_ACTIVE flag is exposed to water, it receives a random fault of fault type "wet".

When an item with a WATER_BREAK or WATER_BREAK_ACTIVE flag is exposed to water, if it has the ELECTRONIC flag, it receives a random fault of fault type "shorted".

When an item with the ELECTRONIC flag is exposed to EMP, it receives a random fault of type "shorted".

Fault type is a new json property for faults.

New "wet" and "shorted" faults added. Fault fixes added for those as well (a few example ones only, more faults and fixes can be added later).

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Health-points damage

Making flags reversable (faults seem more nuanced as you can have multiples for both problems and fixes).

#### Testing

Tested via item unit tests and manually via spawning items, jumping in water, and fixing items.
![Screenshot 1](https://github.com/CleverRaven/Cataclysm-DDA/assets/3600302/1d81a905-1763-4c10-ba0b-e17308387b29)
![Screenshot 2](https://github.com/CleverRaven/Cataclysm-DDA/assets/3600302/e13c767e-97e4-4e62-90e3-1b0d49f4b2e1)
![Screenshot 3](https://github.com/CleverRaven/Cataclysm-DDA/assets/3600302/150aced7-4537-43fa-ab53-3f1a40a5c6a0)

#### Additional context

At this point this needs reviews
Note this affected performance of item.is_broken
This introduces optional types to faults which was out-of-scope for what I wanted to do

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Future work: relevant items also take damage points and/or permanent damage points when they are exposed to water/EMP?

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
