### PR TITLE
Imgui keybindings UI mouse broken

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -284,23 +284,18 @@ void cataimgui::window::draw_colored_text( std::string const &text, nc_color &co
             ImGui::TextColored( { static_cast<float>( rgbCol.Red / 255. ), static_cast<float>( rgbCol.Green / 255. ),
                                   static_cast<float>( rgbCol.Blue / 255. ), static_cast<float>( 255. ) },
                                 "%s", seg.c_str() );
-            GImGui->LastItemData.ID = itemId;
 #else
             SDL_Color c = curses_color_to_SDL( color );
             ImGui::TextColored( { static_cast<float>( c.r / 255. ), static_cast<float>( c.g / 255. ),
                                   static_cast<float>( c.b / 255. ), static_cast<float>( c.a / 255. ) },
                                 "%s", seg.c_str() );
-            GImGui->LastItemData.ID = itemId;
 #endif
+            GImGui->LastItemData.ID = itemId;
             if( is_focused && !*is_focused ) {
                 *is_focused = ImGui::IsItemFocused();
             }
             if( is_hovered && !*is_hovered ) {
-#if defined(TILES) || defined(WIN32)
-                *is_hovered = ImGui::IsItemHovered( ImGuiHoveredFlags_NoNavOverride );
-#else
-                *is_hovered = ImGui::IsItemHovered();
-#endif
+                *is_hovered = GImGui->HoveredId == itemId;
             }
 
         }

--- a/src/input_context.cpp
+++ b/src/input_context.cpp
@@ -726,8 +726,9 @@ void keybindings_ui::draw_controls()
             }
             key_text += string_format( "%s:", ctxt->get_action_name( action_id ) );
             bool is_selected = false;
-            draw_colored_text( key_text, col, 0.0f, &is_selected );
-            if( ( is_selected || ImGui::IsItemHovered() ) && invlet != ' ' ) {
+            bool is_hovered = false;
+            draw_colored_text( key_text, col, 0.0f, status == kb_menu_status::show ? nullptr : &is_selected, nullptr, &is_hovered );
+            if( (is_selected || is_hovered) && invlet != ' ' ) {
                 highlight_row_index = i;
             }
             //ImGui::SameLine();
@@ -1283,15 +1284,16 @@ action_id input_context::display_menu_imgui( const bool permit_execute_action )
             kb_menu.hotkeys = ctxt.get_available_single_char_hotkeys( display_help_hotkeys );
         } else if( !kb_menu.filtered_registered_actions.empty() &&
                    kb_menu.status != kb_menu_status::show ) {
-            size_t hotkey_index = kb_menu.hotkeys.find_first_of( raw_input_char );
-            if( hotkey_index == std::string::npos ) {
-                if( action == "SELECT" && kb_menu.highlight_row_index != -1 ) {
-                    hotkey_index = size_t( kb_menu.highlight_row_index );
-                } else {
+            size_t action_index = SIZE_MAX;
+            if( action == "SELECT" && kb_menu.highlight_row_index != -1 ) {
+                action_index = kb_menu.highlight_row_index;
+            } else {
+                size_t hotkey_index = kb_menu.hotkeys.find_first_of( raw_input_char );
+                if( hotkey_index == std::string::npos ) {
                     continue;
                 }
+                action_index = hotkey_index + kb_menu.scroll_offset;
             }
-            const size_t action_index = hotkey_index + kb_menu.scroll_offset;
             if( action_index >= kb_menu.filtered_registered_actions.size() ) {
                 continue;
             }

--- a/src/input_context.cpp
+++ b/src/input_context.cpp
@@ -727,8 +727,9 @@ void keybindings_ui::draw_controls()
             key_text += string_format( "%s:", ctxt->get_action_name( action_id ) );
             bool is_selected = false;
             bool is_hovered = false;
-            draw_colored_text( key_text, col, 0.0f, status == kb_menu_status::show ? nullptr : &is_selected, nullptr, &is_hovered );
-            if( (is_selected || is_hovered) && invlet != ' ' ) {
+            draw_colored_text( key_text, col, 0.0f, status == kb_menu_status::show ? nullptr : &is_selected,
+                               nullptr, &is_hovered );
+            if( ( is_selected || is_hovered ) && invlet != ' ' ) {
                 highlight_row_index = i;
             }
             //ImGui::SameLine();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fixing inconsistencies with the way mouse works in ImGui keybindings screen."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #72057
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
ImGui::IsItemHovered() method doesn't seem to look directly at the internal Hovered item by ID as expected. Thus I changed the way the hovering is calculated within draw_colored_item to do this.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Opened keybindings, verified that 'hovered item' is identified even when clicking outside the item's text.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
