### PR TITLE
Fixing an ImGui issue where static popups draw at the center of the screen

### DIFF
--- a/src/popup.cpp
+++ b/src/popup.cpp
@@ -41,7 +41,7 @@ class query_popup_impl : public cataimgui::window
         void draw_controls() override;
         cataimgui::bounds get_bounds() override {
             return { -1.f, parent->ontop ? 0 : -1.f,
-                     float( msg_width ) + ( ImGui::GetStyle().WindowBorderSize * 2 ), -1.f };
+                     float( msg_width ) + ( ImGui::GetStyle().WindowBorderSize * 2 ), float( str_height_to_pixels( parent->folded_msg.size() ) ) + ( ImGui::GetStyle().ItemSpacing.y * 2 )};
         }
 };
 
@@ -702,7 +702,6 @@ static_popup::static_popup()
 #else
     if( get_options().has_option( "USE_IMGUI" ) && get_option<bool>( "USE_IMGUI" ) ) {
         ui_imgui = create_or_get_impl();
-        ui_manager::redraw();
     } else {
         ui = create_or_get_adaptor();
     }


### PR DESCRIPTION

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "New ImGui popups show at the center of the screen when query_popup::ontop is set to true"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
popups are supposed to show at the top of the screen when query_popup::ontop is set to true. this currently is not the case.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
This required disabling of auto-sizing with the ImGui popup screen. Auto-sizing with ImGui is incredibly convenient, but requires 2 frames to be drawn before the new UI actually shows on screen. thus ui_manager::redraw was called from the static_popup constructor. But calling this prevented the popup from showing at the top of the screen due to the way ImGui caches window positions
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Disabling auto-sizing in ImGui is not really desirable because it means we need to write code that requires us to know ahead of time the exact size of the window. But the only alternative is to rework the entire drawing strategy of popups to allow ImGui to redraw constantly whille the popup is on screen. This would require way more work.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded the game, verified that the "Drop where?" dialog shows, and shows on the top.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
