### PR TITLE
Remove digit separators and fix body part parser script

### DIFF
--- a/lang/string_extractor/parsers/body_part.py
+++ b/lang/string_extractor/parsers/body_part.py
@@ -9,6 +9,8 @@ def parse_body_part(json, origin):
     if "name" in json:
         name = get_singular_name(json["name"])
         write_text(json["name"], origin, comment="Name of body part")
+    else:
+        name = json["id"]
 
     if "name_multiple" in json:
         write_text(json["name_multiple"], origin, comment="Name of body part")

--- a/lang/string_extractor/parsers/body_part.py
+++ b/lang/string_extractor/parsers/body_part.py
@@ -5,15 +5,17 @@ from ..write_text import write_text
 def parse_body_part(json, origin):
     # See comments in `body_part_struct::load` of bodypart.cpp about why xxx
     # and xxx_multiple are not inside a single translation object.
-    name = get_singular_name(json["name"])
 
-    write_text(json["name"], origin, comment="Name of body part")
+    if "name" in json:
+        name = get_singular_name(json["name"])
+        write_text(json["name"], origin, comment="Name of body part")
 
     if "name_multiple" in json:
         write_text(json["name_multiple"], origin, comment="Name of body part")
 
-    write_text(json["accusative"], origin,
-               comment="Accusative name of body part")
+    if "accusative" in json:
+        write_text(json["accusative"], origin,
+                   comment="Accusative name of body part")
 
     if "accusative_multiple" in json:
         write_text(json["accusative_multiple"], origin,
@@ -23,11 +25,13 @@ def parse_body_part(json, origin):
         write_text(json["encumbrance_text"], origin,
                    comment="Encumbrance text of body part \"{}\"".format(name))
 
-    write_text(json["heading"], origin,
-               comment="Heading of body part \"{}\"".format(name))
+    if "heading" in json:
+        write_text(json["heading"], origin,
+                   comment="Heading of body part \"{}\"".format(name))
 
-    write_text(json["heading_multiple"], origin,
-               comment="Heading of body part \"{}\"".format(name))
+    if "heading_multiple" in json:
+        write_text(json["heading_multiple"], origin,
+                   comment="Heading of body part \"{}\"".format(name))
 
     if "smash_message" in json:
         write_text(json["smash_message"], origin,

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3635,7 +3635,7 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
     const double cur_total_moves = cached_cur_total_moves;
 
     // item_counter represents the percent progress relative to the base batch time
-    // stored precise to 5 decimal places ( e.g. 67.32 percent would be stored as 6'732'000 )
+    // stored precise to 5 decimal places ( e.g. 67.32 percent would be stored as 6732000 )
     const int old_counter = craft.item_counter;
 
     // Delta progress in moves adjusted for current crafting speed /
@@ -3644,21 +3644,21 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
                           exertion_level() );
     const double delta_progress = spent_moves * base_total_moves / cur_total_moves;
     // Current progress in moves
-    const double current_progress = craft.item_counter * base_total_moves / 10'000'000.0 +
+    const double current_progress = craft.item_counter * base_total_moves / 10000000.0 +
                                     delta_progress;
     // Current progress as a percent of base_total_moves to 2 decimal places
-    craft.item_counter = std::round( current_progress / base_total_moves * 10'000'000.0 );
+    craft.item_counter = std::round( current_progress / base_total_moves * 10000000.0 );
     crafter.set_moves( 0 );
 
     // This is to ensure we don't over count skill steps
-    craft.item_counter = std::min( craft.item_counter, 10'000'000 );
+    craft.item_counter = std::min( craft.item_counter, 10000000 );
 
     // This nominal craft time is also how many practice ticks to perform
     // spread out evenly across the actual duration.
     const double total_practice_ticks = rec.time_to_craft_moves( crafter,
                                         recipe_time_flag::ignore_proficiencies ) / 100.0;
 
-    const int ticks_per_practice = 10'000'000.0 / total_practice_ticks;
+    const int ticks_per_practice = 10000000.0 / total_practice_ticks;
     int num_practice_ticks = craft.item_counter / ticks_per_practice -
                              old_counter / ticks_per_practice;
     bool level_up = false;
@@ -3666,7 +3666,7 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
         level_up |= crafter.craft_skill_gain( craft, num_practice_ticks );
     }
     // Proficiencies and tools are gained/consumed after every 5% progress
-    int five_percent_steps = craft.item_counter / 500'000 - old_counter / 500'000;
+    int five_percent_steps = craft.item_counter / 500000 - old_counter / 500000;
     if( five_percent_steps > 0 ) {
         // Divide by 100 for seconds, 20 for 5%
         const time_duration pct_time = time_duration::from_seconds( base_total_moves / 2000 );
@@ -3678,21 +3678,21 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
     }
 
     // Unlike skill, tools are consumed once at the start and should not be consumed at the end
