### PR TITLE
[MoM] Update Night Eyes to the NIGHT_VIS enchantment

### DIFF
--- a/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
+++ b/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
@@ -157,7 +157,7 @@ This is natural painkiller and so has natural effects (reduces speed slightly)<b
 *Duration*: 12 minutes to 23 minutes 20 seconds, plus 6 minutes 12 seconds to 13 minutes 30 seconds minutes per level<br />
 *Stamina Cost*: 1500, minus 65 per level to a minimum of 500<br />
 *Channeling Time*: 50 moves, minus 2 moves per level to a minimum of 20<br />
-*Effects*: Allows the psion to see in the dark.  This is a range multiplier on base night vision, beginning at 2x normal night vision, that increases every 3 power levels: 4x normal at level 6, 6x normal at level 9, and so on.<br />
+*Effects*: Allows the psion to see in the dark.  This increases the psion's night vision by 2 squares plus 1.5 squares per power level.<br />
 *Prerequisites*: Starting power<br />
 
 ## Speed Reader (C)

--- a/data/mods/MindOverMatter/effects/effects_psionic.json
+++ b/data/mods/MindOverMatter/effects/effects_psionic.json
@@ -545,146 +545,26 @@
     "type": "effect_type",
     "id": "effect_clair_night_eyes",
     "//": "Hidden effect, used as a tracker",
