### PR TITLE
Fix nonphysical armor behavior, rework acid vs armor

### DIFF
--- a/data/json/damage_types.json
+++ b/data/json/damage_types.json
@@ -100,7 +100,7 @@
     "//": "corrosive damage, e.g. acid",
     "id": "acid",
     "type": "damage_type",
-    "physical": false,
+    "physical": true,
     "environmental": true,
     "magic_color": "light_green",
     "name": "acid",
@@ -112,7 +112,7 @@
   {
     "id": "acid",
     "type": "damage_info_order",
-    "info_display": "basic",
+    "info_display": "detailed",
     "verb": "corroding",
     "bionic_info": { "order": 500, "show_type": true },
     "protection_info": { "order": 800, "show_type": true },

--- a/data/json/materials.json
+++ b/data/json/materials.json
@@ -11,6 +11,7 @@
     "dmg_adj": [ "scratched", "cut", "cracked", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "gouged",
+    "acid_dmg_verb": "burned",
     "resist": { "bash": 4, "cut": 5, "acid": 10, "heat": 6, "bullet": 3 }
   },
   {
@@ -76,6 +77,7 @@
     "dmg_adj": [ "scratched", "cut", "cracked", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "gouged",
+    "acid_dmg_verb": "burned",
     "fuel_data": { "energy": "1000 kJ" },
     "resist": { "bash": 0, "cut": 0, "acid": 0, "heat": 0, "bullet": 0 }
   },
@@ -136,6 +138,7 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "damaged",
     "cut_dmg_verb": "damaged",
+    "acid_dmg_verb": "burned",
     "fuel_data": {
       "energy": "15600 kJ",
       "explosion_data": { "chance_hot": 5, "chance_cold": 10, "factor": 0.2, "fiery": true, "size_factor": 0.1 }
@@ -161,6 +164,7 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "damaged",
     "cut_dmg_verb": "damaged",
+    "acid_dmg_verb": "burned",
     "fuel_data": {
       "energy": "15600 kJ",
       "explosion_data": { "chance_hot": 5, "chance_cold": 10, "factor": 0.2, "fiery": true, "size_factor": 0.1 }
@@ -188,6 +192,7 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "damaged",
     "cut_dmg_verb": "damaged",
+    "acid_dmg_verb": "burned",
     "fuel_data": { "energy": "24700 kJ" },
     "//": "Burn data is cargo culted from alcohol.",
     "burn_data": [
@@ -212,6 +217,7 @@
     "dmg_adj": [ "agitated", "thinned", "culled", "eradicated" ],
     "bash_dmg_verb": "ripples",
     "cut_dmg_verb": "passed through",
+    "acid_dmg_verb": "sizzled",
     "repaired_with": "water",
     "soft": true,
     "resist": { "bash": 8, "cut": 0, "acid": 8, "heat": 4, "bullet": 4 },
@@ -232,6 +238,7 @@
     "dmg_adj": [ "scratched", "cut", "cracked", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "gouged",
+    "acid_dmg_verb": "burned",
     "resist": { "bash": 8, "cut": 12, "acid": 20, "heat": 8, "bullet": 10 }
   },
   {
@@ -248,6 +255,7 @@
     "dmg_adj": [ "dented", "bent", "smashed", "destroyed" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "burned",
     "resist": { "bash": 1, "cut": 2, "acid": 4, "heat": 2, "bullet": 1 },
     "repair_difficulty": 5
   },
@@ -268,6 +276,7 @@
     "dmg_adj": [ "scratched", "cut", "cracked", "shattered" ],
     "bash_dmg_verb": "cracked",
     "cut_dmg_verb": "chipped",
+    "acid_dmg_verb": "burned",
     "vitamins": [ [ "calcium", 2 ] ],
     "//": "There is some historical evidence that animal bones have been used as an *added* combustion fuel by humans, but bones overall are a difficult material to use for this purpose and vary greatly in their suitability. The primary combustive component is in fact marrow and fats trapped inside the bone, not the bone structure itself.",
     "burn_data": [
@@ -293,6 +302,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "corroded",
     "resist": { "bash": 3, "cut": 4, "acid": 16, "heat": 2, "bullet": 2 },
     "repair_difficulty": 4
   },
@@ -307,6 +317,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "corroded",
     "burn_products": [ [ "scrap_bronze", 0.5 ] ],
     "resist": { "bash": 4, "cut": 5, "acid": 1, "heat": 2, "bullet": 2 },
     "repair_difficulty": 4
@@ -323,6 +334,7 @@
     "dmg_adj": [ "scratched", "cut", "cracked", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "gouged",
+    "acid_dmg_verb": "burned",
     "burn_products": [ [ "corpse_ash", 0.035 ] ],
     "resist": { "bash": 8, "cut": 12, "acid": 20, "heat": 1, "bullet": 10 }
   },
@@ -337,6 +349,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "corroded",
     "burn_products": [ [ "scrap_bronze", 0.5 ] ],
     "resist": { "bash": 5, "cut": 5, "acid": 5, "heat": 2, "bullet": 2 },
     "repair_difficulty": 4
@@ -355,6 +368,7 @@
     "repaired_with": "scrap",
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "corroded",
     "burn_products": [ [ "scrap", 0.5 ] ],
     "resist": { "bash": 6, "cut": 6, "acid": 7, "heat": 3, "bullet": 2 },
     "repair_difficulty": 2
@@ -373,6 +387,7 @@
     "dmg_adj": [ "ripped", "torn", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "cut",
+    "acid_dmg_verb": "burned",
     "burn_data": [
       { "fuel": 0.6, "smoke": 1, "burn": 0.025, "volume_per_turn": "200 ml" },
       { "fuel": 1.2, "smoke": 1, "burn": 0.05, "volume_per_turn": "825 ml" },
@@ -395,6 +410,7 @@
     "dmg_adj": [ "chipped", "cracked", "split", "broken" ],
     "bash_dmg_verb": "cracked",
     "cut_dmg_verb": "cut",
+    "acid_dmg_verb": "corroded",
     "resist": { "bash": 1, "cut": 2, "acid": 10, "heat": 10, "bullet": 2 }
   },
   {
@@ -419,6 +435,7 @@
     "dmg_adj": [ "chipped", "cracked", "split", "broken" ],
     "bash_dmg_verb": "cracked",
     "cut_dmg_verb": "cut",
+    "acid_dmg_verb": "corroded",
     "resist": { "bash": 3, "cut": 5, "acid": 10, "heat": 10, "bullet": 6 }
   },
   {
@@ -436,6 +453,7 @@
     "dmg_adj": [ "chipped", "cracked", "split", "broken" ],
     "bash_dmg_verb": "cracked",
     "cut_dmg_verb": "cut",
+    "acid_dmg_verb": "corroded",
     "resist": { "bash": 6, "cut": 10, "acid": 10, "heat": 10, "bullet": 12 }
   },
   {
@@ -452,6 +470,7 @@
     "dmg_adj": [ "scratched", "cut", "cracked", "shattered" ],
     "bash_dmg_verb": "cracked",
     "cut_dmg_verb": "chipped",
+    "acid_dmg_verb": "burned",
     "repaired_with": "chitin_piece",
     "salvaged_into": "chitin_piece",
     "burn_data": [
@@ -478,6 +497,7 @@
     "dmg_adj": [ "scratched", "cut", "cracked", "shattered" ],
     "bash_dmg_verb": "cracked",
     "cut_dmg_verb": "chipped",
+    "acid_dmg_verb": "burned",
     "burn_data": [
       { "fuel": 0, "smoke": 0, "burn": 0.0001 },
       { "fuel": 0.2, "smoke": 3, "burn": 0.001, "volume_per_turn": "200 ml" },
@@ -500,6 +520,7 @@
     "dmg_adj": [ "scratched", "cut", "cracked", "shattered" ],
     "bash_dmg_verb": "cracked",
     "cut_dmg_verb": "chipped",
+    "acid_dmg_verb": "burned",
     "chip_resist": 10,
     "burn_data": [
       { "fuel": 0, "smoke": 0, "burn": 0.0001 },
@@ -541,6 +562,7 @@
     "dmg_adj": [ "chipped", "scratched", "cracked", "shattered" ],
     "bash_dmg_verb": "cracked",
     "cut_dmg_verb": "cut",
+    "acid_dmg_verb": "burned",
     "burn_products": [ [ "ceramic_shard", 0.5 ] ],
     "resist": { "bash": 2, "cut": 3, "acid": 6, "heat": 3, "bullet": 2 }
   },
@@ -556,6 +578,7 @@
     "dmg_adj": [ "chipped", "scratched", "cracked", "shattered" ],
     "bash_dmg_verb": "cracked",
     "cut_dmg_verb": "cut",
+    "acid_dmg_verb": "burned",
     "resist": { "bash": 2, "cut": 3, "acid": 6, "heat": 3, "bullet": 2 }
   },
   {
@@ -572,6 +595,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "burned",
     "burn_products": [ [ "copper", 0.5 ] ],
     "resist": { "bash": 2, "cut": 3, "acid": 0, "heat": 3, "bullet": 2 },
     "repair_difficulty": 3
@@ -593,6 +617,7 @@
     "dmg_adj": [ "ripped", "torn", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "cut",
+    "acid_dmg_verb": "burned",
     "burn_data": [
       { "fuel": 1, "smoke": 1, "burn": 0.02 },
       { "fuel": 2, "smoke": 1, "burn": 0.04 },
@@ -629,6 +654,7 @@
     "dmg_adj": [ "ripped", "torn", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "cut",
+    "acid_dmg_verb": "burned",
     "burn_data": [
       { "fuel": 1, "smoke": 1, "burn": 0.02 },
       { "fuel": 2, "smoke": 1, "burn": 0.04 },
@@ -654,6 +680,7 @@
     "dmg_adj": [ "ripped", "torn", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "cut",
+    "acid_dmg_verb": "burned",
     "burn_data": [
       { "fuel": 1, "smoke": 1, "burn": 0.02 },
       { "fuel": 2, "smoke": 1, "burn": 0.04 },
@@ -692,6 +719,7 @@
     "dmg_adj": [ "marked", "chipped", "cracked", "shattered" ],
     "bash_dmg_verb": "chipped",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "corroded",
     "resist": { "bash": 5, "cut": 5, "acid": 10, "heat": 3, "bullet": 2 }
   },
   {
@@ -707,6 +735,7 @@
     "dmg_adj": [ "marked", "chipped", "cracked", "shattered" ],
     "bash_dmg_verb": "chipped",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "corroded",
     "resist": { "bash": 5, "cut": 5, "acid": 10, "heat": 3, "bullet": 2 }
   },
   {
@@ -723,6 +752,7 @@
     "dmg_adj": [ "scratched", "damaged", "smashed", "crushed" ],
     "bash_dmg_verb": "damaged",
     "cut_dmg_verb": "damaged",
+    "acid_dmg_verb": "burned",
     "vitamins": [ [ "calcium", 0.5 ], [ "iron", 0.5 ] ],
     "burn_data": [
       { "fuel": 0, "smoke": 1, "burn": 0.002 },
@@ -747,6 +777,7 @@
     "dmg_adj": [ "bruised", "mutilated", "badly mutilated", "thoroughly mutilated" ],
     "bash_dmg_verb": "bruised",
     "cut_dmg_verb": "sliced",
+    "acid_dmg_verb": "burned",
     "vitamins": [ [ "calcium", 0.1 ], [ "iron", 1.3 ] ],
     "//1": "It's rather difficult to find citeable data on how well arbitrary volumes of human flesh burns, so I've settled for just spitballing it, using wood as a baseline and knowing that cremation takes a lot of fuel. Now it burns less well than wood. So, big improvement. This data was last touched 7 years ago, in a 2016 PR which also cleaned up the fire code. They thought it was crusty and nonsensical at the time. I checked to see what had changed since then. Essentially nothing. So these values never made any sense.",
     "burn_data": [
@@ -781,6 +812,7 @@
     "dmg_adj": [ "scratched", "cut", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "sliced",
+    "acid_dmg_verb": "burned",
     "burn_data": [
       { "fuel": 0.02, "smoke": 1, "burn": 0.001, "volume_per_turn": "200 ml" },
       { "fuel": 0.05, "smoke": 2, "burn": 0.002, "volume_per_turn": "500 ml" },
@@ -802,6 +834,7 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "squished",
     "cut_dmg_verb": "cut",
+    "acid_dmg_verb": "corroded",
     "burn_products": [ [ "ceramic_shard", 0.5 ] ],
     "resist": { "bash": 1, "cut": 1, "acid": 4, "heat": 3, "bullet": 1 }
   },
@@ -820,6 +853,7 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "bruised",
     "cut_dmg_verb": "cut",
+    "acid_dmg_verb": "burned",
     "vitamins": [ [ "vitC", 2 ] ],
     "burn_data": [
       { "fuel": 0, "smoke": 1, "burn": 0.002 },
@@ -844,6 +878,7 @@
     "dmg_adj": [ "ripped", "torn", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "sliced",
+    "acid_dmg_verb": "burned",
     "burn_data": [
       { "fuel": 0.6, "smoke": 1, "burn": 0.02 },
       { "fuel": 1, "smoke": 1, "burn": 0.04 },
@@ -869,6 +904,7 @@
     "dmg_adj": [ "ripped", "torn", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "sliced",
+    "acid_dmg_verb": "burned",
     "burn_data": [
       { "fuel": 0.6, "smoke": 1, "burn": 0.02 },
       { "fuel": 1, "smoke": 1, "burn": 0.04 },
@@ -890,6 +926,7 @@
     "dmg_adj": [ "scratched", "cut", "cracked", "shattered" ],
     "bash_dmg_verb": "cracked",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "etched",
     "burn_data": [
       { "fuel": 0, "smoke": 0, "burn": 0 },
       { "fuel": 0, "smoke": 0, "burn": 0 },
@@ -911,6 +948,7 @@
     "dmg_adj": [ "scratched", "cut", "cracked", "shattered" ],
     "bash_dmg_verb": "cracked",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "etched",
     "burn_data": [
       { "fuel": 0, "smoke": 0, "burn": 0 },
       { "fuel": 0, "smoke": 0, "burn": 0 },
@@ -933,6 +971,7 @@
     "dmg_adj": [ "scratched", "cut", "cracked", "shattered" ],
     "bash_dmg_verb": "cracked",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "etched",
     "burn_data": [
       { "fuel": 0, "smoke": 0, "burn": 0 },
       { "fuel": 0, "smoke": 0, "burn": 0 },
@@ -955,6 +994,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "corroded",
     "burn_products": [ [ "gold_small", 0.5 ] ],
     "resist": { "bash": 1, "cut": 1, "acid": 10, "heat": 3, "bullet": 1 },
     "repair_difficulty": 5
@@ -974,6 +1014,7 @@
     "dmg_adj": [ "bruised", "mutilated", "badly mutilated", "thoroughly mutilated" ],
     "bash_dmg_verb": "bruised",
     "cut_dmg_verb": "sliced",
+    "acid_dmg_verb": "burned",
     "vitamins": [ [ "calcium", 0.1 ], [ "iron", 1.3 ] ],
     "burn_data": [
       { "fuel": 0.05, "smoke": 1, "burn": 0.001, "volume_per_turn": "200 ml" },
@@ -999,6 +1040,7 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "damaged",
     "cut_dmg_verb": "damaged",
+    "acid_dmg_verb": "damaged",
     "vitamins": [ [ "iron", 0.2 ], [ "vitC", 0.1 ], [ "calcium", 0.1 ] ],
     "burn_data": [
       { "fuel": 0, "smoke": 1, "burn": 0.002 },
@@ -1021,6 +1063,7 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "damaged",
     "cut_dmg_verb": "damaged",
+    "acid_dmg_verb": "burned",
     "burn_data": [
       { "fuel": 150, "smoke": 6, "burn": 1 },
       { "fuel": 300, "smoke": 6, "burn": 2 },
@@ -1042,6 +1085,7 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "damaged",
     "cut_dmg_verb": "damaged",
+    "acid_dmg_verb": "damaged",
     "//1": "1L adds about 90 minutes to a fire at the lowest intensity bracket.",
     "burn_data": [
       { "fuel": 300, "smoke": 6, "burn": 1 },
@@ -1159,6 +1203,7 @@
     "dmg_adj": [ "bruised", "mutilated", "badly mutilated", "thoroughly mutilated" ],
     "bash_dmg_verb": "bruised",
     "cut_dmg_verb": "sliced",
+    "acid_dmg_verb": "burned",
     "vitamins": [ [ "calcium", 1 ], [ "iron", 1.3 ] ],
     "burn_data": [
       { "fuel": 0, "smoke": 1, "burn": 0.001, "volume_per_turn": "200 ml" },
@@ -1182,6 +1227,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "corroded",
     "burn_products": [ [ "scrap", 0.5 ] ],
     "resist": { "bash": 4, "cut": 4, "acid": 5, "heat": 3, "bullet": 2 },
     "repair_difficulty": 2
@@ -1201,6 +1247,7 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "smashed",
     "cut_dmg_verb": "cut",
+    "acid_dmg_verb": "burned",
     "burn_data": [
       { "fuel": 0, "smoke": 1, "burn": 0.002 },
       { "fuel": 0, "smoke": 3, "burn": 0.002 },
@@ -1224,6 +1271,7 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "smashed",
     "cut_dmg_verb": "cut",
+    "acid_dmg_verb": "burned",
     "burn_data": [
       { "fuel": 0, "smoke": 1, "burn": 0.002 },
       { "fuel": 0, "smoke": 3, "burn": 0.002 },
@@ -1253,6 +1301,7 @@
     "dmg_adj": [ "ripped", "torn", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "cut",
+    "acid_dmg_verb": "burned",
     "resist": { "bash": 1, "cut": 3, "acid": 5, "heat": 1, "bullet": 2, "stab": 5 },
     "repair_difficulty": 4
   },
@@ -1273,6 +1322,7 @@
     "dmg_adj": [ "ripped", "torn", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "cut",
+    "acid_dmg_verb": "burned",
     "resist": { "bash": 1.5, "cut": 2, "acid": 5, "heat": 3, "bullet": 5 },
     "repair_difficulty": 4
   },
@@ -1290,6 +1340,7 @@
     "dmg_adj": [ "ripped", "torn", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "cut",
+    "acid_dmg_verb": "burned",
     "resist": { "bash": 3, "cut": 4, "acid": 5, "heat": 3, "bullet": 5 },
     "repair_difficulty": 5
   },
@@ -1307,6 +1358,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "corroded",
     "burn_products": [ [ "lead", 0.5 ] ],
     "resist": { "bash": 0, "cut": 0, "acid": 8, "heat": 3, "bullet": 0 }
   },
@@ -1327,6 +1379,7 @@
     "dmg_adj": [ "scratched", "cut", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "sliced",
+    "acid_dmg_verb": "burned",
     "burn_data": [
       { "fuel": 0.05, "smoke": 1, "burn": 0.001, "volume_per_turn": "200 ml" },
       { "fuel": 0.1, "smoke": 3, "burn": 0.002, "volume_per_turn": "500 ml" },
@@ -1352,6 +1405,7 @@
     "dmg_adj": [ "scratched", "cut", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "sliced",
+    "acid_dmg_verb": "burned",
     "burn_data": [
       { "fuel": 0.05, "smoke": 1, "burn": 0.001, "volume_per_turn": "200 ml" },
       { "fuel": 0.1, "smoke": 3, "burn": 0.002, "volume_per_turn": "500 ml" },
@@ -1376,6 +1430,7 @@
     "dmg_adj": [ "scratched", "cut", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "sliced",
+    "acid_dmg_verb": "burned",
     "burn_data": [
       { "fuel": 0.05, "smoke": 1, "burn": 0.001, "volume_per_turn": "200 ml" },
       { "fuel": 0.1, "smoke": 3, "burn": 0.002, "volume_per_turn": "500 ml" },
@@ -1401,6 +1456,7 @@
     "dmg_adj": [ "ripped", "torn", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "cut",
+    "acid_dmg_verb": "burned",
     "//1": "Nylon/polyester reacts poorly to flame (it melts) but is hard to light. Doesn't break down easily unless exposed to a high-intensity fire.",
     "burn_data": [
       { "fuel": 0.05, "smoke": 1, "burn": 0.01 },
@@ -1425,6 +1481,7 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "damaged",
     "cut_dmg_verb": "damaged",
+    "acid_dmg_verb": "damaged",
     "vitamins": [ [ "calcium", 1.5 ], [ "iron", 0.1 ] ],
     "burn_data": [
       { "fuel": -100, "smoke": 1, "burn": 1 },
@@ -1448,6 +1505,7 @@
     "dmg_adj": [ "scratched", "cut", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "sliced",
+    "acid_dmg_verb": "burned",
     "//": "Neoprene is considered highly fire-resistant, and it survives much better than most fabrics. Leaving a 1L cube in a small fire for upwards of 20 minutes produces burnt-badly burnt items.",
     "burn_data": [
       { "fuel": 0.001, "smoke": 3, "burn": 0.001, "volume_per_turn": "1 ml" },
@@ -1474,6 +1532,7 @@
     "dmg_adj": [ "ripped", "torn", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "cut",
+    "acid_dmg_verb": "burned",
     "burn_data": [ { "immune": true }, { "immune": true }, { "immune": true } ],
     "resist": { "bash": 1, "cut": 1, "acid": 5, "heat": 20, "bullet": 1 },
     "repair_difficulty": 4
@@ -1491,6 +1550,7 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "damaged",
     "cut_dmg_verb": "damaged",
+    "acid_dmg_verb": "damaged",
     "resist": { "bash": 0, "cut": 0, "acid": 0, "heat": 1, "bullet": 0 }
   },
   {
@@ -1507,6 +1567,7 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "damaged",
     "cut_dmg_verb": "damaged",
+    "acid_dmg_verb": "damaged",
     "burn_data": [
       { "fuel": 300, "smoke": 3, "burn": 1 },
       { "fuel": 600, "smoke": 6, "burn": 2 },
@@ -1530,6 +1591,7 @@
     "salvaged_into": "wax",
     "bash_dmg_verb": "damaged",
     "cut_dmg_verb": "damaged",
+    "acid_dmg_verb": "damaged",
     "//1": "Basically as flammable as a candle.",
     "burn_data": [
       { "fuel": 0.1, "smoke": 1, "burn": 0.001 },
@@ -1552,6 +1614,7 @@
     "salvaged_into": "wax_paraffin",
     "bash_dmg_verb": "damaged",
     "cut_dmg_verb": "damaged",
+    "acid_dmg_verb": "damaged",
     "burn_data": [
       { "fuel": 150, "smoke": 0, "burn": 1 },
       { "fuel": 300, "smoke": 0, "burn": 2 },
@@ -1574,6 +1637,7 @@
     "dmg_adj": [ "ripped", "torn", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "cut",
+    "acid_dmg_verb": "burned",
     "burn_data": [
       { "fuel": 1.1, "smoke": 1, "burn": 0.025 },
       { "fuel": 2.2, "smoke": 1, "burn": 0.05 },
@@ -1595,6 +1659,7 @@
     "dmg_adj": [ "ripped", "torn", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "cut",
+    "acid_dmg_verb": "burned",
     "burn_data": [
       { "fuel": 0.6, "smoke": 1, "burn": 0.025, "volume_per_turn": "200 ml" },
       { "fuel": 1.2, "smoke": 1, "burn": 0.05, "volume_per_turn": "825 ml" },
@@ -1620,6 +1685,7 @@
     "dmg_adj": [ "scratched", "cut", "cracked", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "gouged",
+    "acid_dmg_verb": "melted",
     "//1": "Most consumer polymers and plastics receive a UL94 rating for flammability and the lowest UL94 rating is HB, generally considered self-extinguishing. Plastics are flammable but should only contribute significant fuel in intense fires.",
     "burn_data": [
       { "fuel": 0.1, "smoke": 2, "burn": 0.001 },
@@ -1661,6 +1727,7 @@
     "dmg_adj": [ "scratched", "cut", "cracked", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "gouged",
+    "acid_dmg_verb": "melted",
     "burn_data": [
       { "fuel": 0.1, "smoke": 2, "burn": 0.001 },
       { "fuel": 0.4, "smoke": 3, "burn": 0.003 },
@@ -1696,6 +1763,7 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "damaged",
     "cut_dmg_verb": "damaged",
+    "acid_dmg_verb": "damaged",
     "//": "This is a highly non-specific material which usually can't be found in any great quantity, so it doesn't really matter what the burn_data is.",
     "burn_data": [
       { "fuel": 10, "smoke": 2, "burn": 10 },
@@ -1717,6 +1785,7 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "damaged",
     "cut_dmg_verb": "damaged",
+    "acid_dmg_verb": "damaged",
     "resist": { "bash": 1, "cut": 1, "acid": 0, "heat": 20, "bullet": 1 }
   },
   {
@@ -1733,6 +1802,7 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "damaged",
     "cut_dmg_verb": "damaged",
+    "acid_dmg_verb": "damaged",
     "resist": { "bash": 1, "cut": 1, "acid": 0, "heat": 20, "bullet": 1 }
   },
   {
@@ -1747,6 +1817,7 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "damaged",
     "cut_dmg_verb": "damaged",
+    "acid_dmg_verb": "damaged",
     "resist": { "bash": 0, "cut": 0, "acid": 8, "heat": 3, "bullet": 0 }
   },
   {
@@ -1763,6 +1834,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "corroded",
     "burn_products": [ [ "silver_small", 0.5 ] ],
     "resist": { "bash": 2, "cut": 3, "acid": 10, "heat": 3, "bullet": 2 },
     "repair_difficulty": 5
@@ -1781,6 +1853,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "corroded",
     "burn_products": [ [ "platinum_small", 0.5 ] ],
     "resist": { "bash": 1, "cut": 1, "acid": 10, "heat": 3, "bullet": 1 },
     "repair_difficulty": 5
@@ -1801,6 +1874,7 @@
     "dmg_adj": [ "worn", "stressed", "shredded", "ruined" ],
     "bash_dmg_verb": "stressed",
     "cut_dmg_verb": "slashed",
+    "acid_dmg_verb": "melted",
     "//2": "based on synthetic fabric and wood, trying to get long burning with much smoke but little fuel",
     "burn_data": [
       { "fuel": 1, "smoke": 3, "burn": 0.1, "volume_per_turn": "100 ml" },
@@ -1826,6 +1900,7 @@
     "dmg_adj": [ "worn", "stressed", "shredded", "ruined" ],
     "bash_dmg_verb": "stressed",
     "cut_dmg_verb": "slashed",
+    "acid_dmg_verb": "melted",
     "//2": "based on synthetic fabric and wood, trying to get long burning with much smoke but little fuel",
     "burn_data": [
       { "fuel": 1, "smoke": 3, "burn": 0.1, "volume_per_turn": "100 ml" },
@@ -1845,6 +1920,7 @@
     "dmg_adj": [ "scratched", "cut", "cracked", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "gouged",
+    "acid_dmg_verb": "burned",
     "resist": { "bash": 0, "cut": 0, "acid": 0, "heat": 0, "bullet": 0 }
   },
   {
@@ -1862,6 +1938,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "corroded",
     "burn_products": [ [ "scrap", 0.5 ] ],
     "resist": { "bash": 6, "cut": 6, "acid": 7, "heat": 3, "bullet": 4.5 },
     "repair_difficulty": 3
@@ -1881,6 +1958,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "corroded",
     "burn_products": [ [ "scrap", 0.5 ] ],
     "resist": { "bash": 7, "cut": 7, "acid": 7, "heat": 3, "bullet": 4.5 },
     "repair_difficulty": 4
@@ -1900,6 +1978,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "corroded",
     "burn_products": [ [ "scrap", 0.5 ] ],
     "resist": { "bash": 10, "cut": 10, "acid": 7, "heat": 3, "bullet": 6.5 },
     "repair_difficulty": 5
@@ -1919,6 +1998,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "corroded",
     "burn_products": [ [ "scrap", 0.5 ] ],
     "resist": { "bash": 10, "cut": 10, "acid": 7, "heat": 3, "bullet": 6.5 },
     "repair_difficulty": 6
@@ -1938,6 +2018,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "corroded",
     "burn_products": [ [ "scrap", 0.5 ] ],
     "resist": { "bash": 11, "cut": 11, "acid": 7, "heat": 3, "bullet": 7.5 },
     "repair_difficulty": 7
@@ -1960,6 +2041,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "corroded",
     "burn_products": [ [ "scrap", 0.5 ] ],
     "resist": { "bash": 6, "cut": 6, "acid": 7, "heat": 3, "bullet": 2 },
     "repair_difficulty": 2
@@ -1983,6 +2065,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "corroded",
     "burn_products": [ [ "scrap", 0.5 ] ],
     "resist": { "bash": 6, "cut": 6, "acid": 7, "heat": 3, "bullet": 4.5 },
     "repair_difficulty": 2
@@ -2006,6 +2089,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "corroded",
     "burn_products": [ [ "scrap", 0.5 ] ],
     "resist": { "bash": 7, "cut": 7, "acid": 7, "heat": 3, "bullet": 4.5 },
     "repair_difficulty": 2
@@ -2029,6 +2113,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "corroded",
     "burn_products": [ [ "scrap", 0.5 ] ],
     "resist": { "bash": 10, "cut": 10, "acid": 7, "heat": 3, "bullet": 6.5 },
     "repair_difficulty": 2
@@ -2052,6 +2137,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "corroded",
     "burn_products": [ [ "scrap", 0.5 ] ],
     "resist": { "bash": 10, "cut": 10, "acid": 7, "heat": 3, "bullet": 6.5 },
     "repair_difficulty": 2
@@ -2075,6 +2161,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "corroded",
     "burn_products": [ [ "scrap", 0.5 ] ],
     "resist": { "bash": 11, "cut": 11, "acid": 7, "heat": 3, "bullet": 7.5 },
     "repair_difficulty": 2
@@ -2093,6 +2180,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "corroded",
     "burn_products": [ [ "scrap", 0.5 ] ],
     "resist": { "bash": 6, "cut": 6, "acid": 7, "heat": 3, "bullet": 3 },
     "repair_difficulty": 4
@@ -2110,6 +2198,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "corroded",
     "fuel_data": { "energy": "10000 kJ" },
     "resist": { "bash": 6, "cut": 6, "acid": 7, "heat": 3, "bullet": 3 }
   },
@@ -2126,6 +2215,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "corroded",
     "fuel_data": { "energy": "10000 kJ" },
     "resist": { "bash": 6, "cut": 6, "acid": 7, "heat": 3, "bullet": 3 }
   },
@@ -2143,6 +2233,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "corroded",
     "fuel_data": {
       "//": "Compressed gaseous hydrogen has 9.2 MJ/L.  This stuff has a very high energy density but is also bulky and explosive.",
       "energy": "4000000 kJ",
@@ -2163,6 +2254,7 @@
     "dmg_adj": [ "scratched", "cut", "cracked", "shattered" ],
     "bash_dmg_verb": "cracked",
     "cut_dmg_verb": "chipped",
+    "acid_dmg_verb": "corroded",
     "burn_products": [ [ "pebble", 0.5 ] ],
     "resist": { "bash": 6, "cut": 6, "acid": 8, "heat": 3, "bullet": 3 }
   },
@@ -2213,6 +2305,7 @@
     "dmg_adj": [ "resonating", "cascading", "unravelling", "fractal" ],
     "bash_dmg_verb": "agitated",
     "cut_dmg_verb": "agitated",
+    "acid_dmg_verb": "agitated",
     "resist": { "bash": 160, "cut": 200, "acid": 100, "heat": 100, "bullet": 160 }
   },
   {
@@ -2227,6 +2320,7 @@
     "dmg_adj": [ "resonating", "cascading", "unravelling", "fractal" ],
     "bash_dmg_verb": "agitated",
     "cut_dmg_verb": "agitated",
+    "acid_dmg_verb": "agitated",
     "burn_products": [ [ "pebble", 1 ] ],
     "resist": { "bash": 160, "cut": 200, "acid": 100, "heat": 100, "bullet": 160 }
   },
@@ -2252,6 +2346,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "corroded",
     "resist": { "bash": 6, "cut": 6, "acid": 5, "heat": 3, "bullet": 5 },
     "repair_difficulty": 7
   },
@@ -2269,6 +2364,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "corroded",
     "resist": { "bash": 6, "cut": 6, "acid": 30, "heat": 30, "bullet": 5 }
   },
   {
@@ -2288,6 +2384,7 @@
     "dmg_adj": [ "ripped", "torn", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "cut",
+    "acid_dmg_verb": "melted",
     "//1": "Nylon reacts poorly to flame (it melts) but is hard to light. Doesn't break down easily unless exposed to a high-intensity fire.",
     "burn_data": [
       { "fuel": 0.05, "smoke": 1, "burn": 0.01 },
@@ -2351,6 +2448,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "corroded",
     "resist": { "bash": 2, "cut": 3, "acid": 0, "heat": 3, "bullet": 2 },
     "//1": "No material in game can actually repair this. Difficulty is zero so that second skin can be 'repaired' (fed blood) with the feeding kit trivially.",
     "repair_difficulty": 0
@@ -2374,6 +2472,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "corroded",
     "resist": { "bash": 0, "cut": 0, "acid": 2, "heat": 3, "bullet": 0 },
     "repair_difficulty": 4
   },
@@ -2393,6 +2492,7 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "squished",
     "cut_dmg_verb": "cut",
+    "acid_dmg_verb": "burned",
     "vitamins": [ [ "calcium", 0.1 ], [ "vitC", 0.5 ] ],
     "burn_data": [
       { "fuel": 0, "smoke": 1, "burn": 0.002 },
@@ -2416,6 +2516,7 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "squished",
     "cut_dmg_verb": "cut",
+    "acid_dmg_verb": "burned",
     "vitamins": [ [ "calcium", 0.1 ], [ "vitC", 4 ], [ "iron", 0.1 ] ],
     "burn_data": [
       { "fuel": 0, "smoke": 1, "burn": 0.002 },
@@ -2439,6 +2540,7 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "squished",
     "cut_dmg_verb": "cut",
+    "acid_dmg_verb": "burned",
     "vitamins": [ [ "calcium", 0.3 ], [ "vitC", 0.6 ], [ "iron", 0.8 ] ],
     "burn_data": [
       { "fuel": 0, "smoke": 1, "burn": 0.002 },
@@ -2462,6 +2564,7 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "squished",
     "cut_dmg_verb": "cut",
+    "acid_dmg_verb": "burned",
     "vitamins": [ [ "calcium", 1.8 ], [ "vitC", 5.2 ], [ "iron", 0.9 ] ],
     "burn_data": [
       { "fuel": 0, "smoke": 1, "burn": 0.002 },
@@ -2485,6 +2588,7 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "damaged",
     "cut_dmg_verb": "cut",
+    "acid_dmg_verb": "burned",
     "vitamins": [ [ "calcium", 0.3 ], [ "iron", 1 ] ],
     "burn_data": [
       { "fuel": 0, "smoke": 1, "burn": 0.002 },
@@ -2508,6 +2612,7 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "squished",
     "cut_dmg_verb": "cut",
+    "acid_dmg_verb": "burned",
     "vitamins": [ [ "calcium", 0.4 ], [ "iron", 4 ] ],
     "burn_data": [
       { "fuel": 0, "smoke": 1, "burn": 0.002 },
@@ -2530,6 +2635,7 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "damaged",
     "cut_dmg_verb": "damaged",
+    "acid_dmg_verb": "damaged",
     "burn_data": [
       { "fuel": -100, "smoke": 1, "burn": 1 },
       { "fuel": -50, "smoke": 2, "burn": 1 },
@@ -2565,6 +2671,7 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "damaged",
     "cut_dmg_verb": "damaged",
+    "acid_dmg_verb": "damaged",
     "burn_data": [
       { "fuel": 300, "smoke": 6, "burn": 1 },
       { "fuel": 600, "smoke": 6, "burn": 2 },
@@ -2592,6 +2699,7 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "damaged",
     "cut_dmg_verb": "damaged",
+    "acid_dmg_verb": "damaged",
     "resist": { "bash": 0, "cut": 0, "acid": 0, "heat": 1, "bullet": 0 }
   },
   {
@@ -2609,6 +2717,7 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "squished",
     "cut_dmg_verb": "cut",
+    "acid_dmg_verb": "burned",
     "vitamins": [ [ "iron", 0.1 ] ],
     "//": "This material is used primarily for foodstuffs, and should not provide any significant fuel value.",
     "burn_data": [
@@ -2633,6 +2742,7 @@
     "dmg_adj": [ "scratched", "chipped", "cracked", "splintered" ],
     "bash_dmg_verb": "splintered",
     "cut_dmg_verb": "gouged",
+    "acid_dmg_verb": "burned",
     "burn_data": [
       { "fuel": 1, "smoke": 1, "burn": 0.01, "volume_per_turn": "200 ml" },
       { "fuel": 2, "smoke": 1, "burn": 0.02, "volume_per_turn": "825 ml" },
@@ -2695,6 +2805,7 @@
     "dmg_adj": [ "ripped", "torn", "shredded", "tattered" ],
     "bash_dmg_verb": "torn",
     "cut_dmg_verb": "cut",
+    "acid_dmg_verb": "burned",
     "burn_data": [
       { "fuel": 0.6, "smoke": 1, "burn": 0.025, "volume_per_turn": "200 ml" },
       { "fuel": 1.2, "smoke": 1, "burn": 0.05, "volume_per_turn": "825 ml" },
@@ -2735,6 +2846,7 @@
     "dmg_adj": [ "squished", "squashed", "mashed", "mushed" ],
     "bash_dmg_verb": "squished",
     "cut_dmg_verb": "squished",
+    "acid_dmg_verb": "burned",
     "burn_data": [
       { "fuel": 1, "smoke": 1, "burn": 1, "volume_per_turn": "1250 ml" },
       { "fuel": 2, "smoke": 1, "burn": 2, "volume_per_turn": "2500 ml" },
@@ -2757,6 +2869,7 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "bruised",
     "cut_dmg_verb": "cut",
+    "acid_dmg_verb": "burned",
     "vitamins": [ [ "vitC", 2 ] ],
     "burn_data": [
       { "fuel": 0, "smoke": 1, "burn": 0.002 },
@@ -2780,6 +2893,7 @@
     "dmg_adj": [ "bruised", "mutilated", "badly mutilated", "thoroughly mutilated" ],
     "bash_dmg_verb": "bruised",
     "cut_dmg_verb": "sliced",
+    "acid_dmg_verb": "burned",
     "vitamins": [ [ "calcium", 0.1 ], [ "iron", 1.3 ] ],
     "burn_data": [
       { "fuel": 0, "smoke": 1, "burn": 0.002 },
@@ -2803,6 +2917,7 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "smashed",
     "cut_dmg_verb": "cut",
+    "acid_dmg_verb": "burned",
     "burn_data": [
       { "fuel": 0, "smoke": 1, "burn": 0.002 },
       { "fuel": 0, "smoke": 3, "burn": 0.002 },
@@ -2825,6 +2940,7 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "smashed",
     "cut_dmg_verb": "cut",
+    "acid_dmg_verb": "melted",
     "vitamins": [ [ "calcium", 1.5 ], [ "iron", 0.1 ] ],
     "burn_data": [
       { "fuel": 0, "smoke": 1, "burn": 0.002 },
@@ -2848,6 +2964,7 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "smashed",
     "cut_dmg_verb": "cut",
+    "acid_dmg_verb": "melted",
     "burn_data": [
       { "fuel": -100, "smoke": 1, "burn": 1 },
       { "fuel": -50, "smoke": 2, "burn": 1 },
@@ -2868,6 +2985,7 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "damaged",
     "cut_dmg_verb": "damaged",
+    "acid_dmg_verb": "damaged",
     "resist": { "bash": 1, "cut": 1, "acid": 0, "heat": 20, "bullet": 1 }
   },
   {
@@ -2891,6 +3009,7 @@
     "dmg_adj": [ "dented", "bent", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "corroded",
     "resist": { "bash": 4, "cut": 3, "acid": 4, "heat": 1, "bullet": 2 },
     "repair_difficulty": 4
   },
@@ -2917,6 +3036,7 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "damaged",
     "cut_dmg_verb": "damaged",
+    "acid_dmg_verb": "corroded",
     "resist": { "bash": 1, "cut": 1, "acid": 0, "heat": 20, "bullet": 1 }
   },
   {
@@ -2931,6 +3051,7 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "damaged",
     "cut_dmg_verb": "damaged",
+    "acid_dmg_verb": "damaged",
     "freezing_point": -77.73,
     "resist": { "bash": 0, "cut": 0, "acid": 0, "heat": 0, "bullet": 0, "electric": 0 }
   },
@@ -2947,6 +3068,7 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "damaged",
     "cut_dmg_verb": "damaged",
+    "acid_dmg_verb": "damaged",
     "freezing_point": -77.73,
     "fuel_data": { "energy": "11500 kJ" },
     "resist": { "bash": 0, "cut": 0, "acid": 0, "heat": 0, "bullet": 0, "electric": 0 }
@@ -2965,6 +3087,7 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "damaged",
     "cut_dmg_verb": "damaged",
+    "acid_dmg_verb": "damaged",
     "freezing_point": -55,
     "fuel_data": {
       "energy": "34800 kJ",
@@ -2992,6 +3115,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "corroded",
     "resist": { "bash": 1, "cut": 4, "acid": 4, "heat": 3, "bullet": 4 }
   },
   {
@@ -3008,6 +3132,7 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "damaged",
     "cut_dmg_verb": "damaged",
+    "acid_dmg_verb": "damaged",
     "resist": { "bash": 2, "cut": 5, "acid": 10, "heat": 20, "bullet": 2 }
   },
   {
@@ -3024,6 +3149,7 @@
     "dmg_adj": [ "ripped", "torn", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "sliced",
+    "acid_dmg_verb": "burned",
     "burn_data": [
       { "fuel": 0.6, "smoke": 1, "burn": 0.02 },
       { "fuel": 1, "smoke": 1, "burn": 0.04 },
@@ -3045,6 +3171,7 @@
     "dmg_adj": [ "scratched", "chipped", "cracked", "splintered" ],
     "bash_dmg_verb": "splintered",
     "cut_dmg_verb": "gouged",
+    "acid_dmg_verb": "burned",
     "burn_data": [
       { "fuel": 1, "smoke": 1, "burn": 0.01, "volume_per_turn": "200 ml" },
       { "fuel": 2, "smoke": 1, "burn": 0.02, "volume_per_turn": "825 ml" },
@@ -3069,6 +3196,7 @@
     "dmg_adj": [ "scratched", "cut", "cracked", "shattered" ],
     "bash_dmg_verb": "cracked",
     "cut_dmg_verb": "chipped",
+    "acid_dmg_verb": "burned",
     "vitamins": [ [ "calcium", 2 ] ],
     "burn_data": [
       { "fuel": 0, "smoke": 0, "burn": 0.0003 },
@@ -3091,6 +3219,7 @@
     "dmg_adj": [ "scratched", "cut", "cracked", "shattered" ],
     "bash_dmg_verb": "cracked",
     "cut_dmg_verb": "chipped",
+    "acid_dmg_verb": "burned",
     "vitamins": [ [ "calcium", 2 ] ],
     "burn_data": [
       { "fuel": 0, "smoke": 0, "burn": 0 },
@@ -3131,6 +3260,7 @@
     "dmg_adj": [ "scratched", "cut", "cracked", "shattered" ],
     "bash_dmg_verb": "cracked",
     "cut_dmg_verb": "chipped",
+    "acid_dmg_verb": "burned",
     "resist": { "bash": 3, "cut": 4, "acid": 10, "heat": 2, "bullet": 2 },
     "repair_difficulty": 7
   }

--- a/data/mods/Aftershock/items/materials.json
+++ b/data/mods/Aftershock/items/materials.json
@@ -10,6 +10,7 @@
     "bash_dmg_verb": "dented",
     "breathability": "IMPERMEABLE",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "corroded",
     "resist": { "bash": 4, "cut": 9, "acid": 14, "heat": 4, "bullet": 7, "afs_plasma": 1, "electric": 8 },
     "repair_difficulty": 5
   },
@@ -26,6 +27,7 @@
     "dmg_adj": [ "marked", "dented", "scarred", "broken" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "cut",
+    "acid_dmg_verb": "burned",
     "resist": { "bash": 3, "cut": 3, "acid": 5, "heat": 5, "bullet": 2, "afs_plasma": 1, "electric": 0 },
     "repair_difficulty": 10
   },
@@ -39,6 +41,7 @@
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
     "breathability": "IMPERMEABLE",
+    "acid_dmg_verb": "etched",
     "//": "only to be used in encumbering armors.",
     "resist": { "bash": 8, "cut": 14, "acid": 17, "heat": 14, "bullet": 12, "afs_plasma": 5, "electric": -4 },
     "repair_difficulty": 10
@@ -53,6 +56,7 @@
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
     "breathability": "AVERAGE",
+    "acid_dmg_verb": "burned",
     "//": "mostly meant to be lightweight energy armor.",
     "resist": { "bash": 2, "cut": 4, "acid": 4, "heat": 10, "bullet": 2, "afs_plasma": 10, "electric": 6 },
     "repair_difficulty": 10
@@ -67,6 +71,7 @@
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "cut",
     "breathability": "GOOD",
+    "acid_dmg_verb": "corroded",
     "//": "lightweight high-protection-value armors that degrade easily.",
     "resist": { "bash": 4, "cut": 6, "acid": 6, "heat": 2, "afs_plasma": 2, "bullet": 8, "electric": 0 },
     "repair_difficulty": 9
@@ -84,6 +89,7 @@
     "bash_dmg_verb": "cracked",
     "breathability": "IMPERMEABLE",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "corroded",
     "resist": { "bash": 10, "cut": 6, "acid": 6, "heat": 100, "bullet": 100, "afs_plasma": 0, "electric": 10 },
     "repair_difficulty": 10
   },
@@ -97,6 +103,7 @@
     "bash_dmg_verb": "chipped",
     "breathability": "IMPERMEABLE",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "corroded",
     "resist": { "bash": 4, "cut": 7, "acid": 2, "heat": 4, "bullet": 6, "afs_plasma": 0, "electric": 8 },
     "repair_difficulty": 7
   }

--- a/data/mods/BlazeIndustries/items/materials.json
+++ b/data/mods/BlazeIndustries/items/materials.json
@@ -9,6 +9,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "corroded",
     "resist": { "bash": 4, "cut": 9, "acid": 14, "heat": 4, "bullet": 7, "electric": 8 }
   }
 ]

--- a/data/mods/Magiclysm/materials.json
+++ b/data/mods/Magiclysm/materials.json
@@ -13,6 +13,7 @@
     "dmg_adj": [ "scratched", "cut", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "sliced",
+    "acid_dmg_verb": "burned",
     "resist": { "bash": 14, "cut": 18, "acid": 4, "heat": 20, "bullet": 14, "electric": 2 }
   },
   {
@@ -28,6 +29,7 @@
     "dmg_adj": [ "scratched", "cut", "ripped", "shredded" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "burned",
     "burn_data": [
       { "fuel": 0, "smoke": 0, "burn": 0 },
       { "fuel": 1, "smoke": 1, "burn": 1, "volume_per_turn": "100 ml" },
@@ -48,6 +50,7 @@
     "dmg_adj": [ "scratched", "marked", "cracked", "shattered" ],
     "bash_dmg_verb": "cracked",
     "cut_dmg_verb": "chipped",
+    "acid_dmg_verb": "burned",
     "burn_data": [
       { "fuel": 0, "smoke": 0, "burn": 0 },
       { "fuel": 0, "smoke": 0, "burn": 0 },
@@ -72,6 +75,7 @@
     "dmg_adj": [ "ripped", "torn", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "sliced",
+    "acid_dmg_verb": "burned",
     "burn_data": [
       { "fuel": 1, "smoke": 1, "burn": 1, "volume_per_turn": "1250 ml" },
       { "fuel": 1, "smoke": 1, "burn": 2 },
@@ -95,6 +99,7 @@
     "dmg_adj": [ "scratched", "cut", "cracked", "shattered" ],
     "bash_dmg_verb": "cracked",
     "cut_dmg_verb": "chipped",
+    "acid_dmg_verb": "burned",
     "burn_data": [
       { "fuel": 0, "smoke": 1, "burn": 1, "volume_per_turn": "1250 ml" },
       { "fuel": 1, "smoke": 3, "burn": 1 },
@@ -116,6 +121,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "corroded",
     "burn_products": [ [ "scrap_bronze", 1 ] ],
     "resist": { "bash": 13, "cut": 20, "acid": 7, "heat": 3, "bullet": 16, "electric": 0 },
     "repair_difficulty": 7
@@ -133,6 +139,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "corroded",
     "resist": { "bash": 13, "cut": 20, "acid": 10, "heat": 10, "bullet": 16, "electric": 10 },
     "repair_difficulty": 7
   },
@@ -149,6 +156,7 @@
     "dmg_adj": [ "scratched", "cut", "cracked", "shattered" ],
     "bash_dmg_verb": "cracked",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "etched",
     "resist": { "bash": 10, "cut": 6, "acid": 6, "heat": 0, "bullet": 19, "electric": 10 },
     "repair_difficulty": 5
   },
@@ -171,6 +179,7 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "damaged",
     "cut_dmg_verb": "damaged",
+    "acid_dmg_verb": "damaged",
     "burn_data": [
       { "fuel": 300, "smoke": 6, "burn": 1 },
       { "fuel": 600, "smoke": 6, "burn": 2 },
@@ -234,6 +243,7 @@
     "dmg_adj": [ "scratched", "cut", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "sliced",
+    "acid_dmg_verb": "burned",
     "resist": { "bash": 8, "cut": 13, "acid": 12, "heat": 20, "bullet": 7, "electric": 20 }
   }
 ]

--- a/data/mods/MindOverMatter/materials.json
+++ b/data/mods/MindOverMatter/materials.json
@@ -13,7 +13,8 @@
     "breathability": "SECOND_SKIN",
     "dmg_adj": [ "damaged", "strained", "fractured", "eradicated" ],
     "bash_dmg_verb": "rippled",
-    "cut_dmg_verb": "pierced"
+    "cut_dmg_verb": "pierced",
+    "acid_dmg_verb": "sizzled"
   },
   {
     "type": "material",
@@ -27,6 +28,7 @@
     "resist": { "bash": 5, "cut": 5, "acid": 100, "heat": 10, "bullet": 2, "electric": 100 },
     "dmg_adj": [ "marked", "chipped", "cracked", "shattered" ],
     "bash_dmg_verb": "chipped",
-    "cut_dmg_verb": "scratched"
+    "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "etched"
   }
 ]

--- a/data/mods/My_Sweet_Cataclysm/sweet_materials.json
+++ b/data/mods/My_Sweet_Cataclysm/sweet_materials.json
@@ -12,6 +12,7 @@
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ],
     "bash_dmg_verb": "damaged",
     "cut_dmg_verb": "damaged",
+    "acid_dmg_verb": "damaged",
     "burn_data": [ { "fuel": 1, "smoke": 1, "burn": 1 }, { "fuel": 1, "smoke": 1, "burn": 2 }, { "fuel": 1, "smoke": 1, "burn": 3 } ],
     "resist": { "bash": 0, "cut": 0, "acid": 1, "heat": 1, "bullet": 0, "electric": 1 }
   },
@@ -27,6 +28,7 @@
     "dmg_adj": [ "scratched", "cut", "cracked", "shattered" ],
     "bash_dmg_verb": "cracked",
     "cut_dmg_verb": "chipped",
+    "acid_dmg_verb": "caramelized",
     "burn_products": [ [ "sugar", 1 ] ],
     "burn_data": [ { "fuel": 1, "smoke": 1, "burn": 1 }, { "fuel": 1, "smoke": 1, "burn": 2 }, { "fuel": 1, "smoke": 1, "burn": 3 } ],
     "resist": { "bash": 6, "cut": 6, "acid": 8, "heat": 3, "bullet": 3, "electric": 2 }

--- a/data/mods/TEST_DATA/materials.json
+++ b/data/mods/TEST_DATA/materials.json
@@ -21,6 +21,7 @@
     "//": "Fake material, used to fix density of test items",
     "bash_dmg_verb": "tested",
     "cut_dmg_verb": "tested",
+    "acid_dmg_verb": "tested",
     "dmg_adj": [ "lightly tested", "tested", "very tested", "thoroughly tested" ],
     "resist": { "bash": 0, "cut": 0, "acid": 0, "heat": 0, "bullet": 0, "electric": 0 },
     "chip_resist": 0

--- a/data/mods/Xedra_Evolved/material.json
+++ b/data/mods/Xedra_Evolved/material.json
@@ -16,6 +16,7 @@
     "dmg_adj": [ "ripped", "torn", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "sliced",
+    "acid_dmg_verb": "burned",
     "burn_data": [
       { "fuel": 1, "smoke": 3, "burn": 1, "volume_per_turn": "1250 ml" },
       { "fuel": 1, "smoke": 5, "burn": 2 },
@@ -51,6 +52,7 @@
     "dmg_adj": [ "bruised", "mutilated", "badly mutilated", "thoroughly mutilated" ],
     "bash_dmg_verb": "bruised",
     "cut_dmg_verb": "sliced",
+    "acid_dmg_verb": "burned",
     "vitamins": [ [ "calcium", 0.1 ], [ "iron", 1.3 ], [ "underhill_essence", 10 ] ],
     "burn_data": [
       { "fuel": 1, "smoke": 1, "burn": 1, "volume_per_turn": "2500 ml" },
@@ -80,6 +82,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "corroded",
     "resist": { "bash": 13, "cut": 20, "acid": 10, "heat": 10, "bullet": 16, "electric": 10 },
     "repair_difficulty": 4
   },
@@ -96,6 +99,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "corroded",
     "breathability": "GOOD",
     "resist": { "bash": 13, "cut": 20, "acid": 10, "heat": 10, "bullet": 16, "electric": 10 },
     "repair_difficulty": 5
@@ -118,6 +122,7 @@
     "dmg_adj": [ "ripped", "torn", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "cut",
+    "acid_dmg_verb": "burned",
     "burn_data": [
       { "fuel": 1, "smoke": 1, "burn": 0.02 },
       { "fuel": 2, "smoke": 1, "burn": 0.04 },
@@ -152,6 +157,7 @@
     "salvaged_into": "scrap_dreamdross",
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "burned",
     "breathability": "GOOD",
     "resist": { "bash": 3, "cut": 4, "acid": 16, "heat": 2, "bullet": 2 },
     "repair_difficulty": 5
@@ -172,6 +178,7 @@
     "salvaged_into": "dreamdross_lump",
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "burned",
     "breathability": "GOOD",
     "resist": { "bash": 8, "cut": 9, "acid": 16, "heat": 4, "bullet": 6 },
     "repair_difficulty": 6
@@ -190,6 +197,7 @@
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
+    "acid_dmg_verb": "burned",
     "resist": { "bash": 5, "cut": 5, "acid": -1, "heat": -6, "bullet": 3 }
   },
   {
@@ -215,6 +223,7 @@
     "dmg_adj": [ "scratched", "cut", "shredded", "tattered" ],
     "bash_dmg_verb": "shaken",
     "cut_dmg_verb": "rippled",
+    "acid_dmg_verb": "sizzled",
     "resist": { "bash": 6, "cut": 3, "acid": 20, "heat": 2, "bullet": 3 }
   }
 ]

--- a/data/mods/innawood/materials.json
+++ b/data/mods/innawood/materials.json
@@ -16,6 +16,7 @@
     "dmg_adj": [ "ripped", "torn", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "cut",
+    "acid_dmg_verb": "burned",
     "burn_data": [
       { "fuel": 0.6, "smoke": 1, "burn": 0.025, "volume_per_turn": "200 ml" },
       { "fuel": 1.2, "smoke": 1, "burn": 0.05, "volume_per_turn": "825 ml" },

--- a/imgui.ini
+++ b/imgui.ini
@@ -1,0 +1,5 @@
+[Window][Debug##Default]
+Pos=60,60
+Size=400,400
+Collapsed=0
+

--- a/src/item.h
+++ b/src/item.h
@@ -1288,17 +1288,17 @@ class item : public visitable
                        const std::vector<const part_material *> &armor_mats = {},
                        float avg_thickness = 1.0f ) const;
         /**
-         * Handles the special rules regarding environmental type damage such as fire and acid.
-         * Currently does not damage items as damage to items from fire is handled elsewhere, and
-         * acid is currently not intended to cause item damage.
+         * Handles the special rules regarding environmental type damage, such as acid and heat.
+         * Currently only damages items if the damage is both environmental and physical, such as acid.
+         * Fire damages items elsewhere, and cold/bio/electric can't harm items.
          * @param dmg_type The type of incoming damage
          * @param to_self If this is true, it returns item's own resistance, not one it gives to wearer.
          * @param bodypart_target The bodypart_id or sub_bodypart_id of the target bodypart.
-         * @param base_env_resist Will override the base environmental
+         * @param resist_value Will override the base environmental
          * resistance (to allow hypothetical calculations for gas masks).
          */
         float _environmental_resist( const damage_type_id &dmg_type, bool to_self = false,
-                                     int base_env_resist = 0,
+                                     int resist_value = 0,
                                      bool bp_null = true,
                                      const std::vector<const part_material *> &armor_mats = {} ) const;
         /*@}*/

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -62,7 +62,8 @@ std::string enum_to_string<breathability_rating>( breathability_rating data )
 material_type::material_type() :
     id( material_id::NULL_ID() ),
     _bash_dmg_verb( to_translation( "damages" ) ),
-    _cut_dmg_verb( to_translation( "damages" ) )
+    _cut_dmg_verb( to_translation( "damages" ) ),
+    _acid_dmg_verb( to_translation( "damages" ) )
 {
     _dmg_adj = { to_translation( "lightly damaged" ), to_translation( "damaged" ), to_translation( "very damaged" ), to_translation( "thoroughly damaged" ) };
 }
@@ -120,6 +121,7 @@ void material_type::load( const JsonObject &jsobj, const std::string_view )
 
     mandatory( jsobj, was_loaded, "bash_dmg_verb", _bash_dmg_verb );
     mandatory( jsobj, was_loaded, "cut_dmg_verb", _cut_dmg_verb );
+    mandatory( jsobj, was_loaded, "acid_dmg_verb", _acid_dmg_verb );
 
     mandatory( jsobj, was_loaded, "dmg_adj", _dmg_adj );
 
@@ -225,6 +227,11 @@ bool material_type::has_dedicated_resist( const damage_type_id &dmg_type ) const
 std::string material_type::bash_dmg_verb() const
 {
     return _bash_dmg_verb.translated();
+}
+
+std::string material_type::acid_dmg_verb() const
+{
+    return _acid_dmg_verb.translated();
 }
 
 std::string material_type::cut_dmg_verb() const

--- a/src/material.h
+++ b/src/material.h
@@ -104,6 +104,7 @@ class material_type
 
         translation _bash_dmg_verb;
         translation _cut_dmg_verb;
+        translation _acid_dmg_verb;
         std::vector<translation> _dmg_adj;
 
         std::map<vitamin_id, double> _vitamins;
@@ -138,6 +139,7 @@ class material_type
         bool has_dedicated_resist( const damage_type_id &dmg_type ) const;
         std::string bash_dmg_verb() const;
         std::string cut_dmg_verb() const;
+        std::string acid_dmg_verb() const;
         std::string dmg_adj( int damage_level ) const;
         int chip_resist() const;
         int repair_difficulty() const;

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -1203,7 +1203,7 @@ TEST_CASE( "armor_fit_and_sizing", "[iteminfo][armor][fit]" )
            "--\n"
            "* This clothing <color_c_cyan>can be refitted</color>.\n" );
 
-    // Sided armor is show as sided
+    // Items with "covers" LEG_EITHER, ARM_EITHER, FOOT_EITHER, HAND_EITHER are "sided"
     item briefcase( "test_briefcase" );
     CHECK( item_info_str( briefcase, sided ) ==
            "--\n"
@@ -1230,9 +1230,9 @@ static void expected_armor_values( const item &armor, float bash, float cut, flo
 
 TEST_CASE( "armor_stats", "[armor][protection]" )
 {
-    expected_armor_values( item( itype_zentai ), 0.1f, 0.1f, 0.08f, 0.1f );
-    expected_armor_values( item( itype_tshirt ), 0.1f, 0.1f, 0.08f, 0.1f );
-    expected_armor_values( item( itype_dress_shirt ), 0.1f, 0.1f, 0.08f, 0.1f );
+    expected_armor_values( item( itype_zentai ), 0.1f, 0.1f, 0.08f, 0.1f, 9.0f, 2.0f );
+    expected_armor_values( item( itype_tshirt ), 0.1f, 0.1f, 0.08f, 0.1f, 3.0f );
+    expected_armor_values( item( itype_dress_shirt ), 0.1f, 0.1f, 0.08f, 0.1f, 3.0f );
 }
 
 // Armor protction is based on materials, thickness, and/or environmental protection rating.
@@ -1240,7 +1240,7 @@ TEST_CASE( "armor_stats", "[armor][protection]" )
 //
 // - "materials" determine the resistance factors (bash, cut, fire etc.)
 // - "material_thickness" multiplies bash, cut, and bullet resistance
-// - "environmental_protection" gives acid and fire resist (N/10 if less than 10)
+// - "environmental_protection" gives fire resist (N/10 if less than 10)
 //
 // See doc/DEVELOPER_FAQ.md "How armor protection is calculated" for more.
 //
@@ -1261,9 +1261,9 @@ TEST_CASE( "armor_protection", "[iteminfo][armor][protection][!mayfail]" )
     SECTION( "no protection from physical, no protection from environmental" ) {
         // Long-sleeved shirt, material:cotton, thickness:0.2
         // 1/1/1 bash/cut/bullet x 1 thickness
-        // 0/0/0 acid/fire/env
+        // 3/0/0 acid/fire/env
         item longshirt( "test_longshirt" );
-        expected_armor_values( longshirt, 0.2f, 0.2f, 0.16f, 0.2f );
+        expected_armor_values( longshirt, 0.2f, 0.2f, 0.16f, 0.2f, 3.0f );
         REQUIRE( longshirt.get_covered_body_parts().any() );
 
         // Protection info displayed on two lines
@@ -1273,7 +1273,7 @@ TEST_CASE( "armor_protection", "[iteminfo][armor][protection][!mayfail]" )
                "<color_c_white>Coverage</color>: <color_c_light_blue>Normal</color>.\n"
                "  Default:  <color_c_yellow>90</color>\n"
                "<color_c_white>Protection</color>:\n"
-               "  Negligible Protection\n"
+               "  Acid: <color_c_yellow>3.00</color>\n"
              );
     }
 
@@ -1330,7 +1330,7 @@ TEST_CASE( "armor_protection", "[iteminfo][armor][protection][!mayfail]" )
         item super_tanktop( "test_complex_tanktop" );
         REQUIRE( super_tanktop.get_covered_body_parts().any() );
         // these values are averaged values but test that assumed armor portion is working at all
-        expected_armor_values( super_tanktop, 15.33333f, 15.33333f, 12.26667f, 10.66667f );
+        expected_armor_values( super_tanktop, 15.33333f, 15.33333f, 12.26667f, 10.66667f, 1.0f );
 
         // Protection info displayed on two lines
         CHECK( item_info_str( super_tanktop, more_protection ) ==
@@ -1345,6 +1345,7 @@ TEST_CASE( "armor_protection", "[iteminfo][armor][protection][!mayfail]" )
                "  Cut:  <color_c_red>1.00</color>, <color_c_yellow>12.00</color>, <color_c_green>23.00</color>\n"
                "  Ballistic:  <color_c_red>1.00</color>, <color_c_yellow>8.50</color>, <color_c_green>16.00</color>\n"
                "  Pierce:  <color_c_red>0.80</color>, <color_c_yellow>9.60</color>, <color_c_green>18.40</color>\n"
+               "  Acid:  <color_c_red>3.00</color>, <color_c_yellow>3.00</color>, <color_c_green>14.00</color>\n"
              );
     }
 
@@ -2997,7 +2998,7 @@ TEST_CASE( "Armor_values_preserved_after_copy-from", "[iteminfo][armor][protecti
         "  Cut: <color_c_yellow>16.00</color>\n"
         "  Ballistic: <color_c_yellow>5.60</color>\n"
         "  Pierce: <color_c_yellow>12.80</color>\n"
-        "  Acid: <color_c_yellow>3.60</color>\n"
+        "  Acid: <color_c_yellow>6.00</color>\n"
         "  Fire: <color_c_yellow>1.50</color>\n"
         "  Environmental: <color_c_yellow>6</color>\n";
 
@@ -3015,7 +3016,7 @@ TEST_CASE( "Armor_values_preserved_after_copy-from", "[iteminfo][armor][protecti
         "  Cut: <color_c_yellow>19.20</color>\n"
         "  Ballistic: <color_c_yellow>6.72</color>\n"
         "  Pierce: <color_c_yellow>15.36</color>\n"
-        "  Acid: <color_c_yellow>4.20</color>\n"
+        "  Acid: <color_c_yellow>6.00</color>\n"
         "  Fire: <color_c_yellow>1.75</color>\n"
         "  Environmental: <color_c_yellow>7</color>\n";
 
@@ -3032,7 +3033,7 @@ TEST_CASE( "Armor_values_preserved_after_copy-from", "[iteminfo][armor][protecti
         "  Cut: <color_c_yellow>24.00</color>\n"
         "  Ballistic: <color_c_yellow>8.40</color>\n"
         "  Pierce: <color_c_yellow>19.20</color>\n"
-        "  Acid: <color_c_yellow>4.80</color>\n"
+        "  Acid: <color_c_yellow>6.00</color>\n"
         "  Fire: <color_c_yellow>2.00</color>\n"
         "  Environmental: <color_c_yellow>8</color>\n";
 

--- a/tests/materials_test.cpp
+++ b/tests/materials_test.cpp
@@ -45,9 +45,9 @@ TEST_CASE( "Resistance_vs_material_portions", "[material]" )
     REQUIRE( mostly_plastic.get_base_material().id == material_plastic );
 
     CHECK( mostly_steel.resist( damage_cut ) > mostly_plastic.resist( damage_cut ) );
-    CHECK( mostly_steel.resist( damage_acid ) == mostly_plastic.resist( damage_acid ) );
+    CHECK( mostly_steel.resist( damage_acid ) < mostly_plastic.resist( damage_acid ) );
     CHECK( mostly_steel.resist( damage_bash ) > mostly_plastic.resist( damage_bash ) );
-    CHECK( mostly_steel.resist( damage_heat ) == mostly_plastic.resist( damage_heat ) );
+    CHECK( mostly_steel.resist( damage_heat ) > mostly_plastic.resist( damage_heat ) );
     CHECK( mostly_steel.resist( damage_stab ) > mostly_plastic.resist( damage_stab ) );
     CHECK( mostly_steel.resist( damage_bullet ) > mostly_plastic.resist( damage_bullet ) );
     CHECK( mostly_steel.chip_resistance() > mostly_plastic.chip_resistance() );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Fixes a major material layer bug with nonphysical armor, reworks how acid and armor interact"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
Split from #71584 . This PR just covers the armor changes from that PR, and is submitted with the assumption that the acid changes outlined there (which will shortly get their own PR) have been made.

Armor calculations versus non-physical and environmental attacks didn't come up much in the base game, except against acid, and there were a few bugs with how it was implemented. The code was intended to count all armor materials, ignoring their thickness, and average their protection. However, in many cases it _was_ counting thickness, and in others, if an item with portion data had multiple layers of the same material, they would all be counted. We were also using environmental protection as a multiplier, so that an item with 0 environmental protection would always offer 0 protection from lasers and acid, regardless of its other statistics.

Environmental protection is a concept that predates material layers, breathability, resistances from materials, material portions, and a lot of other tools introduced to improve armor mechanics. It is variably used to protect the wearer from laser beams, poison gas, smoke inhalation, liquid acid, airborne viruses, flamethrower attacks, fungal spores, and probably a lot of other stuff. It isn't derived from materials, it's only ever manually set on items, meaning that items frequently have arbitrary values that are hard to keep track of.

Environmental protection is still a useful concept for airborne particles or gases, but we have better tools for acid, and our acid could be better than it is. Currently, it's a floor hazard that damages people's feet if they stand in it, and practically speaking it's not much else. A good pair of shoes makes any character effectively immune to it, making the many enemies who use it sort of pointless except as a shoe check.

Acid should be blinding people, burning their skin where they're splashed, damaging equipment, and creating hazardous fumes. #71964 adds support for splash attacks, this PR updates armor in preparation for creating acid splash attacks

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

The intent outlined in #71584 is that direct acid damage to creatures should go away. That's not being done in this PR, this is just helping to set that up. Acid does not immediately cause harm the way a knife or a bullet does. It should instead apply damage over time effects and other debuffs. In the case of an attack like the bilious soldier zombie's acidic dart, that should be a stab attack which then causes a damage over time effect. 

The changes below are intended to affect how armor is damaged by acid, with the assumption that whether the character themself was protected from the attack or not is instead determined by breathability and coverage via the mechanics described in #71584 . A leather apron might save you from a splash of acid, but be eaten away by the attack. Similarly, a polyester shirt might let acid right through and be completely fine while a character wearing it was badly burned.

- As before, if a damage type has env: true in its json, it goes through _environmental_resist, rather than _resist when it affects an armored body part. Currently, the two environmental damage types are acid and fire.
- This PR gives acid the ability to damage armor. It does not change how fire damages armor via the burn system.
- Acid has been changed from a nonphysical to a physical damage type, changing how it interacts with armor.
- Environmental protection values do not affect protection from physical attacks, even if they are marked as environmental. This is admittedly a little confusing, but the alternative would be to rename or split the _environmental_resist function and add a new line of json to help the game figure out which one you wanted to use. This method is more concise.
- Acid (physical) and fire (nonphysical) damage do not respect material thickness, nor multiple layers of the same material. This was seemingly always intended (see item.cpp line 8725) but wasn't fully implemented.
- Physical environmental attacks (only acid, at the moment) iterate backwards (so, starting from the outermost) through all the materials on an armor location until the total coverage reaches 100% or there are no more materials left. This is because acid is being splashed on the surface of the item. If you have a piece of brigandine with a 100 coverage canvas exterior, the acid hits that, and does not interact with the steel beneath. If you have brigandine gauntlets with 90 steel coverage on the outside and 100 canvas underneath, 90% of the time, it will use the steel's protection value, and 10% of the time it will use the canvas's. In no case does it use both, and thickness is not counted. If a rubber glove is of a material that acid will not burn, it doesn't matter how thick it is. Similarly, it doesn't matter if your cotton shirt is 5mm thick, acid is going to leave it much worse than it found it.
- Nonphysical environmental attacks (only fire at the moment) add the protection value of all materials on an armor location, adjusted according to their coverage portions, then average the total. As with acid, thickness is not counted.
- An existing check on line 8937, which reduces the chance a piece of armor will be damaged based on the number of body parts it covers, is bypassed in the case of acid, which spreads out over the surface of the item and eats away at it rather than just poking a hole. This is to prevent an item's covered bodyparts from being a greater factor in its acid resistance than the material it's made of. See the alternatives section for more.
- Acid now displays detailed armor information, with low and high rolls shown, the same way other physical damage types do.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
- Fire currently uses a completely different item damage system than any other type of damage. That should probably change at some point.
- I'm not sure if material thickness should count for nonphysical damage (fire) or not. A sheet of steel 1mm thick is going to protect my arm from direct exposure to flame exactly as well as a 3mm sheet. The 3mm sheet will be slower to let the heat of that flame get through, but that heat is already represented by the hot air effect, which is completely distinct from fire protection.
- Similarly, I'm pretty sure material thickness wouldn't help against lasers, as they just scorch the surface of an item.
- If acid no longer respects thickness, some materials will need review, as their base values may be too low.
- It may be wise to split lasers into their own damage type at some point.
- Similarly, if we want to model something like an acidic fog, that should be a nonphysical environmental damage type. Damage type jsons let us derive new armor values from existing ones, so it'd be easy.
- That check on line 8937 bothers me in general. I get the intent behind it and I understand what it's preventing, but it means that a leather body armor is many times less likely to be damaged at all than a leather arm guards, cuirass, and leg guards, even though they're exactly the same thing. It might be nice if items had sort of an HP system that factored in their body parts covered (and thickness!) instead.
 
#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
Ongoing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
