### PR TITLE
keybindings: "Unbound locally!  Underlying global."

### DIFF
--- a/src/input_context.cpp
+++ b/src/input_context.cpp
@@ -238,13 +238,16 @@ std::string input_context::get_desc( const std::string &action_descriptor,
             category, &is_local );
 
     if( events.empty() ) {
-        return is_local ? _( "Unbound locally!" ) : _( "Unbound globally!" );
+        if( is_local ) {
+            bool global_empty = inp_mngr.get_input_for_action( action_descriptor ).empty();
+            return global_empty ? _( "Unbound locally!" ) : _( "Unbound locally!  Underlying global." );
+        } else {
+            return _( "Unbound globally!" );
+        }
     }
 
     std::vector<input_event> inputs_to_show;
-    for( const input_event &events_i : events ) {
-        const input_event &event = events_i;
-
+    for( const input_event &event : events ) {
         if( is_event_type_enabled( event.type ) && evt_filter( event ) ) {
             inputs_to_show.push_back( event );
         }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

It is not clear whether there is global KB under empty local KB. Knowing that would help the player understand what will `-` do
- is -> `-` will uncover the global KB.
- isn't -> `-` will uncover "Unbound globally".

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/e97ef9b5-7847-4e58-a6ce-7cfb4faddd60)

From #58358:
> 5] When using -, some actions will reset to the default value, other keybindings will leave the action unbound. I'm not entirely clear when/why

> 5] The results of using - to remove a keybinding should be clear and predictable

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Instead of just returning "Unbound locally!" first check, if there is at least one global KB under the local overwrite. If so, describe that in the returned string, which then reads "Unbound locally!  Underlying global."

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
You can obtain the "Unbound locally!  Underlying global." state in the following way:
1. Launch game. (You don't have to load a save, yay! Save time!)
2. In the main menu open `Settings` > `Keybindings`.
 ![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/43ae8722-9eb0-4853-b84e-3b264d09c798)
4. Add local KB to something that has global keybinding
 ![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/9fbbe5fd-19c5-42e7-9ce3-adb2f8b47e9d)
5. Add the same local KB to something else (and accept the conflict resolution)
 ![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/81e6be4e-49ff-4db8-8bfc-84da2e5069f5)
6. now the first thing is in the "Unbound locally!  Underlying global." state.

I did the above.

Looked at some menus inside the game. They are usually already broken when expecting a single character and get "Unbound locally!", so I think this is fine.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
