### PR TITLE
Fix several issues of NPC movement

### DIFF
--- a/src/npc_attack.cpp
+++ b/src/npc_attack.cpp
@@ -58,7 +58,8 @@ static bool can_move( const npc &source )
 
 static bool can_move_melee( const npc &source )
 {
-    return can_move( source ) && source.rules.engagement != combat_engagement::FREE_FIRE;
+    return can_move( source ) && source.rules.engagement != combat_engagement::FREE_FIRE &&
+           source.rules.engagement != combat_engagement::NO_MOVE;
 }
 
 bool npc_attack_rating::operator>( const npc_attack_rating &rhs ) const
@@ -285,9 +286,14 @@ void npc_attack_melee::use( npc &source, const tripoint &location ) const
                     //add_msg_debug( debugmode::DF_NPC_MOVEAI,
                     //               "<color_light_gray>%s is at least %i away from allies, enemy within %i of ally.  Going for attack.</color>",
                     //               source.name, source.mem_combat.formation_distance, source.closest_enemy_to_friendly_distance() );
+                } else if( source.mem_combat.formation_distance <= source.mem_combat.engagement_distance ) {
+                    add_msg_debug( debugmode::DF_NPC_MOVEAI,
+                                   "<color_light_gray>%s can't path to melee target, and is staying close to ranged allies.  Stay in place.</color>",
+                                   source.name );
+                    source.move_pause();
                 } else {
                     add_msg_debug( debugmode::DF_NPC_MOVEAI,
-                                   "<color_light_gray>%s can't path to melee target, or is staying close to ranged allies.</color>",
+                                   "<color_light_gray>%s can't path to melee target, and is not staying close to ranged allies.  Get close to player.</color>",
                                    source.name );
                     source.look_for_player( get_player_character() );
                 }

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -1445,10 +1445,12 @@ void npc::move()
     if( action == npc_undecided && is_walking_with() && player_character.in_vehicle &&
         !in_vehicle ) {
         action = npc_follow_embarked;
+        path.clear();
     }
 
     if( action == npc_undecided && is_walking_with() && rules.has_flag( ally_rule::follow_close ) &&
-        rl_dist( pos(), player_character.pos() ) > follow_distance() ) {
+        rl_dist( pos(), player_character.pos() ) > follow_distance() && !( player_character.in_vehicle &&
+                in_vehicle ) ) {
         action = npc_follow_player;
     }
 
@@ -1524,6 +1526,7 @@ void npc::move()
         // check if in vehicle before rushing off to fetch things
         if( is_walking_with() && player_character.in_vehicle ) {
             action = npc_follow_embarked;
+            path.clear();
         } else if( fetching_item ) {
             // Set to true if find_item() found something
             action = npc_pickup;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Currently, there are the following problems with NPC movement:
1. When NPCs use a melee weapon (or a ranged weapon with a higher melee attack rating) and are not allowed to charge, they will constantly attempt to stand on the player's grid and ask the player to make way for them.
2. NPCs may still move when asked to stand still and shoot.
3. When NPCs follow players into vehicles, they may also try to stand on the player's grid.
4. After the NPC follows the player into the vehicle, it may switch repeatedly between the two modes of "following the player" and "following the player into the vehicle", resulting in a funny back-and-forth motion.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
1. When NPCs can't path to melee target and are staying close to ranged allies, they will stay in place.
2. Function 'can_move_melee' will return false when NPCs are not allowed to move.
3. Clear path before NPCs take action “npc_follow_embarked”, which is formulated when they take action "npc_follow_player".
4. NPCs will not take action "npc_follow_player" when they and player are all in vechicles.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Test in game and it works well. No errors have been detected for the time being
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
