### PR TITLE
Update u_val('sold') to n_val('sold')

### DIFF
--- a/data/json/npcs/exodii/exodii_merchant_talk.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk.json
@@ -156,8 +156,8 @@
       },
       {
         "//": "Check to see if you've sold enough for Rubik's trust in you to increase a bit",
-        "condition": { "and": [ { "math": [ "u_val('sold')", ">=", "20" ] }, { "not": { "u_has_faction_trust": 20 } } ] },
-        "effect": [ { "math": [ "u_val('sold')", "-=", "20" ] }, { "u_add_faction_trust": 1 } ]
+        "condition": { "and": [ { "math": [ "n_val('sold')", ">=", "20" ] }, { "not": { "u_has_faction_trust": 20 } } ] },
+        "effect": [ { "math": [ "n_val('sold')", "-=", "20" ] }, { "u_add_faction_trust": 1 } ]
       },
       {
         "//": "Governs the special CBM stock availability and restock, also adds a little extra faction rep.",
@@ -274,8 +274,8 @@
       { "//~": "That was a good exchange", "str": "For a card an' a wink, eh?" }
     ],
     "speaker_effect": {
-      "condition": { "and": [ { "math": [ "u_val('sold')", ">=", "20" ] }, { "not": { "u_has_faction_trust": 21 } } ] },
-      "effect": [ { "math": [ "u_val('sold')", "-=", "20" ] }, { "u_add_faction_trust": 1 } ]
+      "condition": { "and": [ { "math": [ "n_val('sold')", ">=", "20" ] }, { "not": { "u_has_faction_trust": 21 } } ] },
+      "effect": [ { "math": [ "n_val('sold')", "-=", "20" ] }, { "u_add_faction_trust": 1 } ]
     },
     "responses": [
       { "text": "Why are your lockers full of medieval gear?", "topic": "TALK_EXODII_MERCHANT_Stock_Medieval" },

--- a/data/json/npcs/exodii/exodii_merchant_talk_exodization.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk_exodization.json
@@ -24,7 +24,7 @@
     "id": "TALK_EXODII_MERCHANT_Exodize",
     "type": "talk_topic",
     "dynamic_line": {
-      "math": [ "u_val('sold')", "==", "1" ],
+      "math": [ "n_val('sold')", ">=", "100" ],
       "yes": {
         "//~": "Oh HO!  Well, now you're speaking my language.  We can fix you up good, if you're willing to pay us back.  I'll say it as clearly as I can.  If you help us kill the undead, we can help you get fixed up like us, yeah.  Stuck right into your flesh and bone and wired into your brain.  You understand?  If not, we'll ask the Great Grey to help clear it up.",
         "str": "Oh HO!  Well, well.  Now you're yarkin' the King's Anglic.  Aye, us'n can fix ye good, if'n ye're tassed to repay it in kind.  Us'll speak it as clear-like as this Rubik can.  If ye'n use it to put the dead back in the ground, us'n can fix ye with some goods like this, aye.  Stuck in the flesh and to the bone, wired into the brain.  Ye kennit?  If no, us'll speak to the Great Grey for a pint o' the ol' clarity-draught."
@@ -45,28 +45,28 @@
       {
         "text": "If I just keep on killing zombies, you'll help turn me into a cyborg?  Why are we still yarkin', then?  Sign me the heck up.",
         "topic": "TALK_EXODII_MERCHANT_ExodizeMe1",
-        "condition": { "or": [ { "math": [ "u_val('sold')", ">=", "100" ] }, { "u_has_faction_trust": 5 } ] }
+        "condition": { "or": [ { "math": [ "n_val('sold')", ">=", "100" ] }, { "u_has_faction_trust": 5 } ] }
       },
       {
         "text": "On second thought, I'm not sure I want to let a bunch of unfamiliar alien robots do brain surgery on me.",
         "topic": "TALK_EXODII_MERCHANT_ExodizeNope",
-        "condition": { "or": [ { "math": [ "u_val('sold')", ">=", "100" ] }, { "u_has_faction_trust": 5 } ] }
+        "condition": { "or": [ { "math": [ "n_val('sold')", ">=", "100" ] }, { "u_has_faction_trust": 5 } ] }
       },
       {
         "text": "Maybe try that clarity-draught?",
         "topic": "TALK_EXODII_MERCHANT_ExodizeTranslate",
-        "condition": { "or": [ { "math": [ "u_val('sold')", ">=", "100" ] }, { "u_has_faction_trust": 5 } ] }
+        "condition": { "or": [ { "math": [ "n_val('sold')", ">=", "100" ] }, { "u_has_faction_trust": 5 } ] }
       },
       {
         "text": "OK, well, I've got some stuff I could trade right now.",
         "effect": "start_trade",
         "topic": "TALK_EXODII_MERCHANT_DoneTrade",
-        "condition": { "and": [ { "math": [ "u_val('sold')", "<", "100" ] }, { "not": { "u_has_faction_trust": 5 } } ] }
+        "condition": { "and": [ { "math": [ "n_val('sold')", "<", "100" ] }, { "not": { "u_has_faction_trust": 5 } } ] }
       },
       {
         "text": "OK, maybe I'll come back when I've traded a bit more.",
         "topic": "TALK_DONE",
-        "condition": { "and": [ { "math": [ "u_val('sold')", "<", "100" ] }, { "not": { "u_has_faction_trust": 5 } } ] }
+        "condition": { "and": [ { "math": [ "n_val('sold')", "<", "100" ] }, { "not": { "u_has_faction_trust": 5 } } ] }
       }
     ]
   },

--- a/data/mods/translate-dialogue/rubik.json
+++ b/data/mods/translate-dialogue/rubik.json
@@ -254,7 +254,7 @@
     "id": "TALK_EXODII_MERCHANT_Exodize",
     "type": "talk_topic",
     "dynamic_line": {
-      "math": [ "u_val('sold')", ">=", "100" ],
+      "math": [ "n_val('sold')", ">=", "100" ],
       "yes": "Oh HO!  Well, well.  Now you're yarkin' the King's Anglic.  Aye, us'n can fix ye good, if'n ye're tassed to repay it in kind.  Us'll speak it as clear-like as this Rubik can.  If ye'n use it to put the dead back in the ground, us'n can fix ye with some goods like this, aye.  Stuck in the flesh and to the bone, wired into the brain.  Ye kennit?  If no, us'll speak to the Great Grey for a pint o' the ol' clarity-draught.\"\n\n[TRANSLATE:] \"Oh HO!  Well, now you're speaking my language.  We can fix you up good, if you're willing to pay us back.  I'll say it as clearly as I can.  If you help us kill the undead, we can help you get fixed up like us, yeah.  Stuck right into your flesh and bone and wired into your brain.  You understand?  If not, we'll ask the Great Grey to help clear it up.",
       "no": {
         "u_has_faction_trust": 5,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Make Rubik recognize that the player has sold items"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I visited the Exodii on a new character and found that no matter how much I sold, Rubik just kept asking me to sell him things. After some poking around, it looks like 'sold' is supposed to be accessed through n_val (to get the NPC's `op_of_u.sold`).
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Switched all instances of u_val('sold') to n_val('sold'). Rubik was the only one who used this, so it's a pretty isolated change. I also fixed the selection of his line to match the selection of available responses: it was checking sold == 1 instead of sold >= 100 for some reason. (The translation mod also used sold >= 100 for that line.)
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
None. This seems like the only sensible way to make it work.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I made same the changes to my local copy, asked about bionics, got the please sell things line. Sold things, asked the question again, and got the anesthetic quest.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
None
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
