### PR TITLE
Disallow mixed smokeless in handloading

### DIFF
--- a/data/json/items/ammo.json
+++ b/data/json/items/ammo.json
@@ -749,7 +749,7 @@
     "name": { "str_sp": "mixed smokeless gunpowder" },
     "symbol": "=",
     "color": "dark_gray",
-    "description": "Firearm-quality gunpowder, mixed without concern for composition, burn rate, or shape, making it thorougly uselss for reloading ammunition.  It has been slightly ground to make its properties more uniform.",
+    "description": "Firearm-quality gunpowder, mixed without concern for composition, burn rate, or shape, making it thoroughly useless for reloading ammunition.  It has been slightly ground to make its properties more uniform.",
     "container": "bottle_plastic",
     "sealed": false,
     "material": [ "powder" ],

--- a/data/json/items/ammo.json
+++ b/data/json/items/ammo.json
@@ -749,7 +749,7 @@
     "name": { "str_sp": "mixed smokeless gunpowder" },
     "symbol": "=",
     "color": "dark_gray",
-    "description": "Firearm-quality gunpowder, mixed without concern for composition, burn rate, or shape.  It has been slightly ground to make its properties more uniform.  Only the truly desperate would attempt to reload with this.",
+    "description": "Firearm-quality gunpowder, mixed without concern for composition, burn rate, or shape, making it thorougly uselss for reloading ammunition.  It has been slightly ground to make its properties more uniform.",
     "container": "bottle_plastic",
     "sealed": false,
     "material": [ "powder" ],

--- a/data/json/recipes/ammo/pistol.json
+++ b/data/json/recipes/ammo/pistol.json
@@ -486,7 +486,7 @@
     "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 2 ], [ "ammo_32", 1 ] ],
     "//": "207 mg gunpowder rounded to 2 100 mg 'pieces'",
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
-    "components": [ [ [ "gunpowder", 2 ], [ "gunpowder_pistol", 2 ], [ "gunpowder_shotgun", 2 ] ], [ [ "copper", 1 ] ] ]
+    "components": [ [ [ "gunpowder_pistol", 2 ], [ "gunpowder_shotgun", 2 ] ], [ [ "copper", 1 ] ] ]
   },
   {
     "result": "reloaded_32_acp_jhp",
@@ -505,7 +505,7 @@
     "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 2 ], [ "ammo_32", 1 ] ],
     "//": "207 mg gunpowder rounded to 2 100 mg 'pieces'",
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
-    "components": [ [ [ "gunpowder", 2 ], [ "gunpowder_pistol", 2 ], [ "gunpowder_shotgun", 2 ] ], [ [ "copper", 1 ] ] ]
+    "components": [ [ [ "gunpowder_pistol", 2 ], [ "gunpowder_shotgun", 2 ] ], [ [ "copper", 1 ] ] ]
   },
   {
     "result": "reloaded_38_fmj",
@@ -524,7 +524,7 @@
     "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 2 ], [ "ammo_38spc", 1 ] ],
     "//": "315 mg gunpowder rounded to 3 100 mg 'pieces'",
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
-    "components": [ [ [ "gunpowder", 3 ], [ "gunpowder_pistol", 3 ], [ "gunpowder_shotgun", 3 ] ], [ [ "copper", 1 ] ] ]
+    "components": [ [ [ "gunpowder_pistol", 3 ], [ "gunpowder_shotgun", 3 ] ], [ [ "copper", 1 ] ] ]
   },
   {
     "result": "reloaded_38_special",
@@ -543,7 +543,7 @@
     "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 2 ], [ "ammo_38spc", 1 ] ],
     "//": "315 mg gunpowder rounded to 3 100 mg 'pieces'",
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
-    "components": [ [ [ "gunpowder", 3 ], [ "gunpowder_pistol", 3 ], [ "gunpowder_shotgun", 3 ] ] ]
+    "components": [ [ [ "gunpowder_pistol", 3 ], [ "gunpowder_shotgun", 3 ] ] ]
   },
   {
     "result": "reloaded_38_special_p",
@@ -562,7 +562,7 @@
     "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 2 ], [ "ammo_38spc", 1 ] ],
     "//": "447 mg gunpowder rounded to 4 100 mg 'pieces'",
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
-    "components": [ [ [ "gunpowder", 4 ], [ "gunpowder_pistol", 4 ], [ "gunpowder_shotgun", 4 ] ] ]
+    "components": [ [ [ "gunpowder_pistol", 4 ], [ "gunpowder_shotgun", 4 ] ] ]
   },
   {
     "result": "reloaded_357sig_fmj",
@@ -581,7 +581,7 @@
     "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 7 ], [ "ammo_357sig", 1 ] ],
     "//": "370 mg gunpowder rounded to 4 100 mg 'pieces'",
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
-    "components": [ [ [ "gunpowder", 4 ], [ "gunpowder_rifle", 4 ], [ "gunpowder_magnum_pistol", 4 ] ], [ [ "copper", 1 ] ] ]
+    "components": [ [ [ "gunpowder_rifle", 4 ], [ "gunpowder_magnum_pistol", 4 ] ], [ [ "copper", 1 ] ] ]
   },
   {
     "result": "reloaded_357sig_jhp",
@@ -600,7 +600,7 @@
     "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 8 ], [ "ammo_357sig", 1 ] ],
     "//": "531 mg gunpowder rounded to 5 100 mg 'pieces'",
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
-    "components": [ [ [ "gunpowder", 5 ], [ "gunpowder_rifle", 5 ], [ "gunpowder_magnum_pistol", 5 ] ], [ [ "copper", 1 ] ] ]
+    "components": [ [ [ "gunpowder_rifle", 5 ], [ "gunpowder_magnum_pistol", 5 ] ], [ [ "copper", 1 ] ] ]
   },
   {
     "result": "bp_357sig_fmj",
@@ -655,7 +655,7 @@
     "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 3 ], [ "ammo_357mag", 1 ] ],
     "//": "520 mg gunpowder rounded to 5 100 mg 'pieces'",
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
-    "components": [ [ [ "gunpowder", 5 ], [ "gunpowder_rifle", 5 ], [ "gunpowder_magnum_pistol", 5 ] ], [ [ "copper", 1 ] ] ]
+    "components": [ [ [ "gunpowder_rifle", 5 ], [ "gunpowder_magnum_pistol", 5 ] ], [ [ "copper", 1 ] ] ]
   },
   {
     "result": "reloaded_357mag_jhp",
@@ -674,7 +674,7 @@
     "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 4 ], [ "ammo_357mag", 1 ] ],
     "//": "520 mg gunpowder rounded to 5 100 mg 'pieces'",
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
-    "components": [ [ [ "gunpowder", 5 ], [ "gunpowder_rifle", 5 ], [ "gunpowder_magnum_pistol", 5 ] ], [ [ "copper", 1 ] ] ]
+    "components": [ [ [ "gunpowder_rifle", 5 ], [ "gunpowder_magnum_pistol", 5 ] ], [ [ "copper", 1 ] ] ]
   },
   {
     "result": "bp_357mag_fmj",
@@ -750,7 +750,7 @@
     "components": [
       [ [ "40_casing", 1 ] ],
       [ [ "smpistol_primer", 1 ] ],
-      [ [ "gunpowder", 3 ], [ "gunpowder_pistol", 3 ], [ "gunpowder_shotgun", 3 ] ],
+      [ [ "gunpowder_pistol", 3 ], [ "gunpowder_shotgun", 3 ] ],
       [ [ "copper", 1 ] ]
     ]
   },
@@ -774,7 +774,7 @@
     "components": [
       [ [ "40_casing", 1 ] ],
       [ [ "smpistol_primer", 1 ] ],
-      [ [ "gunpowder", 6 ], [ "gunpowder_pistol", 6 ], [ "gunpowder_shotgun", 6 ] ],
+      [ [ "gunpowder_pistol", 6 ], [ "gunpowder_shotgun", 6 ] ],
       [ [ "copper", 1 ] ]
     ]
   },
