### PR TITLE
[Xedra Evolved] Consolidate more Arvore mutations with triggers into one mutation

### DIFF
--- a/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutation_spells.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutation_spells.json
@@ -9,8 +9,28 @@
   {
     "type": "enchantment",
     "id": "arvore_forest_detect_enemies",
-    "condition": "ALWAYS",
-    "values": [ { "value": "MOTION_VISION_RANGE", "add": { "math": [ "( u_val('perception') + u_val('intelligence'))" ] } } ]
+    "condition": {
+      "and": [
+        "u_is_outside",
+        {
+          "or": [
+            { "u_is_on_terrain_with_flag": "SHRUB" },
+            { "u_is_on_terrain_with_flag": "YOUNG" },
+            { "u_is_on_terrain": "t_bamboo_tall" },
+            { "u_is_on_terrain": "t_grass_long" },
+            { "u_at_om_location": "forest" },
+            { "u_at_om_location": "forest_thick" }
+          ]
+        }
+      ]
+    },
+    "values": [
+      { "value": "MOTION_VISION_RANGE", "add": { "math": [ "( u_val('perception') + u_val('intelligence'))" ] } },
+      {
+        "value": "OVERMAP_SIGHT",
+        "add": { "math": [ "(u_has_trait('ARVORE_FOREST_DETECT_AND_OVERMAP') * 2) + (u_has_trait('THRESH_ARVORE') * 2)" ] }
+      }
+    ]
   },
   {
     "type": "enchantment",
@@ -40,9 +60,57 @@
   },
   {
     "type": "enchantment",
+    "id": "ench_arvore_forest_stealth",
+    "condition": {
+      "and": [
+        "u_is_outside",
+        {
+          "or": [
+            { "u_is_on_terrain_with_flag": "SHRUB" },
+            { "u_is_on_terrain_with_flag": "YOUNG" },
+            { "u_is_on_terrain": "t_bamboo_tall" },
+            { "u_is_on_terrain": "t_grass_long" },
+            { "u_at_om_location": "forest" },
+            { "u_at_om_location": "forest_thick" }
+          ]
+        }
+      ]
+    },
+    "values": [ { "value": "STEALTH_MODIFIER", "add": { "math": [ "40 + ( u_has_trait('THRESH_ARVORE') * 20)" ] } } ]
+  },
+  {
+    "type": "enchantment",
     "id": "ench_arvore_sense_sun",
     "condition": { "math": [ "u_val('pos_z')", ">=", "0" ] },
     "ench_effects": [ { "effect": "effect_arvore_sense_sun", "intensity": 1 } ]
+  },
+  {
+    "type": "enchantment",
+    "id": "ench_arvore_wilds_super_mending",
+    "condition": {
+      "and": [
+        "u_is_outside",
+        {
+          "or": [
+            { "u_is_on_terrain_with_flag": "SHRUB" },
+            { "u_is_on_terrain_with_flag": "DIGGABLE" },
+            { "u_is_on_terrain_with_flag": "YOUNG" }
+          ]
+        },
+        { "not": { "u_near_om_location": "road_curved", "range": 1 } },
+        { "not": { "u_near_om_location": "road_four_way", "range": 1 } },
+        { "not": { "u_near_om_location": "road_tee", "range": 1 } },
+        { "not": { "u_near_om_location": "road_straight", "range": 1 } },
+        { "not": { "u_near_om_location": "road_end", "range": 1 } },
+        { "not": { "u_near_om_location": "road_sw", "range": 1 } },
+        { "not": { "u_near_om_location": "road_ne", "range": 1 } },
+        { "not": { "u_near_om_location": "road_ew", "range": 1 } },
+        { "not": { "u_near_om_location": "road_ns", "range": 1 } },
+        { "not": { "u_near_om_location": "road_nesw", "range": 1 } },
+        { "not": { "u_near_om_location": "road", "range": 1 } }
+      ]
+    },
+    "values": [ { "value": "MENDING_MODIFIER", "multiply": 10 } ]
   },
   {
     "type": "enchantment",

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutation_spells.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutation_spells.json
@@ -24,6 +24,26 @@
         }
       ]
     },
