### PR TITLE
[MoM] Update Speed Reader to use READING_SPEED_MULTIPLIER enchantment

### DIFF
--- a/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
+++ b/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
@@ -166,7 +166,7 @@ This is natural painkiller and so has natural effects (reduces speed slightly)<b
 *Duration*: 4 minutes 50 seconds to 16 minutes 20 seconds, plus 2 minutes 30 seconds to 4 minutes 30 seconds minutes per level<br />
 *Stamina Cost*: 2500, minus 125 per level to a minimum of 1000<br />
 *Channeling Time*: 500 moves, minus 12 moves per level to a minimum of 250<br />
-*Effects*: Increases the psion's ability to read and retain information. The psion reads 33% faster and gains 0.15% additional XP per reading increment per power level.<br />
+*Effects*: Increases the psion's ability to read and retain information. The psion reads 20% faster, plus 2% per power level to a maximum of 60% faster, and gains 0.15% additional XP per reading increment per power level.<br />
 *Prerequisites*: Starting power<br />
 
 ## Premonition (C)

--- a/data/mods/MindOverMatter/effects/effects_psionic.json
+++ b/data/mods/MindOverMatter/effects/effects_psionic.json
@@ -709,7 +709,7 @@
           {
             "value": "READING_SPEED_MULTIPLIER",
             "multiply": {
-               "math": [
+              "math": [
                 "max((( -0.15 + ( u_spell_level('clair_speed_reading') * -0.02 ) * (scaling_factor(u_val('intelligence') ) ) ) * u_nether_attunement_power_scaling), -0.6)"
               ]
             }

--- a/data/mods/MindOverMatter/effects/effects_psionic.json
+++ b/data/mods/MindOverMatter/effects/effects_psionic.json
@@ -694,7 +694,29 @@
     "apply_message": "",
     "remove_message": "",
     "rating": "good",
-    "max_duration": "7 days"
+    "max_duration": "7 days",
+    "enchantments": [
+      {
+        "values": [
+          {
+            "value": "READING_EXP",
+            "add": {
+              "math": [
+                "( ( u_spell_level('clair_speed_reading') * 0.15) * (scaling_factor(u_val('intelligence') ))) * u_nether_attunement_power_scaling"
+              ]
+            }
+          },
+          {
+            "value": "READING_SPEED_MULTIPLIER",
+            "multiply": {
+               "math": [
+                "max((( -0.15 + ( u_spell_level('clair_speed_reading') * -0.02 ) * (scaling_factor(u_val('intelligence') ) ) ) * u_nether_attunement_power_scaling), -0.6)"
+              ]
+            }
+          }
+        ]
+      }
+    ]
   },
   {
     "type": "effect_type",

--- a/data/mods/MindOverMatter/enchantments/enchantments_player.json
+++ b/data/mods/MindOverMatter/enchantments/enchantments_player.json
@@ -28,22 +28,6 @@
   },
   {
     "type": "enchantment",
-    "id": "enchant_clair_speed_read",
-    "condition": "ALWAYS",
-    "has": "HELD",
-    "values": [
-      {
-        "value": "READING_EXP",
-        "add": {
-          "math": [
-            "( ( u_spell_level('clair_speed_reading') * 0.15) * (scaling_factor(u_val('intelligence') ))) * u_nether_attunement_power_scaling"
-          ]
-        }
-      }
-    ]
-  },
-  {
-    "type": "enchantment",
     "id": "ench_clair_group_tactics",
     "condition": "ALWAYS",
     "has": "HELD",

--- a/data/mods/MindOverMatter/mutations/temporary.json
+++ b/data/mods/MindOverMatter/mutations/temporary.json
@@ -1,16 +1,6 @@
 [
   {
     "type": "mutation",
-    "id": "CLAIR_SPEED_READ",
-    "name": { "str": "Speed Reader" },
-    "points": 1,
-    "description": "Your powers allow you to absorb knowledge at a greatly accelerated pace.",
-    "reading_speed_multiplier": 0.66,
-    "valid": false,
-    "enchantments": [ "enchant_clair_speed_read" ]
-  },
-  {
-    "type": "mutation",
     "id": "CLAIR_CRAFT_BONUS_01",
     "name": { "str": "Intuitive Artistry" },
     "points": 0,

--- a/data/mods/MindOverMatter/obsolete/enchantments.json
+++ b/data/mods/MindOverMatter/obsolete/enchantments.json
@@ -1,0 +1,18 @@
+[
+  {
+    "type": "enchantment",
+    "id": "enchant_clair_speed_read",
+    "condition": "ALWAYS",
+    "has": "HELD",
+    "values": [
+      {
+        "value": "READING_EXP",
+        "add": {
+          "math": [
+            "( ( u_spell_level('clair_speed_reading') * 0.15) * (scaling_factor(u_val('intelligence') ))) * u_nether_attunement_power_scaling"
+          ]
+        }
+      }
+    ]
+  }
+]

--- a/data/mods/MindOverMatter/obsolete/temporary.json
+++ b/data/mods/MindOverMatter/obsolete/temporary.json
@@ -1,6 +1,16 @@
 [
   {
     "type": "mutation",
+    "id": "CLAIR_SPEED_READ",
+    "name": { "str": "Speed Reader" },
+    "points": 1,
+    "description": "Your powers allow you to absorb knowledge at a greatly accelerated pace.",
+    "reading_speed_multiplier": 0.66,
+    "valid": false,
+    "enchantments": [ "enchant_clair_speed_read" ]
+  },
+  {
+    "type": "mutation",
     "//": "This and following are all necessary because stealth_modifier is mutation only.  Redo the whole thing once it isn't.",
     "id": "PHOTOKINETIC_CAMOUFLAGE_1",
     "name": { "str": "Chameleoflage" },

--- a/data/mods/MindOverMatter/obsolete/temporary.json
+++ b/data/mods/MindOverMatter/obsolete/temporary.json
@@ -1,13 +1,8 @@
 [
   {
-    "type": "mutation",
+    "type": "TRAIT_MIGRATION",
     "id": "CLAIR_SPEED_READ",
-    "name": { "str": "Speed Reader" },
-    "points": 1,
-    "description": "Your powers allow you to absorb knowledge at a greatly accelerated pace.",
-    "reading_speed_multiplier": 0.66,
-    "valid": false,
-    "enchantments": [ "enchant_clair_speed_read" ]
+    "remove": true
   },
   {
     "type": "mutation",

--- a/data/mods/MindOverMatter/powers/clairsentience_concentration_eocs.json
+++ b/data/mods/MindOverMatter/powers/clairsentience_concentration_eocs.json
@@ -90,7 +90,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_CLAIR_SPEED_READING_INITIATE",
-    "condition": { "not": { "u_has_trait": "CLAIR_SPEED_READ" } },
+    "condition": { "not": { "u_has_effect": "effect_clair_speed_reader" } },
     "effect": [
       { "run_eocs": "EOC_POWER_MAINTENANCE_PLUS_ONE" },
       { "u_message": "You feel like sitting down with a good book.", "type": "good" },
@@ -117,18 +117,17 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_CLAIR_REMOVE_SPEED_READ",
-    "condition": { "or": [ { "u_has_trait": "CLAIR_SPEED_READ" }, { "u_has_effect": "effect_clair_speed_reader" } ] },
+    "condition": { "u_has_effect": "effect_clair_speed_reader" },
     "effect": [
       { "u_message": "Your eyes ache a bit.  Maybe it's time to put the book down.", "type": "good" },
       { "run_eocs": "EOC_POWER_MAINTENANCE_MINUS_ONE" },
-      { "u_lose_trait": "CLAIR_SPEED_READ" },
       { "u_lose_effect": "effect_clair_speed_reader" }
     ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_CLAIR_SPEED_READING_DRAIN",
-    "condition": { "u_has_trait": "CLAIR_SPEED_READ" },
+    "condition": { "u_has_effect": "effect_clair_speed_reader" },
     "effect": [
       { "u_cast_spell": { "id": "psionic_maintenance_drained_difficulty_two", "hit_self": true } },
       { "math": [ "u_val('stored_kcal')", "-=", "psionics_kcal_cost(2)" ] },

--- a/data/mods/MindOverMatter/powers/clairsentience_concentration_eocs.json
+++ b/data/mods/MindOverMatter/powers/clairsentience_concentration_eocs.json
@@ -94,7 +94,6 @@
     "effect": [
       { "run_eocs": "EOC_POWER_MAINTENANCE_PLUS_ONE" },
       { "u_message": "You feel like sitting down with a good book.", "type": "good" },
-      { "u_add_trait": "CLAIR_SPEED_READ" },
       { "u_cast_spell": { "id": "psionic_drained_difficulty_two", "hit_self": true } },
       { "u_add_effect": "effect_clair_speed_reader", "duration": "PERMANENT" },
       {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Update Speed Reader to use READING_SPEED_MULTIPLIER enchantment"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

READING_SPEED_MULTIPLIER is now an enchantment, which means it can be manipulated by math.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Obsolete old reading speed mutation and the enchantment attached to it. Add READING_SPEED_MULTIPLIER to the effect, starting at 20% faster and scaling up at 2% faster per power level to a maximum of 60% faster. Edit the concentration EoC to remove all references to the mutation. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Works as intended.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