@@ -795,7 +795,7 @@
     "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 3 ], [ "ammo_10mm", 1 ] ],
     "//": "473 mg gunpowder rounded to 5 100 mg 'pieces'",
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
-    "components": [ [ [ "gunpowder", 5 ], [ "gunpowder_magnum_pistol", 5 ] ], [ [ "copper", 1 ] ] ]
+    "components": [ [ [ "gunpowder_magnum_pistol", 5 ] ], [ [ "copper", 1 ] ] ]
   },
   {
     "result": "reloaded_10mm_fmj",
@@ -814,7 +814,7 @@
     "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 3 ], [ "ammo_10mm", 1 ] ],
     "//": "330 mg gunpowder rounded to 3 100 mg 'pieces'",
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
-    "components": [ [ [ "gunpowder", 3 ], [ "gunpowder_magnum_pistol", 3 ] ], [ [ "copper", 1 ] ] ]
+    "components": [ [ [ "gunpowder_magnum_pistol", 3 ] ], [ [ "copper", 1 ] ] ]
   },
   {
     "result": "bp_10mm_fmj",
@@ -851,7 +851,7 @@
     "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 3 ], [ "ammo_10mm", 1 ] ],
     "//": "330 mg gunpowder rounded to 3 100 mg 'pieces'",
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
-    "components": [ [ [ "gunpowder", 3 ], [ "gunpowder_magnum_pistol", 3 ] ], [ [ "copper", 1 ] ] ]
+    "components": [ [ [ "gunpowder_magnum_pistol", 3 ] ], [ [ "copper", 1 ] ] ]
   },
   {
     "result": "bp_10mm_jhp",
@@ -891,7 +891,7 @@
     "components": [
       [ [ "44_casing", 1 ] ],
       [ [ "lgpistol_primer", 1 ] ],
-      [ [ "gunpowder", 7 ], [ "gunpowder_rifle", 7 ], [ "gunpowder_magnum_pistol", 7 ] ],
+      [ [ "gunpowder_rifle", 7 ], [ "gunpowder_magnum_pistol", 7 ] ],
       [ [ "copper", 2 ] ]
     ]
   },
@@ -915,7 +915,7 @@
     "components": [
       [ [ "44_casing", 1 ] ],
       [ [ "lgpistol_primer", 1 ] ],
-      [ [ "gunpowder", 7 ], [ "gunpowder_rifle", 7 ], [ "gunpowder_magnum_pistol", 7 ] ],
+      [ [ "gunpowder_rifle", 7 ], [ "gunpowder_magnum_pistol", 7 ] ],
       [ [ "copper", 2 ] ]
     ]
   },
@@ -957,7 +957,7 @@
     "components": [
       [ [ "45_casing", 1 ] ],
       [ [ "lgpistol_primer", 1 ] ],
-      [ [ "gunpowder", 3 ], [ "gunpowder_pistol", 3 ], [ "gunpowder_shotgun", 3 ] ],
+      [ [ "gunpowder_pistol", 3 ], [ "gunpowder_shotgun", 3 ] ],
       [ [ "copper", 2 ] ]
     ]
   },
@@ -981,7 +981,7 @@
     "components": [
       [ [ "45_casing", 1 ] ],
       [ [ "lgpistol_primer", 1 ] ],
-      [ [ "gunpowder", 5 ], [ "gunpowder_pistol", 5 ], [ "gunpowder_shotgun", 5 ] ],
+      [ [ "gunpowder_pistol", 5 ], [ "gunpowder_shotgun", 5 ] ],
       [ [ "copper", 1 ] ]
     ]
   },
@@ -1005,7 +1005,7 @@
     "components": [
       [ [ "45_casing", 1 ] ],
       [ [ "lgpistol_primer", 1 ] ],
-      [ [ "gunpowder", 5 ], [ "gunpowder_pistol", 5 ] ],
+      [ [ "gunpowder_pistol", 5 ] ],
       [ [ "copper", 1 ] ]
     ]
   },
@@ -1029,7 +1029,7 @@
     "components": [
       [ [ "454_casing", 1 ] ],
       [ [ "smrifle_primer", 1 ] ],
-      [ [ "gunpowder", 16 ], [ "gunpowder_rifle", 16 ], [ "gunpowder_magnum_pistol", 16 ] ],
+      [ [ "gunpowder_rifle", 16 ], [ "gunpowder_magnum_pistol", 16 ] ],
       [ [ "copper", 2 ] ]
     ]
   },
@@ -1068,7 +1068,7 @@
     "using": [ [ "bullet_forming", 3 ], [ "ammo_bullet", 5 ], [ "ammo_45colt", 1 ] ],
     "//": "505 mg gunpowder rounded to 5 100 mg 'pieces'",
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
-    "components": [ [ [ "gunpowder", 5 ], [ "gunpowder_pistol", 5 ], [ "gunpowder_shotgun", 5 ] ], [ [ "copper", 2 ] ] ]
+    "components": [ [ [ "gunpowder_pistol", 5 ], [ "gunpowder_shotgun", 5 ] ], [ [ "copper", 2 ] ] ]
   },
   {
     "result": "bp_45colt_jhp",
@@ -1105,7 +1105,7 @@
     "using": [ [ "bullet_forming", 3 ], [ "ammo_bullet", 5 ], [ "ammo_45colt", 1 ] ],
     "//": "505 mg gunpowder rounded to 5 100 mg 'pieces'",
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
-    "components": [ [ [ "gunpowder", 5 ], [ "gunpowder_pistol", 5 ], [ "gunpowder_shotgun", 5 ] ], [ [ "copper", 2 ] ] ]
+    "components": [ [ [ "gunpowder_pistol", 5 ], [ "gunpowder_shotgun", 5 ] ], [ [ "copper", 2 ] ] ]
   },
   {
     "result": "bp_45colt_fmj",
@@ -1142,7 +1142,7 @@
     "using": [ [ "bullet_forming", 3 ], [ "ammo_bullet", 5 ], [ "ammo_45colt", 1 ] ],
     "//": "311 mg gunpowder rounded to 3 100 mg 'pieces'",
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
-    "components": [ [ [ "gunpowder", 3 ], [ "gunpowder_pistol", 3 ], [ "gunpowder_shotgun", 3 ] ] ]
+    "components": [ [ [ "gunpowder_pistol", 3 ], [ "gunpowder_shotgun", 3 ] ] ]
   },
   {
     "result": "bp_45colt_cowboy",
@@ -1182,7 +1182,7 @@
     "components": [
       [ [ "46mm_casing", 1 ] ],
       [ [ "smpistol_primer", 1 ] ],
-      [ [ "gunpowder", 4 ], [ "gunpowder_pistol", 4 ] ],
+      [ [ "gunpowder_pistol", 4 ] ],
       [ [ "copper", 1 ] ]
     ]
   },
@@ -1206,7 +1206,7 @@
     "components": [
       [ [ "460_casing", 1 ] ],
       [ [ "lgpistol_primer", 1 ] ],
-      [ [ "gunpowder", 8 ], [ "gunpowder_rifle", 8 ], [ "gunpowder_magnum_pistol", 8 ] ],
+      [ [ "gunpowder_rifle", 8 ], [ "gunpowder_magnum_pistol", 8 ] ],
       [ [ "copper", 2 ] ]
     ]
   },
@@ -1230,7 +1230,7 @@
     "components": [
       [ [ "460_casing", 1 ] ],
       [ [ "lgpistol_primer", 1 ] ],
-      [ [ "gunpowder", 8 ], [ "gunpowder_rifle", 8 ], [ "gunpowder_magnum_pistol", 8 ] ],
+      [ [ "gunpowder_rifle", 8 ], [ "gunpowder_magnum_pistol", 8 ] ],
       [ [ "copper", 2 ] ]
     ]
   },