-    "name": [ "" ],
-    "desc": [ "" ],
-    "rating": "good",
-    "max_duration": "7 days"
-  },
-  {
-    "type": "effect_type",
-    "id": "effect_clair_night_eyes_1",
     "name": [ "Night Eyes" ],
     "desc": [ "You can sense your surroundings in the dark." ],
     "apply_message": "",
     "remove_message": "The darkness hides your surroundings again.",
-    "decay_messages": [
-      [ "The shadows are growing darker and darker to your sight.", "bad" ],
-      [ "Darkness begins to creep across your vision.", "bad" ]
-    ],
     "rating": "good",
     "max_duration": "7 days",
-    "max_intensity": 106,
-    "limb_score_mods": [ { "limb_score": "night_vis", "modifier": 2 } ],
-    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
-  },
-  {
-    "type": "effect_type",
-    "id": "effect_clair_night_eyes_2",
-    "name": [ "Night Eyes" ],
-    "desc": [ "You can sense your surroundings in the dark." ],
-    "apply_message": "",
-    "remove_message": "The darkness hides your surroundings again.",
-    "decay_messages": [
-      [ "The shadows are growing darker and darker to your sight.", "bad" ],
-      [ "Darkness begins to creep across your vision.", "bad" ]
-    ],
-    "rating": "good",
-    "max_duration": "7 days",
-    "max_intensity": 106,
-    "limb_score_mods": [ { "limb_score": "night_vis", "modifier": 4 } ],
-    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
-  },
-  {
-    "type": "effect_type",
-    "id": "effect_clair_night_eyes_3",
-    "name": [ "Night Eyes" ],
-    "desc": [ "You can sense your surroundings in the dark." ],
-    "apply_message": "",
-    "remove_message": "The darkness hides your surroundings again.",
-    "decay_messages": [
-      [ "The shadows are growing darker and darker to your sight.", "bad" ],
-      [ "Darkness begins to creep across your vision.", "bad" ]
-    ],
-    "rating": "good",
-    "max_duration": "7 days",
-    "max_intensity": 106,
-    "limb_score_mods": [ { "limb_score": "night_vis", "modifier": 6 } ],
-    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
-  },
-  {
-    "type": "effect_type",
-    "id": "effect_clair_night_eyes_4",
-    "name": [ "Night Eyes" ],
-    "desc": [ "You can sense your surroundings in the dark." ],
-    "apply_message": "",
-    "remove_message": "The darkness hides your surroundings again.",
-    "decay_messages": [
-      [ "The shadows are growing darker and darker to your sight.", "bad" ],
-      [ "Darkness begins to creep across your vision.", "bad" ]
-    ],
-    "rating": "good",
-    "max_duration": "7 days",
-    "max_intensity": 106,
-    "limb_score_mods": [ { "limb_score": "night_vis", "modifier": 8 } ],
-    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
-  },
-  {
-    "type": "effect_type",
-    "id": "effect_clair_night_eyes_5",
-    "name": [ "Night Eyes" ],
-    "desc": [ "You can sense your surroundings in the dark." ],
-    "apply_message": "",
-    "remove_message": "The darkness hides your surroundings again.",
-    "decay_messages": [
-      [ "The shadows are growing darker and darker to your sight.", "bad" ],
-      [ "Darkness begins to creep across your vision.", "bad" ]
-    ],
-    "rating": "good",
-    "max_duration": "7 days",
-    "max_intensity": 106,
-    "limb_score_mods": [ { "limb_score": "night_vis", "modifier": 10 } ],
-    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
-  },
-  {
-    "type": "effect_type",
-    "id": "effect_clair_night_eyes_6",
-    "name": [ "Night Eyes" ],
-    "desc": [ "You can sense your surroundings in the dark." ],
-    "apply_message": "",
-    "remove_message": "The darkness hides your surroundings again.",
-    "decay_messages": [
-      [ "The shadows are growing darker and darker to your sight.", "bad" ],
-      [ "Darkness begins to creep across your vision.", "bad" ]
-    ],
-    "rating": "good",
-    "max_duration": "7 days",
-    "max_intensity": 106,
-    "limb_score_mods": [ { "limb_score": "night_vis", "modifier": 12 } ],
-    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
-  },
-  {
-    "type": "effect_type",
-    "id": "effect_clair_night_eyes_7",
-    "name": [ "Night Eyes" ],
-    "desc": [ "You can sense your surroundings in the dark." ],
-    "apply_message": "",
-    "remove_message": "The darkness hides your surroundings again.",
-    "decay_messages": [
-      [ "The shadows are growing darker and darker to your sight.", "bad" ],
-      [ "Darkness begins to creep across your vision.", "bad" ]
-    ],
-    "rating": "good",
-    "max_duration": "7 days",
-    "max_intensity": 106,
-    "limb_score_mods": [ { "limb_score": "night_vis", "modifier": 14 } ],
-    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
-  },
-  {
-    "type": "effect_type",
-    "id": "effect_clair_night_eyes_8",
-    "name": [ "Night Eyes" ],
-    "desc": [ "You can sense your surroundings in the dark." ],
-    "apply_message": "",
-    "remove_message": "The darkness hides your surroundings again.",
-    "decay_messages": [
-      [ "The shadows are growing darker and darker to your sight.", "bad" ],
-      [ "Darkness begins to creep across your vision.", "bad" ]
-    ],
-    "rating": "good",
-    "max_duration": "7 days",
-    "max_intensity": 106,
-    "limb_score_mods": [ { "limb_score": "night_vis", "modifier": 16 } ],
-    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
+    "enchantments": [
+      {
+        "values": [
+          {
+            "value": "NIGHT_VIS",
+            "add": {
+              "math": [
+                "( ( ( u_spell_level('clair_night_vision') * 1.5) + 2 ) * (scaling_factor(u_val('intelligence') ) ) ) * u_nether_attunement_power_scaling"
+              ]
+            }
+          }
+        ]
+      }
+    ]
   },
   {
     "type": "effect_type",

--- a/data/mods/MindOverMatter/obsolete/effects.json
+++ b/data/mods/MindOverMatter/obsolete/effects.json
@@ -1,5 +1,5 @@
 [
-   {
+  {
     "type": "effect_type",
     "id": "effect_clair_night_eyes_1",
     "name": [ "Night Eyes" ],

--- a/data/mods/MindOverMatter/obsolete/effects.json
+++ b/data/mods/MindOverMatter/obsolete/effects.json
@@ -1,0 +1,138 @@
+[
+   {
+    "type": "effect_type",
+    "id": "effect_clair_night_eyes_1",
+    "name": [ "Night Eyes" ],
+    "desc": [ "You can sense your surroundings in the dark." ],
+    "apply_message": "",
+    "remove_message": "The darkness hides your surroundings again.",
+    "decay_messages": [
+      [ "The shadows are growing darker and darker to your sight.", "bad" ],
+      [ "Darkness begins to creep across your vision.", "bad" ]
+    ],
+    "rating": "good",
+    "max_duration": "7 days",
+    "max_intensity": 106,
+    "limb_score_mods": [ { "limb_score": "night_vis", "modifier": 2 } ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_clair_night_eyes_2",
+    "name": [ "Night Eyes" ],
+    "desc": [ "You can sense your surroundings in the dark." ],
+    "apply_message": "",
+    "remove_message": "The darkness hides your surroundings again.",
+    "decay_messages": [
+      [ "The shadows are growing darker and darker to your sight.", "bad" ],
+      [ "Darkness begins to creep across your vision.", "bad" ]
+    ],
+    "rating": "good",
+    "max_duration": "7 days",
+    "max_intensity": 106,
+    "limb_score_mods": [ { "limb_score": "night_vis", "modifier": 4 } ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_clair_night_eyes_3",
+    "name": [ "Night Eyes" ],
+    "desc": [ "You can sense your surroundings in the dark." ],
+    "apply_message": "",
+    "remove_message": "The darkness hides your surroundings again.",
+    "decay_messages": [
+      [ "The shadows are growing darker and darker to your sight.", "bad" ],
+      [ "Darkness begins to creep across your vision.", "bad" ]
+    ],
+    "rating": "good",
+    "max_duration": "7 days",
+    "max_intensity": 106,
+    "limb_score_mods": [ { "limb_score": "night_vis", "modifier": 6 } ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_clair_night_eyes_4",
+    "name": [ "Night Eyes" ],
+    "desc": [ "You can sense your surroundings in the dark." ],
+    "apply_message": "",
+    "remove_message": "The darkness hides your surroundings again.",
+    "decay_messages": [
+      [ "The shadows are growing darker and darker to your sight.", "bad" ],
+      [ "Darkness begins to creep across your vision.", "bad" ]
+    ],
+    "rating": "good",
+    "max_duration": "7 days",
+    "max_intensity": 106,
+    "limb_score_mods": [ { "limb_score": "night_vis", "modifier": 8 } ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_clair_night_eyes_5",
+    "name": [ "Night Eyes" ],
+    "desc": [ "You can sense your surroundings in the dark." ],
+    "apply_message": "",
+    "remove_message": "The darkness hides your surroundings again.",
+    "decay_messages": [
+      [ "The shadows are growing darker and darker to your sight.", "bad" ],
+      [ "Darkness begins to creep across your vision.", "bad" ]
+    ],
+    "rating": "good",
+    "max_duration": "7 days",
+    "max_intensity": 106,
+    "limb_score_mods": [ { "limb_score": "night_vis", "modifier": 10 } ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_clair_night_eyes_6",
+    "name": [ "Night Eyes" ],
+    "desc": [ "You can sense your surroundings in the dark." ],
+    "apply_message": "",
+    "remove_message": "The darkness hides your surroundings again.",
+    "decay_messages": [
+      [ "The shadows are growing darker and darker to your sight.", "bad" ],
+      [ "Darkness begins to creep across your vision.", "bad" ]
+    ],
+    "rating": "good",
+    "max_duration": "7 days",
+    "max_intensity": 106,
+    "limb_score_mods": [ { "limb_score": "night_vis", "modifier": 12 } ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_clair_night_eyes_7",
+    "name": [ "Night Eyes" ],
+    "desc": [ "You can sense your surroundings in the dark." ],
+    "apply_message": "",
+    "remove_message": "The darkness hides your surroundings again.",
+    "decay_messages": [
+      [ "The shadows are growing darker and darker to your sight.", "bad" ],
+      [ "Darkness begins to creep across your vision.", "bad" ]
+    ],
+    "rating": "good",
+    "max_duration": "7 days",
+    "max_intensity": 106,
+    "limb_score_mods": [ { "limb_score": "night_vis", "modifier": 14 } ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_clair_night_eyes_8",
+    "name": [ "Night Eyes" ],
+    "desc": [ "You can sense your surroundings in the dark." ],
+    "apply_message": "",
+    "remove_message": "The darkness hides your surroundings again.",
+    "decay_messages": [
+      [ "The shadows are growing darker and darker to your sight.", "bad" ],
+      [ "Darkness begins to creep across your vision.", "bad" ]
+    ],
+    "rating": "good",
+    "max_duration": "7 days",
+    "max_intensity": 106,
+    "limb_score_mods": [ { "limb_score": "night_vis", "modifier": 16 } ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
+  }
+]

--- a/data/mods/MindOverMatter/obsolete/eocs.json
+++ b/data/mods/MindOverMatter/obsolete/eocs.json
@@ -15,5 +15,22 @@
         ]
       }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CLAIR_NIGHT_EYES_SWITCHER",
+    "effect": {
+      "switch": { "math": [ "u_spell_level('clair_night_vision')" ] },
+      "cases": [
+        { "case": 0, "effect": { "u_add_effect": "effect_clair_night_eyes_1", "duration": "PERMANENT" } },
+        { "case": 3, "effect": { "u_add_effect": "effect_clair_night_eyes_2", "duration": "PERMANENT" } },
+        { "case": 6, "effect": { "u_add_effect": "effect_clair_night_eyes_3", "duration": "PERMANENT" } },
+        { "case": 9, "effect": { "u_add_effect": "effect_clair_night_eyes_4", "duration": "PERMANENT" } },
+        { "case": 12, "effect": { "u_add_effect": "effect_clair_night_eyes_5", "duration": "PERMANENT" } },
+        { "case": 15, "effect": { "u_add_effect": "effect_clair_night_eyes_6", "duration": "PERMANENT" } },
+        { "case": 18, "effect": { "u_add_effect": "effect_clair_night_eyes_7", "duration": "PERMANENT" } },
+        { "case": 21, "effect": { "u_add_effect": "effect_clair_night_eyes_8", "duration": "PERMANENT" } }
+      ]
+    }
   }
 ]

--- a/data/mods/MindOverMatter/powers/clairsentience_concentration_eocs.json
+++ b/data/mods/MindOverMatter/powers/clairsentience_concentration_eocs.json
@@ -5,7 +5,7 @@
     "condition": { "not": { "u_has_effect": "effect_clair_night_eyes" } },
     "effect": [
       { "u_message": "You open your senses to the world.", "type": "good" },
-      { "run_eocs": [ "EOC_POWER_MAINTENANCE_PLUS_ONE", "EOC_CLAIR_NIGHT_EYES_SWITCHER" ] },
+      { "run_eocs": [ "EOC_POWER_MAINTENANCE_PLUS_ONE" ] },
       { "u_add_effect": "effect_clair_night_eyes", "duration": "PERMANENT" },
       { "u_cast_spell": { "id": "psionic_drained_difficulty_one", "hit_self": true } },
       {
@@ -25,23 +25,6 @@
       }
     ],
     "false_effect": [ { "run_eocs": "EOC_CLAIR_REMOVE_NIGHT_EYES" } ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_CLAIR_NIGHT_EYES_SWITCHER",
-    "effect": {
-      "switch": { "math": [ "u_spell_level('clair_night_vision')" ] },
-      "cases": [
-        { "case": 0, "effect": { "u_add_effect": "effect_clair_night_eyes_1", "duration": "PERMANENT" } },
-        { "case": 3, "effect": { "u_add_effect": "effect_clair_night_eyes_2", "duration": "PERMANENT" } },
-        { "case": 6, "effect": { "u_add_effect": "effect_clair_night_eyes_3", "duration": "PERMANENT" } },
-        { "case": 9, "effect": { "u_add_effect": "effect_clair_night_eyes_4", "duration": "PERMANENT" } },
-        { "case": 12, "effect": { "u_add_effect": "effect_clair_night_eyes_5", "duration": "PERMANENT" } },
-        { "case": 15, "effect": { "u_add_effect": "effect_clair_night_eyes_6", "duration": "PERMANENT" } },
-        { "case": 18, "effect": { "u_add_effect": "effect_clair_night_eyes_7", "duration": "PERMANENT" } },
-        { "case": 21, "effect": { "u_add_effect": "effect_clair_night_eyes_8", "duration": "PERMANENT" } }
-      ]
-    }
   },
   {
     "type": "effect_on_condition",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Update Night Eyes to the NIGHT_VIS enchantment"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Night Eyes previously used the night_vis limb_score, which did work but was a multiplier on night vision, so it was possible (and easy) to stack up extremely high such that you could see better at night than during the day. NIGHT_VIS is additive (when using `add`), so less likely to rocket up extremely high as quickly. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Obsolete old Night Eyes effects. Rework tracker effect to be the effect and scale at 2 + (level * 1.5) extra squares of night vision. This is affected by Nether Attunement etc as normal, so at high levels of attunement you can still see as well or better at night than during the day.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Level 6 Night Eyes:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/120433252/996771d7-23ab-4b36-9c1a-23880beb57e7)

Level 12 Night Eyes:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/120433252/b986e5a3-3138-4e5e-ba88-d2890e3cf4c0)

Level 12 Night Eyes with Nether Attunement (10):
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/120433252/6b9ef3fe-a794-483b-971d-e66454929ba3)


All pictures taken with Intelligence 8--more intelligence will have a better effect.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
