### PR TITLE
clear window line by line, skipping untouched lines

### DIFF
--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -1162,7 +1162,7 @@ static bool draw_window( Font_Ptr &font, const catacurses::window &w, const poin
 
     bool update = false;
     for( int j = 0; j < win->height; j++ ) {
-        if( !win->line[j].touched ){
+        if( !win->line[j].touched ) {
             continue;
         }
 

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -1155,7 +1155,6 @@ static bool draw_window( Font_Ptr &font, const catacurses::window &w, const poin
                                   WindowHeight / scaling_factor );
     }
 
-    clear_window_area( w );
     cata_cursesport::WINDOW *const win = w.get<cata_cursesport::WINDOW>();
 
     // TODO: Get this from UTF system to make sure it is exactly the kind of space we need
@@ -1163,6 +1162,18 @@ static bool draw_window( Font_Ptr &font, const catacurses::window &w, const poin
 
     bool update = false;
     for( int j = 0; j < win->height; j++ ) {
+        if( !win->line[j].touched ){
+            continue;
+        }
+
+        // Although it would be simpler to clear the whole window at
+        // once, the code sometimes creates overlapping windows. By
+        // only clearing those lines that are touched, we avoid
+        // clearing lines that were already drawn in a previous
+        // window but are untouched in this one.
+        geometry->rect( renderer, point( win->pos.x * fontwidth, ( win->pos.y + j ) * fontheight ),
+                        win->width * fontwidth, fontheight,
+                        color_as_sdl( catacurses::black ) );
         update = true;
         win->line[j].touched = false;
         for( int i = 0; i < win->width; i++ ) {


### PR DESCRIPTION
#### Summary
Bugfixes "fix windows with missing header text"

#### Purpose of change

#### Describe the solution
Many of the windows in the game, especially the ones with scrollbars, create multiple overlapping windows and then draw them in an odd order. This results in overdraw, but that was partly compensated for by the cache that we removed. Now that we clear the whole window in one go, this causes artifacts as we erase text that was already drawn in a different window that overlaps the current one. By erasing only the lines that are touched, we avoid the problem.

Fixes #71994.

#### Describe alternatives you've considered
We could just change every window to avoid the overdraw. It is almost always because it goes back and calls `draw_scrollbar` to add a scrollbar to the window after it has already drawn the window border and header text. By moving the call to `draw_scrollbar` up so that it happens before printing the header text, the problem would also be avoided.

#### Testing
I just manually tried out every window I could find that has a header and a scrollbar, including those mentioned in the bug report.