@@ -1254,7 +1254,7 @@
     "components": [
       [ [ "500_casing", 1 ] ],
       [ [ "lgrifle_primer", 1 ] ],
-      [ [ "gunpowder", 19 ], [ "gunpowder_rifle", 19 ], [ "gunpowder_magnum_pistol", 19 ] ],
+      [ [ "gunpowder_rifle", 19 ], [ "gunpowder_magnum_pistol", 19 ] ],
       [ [ "copper", 5 ] ]
     ]
   },
@@ -1278,7 +1278,7 @@
     "components": [
       [ [ "50ae_casing", 1 ] ],
       [ [ "lgpistol_primer", 1 ] ],
-      [ [ "gunpowder", 16 ], [ "gunpowder_rifle", 16 ], [ "gunpowder_magnum_pistol", 16 ] ],
+      [ [ "gunpowder_rifle", 16 ], [ "gunpowder_magnum_pistol", 16 ] ],
       [ [ "copper", 5 ] ]
     ]
   },
@@ -1302,7 +1302,7 @@
     "components": [
       [ [ "50ae_casing", 1 ] ],
       [ [ "lgpistol_primer", 1 ] ],
-      [ [ "gunpowder", 16 ], [ "gunpowder_rifle", 16 ], [ "gunpowder_magnum_pistol", 16 ] ],
+      [ [ "gunpowder_rifle", 16 ], [ "gunpowder_magnum_pistol", 16 ] ],
       [ [ "copper", 6 ] ]
     ]
   },
@@ -1326,7 +1326,7 @@
     "components": [
       [ [ "57mm_casing", 1 ] ],
       [ [ "smrifle_primer", 1 ] ],
-      [ [ "gunpowder", 4 ], [ "gunpowder_pistol", 4 ] ],
+      [ [ "gunpowder_pistol", 4 ] ],
       [ [ "copper", 1 ] ]
     ]
   },
@@ -1347,7 +1347,7 @@
     "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 2 ], [ "ammo_762_25", 1 ] ],
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
     "//": "390 mg gunpowder rounded to 4 100 mg 'pieces'",
-    "components": [ [ [ "gunpowder", 4 ], [ "gunpowder_pistol", 4 ] ], [ [ "copper", 1 ] ] ]
+    "components": [ [ [ "gunpowder_pistol", 4 ] ], [ [ "copper", 1 ] ] ]
   },
   {
     "result": "reloaded_9mm",
@@ -1366,7 +1366,7 @@
     "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 2 ], [ "ammo_9mm", 1 ] ],
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
     "//": "290 mg gunpowder rounded to 3 100 mg 'pieces'",
-    "components": [ [ [ "gunpowder", 3 ], [ "gunpowder_pistol", 3 ], [ "gunpowder_shotgun", 3 ] ], [ [ "copper", 1 ] ] ]
+    "components": [ [ [ "gunpowder_pistol", 3 ], [ "gunpowder_shotgun", 3 ] ], [ [ "copper", 1 ] ] ]
   },
   {
     "result": "reloaded_9mmP",
@@ -1385,7 +1385,7 @@
     "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 2 ], [ "ammo_9mm", 1 ] ],
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
     "//": "537 mg gunpowder rounded to 5 100 mg 'pieces'",
-    "components": [ [ [ "gunpowder", 5 ], [ "gunpowder_pistol", 5 ] ], [ [ "copper", 1 ] ] ]
+    "components": [ [ [ "gunpowder_pistol", 5 ] ], [ [ "copper", 1 ] ] ]
   },
   {
     "result": "reloaded_9mmP2",
@@ -1404,7 +1404,7 @@
     "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 2 ], [ "ammo_9mm", 1 ] ],
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
     "//": "Arbitrary powder amount as +p+ is not a real standard but an informal one which has about 20% higher pressure than standard 9mm, while +p is a standard that has 10% higher pressure. 580 mg gunpowder rounded to 6 100 mg 'pieces'",
-    "components": [ [ [ "gunpowder", 6 ], [ "gunpowder_pistol", 6 ] ], [ [ "copper", 1 ] ] ]
+    "components": [ [ [ "gunpowder_pistol", 6 ] ], [ [ "copper", 1 ] ] ]
   },
   {
     "result": "reloaded_9mmfmj",
@@ -1423,7 +1423,7 @@
     "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 2 ], [ "ammo_9mm", 1 ] ],
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
     "//": "290 mg gunpowder rounded to 3 100 mg 'pieces'",
-    "components": [ [ [ "gunpowder", 3 ], [ "gunpowder_pistol", 3 ], [ "gunpowder_shotgun", 3 ] ], [ [ "copper", 1 ] ] ]
+    "components": [ [ [ "gunpowder_pistol", 3 ], [ "gunpowder_shotgun", 3 ] ], [ [ "copper", 1 ] ] ]
   },
   {
     "result": "reloaded_9x18mm",
@@ -1445,7 +1445,7 @@
     "components": [
       [ [ "9x18mm_casing", 1 ] ],
       [ [ "smpistol_primer", 1 ] ],
-      [ [ "gunpowder", 4 ], [ "gunpowder_pistol", 4 ], [ "gunpowder_shotgun", 4 ] ],
+      [ [ "gunpowder_pistol", 4 ], [ "gunpowder_shotgun", 4 ] ],
       [ [ "copper", 1 ] ]
     ]
   },
@@ -1469,7 +1469,7 @@
     "components": [
       [ [ "9x18mm_casing", 1 ] ],
       [ [ "smpistol_primer", 1 ] ],
-      [ [ "gunpowder", 4 ], [ "gunpowder_pistol", 4 ], [ "gunpowder_shotgun", 4 ] ],
+      [ [ "gunpowder_pistol", 4 ], [ "gunpowder_shotgun", 4 ] ],
       [ [ "copper", 1 ] ]
     ]
   },
@@ -1493,7 +1493,7 @@
     "components": [
       [ [ "9x18mm_casing", 1 ] ],
       [ [ "smpistol_primer", 1 ] ],
-      [ [ "gunpowder", 5 ], [ "gunpowder_pistol", 5 ], [ "gunpowder_shotgun", 5 ] ],
+      [ [ "gunpowder_pistol", 5 ], [ "gunpowder_shotgun", 5 ] ],
       [ [ "copper", 1 ] ]
     ]
   },
