### PR TITLE
Add book colors in help text

### DIFF
--- a/data/help/texts.json
+++ b/data/help/texts.json
@@ -320,7 +320,24 @@
   {
     "type": "help",
     "order": 21,
-    "name": "<4>: FAQ (contains spoilers!)",
+    "name": "<4>: Description of book colors",
+    "messages": [
+      "BOOK COLORS:",
+      "<color_red>Red</color> = You haven't read it at all",
+      "<color_blue>Blue</color> = You can read to increase your skills from it (or learn & level spells in the case of Magiclysm spellbooks).",
+      "<color_pink>Pink</color> = You do not have the necessary skills to read to increase your skills from it.",
+      "<color_yellow>Yellow</color> = The book cannot be read to increase your skills, but has unlearned recipes.",
+      "<color_light_gray>Grey</color> = You cannot read to increase skills (or spells for Magiclysm spellbooks), and no unmemorized recipes(or spells) remain.",
+      "BOOK RECIPE COLORS",
+      "<color_brown>Brown</color> = You do not have the primary skill requirement to craft that item using the book.",
+      "<color_light_gray>Grey</color> = You can craft the item using the book. The book must be close by or in your inventory to do this.",
+      "<color_white>White</color> = You already know the recipe, and do not need the book to craft it."
+    ]
+  },
+  {
+    "type": "help",
+    "order": 22,
+    "name": "<5>: FAQ (contains spoilers!)",
     "messages": [
       "Q: What is safe mode, and why does it prevent me from moving?\nA: Safe mode is a way to guarantee that you won't die by holding a movement key down.  When a monster comes into view, your movement will be ignored until safe mode is turned off with the <press_safemode> key.  This ensures that the sudden appearance of a monster won't catch you off guard.",
       "Q: It seems like everything I eat makes me sick!  What's wrong?\nA: Lots of the food found in towns is perishable and will only last a few days after the start of a new game.  The electricity went out several days ago, so fruit, milk, and similar foods are the first to go bad.  After the first couple of days, you should switch to canned food, jerky, and hunting.  Also, you should make sure to cook any food and purify any water you come across, as it may contain parasites or otherwise be unsafe.",

--- a/data/help/texts.json
+++ b/data/help/texts.json
@@ -323,14 +323,14 @@
     "name": "<4>: Description of book colors",
     "messages": [
       "BOOK COLORS:",
-      "<color_red>Red</color> = You haven't read it at all",
-      "<color_blue>Blue</color> = You can read to increase your skills from it (or learn & level spells in the case of Magiclysm spellbooks).",
-      "<color_pink>Pink</color> = You do not have the necessary skills to read to increase your skills from it.",
-      "<color_yellow>Yellow</color> = The book cannot be read to increase your skills, but has unlearned recipes.",
-      "<color_light_gray>Grey</color> = You cannot read to increase skills (or spells for Magiclysm spellbooks), and no unmemorized recipes(or spells) remain.",
+      "<color_red>Red</color> = You don't yet know what the book is about.  You can skim it to find out.",
+      "<color_blue>Blue</color> = Reading will increase your skills (or learn & level spells in the case of Magiclysm spellbooks).",
+      "<color_pink>Pink</color> = You do not have the necessary skills to understand and improve your skills.",
+      "<color_yellow>Yellow</color> = Reading will not increase your skills, but the book has recipes you haven't learned yet.",
+      "<color_light_gray>Grey</color> = Reading will not increase your skills (or spells for Magiclysm spellbooks), nor will you learn recipes (or spells).",
       "BOOK RECIPE COLORS",
       "<color_brown>Brown</color> = You do not have the primary skill requirement to craft that item using the book.",
-      "<color_light_gray>Grey</color> = You can craft the item using the book. The book must be close by or in your inventory to do this.",
+      "<color_light_gray>Grey</color> = You can craft the item using the book.  The book must be close by or in your inventory to do this.",
       "<color_white>White</color> = You already know the recipe, and do not need the book to craft it."
     ]
   },


### PR DESCRIPTION
https://github.com/CleverRaven/Cataclysm-DDA/wiki/FAQ-from-Discord

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Add book colors in help text"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Add book colors in help text. Copied from [`FAQ-from-Discord`](https://github.com/CleverRaven/Cataclysm-DDA/wiki/FAQ-from-Discord#books) wiki.
I hope some native speaker will review the text, thanks!
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Added the text, with colors.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Run the game, open the help menu.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
