### PR TITLE
Update nutrients struct to store calories as a 64-bit integer

### DIFF
--- a/src/stomach.cpp
+++ b/src/stomach.cpp
@@ -210,7 +210,7 @@ nutrients &nutrients::operator/=( int r )
     if( !finalized ) {
         debugmsg( "Nutrients not finalized when -= called!" );
     }
-    calories = divide_round_up( calories, r );
+    calories = divide_round_up<int64_t>( calories, r );
     for( const std::pair<const vitamin_id, std::variant<int, vitamin_units::mass>> &vit : vitamins_ ) {
         std::variant<int, vitamin_units::mass> &here = vitamins_[vit.first];
         here = divide_round_up( std::get<int>( here ), r );
@@ -348,7 +348,7 @@ food_summary stomach_contents::digest( const Character &owner, const needs_rates
     // Digest kCal -- use min_kcal by default, but no more than what's in stomach,
     // and no less than percentage_kcal of what's in stomach.
     int kcal_fraction = std::lround( nutr.kcal() * rates.percent_kcal );
-    digested.nutr.calories = half_hours * clamp( rates.min_calories, kcal_fraction * 1000,
+    digested.nutr.calories = half_hours * clamp<int64_t>( rates.min_calories, kcal_fraction * 1000,
                              nutr.calories );
 
     // Digest vitamins just like we did kCal, but we need to do one at a time.

--- a/src/stomach.h
+++ b/src/stomach.h
@@ -35,7 +35,7 @@ const std::vector<std::pair<std::string, mass>> mass_units = { {
 // them
 struct nutrients {
         /** amount of calories (1/1000s of kcal) this food has */
-        int calories = 0;
+        int64_t calories = 0;
 
         /** Replace the values here with the minimum (or maximum) of themselves and the corresponding
          * values taken from r. */


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Stored calories in camp can overflow. The existing 32-bit limit is about 178 worker-days worth of food at EXTRA_EXERCISE. That's not terribly long for bigger camps.

#### Describe the solution
Redefine calories as int64_t (64-bit platform-independent)

Specify using 64-bit for C++'s standard library functions where appropriate

A 64-bit integer can store.... many (BIG NUMBER) times more. For all practical purposes, this should be sufficient for the foreseeable future. If we're still playing CDDA 20 years from now with our photon computers and the 64-bit calorie storage is a problem for our mega-city of 10m individual NPCs, then I guess we can blame me for my lack of foresight.

#### Describe alternatives you've considered
*one-hundred and twenty eight bits*

#### Testing
It compiles. Value seems to persist through save+load, at least for camps
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/396d0466-42ee-483b-8e96-75efe7aee0d3)

(This image shows a store of ~2.3m kilocalories, which is ~2.3b calories. A signed 32-bit integer can only store a positive value of ~2.147b, so the fact that we have more than that means it's working at least here.)

#### Additional context
It helps when you read the compiler warnings