### PR TITLE
Preparation for using typed tripoints consistently

### DIFF
--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -3564,7 +3564,7 @@ static std::pair<size_t, std::string> farm_action( const tripoint_abs_omt &omt_t
             case farm_ops::plow: {
                 if( !farm_json ) {
                     farm_json = std::make_unique<fake_map>();
-                    mapgendata dat( omt_tgt, *farm_json, 0, calendar::turn, nullptr );
+                    mapgendata dat( omt_tgt, *farm_json->cast_to_map(), 0, calendar::turn, nullptr );
                     if( !run_mapgen_func( dat.terrain_type()->get_mapgen_id(), dat ) ) {
                         debugmsg( "Failed to run mapgen for farm map" );
                         break;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -9001,6 +9001,38 @@ bool tinymap::inbounds( const tripoint &p ) const
     return map_boundaries.contains( p );
 }
 
+bool tinymap::inbounds( const tripoint_omt_ms &p ) const
+{
+    constexpr tripoint_omt_ms map_boundary_min( 0, 0, -OVERMAP_DEPTH );
+    constexpr tripoint_omt_ms map_boundary_max( SEEY * 2, SEEX * 2, OVERMAP_HEIGHT + 1 );
+
+    constexpr half_open_cuboid<tripoint_omt_ms> map_boundaries( map_boundary_min, map_boundary_max );
+
+    return map_boundaries.contains( p );
+}
+
+tripoint_range<tripoint> tinymap::points_on_zlevel() const
+{
+    return map::points_on_zlevel();
+}
+
+tripoint_range<tripoint> tinymap::points_on_zlevel( int z ) const
+{
+    return map::points_on_zlevel( z );
+}
+
+tripoint_range<tripoint> tinymap::points_in_rectangle(
+    const tripoint &from, const tripoint &to ) const
+{
+    return map::points_in_rectangle( from, to );
+}
+
+tripoint_range<tripoint> tinymap::points_in_radius(
+    const tripoint &center, size_t radius, size_t radiusz ) const
+{
+    return map::points_in_radius( center, radius, radiusz );
+}
+
 // set up a map just long enough scribble on it
 // this tinymap should never, ever get saved
 fake_map::fake_map( const ter_id &ter_type )
@@ -9008,8 +9040,8 @@ fake_map::fake_map( const ter_id &ter_type )
     const tripoint_abs_sm tripoint_below_zero( 0, 0, fake_map_z );
 
     set_abs_sub( tripoint_below_zero );
-    for( int gridx = 0; gridx < my_MAPSIZE; gridx++ ) {
-        for( int gridy = 0; gridy < my_MAPSIZE; gridy++ ) {
+    for( int gridx = 0; gridx < get_my_MAPSIZE(); gridx++ ) {
+        for( int gridy = 0; gridy < get_my_MAPSIZE(); gridy++ ) {
             std::unique_ptr<submap> sm = std::make_unique<submap>();
 
             sm->set_all_ter( ter_type );

--- a/src/map.h
+++ b/src/map.h
@@ -2380,12 +2380,239 @@ void shift_bitset_cache( std::bitset<SIZE *SIZE> &cache, const point &s );
 bool ter_furn_has_flag( const ter_t &ter, const furn_t &furn, ter_furn_flag flag );
 bool generate_uniform( const tripoint_abs_sm &p, const oter_id &oter );
 bool generate_uniform_omt( const tripoint_abs_sm &p, const oter_id &terrain_type );
-class tinymap : public map
+
+class tinymap : private map
 {
         friend class editmap;
     public:
         tinymap() : map( 2, false ) {}
         bool inbounds( const tripoint &p ) const override;
+        bool inbounds( const tripoint_omt_ms &p ) const;
+
+        map *cast_to_map() {
+            return this;
+        }
+
+        using map::save;
+        using map::load; // TODO: Get rid of the inherited operation. Needs to be done in one go with the
+        // operation below replacing it, as using both concurrently results in ambiguous call profiles
+        // with {x, y, z} parameter calls.
+        //        void load(const tripoint_abs_omt& w, bool update_vehicles,
+        //            bool pump_events = false) {
+        //            map::load(project_to<coords::sm>(w), update_vehicles, pump_events);
+        //        };
+
+        using map::is_main_cleanup_queued;
+        using map::main_cleanup_override;
+        void generate( const tripoint &p, const time_point &when ) {
+            map::generate( p, when );    // TODO: Remove when below is converted
+        }
+        void generate( const tripoint_abs_sm &p, const time_point &when ) {
+            map::generate( p, when );    // TODO: Convert to tripoint_abs_omt
+        }
+        void place_spawns( const mongroup_id &group, int chance, // TODO: Convert to typed
+                           const point &p1, const point &p2, float density,
+                           bool individual = false, bool friendly = false,
+                           const std::optional<std::string> &name = std::nullopt,
+                           int mission_id = -1 ) {
+            map::place_spawns( group, chance, p1, p2, density, individual, friendly, name, mission_id );
+        }
+        void add_spawn( const mtype_id &type, int count, const tripoint &p, // TODO: Make it typed
+                        bool friendly = false, int faction_id = -1, int mission_id = -1,
+                        const std::optional<std::string> &name = std::nullopt ) {
+            map::add_spawn( type, count, p, friendly, faction_id, mission_id, name );
+        }
+
+        using map::translate;
+        ter_id ter( const tripoint &p ) const {
+            return map::ter( p );    // TODO: Make it typed
+        }
+        bool ter_set( const tripoint &p, const ter_id &new_terrain, bool avoid_creatures = false ) {
+            return map::ter_set( p, new_terrain, avoid_creatures );    // TODO: Make it typed
+        }
+        bool has_flag_ter( ter_furn_flag flag, const tripoint &p ) const {
+            return map::has_flag_ter( flag, p );
+        }
+        void draw_line_ter( const ter_id &type, const point &p1, const point &p2,
+                            bool avoid_creature = false ) {
+            map::draw_line_ter( type, p1, p2, avoid_creature );
+        }
+        bool is_last_ter_wall( bool no_furn, const point &p, // TODO: Make it typed
+                               const point &max, direction dir ) const {
+            return map::is_last_ter_wall( no_furn, p, max, dir );
+        }
+        furn_id furn( const point &p ) const {
+            return map::furn( p );    // TODO: Make it typed
+        }
+        furn_id furn( const tripoint &p ) const {
+            return map::furn( p );    // TODO: Make it typed
+        }
+        bool has_furn( const tripoint &p ) const {
+            return map::has_furn( p );    // TODO: Make it typed
+        }
+        void set( const tripoint &p, const ter_id &new_terrain, const furn_id &new_furniture ) {
+            map::set( p, new_terrain, new_furniture );    // TODO: Make it typed
+        }
+        bool furn_set( const point &p, const furn_id &new_furniture,
+                       bool avoid_creatures = false ) { // TODO: Make it typed
+            return furn_set( tripoint( p, abs_sub.z() ), new_furniture, false, avoid_creatures );
+        }
+        bool furn_set( const tripoint &p, const furn_id &new_furniture, bool furn_reset = false,
+                       bool avoid_creatures = false ) {
+            return map::furn_set( p, new_furniture, furn_reset, avoid_creatures ); // TODO: Make it typed
+        }
+        void draw_line_furn( const furn_id &type, const point &p1, const point &p2, // TODO: Make it typed
+                             bool avoid_creatures = false ) {
+            map::draw_line_furn( type, p1, p2, avoid_creatures );
+        }
+        void draw_square_furn( const furn_id &type, const point &p1, const point &p2, // TODO: Make it typed
+                               bool avoid_creatures = false ) {
+            map::draw_square_furn( type, p1, p2, avoid_creatures );
+        }
+        bool has_flag_furn( ter_furn_flag flag, const tripoint &p ) const {
+            return map::has_flag_furn( flag, p );    // TODO: Make it typed
+        }
+        computer *add_computer( const tripoint &p, const std::string &name, int security ) {
+            return map::add_computer( p, name, security );    // TODO: Make it typed
+        }
+        std::string name( const tripoint &p ) {
+            return map::name( p );    // TODO: Make it typed
+        }
+        bool impassable( const tripoint &p ) const {
+            return map::impassable( p );    // TODO: Make it typed
+        }
+        tripoint_range<tripoint> points_on_zlevel() const; // TODO: Make it typed
+        tripoint_range<tripoint> points_on_zlevel( int z ) const; // TODO: Make it typed
+        tripoint_range<tripoint> points_in_rectangle(
+            const tripoint &from, const tripoint &to ) const; // TODO: Make it typed
+        tripoint_range<tripoint> points_in_radius(
+            const tripoint &center, size_t radius, size_t radiusz = 0 ) const; // TODO: Make it typed
+        map_stack i_at( const tripoint &p ) {
+            return map::i_at( p );    // TODO: Make it typed
+        }
+        void spawn_item( const tripoint &p, const itype_id &type_id,
+                         unsigned quantity = 1, int charges = 0,
+                         const time_point &birthday = calendar::start_of_cataclysm, int damlevel = 0,
+                         const std::set<flag_id> &flags = {}, const std::string &variant = "",
+                         const std::string &faction = "" ) {
+            map::spawn_item( p, type_id, quantity, charges, birthday, damlevel, flags, variant,
+                             faction ); // TODO: Make it typed
+        }
+        void spawn_item( const tripoint &p, const std::string &type_id, // TODO: Make it typed
+                         unsigned quantity = 1, int charges = 0,
+                         const time_point &birthday = calendar::start_of_cataclysm, int damlevel = 0,
+                         const std::set<flag_id> &flags = {}, const std::string &variant = "",
+                         const std::string &faction = "" ) {
+            map::spawn_item( p, type_id, quantity, charges, birthday, damlevel, flags, variant, faction );
+        }
+        std::vector<item *> spawn_items( const tripoint &p, const std::vector<item> &new_items ) {
+            return map::spawn_items( p, new_items );    // TODO: Make it typed
+        }
+        item &add_item( const tripoint &p, item new_item ) {
+            return map::add_item( p, new_item );    // TODO: Make it typed
+        }
+        item &add_item_or_charges( const point &p, const item &obj,
+                                   bool overflow = true ) { // TODO: Make it typed
+            return map::add_item_or_charges( tripoint( p, abs_sub.z() ), obj, overflow );
+        }
+        std::vector<item *> put_items_from_loc(
+            const item_group_id &group_id, const tripoint &p,
+            const time_point &turn = calendar::start_of_cataclysm ) {
+            return map::put_items_from_loc( group_id, p, turn ); // TODO: Make it typed
+        }
+        item &add_item_or_charges( const tripoint &pos, item obj, bool overflow = true ) {
+            return map::add_item_or_charges( pos, obj, overflow );    // TODO: Make it typed
+        }
+        std::vector<item *> place_items( // TODO: Make it typed
+            const item_group_id &group_id, int chance, const tripoint &p1, const tripoint &p2,
+            bool ongrass, const time_point &turn, int magazine = 0, int ammo = 0,
+            const std::string &faction = "" ) {
+            return map::place_items( group_id, chance, p1, p2, ongrass, turn, magazine, ammo, faction );
+        }
+        void add_corpse( const tripoint &p ) {
+            map::add_corpse( p );
+        }
+        void i_rem( const tripoint &p, item *it ) {
+            map::i_rem( p, it );    // TODO: Make it typed
+        }
+        void i_clear( const tripoint &p ) {
+            return map::i_clear( p );    //TODO: Make it typed
+        }
+        bool add_field( const tripoint &p, const field_type_id &type_id, int intensity = INT_MAX,
+                        const time_duration &age = 0_turns, bool hit_player = true ) {
+            return map::add_field( p, type_id, intensity, age, hit_player ); // TODO: Make it typed
+        }
+        void delete_field( const tripoint &p, const field_type_id &field_to_remove ) {
+            return map::delete_field( p, field_to_remove );    // TODO: Make it typed
+        }
+        bool has_flag( ter_furn_flag flag, const tripoint &p ) const {
+            return map::has_flag( flag, p );    // TODO: Make it typed
+        }
+        bool has_flag( ter_furn_flag flag, const point &p ) const { // TODO: Make it typed
+            return map::has_flag( flag, p );
+        }
+        void destroy( const tripoint &p, bool silent = false ) {
+            return map::destroy( p, silent );    // TODO: Make it typed
+        }
+        const trap &tr_at( const tripoint &p ) const {
+            return map::tr_at( p );    // TODO: Make it typed
+        }
+        void trap_set( const tripoint &p, const trap_id &type ) {
+            map::trap_set( p, type );    // TODO: Make it typed
+        }
+        void set_signage( const tripoint &p, const std::string &message ) {
+            map::set_signage( p, message );    // TODO: Make it typed
+        }
+        void delete_signage( const tripoint &p ) {
+            map::delete_signage( p );    // TODO: Make it typed
+        }
+        VehicleList get_vehicles() {
+            return map::get_vehicles();
+        }
+        optional_vpart_position veh_at( const tripoint &p ) const {
+            return map::veh_at( p );    // TODO: Make it typed
+        }
+        vehicle *add_vehicle( const vproto_id &type, const tripoint &p, const units::angle &dir,
+                              int init_veh_fuel = -1, int init_veh_status = -1, bool merge_wrecks = true ) {
+            return map::add_vehicle( type, p, dir, init_veh_fuel, init_veh_status,
+                                     merge_wrecks ); // TODO: Make it typed
+        }
+        void add_splatter_trail( const field_type_id &type, const tripoint &from, const tripoint &to ) {
+            return map::add_splatter_trail( type, from, to );    // TODO: Make it typed
+        }
+        void collapse_at( const tripoint &p, bool silent,
+                          bool was_supporting = false, // TODO: Make it typed
+                          bool destroy_pos = true ) {
+            map::collapse_at( p, silent, was_supporting, destroy_pos );
+        }
+        tripoint getlocal( const tripoint &p ) const {
+            return map::getlocal( p );    // TODO: Make it typed
+        }
+        tripoint_abs_sm get_abs_sub() const {
+            return map::get_abs_sub();    // TODO: Convert to tripoint_abs_omt
+        }
+        tripoint getabs( const tripoint &p ) const {
+            return map::getabs( p );    // TODO: Make it typed
+        }
+        tripoint getlocal( const tripoint_abs_ms &p ) const {
+            return map::getlocal( p );
+        }; // TODO: Make it typed (return type)
+        bool is_outside( const tripoint &p ) const {
+            return map::is_outside( p );    // TODO: Make it typed
+        }
+
+        using map::rotate;
+        using map::mirror;
+
+        using map::build_outside_cache;
+
+    protected:
+        using map::set_abs_sub;
+        using map::setsubmap;
+        using map::get_nonant;
+        int get_my_MAPSIZE() {
+            return my_MAPSIZE;
+        }
 };
 
 class fake_map : public tinymap

--- a/src/map.h
+++ b/src/map.h
@@ -2509,7 +2509,7 @@ class tinymap : private map
             return map::spawn_items( p, new_items );    // TODO: Make it typed
         }
         item &add_item( const tripoint &p, item new_item ) {
-            return map::add_item( p, new_item );    // TODO: Make it typed
+            return map::add_item( p, std::move( new_item ) );  // TODO: Make it typed
         }
         item &add_item_or_charges( const point &p, const item &obj,
                                    bool overflow = true ) { // TODO: Make it typed
@@ -2521,7 +2521,7 @@ class tinymap : private map
             return map::put_items_from_loc( group_id, p, turn ); // TODO: Make it typed
         }
         item &add_item_or_charges( const tripoint &pos, item obj, bool overflow = true ) {
-            return map::add_item_or_charges( pos, obj, overflow );    // TODO: Make it typed
+            return map::add_item_or_charges( pos, std::move( obj ), overflow );  // TODO: Make it typed
         }
         std::vector<item *> place_items( // TODO: Make it typed
             const item_group_id &group_id, int chance, const tripoint &p1, const tripoint &p2,

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -420,6 +420,14 @@ static void place_trap_if_clear( map &m, const point &target, trap_id trap_type 
     }
 }
 
+static void place_trap_if_clear( tinymap &m, const point &target, trap_id trap_type )
+{
+    tripoint tri_target( target, m.get_abs_sub().z() );
+    if( m.ter( tri_target ).obj().trap == tr_null ) {
+        mtrap_set( &m, target, trap_type );
+    }
+}
+
 static bool mx_minefield( map &, const tripoint &abs_sub )
 {
     const tripoint_abs_omt abs_omt( sm_to_omt_copy( abs_sub ) );
@@ -684,7 +692,7 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
             for( point &i : blood_track ) {
                 m.add_field( { i, abs_sub.z }, fd_blood, 1 );
             }
-            m.add_field( tripoint_bub_ms{ 1, 6, abs_sub.z }, fd_gibs_flesh, 1 );
+            m.add_field( tripoint { 1, 6, abs_sub.z }, fd_gibs_flesh, 1 );
 
             //Add the culprit
             m.add_vehicle( vehicle_prototype_car_fbi, tripoint( 7, 7, abs_sub.z ), 0_degrees, 70, 1 );
@@ -864,7 +872,7 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
             m.put_items_from_loc( Item_spawn_data_mon_zombie_soldier_death_drops,
             { 23, 12, abs_sub.z } );
             m.add_item_or_charges( tripoint{ 23, 12, abs_sub.z }, body );
-            m.add_field( tripoint_bub_ms{ 23, 12, abs_sub.z }, fd_gibs_flesh, rng( 1, 3 ) );
+            m.add_field( tripoint{ 23, 12, abs_sub.z }, fd_gibs_flesh, rng( 1, 3 ) );
 
             //Spawn broken bench and splintered wood
             m.furn_set( tripoint{ 23, 13, abs_sub.z }, f_null );
@@ -2236,6 +2244,44 @@ void apply_function( const map_extra_id &id, map &m, const tripoint_abs_sm &abs_
         }
         case map_extra_method::update_mapgen: {
             mapgendata dat( project_to<coords::omt>( abs_sub ), m, 0.0f,
+                            calendar::start_of_cataclysm, nullptr );
+            applied_successfully =
+                run_mapgen_update_func( update_mapgen_id( extra.generator_id ), dat );
+            break;
+        }
+        case map_extra_method::null:
+        default:
+            break;
+    }
+
+    if( !applied_successfully ) {
+        return;
+    }
+
+    overmap_buffer.add_extra( project_to<coords::omt>( abs_sub ), id );
+}
+
+void apply_function( const map_extra_id &id, tinymap &m, const tripoint_abs_sm &abs_sub )
+{
+    bool applied_successfully = false;
+
+    const map_extra &extra = id.obj();
+    switch( extra.generator_method ) {
+        case map_extra_method::map_extra_function: {
+            const map_extra_pointer mx_func = get_function( map_extra_id( extra.generator_id ) );
+            if( mx_func != nullptr ) {
+                applied_successfully = mx_func( *m.cast_to_map(), abs_sub.raw() );
+            }
+            break;
+        }
+        case map_extra_method::mapgen: {
+            mapgendata dat( project_to<coords::omt>( abs_sub ), *m.cast_to_map(), 0.0f, calendar::turn,
+                            nullptr );
+            applied_successfully = run_mapgen_func( extra.generator_id, dat );
+            break;
+        }
+        case map_extra_method::update_mapgen: {
+            mapgendata dat( project_to<coords::omt>( abs_sub ), *m.cast_to_map(), 0.0f,
                             calendar::start_of_cataclysm, nullptr );
             applied_successfully =
                 run_mapgen_update_func( update_mapgen_id( extra.generator_id ), dat );

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -412,14 +412,6 @@ static bool mx_helicopter( map &m, const tripoint &abs_sub )
     return true;
 }
 
-static void place_trap_if_clear( map &m, const point &target, trap_id trap_type )
-{
-    tripoint tri_target( target, m.get_abs_sub().z() );
-    if( m.ter( tri_target ).obj().trap == tr_null ) {
-        mtrap_set( &m, target, trap_type );
-    }
-}
-
 static void place_trap_if_clear( tinymap &m, const point &target, trap_id trap_type )
 {
     tripoint tri_target( target, m.get_abs_sub().z() );

--- a/src/map_extras.h
+++ b/src/map_extras.h
@@ -18,6 +18,7 @@
 class JsonObject;
 class map;
 class mapgendata;
+class tinymap;
 struct tripoint;
 template<typename T> class generic_factory;
 template<typename T> struct enum_traits;
@@ -86,6 +87,8 @@ FunctionMap all_functions();
 std::vector<map_extra_id> get_all_function_names();
 
 void apply_function( const map_extra_id &, map &, const tripoint_abs_sm & );
+void apply_function( const map_extra_id &, tinymap &,
+                     const tripoint_abs_sm & ); // TODO: Convert to tripoint_abs_omt
 
 void load( const JsonObject &jo, const std::string &src );
 void check_consistency();

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -7580,7 +7580,15 @@ void line( map *m, const ter_id &type, const point &p1, const point &p2 )
 {
     m->draw_line_ter( type, p1, p2 );
 }
+void line( tinymap *m, const ter_id &type, const point &p1, const point &p2 )
+{
+    m->draw_line_ter( type, p1, p2 );
+}
 void line_furn( map *m, const furn_id &type, const point &p1, const point &p2 )
+{
+    m->draw_line_furn( type, p1, p2 );
+}
+void line_furn( tinymap *m, const furn_id &type, const point &p1, const point &p2 )
 {
     m->draw_line_furn( type, p1, p2 );
 }
@@ -7597,6 +7605,10 @@ void square( map *m, const ter_id &type, const point &p1, const point &p2 )
     m->draw_square_ter( type, p1, p2 );
 }
 void square_furn( map *m, const furn_id &type, const point &p1, const point &p2 )
+{
+    m->draw_square_furn( type, p1, p2 );
+}
+void square_furn( tinymap *m, const furn_id &type, const point &p1, const point &p2 )
 {
     m->draw_square_furn( type, p1, p2 );
 }
@@ -7681,7 +7693,7 @@ bool update_mapgen_function_json::update_map(
     update_tmap.rotate( 4 - rotation );
     update_tmap.mirror( mirror_horizontal, mirror_vertical );
 
-    mapgendata md_base( omt_pos, update_tmap, 0.0f, calendar::start_of_cataclysm, miss );
+    mapgendata md_base( omt_pos, *update_tmap.cast_to_map(), 0.0f, calendar::start_of_cataclysm, miss );
     mapgendata md( md_base, args );
 
     bool const u = update_map( md, offset, verify );
@@ -7808,7 +7820,7 @@ bool apply_construction_marker( const update_mapgen_id &update_mapgen_id,
 
     fake_map tmp_map( t_grass );
 
-    mapgendata base_fake_md( tmp_map, mapgendata::dummy_settings );
+    mapgendata base_fake_md( *tmp_map.cast_to_map(), mapgendata::dummy_settings );
     mapgendata fake_md( base_fake_md, args );
     fake_md.skip = { mapgen_phase::zones };
 
@@ -7825,7 +7837,8 @@ bool apply_construction_marker( const update_mapgen_id &update_mapgen_id,
         // "outer scope" mirroring/rotation is undone. It's unlikely inherent map rotation will
         // be present at the same time as construction rotation/mirroring is, but better safe than sorry.
 
-        mapgendata md_base( omt_pos, update_tmap, 0.0f, calendar::start_of_cataclysm, nullptr );
+        mapgendata md_base( omt_pos, *update_tmap.cast_to_map(), 0.0f, calendar::start_of_cataclysm,
+                            nullptr );
         mapgendata md( md_base, args );
 
         rotation_guard rot( md );
@@ -7867,7 +7880,7 @@ std::pair<std::map<ter_id, int>, std::map<furn_id, int>> get_changed_ids_from_up
 
     fake_map tmp_map( base_ter );
 
-    mapgendata base_fake_md( tmp_map, mapgendata::dummy_settings );
+    mapgendata base_fake_md( *tmp_map.cast_to_map(), mapgendata::dummy_settings );
     mapgendata fake_md( base_fake_md, mapgen_args );
     fake_md.skip = { mapgen_phase::zones };
 

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -24,10 +24,11 @@
 #include "weighted_list.h"
 
 class map;
-template <typename Id> class mapgen_value;
 class mapgendata;
-class mission;
 struct mapgen_arguments;
+template <typename Id> class mapgen_value;
+class mission;
+class tinymap;
 
 using building_gen_pointer = void ( * )( mapgendata & );
 
@@ -637,13 +638,16 @@ enum room_type {
 bool connects_to( const oter_id &there, int dir );
 // wrappers for map:: functions
 void line( map *m, const ter_id &type, const point &p1, const point &p2 );
+void line( tinymap *m, const ter_id &type, const point &p1, const point &p2 );
 void line_furn( map *m, const furn_id &type, const point &p1, const point &p2 );
+void line_furn( tinymap *m, const furn_id &type, const point &p1, const point &p2 );
 void fill_background( map *m, const ter_id &type );
 void fill_background( map *m, ter_id( *f )() );
 void square( map *m, const ter_id &type, const point &p1, const point &p2 );
 void square( map *m, ter_id( *f )(), const point &p1, const point &p2 );
 void square( map *m, const weighted_int_list<ter_id> &f, const point &p1, const point &p2 );
 void square_furn( map *m, const furn_id &type, const point &p1, const point &p2 );
+void square_furn( tinymap *m, const furn_id &type, const point &p1, const point &p2 );
 void rough_circle( map *m, const ter_id &type, const point &, int rad );
 void rough_circle_furn( map *m, const furn_id &type, const point &, int rad );
 void circle( map *m, const ter_id &type, double x, double y, double rad );

--- a/src/mapgen_functions.cpp
+++ b/src/mapgen_functions.cpp
@@ -2345,6 +2345,19 @@ void mtrap_set( map *m, const point &p, trap_id type, bool avoid_creatures )
     m->trap_set( actual_location, type );
 }
 
+void mtrap_set( tinymap *m, const point &p, trap_id type, bool avoid_creatures )
+{
+    if( avoid_creatures ) {
+        Creature *c = get_creature_tracker().creature_at( tripoint_abs_ms( m->getabs( tripoint( p,
+                      m->get_abs_sub().z() ) ) ), true );
+        if( c ) {
+            return;
+        }
+    }
+    tripoint actual_location( p, m->get_abs_sub().z() );
+    m->trap_set( actual_location, type );
+}
+
 void madd_field( map *m, const point &p, field_type_id type, int intensity )
 {
     tripoint actual_location( p, m->get_abs_sub().z() );

--- a/src/mapgen_functions.h
+++ b/src/mapgen_functions.h
@@ -17,7 +17,7 @@ class mission;
 struct mapgen_arguments;
 struct mapgen_parameters;
 struct point;
-struct tinymap;
+class tinymap;
 struct tripoint;
 
 using mapgen_update_func = std::function<void( const tripoint_abs_omt &map_pos3, mission *miss )>;

--- a/src/mapgen_functions.h
+++ b/src/mapgen_functions.h
@@ -17,6 +17,7 @@ class mission;
 struct mapgen_arguments;
 struct mapgen_parameters;
 struct point;
+struct tinymap;
 struct tripoint;
 
 using mapgen_update_func = std::function<void( const tripoint_abs_omt &map_pos3, mission *miss )>;
@@ -57,6 +58,7 @@ void mapgen_ravine_edge( mapgendata &dat );
 // Temporary wrappers
 void mremove_trap( map *m, const point &, trap_id type );
 void mtrap_set( map *m, const point &, trap_id type, bool avoid_creatures = false );
+void mtrap_set( tinymap *m, const point &, trap_id type, bool avoid_creatures = false );
 void madd_field( map *m, const point &, field_type_id type, int intensity );
 void mremove_fields( map *m, const point & );
 

--- a/src/start_location.cpp
+++ b/src/start_location.cpp
@@ -136,7 +136,7 @@ void start_location::finalize()
 }
 
 // check if tile at p should be boarded with some kind of furniture.
-static void add_boardable( const map &m, const tripoint &p, std::vector<tripoint> &vec )
+static void add_boardable( const tinymap &m, const tripoint &p, std::vector<tripoint> &vec )
 {
     if( m.has_furn( p ) ) {
         // Don't need to board this up, is already occupied
@@ -157,7 +157,7 @@ static void add_boardable( const map &m, const tripoint &p, std::vector<tripoint
     vec.push_back( p );
 }
 
-static void board_up( map &m, const tripoint_range<tripoint> &range )
+static void board_up( tinymap &m, const tripoint_range<tripoint> &range )
 {
     std::vector<tripoint> furnitures1;
     std::vector<tripoint> furnitures2;

--- a/tests/map_extra_test.cpp
+++ b/tests/map_extra_test.cpp
@@ -78,7 +78,7 @@ TEST_CASE( "mx_minefield_theoretical_spawn", "[map_extra][overmap]" )
         const map_extra_pointer mx_func = MapExtras::get_function( map_extra_mx_minefield );
 
         // TODO: fix point types
-        return mx_func( tm, tm.get_abs_sub().raw() );
+        return mx_func( *tm.cast_to_map(), tm.get_abs_sub().raw() );
     };
 
     // Pick a point in the middle of the overmap so we don't go out of bounds when setting up

--- a/tests/map_extra_test.cpp
+++ b/tests/map_extra_test.cpp
@@ -78,7 +78,9 @@ TEST_CASE( "mx_minefield_theoretical_spawn", "[map_extra][overmap]" )
         const map_extra_pointer mx_func = MapExtras::get_function( map_extra_mx_minefield );
 
         // TODO: fix point types
-        return mx_func( *tm.cast_to_map(), tm.get_abs_sub().raw() );
+        map *mp = tm.cast_to_map();
+        const tripoint pos = tm.get_abs_sub().raw();
+        return mx_func( *mp, pos );
     };
 
     // Pick a point in the middle of the overmap so we don't go out of bounds when setting up

--- a/tests/mapgen_helpers.cpp
+++ b/tests/mapgen_helpers.cpp
@@ -12,7 +12,7 @@ void common_mapgen_prep( tripoint_abs_omt const &pos, fprep_t const &prep )
     if( prep ) {
         tinymap tm;
         tm.load( project_to<coords::sm>( pos ), true );
-        prep( tm );
+        prep( *tm.cast_to_map() );
     }
 }
 
@@ -27,7 +27,7 @@ void manual_nested_mapgen( tripoint_abs_omt const &pos, nested_mapgen_id const &
 {
     tinymap tm;
     tm.load( project_to<coords::sm>( pos ), true );
-    mapgendata md( pos, tm, 0.0f, calendar::turn, nullptr );
+    mapgendata md( pos, *tm.cast_to_map(), 0.0f, calendar::turn, nullptr );
     const auto &ptr = nested_mapgens[id].funcs().pick();
     ( *ptr )->nest( md, point_zero, "test" );
 }

--- a/tests/vehicle_split_test.cpp
+++ b/tests/vehicle_split_test.cpp
@@ -115,7 +115,7 @@ TEST_CASE( "split_vehicle_during_mapgen", "[vehicle]" )
     tinymap tm;
     // Wherever the main map is, create this tinymap outside its bounds.
     tm.load( here.get_abs_sub() + tripoint( 20, 20, 0 ), false );
-    wipe_map_terrain( &tm );
+    wipe_map_terrain( tm.cast_to_map() );
     REQUIRE( tm.get_vehicles().empty() );
     tripoint vehicle_origin{ 14, 14, 0 };
     vehicle *veh_ptr = tm.add_vehicle( vehicle_prototype_cross_split_test,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary

None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fix #71852
i.e. prepare for a usage of typed points and tripoints for coordinates in a consistent manner.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Separate tinymap's set of operations from map's set by inheriting map privately into tinymap. This makes map's operations unavailable for usage with tinymaps, which means you cannot use the typed operations using the wrong type from map.
This has had a knock-on effect where operations in other files have had to be split into map and tinymap ones.
There are essentially two places where splitting wasn't really feasible, and that's the mapdata struct and operations pointed to from recipes, so those usages unfortunately requires casting. It's probably possible to change the code to deal with this, but it's probably not worth the effort and added complexity.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

- Abandon typed usage completely.
- Use unspecific tripoint_rel_ms throughout and ditch tripoint_bub_ms and tripoint_omt_ms. I don't see any usage for tripoint_ms_sm in the current code base regardless until a potential micromap operating on a single map square is introduced.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

It compiles and loading a save doesn't result in any unexpected errors (expected ones are stuff no longer fitting in pockets, complaints about overmaps no longer supported etc.). Note that there should be no change in functionality as the whole set of changes should be a rearrangement with no functional effect.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

I've failed to find a syntax to allow me to make casting of tinymap to map accessible to usages of tinymap. If there is a syntax for it I'd be grateful to be told what it is.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