@@ -1514,7 +1514,7 @@
     "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 2 ], [ "ammo_38super", 1 ] ],
     "//": "375 mg gunpowder rounded to 4 100 mg 'pieces'",
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
-    "components": [ [ [ "gunpowder", 4 ], [ "gunpowder_pistol", 4 ], [ "gunpowder_shotgun", 4 ] ], [ [ "copper", 1 ] ] ]
+    "components": [ [ [ "gunpowder_pistol", 4 ], [ "gunpowder_shotgun", 4 ] ], [ [ "copper", 1 ] ] ]
   },
   {
     "result": "reloaded_38_super",
@@ -1533,7 +1533,7 @@
     "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 2 ], [ "ammo_38super", 1 ] ],
     "//": "375 mg gunpowder rounded to 4 100 mg 'pieces'",
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
-    "components": [ [ [ "gunpowder", 4 ], [ "gunpowder_pistol", 4 ], [ "gunpowder_shotgun", 4 ] ] ]
+    "components": [ [ [ "gunpowder_pistol", 4 ], [ "gunpowder_shotgun", 4 ] ] ]
   },
   {
     "result": "reloaded_380_JHP",
@@ -1552,7 +1552,7 @@
     "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 2 ], [ "ammo_380", 1 ] ],
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
     "//": "278 mg gunpowder rounded to 3 100 mg 'pieces'",
-    "components": [ [ [ "gunpowder", 3 ], [ "gunpowder_pistol", 3 ], [ "gunpowder_shotgun", 3 ] ], [ [ "copper", 1 ] ] ]
+    "components": [ [ [ "gunpowder_pistol", 3 ], [ "gunpowder_shotgun", 3 ] ], [ [ "copper", 1 ] ] ]
   },
   {
     "result": "reloaded_380_p",
@@ -1571,7 +1571,7 @@
     "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 2 ], [ "ammo_380", 1 ] ],
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
     "//": "320 mg gunpowder rounded to 3 100 mg 'pieces'",
-    "components": [ [ [ "gunpowder", 3 ], [ "gunpowder_pistol", 3 ], [ "gunpowder_shotgun", 3 ] ], [ [ "copper", 1 ] ] ]
+    "components": [ [ [ "gunpowder_pistol", 3 ], [ "gunpowder_shotgun", 3 ] ], [ [ "copper", 1 ] ] ]
   },
   {
     "result": "reloaded_380_FMJ",
@@ -1590,7 +1590,7 @@
     "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 2 ], [ "ammo_380", 1 ] ],
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
     "//": "278 mg gunpowder rounded to 3 100 mg 'pieces'",
-    "components": [ [ [ "gunpowder", 3 ], [ "gunpowder_pistol", 3 ], [ "gunpowder_shotgun", 3 ] ], [ [ "copper", 1 ] ] ]
+    "components": [ [ [ "gunpowder_pistol", 3 ], [ "gunpowder_shotgun", 3 ] ], [ [ "copper", 1 ] ] ]
   },
   {
     "result": "matchhead_9mm",

--- a/data/json/recipes/ammo/pistol.json
+++ b/data/json/recipes/ammo/pistol.json
@@ -1002,12 +1002,7 @@
     "using": [ [ "bullet_forming", 3 ], [ "ammo_bullet", 4 ] ],
     "//": "513 mg gunpowder rounded to 5 100 mg 'pieces'",
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
-    "components": [
-      [ [ "45_casing", 1 ] ],
-      [ [ "lgpistol_primer", 1 ] ],
-      [ [ "gunpowder_pistol", 5 ] ],
-      [ [ "copper", 1 ] ]
-    ]
+    "components": [ [ [ "45_casing", 1 ] ], [ [ "lgpistol_primer", 1 ] ], [ [ "gunpowder_pistol", 5 ] ], [ [ "copper", 1 ] ] ]
   },
   {
     "result": "reloaded_454_Casull",
@@ -1179,12 +1174,7 @@
     "//": "Unable to find load data, used 5.7 data as cartridges are similar. 388 mg gunpowder rounded to 4 100 mg 'pieces'",
     "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 1 ] ],
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
-    "components": [
-      [ [ "46mm_casing", 1 ] ],
-      [ [ "smpistol_primer", 1 ] ],
-      [ [ "gunpowder_pistol", 4 ] ],
-      [ [ "copper", 1 ] ]
-    ]
+    "components": [ [ [ "46mm_casing", 1 ] ], [ [ "smpistol_primer", 1 ] ], [ [ "gunpowder_pistol", 4 ] ], [ [ "copper", 1 ] ] ]
   },
   {
     "result": "reloaded_460_fmj",
@@ -1323,12 +1313,7 @@
     "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 1 ] ],
     "//": "388 mg gunpowder rounded to 4 100 mg 'pieces'",
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
-    "components": [
-      [ [ "57mm_casing", 1 ] ],
-      [ [ "smrifle_primer", 1 ] ],
-      [ [ "gunpowder_pistol", 4 ] ],
-      [ [ "copper", 1 ] ]
-    ]
+    "components": [ [ [ "57mm_casing", 1 ] ], [ [ "smrifle_primer", 1 ] ], [ [ "gunpowder_pistol", 4 ] ], [ [ "copper", 1 ] ] ]
   },
   {
     "result": "reloaded_762_25",

--- a/data/json/recipes/ammo/rifle.json
+++ b/data/json/recipes/ammo/rifle.json
@@ -54,7 +54,7 @@
     "using": [ [ "bullet_forming", 3 ], [ "ammo_bullet", 1 ] ],
     "//": "65 mg gunpowder rounded to 1 100 mg 'pieces'",
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
-    "components": [ [ [ "22_casing_new", 1 ] ], [ [ "gunpowder", 1 ], [ "gunpowder_pistol", 1 ] ], [ [ "copper", 1 ] ] ]
+    "components": [ [ [ "22_casing_new", 1 ] ], [ [ "gunpowder_pistol", 1 ] ], [ [ "copper", 1 ] ] ]
   },
   {
     "result": "reloaded_22_lr",
@@ -73,7 +73,7 @@
     "using": [ [ "bullet_forming", 2 ], [ "ammo_bullet", 1 ] ],
     "//": "65 mg gunpowder rounded to 1 100 mg 'pieces'",
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
-    "components": [ [ [ "22_casing_new", 1 ] ], [ [ "gunpowder", 1 ], [ "gunpowder_pistol", 1 ] ] ]
+    "components": [ [ [ "22_casing_new", 1 ] ], [ [ "gunpowder_pistol", 1 ] ] ]
   },
   {
     "result": "bp_22_fmj",
@@ -131,7 +131,7 @@
     "components": [
       [ [ "223_casing", 1 ] ],
       [ [ "smrifle_primer", 1 ] ],
-      [ [ "gunpowder", 15 ], [ "gunpowder_magnum_pistol", 15 ], [ "gunpowder_rifle", 15 ] ],
+      [ [ "gunpowder_magnum_pistol", 15 ], [ "gunpowder_rifle", 15 ] ],
       [ [ "copper", 1 ] ]
     ]
   },
@@ -170,7 +170,7 @@
     "using": [ [ "bullet_forming", 8 ], [ "ammo_bullet", 3 ], [ "ammo_270win", 1 ] ],
     "//": "2974 mg gunpowder rounded to 30 100 mg 'pieces'",
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
-    "components": [ [ [ "gunpowder", 30 ], [ "gunpowder_magnum_pistol", 30 ], [ "gunpowder_rifle", 30 ] ], [ [ "copper", 1 ] ] ]
+    "components": [ [ [ "gunpowder_magnum_pistol", 30 ], [ "gunpowder_rifle", 30 ] ], [ [ "copper", 1 ] ] ]
   },
   {
     "result": "bp_270win_jsp",
@@ -207,7 +207,7 @@
     "using": [ [ "bullet_forming", 8 ], [ "ammo_bullet", 3 ], [ "ammo_270win", 1 ] ],
     "//": "2974 mg gunpowder rounded to 30 100 mg 'pieces'",
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
-    "components": [ [ [ "gunpowder", 30 ], [ "gunpowder_magnum_pistol", 30 ], [ "gunpowder_rifle", 30 ] ], [ [ "copper", 1 ] ] ]
+    "components": [ [ [ "gunpowder_magnum_pistol", 30 ], [ "gunpowder_rifle", 30 ] ], [ [ "copper", 1 ] ] ]
   },
   {
     "result": "bp_270win_fmj",
@@ -247,7 +247,7 @@
     "components": [
       [ [ "300_casing", 1 ] ],
       [ [ "lgrifle_primer", 1 ] ],
-      [ [ "gunpowder", 43 ], [ "gunpowder_rifle", 43 ], [ "gunpowder_large_rifle", 43 ] ],
+      [ [ "gunpowder_rifle", 43 ], [ "gunpowder_large_rifle", 43 ] ],
       [ [ "copper", 2 ] ]
     ]
   },
