### PR TITLE
Added preprocessor directives to allow building android without imgui.

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -1,3 +1,4 @@
+#if !defined(__ANDROID__)
 #include "cata_imgui.h"
 
 #include <stack>
@@ -472,3 +473,4 @@ cataimgui::bounds cataimgui::window::get_bounds()
 {
     return { -1.f, -1.f, -1.f, -1.f };
 }
+#endif // #if defined(__ANDROID__)

--- a/src/cata_imgui.h
+++ b/src/cata_imgui.h
@@ -1,3 +1,4 @@
+#if !defined(__ANDROID__)
 #pragma once
 #include <string>
 #include <vector>
@@ -105,3 +106,4 @@ void load_colors();
 #endif
 
 } // namespace cataimgui
+#endif // #if defined(__ANDROID)

--- a/src/input_context.cpp
+++ b/src/input_context.cpp
@@ -31,13 +31,14 @@
 #include "string_input_popup.h"
 #include "translations.h"
 #include "ui_manager.h"
-#if !defined(__ANDROID__)
-#include "cata_imgui.h"
-#include "imgui/imgui.h"
 
 enum class kb_menu_status {
     remove, add, add_global, execute, show
 };
+
+#if !defined(__ANDROID__)
+#include "cata_imgui.h"
+#include "imgui/imgui.h"
 
 class keybindings_ui : public cataimgui::window
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -168,7 +168,9 @@ void exit_handler( int s )
         } else
 #endif
         {
+#if !defined(__ANDROID__)
             imclient.reset();
+#endif
             exit( exit_status );
         }
     }

--- a/src/popup.cpp
+++ b/src/popup.cpp
@@ -519,7 +519,6 @@ std::shared_ptr<query_popup_impl> query_popup::create_or_get_impl()
     }
     return impl;
 }
-#endif
 
 query_popup::result query_popup::query_once_imgui()
 {
@@ -615,18 +614,13 @@ query_popup::result query_popup::query_once_imgui()
     return res;
 }
 
-
 query_popup::result query_popup::query()
 {
-#if defined(__ANDROID__)
-    return query_legacy();
-#else
     if( get_options().has_option( "USE_IMGUI" ) && get_option<bool>( "USE_IMGUI" ) ) {
         return query_imgui();
     } else {
         return query_legacy();
     }
-#endif
 }
 
 query_popup::result query_popup::query_imgui()
@@ -639,7 +633,13 @@ query_popup::result query_popup::query_imgui()
     } while( res.wait_input );
     return res;
 }
+#else
 
+query_popup::result query_popup::query()
+{
+    return query_legacy();
+}
+#endif
 
 query_popup::result query_popup::query_legacy()
 {

--- a/src/popup.h
+++ b/src/popup.h
@@ -245,7 +245,9 @@ class query_popup
         };
 
         std::weak_ptr<ui_adaptor> adaptor;
+#if !defined(__ANDROID__)
         std::weak_ptr<query_popup_impl> p_impl;
+#endif
 
         // UI caches
         mutable catacurses::window win;

--- a/src/sdl_font.cpp
+++ b/src/sdl_font.cpp
@@ -22,9 +22,9 @@
 
 #define dbg(x) DebugLog((x),D_SDL) << __FILE__ << ":" << __LINE__ << ": "
 
