### PR TITLE
Fix clang-tidy error in magic_spell_test.cpp

### DIFF
--- a/tests/magic_spell_test.cpp
+++ b/tests/magic_spell_test.cpp
@@ -15,8 +15,8 @@
 #include "type_id.h"
 
 static const spell_id spell_test_spell_box( "test_spell_box" );
-static const spell_id spell_test_spell_tp_mummy( "test_spell_tp_mummy" );
 static const spell_id spell_test_spell_tp_ghost( "test_spell_tp_ghost" );
+static const spell_id spell_test_spell_tp_mummy( "test_spell_tp_mummy" );
 
 // Magic Spell tests
 // -----------------
@@ -597,9 +597,7 @@ TEST_CASE( "spell_effect_-_summon", "[magic][spell][effect][summon]" )
     REQUIRE( creatures.creature_at( dummy_loc ) );
     REQUIRE( g->num_creatures() == 1 );
 
-    spell_id ghost_id( "test_spell_tp_ghost" );
-
-    spell ghost_spell( ghost_id );
+    spell ghost_spell( spell_test_spell_tp_ghost );
     REQUIRE( dummy.magic->has_enough_energy( dummy, ghost_spell ) );
 
     // Summon the ghost in the adjacent space


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
clang-tidy check is failing (https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/8089693719/job/22106019129#step:9:1002) after #72005 was merged.
```
Error: /home/runner/work/Cataclysm-DDA/Cataclysm-DDA/tests/magic_spell_test.cpp:17:1: error: string_id declarations should be sorted. [cata-static-string_id-constants,-warnings-as-errors]
   17 | static const spell_id spell_test_spell_box( "test_spell_box" );
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   18 | static const spell_id spell_test_spell_tp_mummy( "test_spell_tp_mummy" );
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   19 | static const spell_id spell_test_spell_tp_ghost( "test_spell_tp_ghost" );
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   20 | 
/home/runner/work/Cataclysm-DDA/Cataclysm-DDA/tests/magic_spell_test.cpp:19:1: note: 'spell_test_spell_tp_ghost' should be before 'spell_test_spell_tp_mummy'.
   19 | static const spell_id spell_test_spell_tp_ghost( "test_spell_tp_ghost" );
      | ^
Error: /home/runner/work/Cataclysm-DDA/Cataclysm-DDA/tests/magic_spell_test.cpp:19:1: error: Variable 'spell_test_spell_tp_ghost' declared but not used. [cata-unused-statics,-warnings-as-errors]
   19 | static const spell_id spell_test_spell_tp_ghost( "test_spell_tp_ghost" );
      | ^
```
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Fix the two errors.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
