### PR TITLE
Move all teeth mutations to use techniques

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -2441,5 +2441,13 @@
   {
     "id": "DRACULIN_VENOM",
     "type": "json_flag"
+  },
+  {
+    "id": "VENOM1",
+    "type": "json_flag"
+  },
+  {
+    "id": "VENOM2",
+    "type": "json_flag"
   }
 ]

--- a/data/json/items/armor/integrated.json
+++ b/data/json/items/armor/integrated.json
@@ -561,7 +561,9 @@
     "symbol": ";",
     "color": "dark_gray",
     "warmth": 2,
-    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "SKINTIGHT", "PADDED", "NO_SALVAGE" ],
+    "qualities": [ [ "CUT", 2 ], [ "BUTCHER", 4 ] ],
+    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "SKINTIGHT", "PADDED", "NO_SALVAGE", "PROVIDES_TECHNIQUES" ],
+    "techniques": [ "MANDIBLES_BITE", "MANDIBLES_BITE_NATURAL" ],
     "armor": [
       {
         "material": [ { "type": "chitin", "covered_by_mat": 100, "thickness": 3 } ],
@@ -576,7 +578,7 @@
     "type": "ARMOR",
     "category": "armor",
     "name": { "str_sp": "folding fangs" },
-    "description": "Your fangs have properly developed, and are prepared for the kill.",
+    "description": "Your fangs have properly developed, and are prepared for the kill.  They are easier to use against prey that is vulnerable or webbed.",
     "weight": "300 g",
     "volume": "200 ml",
     "price": 0,
@@ -585,7 +587,8 @@
     "symbol": ";",
     "color": "brown",
     "warmth": 2,
-    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "PERSONAL", "WATER_FRIENDLY", "PADDED" ],
+    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "PERSONAL", "WATER_FRIENDLY", "PADDED", "NO_SALVAGE", "PROVIDES_TECHNIQUES" ],
+    "techniques": [ "FOLDING_FANGS_BITE", "FOLDING_FANGS_BITE_NATURAL" ],
     "armor": [
       {
         "material": [ { "type": "sclerotin", "covered_by_mat": 100, "thickness": 3 } ],
@@ -1584,6 +1587,31 @@
     }
   },
   {
+    "id": "integrated_sharkteeth",
+    "type": "ARMOR",
+    "category": "armor",
+    "name": { "str_sp": "fangs" },
+    "description": "Rows of jagged teeth, essentially a biological chainsaw.  They're best used in deep water.",
+    "weight": "100 g",
+    "volume": "150 ml",
+    "price": 0,
+    "price_postapoc": 0,
+    "material": [ "bone" ],
+    "symbol": ",",
+    "color": "white",
+    "qualities": [ [ "CUT", 2 ], [ "BUTCHER", 4 ] ],
+    "techniques": [ "SHARKTEETH_BITE", "SHARKTEETH_BITE_NATURAL" ],
+    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "PERSONAL", "PADDED", "PROVIDES_TECHNIQUES" ],
+    "armor": [
+      {
+        "material": [ { "type": "bone", "covered_by_mat": 100, "thickness": 5 } ],
+        "covers": [ "mouth" ],
+        "coverage": 0,
+        "encumbrance": 0
+      }
+    ]
+  },
+  {
     "id": "integrated_fangs",
     "type": "ARMOR",
     "category": "armor",
@@ -1596,7 +1624,6 @@
     "material": [ "bone" ],
     "symbol": ",",
     "color": "white",
-    "warmth": 5,
     "qualities": [ [ "CUT", 2 ], [ "BUTCHER", 4 ] ],
     "techniques": [ "FANGS_BITE", "FANGS_BITE_NATURAL" ],
     "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "PERSONAL", "PADDED", "PROVIDES_TECHNIQUES" ],
@@ -1622,13 +1649,37 @@
     "material": [ "bone" ],
     "symbol": ",",
     "color": "white",
-    "warmth": 5,
     "qualities": [ [ "CUT", 2 ], [ "BUTCHER", 4 ] ],
     "techniques": [ "VAMPIRE_BITE", "VAMPIRE_BITE_NATURAL" ],
     "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "PERSONAL", "PADDED", "PROVIDES_TECHNIQUES" ],
     "armor": [
       {
         "material": [ { "type": "bone", "covered_by_mat": 100, "thickness": 3.2 } ],
+        "covers": [ "mouth" ],
+        "coverage": 0,
+        "encumbrance": 0
+      }
+    ]
+  },
+  {
+    "id": "integrated_saber_teeth",
+    "type": "ARMOR",
+    "category": "armor",
+    "name": { "str_sp": "saber teeth" },
+    "description": "A pair of enormous fangs, strong enough to punch through bone.",
+    "weight": "200 g",
+    "volume": "250 ml",
+    "price": 0,
+    "price_postapoc": 0,
+    "material": [ "bone" ],
+    "symbol": ",",
+    "color": "white",
+    "qualities": [ [ "CUT", 2 ], [ "BUTCHER", 4 ] ],
+    "techniques": [ "SABER_TEETH_BITE", "SABER_TEETH_BITE_NATURAL" ],
+    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "PERSONAL", "PADDED", "PROVIDES_TECHNIQUES" ],
+    "armor": [
+      {
+        "material": [ { "type": "bone", "covered_by_mat": 100, "thickness": 10 } ],
         "covers": [ "mouth" ],
         "coverage": 0,
         "encumbrance": 0

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -4078,6 +4078,7 @@
     "description": "Your body produces a potent venom.  Cutting or stabbing attacks from mutations have a chance to poison your target.",
     "prereqs": [ "POISRESIST" ],
     "changes_to": [ "POISONOUS2" ],
+    "flags": [ "VENOM1" ],
     "category": [ "SLIME", "TROGLOBITE", "SPIDER", "CEPHALOPOD", "GASTROPOD", "CHIMERA", "BATRACHIAN" ]
   },
   {
@@ -4088,6 +4089,7 @@
     "description": "Your venom has become particularly strong.  You're confident that your bites or other cutting/stabbing natural attacks will take your target down quickly.",
     "prereqs": [ "POISONOUS" ],
     "threshreq": [ "THRESH_SPIDER" ],
+    "flags": [ "VENOM2" ],
     "category": [ "SPIDER" ]
   },
   {
@@ -4909,20 +4911,12 @@
     "visibility": 8,
     "ugliness": 8,
     "mixed_effect": true,
-    "description": "Your face has drastically mutated, with the bones of your jaws having extended forth into a long, tapered snout.  The palate of your mouth is considerably vaulted, with curved, serrated teeth lining your saurian maw and reptilian scales covering your muzzle's exterior.  While paleobiology has evidently not evolved with mouth gear in mind (making such items unwearable), the bite wounds you can now inflict promise the ferocity of long-dead beasts.",
+    "description": "Your face has drastically mutated, with the bones of your jaws having extended forth into a long, tapered snout.  While modern-day gas masks mostly don't account for paleobiology, if you manage to evolve a set of fangs, you will bite with the ferocity of long-dead beasts.",
     "types": [ "MUZZLE" ],
     "prereqs": [ "SNOUT" ],
     "category": [ "RAPTOR" ],
     "restricts_gear": [ "mouth" ],
-    "social_modifiers": { "intimidate": 20 },
-    "attacks": {
-      "attack_text_u": "You dart your head and snap at %s!",
-      "attack_text_npc": "%1$s darts their head and snaps at %2$s!",
-      "blocker_mutations": [ "FANGS" ],
-      "body_part": "mouth",
-      "chance": 18,
-      "base_damage": { "damage_type": "stab", "amount": 18 }
-    }
+    "social_modifiers": { "intimidate": 20 }
   },
   {
     "type": "mutation",
@@ -5406,15 +5400,7 @@
     "leads_to": [ "PROBOSCIS" ],
     "category": [ "INSECT", "SPIDER" ],
     "wet_protection": [ { "part": "mouth", "ignored": 1 } ],
-    "integrated_armor": [ "integrated_mandibles" ],
-    "attacks": {
-      "attack_text_u": "You bite %s with your fangs!",
-      "attack_text_npc": "%1$s bites %2$s with their fangs!",
-      "blocker_mutations": [ "FANGS_SPIDER" ],
-      "body_part": "mouth",
-      "chance": 22,
-      "base_damage": { "damage_type": "cut", "amount": 12 }
-    }
+    "integrated_armor": [ "integrated_mandibles" ]
   },
   {
     "type": "mutation",
@@ -5423,7 +5409,7 @@
     "points": 2,
     "visibility": 6,
     "ugliness": 6,
-    "description": "You have developed deadly extensible fangs, allowing you to bite quickly or ensure your venom goes home, as desired.",
+    "description": "You have developed deadly extensible fangs.  This makes eating slower, but they're great for striking your prey, especially when it's helpless.  Slightly reduces wet effects.",
     "types": [ "TEETH", "MUZZLE" ],
     "cancels": [ "MOUTH_TENTACLES" ],
     "prereqs": [ "MANDIBLES" ],
@@ -5431,15 +5417,7 @@
     "category": [ "SPIDER" ],
     "consume_time_modifier": 2.0,
     "wet_protection": [ { "part": "mouth", "ignored": 1 } ],
-    "integrated_armor": [ "integrated_fangs_spider" ],
-    "attacks": {
-      "attack_text_u": "You bite %s with your fangs!",
-      "attack_text_npc": "%1$s bites %2$s with their fangs!",
-      "blocker_mutations": [ "MANDIBLES" ],
-      "body_part": "mouth",
-      "chance": 22,
-      "base_damage": { "damage_type": "stab", "amount": 15 }
-    }
+    "integrated_armor": [ "integrated_fangs_spider" ]
   },
   {
     "type": "mutation",
@@ -6672,20 +6650,12 @@
     "visibility": 5,
     "ugliness": 4,
     "mixed_effect": true,
-    "description": "Your jaw and nose have extended into a wolfish muzzle.  It lends itself to biting in combat and looks impressive, but prevents wearing mouthgear.",
+    "description": "Your jaw and nose have extended into a wolfish muzzle, making it difficult to find masks that fit.  If you have a set of fangs, you'll be able to trip enemies in combat by biting them.",
     "types": [ "MUZZLE" ],
     "prereqs": [ "SNOUT" ],
     "category": [ "BEAST", "LUPINE" ],
     "restricts_gear": [ "mouth" ],
-    "social_modifiers": { "intimidate": 6 },
-    "attacks": {
-      "attack_text_u": "You nip at %s!",
-      "attack_text_npc": "%1$s nips and harries %2$s!",
-      "blocker_mutations": [ "FANGS" ],
-      "body_part": "mouth",
-      "chance": 18,
-      "base_damage": { "damage_type": "cut", "amount": 4 }
-    }
+    "social_modifiers": { "intimidate": 6 }
   },
   {
     "type": "mutation",
@@ -6695,19 +6665,11 @@
     "visibility": 5,
     "ugliness": 4,
     "mixed_effect": true,
-    "description": "Your jaw and nose have extended into a bearish muzzle.  You could bite with it, and it looks impressive, but it prevents wearing mouthgear.",
+    "description": "Your jaw and nose have extended into a bearish muzzle, which interferes with most face-covering gear.  If you have a set of fangs, this will greatly improve their effectiveness, especially against downed enemies.",
     "types": [ "MUZZLE" ],
     "prereqs": [ "SNOUT" ],
     "category": [ "URSINE" ],
-    "restricts_gear": [ "mouth" ],
-    "attacks": {
-      "attack_text_u": "You bite %s!",
-      "attack_text_npc": "%1$s bites %2$s!",
-      "blocker_mutations": [ "FANGS" ],
-      "body_part": "mouth",
-      "chance": 20,
-      "base_damage": { "damage_type": "cut", "amount": 5 }
-    }
+    "restricts_gear": [ "mouth" ]
   },
   {
     "type": "mutation",
@@ -6716,7 +6678,7 @@
     "points": -2,
     "visibility": 6,
     "ugliness": 4,
-    "description": "Your face and jaw have extended, giving you an alert and attentive appearance.",
+    "description": "Your face and jaw have extended, giving you an alert and attentive appearance.  If you have a pair of matching incisors, you can bite much faster with them than any human ever could.",
     "types": [ "MUZZLE" ],
     "prereqs": [ "SNOUT" ],
     "category": [ "RAT", "MOUSE" ],
@@ -6730,20 +6692,12 @@
     "visibility": 8,
     "ugliness": 8,
     "mixed_effect": true,
-    "description": "Your face and jaws are a shorter version of those found on alligators.  They look NASTY--as do the bite wounds they can inflict--but prevent wearing mouthgear.",
+    "description": "You have a long, powerful set of jaws, like a monitor or a crocodilian.  This makes it hard to find a mask that fits, but with a set of fangs, you could really do some damage.",
     "types": [ "MUZZLE" ],
     "prereqs": [ "SNOUT" ],
     "category": [ "LIZARD" ],
     "restricts_gear": [ "mouth" ],
-    "social_modifiers": { "intimidate": 20 },
-    "attacks": {
-      "attack_text_u": "You bite a chunk out of %s!",
-      "attack_text_npc": "%1$s bites a chunk out of %2$s!",
-      "blocker_mutations": [ "FANGS" ],
-      "body_part": "mouth",
-      "chance": 18,
-      "base_damage": { "damage_type": "stab", "amount": 18 }
-    }
+    "social_modifiers": { "intimidate": 20 }
   },
   {
     "type": "mutation",
@@ -8545,20 +8499,13 @@
     "visibility": 10,
     "ugliness": 8,
     "consume_time_modifier": 0.3,
-    "description": "Your teeth have grown incredibly sharp, and have calcified even further.  In addition to letting you eat much faster, you can use them as a lethal natural weapon, as long as your anatomy favors it.  They also grow very fast, and you harmlessly shed them more or less at random.",
+    "description": "Your teeth have grown incredibly sharp, and have calcified even further.  In addition to letting you eat much faster, you can use them as a lethal natural weapon, especially in deep water.  They also grow very fast, and you harmlessly shed them more or less at random.",
     "prereqs": [ "FANGS" ],
     "types": [ "TEETH" ],
     "category": [ "FISH" ],
     "threshreq": [ "THRESH_FISH" ],
     "social_modifiers": { "intimidate": 5 },
-    "attacks": {
-      "attack_text_u": "You tear into %s with your teeth!",
-      "attack_text_npc": "%1$s tears into %2$s with their teeth!",
-      "body_part": "mouth",
-      "blocker_mutations": [ "MUZZLE", "MUZZLE_LONG", "MUZZLE_RAT" ],
-      "chance": 20,
-      "base_damage": { "damage_type": "stab", "amount": 25 }
-    },
+    "integrated_armor": [ "integrated_sharkteeth" ],
     "purifiable": false
   },
   {

--- a/data/json/techniques.json
+++ b/data/json/techniques.json
@@ -3516,8 +3516,16 @@
         "chance": 70,
         "duration": 3000,
         "on_damage": true,
-        "message": "Saliva glistens across %s's wound!",
+        "message": "Saliva glistens across the wound!",
         "req_flag": "DRACULIN_VENOM"
+      },
+      {
+        "id": "venom_player1",
+        "chance": 70,
+        "duration": 3000,
+        "on_damage": true,
+        "message": "Venom gets into the wound!",
+        "req_flag": "VENOM1"
       }
     ],
     "flat_bonuses": [
@@ -3556,8 +3564,16 @@
         "chance": 70,
         "duration": 3000,
         "on_damage": true,
-        "message": "Saliva glistens across %s's wound!",
+        "message": "Saliva glistens across the wound!",
         "req_flag": "DRACULIN_VENOM"
+      },
+      {
+        "id": "venom_player1",
+        "chance": 70,
+        "duration": 3000,
+        "on_damage": true,
+        "message": "Venom gets into the wound!",
+        "req_flag": "VENOM1"
       }
     ],
     "flat_bonuses": [
@@ -3585,10 +3601,18 @@
       {
         "id": "anticoagulant_draculin",
         "chance": 90,
-        "duration": 6000,
+        "duration": 3000,
         "on_damage": true,
-        "message": "Saliva glistens across %s's wound!",
+        "message": "Saliva glistens across the wound!",
         "req_flag": "DRACULIN_VENOM"
+      },
+      {
+        "id": "venom_player1",
+        "chance": 90,
+        "duration": 600,
+        "on_damage": true,
+        "message": "Venom gets into the wound!",
+        "req_flag": "VENOM1"
       }
     ],
     "flat_bonuses": [
@@ -3596,7 +3620,7 @@
       { "stat": "damage", "type": "stab", "scaling-stat": "unarmed", "scale": 4.4 },
       { "stat": "damage", "type": "bash", "scaling-stat": "str", "scale": 0.75 },
       { "stat": "damage", "type": "bash", "scaling-stat": "unarmed", "scale": 0.24 },
-      { "stat": "arpen", "type": "bash", "scaling-stat": "unar,ed", "scale": 1 },
+      { "stat": "arpen", "type": "bash", "scaling-stat": "unarmed", "scale": 1 },
       { "stat": "arpen", "type": "stab", "scaling-stat": "unarmed", "scale": 1 },
       { "stat": "movecost", "scale": 75 },
       { "stat": "movecost", "scaling-stat": "melee", "scale": -1.25 },
@@ -3628,8 +3652,16 @@
         "chance": 90,
         "duration": 3000,
         "on_damage": true,
-        "message": "Saliva glistens across %s's wound!",
+        "message": "Saliva glistens across the wound!",
         "req_flag": "DRACULIN_VENOM"
+      },
+      {
+        "id": "venom_player1",
+        "chance": 70,
+        "duration": 600,
+        "on_damage": true,
+        "message": "Venom gets into the wound!",
+        "req_flag": "VENOM1"
       }
     ],
     "flat_bonuses": [
@@ -3661,8 +3693,16 @@
         "chance": 90,
         "duration": 3000,
         "on_damage": true,
-        "message": "Saliva glistens across %s's wound!",
+        "message": "Saliva glistens across the wound!",
         "req_flag": "DRACULIN_VENOM"
+      },
+      {
+        "id": "venom_player1",
+        "chance": 70,
+        "duration": 600,
+        "on_damage": true,
+        "message": "Venom gets into the wound!",
+        "req_flag": "VENOM1"
       }
     ],
     "condition": {
@@ -3697,10 +3737,18 @@
       {
         "id": "anticoagulant_draculin",
         "chance": 100,
-        "duration": 6000,
+        "duration": 3000,
         "on_damage": true,
-        "message": "Saliva glistens across %s's wound!",
+        "message": "Saliva glistens across the wound!",
         "req_flag": "DRACULIN_VENOM"
+      },
+      {
+        "id": "venom_player1",
+        "chance": 90,
+        "duration": 600,
+        "on_damage": true,
+        "message": "Venom gets into the wound!",
+        "req_flag": "VENOM1"
       }
     ],
     "attack_vectors": [ "MOUTH" ],
