### PR TITLE
[Bombastic Perks] Fix perk-choosing crash(?)

### DIFF
--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -1063,7 +1063,10 @@
         },
         "failure_explanation": "Requirements Not Met",
         "failure_topic": "TALK_PERK_MENU_FAIL",
-        "effect": [ { "u_mutate_towards": { "context_val": "trait_id" } }, { "math": [ "u_num_perks", "--" ] } ]
+        "effect": [
+          { "u_mutate_towards": { "context_val": "trait_id" }, "category": "ANY", "use_vitamins": false },
+          { "math": [ "u_num_perks", "--" ] }
+        ]
       },
       {
         "text": "Go Back.",
@@ -1089,7 +1092,10 @@
         },
         "failure_explanation": "Requirements Not Met",
         "failure_topic": "TALK_PERK_MENU_FAIL",
-        "effect": [ { "u_mutate_towards": { "context_val": "trait_id" } }, { "math": [ "u_num_perks", "-=", "u_playstyle_cost + 1" ] } ]
+        "effect": [
+          { "u_mutate_towards": { "context_val": "trait_id" }, "category": "ANY", "use_vitamins": false },
+          { "math": [ "u_num_perks", "-=", "u_playstyle_cost + 1" ] }
+        ]
       },
       {
         "text": "Go Back.",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "[Bombastic Perks] Fix perk-choosing crash(?)"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Failing to explicitly list `"category"` and `"use_vitamins"` was causing crashes for some people when selecting a perk. But not me. Everything worked perfectly for me, so there's something else going wrong with `u_mutate_towards` that this PR does not fix.

I am told it fixes #71944
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add `"category": "ANY", "use_vitamins": false` to the perk-gaining EoCs
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

I had no crashes afterwards and could properly select perks, but I also had no crashes before and could properly select perks. Someone on the Discord tested the fix and told me it works.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I still do not know why I had no crashes at all. The documentation states that `category` and `use_vitamins` are optional but that appears to not be the case...except for my machine. Except now that I think about it, I think I _did_ have the same problem in #71724 until I explicitly listed `"category": "MAANTOUCHED"` there.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
