### PR TITLE
[Xedra Evolved] Update Verdant Armor with new enchantments

### DIFF
--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -765,14 +765,6 @@
   },
   {
     "type": "effect_type",
-    "id": "effect_subtle_spell_flag",
-    "//": "Hidden, but provides flags for powers using SUBTLE_SPELL",
-    "name": [ "" ],
-    "desc": [ "" ],
-    "flags": [ "SUBTLE_SPELL" ]
-  },
-  {
-    "type": "effect_type",
     "id": "natures_commune",
     "name": [ "Commune with Nature" ],
     "desc": [ "You are in tune with the natural world, drawing strength from it and calming natural animals." ],
@@ -843,14 +835,6 @@
     "rating": "good",
     "removes_effects": [ "effect_pollen_arvore_weaken" ],
     "enchantments": [ { "emitter": "emit_arvore_poison_pollen" } ]
-  },
-  {
-    "type": "effect_type",
-    "id": "effect_arvore_sense_sun",
-    "//": "Hidden, but provides flags for Sensing the Sun",
-    "name": [ "" ],
-    "desc": [ "" ],
-    "flags": [ "WATCH", "ALARMCLOCK" ]
   },
   {
     "type": "effect_type",

--- a/data/mods/Xedra_Evolved/effects/effects_hidden_flag.json
+++ b/data/mods/Xedra_Evolved/effects/effects_hidden_flag.json
@@ -1,0 +1,58 @@
+[
+  {
+    "type": "effect_type",
+    "id": "effect_subtle_spell_flag",
+    "//": "Hidden, but provides flags for powers using SUBTLE_SPELL",
+    "name": [ "" ],
+    "desc": [ "" ],
+    "flags": [ "SUBTLE_SPELL" ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_steady_flag",
+    "//": "Hidden, but provides the STEADY flag",
+    "name": [ "" ],
+    "desc": [ "" ],
+    "flags": [ "STEADY" ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_no_scent_flag",
+    "//": "Hidden, but provides the NO_SCENT flag",
+    "name": [ "" ],
+    "desc": [ "" ],
+    "flags": [ "NO_SCENT" ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_enhanced_vision_flag",
+    "//": "Hidden, but provides the ENHANCED_VISION flag",
+    "name": [ "" ],
+    "desc": [ "" ],
+    "flags": [ "ENHANCED_VISION" ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_glare_resist_flag",
+    "//": "Hidden, but provides the GLARE_RESIST flag",
+    "name": [ "" ],
+    "desc": [ "" ],
+    "flags": [ "GLARE_RESIST" ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_sludge_immune_flag",
+    "//": "Hidden, but provides the SLUDGE_IMMUNE flag",
+    "name": [ "" ],
+    "desc": [ "" ],
+    "flags": [ "SLUDGE_IMMUNE" ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_arvore_sense_sun",
+    "//": "Hidden, but provides flags for Sensing the Sun",
+    "name": [ "" ],
+    "desc": [ "" ],
+    "flags": [ "WATCH", "ALARMCLOCK" ]
+  }
+]

--- a/data/mods/Xedra_Evolved/enchantments/armor.json
+++ b/data/mods/Xedra_Evolved/enchantments/armor.json
@@ -120,28 +120,34 @@
     "type": "enchantment",
     "has": "WORN",
     "condition": "ALWAYS",
-    "mutations": [ "VERDANT_HELMET" ]
+    "ench_effects": [
+      { "effect": "effect_enhanced_vision_flag", "intensity": 1 },
+      { "effect": "effect_glare_resist_flag", "intensity": 1 }
+    ]
   },
   {
     "id": "ench_verdant_body",
     "type": "enchantment",
     "has": "WORN",
     "condition": "ALWAYS",
-    "mutations": [ "VERDANT_BODY" ]
+    "values": [ { "value": "REGEN_MANA", "multiply": 0.15 } ],
+    "ench_effects": [ { "effect": "effect_no_scent_flag", "intensity": 1 } ]
   },
   {
     "id": "ench_verdant_gauntlets",
     "type": "enchantment",
     "has": "WORN",
     "condition": "ALWAYS",
-    "mutations": [ "VERDANT_GAUNTLETS" ]
+    "values": [ { "value": "CASTING_TIME_MULTIPLIER", "multiply": -0.15 } ],
+    "ench_effects": [ { "effect": "effect_subtle_spell_flag", "intensity": 1 } ]
   },
   {
     "id": "ench_verdant_boots",
     "type": "enchantment",
     "has": "WORN",
     "condition": "ALWAYS",
-    "mutations": [ "VERDANT_BOOTS" ]
+    "values": [ { "value": "FOOTSTEP_NOISE", "multiply": -0.6 } ],
+    "ench_effects": [ { "effect": "effect_steady_flag", "intensity": 1 }, { "effect": "effect_sludge_immune_flag", "intensity": 1 } ]
   },
   {
     "id": "ench_verdant_cloak",

--- a/data/mods/Xedra_Evolved/mutations/temporary.json
+++ b/data/mods/Xedra_Evolved/mutations/temporary.json
@@ -88,48 +88,5 @@
     "starting_trait": false,
     "purifiable": false,
     "activated_eocs": [ "EOC_LUCID_DREAM_FORCE_END" ]
-  },
-  {
-    "type": "mutation",
-    "id": "VERDANT_HELMET",
-    "name": "Verdant Helmet Enchant",
-    "description": "The enchantment for the Verdant Helmet.  Enhances your senses.",
-    "player_display": false,
-    "valid": false,
-    "points": 2,
-    "flags": [ "ENHANCED_VISION", "GLARE_RESIST" ]
-  },
-  {
-    "type": "mutation",
-    "id": "VERDANT_BODY",
-    "name": "Verdant Body Enchant",
-    "description": "The enchantment for the Verdant Cuirass.  Hides your scent and increases your mana regen slightly.",
-    "player_display": false,
-    "valid": false,
-    "points": 2,
-    "mana_regen_multiplier": 1.15,
-    "flags": [ "NO_SCENT" ]
-  },
-  {
-    "type": "mutation",
-    "id": "VERDANT_GAUNTLETS",
-    "name": "Verdant Gauntlet Enchant",
-    "description": "The enchantment for the Verdant Gauntlets.  Makes spellcasting easier.",
-    "player_display": false,
-    "valid": false,
-    "points": 2,
-    "casting_time_multiplier": 0.85,
-    "flags": [ "SUBTLE_SPELL" ]
-  },
-  {
-    "type": "mutation",
-    "id": "VERDANT_BOOTS",
-    "name": "Verdant Boots Enchant",
-    "description": "The enchantment for the Verdant Boots.  Makes you quieter and you can't be slowed too much.",
-    "player_display": false,
-    "valid": false,
-    "points": 2,
-    "noise_modifier": 0.4,
-    "flags": [ "STEADY", "SLUDGE_IMMUNE" ]
   }
 ]

--- a/data/mods/Xedra_Evolved/obsoletion_and_migration/mutations.json
+++ b/data/mods/Xedra_Evolved/obsoletion_and_migration/mutations.json
@@ -429,5 +429,48 @@
     "stealth_modifier": 60,
     "triggers": [ [ { "condition": "u_is_underwater" } ] ],
     "transform": { "target": "UNDINE_WATER_FORM_CAMOUFLAGE", "msg_transform": "", "active": false, "moves": 0 }
+  },
+  {
+    "type": "mutation",
+    "id": "VERDANT_HELMET",
+    "name": "Verdant Helmet Enchant",
+    "description": "The enchantment for the Verdant Helmet.  Enhances your senses.",
+    "player_display": false,
+    "valid": false,
+    "points": 2,
+    "flags": [ "ENHANCED_VISION", "GLARE_RESIST" ]
+  },
+  {
+    "type": "mutation",
+    "id": "VERDANT_BODY",
+    "name": "Verdant Body Enchant",
+    "description": "The enchantment for the Verdant Cuirass.  Hides your scent and increases your mana regen slightly.",
+    "player_display": false,
+    "valid": false,
+    "points": 2,
+    "mana_regen_multiplier": 1.15,
+    "flags": [ "NO_SCENT" ]
+  },
+  {
+    "type": "mutation",
+    "id": "VERDANT_GAUNTLETS",
+    "name": "Verdant Gauntlet Enchant",
+    "description": "The enchantment for the Verdant Gauntlets.  Makes spellcasting easier.",
+    "player_display": false,
+    "valid": false,
+    "points": 2,
+    "casting_time_multiplier": 0.85,
+    "flags": [ "SUBTLE_SPELL" ]
+  },
+  {
+    "type": "mutation",
+    "id": "VERDANT_BOOTS",
+    "name": "Verdant Boots Enchant",
+    "description": "The enchantment for the Verdant Boots.  Makes you quieter and you can't be slowed too much.",
+    "player_display": false,
+    "valid": false,
+    "points": 2,
+    "noise_modifier": 0.4,
+    "flags": [ "STEADY", "SLUDGE_IMMUNE" ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Xedra Evolved] Update Verdant Armor with new enchantments"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Previously, I had to make custom mutations to tie various mutation-only traits to and attach them to wearing the armor. Now, I can just put the traits into the enchantments

(Except flags, those can't be attached directly to enchantments yet)
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Obsolete the mutations, edit the enchantments to carry the values.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Entered game, spawned a set of verdant armor, it works.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

This will not update previous sets of verdant armor because once an item is created its relic_data never changes, but new sets will have the appropriate properties (which is why I didn't migrate the old mutations into nonexistence because it would break old verdant armor sets). 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
