### PR TITLE
Reset user customized `*` actions to default keybindings

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -3353,6 +3353,17 @@
   },
   {
     "type": "keybinding",
+    "id": "RESET",
+    "category": "HELP_KEYBINDINGS",
+    "name": "Reset keybinding",
+    "bindings": [
+      { "input_method": "keyboard_char", "key": "*" },
+      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" }
+    ]
+  },
+  {
+    "type": "keybinding",
     "id": "ADD_LOCAL",
     "category": "HELP_KEYBINDINGS",
     "name": "Add local keybinding",

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -844,30 +844,33 @@ input_manager::t_input_event_list &input_manager::get_or_create_event_list(
     return actions[action_descriptor].input_events;
 }
 
-void input_manager::remove_input_for_action(
+bool input_manager::remove_input_for_action(
     const std::string &action_descriptor, const std::string &context )
 {
     const t_action_contexts::iterator action_context = action_contexts.find( context );
-    if( action_context != action_contexts.end() ) {
-        t_actions &actions = action_context->second;
-        t_actions::iterator action = actions.find( action_descriptor );
-        if( action != actions.end() ) {
-            if( action->second.is_user_created ) {
-                // Since this is a user created hotkey, remove it so that the
-                // user will fallback to the hotkey in the default context.
-                actions.erase( action );
-            } else {
-                // If a context no longer has any keybindings remaining for an action but
-                // there's an attempt to remove bindings anyway, presumably the user wants
-                // to fully remove the binding from that context.
-                if( action->second.input_events.empty() ) {
-                    actions.erase( action );
-                } else {
-                    action->second.input_events.clear();
-                }
-            }
-        }
+    if( action_context == action_contexts.end() ) {
+        return false;
     }
+    t_actions &actions = action_context->second;
+    t_actions::iterator action = actions.find( action_descriptor );
+    if( action == actions.end() ) {
+        return false;
+    }
+    if( action->second.is_user_created ) {
+        // Since this is a user created hotkey, remove it so that the
+        // user will fallback to the hotkey in the default context.
+        actions.erase( action );
+        return true;
+    }
+    // If a context no longer has any keybindings remaining for an action but
+    // there's an attempt to remove bindings anyway, presumably the user wants
+    // to fully remove the binding from that context.
+    if( action->second.input_events.empty() ) {
+        actions.erase( action );
+        return true;
+    }
+    action->second.input_events.clear();
+    return false;
 }
 
 void input_manager::add_input_for_action(

--- a/src/input.h
+++ b/src/input.h
@@ -329,7 +329,10 @@ class input_manager
 
         t_input_event_list &get_or_create_event_list( const std::string &action_descriptor,
                 const std::string &context );
-        void remove_input_for_action( const std::string &action_descriptor, const std::string &context );
+        /**
+         * @return true if `remove_input_for_action` uncovers potentially new global keys. These could cause conflicts.
+         */
+        bool remove_input_for_action( const std::string &action_descriptor, const std::string &context );
         void add_input_for_action( const std::string &action_descriptor, const std::string &context,
                                    const input_event &event );
 

--- a/src/input_context.cpp
+++ b/src/input_context.cpp
@@ -612,7 +612,7 @@ keybindings_ui::keybindings_ui( bool permit_execute_action,
     legend.push_back( colorize( _( "Unbound keys" ), unbound_key ) );
     legend.push_back( colorize( _( "Keybinding active only on this screen" ), local_key ) );
     legend.push_back( colorize( _( "Keybinding active globally" ), global_key ) );
-    legend.push_back( colorize( _( "* User created" ), global_key ) );
+    legend.push_back( colorize( _( "* User customized" ), global_key ) );
     if( permit_execute_action ) {
         legend.push_back( string_format(
                               _( "Press %c to execute action\n" ),
@@ -915,7 +915,7 @@ action_id input_context::display_menu_legacy( const bool permit_execute_action )
     legend += colorize( _( "Unbound keys" ), unbound_key ) + "\n";
     legend += colorize( _( "Keybinding active only on this screen" ), local_key ) + "\n";
     legend += colorize( _( "Keybinding active globally" ), global_key ) + "\n";
-    legend += colorize( _( "* User created" ), global_key ) + "\n";
+    legend += colorize( _( "* User customized" ), global_key ) + "\n";
     if( permit_execute_action ) {
         legend += string_format(
                       _( "Press %c to execute action\n" ),

--- a/src/input_context.h
+++ b/src/input_context.h
@@ -315,6 +315,7 @@ class input_context
                          kb_menu_status status );
         /**
          * Remove an action.
+         * Prompt the user to resolve conflicts if they arise.
          * @return true if keybinding changed
          */
         bool action_remove( const std::string &name, const std::string &action_id, bool is_local,
@@ -427,13 +428,23 @@ class input_context
          */
         std::string get_conflicts( const input_event &event, const std::string &ignore_action ) const;
         /**
-         * Clear an input_event from all conflicting keybindings that are
-         * registered by this input_context.
+         * Clear an input_event from all conflicting keybindings (excluding conflicts for `ignore_action`) that are
+         * registered by this input_context in default and current context (see `category`).
          *
          * @param event The input event to be cleared from conflicting
          * keybindings.
          */
-        void clear_conflicting_keybindings( const input_event &event );
+        void clear_conflicting_keybindings( const input_event &event, const std::string &ignore_action );
+        /**
+         * Find all conflicts for all `events` (excluding conflicts for `ignore_action`).
+         * If there are any, prompt the user "Should they be cleared?".
+         * Then, clear all input_events from all conflicting keybindings (actions)
+         * in both the default and current context (see `category`).
+         *
+         * @param events The input events to be cleared from conflicting actions
+         * @return true if cleared (user agreed) or if no conflicts found
+         */
+        bool resolve_conflicts( const std::vector<input_event> &events, const std::string &ignore_action );
         /**
          * Filter a vector of strings by a phrase, returning only strings that contain the phrase.
          *

--- a/src/input_context.h
+++ b/src/input_context.h
@@ -299,10 +299,10 @@ class input_context
         void register_navigate_ui_list();
 
         /**
-         * Displays the possible actions in the current context and their
+         * Display the possible actions in the current context and their
          * keybindings.
          * @param permit_execute_action If `true` the function allows the user to specify an action to execute
-         * @returns action_id of any action the user specified to execute, or ACTION_NULL if none
+         * @return action_id of any action the user specified to execute, or ACTION_NULL if none
          */
         action_id display_menu( bool permit_execute_action = false );
     private:

--- a/src/input_context.h
+++ b/src/input_context.h
@@ -307,6 +307,12 @@ class input_context
         action_id display_menu( bool permit_execute_action = false );
     private:
         /**
+         * Reset action to default keybindings.
+         * Prompt the user to resolve conflicts if they arise.
+         * @return true if keybinding changed
+         */
+        bool action_reset( const std::string &action_id );
+        /**
          * Prompt the user to add an event to an action.
          * Prompt the user to resolve conflicts if they arise.
          * @return true if keybinding changed

--- a/src/input_context.h
+++ b/src/input_context.h
@@ -17,6 +17,8 @@
 #include "point.h"
 #include "translation.h"
 
+enum class kb_menu_status;
+
 class hotkey_queue;
 #if !defined(__ANDROID__)
 class keybindings_ui;
@@ -303,6 +305,21 @@ class input_context
          * @returns action_id of any action the user specified to execute, or ACTION_NULL if none
          */
         action_id display_menu( bool permit_execute_action = false );
+    private:
+        /**
+         * Prompt the user to add an event to an action.
+         * Prompt the user to resolve conflicts if they arise.
+         * @return true if keybinding changed
+         */
+        bool action_add( const std::string &name, const std::string &action_id, bool is_local,
+                         kb_menu_status status );
+        /**
+         * Remove an action.
+         * @return true if keybinding changed
+         */
+        bool action_remove( const std::string &name, const std::string &action_id, bool is_local,
+                            bool is_empty );
+    public:
 
         /**
          * Temporary method to retrieve the raw input received, so that input_contexts


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "User now can reset customized keybindings to default"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Resolve #71040

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add new button, when clicked / `*` is pressed, the user can select KBs of which action to reset.
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/835e8cd8-d383-4ed2-8d19-b91669eb386a)
Doing that will reset the KB as expected.

When an action's KBs are reset, they can add some KBs that were already in use. Also, when the user removes `-` local KB, it can reveal underlying global KBs. These could have been in use too. This causes a conflict.

Conflict was already solved for adding a single local `+` or global `=` KB. I generalized this to multiple conflicts, a vector of conflicting KBs.

I used conflict resolution in removing `-` action's KBs. This fixes the following bug (or rather a way to get this bug):
**bug**: The same key is bound to two actions.
**reproduction steps**:
1. Have two actions with global KBs (A, B), pick a KB from A (`j` in our case).
 ![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/bc59f478-59d8-4c8e-a753-0d1fb0340d1d)
2. Add some local KB to A (`ctrl + P` in our case)
 ![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/e0c3f644-2e22-4c1e-9c74-8cae7877c9b7)
3. Add `j` as local `+` KB to B
 ![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/78198060-4516-476a-b424-13fd53dd63ea)
4. Remove `-` KBs from A
 ![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/389e426f-274b-43bf-b1c9-ac5706f24a16)
5. Observe that `j` is bound to two actions. This is a mistake, CDDA isn't prepared for that.

In the new version, after step 4, we get the following conflict resolution menu:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/344c49b3-69fe-4d3b-8dab-d7137720988a)
- `No` undoes step 4 - the keybinding isn't removed
- `Yes` removes conflicts
 ![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/4405a564-e978-4527-8042-616aba74f406)

The conflict resolution menu can handle multiple events:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/9427709f-8519-4cc4-9b67-06a1f299bb3d)

The same menu is used for resetting an action's KBs. There, we want to reset to some set of default KBs. This set is checked against KBs already in use and for conflicts, the conflict resolution menu appears.
- `Yes` - conflicts removed and selected action is reset to default KBs
- `No` - nothing happens

The add local `+` or global `=` KB uses the same conflict resolution menu.
BEFORE
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/7a3b5023-1963-4b8a-9129-0aebf124ec44)





<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Too minor to list.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I did the above. It compiled it and it worked.

This all is supported in the imgui screen too:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/634a78a1-9927-4aad-8ae4-ba636e8f1f4a)

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/56b366d6-8f08-4d80-a6fb-69bd3c26b181)
Though, in there, it is possible the conflict window cannot fit the window width (the popups in imgui don't guarantee that).
Also, there isn't the newline before "Continue?" for some reason. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
It should be "remove keybinding<ins>s</ins>" and "reset keybinding<ins>s</ins>", but that would remove a nice symmetry.
Or "remove action" and "reset action", but we don't need to bother the player with what an `action` is.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
