### PR TITLE
Limit the value of studying spell books

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -3993,24 +3993,24 @@ void activity_handlers::study_spell_do_turn( player_activity *act, Character *yo
         }
         const int old_level = studying.get_level();
         const int max_level_from_study = 3;
-        if ( old_level < max_level_from_study ) {
-        // Gain some experience from studying
-        const int xp = roll_remainder( studying.exp_modifier( *you ) / to_turns<float>( 6_seconds ) );
-        act->values[0] += xp;
-        studying.gain_exp( *you, xp );
-        bool leveled_up = you->practice( studying.skill(), xp, studying.get_difficulty( *you ), true );
-        if( leveled_up &&
-            studying.get_difficulty( *you ) < static_cast<int>( you->get_skill_level( studying.skill() ) ) ) {
-            you->handle_skill_warning( studying.skill(),
-                                       true ); // show the skill warning on level up, since we suppress it in practice() above
+        if( old_level < max_level_from_study ) {
+            // Gain some experience from studying
+            const int xp = roll_remainder( studying.exp_modifier( *you ) / to_turns<float>( 6_seconds ) );
+            act->values[0] += xp;
+            studying.gain_exp( *you, xp );
+            bool leveled_up = you->practice( studying.skill(), xp, studying.get_difficulty( *you ), true );
+            if( leveled_up &&
+                studying.get_difficulty( *you ) < static_cast<int>( you->get_skill_level( studying.skill() ) ) ) {
+                you->handle_skill_warning( studying.skill(),
+                                           true ); // show the skill warning on level up, since we suppress it in practice() above
+            }
+            // Notify player if the spell leveled up
+            if( studying.get_level() > old_level ) {
+                you->add_msg_if_player( m_good, _( "You gained a level in %s!" ), studying.name() );
+            }
+        } else if( old_level >= max_level_from_study ) {
+            end_activtity_function();
         }
-        // Notify player if the spell leveled up
-        if( studying.get_level() > old_level ) {
-            you->add_msg_if_player( m_good, _( "You gained a level in %s!" ), studying.name() );
-        }
-} else if ( old_level >= max_level_from_study ) {
-end_activtity_function();
-}
     }
 }
 

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -4009,7 +4009,7 @@ void activity_handlers::study_spell_do_turn( player_activity *act, Character *yo
                 you->add_msg_if_player( m_good, _( "You gained a level in %s!" ), studying.name() );
             }
         } else if( old_level >= max_level_from_study ) {
-            end_activtity_function();
+            act->moves_left = 0;
         }
     }
 }

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -3992,6 +3992,8 @@ void activity_handlers::study_spell_do_turn( player_activity *act, Character *yo
             }
         }
         const int old_level = studying.get_level();
+        const int max_level_from_study = 3;
+        if ( old_level < max_level_from_study ) {
         // Gain some experience from studying
         const int xp = roll_remainder( studying.exp_modifier( *you ) / to_turns<float>( 6_seconds ) );
         act->values[0] += xp;
@@ -4006,6 +4008,9 @@ void activity_handlers::study_spell_do_turn( player_activity *act, Character *yo
         if( studying.get_level() > old_level ) {
             you->add_msg_if_player( m_good, _( "You gained a level in %s!" ), studying.name() );
         }
+} else if ( old_level >= max_level_from_study ) {
+end_activtity_function();
+}
     }
 }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance " Limit studying spellbooks"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Since MAgiclysm was added in repo we've received dozens of reports of players ruining their own fun by spending weeks reading spellbooks to maximize spell level.  I have decided to take aim at this issue.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Limit's studying from spellbooks ability to level a spell above level 3.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Level 5, a percentage of the spell's max level, and jsonizing level per spell.  
5 Maybe, convince me.
Percentage, I don't know how
Jsonizing, never, people will once again optimize themselves out of playing the game.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Testing once it compiles
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