+    "values": [ { "value": "MOTION_VISION_RANGE", "add": { "math": [ "( u_val('perception') + u_val('intelligence'))" ] } } ]
+  },
+  {
+    "type": "enchantment",
+    "id": "arvore_forest_detect_enemies_and_overmap",
+    "condition": {
+      "and": [
+        "u_is_outside",
+        {
+          "or": [
+            { "u_is_on_terrain_with_flag": "SHRUB" },
+            { "u_is_on_terrain_with_flag": "YOUNG" },
+            { "u_is_on_terrain": "t_bamboo_tall" },
+            { "u_is_on_terrain": "t_grass_long" },
+            { "u_at_om_location": "forest" },
+            { "u_at_om_location": "forest_thick" }
+          ]
+        }
+      ]
+    },
     "values": [
       { "value": "MOTION_VISION_RANGE", "add": { "math": [ "( u_val('perception') + u_val('intelligence'))" ] } },
       {

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutations.json
@@ -335,12 +335,7 @@
     "points": 3,
     "visibility": 0,
     "ugliness": 0,
-    "prereqs": [
-      "ARVORE_FOREST_DETECT",
-      "ARVORE_FOREST_DETECT_ON",
-      "ARVORE_FOREST_DETECT_AND_OVERMAP",
-      "ARVORE_FOREST_DETECT_AND_OVERMAP_ON"
-    ],
+    "prereqs": [ "ARVORE_FOREST_DETECT", "ARVORE_FOREST_DETECT_AND_OVERMAP" ],
     "description": "The Arvore are closely tied with the forests and may commune with the trees to learn the layout of the land.  Activate this ability to enter the communion.",
     "category": [ "ARVORE" ],
     "active": true,
@@ -412,7 +407,7 @@
     "enchantments": [
       {
         "condition": { "and": [ "is_day", "u_is_outside" ] },
-        "values": [ { "value": "REGEN_HP", "multiply": 0.5 } ],
+        "values": [ { "value": "REGEN_HP", "multiply": 0.5 }, { "value": "MENDING_MODIFIER", "multiply": 1 } ],
         "ench_effects": [ { "effect": "effect_arvore_vitamin_bonus", "intensity": 1 } ]
       }
     ],
@@ -432,7 +427,11 @@
     "enchantments": [
       {
         "condition": { "and": [ "is_day", "u_is_outside" ] },
-        "values": [ { "value": "REGEN_HP", "multiply": 0.5 }, { "value": "REGEN_MANA", "multiply": 0.5 } ],
+        "values": [
+          { "value": "REGEN_HP", "multiply": 0.5 },
+          { "value": "REGEN_MANA", "multiply": 0.5 },
+          { "value": "MENDING_MODIFIER", "multiply": 1 }
+        ],
         "ench_effects": [ { "effect": "effect_arvore_vitamin_bonus", "intensity": 1 } ]
       }
     ],
@@ -618,12 +617,7 @@
     "ugliness": 0,
     "description": "When one tree in a grove is attacked by insects, soon all trees will produce the deterrent.  +3 Perception.",
     "prereqs": [ "ARVORE_COMMUNE_WITH_NATURE" ],
-    "prereqs2": [
-      "ARVORE_FOREST_DETECT",
-      "ARVORE_FOREST_DETECT_ON",
-      "ARVORE_FOREST_DETECT_AND_OVERMAP",
-      "ARVORE_FOREST_DETECT_AND_OVERMAP_ON"
-    ],
+    "prereqs2": [ "ARVORE_FOREST_DETECT", "ARVORE_FOREST_DETECT_AND_OVERMAP" ],
     "category": [ "ARVORE" ],
     "passive_mods": { "per_mod": 3 }
   },
@@ -634,68 +628,10 @@
     "points": 3,
     "visibility": 0,
     "ugliness": 0,
-    "description": "The forest recognizes your kinship and will hide you beneath its boughs.",
+    "description": "The forest recognizes your kinship and will hide you beneath its boughs.  When in a forest or in thick foliage, enemies will have a harder time spotting you.",
     "category": [ "ARVORE" ],
     "//": "Ideally there'd be some way to detect what sort of terrain was nearby and you'd need a critical mass of foliage, but the below will work for now.",
-    "triggers": [
-      [
-        {
-          "condition": {
-            "and": [
-              "u_is_outside",
-              {
-                "or": [
-                  { "u_is_on_terrain_with_flag": "SHRUB" },
-                  { "u_is_on_terrain": "t_tree_young" },
-                  { "u_is_on_terrain": "t_bamboo_tall" },
-                  { "u_is_on_terrain": "t_grass_long" },
-                  { "u_at_om_location": "forest" },
-                  { "u_at_om_location": "forest_thick" }
-                ]
-              }
-            ]
-          },
-          "msg_on": { "text": "", "rating": "good" }
-        }
-      ]
-    ],
-    "transform": { "target": "ARVORE_FOREST_STEALTH_ON", "msg_transform": "", "active": false, "moves": 0 },
-    "//2": "No messages so you aren't constantly spammed while you're walking around the overmap."
-  },
-  {
-    "type": "mutation",
-    "id": "ARVORE_FOREST_STEALTH_ON",
-    "name": { "str": "Shadow of the Trees (active)" },
-    "points": 3,
-    "visibility": 0,
-    "ugliness": 0,
-    "valid": false,
-    "description": "The forest is hiding you from your enemies.",
-    "category": [ "ARVORE" ],
-    "stealth_modifier": 60,
-    "triggers": [
-      [
-        {
-          "condition": {
-            "or": [
-              { "not": "u_is_outside" },
-              {
-                "and": [
-                  { "not": { "u_is_on_terrain_with_flag": "SHRUB" } },
-                  { "not": { "u_is_on_terrain": "t_tree_young" } },
-                  { "not": { "u_is_on_terrain": "t_bamboo_tall" } },
-                  { "not": { "u_is_on_terrain": "t_grass_long" } },
-                  { "not": { "u_at_om_location": "forest" } },
-                  { "not": { "u_at_om_location": "forest_thick" } }
-                ]
-              }
-            ]
-          },
-          "msg_on": { "text": "", "rating": "good" }
-        }
-      ]
-    ],
-    "transform": { "target": "ARVORE_FOREST_STEALTH", "msg_transform": "", "active": false, "moves": 0 }
+    "enchantments": [ "ench_arvore_forest_stealth" ]
   },
   {
     "type": "mutation",
@@ -804,66 +740,7 @@
     "leads_to": [ "ARVORE_FOREST_MAPPING" ],
     "description": "In the whispers of the leaves and the movement of the grasses, the forest warns you of approaching dangers.  When outside and near thick foliage, you can detect your enemies.",
     "category": [ "ARVORE" ],
-    "triggers": [
-      [
-        {
-          "condition": {
-            "and": [
-              "u_is_outside",
-              {
-                "or": [
-                  { "u_is_on_terrain_with_flag": "SHRUB" },
-                  { "u_is_on_terrain": "t_tree_young" },
-                  { "u_is_on_terrain": "t_bamboo_tall" },
-                  { "u_at_om_location": "forest" },
-                  { "u_at_om_location": "forest_thick" },
-                  { "u_at_om_location": "forest_water" }
-                ]
-              }
-            ]
-          },
-          "msg_on": { "text": "", "rating": "good" }
-        }
-      ]
-    ],
-    "transform": { "target": "ARVORE_FOREST_DETECT_ON", "msg_transform": "", "active": false, "moves": 0 }
-  },
-  {
-    "type": "mutation",
-    "id": "ARVORE_FOREST_DETECT_ON",
-    "name": { "str": "The Forests' Warning (active)" },
-    "points": 2,
-    "visibility": 0,
-    "ugliness": 0,
-    "valid": false,
-    "prereqs": [ "ARVORE_EYES" ],
-    "changes_to": [ "ARVORE_FOREST_DETECT_AND_OVERMAP" ],
-    "description": "In the whispers of the leaves and the movement of the grasses, the forest warns you of approaching dangers.  The foliage is whispering to you of hidden dangers nearby.",
-    "category": [ "ARVORE" ],
-    "enchantments": [ "arvore_forest_detect_enemies" ],
-    "triggers": [
-      [
-        {
-          "condition": {
-            "or": [
-              { "not": "u_is_outside" },
-              {
-                "and": [
-                  { "not": { "u_is_on_terrain_with_flag": "SHRUB" } },
-                  { "not": { "u_is_on_terrain": "t_tree_young" } },
-                  { "not": { "u_is_on_terrain": "t_bamboo_tall" } },
-                  { "not": { "u_at_om_location": "forest" } },
-                  { "not": { "u_at_om_location": "forest_thick" } },
-                  { "not": { "u_at_om_location": "forest_water" } }
-                ]
-              }
-            ]
-          },
-          "msg_on": { "text": "", "rating": "good" }
-        }
-      ]
-    ],
-    "transform": { "target": "ARVORE_FOREST_DETECT", "msg_transform": "", "active": false, "moves": 0 }
+    "enchantments": [ "arvore_forest_detect_enemies" ]
   },
   {
     "type": "mutation",
@@ -872,71 +749,11 @@
     "points": 4,
     "visibility": 0,
     "ugliness": 0,
-    "prereqs": [ "ARVORE_FOREST_DETECT", "ARVORE_FOREST_DETECT_ON" ],
+    "prereqs": [ "ARVORE_FOREST_DETECT" ],
     "leads_to": [ "ARVORE_FOREST_MAPPING" ],
     "description": "In the whispers of the leaves and the movement of the grasses, the forest warns you of approaching dangers.  When outside and near thick foliage, you can detect your enemies.  Also, you can see further when you're standing in a forest.",
     "category": [ "ARVORE" ],
-    "triggers": [
-      [
-        {
-          "condition": {
-            "and": [
-              "u_is_outside",
-              {
-                "or": [
-                  { "u_is_on_terrain_with_flag": "SHRUB" },
-                  { "u_is_on_terrain": "t_tree_young" },
-                  { "u_is_on_terrain": "t_bamboo_tall" },
-                  { "u_at_om_location": "forest" },
-                  { "u_at_om_location": "forest_thick" },
-                  { "u_at_om_location": "forest_water" }
-                ]
-              }
-            ]
-          },
-          "msg_on": { "text": "", "rating": "good" }
-        }
-      ]
-    ],
-    "transform": { "target": "ARVORE_FOREST_DETECT_AND_OVERMAP_ON", "msg_transform": "", "active": false, "moves": 0 }
-  },
-  {
-    "type": "mutation",
-    "id": "ARVORE_FOREST_DETECT_AND_OVERMAP_ON",
-    "name": { "str": "The Whispers of the Leaves (active)" },
-    "points": 2,
-    "visibility": 0,
-    "ugliness": 0,
-    "valid": false,
-    "prereqs": [ "ARVORE_FOREST_DETECT", "ARVORE_FOREST_DETECT_ON" ],
-    "leads_to": [ "ARVORE_FOREST_MAPPING" ],
-    "description": "In the whispers of the leaves and the movement of the grasses, the forest warns you of approaching dangers.  The foliage is whispering to you of hidden dangers nearby and revealing the lay of the land to you.",
-    "category": [ "ARVORE" ],
-    "enchantments": [ "arvore_forest_detect_enemies" ],
-    "overmap_sight": 5,
-    "triggers": [
-      [
-        {
-          "condition": {
-            "or": [
-              { "not": "u_is_outside" },
-              {
-                "and": [
-                  { "not": { "u_is_on_terrain_with_flag": "SHRUB" } },
-                  { "not": { "u_is_on_terrain": "t_tree_young" } },
-                  { "not": { "u_is_on_terrain": "t_bamboo_tall" } },
-                  { "not": { "u_at_om_location": "forest" } },
-                  { "not": { "u_at_om_location": "forest_thick" } },
-                  { "not": { "u_at_om_location": "forest_water" } }
-                ]
-              }
-            ]
-          },
-          "msg_on": { "text": "", "rating": "good" }
-        }
-      ]
-    ],
-    "transform": { "target": "ARVORE_FOREST_DETECT_AND_OVERMAP", "msg_transform": "", "active": false, "moves": 0 }
+    "enchantments": [ "arvore_forest_detect_enemies" ]
   },
   {
     "type": "mutation",
@@ -1052,107 +869,7 @@
     "category": [ "ARVORE" ],
     "threshreq": [ "THRESH_ARVORE" ],
     "flags": [ "MEND_ALL" ],
-    "triggers": [
-      [
-        {
-          "condition": {
-            "and": [
-              {
-                "or": [
-                  "u_is_outside",
-                  { "u_is_on_terrain": "t_barkfloor" },
-                  { "u_is_on_terrain": "t_bramble_door_c" },
-                  { "u_is_on_terrain": "t_bramble_door_o" },
-                  { "u_is_on_terrain": "t_root_floor" }
-                ]
-              },
-              {
-                "or": [
-                  { "u_is_on_terrain_with_flag": "SHRUB" },
-                  { "u_is_on_terrain": "t_tree_young" },
-                  { "u_is_on_terrain": "t_bamboo_tall" },
-                  { "u_is_on_terrain": "t_dirt" },
-                  { "u_is_on_terrain": "t_dirtmound" },
-                  { "u_is_on_terrain": "t_clay" },
-                  { "u_is_on_terrain": "t_sand" },
-                  { "u_is_on_terrain": "t_sandmound" },
-                  { "u_is_on_terrain": "t_grave" },
-                  { "u_is_on_terrain": "t_forestfloor" },
-                  { "u_is_on_terrain": "t_grass" },
-                  { "u_is_on_terrain": "t_grass_long" },
-                  { "u_is_on_terrain": "t_grass_tall" },
-                  { "u_is_on_terrain": "t_grass_dead" },
-                  { "u_is_on_terrain": "t_dirtfloor_no_roof" },
-                  { "u_is_on_terrain": "t_mud" },
-                  { "u_is_on_terrain": "t_dirtfloor_no_roof" },
-                  { "u_is_on_terrain": "t_moss" }
-                ]
-              }
-            ]
-          },
-          "msg_on": { "text": "", "rating": "good" }
-        }
-      ]
-    ],
-    "transform": { "target": "ARVORE_HEAL_LIMB_REGEN_ON", "msg_transform": "", "active": false, "moves": 0 }
-  },
-  {
-    "type": "mutation",
-    "id": "ARVORE_HEAL_LIMB_REGEN_ON",
-    "name": { "str": "Leaves Return When Winter Ends (active)" },
-    "//": "Once limb loss is possible, this mutation should allow the Arvore to regrow lost limbs.",
-    "points": 3,
-    "visibility": 0,
-    "ugliness": 0,
-    "valid": false,
-    "description": "When in wild areas, you can draw on the revitalizing power of the land to heal yourself.  In this natural areas, your limbs are regenerating.",
-    "category": [ "ARVORE" ],
-    "threshreq": [ "THRESH_ARVORE" ],
-    "flags": [ "MEND_ALL" ],
-    "mending_modifier": 20.0,
-    "triggers": [
-      [
-        {
-          "condition": {
-            "or": [
-              {
-                "and": [
-                  { "not": "u_is_outside" },
-                  { "not": { "u_is_on_terrain": "t_barkfloor" } },
-                  { "not": { "u_is_on_terrain": "t_bramble_door_c" } },
-                  { "not": { "u_is_on_terrain": "t_bramble_door_o" } },
-                  { "not": { "u_is_on_terrain": "t_root_floor" } }
-                ]
-              },
-              {
-                "and": [
-                  { "not": { "u_is_on_terrain_with_flag": "SHRUB" } },
-                  { "not": { "u_is_on_terrain": "t_tree_young" } },
-                  { "not": { "u_is_on_terrain": "t_bamboo_tall" } },
-                  { "not": { "u_is_on_terrain": "t_dirt" } },
-                  { "not": { "u_is_on_terrain": "t_dirtmound" } },
-                  { "not": { "u_is_on_terrain": "t_clay" } },
-                  { "not": { "u_is_on_terrain": "t_sand" } },
-                  { "not": { "u_is_on_terrain": "t_sandmound" } },
-                  { "not": { "u_is_on_terrain": "t_grave" } },
-                  { "not": { "u_is_on_terrain": "t_forestfloor" } },
-                  { "not": { "u_is_on_terrain": "t_grass" } },
-                  { "not": { "u_is_on_terrain": "t_grass_long" } },
-                  { "not": { "u_is_on_terrain": "t_grass_tall" } },
-                  { "not": { "u_is_on_terrain": "t_grass_dead" } },
-                  { "not": { "u_is_on_terrain": "t_dirtfloor_no_roof" } },
-                  { "not": { "u_is_on_terrain": "t_mud" } },
-                  { "not": { "u_is_on_terrain": "t_dirtfloor_no_roof" } },
-                  { "not": { "u_is_on_terrain": "t_moss" } }
-                ]
-              }
-            ]
-          },
-          "msg_on": { "text": "", "rating": "good" }
-        }
-      ]
-    ],
-    "transform": { "target": "ARVORE_HEAL_LIMB_REGEN", "msg_transform": "", "active": false, "moves": 0 }
+    "enchantments": [ "ench_arvore_wilds_super_mending" ]
   },
   {
     "type": "mutation",
@@ -1227,7 +944,10 @@
       "ROBOT",
       "HORROR",
       "ABERRATION",
-      "HUMAN"
+      "HUMAN",
+      "VAMPIRE",
+      "NIGHTMARE",
+      "HOMULLUS"
     ],
     "//2": "NETHER_EMANATION missing from the above list is deliberate--they hone in on mental activity and the transformed Arvore still thinks.",
     "enchantments": [ "ench_arvore_tree_form", "ench_arvore_tree_reduce_thirst" ]
@@ -1250,7 +970,8 @@
         "values": [
           { "value": "REGEN_HP", "multiply": 0.5 },
           { "value": "REGEN_MANA", "multiply": 0.5 },
-          { "value": "MAX_MANA", "multiply": 0.5 }
+          { "value": "MAX_MANA", "multiply": 0.5 },
+          { "value": "MENDING_MODIFIER", "multiply": 1 }
         ],
         "ench_effects": [ { "effect": "effect_arvore_vitamin_bonus", "intensity": 1 } ]
       }
