### PR TITLE
Wheel traction fix

### DIFF
--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -2146,7 +2146,6 @@ float map::vehicle_wheel_traction( const vehicle &veh, bool ignore_movement_modi
                 break;
             } else if( !ter_has_flag && mod.move_penalty ) {
                 move_mod += mod.move_penalty;
-                break;
             }
         }
 

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -2129,8 +2129,8 @@ float map::vehicle_wheel_traction( const vehicle &veh, bool ignore_movement_modi
             continue; // No traction from wheel in deep water or air
         }
 
-        int move_mod = move_cost_ter_furn( pp );
-        if( move_mod == 0 ) {
+        const int mc = move_cost_ter_furn( pp );
+        if( mc == 0 ) {
             return 0.0f; // Vehicle locked in wall, shouldn't happen, but does
         }
 
@@ -2139,22 +2139,23 @@ float map::vehicle_wheel_traction( const vehicle &veh, bool ignore_movement_modi
             continue; // Ignore the movement modifier if caller specifies a bool
         }
 
+        int wheel_ter_mod = 0;
         for( const veh_ter_mod &mod : vpi.wheel_info->terrain_modifiers ) {
             const bool ter_has_flag = tr.has_flag( mod.terrain_flag );
             if( ter_has_flag && mod.move_override ) {
-                move_mod = mod.move_override;
+                wheel_ter_mod = mod.move_override;
                 break;
             } else if( !ter_has_flag && mod.move_penalty ) {
-                move_mod += mod.move_penalty;
+                wheel_ter_mod += mod.move_penalty;
             }
         }
 
-        if( move_mod == 0 ) {
-            debugmsg( "move_mod resulted in a 0, ignoring wheel" );
-            continue;
+        if(wheel_ter_mod == 0 ) {
+            wheel_ter_mod = 1;
         }
 
-        traction_wheel_area += 2.0 * vpi.wheel_info->contact_area / move_mod;
+        // normalize mc with base terrain move cost 2
+        traction_wheel_area += 2.0 * vpi.wheel_info->contact_area / (mc * wheel_ter_mod);
     }
 
     return traction_wheel_area;

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -2155,7 +2155,7 @@ float map::vehicle_wheel_traction( const vehicle &veh, bool ignore_movement_modi
         }
 
         // normalize mc with base terrain move cost 2
-        traction_wheel_area += 2.0f * vpi.wheel_info->contact_area / (mc * wheel_ter_mod);
+        traction_wheel_area += 2.0f * vpi.wheel_info->contact_area / ( mc * wheel_ter_mod );
     }
 
     return traction_wheel_area;

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -2150,7 +2150,7 @@ float map::vehicle_wheel_traction( const vehicle &veh, bool ignore_movement_modi
             }
         }
 
-        if(wheel_ter_mod == 0 ) {
+        if( wheel_ter_mod == 0 ) {
             wheel_ter_mod = 1;
         }
 

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -2155,7 +2155,7 @@ float map::vehicle_wheel_traction( const vehicle &veh, bool ignore_movement_modi
         }
 
         // normalize mc with base terrain move cost 2
-        traction_wheel_area += 2.0 * vpi.wheel_info->contact_area / (mc * wheel_ter_mod);
+        traction_wheel_area += 2.0f * vpi.wheel_info->contact_area / (mc * wheel_ter_mod);
     }
 
     return traction_wheel_area;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix `map::vehicle_wheel_traction()` calculation to match the JSON docs on `wheel_terrain_modifiers`"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
This is a change to the formula used in `map::vehicle_wheel_traction()` to more closely match what is described in the documentation in [doc/JSON_INFO.md#the-following-optional-fields-are-specific-to-wheels](https://github.com/CleverRaven/Cataclysm-DDA/blob/1b344056915734313402181513163aeaad0ccab1/doc/JSON_INFO.md#the-following-optional-fields-are-specific-to-wheels), specifically a fix to how the `wheel_terrain_modifiers` are collated and used to calculate the result.

The issue was discovered while reading through how wheels affect vehicle grabs from `src/grab.cpp`.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Wheel terrain modifiers are now added together as described in the examples in [doc/JSON_INFO.md#the-following-optional-fields-are-specific-to-wheels](https://github.com/CleverRaven/Cataclysm-DDA/blob/1b344056915734313402181513163aeaad0ccab1/doc/JSON_INFO.md#the-following-optional-fields-are-specific-to-wheels) and they scale the final result appropriately.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
Potentially, it is the documentation that is wrong. I don't have the necessary expertise to confirm that, though.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
No testing done, I still can't get Cata to compile on my machine.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
On line [src/vehicle_move.cpp#L2158](https://github.com/CleverRaven/Cataclysm-DDA/pull/72015/files#diff-437929ec9b250984e4c40f50d9a48af96c10cfe29ce8669daef86989b7443435R2158), there is potential for a faulty result if `mc` has a value of `1`, but that issue exists in the unchanged version as well.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