@@ -286,7 +286,7 @@
     "using": [ [ "bullet_forming", 12 ], [ "ammo_bullet", 3 ], [ "ammo_3006", 1 ] ],
     "//": "3200 mg gunpowder rounded to 32 100 mg 'pieces'",
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
-    "components": [ [ [ "gunpowder", 32 ], [ "gunpowder_rifle", 32 ], [ "gunpowder_large_rifle", 32 ] ], [ [ "copper", 2 ] ] ]
+    "components": [ [ [ "gunpowder_rifle", 32 ], [ "gunpowder_large_rifle", 32 ] ], [ [ "copper", 2 ] ] ]
   },
   {
     "result": "reloaded_3006_jsp",
@@ -305,7 +305,7 @@
     "using": [ [ "bullet_forming", 12 ], [ "ammo_bullet", 3 ], [ "ammo_3006", 1 ] ],
     "//": "3200 mg gunpowder rounded to 32 100 mg 'pieces'",
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
-    "components": [ [ [ "gunpowder", 32 ], [ "gunpowder_rifle", 32 ], [ "gunpowder_large_rifle", 32 ] ], [ [ "copper", 2 ] ] ]
+    "components": [ [ [ "gunpowder_rifle", 32 ], [ "gunpowder_large_rifle", 32 ] ], [ [ "copper", 2 ] ] ]
   },
   {
     "result": "reloaded_3006fmj",
@@ -324,11 +324,7 @@
     "using": [ [ "bullet_forming", 12 ], [ "ammo_bullet", 2 ], [ "ammo_3006", 1 ] ],
     "//": "3175 mg gunpowder rounded to 32 100 mg 'pieces'",
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
-    "components": [
-      [ [ "gunpowder", 32 ], [ "gunpowder_rifle", 32 ], [ "gunpowder_large_rifle", 32 ] ],
-      [ [ "scrap", 1 ] ],
-      [ [ "copper", 2 ] ]
-    ]
+    "components": [ [ [ "gunpowder_rifle", 32 ], [ "gunpowder_large_rifle", 32 ] ], [ [ "scrap", 1 ] ], [ [ "copper", 2 ] ] ]
   },
   {
     "result": "reloaded_3006_incendiary",
@@ -348,7 +344,7 @@
     "//": "3175 mg gunpowder rounded to 32 100 mg 'pieces'",
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
     "components": [
-      [ [ "gunpowder", 32 ], [ "gunpowder_magnum_pistol", 32 ], [ "gunpowder_rifle", 32 ], [ "gunpowder_large_rifle", 32 ] ],
+      [ [ "gunpowder_magnum_pistol", 32 ], [ "gunpowder_rifle", 32 ], [ "gunpowder_large_rifle", 32 ] ],
       [ [ "copper", 2 ] ],
       [ [ "incendiary", 8 ] ]
     ]
@@ -443,7 +439,7 @@
     "//": "2700 mg gunpowder rounded to 28 100 mg 'pieces'.  168gr SB HPBT 2200, .308 win case, 0.474in s.depth, 2.014 c.len, 2.704g h4895 hodgdon.",
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
     "components": [
-      [ [ "gunpowder", 27 ], [ "gunpowder_magnum_pistol", 27 ], [ "gunpowder_rifle", 27 ], [ "gunpowder_large_rifle", 27 ] ],
+      [ [ "gunpowder_magnum_pistol", 27 ], [ "gunpowder_rifle", 27 ], [ "gunpowder_large_rifle", 27 ] ],
       [ [ "copper", 1 ] ]
     ]
   },
@@ -466,7 +462,7 @@
     "//": "2600 mg gunpowder rounded to 26 100 mg 'pieces'.  168gr SB HPBT 2200, 7.62x51nato case, 0.474in s.depth, 2.014 c.len, 2.605g h4895 hodgdon.",
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
     "components": [
-      [ [ "gunpowder", 26 ], [ "gunpowder_magnum_pistol", 26 ], [ "gunpowder_rifle", 26 ], [ "gunpowder_large_rifle", 26 ] ],
+      [ [ "gunpowder_magnum_pistol", 26 ], [ "gunpowder_rifle", 26 ], [ "gunpowder_large_rifle", 26 ] ],
       [ [ "copper", 1 ] ]
     ]
   },
@@ -527,7 +523,7 @@
     "components": [
       [ [ "4570_casing", 1 ] ],
       [ [ "lgrifle_primer", 1 ] ],
-      [ [ "gunpowder", 28 ], [ "gunpowder_rifle", 28 ], [ "gunpowder_magnum_pistol", 28 ] ],
+      [ [ "gunpowder_rifle", 28 ], [ "gunpowder_magnum_pistol", 28 ] ],
       [ [ "lead", 5 ] ],
       [ [ "copper", 3 ] ]
     ]
@@ -552,7 +548,7 @@
     "components": [
       [ [ "4570_casing", 1 ] ],
       [ [ "lgrifle_primer", 1 ] ],
-      [ [ "gunpowder", 30 ], [ "gunpowder_magnum_pistol", 30 ], [ "gunpowder_rifle", 30 ] ],
+      [ [ "gunpowder_magnum_pistol", 30 ], [ "gunpowder_rifle", 30 ] ],
       [ [ "copper", 5 ] ]
     ]
   },
@@ -576,7 +572,7 @@
     "components": [
       [ [ "4570_casing", 1 ] ],
       [ [ "lgrifle_primer", 1 ] ],
-      [ [ "gunpowder", 19 ], [ "gunpowder_magnum_pistol", 19 ], [ "gunpowder_rifle", 19 ] ],
+      [ [ "gunpowder_magnum_pistol", 19 ], [ "gunpowder_rifle", 19 ] ],
       [ [ "copper", 3 ] ]
     ]
   },
@@ -615,12 +611,7 @@
     "using": [ [ "bullet_forming", 18 ], [ "ammo_bullet", 12 ] ],
     "//": "15800 mg gunpowder rounded to 158 100 mg 'pieces'",
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
-    "components": [
-      [ [ "50_casing", 1 ] ],
-      [ [ "lgrifle_primer", 1 ] ],
-      [ [ "gunpowder", 158 ], [ "gunpowder_large_rifle", 158 ] ],
-      [ [ "copper", 6 ] ]
-    ]
+    "components": [ [ [ "50_casing", 1 ] ], [ [ "lgrifle_primer", 1 ] ], [ [ "gunpowder_large_rifle", 158 ] ], [ [ "copper", 6 ] ] ]
   },
   {
     "result": "bp_50match",
@@ -660,7 +651,7 @@
     "components": [
       [ [ "50_casing", 1 ] ],
       [ [ "lgrifle_primer", 1 ] ],
-      [ [ "gunpowder", 158 ], [ "gunpowder_large_rifle", 158 ] ],
+      [ [ "gunpowder_large_rifle", 158 ] ],
       [ [ "copper", 6 ] ],
       [ [ "incendiary", 20 ] ]
     ]
@@ -709,7 +700,7 @@
     "components": [
       [ [ "50_casing", 1 ] ],
       [ [ "lgrifle_primer", 1 ] ],
-      [ [ "gunpowder", 158 ], [ "gunpowder_large_rifle", 158 ] ],
+      [ [ "gunpowder_large_rifle", 158 ] ],
       [ [ "scrap", 1 ] ],
       [ [ "copper", 6 ] ]
     ]
@@ -758,7 +749,7 @@
     "components": [
       [ [ "545_casing", 1 ] ],
       [ [ "smrifle_primer", 1 ] ],
-      [ [ "gunpowder", 13 ], [ "gunpowder_magnum_pistol", 13 ], [ "gunpowder_rifle", 13 ] ],
+      [ [ "gunpowder_magnum_pistol", 13 ], [ "gunpowder_rifle", 13 ] ],
       [ [ "copper", 1 ] ]
     ]
   },
@@ -800,7 +791,7 @@
     "components": [
       [ [ "545_casing", 1 ] ],
       [ [ "smrifle_primer", 1 ] ],
-      [ [ "gunpowder", 13 ], [ "gunpowder_magnum_pistol", 13 ], [ "gunpowder_rifle", 13 ] ],
+      [ [ "gunpowder_magnum_pistol", 13 ], [ "gunpowder_rifle", 13 ] ],
       [ [ "copper", 1 ] ]
     ]
   },
@@ -839,7 +830,7 @@
     "using": [ [ "bullet_forming", 4 ], [ "ammo_bullet", 3 ], [ "ammo_300blk", 1 ] ],
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
     "//": "1133 mg gunpowder rounded to 11 100 mg 'pieces'",
-    "components": [ [ [ "gunpowder", 11 ], [ "gunpowder_rifle", 11 ] ], [ [ "copper", 1 ] ] ]
+    "components": [ [ [ "gunpowder_rifle", 11 ] ], [ [ "copper", 1 ] ] ]
   },
   {
     "result": "bp_300blk",
@@ -879,7 +870,7 @@
     "components": [
       [ [ "223_casing", 1 ] ],
       [ [ "smrifle_primer", 1 ] ],
-      [ [ "gunpowder", 17 ], [ "gunpowder_magnum_pistol", 17 ], [ "gunpowder_rifle", 17 ] ],
+      [ [ "gunpowder_magnum_pistol", 17 ], [ "gunpowder_rifle", 17 ] ],
       [ [ "copper", 2 ] ]
     ]
   },
