### PR TITLE
github/linux: build a more featureful SDL2 library

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,6 +215,8 @@ jobs:
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux' && matrix.mxe == 'none' && matrix.android == 'none' && !matrix.wasm
         run: |
+          sudo apt-get update
+          sudo apt-get install libsdl2-dev
           git clone https://github.com/libsdl-org/SDL.git --branch release-2.0.20 --depth 1
           cd SDL
           mkdir build
@@ -223,7 +225,6 @@ jobs:
           make -j$((`nproc`+0))
           sudo make install
           cp ../LICENSE.txt ${{ github.workspace }}/LICENSE-SDL.txt
-          sudo apt-get update
           sudo apt-get install libncursesw5-dev libsdl2-ttf-dev libsdl2-image-dev \
             libsdl2-mixer-dev libpulse-dev ccache gettext parallel
       - name: Install Emscripten (WebAssembly)


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
The SDL library we started shipping since #72026 is missing some features - most notably all audio drivers, the full opengl renderer, and IME support.

#### Describe the solution
Install `libsdl2-dev` before building our version of SDL. This pulls in all the headers for its dynamic dependencies too.

#### Describe alternatives you've considered
N/A

#### Testing
Sound, the OpenGL renderer, and ibus IME all work in [this release](https://github.com/andrei8l/Cataclysm-DDA/releases/tag/cdda-experimental-2024-02-28-2122) from [this job](https://github.com/andrei8l/Cataclysm-DDA/actions/runs/8087261184/job/22098834734#step:10:777)

#### Additional context
Naturally, I only noticed this after #72026 was merged because I am big dumb.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
