### PR TITLE
fix some bugs for `run_eoc_until`

### DIFF
--- a/data/mods/TEST_DATA/EOC.json
+++ b/data/mods/TEST_DATA/EOC.json
@@ -183,8 +183,12 @@
     "type": "effect_on_condition",
     "id": "EOC_run_until_test",
     "effect": [
-      { "set_condition": "to_test", "condition": { "math": [ "u_context", "<", "10" ] } },
-      { "run_eoc_until": "EOC_until_nested", "condition": "to_test" }
+      { "math": [ "u_context", "=", "0" ] },
+      {
+        "run_eoc_until": "EOC_until_nested",
+        "condition": { "math": [ "u_context", "<", "10000" ] },
+        "iteration": 10000
+      }
     ]
   },
   {

--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -2160,7 +2160,20 @@ Run EoC multiple times, until specific condition would be met
     "type": "effect_on_condition",
     "id": "EOC_until_nested",
     "effect": [ { "u_spawn_item": "knife_combat" }, { "math": [ "my_variable", "++" ] } ]
+  }
+```
+A loop of 10 iterations.
+```
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_run_until",
+    "effect": { "run_eoc_until": "EOC_until_nested", "iteration": 10 }
   },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_until_nested",
+    "effect": { "u_message": "!!!" }
+  }
 ```
 
 ## Character effects

--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -2137,8 +2137,8 @@ Run EoC multiple times, until specific condition would be met
 | Syntax | Optionality | Value  | Info |
 | --- | --- | --- | --- | 
 | "run_eoc_until" | **mandatory** | string or [variable object](#variable-object) | EoC that would be run multiple times |
-| "condition" | **mandatory** | string or [variable object](#variable-object) | name of condition, that would be checked; doesn't support inline condition, so it should be specified in `set_condition` somewhere before the effect; **condition should return "false" to terminate the loop** | 
-| "iteration" | optional | int or [variable object](#variable-object) | default 100; amount of iteration, that is allowed to run; if amount of iteration exceed this number, EoC is stopped, and game sends the error message | 
+| "condition" | optional | [dialogue condition](#dialogue-conditions) | default a condition that always return true; **condition should return "false" to terminate the loop** | 
+| "iteration" | optional | int or [variable object](#variable-object) | default 100; max amount of iteration, that is allowed to run; if the condition always returns true, the EOC will run for this number of iterations.| 
 
 ##### Valid talkers:
 
@@ -2153,8 +2153,7 @@ Run EoC multiple times, until specific condition would be met
     "type": "effect_on_condition",
     "id": "EOC_run_until",
     "effect": [
-      { "set_condition": "to_test", "condition": { "math": [ "my_variable", "<", "10" ] } },
-      { "run_eoc_until": "EOC_until_nested", "condition": "to_test" }
+      { "run_eoc_until": "EOC_until_nested", "condition": { "math": [ "my_variable", "<", "10" ] } }
     ]
   },
   {

--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -2163,7 +2163,7 @@ Run EoC multiple times, until specific condition would be met
   }
 ```
 A loop of 10 iterations.
-```
+```json
   {
     "type": "effect_on_condition",
     "id": "EOC_run_until",

--- a/src/effect_on_condition.cpp
+++ b/src/effect_on_condition.cpp
@@ -292,14 +292,16 @@ void effect_on_conditions::process_reactivate()
                           g->queued_global_effect_on_conditions, d );
 }
 
-bool effect_on_condition::activate( dialogue &d ) const
+bool effect_on_condition::activate( dialogue &d, bool require_callstack_check ) const
 {
     bool retval = false;
-    d.amend_callstack( "EOC: " + id.str() );
-    if( d.get_callstack().size() > 5000 ) {
-        if( query_yn( string_format( _( "Possible infinite loop in eoc %s.  Stop execution?" ),
-                                     id.str() ) ) ) {
-            return false;
+    if( require_callstack_check ) {
+        d.amend_callstack( "EOC: " + id.str() );
+        if( d.get_callstack().size() > 5000 ) {
+            if( query_yn( string_format( _( "Possible infinite loop in eoc %s.  Stop execution?" ),
+                                         id.str() ) ) ) {
+                return false;
+            }
         }
     }
     // each version needs a copy of the dialogue to pass down

--- a/src/effect_on_condition.h
+++ b/src/effect_on_condition.h
@@ -59,7 +59,7 @@ struct effect_on_condition {
         bool has_false_effect = false;
         event_type required_event;
         duration_or_var recurrence;
-        bool activate( dialogue &d ) const;
+        bool activate( dialogue &d, bool require_callstack_check = true ) const;
         bool check_deactivate( dialogue &d ) const;
         bool test_condition( dialogue &d ) const;
         void apply_true_effects( dialogue &d ) const;

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -860,7 +860,7 @@ TEST_CASE( "EOC_run_until_test", "[eoc]" )
     REQUIRE( globvars.get_global_value( "npctalk_var_key1" ).empty() );
 
     CHECK( effect_on_condition_EOC_run_until_test->activate( d ) );
-    CHECK( std::stod( globvars.get_global_value( "npctalk_var_key1" ) ) == Approx( 10 ) );
+    CHECK( std::stod( globvars.get_global_value( "npctalk_var_key1" ) ) == Approx( 10000 ) );
 }
 
 TEST_CASE( "EOC_run_with_test_expects", "[eoc]" )


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "fix some bugs for `run_eoc_until`"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

1. In the documentation, one field is "iteration", but in the code, the checked field is "iteration_count"

2. When the iteration number is too large, a debugmsg occurs within `eoc->activate` due to the callstack of dialogue being too large.

3. The condition of `run_eoc_until` can only be set in advance using `set_condition`. I don't understand the significance of this. Can't we just use the condition syntax directly?

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

1. I changed the "iteration_count" in the code to "iteration".

2. Add a bool value `require_callstack_check` in `eoc->activate` to determine whether to amend the eoc in the callstack and check the size of callstack. Then, in `run_eoc_until`, amend one eoc into the callstack instead of amending several eocs into the callstack repeatedly in the iteration.

3. use condition syntax directly. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Test function is updated.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
