### PR TITLE
Add Hair Dye

### DIFF
--- a/data/json/effects_on_condition/npc_eocs/appearance_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/appearance_eocs.json
@@ -234,6 +234,137 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "apply_hair_dye",
+    "global": false,
+    "condition": { "expects_vars": [ "color_id" ] },
+    "effect": [
+      {
+        "if": { "u_has_trait": "hair_buzzcut" },
+        "then": [ { "u_lose_trait": "hair_buzzcut" }, { "u_add_trait": "hair_buzzcut", "variant": { "context_val": "color_id" } } ],
+        "else": {
+          "if": { "u_has_trait": "hair_crewcut" },
+          "then": [ { "u_lose_trait": "hair_crewcut" }, { "u_add_trait": "hair_crewcut", "variant": { "context_val": "color_id" } } ],
+          "else": {
+            "if": { "u_has_trait": "hair_short" },
+            "then": [ { "u_lose_trait": "hair_short" }, { "u_add_trait": "hair_short", "variant": { "context_val": "color_id" } } ],
+            "else": {
+              "if": { "u_has_trait": "hair_short_no_fringe" },
+              "then": [
+                { "u_lose_trait": "hair_short_no_fringe" },
+                { "u_add_trait": "hair_short_no_fringe", "variant": { "context_val": "color_id" } }
+              ],
+              "else": {
+                "if": { "u_has_trait": "hair_short_over_eye" },
+                "then": [
+                  { "u_lose_trait": "hair_short_over_eye" },
+                  { "u_add_trait": "hair_short_over_eye", "variant": { "context_val": "color_id" } }
+                ],
+                "else": {
+                  "if": { "or": [ { "u_has_trait": "hair_medium" } ] },
+                  "then": [ { "u_lose_trait": "hair_medium" }, { "u_add_trait": "hair_medium", "variant": { "context_val": "color_id" } } ],
+                  "else": {
+                    "if": { "u_has_trait": "hair_mohawk" },
+                    "then": [ { "u_lose_trait": "hair_mohawk" }, { "u_add_trait": "hair_mohawk", "variant": { "context_val": "color_id" } } ],
+                    "else": {
+                      "if": { "u_has_trait": "hair_long" },
+                      "then": [ { "u_lose_trait": "hair_long" }, { "u_add_trait": "hair_long", "variant": { "context_val": "color_id" } } ],
+                      "else": {
+                        "if": { "u_has_trait": "hair_long_mohawk" },
+                        "then": [
+                          { "u_lose_trait": "hair_long_mohawk" },
+                          { "u_add_trait": "hair_long_mohawk", "variant": { "context_val": "color_id" } }
+                        ],
+                        "else": {
+                          "if": { "u_has_trait": "hair_mullet" },
+                          "then": [ { "u_lose_trait": "hair_mullet" }, { "u_add_trait": "hair_mullet", "variant": { "context_val": "color_id" } } ],
+                          "else": {
+                            "if": { "u_has_trait": "hair_long_over_eye" },
+                            "then": [
+                              { "u_lose_trait": "hair_long_over_eye" },
+                              { "u_add_trait": "hair_long_over_eye", "variant": { "context_val": "color_id" } }
+                            ],
+                            "else": {
+                              "if": { "or": [ { "u_has_trait": "hair_messy" } ] },
+                              "then": [ { "u_lose_trait": "hair_messy" }, { "u_add_trait": "hair_messy", "variant": { "context_val": "color_id" } } ],
+                              "else": {
+                                "if": { "or": [ { "u_has_trait": "hair_very_long" } ] },
+                                "then": [ { "u_lose_trait": "hair_very_long" }, { "u_add_trait": "hair_very_long", "variant": { "context_val": "color_id" } } ],
+                                "else": {
+                                  "if": { "or": [ { "u_has_trait": "hair_extremely_long" } ] },
+                                  "then": [
+                                    { "u_lose_trait": "hair_extremely_long" },
+                                    { "u_add_trait": "hair_extremely_long", "variant": { "context_val": "color_id" } }
+                                  ],
+                                  "else": {
+                                    "if": { "or": [ { "u_has_trait": "hair_body_length" } ] },
+                                    "then": [
+                                      { "u_lose_trait": "hair_body_length" },
+                                      { "u_add_trait": "hair_body_length", "variant": { "context_val": "color_id" } }
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "use_hair_dye_kit",
+    "effect": [
+      {
+        "run_eoc_selector": [
+          "black_hair_dye",
+          "blond_hair_dye",
+          "blue_hair_dye",
+          "brown_hair_dye",
+          "gray_hair_dye",
+          "green_hair_dye",
+          "red_hair_dye",
+          "pink_hair_dye",
+          "white_hair_dye",
+          "EOC_NONE"
+        ],
+        "names": [
+          "Black Dye",
+          "Blond Dye",
+          "Blue Dye",
+          "Brown Dye",
+          "Gray Dye",
+          "Green Dye",
+          "Red Dye",
+          "Pink Dye",
+          "White Dye",
+          "Nevermind"
+        ],
+        "keys": [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "0" ],
+        "descriptions": [
+          "Dye your hair black.",
+          "Dye your hair blond.",
+          "Dye your hair blue.",
+          "Dye your hair brown.",
+          "Dye your hair gray.",
+          "Dye your hair green.",
+          "Dye your hair red.",
+          "Dye your hair pink.",
+          "Dye your hair white.",
+          "Don't do anything."
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "assign_random_natural_hair_color",
     "condition": {
       "and": [
@@ -321,5 +452,95 @@
       { "u_add_var": "natural_hair_color_red", "type": "mutation", "context": "hair_color", "value": "yes" },
       { "u_add_var": "picked_hair_color", "type": "mutation", "context": "hair_color", "value": "yes" }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "black_hair_dye",
+    "condition": { "u_has_item": "hair_dye_black" },
+    "effect": [
+      { "u_message": "You finish dyeing your hair." },
+      { "run_eoc_with": "apply_hair_dye", "variables": { "color_id": "black" } }
+    ],
+    "false_effect": [ { "u_message": "You don't have any black hair dye!" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "blond_hair_dye",
+    "condition": { "u_has_item": "hair_dye_blond" },
+    "effect": [
+      { "u_message": "You finish dyeing your hair." },
+      { "run_eoc_with": "apply_hair_dye", "variables": { "color_id": "blond" } }
+    ],
+    "false_effect": [ { "u_message": "You don't have any blond hair dye!" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "blue_hair_dye",
+    "condition": { "u_has_item": "hair_dye_blue" },
+    "effect": [
+      { "u_message": "You finish dyeing your hair." },
+      { "run_eoc_with": "apply_hair_dye", "variables": { "color_id": "blue" } }
+    ],
+    "false_effect": [ { "u_message": "You don't have any blue hair dye!" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "brown_hair_dye",
+    "condition": { "u_has_item": "hair_dye_brown" },
+    "effect": [
+      { "u_message": "You finish dyeing your hair." },
+      { "run_eoc_with": "apply_hair_dye", "variables": { "color_id": "brown" } }
+    ],
+    "false_effect": [ { "u_message": "You don't have any brown hair dye!" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "gray_hair_dye",
+    "condition": { "u_has_item": "hair_dye_gray" },
+    "effect": [
+      { "u_message": "You finish dyeing your hair." },
+      { "run_eoc_with": "apply_hair_dye", "variables": { "color_id": "gray" } }
+    ],
+    "false_effect": [ { "u_message": "You don't have any gray hair dye!" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "green_hair_dye",
+    "condition": { "u_has_item": "hair_dye_green" },
+    "effect": [
+      { "u_message": "You finish dyeing your hair." },
+      { "run_eoc_with": "apply_hair_dye", "variables": { "color_id": "green" } }
+    ],
+    "false_effect": [ { "u_message": "You don't have any green hair dye!" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "red_hair_dye",
+    "condition": { "u_has_item": "hair_dye_red" },
+    "effect": [
+      { "u_message": "You finish dyeing your hair." },
+      { "run_eoc_with": "apply_hair_dye", "variables": { "color_id": "red" } }
+    ],
+    "false_effect": [ { "u_message": "You don't have any red hair dye!" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "pink_hair_dye",
+    "condition": { "u_has_item": "hair_dye_pink" },
+    "effect": [
+      { "u_message": "You finish dyeing your hair." },
+      { "run_eoc_with": "apply_hair_dye", "variables": { "color_id": "pink" } }
+    ],
+    "false_effect": [ { "u_message": "You don't have any pink hair dye!" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "white_hair_dye",
+    "condition": { "u_has_item": "hair_dye_white" },
+    "effect": [
+      { "u_message": "You finish dyeing your hair." },
+      { "run_eoc_with": "apply_hair_dye", "variables": { "color_id": "white" } }
+    ],
+    "false_effect": [ { "u_message": "You don't have any white hair dye!" } ]
   }
 ]

--- a/data/json/itemgroups/supplies.json
+++ b/data/json/itemgroups/supplies.json
@@ -915,5 +915,27 @@
     "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_glass",
     "entries": [ { "item": "chem_acrylamide", "container-item": "null", "count-min": 1 } ]
+  },
+  {
+    "id": "hair_dye",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "hair_dye_black", "prob": 70, "charges-min": 2, "charges-max": 2 },
+      { "item": "hair_dye_blond", "prob": 70, "charges-min": 2, "charges-max": 2 },
+      { "item": "hair_dye_blue", "prob": 30, "charges-min": 2, "charges-max": 2 },
+      { "item": "hair_dye_brown", "prob": 70, "charges-min": 2, "charges-max": 2 },
+      { "item": "hair_dye_gray", "prob": 50, "charges-min": 2, "charges-max": 2 },
+      { "item": "hair_dye_green", "prob": 30, "charges-min": 2, "charges-max": 2 },
+      { "item": "hair_dye_red", "prob": 30, "charges-min": 2, "charges-max": 2 },
+      { "item": "hair_dye_pink", "prob": 30, "charges-min": 2, "charges-max": 2 },
+      { "item": "hair_dye_white", "prob": 70, "charges-min": 2, "charges-max": 2 }
+    ]
+  },
+  {
+    "id": "hair_dye_display",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [ { "item": "hair_dye_kit", "prob": 100 }, { "group": "hair_dye", "prob": 90 } ]
   }
 ]

--- a/data/json/items/resources/chemicals.json
+++ b/data/json/items/resources/chemicals.json
@@ -176,5 +176,95 @@
     "ammo_type": "components",
     "container": "bottle_plastic_small",
     "count": 2500
+  },
+  {
+    "type": "COMESTIBLE",
+    "id": "abstract_hair_dye",
+    "category": "other",
+    "price": 2000,
+    "price_postapoc": 3000,
+    "name": { "str_sp": "hair dye" },
+    "description": "Some hair dye.",
+    "symbol": "o",
+    "color": "red",
+    "material": [ "paint" ],
+    "volume": "250 ml",
+    "weight": "250 g",
+    "phase": "liquid",
+    "comestible_type": "INVALID",
+    "container": "bottle_plastic",
+    "freezing_point": -4,
+    "charges": 1
+  },
+  {
+    "type": "COMESTIBLE",
+    "id": "hair_dye_black",
+    "name": { "str_sp": "black hair dye" },
+    "description": "Some black hair dye.",
+    "copy-from": "abstract_hair_dye",
+    "color": "black"
+  },
+  {
+    "type": "COMESTIBLE",
+    "id": "hair_dye_blond",
+    "name": { "str_sp": "blond hair dye" },
+    "description": "Some blond hair dye.",
+    "copy-from": "abstract_hair_dye",
+    "color": "yellow"
+  },
+  {
+    "type": "COMESTIBLE",
+    "id": "hair_dye_blue",
+    "name": { "str_sp": "blue hair dye" },
+    "description": "Some blue hair dye.",
+    "copy-from": "abstract_hair_dye",
+    "color": "blue"
+  },
+  {
+    "type": "COMESTIBLE",
+    "id": "hair_dye_brown",
+    "name": { "str_sp": "brown hair dye" },
+    "description": "Some brown hair dye.",
+    "copy-from": "abstract_hair_dye",
+    "color": "brown"
+  },
+  {
+    "type": "COMESTIBLE",
+    "id": "hair_dye_gray",
+    "name": { "str_sp": "gray hair dye" },
+    "description": "Some gray hair dye.",
+    "copy-from": "abstract_hair_dye",
+    "color": "dark_gray"
+  },
+  {
+    "type": "COMESTIBLE",
+    "id": "hair_dye_green",
+    "name": { "str_sp": "green hair dye" },
+    "description": "Some green hair dye.",
+    "copy-from": "abstract_hair_dye",
+    "color": "green"
+  },
+  {
+    "type": "COMESTIBLE",
+    "id": "hair_dye_red",
+    "name": { "str_sp": "red hair dye" },
+    "description": "Some red hair dye.",
+    "copy-from": "abstract_hair_dye"
+  },
+  {
+    "type": "COMESTIBLE",
+    "id": "hair_dye_pink",
+    "name": { "str_sp": "pink hair dye" },
+    "description": "Some pink hair dye.",
+    "copy-from": "abstract_hair_dye",
+    "color": "pink"
+  },
+  {
+    "type": "COMESTIBLE",
+    "id": "hair_dye_white",
+    "name": { "str_sp": "white hair dye" },
+    "description": "Some white hair dye.",
+    "copy-from": "abstract_hair_dye",
+    "color": "white"
   }
 ]

--- a/data/json/items/tool/toiletries.json
+++ b/data/json/items/tool/toiletries.json
@@ -280,5 +280,21 @@
     "color": "yellow",
     "use_action": [ "WASH_ALL_ITEMS" ],
     "flags": [ "ALLOWS_REMOTE_USE", "NO_SALVAGE" ]
+  },
+  {
+    "id": "hair_dye_kit",
+    "type": "TOOL",
+    "name": { "str": "hair dye kit" },
+    "description": "A kit featuring all the tools needed to dye hair, inclduing an applicator brush, combs, and plastic gloves.  ",
+    "ascii_picture": "box_small",
+    "weight": "50 g",
+    "volume": "2250 ml",
+    "longest_side": "21 cm",
+    "price": 0,
+    "price_postapoc": 0,
+    "material": [ "cardboard", "plastic" ],
+    "symbol": ")",
+    "color": "brown",
+    "use_action": { "type": "effect_on_conditions", "description": "Dye your hair", "effect_on_conditions": [ "use_hair_dye_kit" ] }
   }
 ]

--- a/data/json/items/tool/toiletries.json
+++ b/data/json/items/tool/toiletries.json
@@ -285,7 +285,7 @@
     "id": "hair_dye_kit",
     "type": "TOOL",
     "name": { "str": "hair dye kit" },
-    "description": "A kit featuring all the tools needed to dye hair, including an applicator brush, combs, and plastic gloves.  ",
+    "description": "A kit featuring all the tools needed to dye hair, including an applicator brush, combs, and plastic gloves.",
     "ascii_picture": "box_small",
     "weight": "154 g",
     "volume": "2250 ml",

--- a/data/json/items/tool/toiletries.json
+++ b/data/json/items/tool/toiletries.json
@@ -285,7 +285,7 @@
     "id": "hair_dye_kit",
     "type": "TOOL",
     "name": { "str": "hair dye kit" },
-    "description": "A kit featuring all the tools needed to dye hair, inclduing an applicator brush, combs, and plastic gloves.  ",
+    "description": "A kit featuring all the tools needed to dye hair, inclduing an applicator brush, combs, and plastic gloves.",
     "ascii_picture": "box_small",
     "weight": "154 g",
     "volume": "2250 ml",

--- a/data/json/items/tool/toiletries.json
+++ b/data/json/items/tool/toiletries.json
@@ -285,7 +285,7 @@
     "id": "hair_dye_kit",
     "type": "TOOL",
     "name": { "str": "hair dye kit" },
-    "description": "A kit featuring all the tools needed to dye hair, inclduing an applicator brush, combs, and plastic gloves.  ",
+    "description": "A kit featuring all the tools needed to dye hair, includuing an applicator brush, combs, and plastic gloves.  ",
     "ascii_picture": "box_small",
     "weight": "154 g",
     "volume": "2250 ml",

--- a/data/json/items/tool/toiletries.json
+++ b/data/json/items/tool/toiletries.json
@@ -287,7 +287,7 @@
     "name": { "str": "hair dye kit" },
     "description": "A kit featuring all the tools needed to dye hair, inclduing an applicator brush, combs, and plastic gloves.  ",
     "ascii_picture": "box_small",
-    "weight": "50 g",
+    "weight": "154 g",
     "volume": "2250 ml",
     "longest_side": "21 cm",
     "price": 0,

--- a/data/json/mapgen/barber_shop.json
+++ b/data/json/mapgen/barber_shop.json
@@ -95,6 +95,7 @@
       "toilets": { "X": {  } },
       "items": {
         "M": { "item": "cash_register_random", "chance": 100 },
+        "V": { "item": "hair_dye_display", "chance": 70, "repeat": [ 3, 4 ] },
         "S": { "item": "SUS_dishes", "chance": 65 },
         "C": { "item": "SUS_silverware", "chance": 45 },
         "t": { "item": "trash", "chance": 25, "repeat": [ 1, 3 ] },

--- a/data/json/recipes/tools/tool.json
+++ b/data/json/recipes/tools/tool.json
@@ -1636,7 +1636,6 @@
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_TOOLS",
     "skill_used": "fabrication",
-    "difficulty": 0,
     "time": "5 m",
     "reversible": true,
     "autolearn": true,

--- a/data/json/recipes/tools/tool.json
+++ b/data/json/recipes/tools/tool.json
@@ -1628,5 +1628,18 @@
     "using": [ [ "sewing_aramids", 50 ], [ "adhesive", 4 ] ],
     "proficiencies": [ { "proficiency": "prof_polymerworking", "required": false, "time_multiplier": 1.5 } ],
     "components": [ [ [ "rock_wool_bat", 22 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "result": "hair_dye_kit",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_TOOLS",
+    "skill_used": "fabrication",
+    "difficulty": 0,
+    "time": "5 m",
+    "reversible": true,
+    "autolearn": true,
+    "components": [ [ [ "hairbrush", 1 ] ], [ [ "box_small", 1 ] ], [ [ "comb_pocket", 1 ] ], [ [ "gloves_medical", 1 ] ] ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Add hair dye."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Add hair dyes, with a way to use them to change hair color. Part of an ongoing cosmetic project.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Using EOCs, add a hair dye kit that players can find in barber shops, allowing them to apply a hair dye of their choice. This includes all of the current colors of hair, black, brown, blond, blue, white, gray, pink, green, and red.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not doing this.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Walked around barber shops and found the hair dye kits and bottles of dye. Applied each as such, testing with tilesets. Hair color successfully changed with no hiccups.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Currently, hair dye is permanent and doesn't wear off, unless your hair grows out with Natural Hair Growth. I'd like to add dye to it's own independent timer that wears off after 6-8 weeks.

After everything else is done, #71919 should probably be considered for artificial coloring purposes.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
