### PR TITLE
No more infinite farthings from Rubik

### DIFF
--- a/data/json/npcs/exodii/exodii_merchant_talk.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk.json
@@ -525,9 +525,7 @@
       "//~": "Great, I'll put that in the dictionary.  Here's a token of my gratitude for your explanation.",
       "str": "Right so, us'n'll write it in the dicky.  Here, a shiny brass farthing for crossin' the nation."
     },
-    "speaker_effect": {
-      "effect": { "u_add_var": "rubik_intro", "type": "dialogue", "context": "completed", "value": "yes" }
-    },
+    "speaker_effect": { "effect": { "u_add_var": "rubik_intro", "type": "dialogue", "context": "completed", "value": "yes" } },
     "responses": [
       {
         "text": "Now that we've sorted that out, I have to ask.  You're from a place where this happened before, and you escaped to our world?",

--- a/data/json/npcs/exodii/exodii_merchant_talk.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk.json
@@ -508,7 +508,10 @@
       {
         "text": "[INT 7] Sounds like you mean a fusilly is a gun, and a mobbing is a car?",
         "condition": { "u_has_intelligence": 7 },
-        "effect": { "u_add_var": "fussily", "type": "dictionary", "context": "known", "value": "yes" },
+        "effect": [
+          { "u_add_var": "fussily", "type": "dictionary", "context": "known", "value": "yes" },
+          { "u_spawn_item": "rubik_farthing" }
+        ],
         "topic": "TALK_EXODII_MERCHANT_Talk_Intro6"
       },
       { "text": "Can we talk about something else?", "topic": "TALK_EXODII_MERCHANT_Talk" },
@@ -523,10 +526,7 @@
       "str": "Right so, us'n'll write it in the dicky.  Here, a shiny brass farthing for crossin' the nation."
     },
     "speaker_effect": {
-      "effect": [
-        { "u_add_var": "rubik_intro", "type": "dialogue", "context": "completed", "value": "yes" },
-        { "u_spawn_item": "rubik_farthing" }
-      ]
+      "effect": { "u_add_var": "rubik_intro", "type": "dialogue", "context": "completed", "value": "yes" }
     },
     "responses": [
       {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fixes #70825 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Instead of spawning the item every time the farthing topic is displayed, spawn it only once when the player responds to the previous topic.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Spawning it when the player responds to the shiny farthing topic, but that would be clumsy.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Tried the (L)ook/(S)ize up/A/Y/O actions during the topic in question, Rubik doesn't give you another coin.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

None

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
