### PR TITLE
NPCs use their indoor voices when not in danger

### DIFF
--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1779,7 +1779,7 @@ int npc::indoor_voice() const
     // Possible fallthrough: neutral or unaware enemy NPCs talk at default wanted_volume
 
     // Don't wake up friends when using our indoor voice
-    for( auto &bunk_buddy : get_cached_friends() ) {
+    for( const auto &bunk_buddy : get_cached_friends() ) {
         if( !( bunk_buddy.lock() && bunk_buddy.lock()->is_npc() ) ) {
             continue;
         }

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1751,8 +1751,8 @@ void npc::say( const std::string &line, const sounds::sound_t spriority ) const
         sounds::sound( pos(), get_shout_volume(), spriority, sound, false, "speech",
                        male ? "NPC_m" : "NPC_f" );
     } else {
-        sounds::sound( pos(), danger_assessment() > 5 ? 16 : 6, sounds::sound_t::speech, sound, false,
-                       "speech",
+        sounds::sound( pos(), danger_assessment() > NPC_DANGER_VERY_LOW ? 16 : 6, sounds::sound_t::speech,
+                       sound, false, "speech",
                        male ? "NPC_m_loud" : "NPC_f_loud" );
     }
 }

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1780,14 +1780,16 @@ int npc::indoor_voice() const
 
     // Don't wake up friends when using our indoor voice
     for( const auto &bunk_buddy : get_cached_friends() ) {
-        if( !( bunk_buddy.lock() && bunk_buddy.lock()->is_npc() ) ) {
+        Character *char_buddy = nullptr;
+        Creature *buddy = bunk_buddy.lock().get();
+        if( buddy ) {
+            char_buddy = dynamic_cast<Character *>( buddy );
+        }
+        if( !char_buddy ) {
             continue;
         }
-        if( !( bunk_buddy.lock() && bunk_buddy.lock()->is_avatar() ) ) {
-            continue;
-        }
-        if( dynamic_cast<const Character &>( *bunk_buddy.lock() ).has_effect( effect_sleep ) ) {
-            int distance_to_sleeper = rl_dist( pos(), bunk_buddy.lock().get()->pos() );
+        if( char_buddy->has_effect( effect_sleep ) ) {
+            int distance_to_sleeper = rl_dist( pos(), char_buddy->pos() );
             if( wanted_volume >= distance_to_sleeper ) {
                 // Speak just quietly enough to not disturb anyone
                 wanted_volume = distance_to_sleeper - 1;

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1781,10 +1781,8 @@ int npc::indoor_voice() const
     // Don't wake up friends when using our indoor voice
     for( const auto &bunk_buddy : get_cached_friends() ) {
         Character *char_buddy = nullptr;
-        std::shared_ptr<Creature>maybe_buddy = bunk_buddy.lock();
-        Creature *buddy = maybe_buddy.get();
-        if( buddy ) {
-            char_buddy = dynamic_cast<Character *>( buddy );
+        if( auto buddy = bunk_buddy.lock() ) {
+            char_buddy = dynamic_cast<Character *>( buddy.get() );
         }
         if( !char_buddy ) {
             continue;

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1781,7 +1781,8 @@ int npc::indoor_voice() const
     // Don't wake up friends when using our indoor voice
     for( const auto &bunk_buddy : get_cached_friends() ) {
         Character *char_buddy = nullptr;
-        Creature *buddy = bunk_buddy.lock().get();
+        std::shared_ptr<Creature>maybe_buddy = bunk_buddy.lock();
+        Creature *buddy = maybe_buddy.get();
         if( buddy ) {
             char_buddy = dynamic_cast<Character *>( buddy );
         }

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -101,6 +101,7 @@ static const efftype_id effect_pkill3( "pkill3" );
 static const efftype_id effect_pkill_l( "pkill_l" );
 static const efftype_id effect_ridden( "ridden" );
 static const efftype_id effect_riding( "riding" );
+static const efftype_id effect_sleep( "sleep" );
 
 static const faction_id faction_amf( "amf" );
 static const faction_id faction_no_faction( "no_faction" );
@@ -1751,10 +1752,50 @@ void npc::say( const std::string &line, const sounds::sound_t spriority ) const
         sounds::sound( pos(), get_shout_volume(), spriority, sound, false, "speech",
                        male ? "NPC_m" : "NPC_f" );
     } else {
-        sounds::sound( pos(), danger_assessment() > NPC_DANGER_VERY_LOW ? 16 : 6, sounds::sound_t::speech,
+        // Always shouting when in danger or short time since being in danger
+        sounds::sound( pos(), danger_assessment() > NPC_DANGER_VERY_LOW ?
+                       get_shout_volume() : indoor_voice(),
+                       sounds::sound_t::speech,
                        sound, false, "speech",
                        male ? "NPC_m_loud" : "NPC_f_loud" );
     }
+}
+
+int npc::indoor_voice() const
+{
+    const int max_volume = get_shout_volume();
+    const int min_volume = 1;
+    // Actual hearing distance is incredibly dependent on ambient noise and our noise propagation model is... rather binary
+    // But we'll assume people normally want to project their voice about 6 meters away.
+    int wanted_volume = 6;
+    Character &player = get_player_character();
+    const int distance_to_player = rl_dist( pos(), player.pos() );
+    if( is_following() || is_ally( player ) ) {
+        wanted_volume = distance_to_player;
+    } else if( is_enemy() && sees( player.pos() ) ) {
+        // Battle cry! Bandits have no concept of indoor voice, even when not threatened.
+        wanted_volume = max_volume;
+    }
+    // Possible fallthrough: neutral or unaware enemy NPCs talk at default wanted_volume
+
+    // Don't wake up friends when using our indoor voice
+    for( auto &bunk_buddy : get_cached_friends() ) {
+        if( !( bunk_buddy.lock() && bunk_buddy.lock()->is_npc() ) ) {
+            continue;
+        }
+        if( !( bunk_buddy.lock() && bunk_buddy.lock()->is_avatar() ) ) {
+            continue;
+        }
+        if( dynamic_cast<const Character &>( *bunk_buddy.lock() ).has_effect( effect_sleep ) ) {
+            int distance_to_sleeper = rl_dist( pos(), bunk_buddy.lock().get()->pos() );
+            if( wanted_volume >= distance_to_sleeper ) {
+                // Speak just quietly enough to not disturb anyone
+                wanted_volume = distance_to_sleeper - 1;
+            }
+        }
+    }
+
+    return std::clamp( wanted_volume, min_volume, max_volume );
 }
 
 bool npc::wants_to_sell( const item_location &it ) const

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1751,7 +1751,8 @@ void npc::say( const std::string &line, const sounds::sound_t spriority ) const
         sounds::sound( pos(), get_shout_volume(), spriority, sound, false, "speech",
                        male ? "NPC_m" : "NPC_f" );
     } else {
-        sounds::sound( pos(), 16, sounds::sound_t::speech, sound, false, "speech",
+        sounds::sound( pos(), danger_assessment() > 5 ? 16 : 6, sounds::sound_t::speech, sound, false,
+                       "speech",
                        male ? "NPC_m_loud" : "NPC_f_loud" );
     }
 }

--- a/src/npc.h
+++ b/src/npc.h
@@ -59,10 +59,10 @@ class vehicle;
 
 constexpr int8_t NPC_PERSONALITY_MIN = -10;
 constexpr int8_t NPC_PERSONALITY_MAX = 10;
-static constexpr float NPC_DANGER_VERY_LOW = 5.0f;
-static constexpr float NPC_MONSTER_DANGER_MAX = 150.0f;
-static constexpr float NPC_CHARACTER_DANGER_MAX = 250.0f;
-static constexpr float NPC_COWARDICE_MODIFIER = 0.25f;
+constexpr float NPC_DANGER_VERY_LOW = 5.0f;
+constexpr float NPC_MONSTER_DANGER_MAX = 150.0f;
+constexpr float NPC_CHARACTER_DANGER_MAX = 250.0f;
+constexpr float NPC_COWARDICE_MODIFIER = 0.25f;
 
 namespace catacurses
 {

--- a/src/npc.h
+++ b/src/npc.h
@@ -1026,6 +1026,7 @@ class npc : public Character
             return say( string_format( line, std::forward<Args>( args )... ) );
         }
         void say( const std::string &line, sounds::sound_t spriority = sounds::sound_t::speech ) const;
+        int indoor_voice() const;
         void decide_needs();
         void reboot();
         void die( Creature *killer ) override;

--- a/src/npc.h
+++ b/src/npc.h
@@ -59,6 +59,10 @@ class vehicle;
 
 constexpr int8_t NPC_PERSONALITY_MIN = -10;
 constexpr int8_t NPC_PERSONALITY_MAX = 10;
+static constexpr float NPC_DANGER_VERY_LOW = 5.0f;
+static constexpr float NPC_MONSTER_DANGER_MAX = 150.0f;
+static constexpr float NPC_CHARACTER_DANGER_MAX = 250.0f;
+static constexpr float NPC_COWARDICE_MODIFIER = 0.25f;
 
 namespace catacurses
 {

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -151,10 +151,6 @@ static const trait_id trait_RETURN_TO_START_POS( "RETURN_TO_START_POS" );
 static const zone_type_id zone_type_NO_NPC_PICKUP( "NO_NPC_PICKUP" );
 static const zone_type_id zone_type_NPC_RETREAT( "NPC_RETREAT" );
 
-static constexpr float NPC_DANGER_VERY_LOW = 5.0f;
-static constexpr float NPC_MONSTER_DANGER_MAX = 150.0f;
-static constexpr float NPC_CHARACTER_DANGER_MAX = 250.0f;
-static constexpr float NPC_COWARDICE_MODIFIER = 0.25f;
 static constexpr float MAX_FLOAT = 5000000000.0f;
 
 // TODO: These would be much better using common code or constants from character.cpp,

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -649,7 +649,7 @@ void sounds::process_sound_markers( Character *you )
                 !you->has_bionic( bio_sleep_shutdown ) ) {
                 //Not kidding about sleep-through-firefight
                 you->wake_up();
-                add_msg( m_warning, _( "Something is making noise." ) );
+                you->add_msg_if_player( m_warning, _( "Something is making noise." ) );
             } else {
                 continue;
             }


### PR DESCRIPTION
#### Summary
Balance "NPCs don't scream at loudness 16 when just saying normal stuff, unless they're in danger"

#### Purpose of change
Mentioned in #71865 (does not close issue)

NPCs yelling like maniacs in the middle of the night because they wanted to step past you. Then yelling like maniacs to apologize to all the people they just woke up. Brilliant.

#### Describe the solution
Replaced the number `16` with ~~`6` if not in danger~~ math!

Calculate a good volume to use instead of magic numbers, based on whether the player will be able to hear (speak louder if PC is far away)/NPC wants the player to hear. Respects if friends are sleeping (intentionally whispers to avoid waking them up).

#### Describe alternatives you've considered
Why don't we make a slider for the player to micromanage how loud they want their NPCs to yell? (this is not a serious question)

#### Testing
Confirmed it compiles and launches only

#### Additional context
Technically speaking if get_shout_volume() is below 16, they were actually *louder* when speaking normally during danger 🤔 