@@ -1275,6 +996,7 @@
           { "value": "REGEN_HP", "multiply": 0.5 },
           { "value": "REGEN_MANA", "multiply": 0.5 },
           { "value": "MAX_MANA", "multiply": 0.5 },
+          { "value": "MENDING_MODIFIER", "multiply": 1 },
           { "value": "STRENGTH", "add": 2 },
           { "value": "DEXTERITY", "add": 2 },
           { "value": "INTELLIGENCE", "add": 2 },

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutations.json
@@ -753,7 +753,7 @@
     "leads_to": [ "ARVORE_FOREST_MAPPING" ],
     "description": "In the whispers of the leaves and the movement of the grasses, the forest warns you of approaching dangers.  When outside and near thick foliage, you can detect your enemies.  Also, you can see further when you're standing in a forest.",
     "category": [ "ARVORE" ],
-    "enchantments": [ "arvore_forest_detect_enemies" ]
+    "enchantments": [ "arvore_forest_detect_enemies_and_overmap" ]
   },
   {
     "type": "mutation",

--- a/data/mods/Xedra_Evolved/obsoletion_and_migration/mutations.json
+++ b/data/mods/Xedra_Evolved/obsoletion_and_migration/mutations.json
@@ -142,5 +142,172 @@
     "passive_mods": { "str_mod": 2, "dex_mod": 2, "int_mod": 2, "per_mod": 2 },
     "triggers": [ [ { "condition": { "and": [ "is_day", "u_is_outside" ] }, "msg_on": { "text": "", "rating": "good" } } ] ],
     "transform": { "target": "ARVORE_SUN_POWER_MANA_STATS", "msg_transform": "", "active": false, "moves": 0 }
+  },
+  {
+    "type": "mutation",
+    "id": "ARVORE_FOREST_STEALTH_ON",
+    "name": { "str": "Shadow of the Trees (active)" },
+    "points": 3,
+    "visibility": 0,
+    "ugliness": 0,
+    "valid": false,
+    "description": "The forest is hiding you from your enemies.",
+    "category": [ "ARVORE" ],
+    "stealth_modifier": 60,
+    "triggers": [
+      [
+        {
+          "condition": {
+            "and": [
+              "u_is_outside",
+              {
+                "or": [
+                  { "u_is_on_terrain_with_flag": "SHRUB" },
+                  { "u_is_on_terrain": "t_tree_young" },
+                  { "u_is_on_terrain": "t_bamboo_tall" },
+                  { "u_is_on_terrain": "t_grass_long" },
+                  { "u_at_om_location": "forest" },
+                  { "u_at_om_location": "forest_thick" }
+                ]
+              }
+            ]
+          },
+          "msg_on": { "text": "", "rating": "good" }
+        }
+      ]
+    ],
+    "transform": { "target": "ARVORE_FOREST_STEALTH", "msg_transform": "", "active": false, "moves": 0 }
+  },
+  {
+    "type": "mutation",
+    "id": "ARVORE_FOREST_DETECT_ON",
+    "name": { "str": "The Forests' Warning (active)" },
+    "points": 2,
+    "visibility": 0,
+    "ugliness": 0,
+    "valid": false,
+    "prereqs": [ "ARVORE_EYES" ],
+    "changes_to": [ "ARVORE_FOREST_DETECT_AND_OVERMAP" ],
+    "description": "In the whispers of the leaves and the movement of the grasses, the forest warns you of approaching dangers.  The foliage is whispering to you of hidden dangers nearby.",
+    "category": [ "ARVORE" ],
+    "triggers": [
+      [
+        {
+          "condition": {
+            "and": [
+              "u_is_outside",
+              {
+                "or": [
+                  { "u_is_on_terrain_with_flag": "SHRUB" },
+                  { "u_is_on_terrain_with_flag": "YOUNG" },
+                  { "u_is_on_terrain": "t_bamboo_tall" },
+                  { "u_at_om_location": "forest" },
+                  { "u_at_om_location": "forest_thick" },
+                  { "u_at_om_location": "forest_water" }
+                ]
+              }
+            ]
+          },
+          "msg_on": { "text": "", "rating": "good" }
+        }
+      ]
+    ],
+    "transform": { "target": "ARVORE_FOREST_DETECT", "msg_transform": "", "active": false, "moves": 0 }
+  },
+  {
+    "type": "mutation",
+    "id": "ARVORE_FOREST_DETECT_AND_OVERMAP_ON",
+    "name": { "str": "The Whispers of the Leaves (active)" },
+    "points": 2,
+    "visibility": 0,
+    "ugliness": 0,
+    "valid": false,
+    "prereqs": [ "ARVORE_FOREST_DETECT", "ARVORE_FOREST_DETECT_ON" ],
+    "leads_to": [ "ARVORE_FOREST_MAPPING" ],
+    "description": "In the whispers of the leaves and the movement of the grasses, the forest warns you of approaching dangers.  The foliage is whispering to you of hidden dangers nearby and revealing the lay of the land to you.",
+    "category": [ "ARVORE" ],
+    "enchantments": [ "arvore_forest_detect_enemies" ],
+    "overmap_sight": 5,
+    "triggers": [
+      [
+        {
+          "condition": {
+            "and": [
+              "u_is_outside",
+              {
+                "or": [
+                  { "u_is_on_terrain_with_flag": "SHRUB" },
+                  { "u_is_on_terrain": "t_tree_young" },
+                  { "u_is_on_terrain": "t_bamboo_tall" },
+                  { "u_at_om_location": "forest" },
+                  { "u_at_om_location": "forest_thick" },
+                  { "u_at_om_location": "forest_water" }
+                ]
+              }
+            ]
+          },
+          "msg_on": { "text": "", "rating": "good" }
+        }
+      ]
+    ],
+    "transform": { "target": "ARVORE_FOREST_DETECT_AND_OVERMAP", "msg_transform": "", "active": false, "moves": 0 }
+  },
+  {
+    "type": "mutation",
+    "id": "ARVORE_HEAL_LIMB_REGEN_ON",
+    "name": { "str": "Leaves Return When Winter Ends (active)" },
+    "//": "Once limb loss is possible, this mutation should allow the Arvore to regrow lost limbs.",
+    "points": 3,
+    "visibility": 0,
+    "ugliness": 0,
+    "valid": false,
+    "description": "When in wild areas, you can draw on the revitalizing power of the land to heal yourself.  In this natural areas, your limbs are regenerating.",
+    "category": [ "ARVORE" ],
+    "threshreq": [ "THRESH_ARVORE" ],
+    "flags": [ "MEND_ALL" ],
+    "mending_modifier": 20.0,
+    "triggers": [
+      [
+        {
+          "condition": {
+            "and": [
+              {
+                "or": [
+                  "u_is_outside",
+                  { "u_is_on_terrain": "t_barkfloor" },
+                  { "u_is_on_terrain": "t_bramble_door_c" },
+                  { "u_is_on_terrain": "t_bramble_door_o" },
+                  { "u_is_on_terrain": "t_root_floor" }
+                ]
+              },
+              {
+                "or": [
+                  { "u_is_on_terrain_with_flag": "SHRUB" },
+                  { "u_is_on_terrain": "t_tree_young" },
+                  { "u_is_on_terrain": "t_bamboo_tall" },
+                  { "u_is_on_terrain": "t_dirt" },
+                  { "u_is_on_terrain": "t_dirtmound" },
+                  { "u_is_on_terrain": "t_clay" },
+                  { "u_is_on_terrain": "t_sand" },
+                  { "u_is_on_terrain": "t_sandmound" },
+                  { "u_is_on_terrain": "t_grave" },
+                  { "u_is_on_terrain": "t_forestfloor" },
+                  { "u_is_on_terrain": "t_grass" },
+                  { "u_is_on_terrain": "t_grass_long" },
+                  { "u_is_on_terrain": "t_grass_tall" },
+                  { "u_is_on_terrain": "t_grass_dead" },
+                  { "u_is_on_terrain": "t_dirtfloor_no_roof" },
+                  { "u_is_on_terrain": "t_mud" },
+                  { "u_is_on_terrain": "t_dirtfloor_no_roof" },
+                  { "u_is_on_terrain": "t_moss" }
+                ]
+              }
+            ]
+          },
+          "msg_on": { "text": "", "rating": "good" }
+        }
+      ]
+    ],
+    "transform": { "target": "ARVORE_HEAL_LIMB_REGEN", "msg_transform": "", "active": false, "moves": 0 }
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Xedra Evolved] Consolidate more Arvore mutations with triggers into one mutation"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Avoiding too many problems with mutating inactive mutations when transformed to the activate mutations.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Combine Leaves Return When Winter Ends, The Forest's Warning, The Whispers of the Leaves, and Shadow of the Trees.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

New mutations work, old active mutations transform into new combined mutations. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