@@ -903,7 +894,7 @@
     "components": [
       [ [ "223_casing", 1 ] ],
       [ [ "smrifle_primer", 1 ] ],
-      [ [ "gunpowder", 17 ], [ "gunpowder_rifle", 17 ], [ "gunpowder_magnum_pistol", 17 ] ],
+      [ [ "gunpowder_rifle", 17 ], [ "gunpowder_magnum_pistol", 17 ] ],
       [ [ "copper", 1 ] ],
       [ [ "incendiary", 2 ] ]
     ]
@@ -967,7 +958,7 @@
     "using": [ [ "bullet_forming", 8 ], [ "ammo_bullet", 5 ], [ "ammo_458wm", 1 ] ],
     "//": "4296 mg gunpowder rounded to 43 100 mg 'pieces'",
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
-    "components": [ [ [ "gunpowder", 43 ], [ "gunpowder_large_rifle", 43 ] ], [ [ "copper", 10 ] ] ]
+    "components": [ [ [ "gunpowder_large_rifle", 43 ] ], [ [ "copper", 10 ] ] ]
   },
   {
     "result": "bp_458wm",
@@ -1004,7 +995,7 @@
     "using": [ [ "bullet_forming", 9 ], [ "ammo_bullet", 3 ], [ "ammo_762_51", 1 ] ],
     "//": "2812 mg gunpowder rounded to 28 100 mg 'pieces'. .308 146gr Norma FMJ spitz 67651, seated 0.324in, 7.62x51 case, 2.812g Hodgdon H4895.",
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
-    "components": [ [ [ "gunpowder", 28 ], [ "gunpowder_rifle", 28 ], [ "gunpowder_magnum_pistol", 28 ] ], [ [ "copper", 2 ] ] ]
+    "components": [ [ [ "gunpowder_rifle", 28 ], [ "gunpowder_magnum_pistol", 28 ] ], [ [ "copper", 2 ] ] ]
   },
   {
     "result": "reloaded_762_51",
@@ -1024,7 +1015,7 @@
     "using": [ [ "bullet_forming", 9 ], [ "ammo_bullet", 3 ], [ "ammo_308", 1 ] ],
     "//": "2915 mg gunpowder rounded to 29 100 mg 'pieces'. .308 146gr Norma FMJ spitz 67651, seated 0.324in, .308 win case, 2915mg Hodgdon H4895.",
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
-    "components": [ [ [ "gunpowder", 29 ], [ "gunpowder_rifle", 29 ], [ "gunpowder_magnum_pistol", 29 ] ], [ [ "copper", 2 ] ] ]
+    "components": [ [ [ "gunpowder_rifle", 29 ], [ "gunpowder_magnum_pistol", 29 ] ], [ [ "copper", 2 ] ] ]
   },
   {
     "result": "reloaded_762_51_incendiary",
@@ -1044,7 +1035,7 @@
     "//": "2812 mg gunpowder rounded to 28 100 mg 'pieces'. .308 146gr Norma FMJ spitz 67651, seated 0.324in, 7.62x51 case, 2.812g Hodgdon H4895.",
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
     "components": [
-      [ [ "gunpowder", 28 ], [ "gunpowder_magnum_pistol", 28 ], [ "gunpowder_rifle", 28 ], [ "gunpowder_large_rifle", 28 ] ],
+      [ [ "gunpowder_magnum_pistol", 28 ], [ "gunpowder_rifle", 28 ], [ "gunpowder_large_rifle", 28 ] ],
       [ [ "copper", 2 ] ],
       [ [ "incendiary", 6 ] ]
     ]
@@ -1068,7 +1059,7 @@
     "//": "2915 mg gunpowder rounded to 29 100 mg 'pieces'. .308 146gr Norma FMJ spitz 67651, seated 0.324in, .308 win case, 2915mg Hodgdon H4895.",
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
     "components": [
-      [ [ "gunpowder", 29 ], [ "gunpowder_magnum_pistol", 29 ], [ "gunpowder_rifle", 29 ], [ "gunpowder_large_rifle", 29 ] ],
+      [ [ "gunpowder_magnum_pistol", 29 ], [ "gunpowder_rifle", 29 ], [ "gunpowder_large_rifle", 29 ] ],
       [ [ "copper", 2 ] ],
       [ [ "incendiary", 6 ] ]
     ]
@@ -1172,7 +1163,6 @@
       [ [ "762R_casing", 1 ] ],
       [ [ "lgrifle_primer", 1 ] ],
       [
-        [ "gunpowder", 29 ],
         [ "gunpowder_magnum_pistol", 29 ],
         [ "gunpowder_rifle", 29 ],
         [ "gunpowder_large_rifle", 29 ]
@@ -1218,7 +1208,7 @@
     "components": [
       [ [ "762_casing", 1 ] ],
       [ [ "lgrifle_primer", 1 ] ],
-      [ [ "gunpowder", 15 ], [ "gunpowder_magnum_pistol", 15 ], [ "gunpowder_rifle", 15 ] ],
+      [ [ "gunpowder_magnum_pistol", 15 ], [ "gunpowder_rifle", 15 ] ],
       [ [ "copper", 2 ] ]
     ]
   },
@@ -1260,7 +1250,7 @@
     "components": [
       [ [ "762_casing", 1 ] ],
       [ [ "lgrifle_primer", 1 ] ],
-      [ [ "gunpowder", 15 ], [ "gunpowder_magnum_pistol", 15 ], [ "gunpowder_rifle", 15 ] ],
+      [ [ "gunpowder_magnum_pistol", 15 ], [ "gunpowder_rifle", 15 ] ],
       [ [ "copper", 2 ] ]
     ]
   },
