### PR TITLE
Test cases for player's morale after killing an NPC

### DIFF
--- a/tests/morale_test.cpp
+++ b/tests/morale_test.cpp
@@ -211,6 +211,28 @@ TEST_CASE( "player_morale_murdered_innocent", "[player_morale]" )
     REQUIRE( m.get_total_negative_value() == 90 );
 }
 
+TEST_CASE( "player_morale_kills_hostile_bandit", "[player_morale]" )
+{
+    clear_avatar();
+    Character &player = get_player_character();
+    player_morale &m = *player.morale;
+    tripoint next_to = player.adjacent_tile();
+    standard_npc badguy( "Raider", next_to, {}, 0, 8, 8, 8, 7 );
+    // Always-hostile
+    badguy.set_fac_id( "hells_raiders" );
+    badguy.setpos( next_to );
+    badguy.set_all_parts_hp_cur( 1 );
+    CHECK( m.get_total_positive_value() == 0 );
+    CHECK( m.get_total_negative_value() == 0 );
+    CHECK( badguy.is_enemy() == true );
+    CHECK( badguy.guaranteed_hostile() == true );
+    while( !badguy.is_dead_state() ) {
+        player.mod_moves( 1000 );
+        player.melee_attack( badguy, true );
+    }
+    REQUIRE( m.get_total_negative_value() == 0 );
+}
+
 TEST_CASE( "player_morale_fancy_clothes", "[player_morale]" )
 {
     player_morale m;

--- a/tests/morale_test.cpp
+++ b/tests/morale_test.cpp
@@ -196,7 +196,8 @@ TEST_CASE( "player_morale_murdered_innocent", "[player_morale]" )
     tripoint next_to = player.adjacent_tile();
     standard_npc innocent( "Lapin", next_to, {}, 0, 8, 8, 8, 7 );
     // Innocent as could be.
-    innocent.set_fac_id( "lapin" );
+    faction_id lapin( "lapin" );
+    innocent.set_fac( lapin );
     innocent.setpos( next_to );
     innocent.set_all_parts_hp_cur( 1 );
     CHECK( m.get_total_positive_value() == 0 );
@@ -219,12 +220,12 @@ TEST_CASE( "player_morale_kills_hostile_bandit", "[player_morale]" )
     tripoint next_to = player.adjacent_tile();
     standard_npc badguy( "Raider", next_to, {}, 0, 8, 8, 8, 7 );
     // Always-hostile
-    badguy.set_fac_id( "hells_raiders" );
+    faction_id hells_raiders( "hells_raiders" );
+    badguy.set_fac( hells_raiders );
     badguy.setpos( next_to );
     badguy.set_all_parts_hp_cur( 1 );
     CHECK( m.get_total_positive_value() == 0 );
     CHECK( m.get_total_negative_value() == 0 );
-    CHECK( badguy.is_enemy() == true );
     CHECK( badguy.guaranteed_hostile() == true );
     while( !badguy.is_dead_state() ) {
         player.mod_moves( 1000 );


### PR DESCRIPTION
#### Summary
Infrastructure "Test cases for player's morale after killing an NPC"

#### Purpose of change
There have been some recent changes to morale upon killing NPCs. The code handling it is admittedly complex, and difficult to tell by reading exactly when morale penalties are, or are not, applied. Manual testing is difficult and time-consuming.

#### Describe the solution
Make some tests cases. Let the computer do the work for us!

#### Describe alternatives you've considered
Require contributors to submit proof-of-testing forms in triplicate whenever they touch a feature

#### Testing
Tests pass locally.

#### Additional context
CC @fairyarmadillo
You mentioned being unfamiliar with making test cases. This PR is not intended as instruction, but it's a simple setup that works and you may find it useful for the future.