-    if( craft.item_counter >= 10'000'000 ) {
+    if( craft.item_counter >= 10000000 ) {
         --five_percent_steps;
     }
 
     if( five_percent_steps > 0 ) {
         if( !crafter.craft_consume_tools( craft, five_percent_steps, false ) ) {
             // So we don't skip over any tool comsuption
-            craft.item_counter -= craft.item_counter % 500'000 + 1;
+            craft.item_counter -= craft.item_counter % 500000 + 1;
             crafter.cancel_activity();
             return;
         }
     }
 
     // if item_counter has reached 100% or more
-    if( craft.item_counter >= 10'000'000 ) {
+    if( craft.item_counter >= 10000000 ) {
         if( rec.is_practice() && !is_long && craft.get_making_batch_size() == 1 ) {
             if( query_yn( _( "Keep practicing until proficiency increases?" ) ) ) {
                 is_long = true;
@@ -5170,15 +5170,15 @@ void disassemble_activity_actor::do_turn( player_activity &act, Character &who )
     }
 
     if( moves_total == 0 ) {
-        craft.item_counter = 10'000'000;
+        craft.item_counter = 10000000;
     } else {
         const int spent_moves = who.get_moves() * who.exertion_adjusted_move_multiplier( exertion_level() );
-        craft.item_counter += std::round( spent_moves * crafting_speed * 10'000'000.0 / moves_total );
-        craft.item_counter = std::min( craft.item_counter, 10'000'000 );
+        craft.item_counter += std::round( spent_moves * crafting_speed * 10000000.0 / moves_total );
+        craft.item_counter = std::min( craft.item_counter, 10000000 );
         who.set_moves( 0 );
     }
 
-    if( craft.item_counter >= 10'000'000 ) {
+    if( craft.item_counter >= 10000000 ) {
         who.complete_disassemble( target );
     }
 }

--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -50,7 +50,7 @@ class basic_animation
 {
     public:
         explicit basic_animation( const int scale ) :
-            delay( get_option<int>( "ANIMATION_DELAY" ) * scale * 1'000'000L ) {
+            delay( get_option<int>( "ANIMATION_DELAY" ) * scale * 1000000L ) {
         }
 
         void draw() const {
@@ -71,7 +71,7 @@ class basic_animation
             do {
                 const auto sleep_for = std::min( sleep_till - std::chrono::steady_clock::now(),
                                                  // Pump events every 100 ms
-                                                 std::chrono::nanoseconds( 100'000'000 ) );
+                                                 std::chrono::nanoseconds( 100000000 ) );
                 if( sleep_for > std::chrono::nanoseconds( 0 ) ) {
                     std::this_thread::sleep_for( sleep_for );
                     inp_mngr.pump_events();

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -578,10 +578,10 @@ Character::Character() :
     update_type_of_scent( true );
     pkill = 0;
     // 55 Mcal or 55k kcal
-    healthy_calories = 55'000'000;
+    healthy_calories = 55000000;
     base_cardio_acc = 1000;
     // this makes sure characters start with normal bmi
-    stored_calories = healthy_calories - 1'000'000;
+    stored_calories = healthy_calories - 1000000;
     initialize_stomach_contents();
 
     name.clear();

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -2169,7 +2169,7 @@ conditional_t::get_set_dbl( std::string_view checked_value, char scope )
             d.actor( is_npc )->set_mana_cur( ( d.actor( is_npc )->mana_max() * input ) / 100 );
         };
     } else if( checked_value == "stored_kcal_percentage" ) {
-        // 100% is 55'000 kcal, which is considered healthy.
+        // 100% is 55000 kcal, which is considered healthy.
         return [is_npc]( dialogue & d, double input ) {
             d.actor( is_npc )->set_stored_kcal( input * 5500 );
         };

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -2957,7 +2957,7 @@ std::pair<float, float> repair_item_actor::repair_chance(
             break;
         default:
             // 5 is obsoleted reinforcing, remove after 0.H
-            action_difficulty = 1'000'000; // ensure failure
+            action_difficulty = 1000000; // ensure failure
             break;
     }
 

--- a/src/iuse_software_kitten.cpp
+++ b/src/iuse_software_kitten.cpp
@@ -288,11 +288,11 @@ void robot_finds_kitten::process_input()
                 refresh_display();
                 // Sleep for 1 s
                 const auto sleep_till = std::chrono::steady_clock::now()
-                                        + std::chrono::nanoseconds( 1'000'000'000 );
+                                        + std::chrono::nanoseconds( 1000000000 );
                 do {
                     const auto sleep_for = std::min( sleep_till - std::chrono::steady_clock::now(),
                                                      // Pump events every 100 ms
-                                                     std::chrono::nanoseconds( 100'000'000 ) );
+                                                     std::chrono::nanoseconds( 100000000 ) );
                     if( sleep_for > std::chrono::nanoseconds( 0 ) ) {
                         std::this_thread::sleep_for( sleep_for );
                         inp_mngr.pump_events();

--- a/src/npc_attack.cpp
+++ b/src/npc_attack.cpp
@@ -31,7 +31,7 @@ static const float kill_modifier = 1.5f;
 static const int base_time_penalty = 3;
 // we want this out of our hands, pronto.
 // give a large buff to the attack value so it prioritizes this
-static const int base_throw_now = 10'000;
+static const int base_throw_now = 10000;
 } // namespace npc_attack_constants
 
 // TODO: make a better, more generic "check if this projectile is blocked" function

--- a/src/stomach.h
+++ b/src/stomach.h
@@ -20,7 +20,7 @@ using mass = units::quantity<int, units::mass_in_microgram_tag>;
 
 constexpr mass microgram = units::quantity<int, units::mass_in_microgram_tag>( 1, {} );
 constexpr mass milligram = units::quantity<int, units::mass_in_microgram_tag>( 1000, {} );
-constexpr mass gram = units::quantity<int, units::mass_in_microgram_tag>( 1'000'000, {} );
+constexpr mass gram = units::quantity<int, units::mass_in_microgram_tag>( 1000000, {} );
 const std::vector<std::pair<std::string, mass>> mass_units = { {
         { "ug", microgram },
         { "μg", microgram },

--- a/src/units_utility.cpp
+++ b/src/units_utility.cpp
@@ -171,12 +171,12 @@ int convert_length( const units::length &length )
     int ret = to_millimeter( length );
     const bool metric = get_option<std::string>( "DISTANCE_UNITS" ) == "metric";
     if( metric ) {
-        if( ret % 1'000'000 == 0 ) {
+        if( ret % 1000000 == 0 ) {
             // kilometers
-            ret /= 1'000'000;
-        } else if( ret % 1'000 == 0 ) {
+            ret /= 1000000;
+        } else if( ret % 1000 == 0 ) {
             // meters
-            ret /= 1'000;
+            ret /= 1000;
         } else if( ret % 10 == 0 ) {
             // centimeters
             ret /= 10;
@@ -201,10 +201,10 @@ std::string length_units( const units::length &length )
     int length_mm = to_millimeter( length );
     const bool metric = get_option<std::string>( "DISTANCE_UNITS" ) == "metric";
     if( metric ) {
-        if( length_mm % 1'000'000 == 0 ) {
+        if( length_mm % 1000000 == 0 ) {
             //~ kilometers
             return _( "km" );
-        } else if( length_mm % 1'000 == 0 ) {
+        } else if( length_mm % 1000 == 0 ) {
             //~ meters
             return _( "m" );
         } else if( length_mm % 10 == 0 ) {
@@ -261,13 +261,13 @@ std::pair<std::string, std::string> weight_to_string( const
         units::quantity<int, units::mass_in_microgram_tag> &weight )
 {
     using high_res_mass = units::quantity<int, units::mass_in_microgram_tag>;
-    static const high_res_mass gram = high_res_mass( 1'000'000, {} );
-    static const high_res_mass milligram = high_res_mass( 1'000, {} );
+    static const high_res_mass gram = high_res_mass( 1000000, {} );
+    static const high_res_mass milligram = high_res_mass( 1000, {} );
 
     if( weight > gram ) {
-        return {string_format( "%.0f", weight.value() / 1'000'000.f ), "g"};
+        return {string_format( "%.0f", weight.value() / 1000000.f ), "g"};
     } else if( weight > milligram ) {
-        return {string_format( "%.0f", weight.value() / 1'000.f ), "mg"};
+        return {string_format( "%.0f", weight.value() / 1000.f ), "mg"};
     }
     return {string_format( "%d", weight.value() ), "μg"};
 }

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1725,7 +1725,7 @@ std::pair<const itype_id &, int> vehicle::tool_ammo_available( const itype_id &t
         return { itype_id::NULL_ID(), 0 };
     }
     // 2 bil ought to be enough for everyone, and hopefully not overflow int
-    const int64_t max = 2'000'000'000;
+    const int64_t max = 2000000000;
     if( ft->ammo->type == ammo_battery ) {
         return { ft, static_cast<int>( std::min<int64_t>( battery_left(), max ) ) };
     } else {

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -552,7 +552,7 @@ TEST_CASE( "proficiency_gain_short_crafts", "[crafting][proficiency]" )
     REQUIRE( ch.get_proficiency_practice( proficiency_prof_carving ) == 0.0f );
 
     int turns_taken = 0;
-    const int max_turns = 100'000;
+    const int max_turns = 100000;
 
     float time_malus = rec->proficiency_time_maluses( ch );
 
@@ -591,8 +591,8 @@ TEST_CASE( "proficiency_gain_long_craft", "[crafting][proficiency]" )
     // Check exactly one 5% tick has passed
     // 500k counter = 5% progress
     // If counter is 0, this means the craft finished before we gained the proficiency
-    CHECK( craft->item_counter >= 500'000 );
-    CHECK( craft->item_counter < 501'000 );
+    CHECK( craft->item_counter >= 500000 );
+    CHECK( craft->item_counter < 501000 );
 }
 
 static float craft_aggregate_fail_chance( const recipe_id &rid )

--- a/tests/units_test.cpp
+++ b/tests/units_test.cpp
@@ -404,12 +404,12 @@ TEST_CASE( "Specific_energy", "[temperature]" )
 TEST_CASE( "energy_display", "[units][nogame]" )
 {
     CHECK( units::display( units::from_millijoule( 1 ) ) == "1 mJ" );
-    CHECK( units::display( units::from_millijoule( 1'000 ) ) == "1 J" );
-    CHECK( units::display( units::from_millijoule( 1'001 ) ) == "1001 mJ" );
-    CHECK( units::display( units::from_millijoule( 1'000'000 ) ) == "1 kJ" );
-    CHECK( units::display( units::from_millijoule( 1'000'001 ) ) == "1 kJ" );
-    CHECK( units::display( units::from_millijoule( 1'001'000 ) ) == "1001 J" );
-    CHECK( units::display( units::from_millijoule( 1'001'001 ) ) == "1001001 mJ" );
-    CHECK( units::display( units::from_millijoule( 2'147'483'648LL ) ) == "2147483648 mJ" );
-    CHECK( units::display( units::from_millijoule( 4'294'967'296LL ) ) == "4294967296 mJ" );
+    CHECK( units::display( units::from_millijoule( 1000 ) ) == "1 J" );
+    CHECK( units::display( units::from_millijoule( 1001 ) ) == "1001 mJ" );
+    CHECK( units::display( units::from_millijoule( 1000000 ) ) == "1 kJ" );
+    CHECK( units::display( units::from_millijoule( 1000001 ) ) == "1 kJ" );
+    CHECK( units::display( units::from_millijoule( 1001000 ) ) == "1001 J" );
+    CHECK( units::display( units::from_millijoule( 1001001 ) ) == "1001001 mJ" );
+    CHECK( units::display( units::from_millijoule( 2147483648LL ) ) == "2147483648 mJ" );
+    CHECK( units::display( units::from_millijoule( 4294967296LL ) ) == "4294967296 mJ" );
 }

--- a/tests/weather_test.cpp
+++ b/tests/weather_test.cpp
@@ -98,7 +98,7 @@ static year_of_weather_data collect_weather_data( unsigned seed )
 }
 
 // Try a few randomly selected seeds.
-static const std::array<unsigned, 3> seeds = { {317'024'741, 870'078'684, 1'192'447'748} };
+static const std::array<unsigned, 3> seeds = { {317024741, 870078684, 1192447748} };
 
 TEST_CASE( "weather_realism", "[weather]" )
 // Check our simulated weather against numbers from real data


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/72046

Resolve issues like this (https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/8082962435/job/22084936873?pr=72045#step:5:61):

```
> Extracting strings from C++ code
src/activity_actor.cpp:3688: warning: unterminated character constant
src/iuse_software_kitten.cpp:291: warning: unterminated character constant
src/npc_attack.cpp:34: warning: unterminated character constant
src/units_utility.cpp:177: warning: unterminated character constant
src/units_utility.cpp:179: warning: unterminated character constant
src/units_utility.cpp:207: warning: unterminated character constant
src/units_utility.cpp:265: warning: unterminated character constant
src/units_utility.cpp:270: warning: unterminated character constant
src/vehicle_use.cpp:1728: warning: unterminated character constant
Exception when parsing JSON data type "body_part"
Error in JSON object
'{
  "id": "head",
  "type": "body_part",
  "name": "head",
  "copy-from": "head",
  "limb_type": "head",
  "limb_scores": [
    [
      "reaction",
      0.3
    ]
  ],
  "is_vital": true,
  "similar_bodyparts": [
    "head_dragonfly"
  ]
}'
from file: 'data/mods/Limb_WIP/mutations/mutation_limbs.json'
```