@@ -1315,7 +1305,7 @@
     "using": [ [ "bullet_forming", 12 ], [ "ammo_bullet", 3 ], [ "ammo_303", 1 ] ],
     "//": "3100 mg gunpowder rounded to 31 100 mg 'pieces'",
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
-    "components": [ [ [ "gunpowder", 31 ], [ "gunpowder_rifle", 31 ], [ "gunpowder_large_rifle", 31 ] ], [ [ "copper", 2 ] ] ]
+    "components": [ [ [ "gunpowder_rifle", 31 ], [ "gunpowder_large_rifle", 31 ] ], [ [ "copper", 2 ] ] ]
   },
   {
     "result": "reloaded_303fmj",
@@ -1334,7 +1324,7 @@
     "using": [ [ "bullet_forming", 12 ], [ "ammo_bullet", 3 ], [ "ammo_303", 1 ] ],
     "//": "3100 mg gunpowder rounded to 31 100 mg 'pieces'",
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
-    "components": [ [ [ "gunpowder", 31 ], [ "gunpowder_rifle", 31 ], [ "gunpowder_large_rifle", 31 ] ], [ [ "copper", 2 ] ] ]
+    "components": [ [ [ "gunpowder_rifle", 31 ], [ "gunpowder_large_rifle", 31 ] ], [ [ "copper", 2 ] ] ]
   },
   {
     "result": "reloaded_303sp",
@@ -1353,7 +1343,7 @@
     "using": [ [ "bullet_forming", 12 ], [ "ammo_bullet", 3 ], [ "ammo_303", 1 ] ],
     "//": "3100 mg gunpowder rounded to 31 100 mg 'pieces'",
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
-    "components": [ [ [ "gunpowder", 31 ], [ "gunpowder_rifle", 31 ], [ "gunpowder_large_rifle", 31 ] ], [ [ "copper", 2 ] ] ]
+    "components": [ [ [ "gunpowder_rifle", 31 ], [ "gunpowder_large_rifle", 31 ] ], [ [ "copper", 2 ] ] ]
   },
   {
     "result": "bp_303",
@@ -1429,7 +1419,7 @@
     "components": [
       [ [ "77arisaka_casing", 1 ] ],
       [ [ "lgrifle_primer", 1 ] ],
-      [ [ "gunpowder", 37 ], [ "gunpowder_rifle", 37 ], [ "gunpowder_large_rifle", 37 ] ],
+      [ [ "gunpowder_rifle", 37 ], [ "gunpowder_large_rifle", 37 ] ],
       [ [ "lead", 3 ] ],
       [ [ "copper", 3 ] ]
     ]
@@ -1475,7 +1465,7 @@
     "using": [ [ "bullet_forming", 20 ], [ "ammo_bullet", 1 ], [ "ammo_30carbine", 1 ] ],
     "//": "1004 mg gunpowder rounded to 10 100 mg 'pieces'",
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
-    "components": [ [ [ "gunpowder", 10 ], [ "gunpowder_magnum_pistol", 10 ], [ "gunpowder_rifle", 10 ] ], [ [ "copper", 1 ] ] ]
+    "components": [ [ [ "gunpowder_magnum_pistol", 10 ], [ "gunpowder_rifle", 10 ] ], [ [ "copper", 1 ] ] ]
   },
   {
     "result": "bp_30carbine",
@@ -1530,7 +1520,7 @@
     "using": [ [ "bullet_forming", 20 ], [ "ammo_bullet", 1 ], [ "ammo_30carbine", 1 ] ],
     "//": "1004 mg gunpowder rounded to 10 100 mg 'pieces'",
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
-    "components": [ [ [ "gunpowder", 10 ], [ "gunpowder_magnum_pistol", 10 ], [ "gunpowder_rifle", 10 ] ], [ [ "copper", 1 ] ] ]
+    "components": [ [ [ "gunpowder_magnum_pistol", 10 ], [ "gunpowder_rifle", 10 ] ], [ [ "copper", 1 ] ] ]
   },
   {
     "result": "bp_30carbine_jsp",
@@ -1588,7 +1578,7 @@
     "components": [
       [ [ "123ln_casing", 1 ] ],
       [ [ "lgrifle_primer", 1 ] ],
-      [ [ "gunpowder", 32 ], [ "gunpowder_rifle", 32 ], [ "gunpowder_large_rifle", 32 ] ],
+      [ [ "gunpowder_rifle", 32 ], [ "gunpowder_large_rifle", 32 ] ],
       [ [ "copper", 2 ] ]
     ]
   },
@@ -1630,7 +1620,7 @@
     "components": [
       [ [ "50beowulf_casing", 1 ] ],
       [ [ "lgpistol_primer", 1 ] ],
-      [ [ "gunpowder", 17 ], [ "gunpowder_rifle", 17 ], [ "gunpowder_magnum_pistol", 17 ] ],
+      [ [ "gunpowder_rifle", 17 ], [ "gunpowder_magnum_pistol", 17 ] ],
       [ [ "lead", 5 ] ],
       [ [ "copper", 3 ] ]
     ]
@@ -1655,7 +1645,7 @@
     "components": [
       [ [ "50beowulf_casing", 1 ] ],
       [ [ "lgpistol_primer", 1 ] ],
-      [ [ "gunpowder", 21 ], [ "gunpowder_magnum_pistol", 21 ], [ "gunpowder_rifle", 21 ] ],
+      [ [ "gunpowder_magnum_pistol", 21 ], [ "gunpowder_rifle", 21 ] ],
       [ [ "copper", 6 ] ]
     ]
   },
@@ -1723,7 +1713,7 @@
     "components": [
       [ [ "450_casing", 1 ] ],
       [ [ "smrifle_primer", 1 ] ],
-      [ [ "gunpowder", 37 ], [ "gunpowder_rifle", 37 ], [ "gunpowder_magnum_pistol", 37 ] ],
+      [ [ "gunpowder_rifle", 37 ], [ "gunpowder_magnum_pistol", 37 ] ],
       [ [ "lead", 5 ] ],
       [ [ "copper", 3 ] ]
     ]
@@ -1748,7 +1738,7 @@
     "components": [
       [ [ "450_casing", 1 ] ],
       [ [ "smrifle_primer", 1 ] ],
-      [ [ "gunpowder", 34 ], [ "gunpowder_magnum_pistol", 34 ], [ "gunpowder_rifle", 34 ] ],
+      [ [ "gunpowder_magnum_pistol", 34 ], [ "gunpowder_rifle", 34 ] ],
       [ [ "copper", 6 ] ]
     ]
   },
@@ -1816,7 +1806,7 @@
     "components": [
       [ [ "338lapua_casing", 1 ] ],
       [ [ "lgrifle_primer", 1 ] ],
-      [ [ "gunpowder", 58 ], [ "gunpowder_large_rifle", 58 ] ],
+      [ [ "gunpowder_large_rifle", 58 ] ],
       [ [ "lead", 5 ] ],
       [ [ "copper", 3 ] ]
     ]
@@ -1841,7 +1831,7 @@
     "components": [
       [ [ "338lapua_casing", 1 ] ],
       [ [ "lgrifle_primer", 1 ] ],
-      [ [ "gunpowder", 58 ], [ "gunpowder_large_rifle", 58 ] ],
+      [ [ "gunpowder_large_rifle", 58 ] ],
       [ [ "scrap", 1 ] ],
       [ [ "copper", 6 ] ]
     ]
@@ -1866,7 +1856,7 @@
     "components": [
       [ [ "338lapua_casing", 1 ] ],
       [ [ "lgrifle_primer", 1 ] ],
-      [ [ "gunpowder", 58 ], [ "gunpowder_large_rifle", 58 ] ],
+      [ [ "gunpowder_large_rifle", 58 ] ],
       [ [ "scrap", 1 ] ],
       [ [ "copper", 3 ] ],
       [ [ "incendiary", 6 ] ]

--- a/data/json/recipes/ammo/rifle.json
+++ b/data/json/recipes/ammo/rifle.json
@@ -1162,11 +1162,7 @@
     "components": [
       [ [ "762R_casing", 1 ] ],
       [ [ "lgrifle_primer", 1 ] ],
-      [
-        [ "gunpowder_magnum_pistol", 29 ],
-        [ "gunpowder_rifle", 29 ],
-        [ "gunpowder_large_rifle", 29 ]
-      ],
+      [ [ "gunpowder_magnum_pistol", 29 ], [ "gunpowder_rifle", 29 ], [ "gunpowder_large_rifle", 29 ] ],
       [ [ "copper", 2 ] ]
     ]
   },

--- a/data/json/recipes/ammo/shot.json
+++ b/data/json/recipes/ammo/shot.json
@@ -17,7 +17,7 @@
     "using": [ [ "shot_forming", 1 ], [ "ammo_bullet", 11 ], [ "ammo_shot", 1 ] ],
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
     "tools": [ [ [ "press", -1 ] ] ],