@@ -3711,6 +3759,352 @@
       { "stat": "damage", "type": "bash", "scaling-stat": "unarmed", "scale": 0.24 },
       { "stat": "arpen", "type": "bash", "scaling-stat": "unarmed", "scale": 1 },
       { "stat": "arpen", "type": "stab", "scaling-stat": "unarmed", "scale": 1 },
+      { "stat": "movecost", "scale": 75 },
+      { "stat": "movecost", "scaling-stat": "melee", "scale": -1.25 },
+      { "stat": "movecost", "scaling-stat": "dex", "scale": -0.5 }
+    ]
+  },
+  {
+    "type": "technique",
+    "id": "SABER_TEETH_BITE",
+    "name": "Saber Teeth Bite",
+    "melee_allowed": true,
+    "messages": [ "You bite %s", "<npcname> bites %s!" ],
+    "unarmed_allowed": true,
+    "weighting": -5,
+    "reach_ok": false,
+    "attack_override": true,
+    "crit_ok": true,
+    "crit_tec_id": "SABER_TEETH_BITE_CRIT",
+    "attack_vectors": [ "MOUTH" ],
+    "condition": {
+      "and": [
+        { "not": { "u_has_effect": "natural_stance" } },
+        { "and": [ { "not": { "npc_has_flag": "GRAB_FILTER" } }, { "not": { "u_has_effect": "GRAB" } } ] }
+      ]
+    },
+    "tech_effects": [
+      {
+        "id": "anticoagulant_draculin",
+        "chance": 70,
+        "duration": 3000,
+        "on_damage": true,
+        "message": "Saliva glistens across the wound!",
+        "req_flag": "DRACULIN_VENOM"
+      },
+      {
+        "id": "venom_player1",
+        "chance": 70,
+        "duration": 3000,
+        "on_damage": true,
+        "message": "Venom gets into the wound!",
+        "req_flag": "VENOM1"
+      }
+    ],
+    "flat_bonuses": [
+      { "stat": "damage", "type": "stab", "scale": 21 },
+      { "stat": "damage", "type": "stab", "scaling-stat": "unarmed", "scale": 1.0 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "str", "scale": 0.75 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "unarmed", "scale": 0.06 },
+      { "stat": "movecost", "scale": 100 },
+      { "stat": "movecost", "scaling-stat": "melee", "scale": -1.25 },
+      { "stat": "movecost", "scaling-stat": "dex", "scale": -0.5 }
+    ]
+  },
+  {
+    "type": "technique",
+    "id": "SABER_TEETH_BITE_NATURAL",
+    "name": "Saber Teeth Bite",
+    "melee_allowed": true,
+    "messages": [ "You bite %s", "<npcname> bites %s!" ],
+    "unarmed_allowed": true,
+    "weighting": -2,
+    "reach_ok": false,
+    "attack_override": true,
+    "crit_ok": true,
+    "crit_tec_id": "SABER_TEETH_BITE_CRIT",
+    "attack_vectors": [ "MOUTH" ],
+    "tech_effects": [
+      {
+        "id": "anticoagulant_draculin",
+        "chance": 70,
+        "duration": 3000,
+        "on_damage": true,
+        "message": "Saliva glistens across the wound!",
+        "req_flag": "DRACULIN_VENOM"
+      },
+      {
+        "id": "venom_player1",
+        "chance": 70,
+        "duration": 3000,
+        "on_damage": true,
+        "message": "Venom gets into the wound!",
+        "req_flag": "VENOM1"
+      }
+    ],
+    "flat_bonuses": [
+      { "stat": "damage", "type": "stab", "scale": 21 },
+      { "stat": "damage", "type": "stab", "scaling-stat": "unarmed", "scale": 1.0 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "str", "scale": 0.75 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "unarmed", "scale": 0.06 },
+      { "stat": "movecost", "scale": 100 },
+      { "stat": "movecost", "scaling-stat": "melee", "scale": -1.25 },
+      { "stat": "movecost", "scaling-stat": "dex", "scale": -0.5 }
+    ]
+  },
+  {
+    "type": "technique",
+    "id": "SABER_TEETH_BITE_CRIT",
+    "name": "Critical Saber Teeth Bite",
+    "melee_allowed": true,
+    "messages": [ "You viciously bite %s", "<npcname> viciously bites %s!" ],
+    "unarmed_allowed": true,
+    "weighting": -4,
+    "reach_ok": false,
+    "attack_override": true,
+    "crit_tec": true,
+    "attack_vectors": [ "MOUTH" ],
+    "tech_effects": [
+      {
+        "id": "anticoagulant_draculin",
+        "chance": 90,
+        "duration": 3000,
+        "on_damage": true,
+        "message": "Saliva glistens across the wound!",
+        "req_flag": "DRACULIN_VENOM"
+      },
+      {
+        "id": "venom_player1",
+        "chance": 90,
+        "duration": 3000,
+        "on_damage": true,
+        "message": "Venom gets into the wound!",
+        "req_flag": "VENOM1"
+      }
+    ],
+    "flat_bonuses": [
+      { "stat": "damage", "type": "stab", "scale": 21 },
+      { "stat": "damage", "type": "stab", "scaling-stat": "unarmed", "scale": 4.4 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "str", "scale": 0.75 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "unarmed", "scale": 0.24 },
+      { "stat": "arpen", "type": "bash", "scaling-stat": "unarmed", "scale": 1 },
+      { "stat": "arpen", "type": "stab", "scaling-stat": "unarmed", "scale": 1 },
+      { "stat": "movecost", "scale": 100 },
+      { "stat": "movecost", "scaling-stat": "melee", "scale": -1.25 },
+      { "stat": "movecost", "scaling-stat": "dex", "scale": -0.5 }
+    ]
+  },
+  {
+    "type": "technique",
+    "id": "SHARKTEETH_BITE",
+    "name": "Shark Teeth Bite",
+    "melee_allowed": true,
+    "messages": [ "You chomp %s", "<npcname> chomps %s!" ],
+    "unarmed_allowed": true,
+    "weighting": -5,
+    "reach_ok": false,
+    "attack_override": true,
+    "crit_ok": true,
+    "crit_tec_id": "SHARKTEETH_BITE_CRIT",
+    "attack_vectors": [ "MOUTH" ],
+    "condition": {
+      "and": [
+        { "not": "u_is_underwater" },
+        { "and": [ { "not": { "npc_has_flag": "GRAB_FILTER" } }, { "not": { "u_has_effect": "GRAB" } } ] }
+      ]
+    },
+    "tech_effects": [
+      {
+        "id": "anticoagulant_draculin",
+        "chance": 70,
+        "duration": 3000,
+        "on_damage": true,
+        "message": "Saliva glistens across the wound!",
+        "req_flag": "DRACULIN_VENOM"
+      },
+      {
+        "id": "venom_player1",
+        "chance": 70,
+        "duration": 3000,
+        "on_damage": true,
+        "message": "Venom gets into the wound!",
+        "req_flag": "VENOM1"
+      }
+    ],
+    "flat_bonuses": [
+      { "stat": "damage", "type": "cut", "scale": 22 },
+      { "stat": "damage", "type": "cut", "scaling-stat": "unarmed", "scale": 1 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "str", "scale": 0.75 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "unarmed", "scale": 0.06 },
+      { "stat": "movecost", "scale": 100 },
+      { "stat": "movecost", "scaling-stat": "melee", "scale": -1.25 },
+      { "stat": "movecost", "scaling-stat": "dex", "scale": -0.5 }
+    ]
+  },
+  {
+    "type": "technique",
+    "id": "SHARKTEETH_BITE_NATURAL",
+    "name": "Shark Teeth Bite",
+    "melee_allowed": true,
+    "messages": [ "You chomp %s", "<npcname> chomps %s!" ],
+    "unarmed_allowed": true,
+    "weighting": -2,
+    "reach_ok": false,
+    "attack_override": true,
+    "crit_ok": true,
+    "crit_tec_id": "SHARKTEETH_BITE_CRIT",
+    "attack_vectors": [ "MOUTH" ],
+    "condition": {
+      "and": [
+        {
+          "or": [ "u_is_underwater", { "and": [ { "npc_has_flag": "GRAB_FILTER" }, { "u_has_flag": "GRAB" } ] } ]
+        }
+      ]
+    },
+    "tech_effects": [
+      {
+        "id": "anticoagulant_draculin",
+        "chance": 70,
+        "duration": 3000,
+        "on_damage": true,
+        "message": "Saliva glistens across the wound!",
+        "req_flag": "DRACULIN_VENOM"
+      },
+      {
+        "id": "venom_player1",
+        "chance": 70,
+        "duration": 3000,
+        "on_damage": true,
+        "message": "Venom gets into the wound!",
+        "req_flag": "VENOM1"
+      }
+    ],
+    "flat_bonuses": [
+      { "stat": "damage", "type": "cut", "scale": 22 },
+      { "stat": "damage", "type": "cut", "scaling-stat": "unarmed", "scale": 1 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "str", "scale": 0.75 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "unarmed", "scale": 0.06 },
+      { "stat": "movecost", "scale": 100 },
+      { "stat": "movecost", "scaling-stat": "melee", "scale": -1.25 },
+      { "stat": "movecost", "scaling-stat": "dex", "scale": -0.5 }
+    ]
+  },
+  {
+    "type": "technique",
+    "id": "SHARKTEETH_BITE_CRIT",
+    "name": "Critical Shark Teeth Bite",
+    "melee_allowed": true,
+    "messages": [ "You rip into %s with your shark teeth", "<npcname> rips into %s with their shark teeth!" ],
+    "unarmed_allowed": true,
+    "reach_ok": false,
+    "attack_override": true,
+    "crit_tec": true,
+    "attack_vectors": [ "MOUTH" ],
+    "tech_effects": [
+      {
+        "id": "anticoagulant_draculin",
+        "chance": 90,
+        "duration": 3000,
+        "on_damage": true,
+        "message": "Saliva glistens across the wound!",
+        "req_flag": "DRACULIN_VENOM"
+      },
+      {
+        "id": "venom_player1",
+        "chance": 90,
+        "duration": 3000,
+        "on_damage": true,
+        "message": "Venom gets into the wound!",
+        "req_flag": "VENOM1"
+      }
+    ],
+    "flat_bonuses": [
+      { "stat": "damage", "type": "cut", "scale": 22 },
+      { "stat": "damage", "type": "cut", "scaling-stat": "unarmed", "scale": 4.2 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "str", "scale": 0.75 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "unarmed", "scale": 0.24 },
+      { "stat": "arpen", "type": "bash", "scaling-stat": "unarmed", "scale": 1 },
+      { "stat": "arpen", "type": "cut", "scaling-stat": "unarmed", "scale": 0.75 },
+      { "stat": "movecost", "scale": 100 },
+      { "stat": "movecost", "scaling-stat": "melee", "scale": -1.25 },
+      { "stat": "movecost", "scaling-stat": "dex", "scale": -0.5 }
+    ]
+  },
+  {
+    "type": "technique",
+    "id": "MANDIBLES_BITE",
+    "name": "Mandibles Bite",
+    "melee_allowed": true,
+    "messages": [ "You bite %s", "<npcname> bites %s!" ],
+    "unarmed_allowed": true,
+    "weighting": -5,
+    "reach_ok": false,
+    "attack_override": true,
+    "crit_ok": true,
+    "crit_tec_id": "MANDIBLES_BITE_NATURAL",
+    "attack_vectors": [ "MOUTH" ],
+    "condition": {
+      "and": [ { "not": { "npc_has_flag": "GRAB_FILTER" } }, { "not": { "u_has_effect": "GRAB" } }
+      ]
+    },
+    "flat_bonuses": [
+      { "stat": "damage", "type": "cut", "scale": 10 },
+      { "stat": "damage", "type": "cut", "scaling-stat": "unarmed", "scale": 1 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "str", "scale": 0.75 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "unarmed", "scale": 0.06 },
+      { "stat": "movecost", "scale": 75 },
+      { "stat": "movecost", "scaling-stat": "melee", "scale": -1.25 },
+      { "stat": "movecost", "scaling-stat": "dex", "scale": -0.5 }
+    ]
+  },
+  {
+    "type": "technique",
+    "id": "MANDIBLES_BITE_NATURAL",
+    "name": "Mandibles Bite",
+    "melee_allowed": true,
+    "messages": [ "You bite %s", "<npcname> bites %s!" ],
+    "unarmed_allowed": true,
+    "weighting": -2,
+    "reach_ok": false,
+    "attack_override": true,
+    "crit_ok": true,
+    "crit_tec_id": "SHARKTEETH_BITE_CRIT",
+    "attack_vectors": [ "MOUTH" ],
+    "condition": {
+      "and": [
+        {
+          "or": [ "u_is_underwater", { "and": [ { "npc_has_flag": "GRAB_FILTER" }, { "u_has_flag": "GRAB" } ] } ]
+        }
+      ]
+    },
+    "flat_bonuses": [
+      { "stat": "damage", "type": "cut", "scale": 10 },
+      { "stat": "damage", "type": "cut", "scaling-stat": "unarmed", "scale": 1 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "str", "scale": 0.75 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "unarmed", "scale": 0.06 },
+      { "stat": "movecost", "scale": 75 },
+      { "stat": "movecost", "scaling-stat": "melee", "scale": -1.25 },
+      { "stat": "movecost", "scaling-stat": "dex", "scale": -0.5 }
+    ]
+  },
+  {
+    "type": "technique",
+    "id": "MANDIBLES_BITE_CRIT",
+    "name": "Critical Mandibles Bite",
+    "melee_allowed": true,
+    "messages": [ "You viciously bite %s", "<npcname> viciously bites %s!" ],
+    "unarmed_allowed": true,
+    "reach_ok": false,
+    "attack_override": true,
+    "crit_tec": true,
+    "attack_vectors": [ "MOUTH" ],
+    "flat_bonuses": [
+      { "stat": "damage", "type": "cut", "scale": 10 },
+      { "stat": "damage", "type": "cut", "scaling-stat": "unarmed", "scale": 4.2 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "str", "scale": 0.75 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "unarmed", "scale": 0.24 },
+      { "stat": "arpen", "type": "bash", "scaling-stat": "unarmed", "scale": 1 },
+      { "stat": "arpen", "type": "cut", "scaling-stat": "unarmed", "scale": 0.75 },
       { "stat": "movecost", "scale": 75 },
       { "stat": "movecost", "scaling-stat": "melee", "scale": -1.25 },
       { "stat": "movecost", "scaling-stat": "dex", "scale": -0.5 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Moves all teeth mutations to use the new mutation attack system"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
#71874 created a new method for mutation attacks to work. This moves the rest of the TEETH mutation attacks over to that system.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
- FANGS - A quick attack that deals low stab damage.
- FANGS_VAMPIRE - A quick attack that deals moderate stab damage and delivers an anticoagulant effect to the victim.
- FOLDING_FANGS - Pretty much identical to FANGS_VAMPIRE. They don't come with a built-in effect, but still deliver poison if the character has it. Will be used more often if the target is webbed.
- INCISORS - Similar to fangs, but a bit better.
- MANDIBLES - Similar to fangs, but deals cut damage instead.
- SHARKTEETH - Shark teeth deal cut damage and are some of the strongest teeth around. They work more often when the user is swimming.
- SABER TEETH - The strongest stabbing bite, but felines have no muzzle to synergize with.

If you have MUZZLE, MUZZLE_BEAR, MUZZLE_LONG, or MUZZLE_RAPTOR and a set of FANGS, you will gain an additional technique.

- MUZZLE: Downs the opponent if it's a bipedal nonflying enemy, to simulate a wolf's harrying bites. On a crit, it will also down flying and insect/spider type enemies, provided they aren't immune.
- MUZZLE_BEAR: Adds a slower high-damage bite that only procs if the enemy is downed, to simulate a bear just mauling a guy.
- MUZZLE_RAPTOR: Adds a stronger bite attack
- MUZZLE_LONG: Adds a stronger but slower bite attack

Allows bite attacks to apply venom from the Venomous and Strongly Venomous mutations.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
Beaks are apparently going to be a body part that replaces the mouth, so they're waiting on limb stuff to be completed.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
Ongoing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
