### PR TITLE
Allow artifacts with negative resonance (neg cap at -1k)

### DIFF
--- a/src/relic.cpp
+++ b/src/relic.cpp
@@ -799,10 +799,10 @@ relic relic_procgen_data::generate( const relic_procgen_data::generation_rules &
         }
     }
 
-    //add an optional enchantment of the value of ret's power (the artifact being created) - resonance is equal to its power (min zero)
+    //add an optional enchantment of the value of ret's power (the artifact being created) - resonance is equal to its power
     if( rules.resonant ) {
         enchant_cache resonance;
-        int value = std::max( 0, ret.power_level( id ) );
+        int value = std::max( -1000, ret.power_level( id ) );
         resonance.add_value_add( enchant_vals::mod::ARTIFACT_RESONANCE, value );
         resonance.set_has( enchantment::has::HELD );
         ret.add_passive_effect( resonance );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Allow artifacts with negative resonance"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

I like the grind of hunting for artifacts. And I LOVE min-maxing items/skills for a character. Since artifacts aren't allowed a negative resonance, after getting 2-3 artifacts, hunting for more feels really useless. Allowing some artifacts to have at most -1000 resonance, makes hunting for more artifacts feel worthwhile for me. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Making negative resonance artifacts somehow special, but for now, it's just a matter of RNG. If you get lucky, you will find one with enough negative traits to have negative resonance.

Future work should include making these artifacts feel even more unique. 

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

![kuva](https://github.com/CleverRaven/Cataclysm-DDA/assets/56438982/1dd1e847-9d60-4f56-99bb-4ee5161cdcff)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
