### PR TITLE
github: build sdl2 locally for linux releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,8 +215,16 @@ jobs:
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux' && matrix.mxe == 'none' && matrix.android == 'none' && !matrix.wasm
         run: |
+          git clone https://github.com/libsdl-org/SDL.git --branch release-2.0.20 --depth 1
+          cd SDL
+          mkdir build
+          cd build
+          ../configure
+          make -j$((`nproc`+0))
+          sudo make install
+          cp ../LICENSE.txt ${{ github.workspace }}/LICENSE-SDL.txt
           sudo apt-get update
-          sudo apt-get install libncursesw5-dev libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev \
+          sudo apt-get install libncursesw5-dev libsdl2-ttf-dev libsdl2-image-dev \
             libsdl2-mixer-dev libpulse-dev ccache gettext parallel
       - name: Install Emscripten (WebAssembly)
         if: matrix.wasm

--- a/Makefile
+++ b/Makefile
@@ -895,6 +895,11 @@ endif
 
 ifeq ($(TARGETSYSTEM),LINUX)
   BINDIST_EXTRAS += cataclysm-launcher
+  ifneq ("$(wildcard LICENSE-SDL.txt)","")
+    SDL2_solib = $(shell ldd $(TARGET) | grep libSDL2-2\.0 | cut -d ' ' -f 3)
+    INSTALL_EXTRAS += $(SDL2_solib)
+    BINDIST_EXTRAS += LICENSE-SDL.txt
+  endif
   ifeq ($(BACKTRACE),1)
     # -rdynamic needed for symbols in backtraces
     LDFLAGS += -rdynamic
@@ -1296,6 +1301,7 @@ endif  # ifeq ($(NATIVE), osx)
 $(BINDIST): distclean version $(TARGET) $(L10N) $(BINDIST_EXTRAS) $(BINDIST_LOCALE)
 	mkdir -p $(BINDIST_DIR)
 	cp -R $(TARGET) $(BINDIST_EXTRAS) $(BINDIST_DIR)
+	$(foreach lib,$(INSTALL_EXTRAS), install --strip $(lib) $(BINDIST_DIR))
 ifdef LANGUAGES
 	cp -R --parents lang/mo $(BINDIST_DIR)
 endif

--- a/cataclysm-launcher
+++ b/cataclysm-launcher
@@ -45,7 +45,7 @@ fi
 
 if [ "$BIN" ]
 then
-    exec ./$BIN "$@"
+    env LD_LIBRARY_PATH="${DIR}:${LD_LIBRARY_PATH}" ./"${BIN}" "$@"
 else
     printerr "Couldn't find cataclysm game binary in '$DIR'/"
     exit 1


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
imgui needs SDL-2.0.17 but our ubuntu LTS target only ships 2.0.10

* Alternative to: #72024
* Closes: #72022

#### Describe the solution

Build SDL2-2.0.20 (same version as used in CI) locally and include the solib in the bindist
Update the launcher to set LD_LIBRARY_PATH so the binary picks up the shipped library

#### Describe alternatives you've considered

Targeting a newer Ubuntu release like in #72024: this breaks the implicit promise of supporting ubuntu LTS releases. Maybe nobody ever said the words "we promise to support ubuntu LTS releases", but the tooling decisions, build environment, and project history set the expectation that we should.

#### Testing
Ran the binary from [this release](https://github.com/andrei8l/Cataclysm-DDA/releases/tag/cdda-experimental-2024-02-28-0441) from [this job](https://github.com/andrei8l/Cataclysm-DDA/actions/runs/8075384961/job/22062203842), in an Ubuntu 20.04 VM

![Screenshot from 2024-02-28 07-07-15](https://github.com/CleverRaven/Cataclysm-DDA/assets/68240139/15a01dfc-968a-4c14-87b6-d902c000574d)



#### Additional context
Note that this only works when the game is launched with the `cataclysm-launcher` script. Third-party launchers may need to be updated.