-// bitmap font size test
-// return face index that has this size or below
-static int test_face_size( const std::string &f, int size, int faceIndex )
+    // bitmap font size test
+    // return face index that has this size or below
+    static int test_face_size( const std::string &f, int size, int faceIndex )
 {
     const TTF_Font_Ptr fnt( TTF_OpenFontIndex( f.c_str(), size, faceIndex ) );
     if( fnt ) {

--- a/src/sdl_font.cpp
+++ b/src/sdl_font.cpp
@@ -3,7 +3,9 @@
 
 #include "font_loader.h"
 #include "output.h"
+#if !defined(__ANDROID)
 #include "imgui/imgui.h"
+#endif
 #include "sdl_utils.h"
 
 #if defined(_WIN32)
@@ -20,9 +22,9 @@
 
 #define dbg(x) DebugLog((x),D_SDL) << __FILE__ << ":" << __LINE__ << ": "
 
-    // bitmap font size test
-    // return face index that has this size or below
-    static int test_face_size( const std::string &f, int size, int faceIndex )
+// bitmap font size test
+// return face index that has this size or below
+static int test_face_size( const std::string &f, int size, int faceIndex )
 {
     const TTF_Font_Ptr fnt( TTF_OpenFontIndex( f.c_str(), size, faceIndex ) );
     if( fnt ) {
@@ -299,7 +301,7 @@ CachedTTFFont::CachedTTFFont(
         throw std::runtime_error( TTF_GetError() );
     }
     TTF_SetFontStyle( font.get(), TTF_STYLE_NORMAL );
-
+#if !defined(__ANDROID__)
     ImGuiIO &io = ImGui::GetIO();
     if( io.FontDefault == nullptr && typeface.find( "unifont" ) != std::string::npos ) {
         static const std::array<ImWchar, 17> ranges = {
@@ -315,6 +317,7 @@ CachedTTFFont::CachedTTFFont(
         };
         io.FontDefault = io.Fonts->AddFontFromFileTTF( typeface.c_str(), fontsize, nullptr, ranges.data() );
     }
+#endif
 }
 
 SDL_Texture_Ptr CachedTTFFont::create_glyph( const SDL_Renderer_Ptr &renderer,

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -74,7 +74,9 @@
 #include "wcwidth.h"
 #include "cata_imgui.h"
 
+#if !defined(__ANDROID__)
 std::unique_ptr<cataimgui::client> imclient;
+#endif
 
 #if defined(__linux__)
 #   include <cstdlib> // getenv()/setenv()
@@ -421,9 +423,11 @@ static void WinCreate()
         geometry = std::make_unique<DefaultGeometryRenderer>();
     }
 
+#if !defined(__ANDROID__)
     cataimgui::client::sdl_renderer = renderer.get();
     cataimgui::client::sdl_window = window.get();
     imclient = std::make_unique<cataimgui::client>();
+#endif
 
     //io.Fonts->AddFontDefault();
     //io.Fonts->Build();
@@ -434,7 +438,9 @@ static void WinDestroy()
 #if defined(__ANDROID__)
     touch_joystick.reset();
 #endif
+#if !defined(__ANDROID__)
     imclient.reset();
+#endif
     shutdown_sound();
     tilecontext.reset();
     gamepad::quit();
@@ -2857,7 +2863,9 @@ static void CheckMessages()
     bool render_target_reset = false;
 
     while( SDL_PollEvent( &ev ) ) {
+#if !defined(__ANDROID__)
         imclient->process_input( &ev );
+#endif
         switch( ev.type ) {
             case SDL_WINDOWEVENT:
                 switch( ev.window.event ) {

--- a/src/ui_manager.cpp
+++ b/src/ui_manager.cpp
@@ -340,8 +340,9 @@ void ui_adaptor::redraw_invalidated( )
     if( test_mode || ui_stack.empty() ) {
         return;
     }
-
+#if !defined(__ANDROID__)
     imclient->new_frame();
+#endif
 
     restore_on_out_of_scope<bool> prev_redraw_in_progress( redraw_in_progress );
     restore_on_out_of_scope<bool> prev_restart_redrawing( restart_redrawing );
@@ -447,7 +448,9 @@ void ui_adaptor::redraw_invalidated( )
     emscripten_sleep( 1 );
 #endif
 
+#if !defined(__ANDROID__)
     imclient->end_frame();
+#endif
 }
 
 void ui_adaptor::screen_resized()

--- a/src/ui_manager.h
+++ b/src/ui_manager.h
@@ -7,12 +7,14 @@
 #include "cuboid_rectangle.h"
 #include "point.h"
 
+#if !defined(__ANDROID__)
 namespace cataimgui
 {
 class client;
 } // namespace cataimgui
 
 extern std::unique_ptr<cataimgui::client> imclient;
+#endif
 
 namespace catacurses
 {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fixing Android build broken after Imgui integration"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Android build got broke with the ImGui change. Build broken bad.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
I added preprocessor statements to effectively disable ImGui on Android. On Android for any ImGui-enabled UI, we will show the legacy UI for now.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
The proper fix will be to update the version of SDL used in Android. I don't have the energy to open that can of worms right now.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I was able to build it
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