-    "components": [ [ [ "gunpowder", 12 ], [ "gunpowder_pistol", 12 ], [ "gunpowder_shotgun", 12 ] ] ]
+    "components": [ [ [ "gunpowder_pistol", 12 ], [ "gunpowder_shotgun", 12 ] ] ]
   },
   {
     "result": "reloaded_410shot_000",
@@ -37,7 +37,7 @@
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
     "tools": [ [ [ "press", -1 ] ] ],
     "//": "971 mg gunpowder rounded to 10 100 mg 'pieces'",
-    "components": [ [ [ "gunpowder", 10 ], [ "gunpowder_pistol", 10 ], [ "gunpowder_shotgun", 10 ] ] ]
+    "components": [ [ [ "gunpowder_pistol", 10 ], [ "gunpowder_shotgun", 10 ] ] ]
   },
   {
     "result": "bp_410shot_000",
@@ -89,7 +89,7 @@
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
     "tools": [ [ [ "press", -1 ] ] ],
     "//": "1101 mg gunpowder rounded to 11 100 mg 'pieces'",
-    "components": [ [ [ "gunpowder", 11 ], [ "gunpowder_pistol", 11 ], [ "gunpowder_shotgun", 11 ] ] ]
+    "components": [ [ [ "gunpowder_pistol", 11 ], [ "gunpowder_shotgun", 11 ] ] ]
   },
   {
     "result": "bp_410shot_bird",
@@ -141,7 +141,7 @@
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
     "tools": [ [ [ "press", -1 ] ] ],
     "//": "971 mg gunpowder rounded to 10 100 mg 'pieces'",
-    "components": [ [ [ "gunpowder", 10 ], [ "gunpowder_pistol", 10 ], [ "gunpowder_shotgun", 10 ] ] ]
+    "components": [ [ [ "gunpowder_pistol", 10 ], [ "gunpowder_shotgun", 10 ] ] ]
   },
   {
     "result": "bp_410shot_slug",
@@ -193,7 +193,7 @@
     "tools": [ [ [ "press", -1 ] ] ],
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
     "components": [
-      [ [ "gunpowder", 10 ], [ "gunpowder_pistol", 10 ], [ "gunpowder_shotgun", 10 ] ],
+      [ [ "gunpowder_pistol", 10 ], [ "gunpowder_shotgun", 10 ] ],
       [
         [ "scrap", 1 ],
         [ "nails", 4, "LIST" ],
@@ -289,7 +289,7 @@
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
     "tools": [ [ [ "press", -1 ] ] ],
     "//": "1490 mg gunpowder rounded to 15 100 mg 'pieces'",
-    "components": [ [ [ "gunpowder", 15 ], [ "gunpowder_pistol", 15 ], [ "gunpowder_shotgun", 15 ] ] ]
+    "components": [ [ [ "gunpowder_pistol", 15 ], [ "gunpowder_shotgun", 15 ] ] ]
   },
   {
     "result": "reloaded_shot_dragon",
@@ -308,7 +308,7 @@
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
     "tools": [ [ [ "press", -1 ] ] ],
     "//": "same charge as a 1 oz load, could find no reference to actual loading data. 1490 mg gunpowder rounded to 15 100 mg 'pieces'",
-    "components": [ [ [ "gunpowder", 15 ], [ "gunpowder_pistol", 15 ], [ "gunpowder_shotgun", 15 ] ], [ [ "magnesium", 5 ] ] ]
+    "components": [ [ [ "gunpowder_pistol", 15 ], [ "gunpowder_shotgun", 15 ] ], [ [ "magnesium", 5 ] ] ]
   },
   {
     "result": "reloaded_shot_flechette",
@@ -328,7 +328,7 @@
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
     "tools": [ [ [ "press", -1 ] ] ],
     "//": "Wikipedia states the shells contain 20 7.3 grain flechettes for a 146 grain or 1/3 oz load. http://www.sabotdesigns.com/002.html lists flechette velocity at 1950 fps. Gunpowder charge is calculated as if it was a solid slug for sake of ease. 750 mg gunpowder rounded to 8 100 mg 'pieces",
-    "components": [ [ [ "gunpowder", 8 ], [ "gunpowder_pistol", 8 ], [ "gunpowder_shotgun", 8 ] ], [ [ "combatnail", 10 ] ] ]
+    "components": [ [ [ "gunpowder_pistol", 8 ], [ "gunpowder_shotgun", 8 ] ], [ [ "combatnail", 10 ] ] ]
   },
   {
     "result": "reloaded_shot_slug",
@@ -347,7 +347,7 @@
     "//": "assumes 1 oz slug. 1684 mg gunpowder rounded to 17 100 mg 'pieces'",
     "using": [ [ "bullet_forming", 1 ], [ "ammo_bullet", 10 ], [ "ammo_shot", 1 ] ],
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
-    "components": [ [ [ "gunpowder", 17 ], [ "gunpowder_pistol", 17 ], [ "gunpowder_shotgun", 17 ] ] ]
+    "components": [ [ [ "gunpowder_pistol", 17 ], [ "gunpowder_shotgun", 17 ] ] ]
   },
   {
     "result": "bp_shot_00",
@@ -517,7 +517,7 @@
     "//1": "currently halved inputs (rounding up) and result pending fix of casing duplication",
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
     "components": [
-      [ [ "gunpowder", 12 ], [ "gunpowder_pistol", 12 ], [ "gunpowder_shotgun", 12 ] ],
+      [ [ "gunpowder_pistol", 12 ], [ "gunpowder_shotgun", 12 ] ],
       [
         [ "scrap", 1 ],
         [ "nails", 5, "LIST" ],

--- a/data/json/recipes/recipe_ammo.json
+++ b/data/json/recipes/recipe_ammo.json
@@ -602,7 +602,7 @@
     "book_learn": [ [ "recipe_bullets", 2 ], [ "manual_shotgun", 2 ] ],
     "qualities": [ { "id": "CUT", "level": 2 } ],
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
-    "components": [ [ [ "gunpowder", 20 ], [ "chem_black_powder", 20 ] ], [ [ "lead", 24 ] ], [ [ "paper", 1 ], [ "aluminum_foil", 1 ] ] ]
+    "components": [ [ [ "chem_black_powder", 20 ] ], [ [ "lead", 24 ] ], [ [ "paper", 1 ], [ "aluminum_foil", 1 ] ] ]
   },
   {
     "type": "recipe",
@@ -619,7 +619,7 @@
     "qualities": [ { "id": "CUT", "level": 2 } ],
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
     "components": [
-      [ [ "gunpowder", 20 ], [ "chem_black_powder", 20 ] ],
+      [ [ "chem_black_powder", 20 ] ],
       [ [ "bb", 24 ], [ "clockworks", 1 ], [ "pebble", 16 ], [ "bearing", 16 ] ],
       [ [ "paper", 1 ], [ "aluminum_foil", 1 ] ]
     ]
@@ -640,7 +640,7 @@
     "qualities": [ { "id": "CUT", "level": 2 }, { "id": "SAW_M", "level": 1 } ],
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
     "components": [
-      [ [ "gunpowder", 20 ], [ "chem_black_powder", 20 ] ],
+      [ [ "chem_black_powder", 20 ] ],
       [ [ "scrap", 1 ], [ "nails", 8, "LIST" ], [ "copper", 16 ] ],
       [ [ "paper", 1 ], [ "aluminum_foil", 1 ] ]
     ]
@@ -661,7 +661,7 @@
     "qualities": [ { "id": "CUT", "level": 2 }, { "id": "HAMMER", "level": 1 } ],
     "using": [ [ "surface_heat", 2 ] ],
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
-    "components": [ [ [ "gunpowder", 20 ], [ "chem_black_powder", 20 ] ], [ [ "lead", 24 ] ], [ [ "paper", 1 ], [ "aluminum_foil", 1 ] ] ]
+    "components": [ [ [ "chem_black_powder", 20 ] ], [ [ "lead", 24 ] ], [ [ "paper", 1 ], [ "aluminum_foil", 1 ] ] ]
   },
   {
     "type": "recipe",
@@ -678,7 +678,7 @@
     "qualities": [ { "id": "CUT", "level": 2 } ],
     "proficiencies": [ { "proficiency": "prof_handloading" } ],
     "components": [
-      [ [ "gunpowder", 20 ], [ "chem_black_powder", 20 ] ],
+      [ [ "chem_black_powder", 20 ] ],
       [ [ "nails", 8, "LIST" ], [ "combatnail", 8 ] ],
       [ [ "paper", 1 ], [ "aluminum_foil", 1 ] ]
     ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Makes Mixed Smokeless only useful for pyro/explosives"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Mixed smokeless gunpowder should never have been permitted to be added to the game. It goes against CDDA's design principles, and I ~~added ~~ retained it only as a stopgap measure in #33310 .
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Removes Mixed smokeless from all of the recipes for ammunition.
Adjusts the description of mixed smokeless.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
None.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
loaded game. made some gunpowder. Observed recipes available.
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/7764202/ab82c4d7-73e7-4d99-bffa-3fcee9a2fbf6)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
None
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
