### PR TITLE
Move XL/XS prefixes from base game to JSON tags. Part 1.

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -2455,5 +2455,15 @@
   {
     "id": "DRACULIN_VENOM",
     "type": "json_flag"
+  },
+  {
+    "id": "PREFIX_XL",
+    "type": "json_flag",
+    "item_prefix": "XL "
+  },
+  {
+    "id": "PREFIX_XS",
+    "type": "json_flag",
+    "item_prefix": "XS "
   }
 ]

--- a/data/json/items/armor/ammo_pouch.json
+++ b/data/json/items/armor/ammo_pouch.json
@@ -207,17 +207,17 @@
     "id": "xl_chestrig",
     "type": "ARMOR",
     "copy-from": "chestrig",
-    "name": { "str": "XL chest rig" },
+    "name": { "str": "chest rig" },
     "proportional": { "weight": 1.25, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_chestrig",
     "type": "ARMOR",
     "copy-from": "chestrig",
-    "name": { "str": "XS chest rig" },
+    "name": { "str": "chest rig" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "javelin_bag",
@@ -666,17 +666,17 @@
     "id": "xl_tacvest",
     "type": "ARMOR",
     "copy-from": "tacvest",
-    "name": { "str": "XL tac vest" },
+    "name": { "str": "tac vest" },
     "proportional": { "weight": 1.25, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_tacvest",
     "type": "ARMOR",
     "copy-from": "tacvest",
-    "name": { "str": "XS tac vest" },
+    "name": { "str": "tac vest" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "light_load_bearing_vest",
@@ -1245,7 +1245,7 @@
     "id": "xlkevlar",
     "type": "ARMOR",
     "category": "armor",
-    "name": { "str": "XL Kevlar vest" },
+    "name": { "str": "Kevlar vest" },
     "description": "A massive handmade imitation of a proper ballistic vest for abnormally large folks.  Large and heavy, but will still fit under an abnormally large coat.",
     "weight": "4210 g",
     "volume": "8 L",
@@ -1257,7 +1257,7 @@
     "color": "light_gray",
     "warmth": 20,
     "material_thickness": 5,
-    "flags": [ "STURDY", "OVERSIZE" ],
+    "flags": [ "STURDY", "OVERSIZE", "PREFIX_XL" ],
     "armor": [
       {
         "material": [

--- a/data/json/items/armor/arms_armor.json
+++ b/data/json/items/armor/arms_armor.json
@@ -136,17 +136,17 @@
     "id": "xl_armguard_chitin",
     "copy-from": "armguard_chitin",
     "type": "ARMOR",
-    "name": { "str": "pair of XL chitin arm guards", "str_pl": "pairs of XL chitin arm guards" },
+    "name": { "str": "pair of chitin arm guards", "str_pl": "pairs of chitin arm guards" },
     "proportional": { "weight": 1.25, "volume": 1.23 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_armguard_chitin",
     "type": "ARMOR",
     "copy-from": "armguard_chitin",
-    "name": { "str": "pair of XS chitin arm guards", "str_pl": "pairs of XS chitin arm guards" },
+    "name": { "str": "pair of chitin arm guards", "str_pl": "pairs of chitin arm guards" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "armguard_acidchitin",
@@ -161,17 +161,17 @@
     "id": "xl_armguard_acidchitin",
     "copy-from": "armguard_acidchitin",
     "type": "ARMOR",
-    "name": { "str": "pair of XL biosilicified chitin arm guards", "str_pl": "pairs of XL biosilicified chitin arm guards" },
+    "name": { "str": "pair of biosilicified chitin arm guards", "str_pl": "pairs of biosilicified chitin arm guards" },
     "proportional": { "weight": 1.25, "volume": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_armguard_acidchitin",
     "type": "ARMOR",
     "copy-from": "armguard_acidchitin",
-    "name": { "str": "pair of XS biosilicified chitin arm guards", "str_pl": "pairs of XS biosilicified chitin arm guards" },
+    "name": { "str": "pair of biosilicified chitin arm guards", "str_pl": "pairs of biosilicified chitin arm guards" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "cloth_arms_padded",
@@ -260,19 +260,19 @@
   {
     "id": "xl_armguard_hard",
     "type": "ARMOR",
-    "name": { "str": "pair of XL hard arm guards", "str_pl": "pairs of XL hard arm guards" },
+    "name": { "str": "pair of hard arm guards", "str_pl": "pairs of hard arm guards" },
     "weight": "550 g",
     "volume": "4 L",
     "copy-from": "armguard_hard",
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_armguard_hard",
     "type": "ARMOR",
     "copy-from": "armguard_hard",
-    "name": { "str": "pair of XS hard arm guards", "str_pl": "pairs of XS hard arm guards" },
+    "name": { "str": "pair of hard arm guards", "str_pl": "pairs of hard arm guards" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "armguard_larmor",
@@ -308,18 +308,18 @@
   {
     "id": "xl_armguard_larmor",
     "type": "ARMOR",
-    "name": { "str": "pair of XL leather arm guards", "str_pl": "pairs of XL leather arm guards" },
+    "name": { "str": "pair of leather arm guards", "str_pl": "pairs of leather arm guards" },
     "copy-from": "armguard_larmor",
     "proportional": { "weight": 1.25, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_armguard_larmor",
     "type": "ARMOR",
     "copy-from": "armguard_larmor",
-    "name": { "str": "pair of XS leather arm guards", "str_pl": "pairs of XS leather arm guards" },
+    "name": { "str": "pair of leather arm guards", "str_pl": "pairs of leather arm guards" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "armguard_lightplate",
@@ -354,19 +354,19 @@
   {
     "id": "xl_armguard_lightplate",
     "type": "ARMOR",
-    "name": { "str": "pair of XL steel arm guards", "str_pl": "pairs of XL steel arm guards" },
+    "name": { "str": "pair of steel arm guards", "str_pl": "pairs of steel arm guards" },
     "weight": "3243 g",
     "volume": "7 L",
     "copy-from": "armguard_lightplate",
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_armguard_lightplate",
     "type": "ARMOR",
     "copy-from": "armguard_lightplate",
-    "name": { "str": "pair of XS steel arm guards", "str_pl": "pairs of XS steel arm guards" },
+    "name": { "str": "pair of steel arm guards", "str_pl": "pairs of steel arm guards" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "armguard_metal",
@@ -534,18 +534,18 @@
   {
     "id": "xl_armguard_metal",
     "type": "ARMOR",
-    "name": { "str": "pair of XL sheet metal arm guards", "str_pl": "pairs of XL sheet metal arm guards" },
+    "name": { "str": "pair of sheet metal arm guards", "str_pl": "pairs of sheet metal arm guards" },
     "proportional": { "weight": 1.25, "volume": 1.13, "price": 1.25 },
     "copy-from": "armguard_metal",
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_armguard_metal",
     "type": "ARMOR",
     "copy-from": "armguard_metal",
-    "name": { "str": "pair of XS sheet metal arm guards", "str_pl": "pairs of XS sheet metal arm guards" },
+    "name": { "str": "pair of sheet metal arm guards", "str_pl": "pairs of sheet metal arm guards" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "armguard_paper",
@@ -641,19 +641,19 @@
   {
     "id": "xl_armguard_scrap",
     "type": "ARMOR",
-    "name": { "str": "pair of XL scrap arm guards", "str_pl": "pairs of XL scrap arm guards" },
+    "name": { "str": "pair of scrap arm guards", "str_pl": "pairs of scrap arm guards" },
     "weight": "3412 g",
     "volume": "6 L",
     "copy-from": "armguard_scrap",
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_armguard_scrap",
     "type": "ARMOR",
     "copy-from": "armguard_scrap",
-    "name": { "str": "pair of XS scrap arm guards", "str_pl": "pairs of XS scrap arm guards" },
+    "name": { "str": "pair of scrap arm guards", "str_pl": "pairs of scrap arm guards" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "armguard_tire",
@@ -688,18 +688,18 @@
   {
     "id": "xl_armguard_tire",
     "type": "ARMOR",
-    "name": { "str": "pair of XL tire arm guards", "str_pl": "pairs of XL tire arm guards" },
+    "name": { "str": "pair of tire arm guards", "str_pl": "pairs of tire arm guards" },
     "copy-from": "armguard_tire",
     "proportional": { "weight": 1.25, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_armguard_tire",
     "type": "ARMOR",
     "copy-from": "armguard_tire",
-    "name": { "str": "pair of XS tire arm guards", "str_pl": "pairs of XS tire arm guards" },
+    "name": { "str": "pair of tire arm guards", "str_pl": "pairs of tire arm guards" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "armguard_soft",
@@ -733,19 +733,19 @@
   {
     "id": "xl_armguard_soft",
     "type": "ARMOR",
-    "name": { "str": "pair of XL neoprene arm sleeves", "str_pl": "pairs of XL neoprene arm sleeves" },
+    "name": { "str": "pair of neoprene arm sleeves", "str_pl": "pairs of neoprene arm sleeves" },
     "weight": "330 g",
     "volume": "1750 ml",
     "copy-from": "armguard_soft",
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_armguard_soft",
     "type": "ARMOR",
     "copy-from": "armguard_soft",
-    "name": { "str": "pair of XS neoprene arm sleeves", "str_pl": "pairs of XS neoprene arm sleeves" },
+    "name": { "str": "pair of neoprene arm sleeves", "str_pl": "pairs of neoprene arm sleeves" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "gambeson_sleeve",
@@ -771,18 +771,18 @@
   {
     "id": "xl_gambeson_sleeve",
     "type": "ARMOR",
-    "name": { "str": "pair of XL gambeson sleeves", "str_pl": "pairs of XL gambeson sleeves" },
+    "name": { "str": "pair of gambeson sleeves", "str_pl": "pairs of gambeson sleeves" },
     "copy-from": "gambeson_sleeve",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_gambeson_sleeve",
     "type": "ARMOR",
-    "name": { "str": "pair of XS gambeson sleeves", "str_pl": "pairs of XS gambeson sleeves" },
+    "name": { "str": "pair of gambeson sleeves", "str_pl": "pairs of gambeson sleeves" },
     "copy-from": "gambeson_sleeve",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "k_gambeson_sleeve",
@@ -830,18 +830,18 @@
   {
     "id": "xl_k_gambeson_sleeve",
     "type": "ARMOR",
-    "name": { "str": "pair of XL Kevlar gambeson sleeves", "str_pl": "pairs of XL Kevlar gambeson sleeves" },
+    "name": { "str": "pair of Kevlar gambeson sleeves", "str_pl": "pairs of Kevlar gambeson sleeves" },
     "copy-from": "k_gambeson_sleeve",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_k_gambeson_sleeve",
     "type": "ARMOR",
-    "name": { "str": "pair of XS Kevlar gambeson sleeves", "str_pl": "pairs of XS Kevlar gambeson sleeves" },
+    "name": { "str": "pair of Kevlar gambeson sleeves", "str_pl": "pairs of Kevlar gambeson sleeves" },
     "copy-from": "k_gambeson_sleeve",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "abstract": "base_chainmail_arms",
@@ -897,7 +897,7 @@
     "abstract": "xl_chainmail_arms",
     "type": "ARMOR",
     "copy-from": "base_chainmail_arms",
-    "name": { "str": "pair of XL chainmail sleeves", "str_pl": "pairs of XL chainmail sleeves" },
+    "name": { "str": "pair of chainmail sleeves", "str_pl": "pairs of chainmail sleeves" },
     "proportional": { "weight": 1.25, "volume": 1.13, "price": 1.25 },
     "pocket_data": [
       {
@@ -923,13 +923,13 @@
         "flag_restriction": [ "ABLATIVE_CHAINMAIL_ELBOWS" ]
       }
     ],
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "abstract": "xs_chainmail_arms",
     "type": "ARMOR",
     "copy-from": "base_chainmail_arms",
-    "name": { "str": "pair of XS chainmail sleeves", "str_pl": "pairs of XS chainmail sleeves" },
+    "name": { "str": "pair of chainmail sleeves", "str_pl": "pairs of chainmail sleeves" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
     "pocket_data": [
       {
@@ -955,7 +955,7 @@
         "flag_restriction": [ "ABLATIVE_CHAINMAIL_ELBOWS" ]
       }
     ],
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "chainmail_junk_arms",
@@ -992,14 +992,14 @@
     "copy-from": "xl_chainmail_arms",
     "replace_materials": { "steel": "lc_steel_chain" },
     "type": "ARMOR",
-    "name": { "str": "pair of XL mild steel chainmail sleeves", "str_pl": "pairs of XL mild steel chainmail sleeves" }
+    "name": { "str": "pair of mild steel chainmail sleeves", "str_pl": "pairs of mild steel chainmail sleeves" }
   },
   {
     "id": "xs_lc_chainmail_arms",
     "copy-from": "xs_chainmail_arms",
     "replace_materials": { "steel": "lc_steel_chain" },
     "type": "ARMOR",
-    "name": { "str": "pair of XS mild steel chainmail sleeves", "str_pl": "pairs of XS mild steel chainmail sleeves" }
+    "name": { "str": "pair of mild steel chainmail sleeves", "str_pl": "pairs of mild steel chainmail sleeves" }
   },
   {
     "id": "mc_chainmail_arms",
@@ -1021,14 +1021,14 @@
     "type": "ARMOR",
     "copy-from": "xl_chainmail_arms",
     "replace_materials": { "steel": "mc_steel_chain" },
-    "name": { "str": "pair of XL medium steel chainmail sleeves", "str_pl": "pairs of XL medium steel chainmail sleeves" }
+    "name": { "str": "pair of medium steel chainmail sleeves", "str_pl": "pairs of medium steel chainmail sleeves" }
   },
   {
     "id": "xs_mc_chainmail_arms",
     "type": "ARMOR",
     "copy-from": "xs_chainmail_arms",
     "replace_materials": { "steel": "mc_steel_chain" },
-    "name": { "str": "pair of XS medium steel chainmail sleeves", "str_pl": "pairs of XS medium steel chainmail sleeves" }
+    "name": { "str": "pair of medium steel chainmail sleeves", "str_pl": "pairs of medium steel chainmail sleeves" }
   },
   {
     "id": "hc_chainmail_arms",
@@ -1042,14 +1042,14 @@
     "type": "ARMOR",
     "copy-from": "xl_chainmail_arms",
     "replace_materials": { "steel": "hc_steel_chain" },
-    "name": { "str": "pair of XL high steel chainmail sleeves", "str_pl": "pairs of XL high steel chainmail sleeves" }
+    "name": { "str": "pair of high steel chainmail sleeves", "str_pl": "pairs of high steel chainmail sleeves" }
   },
   {
     "id": "xs_hc_chainmail_arms",
     "type": "ARMOR",
     "copy-from": "xs_chainmail_arms",
     "replace_materials": { "steel": "hc_steel_chain" },
-    "name": { "str": "pair of XS high steel chainmail sleeves", "str_pl": "pairs of XS high steel chainmail sleeves" }
+    "name": { "str": "pair of high steel chainmail sleeves", "str_pl": "pairs of high steel chainmail sleeves" }
   },
   {
     "id": "ch_chainmail_arms",
@@ -1063,14 +1063,14 @@
     "type": "ARMOR",
     "copy-from": "xl_chainmail_arms",
     "replace_materials": { "steel": "ch_steel_chain" },
-    "name": { "str": "pair of XL hardened steel chainmail sleeves", "str_pl": "pairs of XL hardened steel chainmail sleeves" }
+    "name": { "str": "pair of hardened steel chainmail sleeves", "str_pl": "pairs of hardened steel chainmail sleeves" }
   },
   {
     "id": "xs_ch_chainmail_arms",
     "type": "ARMOR",
     "copy-from": "xs_chainmail_arms",
     "replace_materials": { "steel": "ch_steel_chain" },
-    "name": { "str": "pair of XS hardened steel chainmail sleeves", "str_pl": "pairs of XS hardened steel chainmail sleeves" }
+    "name": { "str": "pair of hardened steel chainmail sleeves", "str_pl": "pairs of hardened steel chainmail sleeves" }
   },
   {
     "id": "qt_chainmail_arms",
@@ -1084,14 +1084,14 @@
     "type": "ARMOR",
     "copy-from": "xl_chainmail_arms",
     "replace_materials": { "steel": "qt_steel_chain" },
-    "name": { "str": "pair of XL tempered steel chainmail sleeves", "str_pl": "pairs of XL tempered steel chainmail sleeves" }
+    "name": { "str": "pair of tempered steel chainmail sleeves", "str_pl": "pairs of tempered steel chainmail sleeves" }
   },
   {
     "id": "xs_qt_chainmail_arms",
     "type": "ARMOR",
     "copy-from": "xs_chainmail_arms",
     "replace_materials": { "steel": "qt_steel_chain" },
-    "name": { "str": "pair of XS tempered steel chainmail sleeves", "str_pl": "pairs of XS tempered steel chainmail sleeves" }
+    "name": { "str": "pair of tempered steel chainmail sleeves", "str_pl": "pairs of tempered steel chainmail sleeves" }
   },
   {
     "id": "elbow_pads",
@@ -1156,17 +1156,17 @@
     "id": "xl_armguard_bronze",
     "type": "ARMOR",
     "copy-from": "armguard_bronze",
-    "name": { "str": "pair of XL bronze vambraces", "str_pl": "pairs of XL bronze vambraces" },
+    "name": { "str": "pair of bronze vambraces", "str_pl": "pairs of bronze vambraces" },
     "proportional": { "weight": 1.25, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_armguard_bronze",
     "type": "ARMOR",
     "copy-from": "armguard_bronze",
-    "name": { "str": "pair of XS bronze vambraces", "str_pl": "pairs of XS bronze vambraces" },
+    "name": { "str": "pair of bronze vambraces", "str_pl": "pairs of bronze vambraces" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "vambrace_larmor",
@@ -1202,20 +1202,20 @@
   {
     "id": "xl_vambrace_larmor",
     "type": "ARMOR",
-    "name": { "str": "pair of XL leather vambraces", "str_pl": "pairs of XL leather vambraces" },
+    "name": { "str": "pair of leather vambraces", "str_pl": "pairs of leather vambraces" },
     "weight": "531 g",
     "volume": "1250 ml",
     "copy-from": "vambrace_larmor",
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_vambrace_larmor",
     "type": "ARMOR",
     "copy-from": "vambrace_larmor",
     "looks_like": "vambrace_larmor",
-    "name": { "str": "pair of XS leather vambraces", "str_pl": "pairs of XS leather vambraces" },
+    "name": { "str": "pair of leather vambraces", "str_pl": "pairs of leather vambraces" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "armguard_cut_resistant",
@@ -1265,10 +1265,10 @@
   {
     "id": "xl_armor_lc_lightarmguard",
     "type": "ARMOR",
-    "name": { "str": "XL mild steel light arm guard" },
+    "name": { "str": "mild steel light arm guard" },
     "copy-from": "armor_lc_lightarmguard",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_mc_lightarmguard",
@@ -1294,10 +1294,10 @@
   {
     "id": "xl_armor_mc_lightarmguard",
     "type": "ARMOR",
-    "name": { "str": "XL medium steel light arm guard" },
+    "name": { "str": "medium steel light arm guard" },
     "copy-from": "armor_mc_lightarmguard",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_hc_lightarmguard",
@@ -1323,10 +1323,10 @@
   {
     "id": "xl_armor_hc_lightarmguard",
     "type": "ARMOR",
-    "name": { "str": "XL high steel light arm guard" },
+    "name": { "str": "high steel light arm guard" },
     "copy-from": "armor_hc_lightarmguard",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_ch_lightarmguard",
@@ -1352,10 +1352,10 @@
   {
     "id": "xl_armor_ch_lightarmguard",
     "type": "ARMOR",
-    "name": { "str": "XL hardened light arm guard" },
+    "name": { "str": "hardened steel light arm guard" },
     "copy-from": "armor_ch_lightarmguard",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_qt_lightarmguard",
@@ -1381,10 +1381,10 @@
   {
     "id": "xl_armor_qt_lightarmguard",
     "type": "ARMOR",
-    "name": { "str": "XL tempered light arm guard" },
+    "name": { "str": "tempered steel light arm guard" },
     "copy-from": "armor_qt_lightarmguard",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_lc_armguard",
@@ -1424,10 +1424,10 @@
   {
     "id": "xl_armor_lc_armguard",
     "type": "ARMOR",
-    "name": { "str": "XL mild steel arm guard" },
+    "name": { "str": "mild steel arm guard" },
     "copy-from": "armor_lc_armguard",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_mc_armguard",
@@ -1453,10 +1453,10 @@
   {
     "id": "xl_armor_mc_armguard",
     "type": "ARMOR",
-    "name": { "str": "XL medium steel arm guard" },
+    "name": { "str": "medium steel arm guard" },
     "copy-from": "armor_mc_armguard",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_hc_armguard",
@@ -1482,10 +1482,10 @@
   {
     "id": "xl_armor_hc_armguard",
     "type": "ARMOR",
-    "name": { "str": "XL high steel arm guard" },
+    "name": { "str": "high steel arm guard" },
     "copy-from": "armor_hc_armguard",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_ch_armguard",
@@ -1511,16 +1511,16 @@
   {
     "id": "xl_armor_ch_armguard",
     "type": "ARMOR",
-    "name": { "str": "XL hardened arm guard" },
+    "name": { "str": "hardened steel arm guard" },
     "copy-from": "armor_ch_armguard",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_qt_armguard",
     "type": "ARMOR",
     "copy-from": "armor_lc_armguard",
-    "name": { "str": "tempered arm guard" },
+    "name": { "str": "tempered steel arm guard" },
     "material": [ "qt_steel", "qt_steel_chain" ],
     "description": "An armguard, 1.75 mm at the thickest.  The medium steel has been quenched and tempered, offering top of the line protection.",
     "armor": [
@@ -1540,10 +1540,10 @@
   {
     "id": "xl_armor_qt_armguard",
     "type": "ARMOR",
-    "name": { "str": "XL tempered arm guard" },
+    "name": { "str": "tempered steel arm guard" },
     "copy-from": "armor_qt_armguard",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_lc_heavyarmguard",
@@ -1582,10 +1582,10 @@
   {
     "id": "xl_armor_lc_heavyarmguard",
     "type": "ARMOR",
-    "name": { "str": "XL mild steel heavy arm guard" },
+    "name": { "str": "mild steel heavy arm guard" },
     "copy-from": "armor_lc_heavyarmguard",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_mc_heavyarmguard",
@@ -1610,10 +1610,10 @@
   {
     "id": "xl_armor_mc_heavyarmguard",
     "type": "ARMOR",
-    "name": { "str": "XL medium steel heavy arm guard" },
+    "name": { "str": "medium steel heavy arm guard" },
     "copy-from": "armor_mc_heavyarmguard",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_hc_heavyarmguard",
@@ -1638,10 +1638,10 @@
   {
     "id": "xl_armor_hc_heavyarmguard",
     "type": "ARMOR",
-    "name": { "str": "XL high steel heavy arm guard" },
+    "name": { "str": "high steel heavy arm guard" },
     "copy-from": "armor_hc_heavyarmguard",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_ch_heavyarmguard",
@@ -1666,10 +1666,10 @@
   {
     "id": "xl_armor_ch_heavyarmguard",
     "type": "ARMOR",
-    "name": { "str": "XL hardened steel heavy arm guard" },
+    "name": { "str": "hardened steel heavy arm guard" },
     "copy-from": "armor_ch_heavyarmguard",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_qt_heavyarmguard",
@@ -1694,10 +1694,10 @@
   {
     "id": "xl_armor_qt_heavyarmguard",
     "type": "ARMOR",
-    "name": { "str": "XL tempered heavy arm guard" },
+    "name": { "str": "tempered steel heavy arm guard" },
     "copy-from": "armor_qt_heavyarmguard",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "survivor_adhoc_leather_sleeves",

--- a/data/json/items/armor/ballistic_armor.json
+++ b/data/json/items/armor/ballistic_armor.json
@@ -1349,7 +1349,7 @@
     "id": "xl_ballistic_vest",
     "type": "ARMOR",
     "category": "armor",
-    "name": { "str": "XL ballistic vest" },
+    "name": { "str": "ballistic vest" },
     "description": "An enormous handmade ballistic vest built with of lots of salvaged ballistic Kevlar panels.  It's bulkier than a factory made US Army vest, but it is customized for the benefit of an abnormally large mutant who couldn't wear such armors otherwise.  Coated in MOLLE webbing to support modular loadouts for the tacticool mutant.  It could be outfitted with steel plates for further protection.",
     "weight": "4500 g",
     "volume": "9 L",
@@ -1359,7 +1359,7 @@
     "material": [ "nylon", "kevlar_layered" ],
     "color": "light_gray",
     "warmth": 15,
-    "flags": [ "STURDY", "OUTER", "WATER_FRIENDLY", "OVERSIZE" ],
+    "flags": [ "STURDY", "OUTER", "WATER_FRIENDLY", "OVERSIZE", "PREFIX_XL" ],
     "use_action": [ { "type": "attach_molle", "size": 12 }, { "type": "detach_molle" } ],
     "armor": [
       {
@@ -1380,7 +1380,7 @@
     "id": "xl_ballistic_vest_lc",
     "type": "ARMOR",
     "category": "armor",
-    "name": { "str": "XL ballistic vest (mild steel plates)", "str_pl": "XL ballistic vests (mild steel plates)" },
+    "name": { "str": "ballistic vest (mild steel plates)", "str_pl": "ballistic vests (mild steel plates)" },
     "description": "An enormous handmade ballistic vest built with lots of salvaged ballistic Kevlar panels and homemade \"ballistic inserts\" made of mild steel.  The thin metal isn't the most protective, but it's probably better than just plain Kevlar.",
     "weight": "12500 g",
     "volume": "9 L",
@@ -1389,7 +1389,7 @@
     "material": [ "nylon", "kevlar_layered", "lc_steel" ],
     "color": "light_gray",
     "warmth": 20,
-    "flags": [ "STURDY", "OUTER", "WATER_FRIENDLY", "OVERSIZE" ],
+    "flags": [ "STURDY", "OUTER", "WATER_FRIENDLY", "OVERSIZE", "PREFIX_XL" ],
     "use_action": [ { "type": "attach_molle", "size": 12 }, { "type": "detach_molle" } ],
     "armor": [
       {
@@ -1411,7 +1411,7 @@
     "id": "xl_ballistic_vest_qt",
     "type": "ARMOR",
     "category": "armor",
-    "name": { "str": "XL ballistic vest (tempered steel plates)", "str_pl": "XL ballistic vests (tempered steel plates)" },
+    "name": { "str": "ballistic vest (tempered steel plates)", "str_pl": "ballistic vests (tempered steel plates)" },
     "description": "An enormous handmade ballistic vest made of lots of salvaged ballistic Kevlar panels and ten NIJ IIIA plates inserted into custom-made pockets - four each for your front and back and one each for your sides.  Monstrously heavy but extremely protective.",
     "weight": "18000 g",
     "volume": "9 L",
@@ -1421,7 +1421,7 @@
     "material": [ "nylon", "kevlar_layered", "qt_steel" ],
     "color": "light_gray",
     "warmth": 20,
-    "flags": [ "STURDY", "OUTER", "WATER_FRIENDLY", "OVERSIZE" ],
+    "flags": [ "STURDY", "OUTER", "WATER_FRIENDLY", "OVERSIZE", "PREFIX_XL" ],
     "use_action": [ { "type": "attach_molle", "size": 12 }, { "type": "detach_molle" } ],
     "armor": [
       {

--- a/data/json/items/armor/bespoke_armor/custom_bodysuits.json
+++ b/data/json/items/armor/bespoke_armor/custom_bodysuits.json
@@ -191,18 +191,18 @@
   {
     "id": "xl_lsurvivor_jumpsuit",
     "type": "ARMOR",
-    "name": { "str": "XL light Kevlar jumpsuit" },
+    "name": { "str": "light Kevlar jumpsuit" },
     "copy-from": "lsurvivor_jumpsuit",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_lsurvivor_jumpsuit",
     "type": "ARMOR",
-    "name": { "str": "XS light Kevlar jumpsuit" },
+    "name": { "str": "light Kevlar jumpsuit" },
     "copy-from": "lsurvivor_jumpsuit",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "survivor_jumpsuit",
@@ -260,18 +260,18 @@
   {
     "id": "xlsurvivor_jumpsuit",
     "type": "ARMOR",
-    "name": { "str": "XL Kevlar jumpsuit" },
+    "name": { "str": "Kevlar jumpsuit" },
     "copy-from": "survivor_jumpsuit",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xssurvivor_jumpsuit",
     "type": "ARMOR",
-    "name": { "str": "XS Kevlar jumpsuit" },
+    "name": { "str": "Kevlar jumpsuit" },
     "copy-from": "survivor_jumpsuit",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.75 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "hsurvivor_jumpsuit",
@@ -314,18 +314,18 @@
   {
     "id": "xl_hsurvivor_jumpsuit",
     "type": "ARMOR",
-    "name": { "str": "XL steel-plated Kevlar jumpsuit" },
+    "name": { "str": "steel-plated Kevlar jumpsuit" },
     "copy-from": "hsurvivor_jumpsuit",
     "proportional": { "weight": 1.13, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_hsurvivor_jumpsuit",
     "type": "ARMOR",
-    "name": { "str": "XS steel-plated Kevlar jumpsuit" },
+    "name": { "str": "steel-plated Kevlar jumpsuit" },
     "copy-from": "hsurvivor_jumpsuit",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.75 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "wsurvivor_jumpsuit",
@@ -367,18 +367,18 @@
   {
     "id": "xl_wsurvivor_jumpsuit",
     "type": "ARMOR",
-    "name": { "str": "XL fur Kevlar jumpsuit" },
+    "name": { "str": "fur Kevlar jumpsuit" },
     "copy-from": "wsurvivor_jumpsuit",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_wsurvivor_jumpsuit",
     "type": "ARMOR",
-    "name": { "str": "XS fur Kevlar jumpsuit" },
+    "name": { "str": "fur Kevlar jumpsuit" },
     "copy-from": "wsurvivor_jumpsuit",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "wsurvivor_jumpsuit_nofur",
@@ -405,18 +405,18 @@
   {
     "id": "xs_wsurvivor_jumpsuit_nofur",
     "type": "ARMOR",
-    "name": { "str": "XS faux fur Kevlar jumpsuit" },
+    "name": { "str": "faux fur Kevlar jumpsuit" },
     "copy-from": "wsurvivor_jumpsuit_nofur",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "xl_wsurvivor_jumpsuit_nofur",
     "type": "ARMOR",
-    "name": { "str": "XL faux fur Kevlar jumpsuit" },
+    "name": { "str": "faux fur Kevlar jumpsuit" },
     "copy-from": "wsurvivor_jumpsuit_nofur",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "h20survivor_jumpsuit",
@@ -491,18 +491,18 @@
   {
     "id": "xs_h20survivor_jumpsuit",
     "type": "ARMOR",
-    "name": { "str": "XS Kevlar wetsuit" },
+    "name": { "str": "Kevlar wetsuit" },
     "copy-from": "h20survivor_jumpsuit",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "xl_h20survivor_jumpsuit",
     "type": "ARMOR",
-    "name": { "str": "XL Kevlar wetsuit" },
+    "name": { "str": "Kevlar wetsuit" },
     "copy-from": "h20survivor_jumpsuit",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "h20survivor_jumpsuit_light",
@@ -577,18 +577,18 @@
   {
     "id": "xs_h20survivor_jumpsuit_light",
     "type": "ARMOR",
-    "name": { "str": "XS light Kevlar wetsuit oversuit" },
+    "name": { "str": "light Kevlar wetsuit oversuit" },
     "copy-from": "h20survivor_jumpsuit_light",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "xl_h20survivor_jumpsuit_light",
     "type": "ARMOR",
-    "name": { "str": "XL light Kevlar wetsuit oversuit" },
+    "name": { "str": "light Kevlar wetsuit oversuit" },
     "copy-from": "h20survivor_jumpsuit_light",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "thick_h20survivor_jumpsuit",
@@ -663,18 +663,18 @@
   {
     "id": "xs_thick_h20survivor_jumpsuit",
     "type": "ARMOR",
-    "name": { "str": "XS thick Kevlar wetsuit" },
+    "name": { "str": "thick Kevlar wetsuit" },
     "copy-from": "thick_h20survivor_jumpsuit",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "xl_thick_h20survivor_jumpsuit",
     "type": "ARMOR",
-    "name": { "str": "XL thick Kevlar wetsuit" },
+    "name": { "str": "thick Kevlar wetsuit" },
     "copy-from": "thick_h20survivor_jumpsuit",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "fsurvivor_jumpsuit",
@@ -715,17 +715,17 @@
   {
     "id": "xs_fsurvivor_jumpsuit",
     "type": "ARMOR",
-    "name": { "str": "XS Kevlar firesuit" },
+    "name": { "str": "Kevlar firesuit" },
     "copy-from": "fsurvivor_jumpsuit",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "xl_fsurvivor_jumpsuit",
     "type": "ARMOR",
-    "name": { "str": "XL Kevlar firesuit" },
+    "name": { "str": "Kevlar firesuit" },
     "copy-from": "fsurvivor_jumpsuit",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   }
 ]

--- a/data/json/items/armor/bespoke_armor/custom_boots.json
+++ b/data/json/items/armor/bespoke_armor/custom_boots.json
@@ -57,18 +57,18 @@
   {
     "id": "xl_boots_lsurvivor",
     "type": "ARMOR",
-    "name": { "str": "pair of XL light survivor boots", "str_pl": "pairs of XL light survivor boots" },
+    "name": { "str": "pair of light survivor boots", "str_pl": "pairs of light survivor boots" },
     "copy-from": "boots_lsurvivor",
     "proportional": { "weight": 1.4, "volume": 1.4 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_boots_lsurvivor",
     "type": "ARMOR",
     "copy-from": "boots_lsurvivor",
-    "name": { "str": "pair of XS light survivor boots", "str_pl": "pairs of XS light survivor boots" },
+    "name": { "str": "pair of light survivor boots", "str_pl": "pairs of light survivor boots" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "boots_survivor",
@@ -130,16 +130,16 @@
     "type": "ARMOR",
     "copy-from": "boots_survivor",
     "proportional": { "weight": 1.4, "volume": 1.4 },
-    "name": { "str": "pair of XL survivor boots", "str_pl": "pairs of XL survivor boots" },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "name": { "str": "pair of survivor boots", "str_pl": "pairs of survivor boots" },
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "boots_xssurvivor",
     "type": "ARMOR",
     "copy-from": "boots_survivor",
-    "name": { "str": "pair of XS survivor boots", "str_pl": "pairs of XS survivor boots" },
+    "name": { "str": "pair of survivor boots", "str_pl": "pairs of survivor boots" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "boots_wsurvivor_nofur",
@@ -194,17 +194,17 @@
     "id": "xl_boots_wsurvivor_nofur",
     "type": "ARMOR",
     "copy-from": "boots_wsurvivor_nofur",
-    "name": { "str": "pair of XL faux fur winter survivor boots", "str_pl": "pairs of XL faux fur winter survivor boots" },
+    "name": { "str": "pair of faux fur winter survivor boots", "str_pl": "pairs of faux fur winter survivor boots" },
     "proportional": { "weight": 1.3, "volume": 1.3 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_boots_wsurvivor_nofur",
     "type": "ARMOR",
     "copy-from": "boots_wsurvivor_nofur",
-    "name": { "str": "pair of XS faux fur winter survivor boots", "str_pl": "pairs of XS faux fur winter survivor boots" },
+    "name": { "str": "pair of faux fur winter survivor boots", "str_pl": "pairs of faux fur winter survivor boots" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "boots_wsurvivor",
@@ -267,18 +267,18 @@
   {
     "id": "xl_boots_wsurvivor",
     "type": "ARMOR",
-    "name": { "str": "pair of XL winter survivor boots", "str_pl": "pairs of XL winter survivor boots" },
+    "name": { "str": "pair of winter survivor boots", "str_pl": "pairs of winter survivor boots" },
     "copy-from": "boots_wsurvivor",
     "proportional": { "weight": 1.3, "volume": 1.3 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_boots_wsurvivor",
     "type": "ARMOR",
     "copy-from": "boots_wsurvivor",
-    "name": { "str": "pair of XS winter survivor boots", "str_pl": "pairs of XS winter survivor boots" },
+    "name": { "str": "pair of winter survivor boots", "str_pl": "pairs of winter survivor boots" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "boots_h20survivor",
@@ -348,17 +348,17 @@
     "id": "xl_boots_h20survivor",
     "type": "ARMOR",
     "copy-from": "boots_h20survivor",
-    "name": { "str": "pair of XL Kevlar diving boots", "str_pl": "pairs of XL Kevlar diving boots" },
+    "name": { "str": "pair of Kevlar diving boots", "str_pl": "pairs of Kevlar diving boots" },
     "proportional": { "weight": 1.3, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_boots_h20survivor",
     "type": "ARMOR",
     "copy-from": "boots_h20survivor",
-    "name": { "str": "pair of XS Kevlar diving boots", "str_pl": "pairs of XS Kevlar diving boots" },
+    "name": { "str": "pair of Kevlar diving boots", "str_pl": "pairs of Kevlar diving boots" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "boots_h20survivor_light",
@@ -429,17 +429,17 @@
     "id": "xl_boots_h20survivor_light",
     "type": "ARMOR",
     "copy-from": "boots_h20survivor_light",
-    "name": { "str": "pair of XL Kevlar diving overboots", "str_pl": "pairs of XL light Kevlar diving overboots" },
+    "name": { "str": "pair of light Kevlar diving overboots", "str_pl": "pairs of light Kevlar diving overboots" },
     "proportional": { "weight": 1.3, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_boots_h20survivor_light",
     "type": "ARMOR",
     "copy-from": "boots_h20survivor_light",
-    "name": { "str": "pair of XS light Kevlar diving overboots", "str_pl": "pairs of XS light Kevlar diving overboots" },
+    "name": { "str": "pair of light Kevlar diving overboots", "str_pl": "pairs of light Kevlar diving overboots" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "boots_h20survivor_thick",
@@ -509,17 +509,17 @@
     "id": "xl_boots_h20survivor_thick",
     "type": "ARMOR",
     "copy-from": "boots_h20survivor_thick",
-    "name": { "str": "pair of XL thick Kevlar diving boots", "str_pl": "pairs of XL thick Kevlar diving boots" },
+    "name": { "str": "pair of thick Kevlar diving boots", "str_pl": "pairs of thick Kevlar diving boots" },
     "proportional": { "weight": 1.3, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_boots_h20survivor_thick",
     "type": "ARMOR",
     "copy-from": "boots_h20survivor_thick",
-    "name": { "str": "pair of XS thick Kevlar diving boots", "str_pl": "pairs of XS thick Kevlar diving boots" },
+    "name": { "str": "pair of thick Kevlar diving boots", "str_pl": "pairs of thick Kevlar diving boots" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "swim_fins_custom",

--- a/data/json/items/armor/bespoke_armor/custom_gloves.json
+++ b/data/json/items/armor/bespoke_armor/custom_gloves.json
@@ -23,18 +23,18 @@
   {
     "id": "xl_gloves_lsurvivor",
     "type": "ARMOR",
-    "name": { "str": "pair of XL light survivor gloves", "str_pl": "pairs of XL light survivor gloves" },
+    "name": { "str": "pair of light survivor gloves", "str_pl": "pairs of light survivor gloves" },
     "copy-from": "gloves_lsurvivor",
     "proportional": { "weight": 1.5, "volume": 1.5 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_gloves_lsurvivor",
     "type": "ARMOR",
     "copy-from": "gloves_lsurvivor",
-    "name": { "str": "pair of XS light survivor gloves", "str_pl": "pairs of XS light survivor gloves" },
+    "name": { "str": "pair of light survivor gloves", "str_pl": "pairs of light survivor gloves" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "gloves_lsurvivor_fingerless",
@@ -73,18 +73,18 @@
   {
     "id": "xl_gloves_lsurvivor_fingerless",
     "type": "ARMOR",
-    "name": { "str": "pair of XL fingerless light survivor gloves", "str_pl": "pairs of XL fingerless light survivor gloves" },
+    "name": { "str": "pair of fingerless light survivor gloves", "str_pl": "pairs of fingerless light survivor gloves" },
     "copy-from": "gloves_lsurvivor_fingerless",
     "proportional": { "weight": 1.5, "volume": 1.5 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_gloves_lsurvivor_fingerless",
     "type": "ARMOR",
     "copy-from": "gloves_lsurvivor_fingerless",
-    "name": { "str": "pair of XS fingerless light survivor gloves", "str_pl": "pairs of XS fingerless light survivor gloves" },
+    "name": { "str": "pair of fingerless light survivor gloves", "str_pl": "pairs of fingerless light survivor gloves" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "gloves_survivor_fingerless",
@@ -123,18 +123,18 @@
   {
     "id": "xl_gloves_survivor_fingerless",
     "type": "ARMOR",
-    "name": { "str": "pair of XL fingerless survivor gloves", "str_pl": "pairs of XL fingerless survivor gloves" },
+    "name": { "str": "pair of fingerless survivor gloves", "str_pl": "pairs of fingerless survivor gloves" },
     "copy-from": "gloves_survivor_fingerless",
     "proportional": { "weight": 1.5, "volume": 1.5 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_gloves_survivor_fingerless",
     "type": "ARMOR",
     "copy-from": "gloves_survivor_fingerless",
-    "name": { "str": "pair of XS fingerless survivor gloves", "str_pl": "pairs of XS fingerless survivor gloves" },
+    "name": { "str": "pair of fingerless survivor gloves", "str_pl": "pairs of fingerless survivor gloves" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "gloves_survivor",
@@ -161,17 +161,17 @@
     "id": "xl_gloves_survivor",
     "type": "ARMOR",
     "copy-from": "gloves_survivor",
-    "name": { "str": "pair of XL survivor gloves", "str_pl": "pairs of XL survivor gloves" },
+    "name": { "str": "pair of survivor gloves", "str_pl": "pairs of survivor gloves" },
     "proportional": { "weight": 1.5, "volume": 1.5 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_gloves_survivor",
     "type": "ARMOR",
     "copy-from": "gloves_survivor",
-    "name": { "str": "pair of XS survivor gloves", "str_pl": "pairs of XS survivor gloves" },
+    "name": { "str": "pair of survivor gloves", "str_pl": "pairs of survivor gloves" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "gloves_wsurvivor",
@@ -197,18 +197,18 @@
   {
     "id": "xl_gloves_wsurvivor",
     "type": "ARMOR",
-    "name": { "str": "pair of XL winter survivor gloves", "str_pl": "pairs of XL winter survivor gloves" },
+    "name": { "str": "pair of winter survivor gloves", "str_pl": "pairs of winter survivor gloves" },
     "copy-from": "gloves_wsurvivor",
     "proportional": { "weight": 1.5, "volume": 1.5 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_gloves_wsurvivor",
     "type": "ARMOR",
     "copy-from": "gloves_wsurvivor",
-    "name": { "str": "pair of XS winter survivor gloves", "str_pl": "pairs of XS winter survivor gloves" },
+    "name": { "str": "pair of winter survivor gloves", "str_pl": "pairs of winter survivor gloves" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "gloves_wsurvivor_nofur",
@@ -225,18 +225,18 @@
   {
     "id": "xl_gloves_wsurvivor_nofur",
     "type": "ARMOR",
-    "name": { "str": "pair of XL faux fur winter survivor gloves", "str_pl": "pairs of XL faux fur winter survivor gloves" },
+    "name": { "str": "pair of faux fur winter survivor gloves", "str_pl": "pairs of faux fur winter survivor gloves" },
     "copy-from": "gloves_wsurvivor_nofur",
     "proportional": { "weight": 1.5, "volume": 1.5 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_gloves_wsurvivor_nofur",
     "type": "ARMOR",
     "copy-from": "gloves_wsurvivor_nofur",
-    "name": { "str": "pair of XS faux fur winter survivor gloves", "str_pl": "pairs of XS faux fur winter survivor gloves" },
+    "name": { "str": "pair of faux fur winter survivor gloves", "str_pl": "pairs of faux fur winter survivor gloves" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "gloves_h20survivor",
@@ -273,17 +273,17 @@
     "id": "xl_gloves_h20survivor",
     "type": "ARMOR",
     "copy-from": "gloves_h20survivor",
-    "name": { "str": "pair of XL Kevlar wetsuit gloves", "str_pl": "pairs of XL Kevlar wetsuit gloves" },
+    "name": { "str": "pair of Kevlar wetsuit gloves", "str_pl": "pairs of Kevlar wetsuit gloves" },
     "proportional": { "weight": 1.3, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_gloves_h20survivor",
     "type": "ARMOR",
     "copy-from": "gloves_h20survivor",
-    "name": { "str": "pair of XS Kevlar wetsuit gloves", "str_pl": "pairs of XS Kevlar wetsuit gloves" },
+    "name": { "str": "pair of Kevlar wetsuit gloves", "str_pl": "pairs of Kevlar wetsuit gloves" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "gloves_h20survivor_light",
@@ -321,17 +321,17 @@
     "id": "xl_gloves_h20survivor_light",
     "type": "ARMOR",
     "copy-from": "gloves_h20survivor_light",
-    "name": { "str": "pair of XL light Kevlar wetsuit overgloves", "str_pl": "pairs of XL light Kevlar wetsuit overgloves" },
+    "name": { "str": "pair of light Kevlar wetsuit overgloves", "str_pl": "pairs of light Kevlar wetsuit overgloves" },
     "proportional": { "weight": 1.3, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_gloves_h20survivor_light",
     "type": "ARMOR",
     "copy-from": "gloves_h20survivor_light",
-    "name": { "str": "pair of XS light Kevlar wetsuit overgloves", "str_pl": "pairs of XS light Kevlar wetsuit overgloves" },
+    "name": { "str": "pair of light Kevlar wetsuit overgloves", "str_pl": "pairs of light Kevlar wetsuit overgloves" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "gloves_h20survivor_thick",
@@ -368,16 +368,16 @@
     "id": "xl_gloves_h20survivor_thick",
     "type": "ARMOR",
     "copy-from": "gloves_h20survivor_thick",
-    "name": { "str": "pair of XL Kevlar wetsuit gloves", "str_pl": "pairs of XL Kevlar wetsuit gloves" },
+    "name": { "str": "pair of Kevlar wetsuit gloves", "str_pl": "pairs of Kevlar wetsuit gloves" },
     "proportional": { "weight": 1.3, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_gloves_h20survivor_thick",
     "type": "ARMOR",
     "copy-from": "gloves_h20survivor_thick",
-    "name": { "str": "pair of XS Kevlar wetsuit gloves", "str_pl": "pairs of XS Kevlar wetsuit gloves" },
+    "name": { "str": "pair of Kevlar wetsuit gloves", "str_pl": "pairs of Kevlar wetsuit gloves" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   }
 ]

--- a/data/json/items/armor/bespoke_armor/custom_headgear.json
+++ b/data/json/items/armor/bespoke_armor/custom_headgear.json
@@ -52,17 +52,17 @@
     "id": "xl_helmet_nomad",
     "type": "ARMOR",
     "copy-from": "helmet_nomad",
-    "name": { "str": "XL nomad cowl" },
+    "name": { "str": "nomad cowl" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_helmet_nomad",
     "type": "ARMOR",
     "copy-from": "helmet_nomad",
-    "name": { "str": "XS nomad cowl" },
+    "name": { "str": "nomad cowl" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "hood_survivor",
@@ -113,33 +113,33 @@
     "id": "xl_hood_wsurvivor",
     "type": "ARMOR",
     "copy-from": "hood_wsurvivor",
-    "name": { "str": "XL winter survivor hood" },
+    "name": { "str": "winter survivor hood" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_hood_wsurvivor",
     "type": "ARMOR",
     "copy-from": "hood_wsurvivor",
-    "name": { "str": "XS winter survivor hood" },
+    "name": { "str": "winter survivor hood" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "hood_xlsurvivor",
     "type": "ARMOR",
     "copy-from": "hood_survivor",
-    "name": { "str": "XL survivor hood" },
+    "name": { "str": "survivor hood" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "hood_xssurvivor",
     "type": "ARMOR",
     "copy-from": "hood_survivor",
-    "name": { "str": "XS survivor hood" },
+    "name": { "str": "survivor hood" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "hood_lsurvivor",
@@ -167,17 +167,17 @@
     "id": "xl_hood_lsurvivor",
     "type": "ARMOR",
     "copy-from": "hood_lsurvivor",
-    "name": { "str": "XL light survivor hood" },
+    "name": { "str": "light survivor hood" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_hood_lsurvivor",
     "type": "ARMOR",
     "copy-from": "hood_lsurvivor",
-    "name": { "str": "XS light survivor hood" },
+    "name": { "str": "light survivor hood" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "hood_wsurvivor_nofur",
@@ -198,17 +198,17 @@
     "material": [ "kevlar_layered", "faux_fur" ],
     "color": "pink",
     "warmth": 65,
-    "name": { "str": "XL faux fur winter survivor hood" },
+    "name": { "str": "winter faux fur survivor hood" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_hood_wsurvivor_nofur",
     "type": "ARMOR",
     "copy-from": "hood_wsurvivor_nofur",
-    "name": { "str": "XS faux fur winter survivor hood" },
+    "name": { "str": "winter faux fur survivor hood" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "flags": [ "UNDERSIZE" ]
+    "flags": [ "UNDERSIZE", "PREFIX_XS" ]
   },
   {
     "id": "hood_h20survivor",
@@ -276,17 +276,17 @@
     "id": "xl_hood_h20survivor",
     "type": "ARMOR",
     "copy-from": "hood_h20survivor",
-    "name": { "str": "XL Kevlar wetsuit hood" },
+    "name": { "str": "Kevlar wetsuit hood" },
     "proportional": { "weight": 1.3, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_hood_h20survivor",
     "type": "ARMOR",
     "copy-from": "hood_h20survivor",
-    "name": { "str": "XS Kevlar wetsuit hood" },
+    "name": { "str": "Kevlar wetsuit hood" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "hood_h20survivor_light",
@@ -355,17 +355,17 @@
     "id": "xl_hood_h20survivor_light",
     "type": "ARMOR",
     "copy-from": "hood_h20survivor_light",
-    "name": { "str": "XL light Kevlar wetsuit overhood" },
+    "name": { "str": "light Kevlar wetsuit overhood" },
     "proportional": { "weight": 1.3, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_hood_h20survivor_light",
     "type": "ARMOR",
     "copy-from": "hood_h20survivor_light",
-    "name": { "str": "XS light Kevlar wetsuit overhood" },
+    "name": { "str": "light Kevlar wetsuit overhood" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "hood_h20survivor_thick",
@@ -433,17 +433,17 @@
     "id": "xl_hood_h20survivor_thick",
     "type": "ARMOR",
     "copy-from": "hood_h20survivor_thick",
-    "name": { "str": "XL thick Kevlar wetsuit hood" },
+    "name": { "str": "thick Kevlar wetsuit hood" },
     "proportional": { "weight": 1.3, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_hood_h20survivor_thick",
     "type": "ARMOR",
     "copy-from": "hood_h20survivor_thick",
-    "name": { "str": "XS thick Kevlar wetsuit hood" },
+    "name": { "str": "thick Kevlar wetsuit hood" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "helmet_scavenger",
@@ -472,16 +472,16 @@
     "id": "xl_helmet_scavenger",
     "type": "ARMOR",
     "copy-from": "helmet_scavenger",
-    "name": { "str": "XL scavenger cowl" },
+    "name": { "str": "scavenger cowl" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "helmet_scavenger_xs",
     "type": "ARMOR",
     "copy-from": "helmet_scavenger",
-    "name": { "str": "XS scavenger cowl" },
+    "name": { "str": "scavenger cowl" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   }
 ]

--- a/data/json/items/armor/bespoke_armor/custom_legs.json
+++ b/data/json/items/armor/bespoke_armor/custom_legs.json
@@ -67,17 +67,17 @@
     "id": "xl_lsurvivor_pants",
     "type": "ARMOR",
     "copy-from": "lsurvivor_pants",
-    "name": { "str_sp": "XL light survivor cargo pants" },
+    "name": { "str_sp": "light survivor cargo pants" },
     "proportional": { "weight": 1.25, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_lsurvivor_pants",
     "type": "ARMOR",
     "copy-from": "lsurvivor_pants",
-    "name": { "str_sp": "XS light survivor cargo pants" },
+    "name": { "str_sp": "light survivor cargo pants" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "pants_survivor",
@@ -162,17 +162,17 @@
     "id": "xl_pants_survivor",
     "type": "ARMOR",
     "copy-from": "pants_survivor",
-    "name": { "str_sp": "XL survivor cargo pants" },
+    "name": { "str_sp": "survivor cargo pants" },
     "proportional": { "weight": 1.25, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_pants_survivor",
     "type": "ARMOR",
     "copy-from": "pants_survivor",
-    "name": { "str_sp": "XS survivor cargo pants" },
+    "name": { "str_sp": "survivor cargo pants" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "armor_mercenary_bottom",

--- a/data/json/items/armor/bespoke_armor/custom_overcoats.json
+++ b/data/json/items/armor/bespoke_armor/custom_overcoats.json
@@ -78,18 +78,18 @@
   {
     "id": "xl_duster_survivor",
     "type": "ARMOR",
-    "name": { "str": "XL survivor duster" },
+    "name": { "str": "survivor duster" },
     "copy-from": "duster_survivor",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_duster_survivor",
     "type": "ARMOR",
     "copy-from": "duster_survivor",
-    "name": { "str": "XS survivor duster" },
+    "name": { "str": "survivor duster" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "sleeveless_duster_survivor",

--- a/data/json/items/armor/bespoke_armor/cuttingroom.json
+++ b/data/json/items/armor/bespoke_armor/cuttingroom.json
@@ -24,18 +24,18 @@
   {
     "id": "xl_boots_fsurvivor",
     "type": "ARMOR",
-    "name": { "str": "pair of XL survivor fireboots", "str_pl": "pairs of XL survivor fireboots" },
+    "name": { "str": "pair of survivor fireboots", "str_pl": "pairs of survivor fireboots" },
     "copy-from": "boots_fsurvivor",
     "proportional": { "weight": 1.5, "volume": 1.5 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_boots_fsurvivor",
     "type": "ARMOR",
     "copy-from": "boots_fsurvivor",
-    "name": { "str": "pair of XS survivor fireboots", "str_pl": "pairs of XS survivor fireboots" },
+    "name": { "str": "pair of survivor fireboots", "str_pl": "pairs of survivor fireboots" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "boots_hsurvivor",
@@ -62,18 +62,18 @@
   {
     "id": "xl_boots_hsurvivor",
     "type": "ARMOR",
-    "name": { "str": "pair of XL heavy survivor boots", "str_pl": "pairs of XL heavy survivor boots" },
+    "name": { "str": "pair of heavy survivor boots", "str_pl": "pairs of heavy survivor boots" },
     "copy-from": "boots_hsurvivor",
     "proportional": { "weight": 1.2, "volume": 1.2 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_boots_hsurvivor",
     "type": "ARMOR",
     "copy-from": "boots_hsurvivor",
-    "name": { "str": "pair of XS heavy survivor boots", "str_pl": "pairs of XS heavy survivor boots" },
+    "name": { "str": "pair of heavy survivor boots", "str_pl": "pairs of heavy survivor boots" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "gloves_hsurvivor",
@@ -99,18 +99,18 @@
   {
     "id": "xl_gloves_hsurvivor",
     "type": "ARMOR",
-    "name": { "str": "pair of XL heavy survivor gloves", "str_pl": "pairs of XL heavy survivor gloves" },
+    "name": { "str": "pair of heavy survivor gloves", "str_pl": "pairs of heavy survivor gloves" },
     "copy-from": "gloves_hsurvivor",
     "proportional": { "weight": 1.5, "volume": 1.5 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_gloves_hsurvivor",
     "type": "ARMOR",
     "copy-from": "gloves_hsurvivor",
-    "name": { "str": "pair of XS heavy survivor gloves", "str_pl": "pairs of XS heavy survivor gloves" },
+    "name": { "str": "pair of heavy survivor gloves", "str_pl": "pairs of heavy survivor gloves" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "gloves_fsurvivor",
@@ -136,18 +136,18 @@
   {
     "id": "xl_gloves_fsurvivor",
     "type": "ARMOR",
-    "name": { "str": "pair of XL survivor firegloves", "str_pl": "pairs of XL survivor firegloves" },
+    "name": { "str": "pair of survivor firegloves", "str_pl": "pairs of survivor firegloves" },
     "copy-from": "gloves_fsurvivor",
     "proportional": { "weight": 1.5, "volume": 1.5 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_gloves_fsurvivor",
     "type": "ARMOR",
     "copy-from": "gloves_fsurvivor",
-    "name": { "str": "pair of XS survivor firegloves", "str_pl": "pairs of XS survivor firegloves" },
+    "name": { "str": "pair of survivor firegloves", "str_pl": "pairs of survivor firegloves" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "hood_fsurvivor",
@@ -175,17 +175,17 @@
     "id": "xl_hood_fsurvivor",
     "type": "ARMOR",
     "copy-from": "hood_fsurvivor",
-    "name": { "str": "XL survivor firehood" },
+    "name": { "str": "survivor firehood" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_hood_fsurvivor",
     "type": "ARMOR",
     "copy-from": "hood_fsurvivor",
-    "name": { "str": "XS survivor firehood" },
+    "name": { "str": "survivor firehood" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "fsurvivor_suit",
@@ -225,18 +225,18 @@
   {
     "id": "xl_fsurvivor_suit",
     "type": "ARMOR",
-    "name": { "str": "XL survivor firesuit" },
+    "name": { "str": "survivor firesuit" },
     "copy-from": "fsurvivor_suit",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_fsurvivor_suit",
     "type": "ARMOR",
     "copy-from": "fsurvivor_suit",
-    "name": { "str": "XS survivor firesuit" },
+    "name": { "str": "survivor firesuit" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "hsurvivor_suit",
@@ -274,17 +274,17 @@
     "id": "xlhsurvivor_suit",
     "type": "ARMOR",
     "copy-from": "hsurvivor_suit",
-    "name": { "str": "XL heavy survivor suit" },
+    "name": { "str": "heavy survivor suit" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xshsurvivor_suit",
     "type": "ARMOR",
     "copy-from": "hsurvivor_suit",
-    "name": { "str": "XS heavy survivor suit" },
+    "name": { "str": "heavy survivor suit" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "lsurvivor_armor",
@@ -380,18 +380,18 @@
   {
     "id": "xl_lsurvivor_armor",
     "type": "ARMOR",
-    "name": { "str": "XL mercenary body armor" },
+    "name": { "str": "mercenary body armor" },
     "copy-from": "lsurvivor_armor",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_lsurvivor_armor",
     "type": "ARMOR",
     "copy-from": "lsurvivor_armor",
-    "name": { "str": "XS mercenary body armor" },
+    "name": { "str": "mercenary body armor" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "lsurvivor_suit",
@@ -426,10 +426,10 @@
   {
     "id": "xl_lsurvivor_suit",
     "type": "ARMOR",
-    "name": { "str": "XL light survivor suit" },
+    "name": { "str": "light survivor suit" },
     "copy-from": "lsurvivor_suit",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "survivor_suit",
@@ -466,7 +466,7 @@
     "id": "xlsurvivor_suit",
     "type": "ARMOR",
     "category": "armor",
-    "name": { "str": "XL survivor suit" },
+    "name": { "str": "survivor suit" },
     "description": "A massive hand-built combination armor made from a bulletproof vest and a reinforced leather jumpsuit.  Protects from the elements as well as from harm.",
     "weight": "12400 g",
     "volume": "18 L",
@@ -494,7 +494,7 @@
     "material_thickness": 4,
     "valid_mods": [ "steel_padded" ],
     "environmental_protection": 3,
-    "flags": [ "OVERSIZE", "VARSIZE", "WATERPROOF", "POCKETS", "HOOD", "RAINPROOF", "STURDY", "OBSOLETE" ],
+    "flags": [ "OVERSIZE", "PREFIX_XL", "VARSIZE", "WATERPROOF", "POCKETS", "HOOD", "RAINPROOF", "STURDY", "OBSOLETE" ],
     "melee_damage": { "bash": 6 }
   },
   {
@@ -533,10 +533,10 @@
   {
     "id": "xl_wsurvivor_suit",
     "type": "ARMOR",
-    "name": { "str": "XL winter survivor suit" },
+    "name": { "str": "winter survivor suit" },
     "copy-from": "wsurvivor_suit",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "wsurvivor_suit_nofur",
@@ -553,13 +553,13 @@
   {
     "id": "xl_wsurvivor_suit_nofur",
     "type": "ARMOR",
-    "name": { "str": "XL winter survivor suit" },
+    "name": { "str": "winter survivor suit" },
     "copy-from": "wsurvivor_suit",
     "material": [ "kevlar_layered", "faux_fur" ],
     "color": "pink",
     "warmth": 65,
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "h20survivor_suit",

--- a/data/json/items/armor/bespoke_armor/utility.json
+++ b/data/json/items/armor/bespoke_armor/utility.json
@@ -183,16 +183,16 @@
     "id": "xl_survivor_vest",
     "type": "ARMOR",
     "copy-from": "survivor_vest",
-    "name": { "str": "XL survivor harness", "str_pl": "XL survivor harnesses" },
+    "name": { "str": "survivor harness", "str_pl": "survivor harnesses" },
     "proportional": { "weight": 1.25, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_survivor_vest",
     "type": "ARMOR",
     "copy-from": "survivor_vest",
-    "name": { "str": "XS survivor harness", "str_pl": "XS survivor harnesses" },
+    "name": { "str": "survivor harness", "str_pl": "survivor harnesses" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   }
 ]

--- a/data/json/items/armor/boots.json
+++ b/data/json/items/armor/boots.json
@@ -88,19 +88,19 @@
   {
     "id": "xl_boots",
     "type": "ARMOR",
-    "name": { "str": "pair of XL boots", "str_pl": "pairs of XL boots" },
+    "name": { "str": "pair of boots", "str_pl": "pairs of boots" },
     "copy-from": "boots",
     "proportional": { "weight": 1.25, "volume": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_boots",
     "type": "ARMOR",
     "copy-from": "boots",
     "looks_like": "boots",
-    "name": { "str": "pair of XS boots", "str_pl": "pairs of XS boots" },
+    "name": { "str": "pair of boots", "str_pl": "pairs of boots" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "boots_bone",
@@ -240,19 +240,19 @@
   {
     "id": "xl_boots_chitin",
     "type": "ARMOR",
-    "name": { "str": "pair of XL chitinous boots", "str_pl": "pairs of XL chitinous boots" },
+    "name": { "str": "pair of chitinous boots", "str_pl": "pairs of chitinous boots" },
     "copy-from": "boots_chitin",
     "proportional": { "weight": 1.25, "volume": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_boots_chitin",
     "type": "ARMOR",
     "copy-from": "boots_chitin",
     "looks_like": "boots_chitin",
-    "name": { "str": "pair of XS chitinous boots", "str_pl": "pairs of XS chitinous boots" },
+    "name": { "str": "pair of chitinous boots", "str_pl": "pairs of chitinous boots" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "boots_acidchitin",
@@ -267,18 +267,18 @@
   {
     "id": "xl_boots_acidchitin",
     "type": "ARMOR",
-    "name": { "str": "pair of XL biosilicified chitin boots", "str_pl": "pairs of XL biosilicified chitin boots" },
+    "name": { "str": "pair of biosilicified chitin boots", "str_pl": "pairs of biosilicified chitin boots" },
     "copy-from": "boots_acidchitin",
     "proportional": { "weight": 1.25, "volume": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_boots_acidchitin",
     "type": "ARMOR",
     "copy-from": "boots_acidchitin",
-    "name": { "str": "pair of XS biosilicified chitin boots", "str_pl": "pairs of XS biosilicified chitin boots" },
+    "name": { "str": "pair of biosilicified chitin boots", "str_pl": "pairs of biosilicified chitin boots" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "boots_combat",
@@ -495,18 +495,18 @@
   {
     "id": "xl_boots_fur",
     "type": "ARMOR",
-    "name": { "str": "pair of XL fur boots", "str_pl": "pairs of XL fur boots" },
+    "name": { "str": "pair of fur boots", "str_pl": "pairs of fur boots" },
     "copy-from": "boots_fur",
     "proportional": { "weight": 1.15, "volume": 1.15 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_boots_fur",
     "type": "ARMOR",
     "copy-from": "boots_fur",
-    "name": { "str": "pair of XS fur boots", "str_pl": "pairs of XS fur boots" },
+    "name": { "str": "pair of fur boots", "str_pl": "pairs of fur boots" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "boots_faux_fur",
@@ -561,18 +561,18 @@
   {
     "id": "xl_boots_faux_fur",
     "type": "ARMOR",
-    "name": { "str": "pair of XL faux fur boots", "str_pl": "pairs of XL faux fur boots" },
+    "name": { "str": "pair of faux fur boots", "str_pl": "pairs of faux fur boots" },
     "copy-from": "boots_faux_fur",
     "proportional": { "weight": 1.15, "volume": 1.15 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_boots_faux_fur",
     "type": "ARMOR",
     "copy-from": "boots_faux_fur",
-    "name": { "str": "pair of XS faux fur boots", "str_pl": "pairs of XS faux fur boots" },
+    "name": { "str": "pair of faux fur boots", "str_pl": "pairs of faux fur boots" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "boots_hiking",
@@ -645,18 +645,18 @@
   {
     "id": "xl_boots_larmor",
     "type": "ARMOR",
-    "name": { "str": "pair of XL leather armor boots", "str_pl": "pairs of XL leather armor boots" },
+    "name": { "str": "pair of leather armor boots", "str_pl": "pairs of leather armor boots" },
     "copy-from": "boots_larmor",
     "proportional": { "weight": 1.3, "volume": 1.3 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_boots_larmor",
     "type": "ARMOR",
     "copy-from": "boots_larmor",
-    "name": { "str": "pair of XS leather armor boots", "str_pl": "pairs of XS leather armor boots" },
+    "name": { "str": "pair of leather armor boots", "str_pl": "pairs of leather armor boots" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "boots_plate",
@@ -711,18 +711,18 @@
   {
     "id": "xl_boots_plate",
     "type": "ARMOR",
-    "name": { "str": "pair of XL armored boots", "str_pl": "pairs of XL armored boots" },
+    "name": { "str": "pair of armored boots", "str_pl": "pairs of armored boots" },
     "copy-from": "boots_plate",
     "proportional": { "weight": 1.25, "volume": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_boots_plate",
     "type": "ARMOR",
     "copy-from": "boots_plate",
-    "name": { "str": "pair of XS armored boots", "str_pl": "pairs of XS armored boots" },
+    "name": { "str": "pair of armored boots", "str_pl": "pairs of armored boots" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "boots_rubber",
@@ -818,18 +818,18 @@
   {
     "id": "xl_boots_scrap",
     "type": "ARMOR",
-    "name": { "str": "pair of XL scrap boots", "str_pl": "pairs of XL scrap boots" },
+    "name": { "str": "pair of scrap boots", "str_pl": "pairs of scrap boots" },
     "copy-from": "boots_scrap",
     "proportional": { "weight": 1.3, "volume": 1.3 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_boots_scrap",
     "type": "ARMOR",
     "copy-from": "boots_scrap",
-    "name": { "str": "pair of XS scrap boots", "str_pl": "pairs of XS scrap boots" },
+    "name": { "str": "pair of scrap boots", "str_pl": "pairs of scrap boots" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "sabaton_metal_sheets",
@@ -1078,18 +1078,18 @@
   {
     "id": "xl_boots_winter",
     "type": "ARMOR",
-    "name": { "str": "pair of XL winter boots", "str_pl": "pairs of XL winter boots" },
+    "name": { "str": "pair of winter boots", "str_pl": "pairs of winter boots" },
     "copy-from": "boots_winter",
     "proportional": { "weight": 1.3, "volume": 1.3 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_boots_winter",
     "type": "ARMOR",
     "copy-from": "boots_winter",
-    "name": { "str": "pair of XS winter boots", "str_pl": "pairs of XS winter boots" },
+    "name": { "str": "pair of winter boots", "str_pl": "pairs of winter boots" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "cleats",
@@ -2539,17 +2539,17 @@
     "id": "xl_lc_chainmail_feet",
     "type": "ARMOR",
     "copy-from": "lc_chainmail_feet",
-    "name": { "str": "pair of XL mild steel chainmail chausses", "str_pl": "pairs of XL mild steel chainmail chausses" },
+    "name": { "str": "pair of mild steel chainmail chausses", "str_pl": "pairs of mild steel chainmail chausses" },
     "proportional": { "weight": 2, "volume": 2 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_lc_chainmail_feet",
     "type": "ARMOR",
     "copy-from": "lc_chainmail_feet",
-    "name": { "str": "pair of XS mild steel chainmail chausses", "str_pl": "pairs of XS mild steel chainmail chausses" },
+    "name": { "str": "pair of mild steel chainmail chausses", "str_pl": "pairs of mild steel chainmail chausses" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "mc_chainmail_feet",
@@ -2563,18 +2563,18 @@
     "id": "xl_mc_chainmail_feet",
     "type": "ARMOR",
     "copy-from": "mc_chainmail_feet",
-    "name": { "str": "pair of XL medium steel chainmail chausses", "str_pl": "pairs of XL medium steel chainmail chausses" },
+    "name": { "str": "pair of medium steel chainmail chausses", "str_pl": "pairs of medium steel chainmail chausses" },
     "proportional": { "weight": 2, "volume": 2 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_mc_chainmail_feet",
     "type": "ARMOR",
     "copy-from": "mc_chainmail_feet",
     "looks_like": "chainmail_feet",
-    "name": { "str": "pair of XS medium steel chainmail chausses", "str_pl": "pairs of XS medium steel chainmail chausses" },
+    "name": { "str": "pair of medium steel chainmail chausses", "str_pl": "pairs of medium steel chainmail chausses" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "hc_chainmail_feet",
@@ -2588,17 +2588,17 @@
     "id": "xl_hc_chainmail_feet",
     "type": "ARMOR",
     "copy-from": "hc_chainmail_feet",
-    "name": { "str": "pair of XL high steel chainmail chausses", "str_pl": "pairs of XL high steel chainmail chausses" },
+    "name": { "str": "pair of high steel chainmail chausses", "str_pl": "pairs of high steel chainmail chausses" },
     "proportional": { "weight": 2, "volume": 2 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_hc_chainmail_feet",
     "type": "ARMOR",
     "copy-from": "hc_chainmail_feet",
-    "name": { "str": "pair of XS high steel chainmail chausses", "str_pl": "pairs of XS high steel chainmail chausses" },
+    "name": { "str": "pair of high steel chainmail chausses", "str_pl": "pairs of high steel chainmail chausses" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "ch_chainmail_feet",
@@ -2612,17 +2612,17 @@
     "id": "xl_ch_chainmail_feet",
     "type": "ARMOR",
     "copy-from": "ch_chainmail_feet",
-    "name": { "str": "pair of XL hardened steel chainmail chausses", "str_pl": "pairs of XL hardened steel chainmail chausses" },
+    "name": { "str": "pair of hardened steel chainmail chausses", "str_pl": "pairs of hardened steel chainmail chausses" },
     "proportional": { "weight": 2, "volume": 2 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_ch_chainmail_feet",
     "type": "ARMOR",
     "copy-from": "ch_chainmail_feet",
-    "name": { "str": "pair of XS hardened steel chainmail chausses", "str_pl": "pairs of XS hardened steel chainmail chausses" },
+    "name": { "str": "pair of hardened steel chainmail chausses", "str_pl": "pairs of hardened steel chainmail chausses" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "qt_chainmail_feet",
@@ -2636,17 +2636,17 @@
     "id": "xl_qt_chainmail_feet",
     "type": "ARMOR",
     "copy-from": "qt_chainmail_feet",
-    "name": { "str": "pair of XL tempered steel chainmail chausses", "str_pl": "pairs of XL tempered steel chainmail chausses" },
+    "name": { "str": "pair of tempered steel chainmail chausses", "str_pl": "pairs of tempered steel chainmail chausses" },
     "proportional": { "weight": 2, "volume": 2 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_qt_chainmail_feet",
     "type": "ARMOR",
     "copy-from": "qt_chainmail_feet",
-    "name": { "str": "pair of XS tempered steel chainmail chausses", "str_pl": "pairs of XS tempered steel chainmail chausses" },
+    "name": { "str": "pair of tempered steel chainmail chausses", "str_pl": "pairs of tempered steel chainmail chausses" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "nomex_socks",
@@ -2671,19 +2671,19 @@
   {
     "id": "xlnomex_socks",
     "type": "ARMOR",
-    "name": { "str": "pair of XL flame-resistant socks", "str_pl": "pairs of XL flame-resistant socks" },
+    "name": { "str": "pair of flame-resistant socks", "str_pl": "pairs of flame-resistant socks" },
     "weight": "300 g",
     "volume": "1000 ml",
     "copy-from": "nomex_socks",
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xsnomex_socks",
     "type": "ARMOR",
     "copy-from": "nomex_socks",
-    "name": { "str": "pair of XS flame-resistant socks", "str_pl": "pairs of XS flame-resistant socks" },
+    "name": { "str": "pair of flame-resistant socks", "str_pl": "pairs of flame-resistant socks" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "socks",
@@ -2706,19 +2706,19 @@
   {
     "id": "xlsocks",
     "type": "ARMOR",
-    "name": { "str": "pair of XL socks", "str_pl": "pairs of XL socks" },
+    "name": { "str": "pair of socks", "str_pl": "pairs of socks" },
     "weight": "58 g",
     "volume": "250 ml",
     "copy-from": "socks",
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xssocks",
     "type": "ARMOR",
     "copy-from": "socks",
-    "name": { "str": "pair of XS socks", "str_pl": "pairs of XS socks" },
+    "name": { "str": "pair of socks", "str_pl": "pairs of socks" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "socks_ankle",
@@ -2837,19 +2837,19 @@
   {
     "id": "xlsocks_wool",
     "type": "ARMOR",
-    "name": { "str": "pair of XL wool socks", "str_pl": "pairs of XL wool socks" },
+    "name": { "str": "pair of wool socks", "str_pl": "pairs of wool socks" },
     "weight": "77 g",
     "volume": "500 ml",
     "copy-from": "socks_wool",
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xssocks_wool",
     "type": "ARMOR",
     "copy-from": "socks_wool",
-    "name": { "str": "pair of XS wool socks", "str_pl": "pairs of XS wool socks" },
+    "name": { "str": "pair of wool socks", "str_pl": "pairs of wool socks" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "stockings",
@@ -3321,9 +3321,9 @@
     "id": "xl_lc_sabaton",
     "type": "ARMOR",
     "copy-from": "lc_sabaton",
-    "name": { "str": "XL mild steel sabaton" },
+    "name": { "str": "mild steel sabaton" },
     "proportional": { "weight": 1.25, "volume": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "mc_sabaton",
@@ -3336,9 +3336,9 @@
     "id": "xl_mc_sabaton",
     "type": "ARMOR",
     "copy-from": "mc_sabaton",
-    "name": { "str": "XL medium steel sabaton" },
+    "name": { "str": "medium steel sabaton" },
     "proportional": { "weight": 1.25, "volume": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "hc_sabaton",
@@ -3351,9 +3351,9 @@
     "id": "xl_hc_sabaton",
     "type": "ARMOR",
     "copy-from": "hc_sabaton",
-    "name": { "str": "XL high steel sabaton" },
+    "name": { "str": "high steel sabaton" },
     "proportional": { "weight": 1.25, "volume": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "ch_sabaton",
@@ -3366,9 +3366,9 @@
     "id": "xl_ch_sabaton",
     "type": "ARMOR",
     "copy-from": "ch_sabaton",
-    "name": { "str": "XL hardened steel sabaton" },
+    "name": { "str": "hardened steel sabaton" },
     "proportional": { "weight": 1.25, "volume": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "qt_sabaton",
@@ -3381,8 +3381,8 @@
     "id": "xl_qt_sabaton",
     "type": "ARMOR",
     "copy-from": "qt_sabaton",
-    "name": { "str": "XL tempered steel sabaton" },
+    "name": { "str": "tempered steel sabaton" },
     "proportional": { "weight": 1.25, "volume": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   }
 ]

--- a/data/json/items/armor/brigandine.json
+++ b/data/json/items/armor/brigandine.json
@@ -46,17 +46,17 @@
     "id": "xl_armor_lc_brigandine",
     "type": "ARMOR",
     "copy-from": "armor_lc_brigandine",
-    "name": { "str": "XL mild steel brigandine" },
+    "name": { "str": "mild steel brigandine" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_lc_brigandine_xs",
     "type": "ARMOR",
     "copy-from": "armor_lc_brigandine",
-    "name": { "str": "XS mild steel brigandine" },
+    "name": { "str": "mild steel brigandine" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "armor_lc_brigandine_shoulders",
@@ -113,17 +113,17 @@
     "id": "xl_armor_lc_brigandine_shoulders",
     "type": "ARMOR",
     "copy-from": "armor_lc_brigandine_shoulders",
-    "name": { "str": "XL mild steel brigandine with shoulder guards", "str_pl": "XL mild steel brigandines with shoulder guards" },
+    "name": { "str": "mild steel brigandine with shoulder guards", "str_pl": "mild steel brigandines with shoulder guards" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_lc_brigandine_shoulders_xs",
     "type": "ARMOR",
     "copy-from": "armor_lc_brigandine_shoulders",
-    "name": { "str": "XS mild steel brigandine with shoulder guards", "str_pl": "XS mild steel brigandines with shoulder guards" },
+    "name": { "str": "mild steel brigandine with shoulder guards", "str_pl": "mild steel brigandines with shoulder guards" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "armor_lc_coat_brigandine",
@@ -183,17 +183,17 @@
     "id": "xl_armor_lc_coat_brigandine",
     "type": "ARMOR",
     "copy-from": "armor_lc_coat_brigandine",
-    "name": { "str": "XL mild steel brigandine coat" },
+    "name": { "str": "mild steel brigandine coat" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_lc_coat_brigandine_xs",
     "type": "ARMOR",
     "copy-from": "armor_lc_coat_brigandine",
-    "name": { "str": "XS mild steel brigandine coat" },
+    "name": { "str": "mild steel brigandine coat" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "armor_lc_coat_brigandine_shoulders",
@@ -265,22 +265,22 @@
     "type": "ARMOR",
     "copy-from": "armor_lc_coat_brigandine_shoulders",
     "name": {
-      "str": "XL mild steel brigandine coat with shoulder guards",
-      "str_pl": "XL mild steel brigandine coats with shoulder guards"
+      "str": "mild steel brigandine coat with shoulder guards",
+      "str_pl": "mild steel brigandine coats with shoulder guards"
     },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_lc_coat_brigandine_shoulders_xs",
     "type": "ARMOR",
     "copy-from": "armor_lc_coat_brigandine_shoulders",
     "name": {
-      "str": "XS mild steel brigandine coat with shoulder guards",
-      "str_pl": "XS mild steel brigandine coats with shoulder guards"
+      "str": "mild steel brigandine coat with shoulder guards",
+      "str_pl": "mild steel brigandine coats with shoulder guards"
     },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "armor_mc_brigandine",
@@ -293,17 +293,17 @@
     "id": "xl_armor_mc_brigandine",
     "type": "ARMOR",
     "copy-from": "armor_mc_brigandine",
-    "name": { "str": "XL medium steel brigandine" },
+    "name": { "str": "medium steel brigandine" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_mc_brigandine_xs",
     "type": "ARMOR",
     "copy-from": "armor_mc_brigandine",
-    "name": { "str": "XS medium steel brigandine" },
+    "name": { "str": "medium steel brigandine" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "armor_mc_brigandine_shoulders",
@@ -316,23 +316,17 @@
     "id": "xl_armor_mc_brigandine_shoulders",
     "type": "ARMOR",
     "copy-from": "armor_mc_brigandine_shoulders",
-    "name": {
-      "str": "XL medium steel brigandine with shoulder guards",
-      "str_pl": "XL medium steel brigandines with shoulder guards"
-    },
+    "name": { "str": "medium steel brigandine with shoulder guards", "str_pl": "medium steel brigandines with shoulder guards" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_mc_brigandine_shoulders_xs",
     "type": "ARMOR",
     "copy-from": "armor_mc_brigandine_shoulders",
-    "name": {
-      "str": "XS medium steel brigandine with shoulder guards",
-      "str_pl": "XS medium steel brigandines with shoulder guards"
-    },
+    "name": { "str": "medium steel brigandine with shoulder guards", "str_pl": "medium steel brigandines with shoulder guards" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "armor_mc_coat_brigandine",
@@ -345,17 +339,17 @@
     "id": "xl_armor_mc_coat_brigandine",
     "type": "ARMOR",
     "copy-from": "armor_mc_coat_brigandine",
-    "name": { "str": "XL medium steel brigandine coat" },
+    "name": { "str": "medium steel brigandine coat" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_mc_coat_brigandine_xs",
     "type": "ARMOR",
     "copy-from": "armor_mc_coat_brigandine",
-    "name": { "str": "XS medium steel brigandine coat" },
+    "name": { "str": "medium steel brigandine coat" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "armor_mc_coat_brigandine_shoulders",
@@ -372,22 +366,22 @@
     "type": "ARMOR",
     "copy-from": "armor_mc_coat_brigandine_shoulders",
     "name": {
-      "str": "XL medium steel brigandine coat with shoulder guards",
-      "str_pl": "XL medium steel brigandine coats with shoulder guards"
+      "str": "medium steel brigandine coat with shoulder guards",
+      "str_pl": "medium steel brigandine coats with shoulder guards"
     },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_mc_coat_brigandine_shoulders_xs",
     "type": "ARMOR",
     "copy-from": "armor_mc_coat_brigandine_shoulders",
     "name": {
-      "str": "XS medium steel brigandine coat with shoulder guards",
-      "str_pl": "XS medium steel brigandine coats with shoulder guards"
+      "str": "medium steel brigandine coat with shoulder guards",
+      "str_pl": "medium steel brigandine coats with shoulder guards"
     },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "armor_hc_brigandine",
@@ -400,17 +394,17 @@
     "id": "xl_armor_hc_brigandine",
     "type": "ARMOR",
     "copy-from": "armor_hc_brigandine",
-    "name": { "str": "XL high steel brigandine" },
+    "name": { "str": "high steel brigandine" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_hc_brigandine_xs",
     "type": "ARMOR",
     "copy-from": "armor_hc_brigandine",
-    "name": { "str": "XS high steel brigandine" },
+    "name": { "str": "high steel brigandine" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "armor_hc_brigandine_shoulders",
@@ -423,17 +417,17 @@
     "id": "xl_armor_hc_brigandine_shoulders",
     "type": "ARMOR",
     "copy-from": "armor_hc_brigandine_shoulders",
-    "name": { "str": "XL high steel brigandine with shoulder guards", "str_pl": "XL high steel brigandines with shoulder guards" },
+    "name": { "str": "high steel brigandine with shoulder guards", "str_pl": "high steel brigandines with shoulder guards" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_hc_brigandine_shoulders_xs",
     "type": "ARMOR",
     "copy-from": "armor_hc_brigandine_shoulders",
-    "name": { "str": "XS high steel brigandine with shoulder guards", "str_pl": "XS high steel brigandines with shoulder guards" },
+    "name": { "str": "high steel brigandine with shoulder guards", "str_pl": "high steel brigandines with shoulder guards" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "armor_hc_coat_brigandine",
@@ -446,17 +440,17 @@
     "id": "xl_armor_hc_coat_brigandine",
     "type": "ARMOR",
     "copy-from": "armor_hc_coat_brigandine",
-    "name": { "str": "XL high steel brigandine coat" },
+    "name": { "str": "high steel brigandine coat" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_hc_coat_brigandine_xs",
     "type": "ARMOR",
     "copy-from": "armor_hc_coat_brigandine",
-    "name": { "str": "XS high steel brigandine coat" },
+    "name": { "str": "high steel brigandine coat" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "armor_hc_coat_brigandine_shoulders",
@@ -473,22 +467,22 @@
     "type": "ARMOR",
     "copy-from": "armor_hc_coat_brigandine_shoulders",
     "name": {
-      "str": "XL high steel brigandine coat with shoulder guards",
-      "str_pl": "XL high steel brigandine coats with shoulder guards"
+      "str": "high steel brigandine coat with shoulder guards",
+      "str_pl": "high steel brigandine coats with shoulder guards"
     },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_hc_coat_brigandine_shoulders_xs",
     "type": "ARMOR",
     "copy-from": "armor_hc_coat_brigandine_shoulders",
     "name": {
-      "str": "XS high steel brigandine coat with shoulder guards",
-      "str_pl": "XS high steel brigandine coats with shoulder guards"
+      "str": "high steel brigandine coat with shoulder guards",
+      "str_pl": "high steel brigandine coats with shoulder guards"
     },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "armor_ch_brigandine",
@@ -501,17 +495,17 @@
     "id": "xl_armor_ch_brigandine",
     "type": "ARMOR",
     "copy-from": "armor_ch_brigandine",
-    "name": { "str": "XL hardened brigandine" },
+    "name": { "str": "hardened brigandine" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_ch_brigandine_xs",
     "type": "ARMOR",
     "copy-from": "armor_ch_brigandine",
-    "name": { "str": "XS hardened brigandine" },
+    "name": { "str": "hardened brigandine" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "armor_ch_brigandine_shoulders",
@@ -524,17 +518,17 @@
     "id": "xl_armor_ch_brigandine_shoulders",
     "type": "ARMOR",
     "copy-from": "armor_ch_brigandine_shoulders",
-    "name": { "str": "XL hardened brigandine with shoulder guards", "str_pl": "XL hardened brigandines with shoulder guards" },
+    "name": { "str": "hardened brigandine with shoulder guards", "str_pl": "hardened brigandines with shoulder guards" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_ch_brigandine_shoulders_xs",
     "type": "ARMOR",
     "copy-from": "armor_ch_brigandine_shoulders",
-    "name": { "str": "XS hardened brigandine with shoulder guards", "str_pl": "XS hardened brigandines with shoulder guards" },
+    "name": { "str": "hardened brigandine with shoulder guards", "str_pl": "hardened brigandines with shoulder guards" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "armor_ch_coat_brigandine",
@@ -547,17 +541,17 @@
     "id": "xl_armor_ch_coat_brigandine",
     "type": "ARMOR",
     "copy-from": "armor_ch_coat_brigandine",
-    "name": { "str": "XL hardened brigandine coat" },
+    "name": { "str": "hardened brigandine coat" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_ch_coat_brigandine_xs",
     "type": "ARMOR",
     "copy-from": "armor_ch_coat_brigandine",
-    "name": { "str": "XS hardened brigandine coat" },
+    "name": { "str": "hardened brigandine coat" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "armor_ch_coat_brigandine_shoulders",
@@ -570,23 +564,17 @@
     "id": "xl_armor_ch_coat_brigandine_shoulders",
     "type": "ARMOR",
     "copy-from": "armor_ch_coat_brigandine_shoulders",
-    "name": {
-      "str": "XL hardened brigandine coat with shoulder guards",
-      "str_pl": "XL hardened brigandine coats with shoulder guards"
-    },
+    "name": { "str": "hardened brigandine coat with shoulder guards", "str_pl": "hardened brigandine coats with shoulder guards" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_ch_coat_brigandine_shoulders_xs",
     "type": "ARMOR",
     "copy-from": "armor_ch_coat_brigandine_shoulders",
-    "name": {
-      "str": "XS hardened brigandine coat with shoulder guards",
-      "str_pl": "XS hardened brigandine coats with shoulder guards"
-    },
+    "name": { "str": "hardened brigandine coat with shoulder guards", "str_pl": "hardened brigandine coats with shoulder guards" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "armor_qt_brigandine",
@@ -599,17 +587,17 @@
     "id": "xl_armor_qt_brigandine",
     "type": "ARMOR",
     "copy-from": "armor_qt_brigandine",
-    "name": { "str": "XL tempered brigandine" },
+    "name": { "str": "tempered brigandine" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_qt_brigandine_xs",
     "type": "ARMOR",
     "copy-from": "armor_qt_brigandine",
-    "name": { "str": "XS tempered brigandine" },
+    "name": { "str": "tempered brigandine" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "armor_qt_brigandine_shoulders",
@@ -622,17 +610,17 @@
     "id": "xl_armor_qt_brigandine_shoulders",
     "type": "ARMOR",
     "copy-from": "armor_qt_brigandine_shoulders",
-    "name": { "str": "XL tempered brigandine with shoulder guards", "str_pl": "XL tempered brigandines with shoulder guards" },
+    "name": { "str": "tempered brigandine with shoulder guards", "str_pl": "tempered brigandines with shoulder guards" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_qt_brigandine_shoulders_xs",
     "type": "ARMOR",
     "copy-from": "armor_qt_brigandine_shoulders",
-    "name": { "str": "XS tempered brigandine with shoulder guards", "str_pl": "XS tempered brigandines with shoulder guards" },
+    "name": { "str": "tempered brigandine with shoulder guards", "str_pl": "tempered brigandines with shoulder guards" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "armor_qt_coat_brigandine",
@@ -645,17 +633,17 @@
     "id": "xl_armor_qt_coat_brigandine",
     "type": "ARMOR",
     "copy-from": "armor_qt_coat_brigandine",
-    "name": { "str": "XL tempered brigandine coat" },
+    "name": { "str": "tempered brigandine coat" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_qt_coat_brigandine_xs",
     "type": "ARMOR",
     "copy-from": "armor_qt_coat_brigandine",
-    "name": { "str": "XS tempered brigandine coat" },
+    "name": { "str": "tempered brigandine coat" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "armor_qt_coat_brigandine_shoulders",
@@ -668,23 +656,17 @@
     "id": "xl_armor_qt_coat_brigandine_shoulders",
     "type": "ARMOR",
     "copy-from": "armor_qt_coat_brigandine_shoulders",
-    "name": {
-      "str": "XL tempered brigandine coat with shoulder guards",
-      "str_pl": "XL tempered brigandine coats with shoulder guards"
-    },
+    "name": { "str": "tempered brigandine coat with shoulder guards", "str_pl": "tempered brigandine coats with shoulder guards" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_qt_coat_brigandine_shoulders_xs",
     "type": "ARMOR",
     "copy-from": "armor_qt_coat_brigandine_shoulders",
-    "name": {
-      "str": "XS tempered brigandine coat with shoulder guards",
-      "str_pl": "XS tempered brigandine coats with shoulder guards"
-    },
+    "name": { "str": "tempered brigandine coat with shoulder guards", "str_pl": "tempered brigandine coats with shoulder guards" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "armguard_lc_brigandine",
@@ -724,17 +706,17 @@
     "id": "xl_armguard_lc_brigandine",
     "type": "ARMOR",
     "copy-from": "armguard_lc_brigandine",
-    "name": { "str": "XL pair of mild steel splint arm guards", "str_pl": "XL pairs of mild steel splint arm guards" },
+    "name": { "str": "pair of mild steel splint arm guards", "str_pl": "pairs of mild steel splint arm guards" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armguard_lc_brigandine_xs",
     "type": "ARMOR",
     "copy-from": "armguard_lc_brigandine",
-    "name": { "str": "XS pair of mild steel splint arm guards", "str_pl": "XS pairs of mild steel splint arm guards" },
+    "name": { "str": "pair of mild steel splint arm guards", "str_pl": "pairs of mild steel splint arm guards" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "armguard_mc_brigandine",
@@ -747,17 +729,17 @@
     "id": "xl_armguard_mc_brigandine",
     "type": "ARMOR",
     "copy-from": "armguard_mc_brigandine",
-    "name": { "str": "XL pair of medium steel splint arm guards", "str_pl": "XL pairs of medium steel splint arm guards" },
+    "name": { "str": "pair of medium steel splint arm guards", "str_pl": "pairs of medium steel splint arm guards" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armguard_mc_brigandine_xs",
     "type": "ARMOR",
     "copy-from": "armguard_mc_brigandine",
-    "name": { "str": "XS pair of medium steel splint arm guards", "str_pl": "XS pairs of medium steel splint arm guards" },
+    "name": { "str": "pair of medium steel splint arm guards", "str_pl": "pairs of medium steel splint arm guards" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "armguard_hc_brigandine",
@@ -770,17 +752,17 @@
     "id": "xl_armguard_hc_brigandine",
     "type": "ARMOR",
     "copy-from": "armguard_hc_brigandine",
-    "name": { "str": "XL pair of high steel splint arm guards", "str_pl": "XL pairs of high steel splint arm guards" },
+    "name": { "str": "pair of high steel splint arm guards", "str_pl": "pairs of high steel splint arm guards" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armguard_hc_brigandine_xs",
     "type": "ARMOR",
     "copy-from": "armguard_hc_brigandine",
-    "name": { "str": "XS pair of high steel splint arm guards", "str_pl": "XS pairs of high steel splint arm guards" },
+    "name": { "str": "pair of high steel splint arm guards", "str_pl": "pairs of high steel splint arm guards" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "armguard_ch_brigandine",
@@ -793,17 +775,17 @@
     "id": "xl_armguard_ch_brigandine",
     "type": "ARMOR",
     "copy-from": "armguard_ch_brigandine",
-    "name": { "str": "XL pair of hardened splint arm guards", "str_pl": "XL pairs of hardened splint arm guards" },
+    "name": { "str": "pair of hardened splint arm guards", "str_pl": "pairs of hardened splint arm guards" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armguard_ch_brigandine_xs",
     "type": "ARMOR",
     "copy-from": "armguard_ch_brigandine",
-    "name": { "str": "XS pair of hardened splint arm guards", "str_pl": "XS pairs of hardened splint arm guards" },
+    "name": { "str": "pair of hardened splint arm guards", "str_pl": "pairs of hardened splint arm guards" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "armguard_qt_brigandine",
@@ -816,17 +798,17 @@
     "id": "xl_armguard_qt_brigandine",
     "type": "ARMOR",
     "copy-from": "armguard_qt_brigandine",
-    "name": { "str": "XL pair of tempered splint arm guards", "str_pl": "XL pairs of tempered splint arm guards" },
+    "name": { "str": "pair of tempered splint arm guards", "str_pl": "pairs of tempered splint arm guards" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armguard_qt_brigandine_xs",
     "type": "ARMOR",
     "copy-from": "armguard_qt_brigandine",
-    "name": { "str": "XS pair of tempered splint arm guards", "str_pl": "XS pairs of tempered splint arm guards" },
+    "name": { "str": "pair of tempered splint arm guards", "str_pl": "pairs of tempered splint arm guards" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "legguard_lc_brigandine",
@@ -865,17 +847,17 @@
     "id": "xl_legguard_lc_brigandine",
     "type": "ARMOR",
     "copy-from": "legguard_lc_brigandine",
-    "name": { "str": "XL pair of mild steel splint leg guards", "str_pl": "XL pairs of mild steel splint leg guards" },
+    "name": { "str": "pair of mild steel splint leg guards", "str_pl": "pairs of mild steel splint leg guards" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "legguard_lc_brigandine_xs",
     "type": "ARMOR",
     "copy-from": "legguard_lc_brigandine",
-    "name": { "str": "XS pair of mild steel splint leg guards", "str_pl": "XS pairs of mild steel splint leg guards" },
+    "name": { "str": "pair of mild steel splint leg guards", "str_pl": "pairs of mild steel splint leg guards" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "legguard_mc_brigandine",
@@ -888,17 +870,17 @@
     "id": "xl_legguard_mc_brigandine",
     "type": "ARMOR",
     "copy-from": "legguard_mc_brigandine",
-    "name": { "str": "XL pair of medium steel splint leg guards", "str_pl": "XL pairs of medium steel splint leg guards" },
+    "name": { "str": "pair of medium steel splint leg guards", "str_pl": "pairs of medium steel splint leg guards" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "legguard_mc_brigandine_xs",
     "type": "ARMOR",
     "copy-from": "legguard_mc_brigandine",
-    "name": { "str": "XS pair of medium steel splint leg guards", "str_pl": "XS pairs of medium steel splint leg guards" },
+    "name": { "str": "pair of medium steel splint leg guards", "str_pl": "pairs of medium steel splint leg guards" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "legguard_hc_brigandine",
@@ -911,17 +893,17 @@
     "id": "xl_legguard_hc_brigandine",
     "type": "ARMOR",
     "copy-from": "legguard_hc_brigandine",
-    "name": { "str": "XL pair of high steel splint leg guards", "str_pl": "XL pairs of high steel splint leg guards" },
+    "name": { "str": "pair of high steel splint leg guards", "str_pl": "pairs of high steel splint leg guards" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "legguard_hc_brigandine_xs",
     "type": "ARMOR",
     "copy-from": "legguard_hc_brigandine",
-    "name": { "str": "XS pair of high steel splint leg guards", "str_pl": "XS pairs of high steel splint leg guards" },
+    "name": { "str": "pair of high steel splint leg guards", "str_pl": "pairs of high steel splint leg guards" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "legguard_ch_brigandine",
@@ -934,17 +916,17 @@
     "id": "xl_legguard_ch_brigandine",
     "type": "ARMOR",
     "copy-from": "legguard_ch_brigandine",
-    "name": { "str": "XL pair of hardened splint leg guards", "str_pl": "XL pairs of hardened splint leg guards" },
+    "name": { "str": "pair of hardened splint leg guards", "str_pl": "pairs of hardened splint leg guards" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "legguard_ch_brigandine_xs",
     "type": "ARMOR",
     "copy-from": "legguard_ch_brigandine",
-    "name": { "str": "XS pair of hardened splint leg guards", "str_pl": "XS pairs of hardened splint leg guards" },
+    "name": { "str": "pair of hardened splint leg guards", "str_pl": "pairs of hardened splint leg guards" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "legguard_qt_brigandine",
@@ -957,17 +939,17 @@
     "id": "xl_legguard_qt_brigandine",
     "type": "ARMOR",
     "copy-from": "legguard_qt_brigandine",
-    "name": { "str": "XL pair of tempered splint leg guards", "str_pl": "XL pairs of tempered splint leg guards" },
+    "name": { "str": "pair of tempered splint leg guards", "str_pl": "pairs of tempered splint leg guards" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "legguard_qt_brigandine_xs",
     "type": "ARMOR",
     "copy-from": "legguard_qt_brigandine",
-    "name": { "str": "XS pair of tempered splint leg guards", "str_pl": "XS pairs of tempered splint leg guards" },
+    "name": { "str": "pair of tempered splint leg guards", "str_pl": "pairs of tempered splint leg guards" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "lc_vambrace_brigandine",
@@ -1007,17 +989,17 @@
     "id": "xl_lc_vambrace_brigandine",
     "type": "ARMOR",
     "copy-from": "lc_vambrace_brigandine",
-    "name": { "str": "XL pair of mild steel splint vambraces", "str_pl": "XL pairs of mild steel splint vambraces" },
+    "name": { "str": "pair of mild steel splint vambraces", "str_pl": "pairs of mild steel splint vambraces" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_lc_vambrace_brigandine",
     "type": "ARMOR",
     "copy-from": "lc_vambrace_brigandine",
-    "name": { "str": "XS pair of mild steel splint vambraces", "str_pl": "XS pairs of mild steel splint vambraces" },
+    "name": { "str": "pair of mild steel splint vambraces", "str_pl": "pairs of mild steel splint vambraces" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "mc_vambrace_brigandine",
@@ -1030,17 +1012,17 @@
     "id": "xl_mc_vambrace_brigandine",
     "type": "ARMOR",
     "copy-from": "mc_vambrace_brigandine",
-    "name": { "str": "XL pair of medium steel splint vambraces", "str_pl": "XL pairs of medium steel splint vambraces" },
+    "name": { "str": "pair of medium steel splint vambraces", "str_pl": "pairs of medium steel splint vambraces" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_mc_vambrace_brigandine",
     "type": "ARMOR",
     "copy-from": "mc_vambrace_brigandine",
-    "name": { "str": "XS pair of medium steel splint vambraces", "str_pl": "XS pairs of medium steel splint vambraces" },
+    "name": { "str": "pair of medium steel splint vambraces", "str_pl": "pairs of medium steel splint vambraces" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "hc_vambrace_brigandine",
@@ -1053,17 +1035,17 @@
     "id": "xl_hc_vambrace_brigandine",
     "type": "ARMOR",
     "copy-from": "hc_vambrace_brigandine",
-    "name": { "str": "XL pair of high steel splint vambraces", "str_pl": "XL pairs of high steel splint vambraces" },
+    "name": { "str": "pair of high steel splint vambraces", "str_pl": "pairs of high steel splint vambraces" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_hc_vambrace_brigandine",
     "type": "ARMOR",
     "copy-from": "hc_vambrace_brigandine",
-    "name": { "str": "XS pair of high steel splint vambraces", "str_pl": "XS pairs of high steel splint vambraces" },
+    "name": { "str": "pair of high steel splint vambraces", "str_pl": "pairs of high steel splint vambraces" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "ch_vambrace_brigandine",
@@ -1076,17 +1058,17 @@
     "id": "xl_ch_vambrace_brigandine",
     "type": "ARMOR",
     "copy-from": "ch_vambrace_brigandine",
-    "name": { "str": "XL pair of hardened splint vambraces", "str_pl": "XL pairs of hardened splint vambraces" },
+    "name": { "str": "pair of hardened splint vambraces", "str_pl": "pairs of hardened splint vambraces" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_ch_vambrace_brigandine",
     "type": "ARMOR",
     "copy-from": "ch_vambrace_brigandine",
-    "name": { "str": "XS pair of hardened splint vambraces", "str_pl": "XS pairs of hardened splint vambraces" },
+    "name": { "str": "pair of hardened splint vambraces", "str_pl": "pairs of hardened splint vambraces" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "qt_vambrace_brigandine",
@@ -1099,17 +1081,17 @@
     "id": "xl_qt_vambrace_brigandine",
     "type": "ARMOR",
     "copy-from": "qt_vambrace_brigandine",
-    "name": { "str": "XL pair of tempered splint vambraces", "str_pl": "XL pairs of tempered splint vambraces" },
+    "name": { "str": "pair of tempered splint vambraces", "str_pl": "pairs of tempered splint vambraces" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_qt_vambrace_brigandine",
     "type": "ARMOR",
     "copy-from": "qt_vambrace_brigandine",
-    "name": { "str": "XS pair of tempered splint vambraces", "str_pl": "XS pairs of tempered splint vambraces" },
+    "name": { "str": "pair of tempered splint vambraces", "str_pl": "pairs of tempered splint vambraces" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "lc_greaves_brigandine",
@@ -1148,17 +1130,17 @@
     "id": "xl_lc_greaves_brigandine",
     "type": "ARMOR",
     "copy-from": "lc_greaves_brigandine",
-    "name": { "str": "XL pair of mild steel splint greaves", "str_pl": "XL pairs of mild steel splint greaves" },
+    "name": { "str": "pair of mild steel splint greaves", "str_pl": "pairs of mild steel splint greaves" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_lc_greaves_brigandine",
     "type": "ARMOR",
     "copy-from": "lc_greaves_brigandine",
-    "name": { "str": "XS pair of mild steel splint greaves", "str_pl": "XS pairs of mild steel splint greaves" },
+    "name": { "str": "pair of mild steel splint greaves", "str_pl": "pairs of mild steel splint greaves" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "mc_greaves_brigandine",
@@ -1171,17 +1153,17 @@
     "id": "xl_mc_greaves_brigandine",
     "type": "ARMOR",
     "copy-from": "mc_greaves_brigandine",
-    "name": { "str": "XL pair of medium steel splint greaves", "str_pl": "XL pairs of medium steel splint greaves" },
+    "name": { "str": "pair of medium steel splint greaves", "str_pl": "pairs of medium steel splint greaves" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_mc_greaves_brigandine",
     "type": "ARMOR",
     "copy-from": "mc_greaves_brigandine",
-    "name": { "str": "XS pair of medium steel splint greaves", "str_pl": "XS pairs of medium steel splint greaves" },
+    "name": { "str": "pair of medium steel splint greaves", "str_pl": "pairs of medium steel splint greaves" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "hc_greaves_brigandine",
@@ -1194,17 +1176,17 @@
     "id": "xl_hc_greaves_brigandine",
     "type": "ARMOR",
     "copy-from": "hc_greaves_brigandine",
-    "name": { "str": "XL pair of high steel splint greaves", "str_pl": "XL pairs of high steel splint greaves" },
+    "name": { "str": "pair of high steel splint greaves", "str_pl": "pairs of high steel splint greaves" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_hc_greaves_brigandine",
     "type": "ARMOR",
     "copy-from": "hc_greaves_brigandine",
-    "name": { "str": "XS pair of high steel splint greaves", "str_pl": "XS pairs of high steel splint greaves" },
+    "name": { "str": "pair of high steel splint greaves", "str_pl": "pairs of high steel splint greaves" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "ch_greaves_brigandine",
@@ -1217,17 +1199,17 @@
     "id": "xl_ch_greaves_brigandine",
     "type": "ARMOR",
     "copy-from": "ch_greaves_brigandine",
-    "name": { "str": "XL pair of hardened splint greaves", "str_pl": "XL pairs of hardened splint greaves" },
+    "name": { "str": "pair of hardened splint greaves", "str_pl": "pairs of hardened splint greaves" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_ch_greaves_brigandine",
     "type": "ARMOR",
     "copy-from": "ch_greaves_brigandine",
-    "name": { "str": "XS pair of hardened splint greaves", "str_pl": "XS pairs of hardened splint greaves" },
+    "name": { "str": "pair of hardened splint greaves", "str_pl": "pairs of hardened splint greaves" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "qt_greaves_brigandine",
@@ -1240,17 +1222,17 @@
     "id": "xl_qt_greaves_brigandine",
     "type": "ARMOR",
     "copy-from": "qt_greaves_brigandine",
-    "name": { "str": "XL pair of tempered splint greaves", "str_pl": "XL pairs of tempered splint greaves" },
+    "name": { "str": "pair of tempered splint greaves", "str_pl": "pairs of tempered splint greaves" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_qt_greaves_brigandine",
     "type": "ARMOR",
     "copy-from": "qt_greaves_brigandine",
-    "name": { "str": "XS pair of tempered splint greaves", "str_pl": "XS pairs of tempered splint greaves" },
+    "name": { "str": "pair of tempered splint greaves", "str_pl": "pairs of tempered splint greaves" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "lc_brigandine_hands",
@@ -1302,17 +1284,17 @@
     "id": "xl_lc_brigandine_hands",
     "type": "ARMOR",
     "copy-from": "lc_brigandine_hands",
-    "name": { "str": "XL pair of mild steel brigandine gloves", "str_pl": "XL pairs of mild steel brigandine gloves" },
+    "name": { "str": "pair of mild steel brigandine gloves", "str_pl": "pairs of mild steel brigandine gloves" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "lc_brigandine_hands_xs",
     "type": "ARMOR",
     "copy-from": "lc_brigandine_hands",
-    "name": { "str": "XS pair of mild steel brigandine gloves", "str_pl": "XS pairs of mild steel brigandine gloves" },
+    "name": { "str": "pair of mild steel brigandine gloves", "str_pl": "pairs of mild steel brigandine gloves" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "mc_brigandine_hands",
@@ -1325,17 +1307,17 @@
     "id": "xl_mc_brigandine_hands",
     "type": "ARMOR",
     "copy-from": "mc_brigandine_hands",
-    "name": { "str": "XL pair of medium steel brigandine gloves", "str_pl": "XL pairs of medium steel brigandine gloves" },
+    "name": { "str": "pair of medium steel brigandine gloves", "str_pl": "pairs of medium steel brigandine gloves" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "mc_brigandine_hands_xs",
     "type": "ARMOR",
     "copy-from": "mc_brigandine_hands",
-    "name": { "str": "XS pair of medium steel brigandine gloves", "str_pl": "XS pairs of medium steel brigandine gloves" },
+    "name": { "str": "pair of medium steel brigandine gloves", "str_pl": "pairs of medium steel brigandine gloves" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "hc_brigandine_hands",
@@ -1348,17 +1330,17 @@
     "id": "xl_hc_brigandine_hands",
     "type": "ARMOR",
     "copy-from": "hc_brigandine_hands",
-    "name": { "str": "XL pair of high steel brigandine gloves", "str_pl": "XL pairs of high steel brigandine gloves" },
+    "name": { "str": "pair of high steel brigandine gloves", "str_pl": "pairs of high steel brigandine gloves" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "hc_brigandine_hands_xs",
     "type": "ARMOR",
     "copy-from": "hc_brigandine_hands",
-    "name": { "str": "XS pair of high steel brigandine gloves", "str_pl": "XS pairs of high steel brigandine gloves" },
+    "name": { "str": "pair of high steel brigandine gloves", "str_pl": "pairs of high steel brigandine gloves" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "ch_brigandine_hands",
@@ -1371,17 +1353,17 @@
     "id": "xl_ch_brigandine_hands",
     "type": "ARMOR",
     "copy-from": "ch_brigandine_hands",
-    "name": { "str": "XL pair of hardened brigandine gloves", "str_pl": "XL pairs of hardened brigandine gloves" },
+    "name": { "str": "pair of hardened brigandine gloves", "str_pl": "pairs of hardened brigandine gloves" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "ch_brigandine_hands_xs",
     "type": "ARMOR",
     "copy-from": "ch_brigandine_hands",
-    "name": { "str": "XS pair of hardened brigandine gloves", "str_pl": "XS pairs of hardened brigandine gloves" },
+    "name": { "str": "pair of hardened brigandine gloves", "str_pl": "pairs of hardened brigandine gloves" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "qt_brigandine_hands",
@@ -1394,17 +1376,17 @@
     "id": "xl_qt_brigandine_hands",
     "type": "ARMOR",
     "copy-from": "qt_brigandine_hands",
-    "name": { "str": "XL pair of tempered brigandine gloves", "str_pl": "XL pairs of tempered brigandine gloves" },
+    "name": { "str": "pair of tempered brigandine gloves", "str_pl": "pairs of tempered brigandine gloves" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "qt_brigandine_hands_xs",
     "type": "ARMOR",
     "copy-from": "qt_brigandine_hands",
-    "name": { "str": "XS pair of tempered brigandine gloves", "str_pl": "XS pairs of tempered brigandine gloves" },
+    "name": { "str": "pair of tempered brigandine gloves", "str_pl": "pairs of tempered brigandine gloves" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "lc_knee_guards",
@@ -1439,17 +1421,17 @@
     "id": "xl_lc_knee_guards",
     "type": "ARMOR",
     "copy-from": "lc_knee_guards",
-    "name": { "str": "XL pair of mild steel knee guards", "str_pl": "XL pairs of mild steel knee guards" },
+    "name": { "str": "pair of mild steel knee guards", "str_pl": "pairs of mild steel knee guards" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "lc_knee_guards_xs",
     "type": "ARMOR",
     "copy-from": "lc_knee_guards",
-    "name": { "str": "XS pair of mild steel knee guards", "str_pl": "XS pairs of mild steel knee guards" },
+    "name": { "str": "pair of mild steel knee guards", "str_pl": "pairs of mild steel knee guards" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "mc_knee_guards",
@@ -1462,17 +1444,17 @@
     "id": "xl_mc_knee_guards",
     "type": "ARMOR",
     "copy-from": "mc_knee_guards",
-    "name": { "str": "XL pair of medium steel knee guards", "str_pl": "XL pairs of medium steel knee guards" },
+    "name": { "str": "pair of medium steel knee guards", "str_pl": "pairs of medium steel knee guards" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "mc_knee_guards_xs",
     "type": "ARMOR",
     "copy-from": "mc_knee_guards",
-    "name": { "str": "XS pair of medium steel knee guards", "str_pl": "XS pairs of medium steel knee guards" },
+    "name": { "str": "pair of medium steel knee guards", "str_pl": "pairs of medium steel knee guards" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "hc_knee_guards",
@@ -1485,17 +1467,17 @@
     "id": "xl_hc_knee_guards",
     "type": "ARMOR",
     "copy-from": "hc_knee_guards",
-    "name": { "str": "XL pair of high steel knee guards", "str_pl": "XL pairs of high steel knee guards" },
+    "name": { "str": "pair of high steel knee guards", "str_pl": "pairs of high steel knee guards" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "hc_knee_guards_xs",
     "type": "ARMOR",
     "copy-from": "hc_knee_guards",
-    "name": { "str": "XS pair of high steel knee guards", "str_pl": "XS pairs of high steel knee guards" },
+    "name": { "str": "pair of high steel knee guards", "str_pl": "pairs of high steel knee guards" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "ch_knee_guards",
@@ -1508,17 +1490,17 @@
     "id": "xl_ch_knee_guards",
     "type": "ARMOR",
     "copy-from": "ch_knee_guards",
-    "name": { "str": "XL pair of hardened knee guards", "str_pl": "XL pairs of hardened knee guards" },
+    "name": { "str": "pair of hardened knee guards", "str_pl": "pairs of hardened knee guards" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "ch_knee_guards_xs",
     "type": "ARMOR",
     "copy-from": "ch_knee_guards",
-    "name": { "str": "XS pair of hardened knee guards", "str_pl": "XS pairs of hardened knee guards" },
+    "name": { "str": "pair of hardened knee guards", "str_pl": "pairs of hardened knee guards" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "qt_knee_guards",
@@ -1531,17 +1513,17 @@
     "id": "xl_qt_knee_guards",
     "type": "ARMOR",
     "copy-from": "qt_knee_guards",
-    "name": { "str": "XL pair of tempered knee guards", "str_pl": "XL pairs of tempered knee guards" },
+    "name": { "str": "pair of tempered knee guards", "str_pl": "pairs of tempered knee guards" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "qt_knee_guards_xs",
     "type": "ARMOR",
     "copy-from": "qt_knee_guards",
-    "name": { "str": "XS pair of tempered knee guards", "str_pl": "XS pairs of tempered knee guards" },
+    "name": { "str": "pair of tempered knee guards", "str_pl": "pairs of tempered knee guards" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "lc_elbow_guards",
@@ -1576,17 +1558,17 @@
     "id": "xl_lc_elbow_guards",
     "type": "ARMOR",
     "copy-from": "lc_elbow_guards",
-    "name": { "str": "XL pair of mild steel elbow guards", "str_pl": "XL pairs of mild steel elbow guards" },
+    "name": { "str": "pair of mild steel elbow guards", "str_pl": "pairs of mild steel elbow guards" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "lc_elbow_guards_xs",
     "type": "ARMOR",
     "copy-from": "lc_elbow_guards",
-    "name": { "str": "XS pair of mild steel elbow guards", "str_pl": "XS pairs of mild steel elbow guards" },
+    "name": { "str": "pair of mild steel elbow guards", "str_pl": "pairs of mild steel elbow guards" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "mc_elbow_guards",
@@ -1599,17 +1581,17 @@
     "id": "xl_mc_elbow_guards",
     "type": "ARMOR",
     "copy-from": "mc_elbow_guards",
-    "name": { "str": "XL pair of medium steel elbow guards", "str_pl": "XL pairs of medium steel elbow guards" },
+    "name": { "str": "pair of medium steel elbow guards", "str_pl": "pairs of medium steel elbow guards" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "mc_elbow_guards_xs",
     "type": "ARMOR",
     "copy-from": "mc_elbow_guards",
-    "name": { "str": "XS pair of medium steel elbow guards", "str_pl": "XS pairs of medium steel elbow guards" },
+    "name": { "str": "pair of medium steel elbow guards", "str_pl": "pairs of medium steel elbow guards" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "hc_elbow_guards",
@@ -1622,17 +1604,17 @@
     "id": "xl_hc_elbow_guards",
     "type": "ARMOR",
     "copy-from": "hc_elbow_guards",
-    "name": { "str": "XL pair of high steel elbow guards", "str_pl": "XL pairs of high steel elbow guards" },
+    "name": { "str": "pair of high steel elbow guards", "str_pl": "pairs of high steel elbow guards" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "hc_elbow_guards_xs",
     "type": "ARMOR",
     "copy-from": "hc_elbow_guards",
-    "name": { "str": "XS pair of high steel elbow guards", "str_pl": "XS pairs of high steel elbow guards" },
+    "name": { "str": "pair of high steel elbow guards", "str_pl": "pairs of high steel elbow guards" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "ch_elbow_guards",
@@ -1645,17 +1627,17 @@
     "id": "xl_ch_elbow_guards",
     "type": "ARMOR",
     "copy-from": "ch_elbow_guards",
-    "name": { "str": "XL pair of hardened elbow guards", "str_pl": "XL pairs of hardened elbow guards" },
+    "name": { "str": "pair of hardened elbow guards", "str_pl": "pairs of hardened elbow guards" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "ch_elbow_guards_xs",
     "type": "ARMOR",
     "copy-from": "ch_elbow_guards",
-    "name": { "str": "XS pair of hardened elbow guards", "str_pl": "XS pairs of hardened elbow guards" },
+    "name": { "str": "pair of hardened elbow guards", "str_pl": "pairs of hardened elbow guards" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "qt_elbow_guards",
@@ -1668,17 +1650,17 @@
     "id": "xl_qt_elbow_guards",
     "type": "ARMOR",
     "copy-from": "qt_elbow_guards",
-    "name": { "str": "XL pair of tempered elbow guards", "str_pl": "XL pairs of tempered elbow guards" },
+    "name": { "str": "pair of tempered elbow guards", "str_pl": "pairs of tempered elbow guards" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "qt_elbow_guards_xs",
     "type": "ARMOR",
     "copy-from": "qt_elbow_guards",
-    "name": { "str": "XS pair of tempered elbow guards", "str_pl": "XS pairs of tempered elbow guards" },
+    "name": { "str": "pair of tempered elbow guards", "str_pl": "pairs of tempered elbow guards" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "lc_shoulder_guards",
@@ -1698,15 +1680,17 @@
     "id": "xl_lc_shoulder_guards",
     "type": "GENERIC",
     "copy-from": "lc_shoulder_guards",
-    "name": { "str": "XL pair of mild steel shoulder guards", "str_pl": "XL pairs of mild steel shoulder guards" },
-    "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 }
+    "name": { "str": "pair of mild steel shoulder guards", "str_pl": "pairs of mild steel shoulder guards" },
+    "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
+    "extend": { "flags": [ "PREFIX_XL" ] }
   },
   {
     "id": "lc_shoulder_guards_xs",
     "type": "GENERIC",
     "copy-from": "lc_shoulder_guards",
-    "name": { "str": "XS pair of mild steel shoulder guards", "str_pl": "XS pairs of mild steel shoulder guards" },
-    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 }
+    "name": { "str": "pair of mild steel shoulder guards", "str_pl": "pairs of mild steel shoulder guards" },
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
+    "extend": { "flags": [ "PREFIX_XS" ] }
   },
   {
     "id": "mc_shoulder_guards",
@@ -1719,15 +1703,17 @@
     "id": "xl_mc_shoulder_guards",
     "type": "GENERIC",
     "copy-from": "mc_shoulder_guards",
-    "name": { "str": "XL pair of medium steel shoulder guards", "str_pl": "XL pairs of medium steel shoulder guards" },
-    "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 }
+    "name": { "str": "pair of medium steel shoulder guards", "str_pl": "pairs of medium steel shoulder guards" },
+    "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
+    "extend": { "flags": [ "PREFIX_XL" ] }
   },
   {
     "id": "mc_shoulder_guards_xs",
     "type": "GENERIC",
     "copy-from": "mc_shoulder_guards",
-    "name": { "str": "XS pair of medium steel shoulder guards", "str_pl": "XS pairs of medium steel shoulder guards" },
-    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 }
+    "name": { "str": "pair of medium steel shoulder guards", "str_pl": "pairs of medium steel shoulder guards" },
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
+    "extend": { "flags": [ "PREFIX_XS" ] }
   },
   {
     "id": "hc_shoulder_guards",
@@ -1740,15 +1726,17 @@
     "id": "xl_hc_shoulder_guards",
     "type": "GENERIC",
     "copy-from": "hc_shoulder_guards",
-    "name": { "str": "XL pair of high steel shoulder guards", "str_pl": "XL pairs of high steel shoulder guards" },
-    "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 }
+    "name": { "str": "pair of high steel shoulder guards", "str_pl": "pairs of high steel shoulder guards" },
+    "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
+    "extend": { "flags": [ "PREFIX_XL" ] }
   },
   {
     "id": "hc_shoulder_guards_xs",
     "type": "GENERIC",
     "copy-from": "hc_shoulder_guards",
-    "name": { "str": "XS pair of high steel shoulder guards", "str_pl": "XS pairs of high steel shoulder guards" },
-    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 }
+    "name": { "str": "pair of high steel shoulder guards", "str_pl": "pairs of high steel shoulder guards" },
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
+    "extend": { "flags": [ "PREFIX_XS" ] }
   },
   {
     "id": "ch_shoulder_guards",
@@ -1761,15 +1749,17 @@
     "id": "xl_ch_shoulder_guards",
     "type": "GENERIC",
     "copy-from": "ch_shoulder_guards",
-    "name": { "str": "XL pair of hardened shoulder guards", "str_pl": "XL pairs of hardened shoulder guards" },
-    "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 }
+    "name": { "str": "pair of hardened shoulder guards", "str_pl": "pairs of hardened shoulder guards" },
+    "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
+    "extend": { "flags": [ "PREFIX_XL" ] }
   },
   {
     "id": "ch_shoulder_guards_xs",
     "type": "GENERIC",
     "copy-from": "ch_shoulder_guards",
-    "name": { "str": "XS pair of hardened shoulder guards", "str_pl": "XS pairs of hardened shoulder guards" },
-    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 }
+    "name": { "str": "pair of hardened shoulder guards", "str_pl": "pairs of hardened shoulder guards" },
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
+    "extend": { "flags": [ "PREFIX_XS" ] }
   },
   {
     "id": "qt_shoulder_guards",
@@ -1782,14 +1772,16 @@
     "id": "xl_qt_shoulder_guards",
     "type": "GENERIC",
     "copy-from": "qt_shoulder_guards",
-    "name": { "str": "XL pair of tempered shoulder guards", "str_pl": "XL pairs of tempered shoulder guards" },
-    "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 }
+    "name": { "str": "pair of tempered shoulder guards", "str_pl": "pairs of tempered shoulder guards" },
+    "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
+    "extend": { "flags": [ "PREFIX_XL" ] }
   },
   {
     "id": "qt_shoulder_guards_xs",
     "type": "GENERIC",
     "copy-from": "qt_shoulder_guards",
-    "name": { "str": "XS pair of tempered shoulder guards", "str_pl": "XS pairs of tempered shoulder guards" },
-    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 }
+    "name": { "str": "pair of tempered shoulder guards", "str_pl": "pairs of tempered shoulder guards" },
+    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
+    "extend": { "flags": [ "PREFIX_XS" ] }
   }
 ]

--- a/data/json/items/armor/coats.json
+++ b/data/json/items/armor/coats.json
@@ -211,18 +211,18 @@
   {
     "id": "xl_coat_fur",
     "type": "ARMOR",
-    "name": { "str": "XL fur coat" },
+    "name": { "str": "fur coat" },
     "copy-from": "coat_fur",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_coat_fur",
     "type": "ARMOR",
     "copy-from": "coat_fur",
-    "name": { "str": "XS fur coat" },
+    "name": { "str": "fur coat" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "coat_faux_fur",
@@ -239,18 +239,18 @@
   {
     "id": "xl_coat_faux_fur",
     "type": "ARMOR",
-    "name": { "str": "XL faux fur coat" },
+    "name": { "str": "faux fur coat" },
     "copy-from": "coat_faux_fur",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_coat_faux_fur",
     "type": "ARMOR",
     "copy-from": "coat_faux_fur",
-    "name": { "str": "XS faux fur coat" },
+    "name": { "str": "faux fur coat" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "coat_lab",
@@ -582,34 +582,34 @@
   {
     "id": "xl_duster_fur",
     "type": "ARMOR",
-    "name": { "str": "XL fur duster" },
+    "name": { "str": "fur duster" },
     "copy-from": "duster_fur",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_duster_fur",
     "type": "ARMOR",
     "copy-from": "duster_fur",
-    "name": { "str": "XS fur duster" },
+    "name": { "str": "fur duster" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "xl_duster",
     "type": "ARMOR",
-    "name": { "str": "XL duster" },
+    "name": { "str": "duster" },
     "copy-from": "duster",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_duster",
     "type": "ARMOR",
     "copy-from": "duster",
-    "name": { "str": "XS duster" },
+    "name": { "str": "duster" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "duster_faux_fur",
@@ -625,18 +625,18 @@
   {
     "id": "xl_duster_faux_fur",
     "type": "ARMOR",
-    "name": { "str": "XL faux fur duster" },
+    "name": { "str": "faux fur duster" },
     "copy-from": "duster_faux_fur",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_duster_faux_fur",
     "type": "ARMOR",
     "copy-from": "duster_faux_fur",
-    "name": { "str": "XS faux fur duster" },
+    "name": { "str": "faux fur duster" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "duster_leather",
@@ -715,18 +715,18 @@
   {
     "id": "xl_duster_leather",
     "type": "ARMOR",
-    "name": { "str": "XL leather duster" },
+    "name": { "str": "leather duster" },
     "copy-from": "duster_leather",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_duster_leather",
     "type": "ARMOR",
     "copy-from": "duster_leather",
-    "name": { "str": "XS leather duster" },
+    "name": { "str": "leather duster" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "greatcoat",

--- a/data/json/items/armor/gambesons.json
+++ b/data/json/items/armor/gambesons.json
@@ -50,19 +50,18 @@
   {
     "id": "xl_gambeson",
     "type": "ARMOR",
-    "name": { "str": "XL gambeson" },
     "copy-from": "gambeson",
+    "name": { "str": "padded gambeson" },
     "proportional": { "weight": 1.5, "volume": 1.5, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "gambeson_xs",
     "type": "ARMOR",
     "copy-from": "gambeson",
-    "looks_like": "gambeson",
-    "name": { "str": "XS gambeson" },
+    "name": { "str": "padded gambeson" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "gambeson_vest",
@@ -105,24 +104,23 @@
   {
     "id": "xl_gambeson_vest",
     "type": "ARMOR",
-    "name": { "str": "XL gambeson vest" },
+    "name": { "str": "padded gambeson vest" },
     "copy-from": "gambeson_vest",
     "proportional": { "weight": 1.5, "volume": 1.5, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "gambeson_vest_xs",
     "type": "ARMOR",
     "copy-from": "gambeson_vest",
-    "looks_like": "gambeson",
-    "name": { "str": "XS gambeson vest" },
+    "name": { "str": "padded gambeson vest" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "gambeson_pants",
     "type": "ARMOR",
-    "name": { "str_sp": "padded arming pants" },
+    "name": { "str": "padded arming pants", "str_pl": "pairs of padded arming pants" },
     "description": "Thick pants made of quilted fabric, meant to be worn alongside a gambeson under or without armor.",
     "weight": "2736 g",
     "volume": "1750 ml",
@@ -150,18 +148,18 @@
   {
     "id": "xl_gambeson_pants",
     "type": "ARMOR",
-    "name": { "str": "XL arming pants", "str_pl": "pairs of XL arming pants" },
+    "name": { "str": "padded arming pants", "str_pl": "pairs of padded arming pants" },
     "copy-from": "gambeson_pants",
     "proportional": { "weight": 1.5, "volume": 1.5, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "gambeson_pants_xs",
     "type": "ARMOR",
-    "name": { "str": "XL arming pants", "str_pl": "pairs of XL arming pants" },
+    "name": { "str": "padded arming pants", "str_pl": "pairs of padded arming pants" },
     "copy-from": "gambeson_pants",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "gambeson_hood",
@@ -198,19 +196,19 @@
     "id": "xl_gambeson_hood",
     "//": "surface area of XL body assumed to be 50% greater and materials used are also 50% greater.",
     "type": "ARMOR",
-    "name": { "str": "XL padded coif" },
+    "name": { "str": "padded coif" },
     "copy-from": "gambeson_hood",
     "proportional": { "weight": 1.5, "volume": 1.5, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_gambeson_hood",
-    "//": "surface area of XL body assumed to be 75% size and materials used are also 75% as much.",
+    "//": "surface area of XS body assumed to be 75% size and materials used are also 75% as much.",
     "type": "ARMOR",
-    "name": { "str": "XS padded coif" },
+    "name": { "str": "padded coif" },
     "copy-from": "gambeson_hood",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "aketon_canvas",
@@ -259,19 +257,19 @@
     "id": "xl_aketon_canvas",
     "//": "surface area of XL body assumed to be 50% greater and materials used are also 50% greater.",
     "type": "ARMOR",
-    "name": { "str": "XL canvas aketon" },
+    "name": { "str": "canvas aketon" },
     "copy-from": "aketon_canvas",
     "proportional": { "weight": 1.5, "volume": 1.5, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_aketon_canvas",
-    "//": "surface area of XL body assumed to be 75% size and materials used are also 75% as much.",
+    "//": "surface area of XS body assumed to be 75% size and materials used are also 75% as much.",
     "type": "ARMOR",
-    "name": { "str": "XS canvas aketon" },
+    "name": { "str": "canvas aketon" },
     "copy-from": "aketon_canvas",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "aketon_canvas_vest",
@@ -308,19 +306,19 @@
     "id": "xl_aketon_canvas_vest",
     "//": "surface area of XL body assumed to be 50% greater and materials used are also 50% greater.",
     "type": "ARMOR",
-    "name": { "str": "XL canvas aketon vest" },
+    "name": { "str": "canvas aketon vest" },
     "copy-from": "aketon_canvas_vest",
     "proportional": { "weight": 1.5, "volume": 1.5, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_aketon_canvas_vest",
-    "//": "surface area of XL body assumed to be 75% size and materials used are also 75% as much.",
+    "//": "surface area of XS body assumed to be 75% size and materials used are also 75% as much.",
     "type": "ARMOR",
-    "name": { "str": "XS canvas aketon vest" },
+    "name": { "str": "canvas aketon vest" },
     "copy-from": "aketon_canvas_vest",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "aketon_pants_canvas",
@@ -357,19 +355,19 @@
     "id": "xl_aketon_pants_canvas",
     "//": "surface area of XL body assumed to be 50% greater and materials used are also 50% greater.",
     "type": "ARMOR",
-    "name": { "str": "XL canvas arming pants", "str_pl": "pairs of XL canvas arming pants" },
+    "name": { "str": "canvas arming pants", "str_pl": "pairs of canvas arming pants" },
     "copy-from": "aketon_pants_canvas",
     "proportional": { "weight": 1.5, "volume": 1.5, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_aketon_pants_canvas",
-    "//": "surface area of XL body assumed to be 75% size and materials used are also 75% as much.",
+    "//": "surface area of XS body assumed to be 75% size and materials used are also 75% as much.",
     "type": "ARMOR",
-    "name": { "str": "XS canvas arming pants", "str_pl": "pairs of XS canvas arming pants" },
+    "name": { "str": "canvas arming pants", "str_pl": "pairs of canvas arming pants" },
     "copy-from": "aketon_pants_canvas",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "aketon_hood_canvas",
@@ -407,19 +405,19 @@
     "id": "xl_aketon_hood_canvas",
     "//": "surface area of XL body assumed to be 50% greater and materials used are also 50% greater.",
     "type": "ARMOR",
-    "name": { "str": "XL canvas coif" },
+    "name": { "str": "canvas coif" },
     "copy-from": "aketon_hood_canvas",
     "proportional": { "weight": 1.5, "volume": 1.5, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_aketon_hood_canvas",
-    "//": "surface area of XL body assumed to be 75% size and materials used are also 75% as much.",
+    "//": "surface area of XS body assumed to be 75% size and materials used are also 75% as much.",
     "type": "ARMOR",
-    "name": { "str": "XS canvas coif" },
+    "name": { "str": "canvas coif" },
     "copy-from": "aketon_hood_canvas",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "aketon_gloves_canvas",
@@ -456,19 +454,19 @@
     "id": "xl_aketon_gloves_canvas",
     "//": "surface area of XL body assumed to be 50% greater and materials used are also 50% greater.",
     "type": "ARMOR",
-    "name": { "str": "XL canvas arming gloves", "str_pl": "pairs of XL canvas arming gloves" },
+    "name": { "str": "canvas arming gloves", "str_pl": "pairs of canvas arming gloves" },
     "copy-from": "aketon_gloves_canvas",
     "proportional": { "weight": 1.5, "volume": 1.5, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_aketon_gloves_canvas",
-    "//": "surface area of XL body assumed to be 75% size and materials used are also 75% as much.",
+    "//": "surface area of XS body assumed to be 75% size and materials used are also 75% as much.",
     "type": "ARMOR",
-    "name": { "str": "XS canvas arming gloves", "str_pl": "pairs of XS canvas arming gloves" },
+    "name": { "str": "canvas arming gloves", "str_pl": "pairs of canvas arming gloves" },
     "copy-from": "aketon_gloves_canvas",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "gambeson_canvas",
@@ -528,19 +526,19 @@
     "id": "xl_gambeson_canvas",
     "//": "surface area of XL body assumed to be 50% greater and materials used are also 50% greater.",
     "type": "ARMOR",
-    "name": { "str": "XL canvas gambeson" },
+    "name": { "str": "canvas gambeson" },
     "copy-from": "gambeson_canvas",
     "proportional": { "weight": 1.5, "volume": 1.5, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_gambeson_canvas",
-    "//": "surface area of XL body assumed to be 75% size and materials used are also 75% as much.",
+    "//": "surface area of XS body assumed to be 75% size and materials used are also 75% as much.",
     "type": "ARMOR",
-    "name": { "str": "XS canvas gambeson" },
+    "name": { "str": "canvas gambeson" },
     "copy-from": "gambeson_canvas",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "gambeson_canvas_thinsleeved",
@@ -601,19 +599,19 @@
     "id": "xl_gambeson_canvas_thinsleeved",
     "//": "surface area of XL body assumed to be 50% greater and materials used are also 50% greater.",
     "type": "ARMOR",
-    "name": { "str": "XL thin-sleeved canvas gambeson" },
+    "name": { "str": "thin-sleeved canvas gambeson" },
     "copy-from": "gambeson_canvas_thinsleeved",
     "proportional": { "weight": 1.5, "volume": 1.5, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_gambeson_canvas_thinsleeved",
-    "//": "surface area of XL body assumed to be 75% size and materials used are also 75% as much.",
+    "//": "surface area of XS body assumed to be 75% size and materials used are also 75% as much.",
     "type": "ARMOR",
-    "name": { "str": "XS thin-sleeved canvas gambeson" },
+    "name": { "str": "thin-sleeved canvas gambeson" },
     "copy-from": "gambeson_canvas_thinsleeved",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "gambeson_canvas_vest",
@@ -662,19 +660,19 @@
     "id": "xl_gambeson_canvas_vest",
     "//": "surface area of XL body assumed to be 50% greater and materials used are also 50% greater.",
     "type": "ARMOR",
-    "name": { "str": "XL sleeveless canvas gambeson" },
+    "name": { "str": "sleeveless canvas gambeson" },
     "copy-from": "gambeson_canvas_vest",
     "proportional": { "weight": 1.5, "volume": 1.5, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_gambeson_canvas_vest",
-    "//": "surface area of XL body assumed to be 75% size and materials used are also 75% as much.",
+    "//": "surface area of XS body assumed to be 75% size and materials used are also 75% as much.",
     "type": "ARMOR",
-    "name": { "str": "XS sleeveless canvas gambeson" },
+    "name": { "str": "sleeveless canvas gambeson" },
     "copy-from": "gambeson_canvas_vest",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "gambeson_pants_canvas",
@@ -711,19 +709,19 @@
     "id": "xl_gambeson_pants_canvas",
     "//": "surface area of XL body assumed to be 50% greater and materials used are also 50% greater.",
     "type": "ARMOR",
-    "name": { "str": "XL canvas heavy arming pants", "str_pl": "pairs of XL canvas heavy arming pants" },
+    "name": { "str": "canvas heavy arming pants", "str_pl": "pairs of canvas heavy arming pants" },
     "copy-from": "gambeson_pants_canvas",
     "proportional": { "weight": 1.5, "volume": 1.5, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_gambeson_pants_canvas",
-    "//": "surface area of XL body assumed to be 75% size and materials used are also 75% as much.",
+    "//": "surface area of XS body assumed to be 75% size and materials used are also 75% as much.",
     "type": "ARMOR",
-    "name": { "str": "XS canvas heavy arming pants", "str_pl": "pairs of XS canvas heavy arming pants" },
+    "name": { "str": "canvas heavy arming pants", "str_pl": "pairs of canvas heavy arming pants" },
     "copy-from": "gambeson_pants_canvas",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "gambeson_gloves_canvas",
@@ -778,19 +776,19 @@
     "id": "xl_gambeson_gloves_canvas",
     "//": "surface area of XL body assumed to be 50% greater and materials used are also 50% greater.",
     "type": "ARMOR",
-    "name": { "str": "XL canvas arming mittens", "str_pl": "pairs of XL canvas arming mittens" },
+    "name": { "str": "canvas arming mittens", "str_pl": "pairs of canvas arming mittens" },
     "copy-from": "gambeson_gloves_canvas",
     "proportional": { "weight": 1.5, "volume": 1.5, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_gambeson_gloves_canvas",
-    "//": "surface area of XL body assumed to be 75% size and materials used are also 75% as much.",
+    "//": "surface area of XS body assumed to be 75% size and materials used are also 75% as much.",
     "type": "ARMOR",
-    "name": { "str": "XS canvas arming mittens", "str_pl": "pairs of XS canvas arming mittens" },
+    "name": { "str": "canvas arming mittens", "str_pl": "pairs of canvas arming mittens" },
     "copy-from": "gambeson_gloves_canvas",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "aketon_nylon",
@@ -839,19 +837,19 @@
     "id": "xl_aketon_nylon",
     "//": "surface area of XL body assumed to be 50% greater and materials used are also 50% greater.",
     "type": "ARMOR",
-    "name": { "str": "XL nylon aketon" },
+    "name": { "str": "nylon aketon" },
     "copy-from": "aketon_nylon",
     "proportional": { "weight": 1.5, "volume": 1.5, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_aketon_nylon",
-    "//": "surface area of XL body assumed to be 75% size and materials used are also 75% as much.",
+    "//": "surface area of XS body assumed to be 75% size and materials used are also 75% as much.",
     "type": "ARMOR",
-    "name": { "str": "XS nylon aketon" },
+    "name": { "str": "nylon aketon" },
     "copy-from": "aketon_nylon",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "aketon_nylon_vest",
@@ -888,19 +886,19 @@
     "id": "xl_aketon_nylon_vest",
     "//": "surface area of XL body assumed to be 50% greater and materials used are also 50% greater.",
     "type": "ARMOR",
-    "name": { "str": "XL nylon aketon vest" },
+    "name": { "str": "nylon aketon vest" },
     "copy-from": "aketon_nylon_vest",
     "proportional": { "weight": 1.5, "volume": 1.5, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_aketon_nylon_vest",
-    "//": "surface area of XL body assumed to be 75% size and materials used are also 75% as much.",
+    "//": "surface area of XS body assumed to be 75% size and materials used are also 75% as much.",
     "type": "ARMOR",
-    "name": { "str": "XS nylon aketon vest" },
+    "name": { "str": "nylon aketon vest" },
     "copy-from": "aketon_canvas_vest",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "aketon_pants_nylon",
@@ -937,19 +935,19 @@
     "id": "xl_aketon_pants_nylon",
     "//": "surface area of XL body assumed to be 50% greater and materials used are also 50% greater.",
     "type": "ARMOR",
-    "name": { "str": "XL nylon arming pants", "str_pl": "pairs of XL nylon arming pants" },
+    "name": { "str": "nylon arming pants", "str_pl": "pairs of nylon arming pants" },
     "copy-from": "aketon_pants_nylon",
     "proportional": { "weight": 1.5, "volume": 1.5, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_aketon_pants_nylon",
-    "//": "surface area of XL body assumed to be 75% size and materials used are also 75% as much.",
+    "//": "surface area of XS body assumed to be 75% size and materials used are also 75% as much.",
     "type": "ARMOR",
-    "name": { "str": "XS nylon arming pants", "str_pl": "pairs of XS nylon arming pants" },
+    "name": { "str": "nylon arming pants", "str_pl": "pairs of nylon arming pants" },
     "copy-from": "aketon_pants_nylon",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "aketon_hood_nylon",
@@ -987,19 +985,19 @@
     "id": "xl_aketon_hood_nylon",
     "//": "surface area of XL body assumed to be 50% greater and materials used are also 50% greater.",
     "type": "ARMOR",
-    "name": { "str": "XL nylon coif" },
+    "name": { "str": "nylon coif" },
     "copy-from": "aketon_hood_canvas",
     "proportional": { "weight": 1.5, "volume": 1.5, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_aketon_hood_nylon",
-    "//": "surface area of XL body assumed to be 75% size and materials used are also 75% as much.",
+    "//": "surface area of XS body assumed to be 75% size and materials used are also 75% as much.",
     "type": "ARMOR",
-    "name": { "str": "XS nylon coif" },
+    "name": { "str": "nylon coif" },
     "copy-from": "aketon_hood_canvas",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "aketon_gloves_nylon",
@@ -1036,19 +1034,19 @@
     "id": "xl_aketon_gloves_nylon",
     "//": "surface area of XL body assumed to be 50% greater and materials used are also 50% greater.",
     "type": "ARMOR",
-    "name": { "str": "XL nylon arming gloves", "str_pl": "pairs of XL nylon arming gloves" },
+    "name": { "str": "nylon arming gloves", "str_pl": "pairs of nylon arming gloves" },
     "copy-from": "aketon_gloves_nylon",
     "proportional": { "weight": 1.5, "volume": 1.5, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_aketon_gloves_nylon",
-    "//": "surface area of XL body assumed to be 75% size and materials used are also 75% as much.",
+    "//": "surface area of XS body assumed to be 75% size and materials used are also 75% as much.",
     "type": "ARMOR",
-    "name": { "str": "XS nylon arming gloves", "str_pl": "pairs of XS nylon arming gloves" },
+    "name": { "str": "nylon arming gloves", "str_pl": "pairs of nylon arming gloves" },
     "copy-from": "aketon_gloves_nylon",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "gambeson_nylon",
@@ -1108,19 +1106,19 @@
     "id": "xl_gambeson_nylon",
     "//": "surface area of XL body assumed to be 50% greater and materials used are also 50% greater.",
     "type": "ARMOR",
-    "name": { "str": "XL nylon gambeson" },
+    "name": { "str": "nylon gambeson" },
     "copy-from": "gambeson_nylon",
     "proportional": { "weight": 1.5, "volume": 1.5, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_gambeson_nylon",
-    "//": "surface area of XL body assumed to be 75% size and materials used are also 75% as much.",
+    "//": "surface area of XS body assumed to be 75% size and materials used are also 75% as much.",
     "type": "ARMOR",
-    "name": { "str": "XS nylon gambeson" },
+    "name": { "str": "nylon gambeson" },
     "copy-from": "gambeson_nylon",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "gambeson_nylon_thinsleeved",
@@ -1131,7 +1129,7 @@
     "//3": "8 layers thick waist. human waist is about 3ft circumference with the extra padding, and reaches to about below knees. doesn't usually cover the whole circumference so guessing about 1.5x2.5x8 total surface area divided by 1x2 ft for about 15-18 extra sheets, about 810g if 15 sheets.",
     "//4": "5670g + 972g + 810g = 7452g combined",
     "type": "ARMOR",
-    "name": { "str": "nylon thin-sleeved gambeson" },
+    "name": { "str": "thin-sleeved nylon gambeson" },
     "description": "A thick cloth greatcoat intended to be worn as standalone armor, as it's a little too thick to comfortably add chainmail or a cuirass on top.  Made of thirty layers of tough nylon, this will protect you from almost everything, but it's very heavy and warm.  The sleeves are a lot thinner for flexibility and it drapes below your legs, providing additional protection there.",
     "weight": "7452 g",
     "volume": "7000 ml",
@@ -1181,19 +1179,19 @@
     "id": "xl_gambeson_nylon_thinsleeved",
     "//": "surface area of XL body assumed to be 50% greater and materials used are also 50% greater.",
     "type": "ARMOR",
-    "name": { "str": "XL thin-sleeved nylon gambeson" },
+    "name": { "str": "thin-sleeved nylon gambeson" },
     "copy-from": "gambeson_nylon_thinsleeved",
     "proportional": { "weight": 1.5, "volume": 1.5, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_gambeson_nylon_thinsleeved",
-    "//": "surface area of XL body assumed to be 75% size and materials used are also 75% as much.",
+    "//": "surface area of XS body assumed to be 75% size and materials used are also 75% as much.",
     "type": "ARMOR",
-    "name": { "str": "XS thin-sleeved nylon gambeson" },
+    "name": { "str": "thin-sleeved nylon gambeson" },
     "copy-from": "gambeson_nylon_thinsleeved",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "gambeson_nylon_vest",
@@ -1203,7 +1201,7 @@
     "//2": "8 layers thick waist. human waist is about 3ft circumference with the extra padding, and reaches to about below knees. doesn't usually cover the whole circumference so guessing about 1.5x2.5x8 total surface area divided by 1x2 ft for about 15-18 extra sheets, about 810g if 15 sheets.",
     "//3": "5670g + 810g = 6480g combined",
     "type": "ARMOR",
-    "name": { "str": "nylon sleeveless gambeson" },
+    "name": { "str": "sleeveless nylon gambeson" },
     "description": "A thick cloth surcoat intended to be worn as standalone armor, as it's a little too thick to comfortably add chainmail or a cuirass on top.  Made of thirty layers of tough nylon, this will protect you from almost everything, but it's very heavy and warm.  It drapes below your legs, providing additional protection there, and it lacks sleeves entirely.",
     "weight": "6480 g",
     "volume": "6000 ml",
@@ -1242,19 +1240,19 @@
     "id": "xl_gambeson_nylon_vest",
     "//": "surface area of XL body assumed to be 50% greater and materials used are also 50% greater.",
     "type": "ARMOR",
-    "name": { "str": "XL sleeveless nylon gambeson" },
+    "name": { "str": "sleeveless nylon gambeson" },
     "copy-from": "gambeson_nylon_vest",
     "proportional": { "weight": 1.5, "volume": 1.5, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_gambeson_nylon_vest",
-    "//": "surface area of XL body assumed to be 75% size and materials used are also 75% as much.",
+    "//": "surface area of XS body assumed to be 75% size and materials used are also 75% as much.",
     "type": "ARMOR",
-    "name": { "str": "XS sleeveless nylon gambeson" },
+    "name": { "str": "sleeveless nylon gambeson" },
     "copy-from": "gambeson_nylon_vest",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "gambeson_pants_nylon",
@@ -1291,19 +1289,19 @@
     "id": "xl_gambeson_pants_nylon",
     "//": "surface area of XL body assumed to be 50% greater and materials used are also 50% greater.",
     "type": "ARMOR",
-    "name": { "str": "XL nylon heavy arming pants", "str_pl": "pairs of XL nylon heavy arming pants" },
+    "name": { "str": "nylon heavy arming pants", "str_pl": "pairs of nylon heavy arming pants" },
     "copy-from": "gambeson_pants_nylon",
     "proportional": { "weight": 1.5, "volume": 1.5, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_gambeson_pants_nylon",
-    "//": "surface area of XL body assumed to be 75% size and materials used are also 75% as much.",
+    "//": "surface area of XS body assumed to be 75% size and materials used are also 75% as much.",
     "type": "ARMOR",
-    "name": { "str": "XS nylon heavy arming pants", "str_pl": "pairs of XS nylon heavy arming pants" },
+    "name": { "str": "nylon heavy arming pants", "str_pl": "pairs of nylon heavy arming pants" },
     "copy-from": "gambeson_pants_nylon",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "gambeson_gloves_nylon",
@@ -1358,19 +1356,19 @@
     "id": "xl_gambeson_gloves_nylon",
     "//": "surface area of XL body assumed to be 50% greater and materials used are also 50% greater.",
     "type": "ARMOR",
-    "name": { "str": "XL nylon arming mittens", "str_pl": "pairs of XL canvas arming mittens" },
+    "name": { "str": "nylon arming mittens", "str_pl": "pairs of nylon arming mittens" },
     "copy-from": "gambeson_gloves_nylon",
     "proportional": { "weight": 1.5, "volume": 1.5, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_gambeson_gloves_nylon",
-    "//": "surface area of XL body assumed to be 75% size and materials used are also 75% as much.",
+    "//": "surface area of XS body assumed to be 75% size and materials used are also 75% as much.",
     "type": "ARMOR",
-    "name": { "str": "XS nylon arming mittens", "str_pl": "pairs of XS nylon arming mittens" },
+    "name": { "str": "nylon arming mittens", "str_pl": "pairs of nylon arming mittens" },
     "copy-from": "gambeson_gloves_nylon",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "aketon_wool",
@@ -1420,19 +1418,19 @@
     "id": "xl_aketon_wool",
     "//": "surface area of XL body assumed to be 50% greater and materials used are also 50% greater.",
     "type": "ARMOR",
-    "name": { "str": "XL wool aketon" },
+    "name": { "str": "wool aketon" },
     "copy-from": "aketon_wool",
     "proportional": { "weight": 1.5, "volume": 1.5, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_aketon_wool",
-    "//": "surface area of XL body assumed to be 75% size and materials used are also 75% as much.",
+    "//": "surface area of XS body assumed to be 75% size and materials used are also 75% as much.",
     "type": "ARMOR",
-    "name": { "str": "XS wool aketon" },
+    "name": { "str": "wool aketon" },
     "copy-from": "aketon_wool",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "aketon_wool_vest",
@@ -1470,19 +1468,19 @@
     "id": "xl_aketon_wool_vest",
     "//": "surface area of XL body assumed to be 50% greater and materials used are also 50% greater.",
     "type": "ARMOR",
-    "name": { "str": "XL wool aketon vest" },
+    "name": { "str": "wool aketon vest" },
     "copy-from": "aketon_wool_vest",
     "proportional": { "weight": 1.5, "volume": 1.5, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_aketon_wool_vest",
-    "//": "surface area of XL body assumed to be 75% size and materials used are also 75% as much.",
+    "//": "surface area of XS body assumed to be 75% size and materials used are also 75% as much.",
     "type": "ARMOR",
-    "name": { "str": "XS wool aketon vest" },
+    "name": { "str": "wool aketon vest" },
     "copy-from": "aketon_wool_vest",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "aketon_pants_wool",
@@ -1519,19 +1517,19 @@
     "id": "xl_aketon_pants_wool",
     "//": "surface area of XL body assumed to be 50% greater and materials used are also 50% greater.",
     "type": "ARMOR",
-    "name": { "str": "XL wool arming pants", "str_pl": "pairs of XL wool arming pants" },
+    "name": { "str": "wool arming pants", "str_pl": "pairs of wool arming pants" },
     "copy-from": "aketon_pants_wool",
     "proportional": { "weight": 1.5, "volume": 1.5, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_aketon_pants_wool",
-    "//": "surface area of XL body assumed to be 75% size and materials used are also 75% as much.",
+    "//": "surface area of XS body assumed to be 75% size and materials used are also 75% as much.",
     "type": "ARMOR",
-    "name": { "str": "XS wool arming pants", "str_pl": "pairs of XS wool arming pants" },
+    "name": { "str": "wool arming pants", "str_pl": "pairs of wool arming pants" },
     "copy-from": "aketon_pants_canvas",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "aketon_hood_wool",
@@ -1570,19 +1568,19 @@
     "id": "xl_aketon_hood_wool",
     "//": "surface area of XL body assumed to be 50% greater and materials used are also 50% greater.",
     "type": "ARMOR",
-    "name": { "str": "XL wool coif" },
+    "name": { "str": "wool coif" },
     "copy-from": "aketon_hood_wool",
     "proportional": { "weight": 1.5, "volume": 1.5, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_aketon_hood_wool",
-    "//": "surface area of XL body assumed to be 75% size and materials used are also 75% as much.",
+    "//": "surface area of XS body assumed to be 75% size and materials used are also 75% as much.",
     "type": "ARMOR",
-    "name": { "str": "XS wool coif" },
+    "name": { "str": "wool coif" },
     "copy-from": "aketon_hood_wool",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "aketon_gloves_wool",
@@ -1620,19 +1618,19 @@
     "id": "xl_aketon_gloves_wool",
     "//": "surface area of XL body assumed to be 50% greater and materials used are also 50% greater.",
     "type": "ARMOR",
-    "name": { "str": "XL wool arming gloves", "str_pl": "pairs of XL wool arming gloves" },
+    "name": { "str": "wool arming gloves", "str_pl": "pairs of wool arming gloves" },
     "copy-from": "aketon_gloves_wool",
     "proportional": { "weight": 1.5, "volume": 1.5, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_aketon_gloves_wool",
-    "//": "surface area of XL body assumed to be 75% size and materials used are also 75% as much.",
+    "//": "surface area of XS body assumed to be 75% size and materials used are also 75% as much.",
     "type": "ARMOR",
-    "name": { "str": "XS wool arming gloves", "str_pl": "pairs of XS wool arming gloves" },
+    "name": { "str": "wool arming gloves", "str_pl": "pairs of wool arming gloves" },
     "copy-from": "aketon_gloves_wool",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "gambeson_wool",
@@ -1693,19 +1691,19 @@
     "id": "xl_gambeson_wool",
     "//": "surface area of XL body assumed to be 50% greater and materials used are also 50% greater.",
     "type": "ARMOR",
-    "name": { "str": "XL wool gambeson" },
+    "name": { "str": "wool gambeson" },
     "copy-from": "gambeson_wool",
     "proportional": { "weight": 1.5, "volume": 1.5, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_gambeson_wool",
-    "//": "surface area of XL body assumed to be 75% size and materials used are also 75% as much.",
+    "//": "surface area of XS body assumed to be 75% size and materials used are also 75% as much.",
     "type": "ARMOR",
-    "name": { "str": "XS wool gambeson" },
+    "name": { "str": "wool gambeson" },
     "copy-from": "gambeson_wool",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "gambeson_wool_thinsleeved",
@@ -1767,19 +1765,19 @@
     "id": "xl_gambeson_wool_thinsleeved",
     "//": "surface area of XL body assumed to be 50% greater and materials used are also 50% greater.",
     "type": "ARMOR",
-    "name": { "str": "XL thin-sleeved wool gambeson" },
+    "name": { "str": "thin-sleeved wool gambeson" },
     "copy-from": "gambeson_wool_thinsleeved",
     "proportional": { "weight": 1.5, "volume": 1.5, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_gambeson_wool_thinsleeved",
-    "//": "surface area of XL body assumed to be 75% size and materials used are also 75% as much.",
+    "//": "surface area of XS body assumed to be 75% size and materials used are also 75% as much.",
     "type": "ARMOR",
-    "name": { "str": "XS thin-sleeved wool gambeson" },
+    "name": { "str": "thin-sleeved wool gambeson" },
     "copy-from": "gambeson_wool_thinsleeved",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "gambeson_wool_vest",
@@ -1829,19 +1827,19 @@
     "id": "xl_gambeson_wool_vest",
     "//": "surface area of XL body assumed to be 50% greater and materials used are also 50% greater.",
     "type": "ARMOR",
-    "name": { "str": "XL sleeveless wool gambeson" },
+    "name": { "str": "sleeveless wool gambeson" },
     "copy-from": "gambeson_wool_vest",
     "proportional": { "weight": 1.5, "volume": 1.5, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_gambeson_wool_vest",
-    "//": "surface area of XL body assumed to be 75% size and materials used are also 75% as much.",
+    "//": "surface area of XS body assumed to be 75% size and materials used are also 75% as much.",
     "type": "ARMOR",
-    "name": { "str": "XS sleeveless wool gambeson" },
+    "name": { "str": "sleeveless wool gambeson" },
     "copy-from": "gambeson_wool_vest",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "gambeson_pants_wool",
@@ -1879,19 +1877,19 @@
     "id": "xl_gambeson_pants_wool",
     "//": "surface area of XL body assumed to be 50% greater and materials used are also 50% greater.",
     "type": "ARMOR",
-    "name": { "str": "XL wool heavy arming pants", "str_pl": "pairs of XL wool heavy arming pants" },
+    "name": { "str": "wool heavy arming pants", "str_pl": "pairs of wool heavy arming pants" },
     "copy-from": "gambeson_pants_wool",
     "proportional": { "weight": 1.5, "volume": 1.5, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_gambeson_pants_wool",
-    "//": "surface area of XL body assumed to be 75% size and materials used are also 75% as much.",
+    "//": "surface area of XS body assumed to be 75% size and materials used are also 75% as much.",
     "type": "ARMOR",
-    "name": { "str": "XS wool heavy arming pants", "str_pl": "pairs of XS wool heavy arming pants" },
+    "name": { "str": "wool heavy arming pants", "str_pl": "pairs of wool heavy arming pants" },
     "copy-from": "gambeson_pants_wool",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "gambeson_gloves_wool",
@@ -1947,18 +1945,18 @@
     "id": "xl_gambeson_gloves_wool",
     "//": "surface area of XL body assumed to be 50% greater and materials used are also 50% greater.",
     "type": "ARMOR",
-    "name": { "str": "XL wool arming mittens", "str_pl": "pairs of XL wool arming mittens" },
+    "name": { "str": "wool arming mittens", "str_pl": "pairs of wool arming mittens" },
     "copy-from": "gambeson_gloves_wool",
     "proportional": { "weight": 1.5, "volume": 1.5, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_gambeson_gloves_wool",
-    "//": "surface area of XL body assumed to be 75% size and materials used are also 75% as much.",
+    "//": "surface area of XS body assumed to be 75% size and materials used are also 75% as much.",
     "type": "ARMOR",
-    "name": { "str": "XS wool arming mittens", "str_pl": "pairs of XS wool arming mittens" },
+    "name": { "str": "wool arming mittens", "str_pl": "pairs of wool arming mittens" },
     "copy-from": "gambeson_gloves_wool",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   }
 ]

--- a/data/json/items/armor/gloves.json
+++ b/data/json/items/armor/gloves.json
@@ -93,17 +93,17 @@
     "id": "xl_lc_chainmail_hands",
     "type": "ARMOR",
     "copy-from": "lc_chainmail_hands",
-    "name": { "str": "pair of XL mild steel chainmail gloves", "str_pl": "pairs of XL mild steel chainmail gloves" },
+    "name": { "str": "pair of mild steel chainmail gloves", "str_pl": "pairs of mild steel chainmail gloves" },
     "proportional": { "weight": 1.5, "volume": 1.5 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_lc_chainmail_hands",
     "type": "ARMOR",
     "copy-from": "lc_chainmail_hands",
-    "name": { "str": "pair of XS mild steel chainmail gloves", "str_pl": "pairs of XS mild steel chainmail gloves" },
+    "name": { "str": "pair of mild steel chainmail gloves", "str_pl": "pairs of mild steel chainmail gloves" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "mc_chainmail_hands",
@@ -116,17 +116,17 @@
     "id": "xl_mc_chainmail_hands",
     "type": "ARMOR",
     "copy-from": "mc_chainmail_hands",
-    "name": { "str": "pair of XL medium steel chainmail gloves", "str_pl": "pairs of XL medium steel chainmail gloves" },
+    "name": { "str": "pair of medium steel chainmail gloves", "str_pl": "pairs of medium steel chainmail gloves" },
     "proportional": { "weight": 1.5, "volume": 1.5 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_mc_chainmail_hands",
     "type": "ARMOR",
     "copy-from": "mc_chainmail_hands",
-    "name": { "str": "pair of XS medium steel chainmail gloves", "str_pl": "pairs of XS medium steel chainmail gloves" },
+    "name": { "str": "pair of medium steel chainmail gloves", "str_pl": "pairs of medium steel chainmail gloves" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "hc_chainmail_hands",
@@ -139,17 +139,17 @@
     "id": "xl_hc_chainmail_hands",
     "type": "ARMOR",
     "copy-from": "hc_chainmail_hands",
-    "name": { "str": "pair of XL high steel chainmail gloves", "str_pl": "pairs of XL high steel chainmail gloves" },
+    "name": { "str": "pair of high steel chainmail gloves", "str_pl": "pairs of high steel chainmail gloves" },
     "proportional": { "weight": 1.5, "volume": 1.5 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_hc_chainmail_hands",
     "type": "ARMOR",
     "copy-from": "hc_chainmail_hands",
-    "name": { "str": "pair of XS high steel chainmail gloves", "str_pl": "pairs of XS high steel chainmail gloves" },
+    "name": { "str": "pair of high steel chainmail gloves", "str_pl": "pairs of high steel chainmail gloves" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "ch_chainmail_hands",
@@ -162,17 +162,17 @@
     "id": "xl_ch_chainmail_hands",
     "type": "ARMOR",
     "copy-from": "ch_chainmail_hands",
-    "name": { "str": "pair of XL hardened steel chainmail gloves", "str_pl": "pairs of XL hardened steel chainmail gloves" },
+    "name": { "str": "pair of hardened steel chainmail gloves", "str_pl": "pairs of hardened steel chainmail gloves" },
     "proportional": { "weight": 1.5, "volume": 1.5 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_ch_chainmail_hands",
     "type": "ARMOR",
     "copy-from": "ch_chainmail_hands",
-    "name": { "str": "pair of XS hardened steel chainmail gloves", "str_pl": "pairs of XS hardened steel chainmail gloves" },
+    "name": { "str": "pair of hardened steel chainmail gloves", "str_pl": "pairs of hardened steel chainmail gloves" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "qt_chainmail_hands",
@@ -186,17 +186,17 @@
     "id": "xl_qt_chainmail_hands",
     "type": "ARMOR",
     "copy-from": "qt_chainmail_hands",
-    "name": { "str": "pair of XL tempered steel chainmail gloves", "str_pl": "pairs of XL tempered steel chainmail gloves" },
+    "name": { "str": "pair of tempered steel chainmail gloves", "str_pl": "pairs of tempered steel chainmail gloves" },
     "proportional": { "weight": 1.5, "volume": 1.5 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_qt_chainmail_hands",
     "type": "ARMOR",
     "copy-from": "qt_chainmail_hands",
-    "name": { "str": "pair of XS tempered steel chainmail gloves", "str_pl": "pairs of XS tempered steel chainmail gloves" },
+    "name": { "str": "pair of tempered steel chainmail gloves", "str_pl": "pairs of tempered steel chainmail gloves" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "fire_gauntlets",
@@ -256,18 +256,18 @@
   {
     "id": "xl_gauntlets_chitin",
     "type": "ARMOR",
-    "name": { "str": "pair of XL chitinous gauntlets", "str_pl": "pairs of XL chitinous gauntlets" },
+    "name": { "str": "pair of chitinous gauntlets", "str_pl": "pairs of chitinous gauntlets" },
     "copy-from": "gauntlets_chitin",
     "proportional": { "weight": 1.5, "volume": 1.5 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_gauntlets_chitin",
     "type": "ARMOR",
     "copy-from": "gauntlets_chitin",
-    "name": { "str": "pair of XS chitinous gauntlets", "str_pl": "pairs of XS chitinous gauntlets" },
+    "name": { "str": "pair of chitinous gauntlets", "str_pl": "pairs of chitinous gauntlets" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "gauntlets_acidchitin",
@@ -282,18 +282,18 @@
   {
     "id": "xl_gauntlets_acidchitin",
     "type": "ARMOR",
-    "name": { "str": "pair of XL biosilicified chitin gauntlets", "str_pl": "pairs of XL biosilicified chitin gauntlets" },
+    "name": { "str": "pair of biosilicified chitin gauntlets", "str_pl": "pairs of biosilicified chitin gauntlets" },
     "copy-from": "gauntlets_acidchitin",
     "proportional": { "weight": 1.5, "volume": 1.5 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_gauntlets_acidchitin",
     "type": "ARMOR",
     "copy-from": "gauntlets_acidchitin",
-    "name": { "str": "pair of XS biosilicified chitin gauntlets", "str_pl": "pairs of XS biosilicified chitin gauntlets" },
+    "name": { "str": "pair of biosilicified chitin gauntlets", "str_pl": "pairs of biosilicified chitin gauntlets" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "gloves_claws",
@@ -396,19 +396,19 @@
   {
     "id": "xl_gauntlets_larmor",
     "type": "ARMOR",
-    "name": { "str": "pair of XL leather armor gauntlets", "str_pl": "pairs of XL leather armor gauntlets" },
+    "name": { "str": "pair of leather armor gauntlets", "str_pl": "pairs of leather armor gauntlets" },
     "copy-from": "gauntlets_larmor",
     "proportional": { "weight": 1.5, "volume": 1.5 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_gauntlets_larmor",
     "type": "ARMOR",
     "copy-from": "gauntlets_larmor",
     "looks_like": "gauntlets_larmor",
-    "name": { "str": "pair of XS leather armor gauntlets", "str_pl": "pairs of XS leather armor gauntlets" },
+    "name": { "str": "pair of leather armor gauntlets", "str_pl": "pairs of leather armor gauntlets" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "gloves_bag",
@@ -581,19 +581,19 @@
   {
     "id": "xl_gloves_fur",
     "type": "ARMOR",
-    "name": { "str": "pair of XL fur gloves", "str_pl": "pairs of XL fur gloves" },
+    "name": { "str": "pair of fur gloves", "str_pl": "pairs of fur gloves" },
     "copy-from": "gloves_fur",
     "proportional": { "weight": 1.6, "volume": 1.6 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_gloves_fur",
     "type": "ARMOR",
     "copy-from": "gloves_fur",
     "looks_like": "gloves_fur",
-    "name": { "str": "pair of XS fur gloves", "str_pl": "pairs of XS fur gloves" },
+    "name": { "str": "pair of fur gloves", "str_pl": "pairs of fur gloves" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "gloves_faux_fur",
@@ -607,7 +607,7 @@
     "to_hit": 1,
     "material": [ "faux_fur" ],
     "symbol": "[",
-    "looks_like": "fire_gauntlets",
+    "looks_like": "gloves_fur",
     "color": "brown",
     "warmth": 55,
     "material_thickness": 3,
@@ -616,19 +616,18 @@
   {
     "id": "xl_gloves_faux_fur",
     "type": "ARMOR",
-    "name": { "str": "pair of XL faux fur gloves", "str_pl": "pairs of XL faux fur gloves" },
+    "name": { "str": "pair of faux fur gloves", "str_pl": "pairs of faux fur gloves" },
     "copy-from": "gloves_faux_fur",
     "proportional": { "weight": 1.6, "volume": 1.6 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_gloves_faux_fur",
     "type": "ARMOR",
     "copy-from": "gloves_faux_fur",
-    "looks_like": "gloves_fur",
-    "name": { "str": "pair of XS faux fur gloves", "str_pl": "pairs of XS fur gloves" },
+    "name": { "str": "pair of faux fur gloves", "str_pl": "pairs of faux fur gloves" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "glove_jackson",
@@ -679,19 +678,19 @@
   {
     "id": "xl_gloves_leather",
     "type": "ARMOR",
-    "name": { "str": "pair of XL leather gloves", "str_pl": "pairs of XL leather gloves" },
+    "name": { "str": "pair of leather gloves", "str_pl": "pairs of leather gloves" },
     "copy-from": "gloves_leather",
     "proportional": { "weight": 1.5, "volume": 1.5 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_gloves_leather",
     "type": "ARMOR",
     "copy-from": "gloves_leather",
     "looks_like": "gloves_leather",
-    "name": { "str": "pair of XS leather gloves", "str_pl": "pairs of XS leather gloves" },
+    "name": { "str": "pair of leather gloves", "str_pl": "pairs of leather gloves" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "gloves_denim",
@@ -765,19 +764,19 @@
   {
     "id": "xl_gloves_light",
     "type": "ARMOR",
-    "name": { "str": "pair of XL light gloves", "str_pl": "pairs of XL light gloves" },
+    "name": { "str": "pair of light gloves", "str_pl": "pairs of light gloves" },
     "copy-from": "gloves_light",
     "proportional": { "weight": 1.5, "volume": 1.5 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_gloves_light",
     "type": "ARMOR",
     "copy-from": "gloves_light",
     "looks_like": "gloves_light",
-    "name": { "str": "pair of XS light gloves", "str_pl": "pairs of XS light gloves" },
+    "name": { "str": "pair of light gloves", "str_pl": "pairs of light gloves" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "gloves_liner",
@@ -801,19 +800,19 @@
   {
     "id": "xl_gloves_liner",
     "type": "ARMOR",
-    "name": { "str": "pair of XL glove liners", "str_pl": "pairs of XL glove liners" },
+    "name": { "str": "pair of glove liners", "str_pl": "pairs of glove liners" },
     "copy-from": "gloves_liner",
     "proportional": { "weight": 2, "volume": 2 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_gloves_liner",
     "type": "ARMOR",
     "copy-from": "gloves_liner",
     "looks_like": "gloves_liner",
-    "name": { "str": "pair of XS glove liners", "str_pl": "pairs of XS glove liners" },
+    "name": { "str": "pair of glove liners", "str_pl": "pairs of glove liners" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "gloves_medical",
@@ -912,19 +911,19 @@
   {
     "id": "xl_gloves_plate",
     "type": "ARMOR",
-    "name": { "str": "pair of XL armored gauntlets", "str_pl": "pairs of XL armored gauntlets" },
+    "name": { "str": "pair of armored gauntlets", "str_pl": "pairs of armored gauntlets" },
     "copy-from": "gloves_plate",
     "proportional": { "weight": 1.5, "volume": 1.5 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_gloves_plate",
     "type": "ARMOR",
     "copy-from": "gloves_plate",
     "looks_like": "gloves_plate",
-    "name": { "str": "pair of XS armored gauntlets", "str_pl": "pairs of XS armored gauntlets" },
+    "name": { "str": "pair of armored gauntlets", "str_pl": "pairs of armored gauntlets" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "gloves_rubber",
@@ -1006,19 +1005,19 @@
   {
     "id": "xl_gloves_wool",
     "type": "ARMOR",
-    "name": { "str": "pair of XL wool gloves", "str_pl": "pairs of XL wool gloves" },
+    "name": { "str": "pair of wool gloves", "str_pl": "pairs of wool gloves" },
     "copy-from": "gloves_wool",
     "proportional": { "weight": 1.4, "volume": 1.4 },
-    "flags": [ "OVERSIZE" ]
+    "flags": [ "OVERSIZE", "PREFIX_XL" ]
   },
   {
     "id": "xs_gloves_wool",
     "type": "ARMOR",
     "copy-from": "gloves_wool",
     "looks_like": "gloves_wool",
-    "name": { "str": "pair of XS wool gloves", "str_pl": "pairs of XS wool gloves" },
+    "name": { "str": "pair of wool gloves", "str_pl": "pairs of wool gloves" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "flags": [ "UNDERSIZE" ]
+    "flags": [ "UNDERSIZE", "PREFIX_XS" ]
   },
   {
     "id": "gloves_work",
@@ -1454,9 +1453,9 @@
     "id": "xl_lc_demi_gaunt",
     "type": "ARMOR",
     "copy-from": "lc_demi_gaunt",
-    "name": { "str": "pair of XL mild steel demi-gauntlets", "str_pl": "pairs of XL mild steel demi-gauntlets" },
+    "name": { "str": "pair of mild steel demi-gauntlets", "str_pl": "pairs of mild steel demi-gauntlets" },
     "proportional": { "weight": 1.5, "volume": 1.5 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "mc_demi_gaunt",
@@ -1469,9 +1468,9 @@
     "id": "xl_mc_demi_gaunt",
     "type": "ARMOR",
     "copy-from": "mc_demi_gaunt",
-    "name": { "str": "pair of XL medium steel demi-gauntlets", "str_pl": "pairs of XL medium steel demi-gauntlets" },
+    "name": { "str": "pair of medium steel demi-gauntlets", "str_pl": "pairs of medium steel demi-gauntlets" },
     "proportional": { "weight": 1.5, "volume": 1.5 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "hc_demi_gaunt",
@@ -1483,10 +1482,10 @@
   {
     "id": "xl_hc_demi_gaunt",
     "type": "ARMOR",
-    "name": { "str": "pair of XL high steel demi-gauntlets", "str_pl": "pairs of XL high steel demi-gauntlets" },
+    "name": { "str": "pair of high steel demi-gauntlets", "str_pl": "pairs of high steel demi-gauntlets" },
     "copy-from": "hc_demi_gaunt",
     "proportional": { "weight": 1.5, "volume": 1.5 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "ch_demi_gaunt",
@@ -1498,11 +1497,11 @@
   {
     "id": "xl_ch_demi_gaunt",
     "type": "ARMOR",
-    "name": { "str": "pair of XL hardened steel demi-gauntlets", "str_pl": "pairs of XL hardened steel demi-gauntlets" },
+    "name": { "str": "pair of hardened steel demi-gauntlets", "str_pl": "pairs of hardened steel demi-gauntlets" },
     "copy-from": "ch_demi_gaunt",
     "material": [ "qt_steel", "qt_steel_chain" ],
     "proportional": { "weight": 1.5, "volume": 1.5 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "qt_demi_gaunt",
@@ -1514,10 +1513,10 @@
   {
     "id": "xl_qt_demi_gaunt",
     "type": "ARMOR",
-    "name": { "str": "pair of XL tempered steel demi-gauntlets", "str_pl": "pairs of XL tempered steel demi-gauntlets" },
+    "name": { "str": "pair of tempered steel demi-gauntlets", "str_pl": "pairs of tempered steel demi-gauntlets" },
     "copy-from": "qt_demi_gaunt",
     "proportional": { "weight": 1.5, "volume": 1.5 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "lc_mitten_gaunt",
@@ -1575,9 +1574,9 @@
     "id": "xl_lc_mitten_gaunt",
     "type": "ARMOR",
     "copy-from": "lc_mitten_gaunt",
-    "name": { "str": "pair of XL mild steel mitten gauntlets", "str_pl": "pairs of XL mild steel mitten gauntlets" },
+    "name": { "str": "pair of mild steel mitten gauntlets", "str_pl": "pairs of mild steel mitten gauntlets" },
     "proportional": { "weight": 1.5, "volume": 1.5 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "mc_mitten_gaunt",
@@ -1590,9 +1589,9 @@
     "id": "xl_mc_mitten_gaunt",
     "type": "ARMOR",
     "copy-from": "mc_mitten_gaunt",
-    "name": { "str": "pair of XL medium steel mitten gauntlets", "str_pl": "pairs of XL medium steel mitten gauntlets" },
+    "name": { "str": "pair of medium steel mitten gauntlets", "str_pl": "pairs of medium steel mitten gauntlets" },
     "proportional": { "weight": 1.5, "volume": 1.5 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "hc_mitten_gaunt",
@@ -1605,9 +1604,9 @@
     "id": "xl_hc_mitten_gaunt",
     "type": "ARMOR",
     "copy-from": "hc_mitten_gaunt",
-    "name": { "str": "pair of XL high steel mitten gauntlets", "str_pl": "pairs of XL high steel mitten gauntlets" },
+    "name": { "str": "pair of high steel mitten gauntlets", "str_pl": "pairs of high steel mitten gauntlets" },
     "proportional": { "weight": 1.5, "volume": 1.5 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "ch_mitten_gaunt",
@@ -1620,9 +1619,9 @@
     "id": "xl_ch_mitten_gaunt",
     "type": "ARMOR",
     "copy-from": "ch_mitten_gaunt",
-    "name": { "str": "pair of XL hardened steel mitten gauntlets", "str_pl": "pairs of XL hardened steel mitten gauntlets" },
+    "name": { "str": "pair of hardened steel mitten gauntlets", "str_pl": "pairs of hardened steel mitten gauntlets" },
     "proportional": { "weight": 1.5, "volume": 1.5 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "qt_mitten_gaunt",
@@ -1635,9 +1634,9 @@
     "id": "xl_qt_mitten_gaunt",
     "type": "ARMOR",
     "copy-from": "qt_mitten_gaunt",
-    "name": { "str": "pair of XL tempered steel mitten gauntlets", "str_pl": "pairs of XL tempered steel mitten gauntlets" },
+    "name": { "str": "pair of tempered steel mitten gauntlets", "str_pl": "pairs of tempered steel mitten gauntlets" },
     "proportional": { "weight": 1.5, "volume": 1.5 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "gloves_airsoft",

--- a/data/json/items/armor/head_attachments.json
+++ b/data/json/items/armor/head_attachments.json
@@ -319,17 +319,17 @@
     "id": "xl_lc_chainmail_face",
     "type": "ARMOR",
     "copy-from": "lc_chainmail_face",
-    "name": { "str": "XL mild steel chainmail partial aventail" },
+    "name": { "str": "mild steel chainmail partial aventail" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_lc_chainmail_face",
     "type": "ARMOR",
     "copy-from": "lc_chainmail_face",
-    "name": { "str": "XS mild steel chainmail partial aventail" },
+    "name": { "str": "mild steel chainmail partial aventail" },
     "proportional": { "weight": 0.75, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "mc_chainmail_face",
@@ -342,17 +342,17 @@
     "id": "xl_mc_chainmail_face",
     "type": "ARMOR",
     "copy-from": "mc_chainmail_face",
-    "name": { "str": "XL medium steel chainmail partial aventail" },
+    "name": { "str": "medium steel chainmail partial aventail" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_mc_chainmail_face",
     "type": "ARMOR",
     "copy-from": "mc_chainmail_face",
-    "name": { "str": "XS medium steel chainmail partial aventail" },
+    "name": { "str": "medium steel chainmail partial aventail" },
     "proportional": { "weight": 0.75, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "hc_chainmail_face",
@@ -365,17 +365,17 @@
     "id": "xl_hc_chainmail_face",
     "type": "ARMOR",
     "copy-from": "hc_chainmail_face",
-    "name": { "str": "XL high steel chainmail partial aventail" },
+    "name": { "str": "high steel chainmail partial aventail" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_hc_chainmail_face",
     "type": "ARMOR",
     "copy-from": "hc_chainmail_face",
-    "name": { "str": "XS high steel chainmail partial aventail" },
+    "name": { "str": "high steel chainmail partial aventail" },
     "proportional": { "weight": 0.75, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "qt_chainmail_face",
@@ -388,17 +388,17 @@
     "id": "xl_qt_chainmail_face",
     "type": "ARMOR",
     "copy-from": "qt_chainmail_face",
-    "name": { "str": "XL tempered steel chainmail partial aventail" },
+    "name": { "str": "tempered steel chainmail partial aventail" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_qt_chainmail_face",
     "type": "ARMOR",
     "copy-from": "qt_chainmail_face",
-    "name": { "str": "XS tempered steel chainmail partial aventail" },
+    "name": { "str": "tempered steel chainmail partial aventail" },
     "proportional": { "weight": 0.75, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "ch_chainmail_face",
@@ -412,17 +412,17 @@
     "id": "xl_ch_chainmail_face",
     "type": "ARMOR",
     "copy-from": "ch_chainmail_face",
-    "name": { "str": "XL hardened steel chainmail partial aventail" },
+    "name": { "str": "hardened steel chainmail partial aventail" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_ch_chainmail_face",
     "type": "ARMOR",
     "copy-from": "ch_chainmail_face",
-    "name": { "str": "XS hardened steel chainmail partial aventail" },
+    "name": { "str": "hardened steel chainmail partial aventail" },
     "proportional": { "weight": 0.75, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "lc_chainmail_aventail",
@@ -460,17 +460,17 @@
     "id": "xl_lc_chainmail_aventail",
     "type": "ARMOR",
     "copy-from": "lc_chainmail_aventail",
-    "name": { "str": "XL mild steel chainmail aventail" },
+    "name": { "str": "mild steel chainmail aventail" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_lc_chainmail_aventail",
     "type": "ARMOR",
     "copy-from": "lc_chainmail_aventail",
-    "name": { "str": "XS mild steel chainmail aventail" },
+    "name": { "str": "mild steel chainmail aventail" },
     "proportional": { "weight": 0.75, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "mc_chainmail_aventail",
@@ -483,17 +483,17 @@
     "id": "xl_mc_chainmail_aventail",
     "type": "ARMOR",
     "copy-from": "mc_chainmail_aventail",
-    "name": { "str": "XL medium steel chainmail aventail" },
+    "name": { "str": "medium steel chainmail aventail" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_mc_chainmail_aventail",
     "type": "ARMOR",
     "copy-from": "mc_chainmail_aventail",
-    "name": { "str": "XS medium steel chainmail aventail" },
+    "name": { "str": "medium steel chainmail aventail" },
     "proportional": { "weight": 0.75, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "hc_chainmail_aventail",
@@ -506,17 +506,17 @@
     "id": "xl_hc_chainmail_aventail",
     "type": "ARMOR",
     "copy-from": "hc_chainmail_aventail",
-    "name": { "str": "XL high steel chainmail aventail" },
+    "name": { "str": "high steel chainmail aventail" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_hc_chainmail_aventail",
     "type": "ARMOR",
     "copy-from": "hc_chainmail_aventail",
-    "name": { "str": "XS high steel chainmail aventail" },
+    "name": { "str": "high steel chainmail aventail" },
     "proportional": { "weight": 0.75, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "qt_chainmail_aventail",
@@ -529,17 +529,17 @@
     "id": "xl_qt_chainmail_aventail",
     "type": "ARMOR",
     "copy-from": "qt_chainmail_aventail",
-    "name": { "str": "XL tempered steel chainmail aventail" },
+    "name": { "str": "tempered steel chainmail aventail" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_qt_chainmail_aventail",
     "type": "ARMOR",
     "copy-from": "qt_chainmail_aventail",
-    "name": { "str": "XS tempered steel chainmail aventail" },
+    "name": { "str": "tempered steel chainmail aventail" },
     "proportional": { "weight": 0.75, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "ch_chainmail_aventail",
@@ -552,17 +552,17 @@
     "id": "xl_ch_chainmail_aventail",
     "type": "ARMOR",
     "copy-from": "ch_chainmail_aventail",
-    "name": { "str": "XL hardened steel chainmail aventail" },
+    "name": { "str": "hardened steel chainmail aventail" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_ch_chainmail_aventail",
     "type": "ARMOR",
     "copy-from": "ch_chainmail_aventail",
-    "name": { "str": "XS hardened steel chainmail aventail" },
+    "name": { "str": "hardened steel chainmail aventail" },
     "proportional": { "weight": 0.75, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "lc_steel_facemask",
@@ -600,17 +600,17 @@
     "id": "xl_lc_steel_facemask",
     "type": "ARMOR",
     "copy-from": "lc_steel_facemask",
-    "name": { "str": "XL mild steel armored face mask" },
+    "name": { "str": "mild steel armored face mask" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_lc_steel_facemask",
     "type": "ARMOR",
     "copy-from": "lc_steel_facemask",
-    "name": { "str": "XS mild steel armored face mask" },
+    "name": { "str": "mild steel armored face mask" },
     "proportional": { "weight": 0.75, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "mc_steel_facemask",
@@ -624,17 +624,17 @@
     "id": "xl_mc_steel_facemask",
     "type": "ARMOR",
     "copy-from": "mc_steel_facemask",
-    "name": { "str": "XL medium steel armored face mask" },
+    "name": { "str": "medium steel armored face mask" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_mc_steel_facemask",
     "type": "ARMOR",
     "copy-from": "mc_steel_facemask",
-    "name": { "str": "XS medium steel armored face mask" },
+    "name": { "str": "medium steel armored face mask" },
     "proportional": { "weight": 0.75, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "hc_steel_facemask",
@@ -648,17 +648,17 @@
     "id": "xl_hc_steel_facemask",
     "type": "ARMOR",
     "copy-from": "hc_steel_facemask",
-    "name": { "str": "XL high steel armored face mask" },
+    "name": { "str": "high steel armored face mask" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_hc_steel_facemask",
     "type": "ARMOR",
     "copy-from": "hc_steel_facemask",
-    "name": { "str": "XS high steel armored face mask" },
+    "name": { "str": "high steel armored face mask" },
     "proportional": { "weight": 0.75, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "qt_steel_facemask",
@@ -684,17 +684,17 @@
     "id": "xl_qt_steel_facemask",
     "type": "ARMOR",
     "copy-from": "qt_steel_facemask",
-    "name": { "str": "XL tempered steel armored face mask" },
+    "name": { "str": "tempered steel armored face mask" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_qt_steel_facemask",
     "type": "ARMOR",
     "copy-from": "qt_steel_facemask",
-    "name": { "str": "XS tempered steel armored face mask" },
+    "name": { "str": "tempered steel armored face mask" },
     "proportional": { "weight": 0.75, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "ch_steel_facemask",
@@ -729,16 +729,16 @@
     "id": "xl_ch_steel_facemask",
     "type": "ARMOR",
     "copy-from": "ch_steel_facemask",
-    "name": { "str": "XL hardened steel armored face mask" },
+    "name": { "str": "hardened steel armored face mask" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_ch_steel_facemask",
     "type": "ARMOR",
     "copy-from": "ch_steel_facemask",
-    "name": { "str": "XS hardened steel armored face mask" },
+    "name": { "str": "hardened steel armored face mask" },
     "proportional": { "weight": 0.75, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   }
 ]

--- a/data/json/items/armor/helmets.json
+++ b/data/json/items/armor/helmets.json
@@ -599,17 +599,17 @@
     "id": "xl_helmet_barbute",
     "type": "ARMOR",
     "copy-from": "helmet_barbute",
-    "name": { "str": "XL barbute helm" },
+    "name": { "str": "barbute helm" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "helmet_barbute_xs",
     "type": "ARMOR",
     "copy-from": "helmet_barbute",
-    "name": { "str": "XS barbute helm" },
+    "name": { "str": "barbute helm" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "flags": [ "VARSIZE", "STURDY", "UNDERSIZE" ]
+    "flags": [ "VARSIZE", "STURDY", "UNDERSIZE", "PREFIX_XS" ]
   },
   {
     "id": "helmet_bike",
@@ -722,18 +722,18 @@
     "id": "xl_helmet_chitin",
     "type": "ARMOR",
     "copy-from": "helmet_chitin",
-    "name": { "str": "XL chitinous helmet" },
+    "name": { "str": "chitinous helmet" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "helmet_chitin_xs",
     "type": "ARMOR",
     "copy-from": "helmet_chitin",
     "looks_like": "helmet_chitin",
-    "name": { "str": "XS chitinous helmet" },
+    "name": { "str": "chitinous helmet" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "flags": [ "WATERPROOF", "STURDY", "UNDERSIZE" ]
+    "flags": [ "WATERPROOF", "STURDY", "UNDERSIZE", "PREFIX_XS" ]
   },
   {
     "id": "helmet_conical",
@@ -768,18 +768,18 @@
     "id": "xl_helmet_conical",
     "type": "ARMOR",
     "copy-from": "helmet_conical",
-    "name": { "str": "XL conical helm" },
+    "name": { "str": "conical helm" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "helmet_conical_xs",
     "type": "ARMOR",
     "copy-from": "helmet_conical",
     "looks_like": "helmet_conical",
-    "name": { "str": "XS conical helm" },
+    "name": { "str": "conical helm" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "flags": [ "VARSIZE", "STURDY", "UNDERSIZE" ]
+    "flags": [ "VARSIZE", "STURDY", "UNDERSIZE", "PREFIX_XS" ]
   },
   {
     "id": "helmet_acidchitin",
@@ -796,18 +796,18 @@
     "id": "xl_helmet_acidchitin",
     "type": "ARMOR",
     "copy-from": "helmet_acidchitin",
-    "name": { "str": "XL biosilicified chitin helmet" },
+    "name": { "str": "biosilicified chitin helmet" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "helmet_acidchitin_xs",
     "type": "ARMOR",
     "copy-from": "helmet_acidchitin",
     "looks_like": "helmet_acidchitin",
-    "name": { "str": "XS biosilicified chitin helmet" },
+    "name": { "str": "biosilicified chitin helmet" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "helmet_football",
@@ -904,17 +904,17 @@
     "id": "xl_helmet_galea",
     "type": "ARMOR",
     "copy-from": "helmet_galea",
-    "name": { "str": "XL galea", "str_pl": "XL galeae" },
+    "name": { "str": "galea", "str_pl": "galeae" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "helmet_galea_xs",
     "type": "ARMOR",
     "copy-from": "helmet_galea",
-    "name": { "str": "XS galea", "str_pl": "XS galeae" },
+    "name": { "str": "galea", "str_pl": "galeae" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "flags": [ "VARSIZE", "STURDY", "UNDERSIZE" ]
+    "flags": [ "VARSIZE", "STURDY", "UNDERSIZE", "PREFIX_XS" ]
   },
   {
     "id": "helmet_kabuto",
@@ -970,18 +970,17 @@
     "id": "xl_helmet_kabuto",
     "type": "ARMOR",
     "copy-from": "helmet_kabuto",
-    "name": { "str_sp": "XL kabuto" },
+    "name": { "str_sp": "kabuto" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "helmet_kabuto_xs",
     "type": "ARMOR",
     "copy-from": "helmet_kabuto",
-    "looks_like": "helmet_kabuto",
-    "name": { "str_sp": "XS kabuto" },
+    "name": { "str_sp": "kabuto" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "flags": [ "STURDY", "UNDERSIZE" ]
+    "flags": [ "STURDY", "UNDERSIZE", "PREFIX_XS" ]
   },
   {
     "id": "helmet_larmor",
@@ -1015,17 +1014,17 @@
     "id": "xl_helmet_larmor",
     "type": "ARMOR",
     "copy-from": "helmet_larmor",
-    "name": { "str": "XL leather armor helmet" },
+    "name": { "str": "leather armor helmet" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "helmet_larmor_xs",
     "type": "ARMOR",
     "copy-from": "helmet_larmor",
-    "name": { "str": "XS leather armor helmet" },
+    "name": { "str": "leather armor helmet" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "flags": [ "VARSIZE", "WATER_FRIENDLY", "STURDY", "UNDERSIZE" ]
+    "flags": [ "VARSIZE", "WATER_FRIENDLY", "STURDY", "UNDERSIZE", "PREFIX_XS" ]
   },
   {
     "id": "helmet_skull",
@@ -1349,17 +1348,17 @@
     "id": "xl_helmet_nasal",
     "type": "ARMOR",
     "copy-from": "helmet_nasal",
-    "name": { "str": "XL nasal helm" },
+    "name": { "str": "nasal helm" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "helmet_nasal_xs",
     "type": "ARMOR",
     "copy-from": "helmet_nasal",
-    "name": { "str": "XS nasal helm" },
+    "name": { "str": "nasal helm" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "flags": [ "VARSIZE", "STURDY", "UNDERSIZE" ]
+    "flags": [ "VARSIZE", "STURDY", "UNDERSIZE", "PREFIX_XS" ]
   },
   {
     "id": "lc_helmet_nasal",
@@ -1427,109 +1426,109 @@
     "id": "xl_lc_helmet_nasal",
     "type": "ARMOR",
     "copy-from": "lc_helmet_nasal",
-    "name": { "str": "mild steel XL nasal helm" },
+    "name": { "str": "mild steel nasal helm" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_lc_helmet_nasal",
     "type": "ARMOR",
     "copy-from": "lc_helmet_nasal",
-    "name": { "str": "mild steel XS nasal helm" },
+    "name": { "str": "mild steel nasal helm" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "flags": [ "VARSIZE", "STURDY", "UNDERSIZE" ]
+    "flags": [ "VARSIZE", "STURDY", "UNDERSIZE", "PREFIX_XS" ]
   },
   {
     "id": "mc_helmet_nasal",
     "type": "ARMOR",
     "copy-from": "lc_helmet_nasal",
-    "name": { "str": "medium steel nasal helmet" },
+    "name": { "str": "medium steel nasal helm" },
     "replace_materials": { "lc_steel": "mc_steel" }
   },
   {
     "id": "xl_mc_helmet_nasal",
     "type": "ARMOR",
     "copy-from": "mc_helmet_nasal",
-    "name": { "str": "medium steel XL nasal helm" },
+    "name": { "str": "medium steel nasal helm" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_mc_helmet_nasal",
     "type": "ARMOR",
     "copy-from": "mc_helmet_nasal",
-    "name": { "str": "medium steel XS nasal helm" },
+    "name": { "str": "medium steel nasal helm" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "flags": [ "VARSIZE", "STURDY", "UNDERSIZE" ]
+    "flags": [ "VARSIZE", "STURDY", "UNDERSIZE", "PREFIX_XS" ]
   },
   {
     "id": "hc_helmet_nasal",
     "type": "ARMOR",
     "copy-from": "lc_helmet_nasal",
-    "name": { "str": "high steel nasal helmet" },
+    "name": { "str": "high steel nasal helm" },
     "replace_materials": { "lc_steel": "hc_steel" }
   },
   {
     "id": "xl_hc_helmet_nasal",
     "type": "ARMOR",
     "copy-from": "hc_helmet_nasal",
-    "name": { "str": "high steel XL nasal helm" },
+    "name": { "str": "high steel nasal helm" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_hc_helmet_nasal",
     "type": "ARMOR",
     "copy-from": "hc_helmet_nasal",
-    "name": { "str": "high steel XS nasal helm" },
+    "name": { "str": "high steel nasal helm" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "flags": [ "VARSIZE", "STURDY", "UNDERSIZE" ]
+    "flags": [ "VARSIZE", "STURDY", "UNDERSIZE", "PREFIX_XS" ]
   },
   {
     "id": "qt_helmet_nasal",
     "type": "ARMOR",
     "copy-from": "lc_helmet_nasal",
-    "name": { "str": "tempered steel nasal helmet" },
+    "name": { "str": "tempered steel nasal helm" },
     "replace_materials": { "lc_steel": "qt_steel" }
   },
   {
     "id": "xl_qt_helmet_nasal",
     "type": "ARMOR",
     "copy-from": "qt_helmet_nasal",
-    "name": { "str": "tempered steel XL nasal helm" },
+    "name": { "str": "tempered steel nasal helm" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_qt_helmet_nasal",
     "type": "ARMOR",
     "copy-from": "qt_helmet_nasal",
-    "name": { "str": "tempered steel XS nasal helm" },
+    "name": { "str": "tempered steel nasal helm" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "flags": [ "VARSIZE", "STURDY", "UNDERSIZE" ]
+    "flags": [ "VARSIZE", "STURDY", "UNDERSIZE", "PREFIX_XS" ]
   },
   {
     "id": "ch_helmet_nasal",
     "type": "ARMOR",
     "copy-from": "lc_helmet_nasal",
-    "name": { "str": "hardened steel nasal helmet" },
+    "name": { "str": "hardened steel nasal helm" },
     "replace_materials": { "lc_steel": "ch_steel" }
   },
   {
     "id": "xl_ch_helmet_nasal",
     "type": "ARMOR",
     "copy-from": "ch_helmet_nasal",
-    "name": { "str": "hardened steel XL nasal helm" },
+    "name": { "str": "hardened steel nasal helm" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_ch_helmet_nasal",
     "type": "ARMOR",
     "copy-from": "ch_helmet_nasal",
-    "name": { "str": "hardened steel XS nasal helm" },
+    "name": { "str": "hardened steel nasal helm" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "flags": [ "VARSIZE", "STURDY", "UNDERSIZE" ]
+    "flags": [ "VARSIZE", "STURDY", "UNDERSIZE", "PREFIX_XS" ]
   },
   {
     "id": "helmet_plate",
@@ -1561,17 +1560,17 @@
     "id": "xl_helmet_plate",
     "type": "ARMOR",
     "copy-from": "helmet_plate",
-    "name": { "str": "XL great helm" },
+    "name": { "str": "great helm" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "helmet_plate_xs",
     "type": "ARMOR",
     "copy-from": "helmet_plate",
-    "name": { "str": "XS great helm" },
+    "name": { "str": "great helm" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "flags": [ "VARSIZE", "STURDY", "UNDERSIZE" ]
+    "flags": [ "VARSIZE", "STURDY", "UNDERSIZE", "PREFIX_XS" ]
   },
   {
     "id": "helmet_kettle",
@@ -1616,9 +1615,9 @@
     "id": "xl_helmet_kettle",
     "type": "ARMOR",
     "copy-from": "helmet_kettle",
-    "name": { "str": "XL kettle helmet" },
+    "name": { "str": "kettle helmet" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "helmet_scrap",
@@ -1655,17 +1654,17 @@
     "id": "xl_helmet_scrap",
     "type": "ARMOR",
     "copy-from": "helmet_scrap",
-    "name": { "str": "XL scrap helmet" },
+    "name": { "str": "scrap helmet" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "helmet_scrap_xs",
     "type": "ARMOR",
     "copy-from": "helmet_scrap",
-    "name": { "str": "XS scrap helmet" },
+    "name": { "str": "scrap helmet" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "helmet_metal_sheets_full",
@@ -1885,17 +1884,17 @@
     "id": "xl_helmet_corinthian",
     "type": "ARMOR",
     "copy-from": "helmet_corinthian",
-    "name": { "str": "XL Corinthian helm" },
+    "name": { "str": "Corinthian helm" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "helmet_corinthian_xs",
     "type": "ARMOR",
     "copy-from": "helmet_corinthian",
-    "name": { "str": "XS Corinthian helm" },
+    "name": { "str": "Corinthian helm" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "helmet_bronze",
@@ -1931,22 +1930,22 @@
     "id": "xl_helmet_bronze",
     "type": "ARMOR",
     "copy-from": "helmet_bronze",
-    "name": { "str": "XL bronze helmet" },
+    "name": { "str": "bronze helmet" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_helmet_bronze",
     "type": "ARMOR",
     "copy-from": "helmet_bronze",
-    "name": { "str": "XS bronze helmet" },
+    "name": { "str": "bronze helmet" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "pot_xlhelmet",
     "type": "ARMOR",
-    "name": { "str": "XL pot helmet" },
+    "name": { "str": "pot helmet" },
     "description": "A huge makeshift helmet made from a canning pot.  For the truly desperate man-bear-pig.",
     "weight": "6425 g",
     "volume": "25 L",
@@ -1957,7 +1956,7 @@
     "looks_like": "pot_helmet",
     "copy-from": "pot_helmet",
     "material_thickness": 2,
-    "extend": { "flags": [ "OVERSIZE" ] },
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] },
     "armor": [
       {
         "encumbrance_modifiers": [ "IMBALANCED" ],
@@ -1973,10 +1972,10 @@
     "id": "pot_helmet_xs",
     "type": "ARMOR",
     "copy-from": "pot_helmet",
-    "name": { "str": "XS pot helmet" },
+    "name": { "str": "pot helmet" },
     "description": "A helmet made from a soup pot.  It's not very good protection, but it's better than nothing.",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "lc_lighthelm_close",
@@ -2057,7 +2056,7 @@
   {
     "id": "xl_lc_lighthelm_close",
     "type": "ARMOR",
-    "name": { "str": "XL mild steel light close helm" },
+    "name": { "str": "mild steel light close helm" },
     "copy-from": "lc_lighthelm_close",
     "use_action": {
       "type": "transform",
@@ -2066,16 +2065,16 @@
       "menu_text": "Raise"
     },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xl_lc_lighthelm_close_raised",
     "type": "ARMOR",
-    "name": { "str": "XL mild steel light close helm (raised)", "str_pl": "XL mild steel light close helms (raised)" },
+    "name": { "str": "mild steel light close helm (raised)", "str_pl": "mild steel light close helms (raised)" },
     "copy-from": "lc_lighthelm_close_raised",
     "use_action": { "type": "transform", "msg": "You lower the helm's visor.", "target": "xl_lc_lighthelm_close", "menu_text": "Lower" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "mc_lighthelm_close",
@@ -2101,7 +2100,7 @@
   {
     "id": "xl_mc_lighthelm_close",
     "type": "ARMOR",
-    "name": { "str": "XL medium steel light close helm" },
+    "name": { "str": "medium steel light close helm" },
     "copy-from": "mc_lighthelm_close",
     "use_action": {
       "type": "transform",
@@ -2110,16 +2109,16 @@
       "menu_text": "Raise"
     },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xl_mc_lighthelm_close_raised",
     "type": "ARMOR",
-    "name": { "str": "XL medium steel light close helm (raised)", "str_pl": "XL medium steel light close helms (raised)" },
+    "name": { "str": "medium steel light close helm (raised)", "str_pl": "medium steel light close helms (raised)" },
     "copy-from": "mc_lighthelm_close_raised",
     "use_action": { "type": "transform", "msg": "You lower the helm's visor.", "target": "xl_mc_lighthelm_close", "menu_text": "Lower" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "hc_lighthelm_close",
@@ -2145,7 +2144,7 @@
   {
     "id": "xl_hc_lighthelm_close",
     "type": "ARMOR",
-    "name": { "str": "XL high steel light close helm" },
+    "name": { "str": "high steel light close helm" },
     "copy-from": "hc_lighthelm_close",
     "use_action": {
       "type": "transform",
@@ -2154,16 +2153,16 @@
       "menu_text": "Raise"
     },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xl_hc_lighthelm_close_raised",
     "type": "ARMOR",
-    "name": { "str": "XL high steel light close helm (raised)", "str_pl": "XL high steel light close helms (raised)" },
+    "name": { "str": "high steel light close helm (raised)", "str_pl": "high steel light close helms (raised)" },
     "copy-from": "hc_lighthelm_close_raised",
     "use_action": { "type": "transform", "msg": "You lower the helm's visor.", "target": "xl_hc_lighthelm_close", "menu_text": "Lower" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "ch_lighthelm_close",
@@ -2189,7 +2188,7 @@
   {
     "id": "xl_ch_lighthelm_close",
     "type": "ARMOR",
-    "name": { "str": "XL hardened steel light close helm" },
+    "name": { "str": "hardened steel light close helm" },
     "copy-from": "ch_lighthelm_close",
     "use_action": {
       "type": "transform",
@@ -2198,16 +2197,16 @@
       "menu_text": "Raise"
     },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xl_ch_lighthelm_close_raised",
     "type": "ARMOR",
-    "name": { "str": "XL hardened steel light close helm (raised)", "str_pl": "XL hardened steel light close helms (raised)" },
+    "name": { "str": "hardened steel light close helm (raised)", "str_pl": "hardened steel light close helms (raised)" },
     "copy-from": "ch_lighthelm_close_raised",
     "use_action": { "type": "transform", "msg": "You lower the helm's visor.", "target": "xl_ch_lighthelm_close", "menu_text": "Lower" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "qt_lighthelm_close",
@@ -2233,7 +2232,7 @@
   {
     "id": "xl_qt_lighthelm_close",
     "type": "ARMOR",
-    "name": { "str": "XL tempered steel light close helm" },
+    "name": { "str": "tempered steel light close helm" },
     "copy-from": "qt_lighthelm_close",
     "use_action": {
       "type": "transform",
@@ -2242,16 +2241,16 @@
       "menu_text": "Raise"
     },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xl_qt_lighthelm_close_raised",
     "type": "ARMOR",
-    "name": { "str": "XL tempered steel light close helm (raised)", "str_pl": "XL tempered steel light close helms (raised)" },
+    "name": { "str": "tempered steel light close helm (raised)", "str_pl": "tempered steel light close helms (raised)" },
     "copy-from": "qt_lighthelm_close_raised",
     "use_action": { "type": "transform", "msg": "You lower the helm's visor.", "target": "xl_qt_lighthelm_close", "menu_text": "Lower" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "lc_helm_close",
@@ -2327,20 +2326,20 @@
   {
     "id": "xl_lc_helm_close",
     "type": "ARMOR",
-    "name": { "str": "XL mild steel close helm" },
+    "name": { "str": "mild steel close helm" },
     "copy-from": "lc_helm_close",
     "use_action": { "type": "transform", "msg": "You raise the helm's visor.", "target": "xl_lc_helm_close_raised", "menu_text": "Raise" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xl_lc_helm_close_raised",
     "type": "ARMOR",
-    "name": { "str": "XL mild steel close helm (raised)", "str_pl": "XL mild steel close helms (raised)" },
+    "name": { "str": "mild steel close helm (raised)", "str_pl": "mild steel close helms (raised)" },
     "copy-from": "lc_helm_close_raised",
     "use_action": { "type": "transform", "msg": "You lower the helm's visor.", "target": "xl_lc_helm_close", "menu_text": "Lower" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "mc_helm_close",
@@ -2361,20 +2360,20 @@
   {
     "id": "xl_mc_helm_close",
     "type": "ARMOR",
-    "name": { "str": "XL medium steel close helm" },
+    "name": { "str": "medium steel close helm" },
     "copy-from": "mc_helm_close",
     "use_action": { "type": "transform", "msg": "You raise the helm's visor.", "target": "xl_mc_helm_close_raised", "menu_text": "Raise" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xl_mc_helm_close_raised",
     "type": "ARMOR",
-    "name": { "str": "XL medium steel close helm (raised)", "str_pl": "XL medium steel close helms (raised)" },
+    "name": { "str": "medium steel close helm (raised)", "str_pl": "medium steel close helms (raised)" },
     "copy-from": "mc_helm_close_raised",
     "use_action": { "type": "transform", "msg": "You lower the helm's visor.", "target": "xl_mc_helm_close", "menu_text": "Lower" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "hc_helm_close",
@@ -2395,20 +2394,20 @@
   {
     "id": "xl_hc_helm_close",
     "type": "ARMOR",
-    "name": { "str": "XL high steel close helm" },
+    "name": { "str": "high steel close helm" },
     "copy-from": "hc_helm_close",
     "use_action": { "type": "transform", "msg": "You raise the helm's visor.", "target": "xl_hc_helm_close_raised", "menu_text": "Raise" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xl_hc_helm_close_raised",
     "type": "ARMOR",
-    "name": { "str": "XL high steel close helm (raised)", "str_pl": "XL high steel close helms (raised)" },
+    "name": { "str": "high steel close helm (raised)", "str_pl": "high steel close helms (raised)" },
     "copy-from": "hc_helm_close_raised",
     "use_action": { "type": "transform", "msg": "You lower the helm's visor.", "target": "xl_hc_helm_close", "menu_text": "Lower" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "ch_helm_close",
@@ -2429,20 +2428,20 @@
   {
     "id": "xl_ch_helm_close",
     "type": "ARMOR",
-    "name": { "str": "XL hardened steel close helm" },
+    "name": { "str": "hardened steel close helm" },
     "copy-from": "ch_helm_close",
     "use_action": { "type": "transform", "msg": "You raise the helm's visor.", "target": "xl_ch_helm_close_raised", "menu_text": "Raise" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xl_ch_helm_close_raised",
     "type": "ARMOR",
-    "name": { "str": "XL hardened steel close helm (raised)", "str_pl": "XL hardened steel close helms (raised)" },
+    "name": { "str": "hardened steel close helm (raised)", "str_pl": "hardened steel close helms (raised)" },
     "copy-from": "ch_helm_close_raised",
     "use_action": { "type": "transform", "msg": "You lower the helm's visor.", "target": "xl_ch_helm_close", "menu_text": "Lower" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "qt_helm_close",
@@ -2463,20 +2462,20 @@
   {
     "id": "xl_qt_helm_close",
     "type": "ARMOR",
-    "name": { "str": "XL tempered steel close helm" },
+    "name": { "str": "tempered steel close helm" },
     "copy-from": "qt_helm_close",
     "use_action": { "type": "transform", "msg": "You raise the helm's visor.", "target": "xl_qt_helm_close_raised", "menu_text": "Raise" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xl_qt_helm_close_raised",
     "type": "ARMOR",
-    "name": { "str": "XL tempered steel close helm (raised)", "str_pl": "XL tempered steel close helms (raised)" },
+    "name": { "str": "tempered steel close helm (raised)", "str_pl": "tempered steel close helms (raised)" },
     "copy-from": "qt_helm_close_raised",
     "use_action": { "type": "transform", "msg": "You lower the helm's visor.", "target": "xl_qt_helm_close", "menu_text": "Lower" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "lc_heavyhelm_close",
@@ -2556,7 +2555,7 @@
   {
     "id": "xl_lc_heavyhelm_close",
     "type": "ARMOR",
-    "name": { "str": "XL mild steel heavy close helm" },
+    "name": { "str": "mild steel heavy close helm" },
     "copy-from": "lc_heavyhelm_close",
     "use_action": {
       "type": "transform",
@@ -2565,16 +2564,16 @@
       "menu_text": "Raise"
     },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xl_lc_heavyhelm_close_raised",
     "type": "ARMOR",
-    "name": { "str": "XL mild steel heavy close helm (raised)", "str_pl": "XL mild steel heavy close helms (raised)" },
+    "name": { "str": "mild steel heavy close helm (raised)", "str_pl": "mild steel heavy close helms (raised)" },
     "copy-from": "lc_heavyhelm_close_raised",
     "use_action": { "type": "transform", "msg": "You lower the helm's visor.", "target": "xl_lc_heavyhelm_close", "menu_text": "Lower" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "mc_heavyhelm_close",
@@ -2600,7 +2599,7 @@
   {
     "id": "xl_mc_heavyhelm_close",
     "type": "ARMOR",
-    "name": { "str": "XL medium steel heavy close helm" },
+    "name": { "str": "medium steel heavy close helm" },
     "copy-from": "mc_heavyhelm_close",
     "use_action": {
       "type": "transform",
@@ -2609,16 +2608,16 @@
       "menu_text": "Raise"
     },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xl_mc_heavyhelm_close_raised",
     "type": "ARMOR",
-    "name": { "str": "XL medium steel heavy close helm (raised)", "str_pl": "XL medium steel heavy close helms (raised)" },
+    "name": { "str": "medium steel heavy close helm (raised)", "str_pl": "medium steel heavy close helms (raised)" },
     "copy-from": "mc_heavyhelm_close_raised",
     "use_action": { "type": "transform", "msg": "You lower the helm's visor.", "target": "xl_mc_heavyhelm_close", "menu_text": "Lower" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "hc_heavyhelm_close",
@@ -2644,7 +2643,7 @@
   {
     "id": "xl_hc_heavyhelm_close",
     "type": "ARMOR",
-    "name": { "str": "XL high steel heavy close helm" },
+    "name": { "str": "high steel heavy close helm" },
     "copy-from": "hc_heavyhelm_close",
     "use_action": {
       "type": "transform",
@@ -2653,16 +2652,16 @@
       "menu_text": "Raise"
     },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xl_hc_heavyhelm_close_raised",
     "type": "ARMOR",
-    "name": { "str": "XL high steel heavy close helm (raised)", "str_pl": "XL high steel heavy close helms (raised)" },
+    "name": { "str": "high steel heavy close helm (raised)", "str_pl": "high steel heavy close helms (raised)" },
     "copy-from": "hc_heavyhelm_close_raised",
     "use_action": { "type": "transform", "msg": "You lower the helm's visor.", "target": "xl_hc_heavyhelm_close", "menu_text": "Lower" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "ch_heavyhelm_close",
@@ -2688,7 +2687,7 @@
   {
     "id": "xl_ch_heavyhelm_close",
     "type": "ARMOR",
-    "name": { "str": "XL hardened steel heavy close helm" },
+    "name": { "str": "hardened steel heavy close helm" },
     "copy-from": "ch_heavyhelm_close",
     "use_action": {
       "type": "transform",
@@ -2697,16 +2696,16 @@
       "menu_text": "Raise"
     },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xl_ch_heavyhelm_close_raised",
     "type": "ARMOR",
-    "name": { "str": "XL hardened steel heavy close helm (raised)", "str_pl": "XL hardened steel heavy close helms (raised)" },
+    "name": { "str": "hardened steel heavy close helm (raised)", "str_pl": "hardened steel heavy close helms (raised)" },
     "copy-from": "ch_heavyhelm_close_raised",
     "use_action": { "type": "transform", "msg": "You lower the helm's visor.", "target": "xl_ch_heavyhelm_close", "menu_text": "Lower" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "qt_heavyhelm_close",
@@ -2732,7 +2731,7 @@
   {
     "id": "xl_qt_heavyhelm_close",
     "type": "ARMOR",
-    "name": { "str": "XL tempered steel heavy close helm" },
+    "name": { "str": "tempered steel heavy close helm" },
     "copy-from": "qt_heavyhelm_close",
     "use_action": {
       "type": "transform",
@@ -2741,16 +2740,16 @@
       "menu_text": "Raise"
     },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xl_qt_heavyhelm_close_raised",
     "type": "ARMOR",
-    "name": { "str": "XL tempered steel heavy close helm (raised)", "str_pl": "XL tempered steel heavy close helms (raised)" },
+    "name": { "str": "tempered steel heavy close helm (raised)", "str_pl": "tempered steel heavy close helms (raised)" },
     "copy-from": "qt_heavyhelm_close_raised",
     "use_action": { "type": "transform", "msg": "You lower the helm's visor.", "target": "xl_qt_heavyhelm_close", "menu_text": "Lower" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "airsoft_helmet",
@@ -2914,17 +2913,17 @@
     "id": "xl_lc_helmet_turban",
     "type": "ARMOR",
     "copy-from": "lc_helmet_turban",
-    "name": { "str": "mild steel XL turban helmet" },
+    "name": { "str": "mild steel turban helmet" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_lc_helmet_turban",
     "type": "ARMOR",
     "copy-from": "lc_helmet_turban",
-    "name": { "str": "mild steel XS turban helmet" },
+    "name": { "str": "mild steel turban helmet" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "mc_helmet_turban",
@@ -2937,17 +2936,17 @@
     "id": "xl_mc_helmet_turban",
     "type": "ARMOR",
     "copy-from": "mc_helmet_turban",
-    "name": { "str": "medium steel XL turban helmet" },
+    "name": { "str": "medium steel turban helmet" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_mc_helmet_turban",
     "type": "ARMOR",
     "copy-from": "mc_helmet_turban",
-    "name": { "str": "medium steel XS turban helmet" },
+    "name": { "str": "medium steel turban helmet" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "hc_helmet_turban",
@@ -2960,17 +2959,17 @@
     "id": "xl_hc_helmet_turban",
     "type": "ARMOR",
     "copy-from": "hc_helmet_turban",
-    "name": { "str": "high steel XL turban helmet" },
+    "name": { "str": "high steel turban helmet" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_hc_helmet_turban",
     "type": "ARMOR",
     "copy-from": "hc_helmet_turban",
-    "name": { "str": "high steel XS turban helmet" },
+    "name": { "str": "high steel turban helmet" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "flags": [ "VARSIZE", "STURDY", "UNDERSIZE" ]
+    "flags": [ "VARSIZE", "STURDY", "UNDERSIZE", "PREFIX_XS" ]
   },
   {
     "id": "qt_helmet_turban",
@@ -2983,17 +2982,17 @@
     "id": "xl_qt_helmet_turban",
     "type": "ARMOR",
     "copy-from": "qt_helmet_turban",
-    "name": { "str": "tempered steel XL turban helmet" },
+    "name": { "str": "tempered steel turban helmet" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_qt_helmet_turban",
     "type": "ARMOR",
     "copy-from": "qt_helmet_turban",
-    "name": { "str": "tempered steel XS turban helmet" },
+    "name": { "str": "tempered steel turban helmet" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "flags": [ "VARSIZE", "STURDY", "UNDERSIZE" ]
+    "flags": [ "VARSIZE", "STURDY", "UNDERSIZE", "PREFIX_XS" ]
   },
   {
     "id": "ch_helmet_turban",
@@ -3006,16 +3005,16 @@
     "id": "xl_ch_helmet_turban",
     "type": "ARMOR",
     "copy-from": "ch_helmet_turban",
-    "name": { "str": "hardened steel XL turban helmet" },
+    "name": { "str": "hardened steel turban helmet" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_ch_helmet_turban",
     "type": "ARMOR",
     "copy-from": "ch_helmet_turban",
-    "name": { "str": "hardened steel XS turban helmet" },
+    "name": { "str": "hardened steel turban helmet" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "flags": [ "VARSIZE", "STURDY", "UNDERSIZE" ]
+    "flags": [ "VARSIZE", "STURDY", "UNDERSIZE", "PREFIX_XS" ]
   }
 ]

--- a/data/json/items/armor/hoods.json
+++ b/data/json/items/armor/hoods.json
@@ -80,17 +80,17 @@
     "id": "xl_lc_chainmail_hood",
     "type": "ARMOR",
     "copy-from": "lc_chainmail_hood",
-    "name": { "str": "XL mild steel chainmail coif" },
+    "name": { "str": "mild steel chainmail coif" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_lc_chainmail_hood",
     "type": "ARMOR",
     "copy-from": "lc_chainmail_hood",
-    "name": { "str": "XS mild steel chainmail coif" },
+    "name": { "str": "mild steel chainmail coif" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "mc_chainmail_hood",
@@ -103,17 +103,17 @@
     "id": "xl_mc_chainmail_hood",
     "type": "ARMOR",
     "copy-from": "mc_chainmail_hood",
-    "name": { "str": "XL medium steel chainmail coif" },
+    "name": { "str": "medium steel chainmail coif" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_mc_chainmail_hood",
     "type": "ARMOR",
     "copy-from": "mc_chainmail_hood",
-    "name": { "str": "XS medium steel chainmail coif" },
+    "name": { "str": "medium steel chainmail coif" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "hc_chainmail_hood",
@@ -126,17 +126,17 @@
     "id": "xl_hc_chainmail_hood",
     "type": "ARMOR",
     "copy-from": "hc_chainmail_hood",
-    "name": { "str": "XL high steel chainmail coif" },
+    "name": { "str": "high steel chainmail coif" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_hc_chainmail_hood",
     "type": "ARMOR",
     "copy-from": "hc_chainmail_hood",
-    "name": { "str": "XS high steel chainmail coif" },
+    "name": { "str": "high steel chainmail coif" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "ch_chainmail_hood",
@@ -149,17 +149,17 @@
     "id": "xl_ch_chainmail_hood",
     "type": "ARMOR",
     "copy-from": "ch_chainmail_hood",
-    "name": { "str": "XL hardened steel chainmail coif" },
+    "name": { "str": "hardened steel chainmail coif" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_ch_chainmail_hood",
     "type": "ARMOR",
     "copy-from": "ch_chainmail_hood",
-    "name": { "str": "XS hardened steel chainmail coif" },
+    "name": { "str": "hardened steel chainmail coif" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "qt_chainmail_hood",
@@ -172,17 +172,17 @@
     "id": "xl_qt_chainmail_hood",
     "type": "ARMOR",
     "copy-from": "qt_chainmail_hood",
-    "name": { "str": "XL tempered steel chainmail coif" },
+    "name": { "str": "tempered steel chainmail coif" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_qt_chainmail_hood",
     "type": "ARMOR",
     "copy-from": "qt_chainmail_hood",
-    "name": { "str": "XS tempered steel chainmail coif" },
+    "name": { "str": "tempered steel chainmail coif" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "hood_rain",

--- a/data/json/items/armor/legs_armor.json
+++ b/data/json/items/armor/legs_armor.json
@@ -135,18 +135,18 @@
     "id": "xl_legguard_chitin",
     "copy-from": "legguard_chitin",
     "type": "ARMOR",
-    "name": { "str": "pair of XL chitin leg guards", "str_pl": "pairs of XL chitin leg guards" },
+    "name": { "str": "pair of chitin leg guards", "str_pl": "pairs of chitin leg guards" },
     "material": [ "chitin" ],
     "proportional": { "weight": 1.5, "volume": 1.5 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_legguard_chitin",
     "type": "ARMOR",
     "copy-from": "legguard_chitin",
-    "name": { "str": "pair of XS chitin leg guards", "str_pl": "pairs of XS chitin leg guards" },
+    "name": { "str": "pair of chitin leg guards", "str_pl": "pairs of chitin leg guards" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "legguard_acidchitin",
@@ -162,19 +162,19 @@
     "id": "xl_legguard_acidchitin",
     "copy-from": "legguard_acidchitin",
     "type": "ARMOR",
-    "name": { "str": "pair of XL biosilicified chitin leg guards", "str_pl": "pairs of XL biosilicified chitin guards" },
+    "name": { "str": "pair of biosilicified chitin leg guards", "str_pl": "pairs of biosilicified chitin leg guards" },
     "material": [ "acidchitin" ],
     "proportional": { "weight": 1.5, "volume": 1.5 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_legguard_acidchitin",
     "copy-from": "legguard_acidchitin",
     "type": "ARMOR",
-    "name": { "str": "pair of XS biosilicified chitin leg guards", "str_pl": "pairs of XS biosilicified chitin guards" },
+    "name": { "str": "pair of biosilicified chitin leg guards", "str_pl": "pairs of biosilicified chitin leg guards" },
     "material": [ "acidchitin" ],
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "bunker_pants",
@@ -283,7 +283,7 @@
     "abstract": "xl_chainmail_legs",
     "type": "ARMOR",
     "copy-from": "base_chainmail_legs",
-    "name": { "str": "XL chainmail leggings", "str_pl": "pairs of XL chainmail leggings" },
+    "name": { "str": "chainmail leggings", "str_pl": "pairs of chainmail leggings" },
     "proportional": { "weight": 1.25, "volume": 1.13, "price": 1.25 },
     "pocket_data": [
       {
@@ -309,13 +309,13 @@
         "flag_restriction": [ "ABLATIVE_CHAINMAIL_KNEES" ]
       }
     ],
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "abstract": "xs_chainmail_legs",
     "type": "ARMOR",
     "copy-from": "base_chainmail_legs",
-    "name": { "str": "XS chainmail leggings", "str_pl": "pairs of XS chainmail leggings" },
+    "name": { "str": "chainmail leggings", "str_pl": "pairs of chainmail leggings" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
     "pocket_data": [
       {
@@ -341,7 +341,7 @@
         "flag_restriction": [ "ABLATIVE_CHAINMAIL_KNEES" ]
       }
     ],
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "abstract": "base_chainmail_half_legs",
@@ -367,7 +367,7 @@
     "abstract": "xl_chainmail_half_legs",
     "type": "ARMOR",
     "copy-from": "base_chainmail_half_legs",
-    "name": { "str": "XL chainmail half-leggings", "str_pl": "pairs of XL chainmail half-leggings" },
+    "name": { "str": "chainmail half-leggings", "str_pl": "pairs of chainmail half-leggings" },
     "proportional": { "weight": 1.25, "volume": 1.13, "price": 1.25 },
     "pocket_data": [
       {
@@ -393,13 +393,13 @@
         "flag_restriction": [ "ABLATIVE_CHAINMAIL_KNEES" ]
       }
     ],
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "abstract": "xs_chainmail_half_legs",
     "type": "ARMOR",
     "copy-from": "base_chainmail_half_legs",
-    "name": { "str": "XS chainmail half-leggings", "str_pl": "pairs of XS chainmail half-leggings" },
+    "name": { "str": "chainmail half-leggings", "str_pl": "pairs of chainmail half-leggings" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
     "pocket_data": [
       {
@@ -425,7 +425,7 @@
         "flag_restriction": [ "ABLATIVE_CHAINMAIL_KNEES" ]
       }
     ],
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "chainmail_junk_legs",
@@ -447,14 +447,14 @@
     "type": "ARMOR",
     "copy-from": "xl_chainmail_legs",
     "replace_materials": { "steel": "lc_steel_chain" },
-    "name": { "str": "XL mild steel chainmail leggings", "str_pl": "pairs of XL mild steel chainmail leggings" }
+    "name": { "str": "mild steel chainmail leggings", "str_pl": "pairs of mild steel chainmail leggings" }
   },
   {
     "id": "xs_lc_chainmail_legs",
     "type": "ARMOR",
     "copy-from": "xs_chainmail_legs",
     "replace_materials": { "steel": "lc_steel_chain" },
-    "name": { "str": "XS mild steel chainmail leggings", "str_pl": "pairs of XS mild steel chainmail leggings" }
+    "name": { "str": "mild steel chainmail leggings", "str_pl": "pairs of mild steel chainmail leggings" }
   },
   {
     "id": "mc_chainmail_legs",
@@ -468,14 +468,14 @@
     "type": "ARMOR",
     "copy-from": "xl_chainmail_legs",
     "replace_materials": { "steel": "mc_steel_chain" },
-    "name": { "str": "XL medium steel chainmail leggings", "str_pl": "pairs of XL medium steel chainmail leggings" }
+    "name": { "str": "medium steel chainmail leggings", "str_pl": "pairs of medium steel chainmail leggings" }
   },
   {
     "id": "xs_mc_chainmail_legs",
     "type": "ARMOR",
     "copy-from": "xs_chainmail_legs",
     "replace_materials": { "steel": "mc_steel_chain" },
-    "name": { "str": "XS medium steel chainmail leggings", "str_pl": "pairs of XS medium steel chainmail leggings" }
+    "name": { "str": "medium steel chainmail leggings", "str_pl": "pairs of medium steel chainmail leggings" }
   },
   {
     "id": "hc_chainmail_legs",
@@ -489,14 +489,14 @@
     "type": "ARMOR",
     "copy-from": "xl_chainmail_legs",
     "replace_materials": { "steel": "hc_steel_chain" },
-    "name": { "str": "XL high steel chainmail leggings", "str_pl": "pairs of XL high steel chainmail leggings" }
+    "name": { "str": "high steel chainmail leggings", "str_pl": "pairs of high steel chainmail leggings" }
   },
   {
     "id": "xs_hc_chainmail_legs",
     "type": "ARMOR",
     "copy-from": "xs_chainmail_legs",
     "replace_materials": { "steel": "hc_steel_chain" },
-    "name": { "str": "XS high steel chainmail leggings", "str_pl": "pairs of XS high steel chainmail leggings" }
+    "name": { "str": "high steel chainmail leggings", "str_pl": "pairs of high steel chainmail leggings" }
   },
   {
     "id": "ch_chainmail_legs",
@@ -510,14 +510,14 @@
     "type": "ARMOR",
     "copy-from": "xl_chainmail_legs",
     "replace_materials": { "steel": "ch_steel_chain" },
-    "name": { "str": "XL hardened steel chainmail leggings", "str_pl": "pairs of XL hardened steel chainmail leggings" }
+    "name": { "str": "hardened steel chainmail leggings", "str_pl": "pairs of hardened steel chainmail leggings" }
   },
   {
     "id": "xs_ch_chainmail_legs",
     "type": "ARMOR",
     "copy-from": "xs_chainmail_legs",
     "replace_materials": { "steel": "ch_steel_chain" },
-    "name": { "str": "XS hardened steel chainmail leggings", "str_pl": "pairs of XS hardened steel chainmail leggings" }
+    "name": { "str": "hardened steel chainmail leggings", "str_pl": "pairs of hardened steel chainmail leggings" }
   },
   {
     "id": "qt_chainmail_legs",
@@ -531,14 +531,14 @@
     "type": "ARMOR",
     "copy-from": "xl_chainmail_legs",
     "replace_materials": { "steel": "qt_steel_chain" },
-    "name": { "str": "XL tempered steel chainmail leggings", "str_pl": "pairs of XL tempered steel chainmail leggings" }
+    "name": { "str": "tempered steel chainmail leggings", "str_pl": "pairs of tempered steel chainmail leggings" }
   },
   {
     "id": "xs_qt_chainmail_legs",
     "type": "ARMOR",
     "copy-from": "xs_chainmail_legs",
     "replace_materials": { "steel": "qt_steel_chain" },
-    "name": { "str": "XS tempered steel chainmail leggings", "str_pl": "pairs of XS tempered steel chainmail leggings" }
+    "name": { "str": "tempered steel chainmail leggings", "str_pl": "pairs of tempered steel chainmail leggings" }
   },
   {
     "id": "lc_chainmail_half_legs",
@@ -552,14 +552,14 @@
     "type": "ARMOR",
     "copy-from": "xl_chainmail_half_legs",
     "replace_materials": { "steel": "lc_steel_chain" },
-    "name": { "str": "XL mild steel chainmail half-leggings", "str_pl": "pairs of XL mild steel chainmail half-leggings" }
+    "name": { "str": "mild steel chainmail half-leggings", "str_pl": "pairs of mild steel chainmail half-leggings" }
   },
   {
     "id": "xs_lc_chainmail_half_legs",
     "type": "ARMOR",
     "copy-from": "xs_chainmail_half_legs",
     "replace_materials": { "steel": "lc_steel_chain" },
-    "name": { "str": "XS mild steel chainmail half-leggings", "str_pl": "pairs of XS mild steel chainmail half-leggings" }
+    "name": { "str": "mild steel chainmail half-leggings", "str_pl": "pairs of mild steel chainmail half-leggings" }
   },
   {
     "id": "mc_chainmail_half_legs",
@@ -573,14 +573,14 @@
     "type": "ARMOR",
     "copy-from": "xl_chainmail_half_legs",
     "replace_materials": { "steel": "mc_steel_chain" },
-    "name": { "str": "XL medium steel chainmail half-leggings", "str_pl": "pairs of XL medium steel chainmail half-leggings" }
+    "name": { "str": "medium steel chainmail half-leggings", "str_pl": "pairs of medium steel chainmail half-leggings" }
   },
   {
     "id": "xs_mc_chainmail_half_legs",
     "type": "ARMOR",
     "copy-from": "xs_chainmail_half_legs",
     "replace_materials": { "steel": "mc_steel_chain" },
-    "name": { "str": "XS medium steel chainmail half-leggings", "str_pl": "pairs of XS medium steel chainmail half-leggings" }
+    "name": { "str": "medium steel chainmail half-leggings", "str_pl": "pairs of medium steel chainmail half-leggings" }
   },
   {
     "id": "hc_chainmail_half_legs",
@@ -594,14 +594,14 @@
     "type": "ARMOR",
     "copy-from": "xl_chainmail_half_legs",
     "replace_materials": { "steel": "hc_steel_chain" },
-    "name": { "str": "XL high steel chainmail half-leggings", "str_pl": "pairs of XL high steel chainmail half-leggings" }
+    "name": { "str": "high steel chainmail half-leggings", "str_pl": "pairs of high steel chainmail half-leggings" }
   },
   {
     "id": "xs_hc_chainmail_half_legs",
     "type": "ARMOR",
     "copy-from": "xs_chainmail_half_legs",
     "replace_materials": { "steel": "hc_steel_chain" },
-    "name": { "str": "XS high steel chainmail half-leggings", "str_pl": "pairs of XS high steel chainmail half-leggings" }
+    "name": { "str": "high steel chainmail half-leggings", "str_pl": "pairs of high steel chainmail half-leggings" }
   },
   {
     "id": "ch_chainmail_half_legs",
@@ -615,14 +615,14 @@
     "type": "ARMOR",
     "copy-from": "xl_chainmail_half_legs",
     "replace_materials": { "steel": "ch_steel_chain" },
-    "name": { "str": "XL hardened steel chainmail half-leggings", "str_pl": "pairs of XL hardened steel chainmail half-leggings" }
+    "name": { "str": "hardened steel chainmail half-leggings", "str_pl": "pairs of hardened steel chainmail half-leggings" }
   },
   {
     "id": "xs_ch_chainmail_half_legs",
     "type": "ARMOR",
     "copy-from": "xs_chainmail_half_legs",
     "replace_materials": { "steel": "ch_steel_chain" },
-    "name": { "str": "XS hardened steel chainmail half-leggings", "str_pl": "pairs of XS hardened steel chainmail half-leggings" }
+    "name": { "str": "hardened steel chainmail half-leggings", "str_pl": "pairs of hardened steel chainmail half-leggings" }
   },
   {
     "id": "qt_chainmail_half_legs",
@@ -636,14 +636,14 @@
     "type": "ARMOR",
     "copy-from": "xl_chainmail_half_legs",
     "replace_materials": { "steel": "qt_steel_chain" },
-    "name": { "str": "XL tempered steel chainmail half-leggings", "str_pl": "pairs of XL tempered steel chainmail half-leggings" }
+    "name": { "str": "tempered steel chainmail half-leggings", "str_pl": "pairs of tempered steel chainmail half-leggings" }
   },
   {
     "id": "xs_qt_chainmail_half_legs",
     "type": "ARMOR",
     "copy-from": "xs_chainmail_half_legs",
     "replace_materials": { "steel": "qt_steel_chain" },
-    "name": { "str": "XS tempered steel chainmail half-leggings", "str_pl": "pairs of XS tempered steel chainmail half-leggings" }
+    "name": { "str": "tempered steel chainmail half-leggings", "str_pl": "pairs of tempered steel chainmail half-leggings" }
   },
   {
     "id": "leggings_thessalonian",
@@ -811,17 +811,17 @@
     "id": "xl_legguard_bronze",
     "type": "ARMOR",
     "copy-from": "legguard_bronze",
-    "name": { "str": "pair of XL bronze greaves", "str_pl": "pairs of XL bronze greaves" },
+    "name": { "str": "pair of bronze greaves", "str_pl": "pairs of bronze greaves" },
     "proportional": { "weight": 1.25, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_legguard_bronze",
     "type": "ARMOR",
     "copy-from": "legguard_bronze",
-    "name": { "str": "pair of XS bronze greaves", "str_pl": "pairs of XS bronze greaves" },
+    "name": { "str": "pair of bronze greaves", "str_pl": "pairs of bronze greaves" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "legguard_hard",
@@ -888,17 +888,17 @@
     "id": "xl_legguard_lightplate",
     "type": "ARMOR",
     "copy-from": "legguard_lightplate",
-    "name": { "str": "pair of XL steel leg guards", "str_pl": "pairs of XL steel leg guards" },
+    "name": { "str": "pair of steel leg guards", "str_pl": "pairs of steel leg guards" },
     "proportional": { "weight": 1.25, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_legguard_lightplate",
     "type": "ARMOR",
     "copy-from": "legguard_lightplate",
-    "name": { "str": "pair of XS steel leg guards", "str_pl": "pairs of XS steel leg guards" },
+    "name": { "str": "pair of steel leg guards", "str_pl": "pairs of steel leg guards" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "legguard_metal",
@@ -934,17 +934,17 @@
     "id": "xl_legguard_metal",
     "type": "ARMOR",
     "copy-from": "legguard_metal",
-    "name": { "str": "pair of XL iron greaves", "str_pl": "pairs of XL iron greaves" },
+    "name": { "str": "pair of iron greaves", "str_pl": "pairs of iron greaves" },
     "proportional": { "weight": 1.25, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_legguard_metal",
     "type": "ARMOR",
     "copy-from": "legguard_metal",
-    "name": { "str": "pair of XS iron greaves", "str_pl": "pairs of XS iron greaves" },
+    "name": { "str": "pair of iron greaves", "str_pl": "pairs of iron greaves" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "legguard_metal_sheets",
@@ -1110,17 +1110,17 @@
     "id": "xl_legguard_metal_sheets",
     "type": "ARMOR",
     "copy-from": "legguard_metal_sheets",
-    "name": { "str": "pair of XL sheet metal leg guards", "str_pl": "pairs of XL sheet metal leg guards" },
+    "name": { "str": "pair of sheet metal leg guards", "str_pl": "pairs of sheet metal leg guards" },
     "proportional": { "weight": 1.25, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_legguard_metal_sheets",
     "type": "ARMOR",
     "copy-from": "legguard_metal_sheets",
-    "name": { "str": "pair of XS sheet metal leg guards", "str_pl": "pairs of XS sheet metal leg guards" },
+    "name": { "str": "pair of sheet metal leg guards", "str_pl": "pairs of sheet metal leg guards" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "legguard_paper",
@@ -1216,17 +1216,17 @@
     "id": "xl_legguard_scrap",
     "type": "ARMOR",
     "copy-from": "legguard_scrap",
-    "name": { "str": "pair of XL scrap leg guards", "str_pl": "pairs of XL scrap leg guards" },
+    "name": { "str": "pair of scrap leg guards", "str_pl": "pairs of scrap leg guards" },
     "proportional": { "weight": 1.25, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_legguard_scrap",
     "type": "ARMOR",
     "copy-from": "legguard_scrap",
-    "name": { "str": "pair of XS scrap leg guards", "str_pl": "pairs of XS scrap leg guards" },
+    "name": { "str": "pair of scrap leg guards", "str_pl": "pairs of scrap leg guards" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "legguard_tire",
@@ -1262,17 +1262,17 @@
     "id": "xl_legguard_tire",
     "type": "ARMOR",
     "copy-from": "legguard_tire",
-    "name": { "str": "pair of XL tire leg guards", "str_pl": "pairs of XL tire leg guards" },
+    "name": { "str": "pair of tire leg guards", "str_pl": "pairs of tire leg guards" },
     "proportional": { "weight": 1.25, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_legguard_tire",
     "type": "ARMOR",
     "copy-from": "legguard_tire",
-    "name": { "str": "pair of XS tire leg guards", "str_pl": "pairs of XS tire leg guards" },
+    "name": { "str": "pair of tire leg guards", "str_pl": "pairs of tire leg guards" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "motorbike_pants",
@@ -1553,10 +1553,10 @@
   {
     "id": "xl_armor_lc_light_leg_guard",
     "type": "ARMOR",
-    "name": { "str": "XL mild steel light leg guard" },
+    "name": { "str": "mild steel light leg guard" },
     "copy-from": "armor_lc_light_leg_guard",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_mc_light_leg_guard",
@@ -1569,10 +1569,10 @@
   {
     "id": "xl_armor_mc_light_leg_guard",
     "type": "ARMOR",
-    "name": { "str": "XL medium steel light leg guard" },
+    "name": { "str": "medium steel light leg guard" },
     "copy-from": "armor_mc_light_leg_guard",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_hc_light_leg_guard",
@@ -1585,10 +1585,10 @@
   {
     "id": "xl_armor_hc_light_leg_guard",
     "type": "ARMOR",
-    "name": { "str": "XL high steel light leg guard" },
+    "name": { "str": "high steel light leg guard" },
     "copy-from": "armor_hc_light_leg_guard",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_ch_light_leg_guard",
@@ -1602,10 +1602,10 @@
   {
     "id": "xl_armor_ch_light_leg_guard",
     "type": "ARMOR",
-    "name": { "str": "XL hardened light leg guard" },
+    "name": { "str": "hardened light leg guard" },
     "copy-from": "armor_ch_light_leg_guard",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_qt_light_leg_guard",
@@ -1618,10 +1618,10 @@
   {
     "id": "xl_armor_qt_light_leg_guard",
     "type": "ARMOR",
-    "name": { "str": "XL tempered light leg guard" },
+    "name": { "str": "tempered light leg guard" },
     "copy-from": "armor_qt_light_leg_guard",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_lc_leg_guard",
@@ -1661,10 +1661,10 @@
   {
     "id": "xl_armor_lc_leg_guard",
     "type": "ARMOR",
-    "name": { "str": "XL mild steel leg guard" },
+    "name": { "str": "mild steel leg guard" },
     "copy-from": "armor_lc_leg_guard",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_mc_leg_guard",
@@ -1677,10 +1677,10 @@
   {
     "id": "xl_armor_mc_leg_guard",
     "type": "ARMOR",
-    "name": { "str": "XL medium steel leg guard" },
+    "name": { "str": "medium steel leg guard" },
     "copy-from": "armor_mc_leg_guard",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_hc_leg_guard",
@@ -1693,10 +1693,10 @@
   {
     "id": "xl_armor_hc_leg_guard",
     "type": "ARMOR",
-    "name": { "str": "XL high steel leg guard" },
+    "name": { "str": "high steel leg guard" },
     "copy-from": "armor_hc_leg_guard",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_ch_leg_guard",
@@ -1709,10 +1709,10 @@
   {
     "id": "xl_armor_ch_leg_guard",
     "type": "ARMOR",
-    "name": { "str": "XL hardened leg guard" },
+    "name": { "str": "hardened leg guard" },
     "copy-from": "armor_ch_leg_guard",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_qt_leg_guard",
@@ -1725,10 +1725,10 @@
   {
     "id": "xl_armor_qt_leg_guard",
     "type": "ARMOR",
-    "name": { "str": "XL tempered leg guard" },
+    "name": { "str": "tempered leg guard" },
     "copy-from": "armor_qt_leg_guard",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_lc_heavy_leg_guard",
@@ -1768,10 +1768,10 @@
   {
     "id": "xl_armor_lc_heavy_leg_guard",
     "type": "ARMOR",
-    "name": { "str": "XL mild steel heavy leg guard" },
+    "name": { "str": "mild steel heavy leg guard" },
     "copy-from": "armor_lc_heavy_leg_guard",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_mc_heavy_leg_guard",
@@ -1784,10 +1784,10 @@
   {
     "id": "xl_armor_mc_heavy_leg_guard",
     "type": "ARMOR",
-    "name": { "str": "XL medium steel heavy leg guard" },
+    "name": { "str": "medium steel heavy leg guard" },
     "copy-from": "armor_mc_heavy_leg_guard",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_hc_heavy_leg_guard",
@@ -1800,10 +1800,10 @@
   {
     "id": "xl_armor_hc_heavy_leg_guard",
     "type": "ARMOR",
-    "name": { "str": "XL high steel heavy leg guard" },
+    "name": { "str": "high steel heavy leg guard" },
     "copy-from": "armor_hc_heavy_leg_guard",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_ch_heavy_leg_guard",
@@ -1816,10 +1816,10 @@
   {
     "id": "xl_armor_ch_heavy_leg_guard",
     "type": "ARMOR",
-    "name": { "str": "XL hardened heavy leg guard" },
+    "name": { "str": "hardened heavy leg guard" },
     "copy-from": "armor_ch_heavy_leg_guard",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_qt_heavy_leg_guard",
@@ -1832,10 +1832,10 @@
   {
     "id": "xl_armor_qt_heavy_leg_guard",
     "type": "ARMOR",
-    "name": { "str": "XL tempered heavy leg guard" },
+    "name": { "str": "tempered heavy leg guard" },
     "copy-from": "armor_qt_heavy_leg_guard",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "survivor_adhoc_leather_pants",
@@ -2008,17 +2008,17 @@
   {
     "id": "xl_legguard_larmor",
     "type": "ARMOR",
-    "name": { "str": "pair of XL leather leg guards", "str_pl": "pairs of XL leather leg guards" },
+    "name": { "str": "pair of leather leg guards", "str_pl": "pairs of leather leg guards" },
     "copy-from": "legguard_larmor",
     "proportional": { "weight": 1.25, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_legguard_larmor",
     "type": "ARMOR",
     "copy-from": "legguard_larmor",
-    "name": { "str": "pair of XS leather leg guards", "str_pl": "pairs of XS leather leg guards" },
+    "name": { "str": "pair of leather leg guards", "str_pl": "pairs of leather leg guards" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   }
 ]

--- a/data/json/items/armor/suits_clothes.json
+++ b/data/json/items/armor/suits_clothes.json
@@ -457,7 +457,7 @@
   {
     "id": "jumpsuit_xl",
     "type": "ARMOR",
-    "name": { "str": "XL jumpsuit" },
+    "name": { "str": "jumpsuit" },
     "description": "A thin, short-sleeved jumpsuit updated for the trans-human who needs full-body clothing.  Provides some storage and is adjustable to minimize encumbrance.",
     "weight": "810 g",
     "volume": "5 L",
@@ -505,17 +505,16 @@
     ],
     "warmth": 15,
     "material_thickness": 1,
-    "flags": [ "POCKETS", "OVERSIZE" ]
+    "flags": [ "POCKETS", "OVERSIZE", "PREFIX_XL" ]
   },
   {
     "id": "jumpsuit_xs",
     "type": "ARMOR",
     "copy-from": "jumpsuit",
-    "looks_like": "jumpsuit",
-    "name": { "str": "XS jumpsuit" },
+    "name": { "str": "jumpsuit" },
     "description": "A thin, short-sleeved jumpsuit; similar to those worn by prisoners.  Provides decent storage and is not very encumbering.",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "jumpsuit_skeleton",

--- a/data/json/items/armor/suits_protection.json
+++ b/data/json/items/armor/suits_protection.json
@@ -64,19 +64,19 @@
   {
     "id": "xl_armor_chitin",
     "type": "ARMOR",
-    "name": { "str": "XL chitinous armor" },
+    "name": { "str": "chitinous armor" },
     "copy-from": "armor_chitin",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_chitin_xs",
     "type": "ARMOR",
     "copy-from": "armor_chitin",
     "looks_like": "armor_chitin",
-    "name": { "str": "XS chitinous armor" },
+    "name": { "str": "chitinous armor" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "flags": [ "STURDY", "OUTER", "UNDERSIZE" ]
+    "flags": [ "STURDY", "OUTER", "UNDERSIZE", "PREFIX_XS" ]
   },
   {
     "id": "armor_acidchitin",
@@ -93,19 +93,19 @@
   {
     "id": "xl_armor_acidchitin",
     "type": "ARMOR",
-    "name": { "str": "XL biosilicified chitin armor" },
+    "name": { "str": "biosilicified chitin armor" },
     "copy-from": "armor_acidchitin",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_acidchitin_xs",
     "type": "ARMOR",
     "copy-from": "armor_acidchitin",
     "looks_like": "armor_acidchitin",
-    "name": { "str": "XS biosilicified chitin armor" },
+    "name": { "str": "biosilicified chitin armor" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "armor_farmor",
@@ -153,19 +153,19 @@
   {
     "id": "xl_armor_farmor",
     "type": "ARMOR",
-    "name": { "str": "XL fur body armor" },
+    "name": { "str": "fur body armor" },
     "copy-from": "armor_farmor",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_farmor_xs",
     "type": "ARMOR",
     "copy-from": "armor_farmor",
     "looks_like": "armor_farmor",
-    "name": { "str": "XS fur body armor" },
+    "name": { "str": "fur body armor" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "flags": [ "VARSIZE", "POCKETS", "WATERPROOF", "STURDY", "OUTER", "UNDERSIZE" ]
+    "flags": [ "VARSIZE", "POCKETS", "WATERPROOF", "STURDY", "OUTER", "UNDERSIZE", "PREFIX_XS" ]
   },
   {
     "id": "armor_faux_farmor",
@@ -212,19 +212,18 @@
   {
     "id": "xl_armor_faux_farmor",
     "type": "ARMOR",
-    "name": { "str": "XL faux fur body armor" },
+    "name": { "str": "faux fur body armor" },
     "copy-from": "armor_faux_farmor",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_faux_farmor_xs",
     "type": "ARMOR",
     "copy-from": "armor_faux_farmor",
-    "looks_like": "armor_farmor",
-    "name": { "str": "XS faux fur body armor" },
+    "name": { "str": "faux fur body armor" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "flags": [ "VARSIZE", "POCKETS", "WATERPROOF", "STURDY", "OUTER", "UNDERSIZE" ]
+    "flags": [ "VARSIZE", "POCKETS", "WATERPROOF", "STURDY", "OUTER", "UNDERSIZE", "PREFIX_XS" ]
   },
   {
     "id": "armor_larmor",
@@ -261,19 +260,19 @@
   {
     "id": "xl_armor_larmor",
     "type": "ARMOR",
-    "name": { "str": "XL leather body armor" },
+    "name": { "str": "leather body armor" },
     "copy-from": "armor_larmor",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_larmor_xs",
     "type": "ARMOR",
     "copy-from": "armor_larmor",
     "looks_like": "armor_larmor",
-    "name": { "str": "XS leather body armor" },
+    "name": { "str": "leather body armor" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "flags": [ "VARSIZE", "STURDY", "OUTER", "UNDERSIZE" ]
+    "flags": [ "VARSIZE", "STURDY", "OUTER", "UNDERSIZE", "PREFIX_XS" ]
   },
   {
     "id": "armor_junk_lightplate",
@@ -632,10 +631,10 @@
   {
     "id": "xl_armor_lc_lightplate",
     "type": "ARMOR",
-    "name": { "str": "XL mild steel light plate armor" },
+    "name": { "str": "mild steel light plate armor" },
     "copy-from": "armor_lc_lightplate",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_mc_lightplate",
@@ -648,10 +647,10 @@
   {
     "id": "xl_armor_mc_lightplate",
     "type": "ARMOR",
-    "name": { "str": "XL mild steel light plate armor" },
+    "name": { "str": "medium steel light plate armor" },
     "copy-from": "armor_mc_lightplate",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_hc_lightplate",
@@ -664,10 +663,10 @@
   {
     "id": "xl_armor_hc_lightplate",
     "type": "ARMOR",
-    "name": { "str": "XL high steel light plate armor" },
+    "name": { "str": "high steel light plate armor" },
     "copy-from": "armor_hc_lightplate",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_ch_lightplate",
@@ -680,10 +679,10 @@
   {
     "id": "xl_armor_ch_lightplate",
     "type": "ARMOR",
-    "name": { "str": "XL hardened light plate armor" },
+    "name": { "str": "hardened steel light plate armor" },
     "copy-from": "armor_ch_lightplate",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_qt_lightplate",
@@ -696,10 +695,10 @@
   {
     "id": "xl_armor_qt_lightplate",
     "type": "ARMOR",
-    "name": { "str": "XL tempered steel light plate armor" },
+    "name": { "str": "tempered steel light plate armor" },
     "copy-from": "armor_qt_lightplate",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_lc_plate",
@@ -757,10 +756,10 @@
   {
     "id": "xl_armor_lc_plate",
     "type": "ARMOR",
-    "name": { "str": "XL mild steel plate armor" },
+    "name": { "str": "mild steel plate armor" },
     "copy-from": "armor_lc_plate",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_mc_plate",
@@ -773,10 +772,10 @@
   {
     "id": "xl_armor_mc_plate",
     "type": "ARMOR",
-    "name": { "str": "XL medium steel plate armor" },
+    "name": { "str": "medium steel plate armor" },
     "copy-from": "armor_mc_plate",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_hc_plate",
@@ -790,27 +789,27 @@
   {
     "id": "xl_armor_hc_plate",
     "type": "ARMOR",
-    "name": { "str": "XL high steel plate armor" },
+    "name": { "str": "high steel plate armor" },
     "copy-from": "armor_hc_plate",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_ch_plate",
     "type": "ARMOR",
     "copy-from": "armor_lc_plate",
     "material": [ "ch_steel", "ch_steel_chain" ],
-    "name": { "str": "hardened plate armor" },
+    "name": { "str": "hardened steel plate armor" },
     "description": "A suit of plate armor with a 4 mm thick chestpiece.  The mild steel has been hardened, offering superior protection.",
     "replace_materials": { "lc_steel": "ch_steel", "lc_steel_chain": "ch_steel_chain" }
   },
   {
     "id": "xl_armor_ch_plate",
     "type": "ARMOR",
-    "name": { "str": "XL hardened plate armor" },
+    "name": { "str": "hardened steel plate armor" },
     "copy-from": "armor_ch_plate",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_qt_plate",
@@ -824,10 +823,10 @@
   {
     "id": "xl_armor_qt_plate",
     "type": "ARMOR",
-    "name": { "str": "XL tempered steel plate armor" },
+    "name": { "str": "tempered steel plate armor" },
     "copy-from": "armor_qt_plate",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_lc_heavyplate",
@@ -885,10 +884,10 @@
   {
     "id": "xl_armor_lc_heavyplate",
     "type": "ARMOR",
-    "name": { "str": "XL mild steel heavy plate armor" },
+    "name": { "str": "mild steel heavy plate armor" },
     "copy-from": "armor_lc_heavyplate",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_mc_heavyplate",
@@ -901,10 +900,10 @@
   {
     "id": "xl_armor_mc_heavyplate",
     "type": "ARMOR",
-    "name": { "str": "XL medium steel heavy plate armor" },
+    "name": { "str": "medium steel heavy plate armor" },
     "copy-from": "armor_mc_heavyplate",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_hc_heavyplate",
@@ -917,10 +916,10 @@
   {
     "id": "xl_armor_hc_heavyplate",
     "type": "ARMOR",
-    "name": { "str": "XL high steel heavy plate armor" },
+    "name": { "str": "high steel heavy plate armor" },
     "copy-from": "armor_hc_heavyplate",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_ch_heavyplate",
@@ -933,10 +932,10 @@
   {
     "id": "xl_armor_ch_heavyplate",
     "type": "ARMOR",
-    "name": { "str": "XL hardened heavy plate armor" },
+    "name": { "str": "hardened steel heavy plate armor" },
     "copy-from": "armor_ch_heavyplate",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_qt_heavyplate",
@@ -949,10 +948,10 @@
   {
     "id": "xl_armor_qt_heavyplate",
     "type": "ARMOR",
-    "name": { "str": "XL tempered heavy plate armor" },
+    "name": { "str": "tempered steel heavy plate armor" },
     "copy-from": "armor_qt_heavyplate",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_plarmor",
@@ -1023,19 +1022,19 @@
   {
     "id": "xl_armor_plarmor",
     "type": "ARMOR",
-    "name": { "str": "XL plated leather armor" },
+    "name": { "str": "plated leather armor" },
     "copy-from": "armor_plarmor",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_plarmor_xs",
     "type": "ARMOR",
     "copy-from": "armor_plarmor",
     "looks_like": "armor_plarmor",
-    "name": { "str": "XS plated leather armor" },
+    "name": { "str": "plated leather armor" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "armor_junk_plate",
@@ -1201,17 +1200,17 @@
     "id": "armor_xl_scrapsuit",
     "type": "ARMOR",
     "copy-from": "armor_scrapsuit",
-    "name": { "str": "XL scrap suit" },
+    "name": { "str": "scrap suit" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_xs_scrapsuit",
     "type": "ARMOR",
     "copy-from": "armor_scrapsuit",
-    "name": { "str": "XS scrap suit" },
+    "name": { "str": "scrap suit" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "armor_tiresuit",
@@ -1335,7 +1334,7 @@
   {
     "abstract": "xl_chainmail_hauberk",
     "type": "ARMOR",
-    "name": { "str": "XL chainmail hauberk" },
+    "name": { "str": "chainmail hauberk" },
     "copy-from": "base_chainmail_hauberk",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
     "pocket_data": [
@@ -1373,13 +1372,13 @@
         "flag_restriction": [ "ABLATIVE_CHAINMAIL_ELBOWS" ]
       }
     ],
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "abstract": "xs_chainmail_hauberk",
     "type": "ARMOR",
     "copy-from": "base_chainmail_hauberk",
-    "name": { "str": "XS chainmail hauberk" },
+    "name": { "str": "chainmail hauberk" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
     "pocket_data": [
       {
@@ -1416,7 +1415,7 @@
         "flag_restriction": [ "ABLATIVE_CHAINMAIL_ELBOWS" ]
       }
     ],
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "chainmail_junk_hauberk",
@@ -1452,14 +1451,14 @@
     "type": "ARMOR",
     "copy-from": "xl_chainmail_hauberk",
     "replace_materials": { "steel": "lc_steel_chain" },
-    "name": { "str": "XL mild steel chainmail hauberk" }
+    "name": { "str": "mild steel chainmail hauberk" }
   },
   {
     "id": "lc_chainmail_hauberk_xs",
     "type": "ARMOR",
     "copy-from": "xs_chainmail_hauberk",
     "replace_materials": { "steel": "lc_steel_chain" },
-    "name": { "str": "XS mild steel chainmail hauberk" }
+    "name": { "str": "mild steel chainmail hauberk" }
   },
   {
     "id": "mc_chainmail_hauberk",
@@ -1473,14 +1472,14 @@
     "type": "ARMOR",
     "copy-from": "xl_chainmail_hauberk",
     "replace_materials": { "steel": "mc_steel_chain" },
-    "name": { "str": "XL medium steel chainmail hauberk" }
+    "name": { "str": "medium steel chainmail hauberk" }
   },
   {
     "id": "mc_chainmail_hauberk_xs",
     "type": "ARMOR",
     "copy-from": "xs_chainmail_hauberk",
     "replace_materials": { "steel": "mc_steel_chain" },
-    "name": { "str": "XS medium steel chainmail hauberk" }
+    "name": { "str": "medium steel chainmail hauberk" }
   },
   {
     "id": "hc_chainmail_hauberk",
@@ -1494,14 +1493,14 @@
     "type": "ARMOR",
     "copy-from": "xl_chainmail_hauberk",
     "replace_materials": { "steel": "hc_steel_chain" },
-    "name": { "str": "XL high steel chainmail hauberk" }
+    "name": { "str": "high steel chainmail hauberk" }
   },
   {
     "id": "hc_chainmail_hauberk_xs",
     "type": "ARMOR",
     "copy-from": "xs_chainmail_hauberk",
     "replace_materials": { "steel": "hc_steel_chain" },
-    "name": { "str": "XS high steel chainmail hauberk" }
+    "name": { "str": "high steel chainmail hauberk" }
   },
   {
     "id": "ch_chainmail_hauberk",
@@ -1515,14 +1514,14 @@
     "type": "ARMOR",
     "copy-from": "xl_chainmail_hauberk",
     "replace_materials": { "steel": "ch_steel_chain" },
-    "name": { "str": "XL hardened steel chainmail hauberk" }
+    "name": { "str": "hardened steel chainmail hauberk" }
   },
   {
     "id": "ch_chainmail_hauberk_xs",
     "type": "ARMOR",
     "copy-from": "xs_chainmail_hauberk",
     "replace_materials": { "steel": "ch_steel_chain" },
-    "name": { "str": "XS hardened steel chainmail hauberk" }
+    "name": { "str": "hardened steel chainmail hauberk" }
   },
   {
     "id": "qt_chainmail_hauberk",
@@ -1536,14 +1535,14 @@
     "type": "ARMOR",
     "copy-from": "xl_chainmail_hauberk",
     "replace_materials": { "steel": "qt_steel_chain" },
-    "name": { "str": "XL tempered steel chainmail hauberk" }
+    "name": { "str": "tempered steel chainmail hauberk" }
   },
   {
     "id": "qt_chainmail_hauberk_xs",
     "type": "ARMOR",
     "copy-from": "xs_chainmail_hauberk",
     "replace_materials": { "steel": "qt_steel_chain" },
-    "name": { "str": "XS tempered steel chainmail hauberk" }
+    "name": { "str": "tempered steel chainmail hauberk" }
   },
   {
     "abstract": "base_chainmail_sjumpsuit",
@@ -1606,7 +1605,7 @@
   {
     "abstract": "xl_chainmail_sjumpsuit",
     "type": "ARMOR",
-    "name": { "str": "XL chainmail sleeveless jumpsuit" },
+    "name": { "str": "chainmail sleeveless jumpsuit" },
     "copy-from": "base_chainmail_sjumpsuit",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
     "pocket_data": [
@@ -1644,13 +1643,13 @@
         "flag_restriction": [ "ABLATIVE_CHAINMAIL_KNEES" ]
       }
     ],
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "abstract": "xs_chainmail_sjumpsuit",
     "type": "ARMOR",
     "copy-from": "base_chainmail_sjumpsuit",
-    "name": { "str": "XS chainmail sleeveless jumpsuit" },
+    "name": { "str": "chainmail sleeveless jumpsuit" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
     "pocket_data": [
       {
@@ -1687,7 +1686,7 @@
         "flag_restriction": [ "ABLATIVE_CHAINMAIL_KNEES" ]
       }
     ],
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "lc_chainmail_sjumpsuit",
@@ -1701,14 +1700,14 @@
     "type": "ARMOR",
     "copy-from": "xl_chainmail_sjumpsuit",
     "replace_materials": { "steel": "lc_steel_chain" },
-    "name": { "str": "XL mild steel chainmail sleeveless jumpsuit" }
+    "name": { "str": "mild steel chainmail sleeveless jumpsuit" }
   },
   {
     "id": "lc_chainmail_sjumpsuit_xs",
     "type": "ARMOR",
     "copy-from": "xs_chainmail_sjumpsuit",
     "replace_materials": { "steel": "lc_steel_chain" },
-    "name": { "str": "XS mild steel chainmail sleeveless jumpsuit" }
+    "name": { "str": "mild steel chainmail sleeveless jumpsuit" }
   },
   {
     "id": "mc_chainmail_sjumpsuit",
@@ -1722,14 +1721,14 @@
     "type": "ARMOR",
     "copy-from": "xl_chainmail_sjumpsuit",
     "replace_materials": { "steel": "mc_steel_chain" },
-    "name": { "str": "XL medium steel chainmail sleeveless jumpsuit" }
+    "name": { "str": "medium steel chainmail sleeveless jumpsuit" }
   },
   {
     "id": "mc_chainmail_sjumpsuit_xs",
     "type": "ARMOR",
     "copy-from": "xs_chainmail_sjumpsuit",
     "replace_materials": { "steel": "mc_steel_chain" },
-    "name": { "str": "XS medium steel chainmail sleeveless jumpsuit" }
+    "name": { "str": "medium steel chainmail sleeveless jumpsuit" }
   },
   {
     "id": "hc_chainmail_sjumpsuit",
@@ -1743,14 +1742,14 @@
     "type": "ARMOR",
     "copy-from": "xl_chainmail_sjumpsuit",
     "replace_materials": { "steel": "hc_steel_chain" },
-    "name": { "str": "XL high steel chainmail sleeveless jumpsuit" }
+    "name": { "str": "high steel chainmail sleeveless jumpsuit" }
   },
   {
     "id": "hc_chainmail_sjumpsuit_xs",
     "type": "ARMOR",
     "copy-from": "xs_chainmail_sjumpsuit",
     "replace_materials": { "steel": "hc_steel_chain" },
-    "name": { "str": "XS high steel chainmail sleeveless jumpsuit" }
+    "name": { "str": "high steel chainmail sleeveless jumpsuit" }
   },
   {
     "id": "ch_chainmail_sjumpsuit",
@@ -1764,14 +1763,14 @@
     "type": "ARMOR",
     "copy-from": "xl_chainmail_sjumpsuit",
     "replace_materials": { "steel": "ch_steel_chain" },
-    "name": { "str": "XL hardened steel chainmail sleeveless jumpsuit" }
+    "name": { "str": "hardened steel chainmail sleeveless jumpsuit" }
   },
   {
     "id": "ch_chainmail_sjumpsuit_xs",
     "type": "ARMOR",
     "copy-from": "xs_chainmail_sjumpsuit",
     "replace_materials": { "steel": "ch_steel_chain" },
-    "name": { "str": "XS hardened steel chainmail sleeveless jumpsuit" }
+    "name": { "str": "hardened steel chainmail sleeveless jumpsuit" }
   },
   {
     "id": "qt_chainmail_sjumpsuit",
@@ -1785,14 +1784,14 @@
     "type": "ARMOR",
     "copy-from": "xl_chainmail_sjumpsuit",
     "replace_materials": { "steel": "qt_steel_chain" },
-    "name": { "str": "XL tempered steel chainmail sleeveless jumpsuit" }
+    "name": { "str": "tempered steel chainmail sleeveless jumpsuit" }
   },
   {
     "id": "qt_chainmail_sjumpsuit_xs",
     "type": "ARMOR",
     "copy-from": "xs_chainmail_sjumpsuit",
     "replace_materials": { "steel": "qt_steel_chain" },
-    "name": { "str": "XS tempered steel chainmail sleeveless jumpsuit" }
+    "name": { "str": "tempered steel chainmail sleeveless jumpsuit" }
   },
   {
     "abstract": "base_chainmail_jumpsuit",
@@ -1875,7 +1874,7 @@
   {
     "abstract": "xl_chainmail_jumpsuit",
     "type": "ARMOR",
-    "name": { "str": "XL chainmail jumpsuit" },
+    "name": { "str": "chainmail jumpsuit" },
     "copy-from": "base_chainmail_jumpsuit",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
     "pocket_data": [
@@ -1935,13 +1934,13 @@
         "flag_restriction": [ "ABLATIVE_CHAINMAIL_KNEES" ]
       }
     ],
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "abstract": "xs_chainmail_jumpsuit",
     "type": "ARMOR",
     "copy-from": "base_chainmail_jumpsuit",
-    "name": { "str": "XS chainmail jumpsuit" },
+    "name": { "str": "chainmail jumpsuit" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
     "pocket_data": [
       {
@@ -2000,7 +1999,7 @@
         "flag_restriction": [ "ABLATIVE_CHAINMAIL_KNEES" ]
       }
     ],
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "lc_chainmail_jumpsuit",
@@ -2014,14 +2013,14 @@
     "type": "ARMOR",
     "copy-from": "xl_chainmail_jumpsuit",
     "replace_materials": { "steel": "lc_steel_chain" },
-    "name": { "str": "XL mild steel chainmail jumpsuit" }
+    "name": { "str": "mild steel chainmail jumpsuit" }
   },
   {
     "id": "lc_chainmail_jumpsuit_xs",
     "type": "ARMOR",
     "copy-from": "xs_chainmail_jumpsuit",
     "replace_materials": { "steel": "lc_steel_chain" },
-    "name": { "str": "XS mild steel chainmail jumpsuit" }
+    "name": { "str": "mild steel chainmail jumpsuit" }
   },
   {
     "id": "mc_chainmail_jumpsuit",
@@ -2035,14 +2034,14 @@
     "type": "ARMOR",
     "copy-from": "xl_chainmail_jumpsuit",
     "replace_materials": { "steel": "mc_steel_chain" },
-    "name": { "str": "XL medium steel chainmail jumpsuit" }
+    "name": { "str": "medium steel chainmail jumpsuit" }
   },
   {
     "id": "mc_chainmail_jumpsuit_xs",
     "type": "ARMOR",
     "copy-from": "xs_chainmail_jumpsuit",
     "replace_materials": { "steel": "mc_steel_chain" },
-    "name": { "str": "XS medium steel chainmail jumpsuit" }
+    "name": { "str": "medium steel chainmail jumpsuit" }
   },
   {
     "id": "hc_chainmail_jumpsuit",
@@ -2056,14 +2055,14 @@
     "type": "ARMOR",
     "copy-from": "xl_chainmail_jumpsuit",
     "replace_materials": { "steel": "hc_steel_chain" },
-    "name": { "str": "XL high steel chainmail jumpsuit" }
+    "name": { "str": "high steel chainmail jumpsuit" }
   },
   {
     "id": "hc_chainmail_jumpsuit_xs",
     "type": "ARMOR",
     "copy-from": "xs_chainmail_jumpsuit",
     "replace_materials": { "steel": "hc_steel_chain" },
-    "name": { "str": "XS high steel chainmail jumpsuit" }
+    "name": { "str": "high steel chainmail jumpsuit" }
   },
   {
     "id": "ch_chainmail_jumpsuit",
@@ -2077,14 +2076,14 @@
     "type": "ARMOR",
     "copy-from": "xl_chainmail_jumpsuit",
     "replace_materials": { "steel": "ch_steel_chain" },
-    "name": { "str": "XL hardened steel chainmail jumpsuit" }
+    "name": { "str": "hardened steel chainmail jumpsuit" }
   },
   {
     "id": "ch_chainmail_jumpsuit_xs",
     "type": "ARMOR",
     "copy-from": "xs_chainmail_jumpsuit",
     "replace_materials": { "steel": "ch_steel_chain" },
-    "name": { "str": "XS hardened steel chainmail jumpsuit" }
+    "name": { "str": "hardened steel chainmail jumpsuit" }
   },
   {
     "id": "qt_chainmail_jumpsuit",
@@ -2098,14 +2097,14 @@
     "type": "ARMOR",
     "copy-from": "xl_chainmail_jumpsuit",
     "replace_materials": { "steel": "qt_steel_chain" },
-    "name": { "str": "XL tempered steel chainmail jumpsuit" }
+    "name": { "str": "tempered steel chainmail jumpsuit" }
   },
   {
     "id": "qt_chainmail_jumpsuit_xs",
     "type": "ARMOR",
     "copy-from": "xs_chainmail_jumpsuit",
     "replace_materials": { "steel": "qt_steel_chain" },
-    "name": { "str": "XS tempered steel chainmail jumpsuit" }
+    "name": { "str": "tempered steel chainmail jumpsuit" }
   },
   {
     "abstract": "base_chainmail_suit",
@@ -2183,7 +2182,7 @@
   {
     "abstract": "xl_chainmail_suit",
     "type": "ARMOR",
-    "name": { "str": "XL chainmail armor" },
+    "name": { "str": "chainmail armor" },
     "copy-from": "base_chainmail_suit",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
     "pocket_data": [
@@ -2243,13 +2242,13 @@
         "flag_restriction": [ "ABLATIVE_CHAINMAIL_KNEES" ]
       }
     ],
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "abstract": "xs_chainmail_suit",
     "type": "ARMOR",
     "copy-from": "base_chainmail_suit",
-    "name": { "str": "XS chainmail armor" },
+    "name": { "str": "chainmail armor" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
     "pocket_data": [
       {
@@ -2308,7 +2307,7 @@
         "flag_restriction": [ "ABLATIVE_CHAINMAIL_KNEES" ]
       }
     ],
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "chainmail_junk_suit",
@@ -2338,14 +2337,14 @@
     "type": "ARMOR",
     "copy-from": "xl_chainmail_suit",
     "replace_materials": { "steel": "lc_steel_chain" },
-    "name": { "str": "XL mild steel chainmail armor" }
+    "name": { "str": "mild steel chainmail armor" }
   },
   {
     "id": "lc_chainmail_suit_xs",
     "type": "ARMOR",
     "copy-from": "xs_chainmail_suit",
     "replace_materials": { "steel": "lc_steel_chain" },
-    "name": { "str": "XS mild steel chainmail armor" }
+    "name": { "str": "mild steel chainmail armor" }
   },
   {
     "id": "mc_chainmail_suit",
@@ -2359,14 +2358,14 @@
     "type": "ARMOR",
     "copy-from": "xl_chainmail_suit",
     "replace_materials": { "steel": "mc_steel_chain" },
-    "name": { "str": "XL medium steel chainmail armor" }
+    "name": { "str": "medium steel chainmail armor" }
   },
   {
     "id": "mc_chainmail_suit_xs",
     "type": "ARMOR",
     "copy-from": "xs_chainmail_suit",
     "replace_materials": { "steel": "mc_steel_chain" },
-    "name": { "str": "XS medium steel chainmail armor" }
+    "name": { "str": "medium steel chainmail armor" }
   },
   {
     "id": "hc_chainmail_suit",
@@ -2380,14 +2379,14 @@
     "type": "ARMOR",
     "copy-from": "xl_chainmail_suit",
     "replace_materials": { "steel": "hc_steel_chain" },
-    "name": { "str": "XL high steel chainmail armor" }
+    "name": { "str": "high steel chainmail armor" }
   },
   {
     "id": "hc_chainmail_suit_xs",
     "type": "ARMOR",
     "copy-from": "xs_chainmail_suit",
     "replace_materials": { "steel": "hc_steel_chain" },
-    "name": { "str": "XS high steel chainmail armor" }
+    "name": { "str": "high steel chainmail armor" }
   },
   {
     "id": "ch_chainmail_suit",
@@ -2401,14 +2400,14 @@
     "type": "ARMOR",
     "copy-from": "xl_chainmail_suit",
     "replace_materials": { "steel": "ch_steel_chain" },
-    "name": { "str": "XL hardened steel chainmail armor" }
+    "name": { "str": "hardened steel chainmail armor" }
   },
   {
     "id": "ch_chainmail_suit_xs",
     "type": "ARMOR",
     "copy-from": "xs_chainmail_suit",
     "replace_materials": { "steel": "ch_steel_chain" },
-    "name": { "str": "XS hardened steel chainmail armor" }
+    "name": { "str": "hardened steel chainmail armor" }
   },
   {
     "id": "qt_chainmail_suit",
@@ -2422,14 +2421,14 @@
     "type": "ARMOR",
     "copy-from": "xl_chainmail_suit",
     "replace_materials": { "steel": "qt_steel_chain" },
-    "name": { "str": "XL tempered steel chainmail armor" }
+    "name": { "str": "tempered steel chainmail armor" }
   },
   {
     "id": "qt_chainmail_suit_xs",
     "type": "ARMOR",
     "copy-from": "xs_chainmail_suit",
     "replace_materials": { "steel": "qt_steel_chain" },
-    "name": { "str": "XS tempered steel chainmail armor" }
+    "name": { "str": "tempered steel chainmail armor" }
   },
   {
     "id": "chainmail_suit_faraday",
@@ -2495,7 +2494,7 @@
     "id": "xl_chainmail_suit_faraday",
     "type": "ARMOR",
     "copy-from": "chainmail_suit_faraday",
-    "name": { "str": "XL faraday chainmail suit" },
+    "name": { "str": "faraday chainmail suit" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
     "pocket_data": [
       {
@@ -2544,14 +2543,14 @@
         "flag_restriction": [ "ABLATIVE_CHAINMAIL_KNEES" ]
       }
     ],
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "chainmail_suit_faraday_xs",
     "type": "ARMOR",
     "copy-from": "chainmail_suit_faraday",
     "looks_like": "chainmail_suit_faraday",
-    "name": { "str": "XS faraday chainmail suit" },
+    "name": { "str": "faraday chainmail suit" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
     "pocket_data": [
       {
@@ -2600,7 +2599,7 @@
         "flag_restriction": [ "ABLATIVE_CHAINMAIL_KNEES" ]
       }
     ],
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "cleansuit",
@@ -2659,19 +2658,19 @@
   {
     "id": "xl_entry_suit",
     "type": "ARMOR",
-    "name": { "str": "XL entry suit" },
+    "name": { "str": "entry suit" },
     "copy-from": "entry_suit",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "entry_suit_xs",
     "type": "ARMOR",
     "copy-from": "entry_suit",
     "looks_like": "entry_suit",
-    "name": { "str": "XS entry suit" },
+    "name": { "str": "entry suit" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "bite_suit",
@@ -2784,19 +2783,19 @@
   {
     "id": "xl_nomex_suit",
     "type": "ARMOR",
-    "name": { "str": "XL flame-resistant suit" },
+    "name": { "str": "flame-resistant suit" },
     "copy-from": "nomex_suit",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "nomex_suit_xs",
     "type": "ARMOR",
     "copy-from": "nomex_suit",
     "looks_like": "nomex_suit",
-    "name": { "str": "XS flame-resistant suit" },
+    "name": { "str": "flame-resistant suit" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "robofac_enviro_suit",

--- a/data/json/items/armor/swimming.json
+++ b/data/json/items/armor/swimming.json
@@ -630,17 +630,17 @@
     "id": "xl_wetsuit_booties",
     "type": "ARMOR",
     "copy-from": "wetsuit_booties",
-    "name": { "str": "pair of XL diving socks", "str_pl": "pairs of XL diving socks" },
+    "name": { "str": "pair of diving socks", "str_pl": "pairs of diving socks" },
     "proportional": { "weight": 1.25, "volume": 1.25, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_wetsuit_booties",
     "type": "ARMOR",
     "copy-from": "wetsuit_booties",
-    "name": { "str": "pair of XS diving socks", "str_pl": "pairs of XS diving socks" },
+    "name": { "str": "pair of diving socks", "str_pl": "pairs of diving socks" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.75 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "wetsuit_booties_thick",
@@ -702,17 +702,17 @@
     "id": "xl_wetsuit_booties_thick",
     "type": "ARMOR",
     "copy-from": "wetsuit_booties_thick",
-    "name": { "str": "pair of XL diving socks", "str_pl": "pairs of XL diving socks" },
+    "name": { "str": "pair of thick diving boots", "str_pl": "pairs of thick diving boots" },
     "proportional": { "weight": 1.25, "volume": 1.25, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_wetsuit_booties_thick",
     "type": "ARMOR",
     "copy-from": "wetsuit_booties_thick",
-    "name": { "str": "pair of XS diving socks", "str_pl": "pairs of XS diving socks" },
+    "name": { "str": "pair of thick diving boots", "str_pl": "pairs of thick diving boots" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.75 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "swim_fins",
@@ -812,17 +812,17 @@
     "id": "xl_wetsuit",
     "type": "ARMOR",
     "copy-from": "wetsuit",
-    "name": { "str": "XL wetsuit" },
+    "name": { "str": "wetsuit" },
     "proportional": { "weight": 1.25, "volume": 1.25, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_wetsuit",
     "type": "ARMOR",
     "copy-from": "wetsuit",
-    "name": { "str": "XS wetsuit" },
+    "name": { "str": "wetsuit" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.75 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "wetsuit_thick",
@@ -878,17 +878,17 @@
     "id": "xl_wetsuit_thick",
     "type": "ARMOR",
     "copy-from": "wetsuit_thick",
-    "name": { "str": "XL thick wetsuit" },
+    "name": { "str": "thick wetsuit" },
     "proportional": { "weight": 1.25, "volume": 1.25, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_wetsuit_thick",
     "type": "ARMOR",
     "copy-from": "wetsuit_thick",
-    "name": { "str": "XS thick wetsuit" },
+    "name": { "str": "thick wetsuit" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.75 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "wetsuit_hood",
@@ -922,17 +922,17 @@
     "id": "xl_wetsuit_hood",
     "type": "ARMOR",
     "copy-from": "wetsuit_hood",
-    "name": { "str": "XL wetsuit hood" },
+    "name": { "str": "wetsuit hood" },
     "proportional": { "weight": 1.25, "volume": 1.25, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_wetsuit_hood",
     "type": "ARMOR",
     "copy-from": "wetsuit_hood",
-    "name": { "str": "XS wetsuit hood" },
+    "name": { "str": "wetsuit hood" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.75 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "wetsuit_hood_thick",
@@ -960,17 +960,17 @@
     "id": "xl_wetsuit_hood_thick",
     "type": "ARMOR",
     "copy-from": "wetsuit_hood_thick",
-    "name": { "str": "XL thick wetsuit hood" },
+    "name": { "str": "thick wetsuit hood" },
     "proportional": { "weight": 1.25, "volume": 1.25, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_wetsuit_hood_thick",
     "type": "ARMOR",
     "copy-from": "wetsuit_hood_thick",
-    "name": { "str": "XS thick wetsuit hood" },
+    "name": { "str": "thick wetsuit hood" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.75 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "wetsuit_jacket",
@@ -1014,17 +1014,17 @@
     "id": "xl_wetsuit_jacket",
     "type": "ARMOR",
     "copy-from": "wetsuit_jacket",
-    "name": { "str": "XL wetsuit jacket" },
+    "name": { "str": "wetsuit jacket" },
     "proportional": { "weight": 1.25, "volume": 1.25, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_wetsuit_jacket",
     "type": "ARMOR",
     "copy-from": "wetsuit_jacket",
-    "name": { "str": "XS wetsuit jacket" },
+    "name": { "str": "wetsuit jacket" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.75 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "wetsuit_top",
@@ -1077,17 +1077,17 @@
     "id": "xl_wetsuit_top",
     "type": "ARMOR",
     "copy-from": "wetsuit_top",
-    "name": { "str": "XL wetsuit shirt" },
+    "name": { "str": "wetsuit shirt" },
     "proportional": { "weight": 1.25, "volume": 1.25, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_wetsuit_top",
     "type": "ARMOR",
     "copy-from": "wetsuit_top",
-    "name": { "str": "XS wetsuit shirt" },
+    "name": { "str": "wetsuit shirt" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.75 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "wetsuit_top_sleeved_thin",
@@ -1125,17 +1125,17 @@
     "id": "xl_wetsuit_top_sleeved_thin",
     "type": "ARMOR",
     "copy-from": "wetsuit_top_sleeved_thin",
-    "name": { "str": "XL thin wetsuit long-sleeved shirt" },
+    "name": { "str": "thin wetsuit long-sleeved shirt" },
     "proportional": { "weight": 1.25, "volume": 1.25, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_wetsuit_top_sleeved_thin",
     "type": "ARMOR",
     "copy-from": "wetsuit_top_sleeved_thin",
-    "name": { "str": "XS thin wetsuit long-sleeved shirt" },
+    "name": { "str": "thin wetsuit long-sleeved shirt" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.75 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "wetsuit_top_sleeved",
@@ -1179,17 +1179,17 @@
     "id": "xl_wetsuit_top_sleeved",
     "type": "ARMOR",
     "copy-from": "wetsuit_top_sleeved",
-    "name": { "str": "XL wetsuit long-sleeved shirt" },
+    "name": { "str": "wetsuit long-sleeved shirt" },
     "proportional": { "weight": 1.25, "volume": 1.25, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_wetsuit_top_sleeved",
     "type": "ARMOR",
     "copy-from": "wetsuit_top_sleeved",
-    "name": { "str": "XS wetsuit long-sleeved shirt" },
+    "name": { "str": "wetsuit long-sleeved shirt" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.75 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "wetsuit_pants_thin",
@@ -1218,17 +1218,17 @@
     "id": "xl_wetsuit_pants_thin",
     "type": "ARMOR",
     "copy-from": "wetsuit_pants_thin",
-    "name": { "str_sp": "XL thin wetsuit pants" },
+    "name": { "str_sp": "thin wetsuit pants" },
     "proportional": { "weight": 1.25, "volume": 1.25, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_wetsuit_pants_thin",
     "type": "ARMOR",
     "copy-from": "wetsuit_pants_thin",
-    "name": { "str_sp": "XS thin wetsuit pants" },
+    "name": { "str_sp": "thin wetsuit pants" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.75 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "wetsuit_pants",
@@ -1263,17 +1263,17 @@
     "id": "xl_wetsuit_pants",
     "type": "ARMOR",
     "copy-from": "wetsuit_pants",
-    "name": { "str_sp": "XL wetsuit pants" },
+    "name": { "str_sp": "wetsuit pants" },
     "proportional": { "weight": 1.25, "volume": 1.25, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_wetsuit_pants",
     "type": "ARMOR",
     "copy-from": "wetsuit_pants",
-    "name": { "str_sp": "XS wetsuit pants" },
+    "name": { "str_sp": "wetsuit pants" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.75 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "wetsuit_shorts",
@@ -1317,17 +1317,17 @@
     "id": "xl_wetsuit_shorts",
     "type": "ARMOR",
     "copy-from": "wetsuit_shorts",
-    "name": { "str_sp": "XL wetsuit shorts" },
+    "name": { "str_sp": "wetsuit shorts" },
     "proportional": { "weight": 1.25, "volume": 1.25, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_wetsuit_shorts",
     "type": "ARMOR",
     "copy-from": "wetsuit_shorts",
-    "name": { "str_sp": "XS wetsuit shorts" },
+    "name": { "str_sp": "wetsuit shorts" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.75 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "wetsuit_shorts_technical",
@@ -1461,7 +1461,7 @@
     "id": "xl_wetsuit_shorts_technical",
     "type": "ARMOR",
     "copy-from": "wetsuit_shorts_technical",
-    "name": { "str_sp": "XL wetsuit technical shorts" },
+    "name": { "str_sp": "wetsuit technical shorts" },
     "proportional": { "weight": 1.25, "volume": 1.25, "price": 1.25 },
     "use_action": {
       "type": "transform",
@@ -1469,13 +1469,13 @@
       "target": "xl_wetsuit_shorts_technical_loose",
       "menu_text": "Loosen"
     },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_wetsuit_shorts_technical",
     "type": "ARMOR",
     "copy-from": "wetsuit_shorts_technical",
-    "name": { "str_sp": "XS wetsuit technical shorts" },
+    "name": { "str_sp": "wetsuit technical shorts" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.75 },
     "use_action": {
       "type": "transform",
@@ -1483,7 +1483,7 @@
       "target": "xs_wetsuit_shorts_technical_loose",
       "menu_text": "Loosen"
     },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "wetsuit_shorts_technical_loose",
@@ -1498,7 +1498,7 @@
     "id": "xl_wetsuit_shorts_technical_loose",
     "type": "ARMOR",
     "copy-from": "xl_wetsuit_shorts_technical",
-    "name": { "str_sp": "XL wetsuit technical shorts (loose)" },
+    "name": { "str_sp": "wetsuit technical shorts (loose)" },
     "use_action": { "type": "transform", "msg": "You tighten your %s.", "target": "xl_wetsuit_shorts_technical", "menu_text": "Tighten" },
     "delete": { "flags": [ "SKINTIGHT" ] }
   },
@@ -1506,7 +1506,7 @@
     "id": "xs_wetsuit_shorts_technical_loose",
     "type": "ARMOR",
     "copy-from": "xs_wetsuit_shorts_technical",
-    "name": { "str_sp": "XS wetsuit technical shorts (loose)" },
+    "name": { "str_sp": "wetsuit technical shorts (loose)" },
     "use_action": { "type": "transform", "msg": "You tighten your %s.", "target": "xs_wetsuit_shorts_technical", "menu_text": "Tighten" },
     "delete": { "flags": [ "SKINTIGHT" ] }
   },
@@ -1583,17 +1583,17 @@
     "id": "xl_wetsuit_spring",
     "type": "ARMOR",
     "copy-from": "wetsuit_spring",
-    "name": { "str": "XL spring suit" },
+    "name": { "str": "spring suit" },
     "proportional": { "weight": 1.25, "volume": 1.25, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_wetsuit_spring",
     "type": "ARMOR",
     "copy-from": "wetsuit_spring",
-    "name": { "str": "XS spring suit" },
+    "name": { "str": "spring suit" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.75 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "wetsuit_spring_sleeveless",
@@ -1638,17 +1638,17 @@
     "id": "xl_wetsuit_spring_sleeveless",
     "type": "ARMOR",
     "copy-from": "wetsuit_spring_sleeveless",
-    "name": { "str": "XL sleeveless spring suit" },
+    "name": { "str": "sleeveless spring suit" },
     "proportional": { "weight": 1.25, "volume": 1.25, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_wetsuit_spring_sleeveless",
     "type": "ARMOR",
     "copy-from": "wetsuit_spring_sleeveless",
-    "name": { "str": "XS sleeveless spring suit" },
+    "name": { "str": "sleeveless spring suit" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.75 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "shark_suit_faraday",
@@ -1687,17 +1687,17 @@
     "id": "xl_shark_suit_faraday",
     "type": "ARMOR",
     "copy-from": "shark_suit_faraday",
-    "name": { "str": "XL faraday sharksuit" },
+    "name": { "str": "faraday sharksuit" },
     "proportional": { "weight": 1.25, "volume": 1.25, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_shark_suit_faraday",
     "type": "ARMOR",
     "copy-from": "shark_suit_faraday",
-    "name": { "str": "XS faraday sharksuit" },
+    "name": { "str": "faraday sharksuit" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.75 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "shark_suit",
@@ -1736,17 +1736,17 @@
     "id": "xl_shark_suit",
     "type": "ARMOR",
     "copy-from": "shark_suit_faraday",
-    "name": { "str": "XL sharksuit" },
+    "name": { "str": "sharksuit" },
     "proportional": { "weight": 1.25, "volume": 1.25, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_shark_suit",
     "type": "ARMOR",
     "copy-from": "shark_suit",
-    "name": { "str": "XS sharksuit" },
+    "name": { "str": "sharksuit" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.75 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "goggles_swim",
@@ -1811,17 +1811,17 @@
     "id": "xl_wetsuit_gloves",
     "type": "ARMOR",
     "copy-from": "wetsuit_gloves",
-    "name": { "str": "pair of XL diving gloves", "str_pl": "pairs of XL diving gloves" },
+    "name": { "str": "pair of diving gloves", "str_pl": "pairs of diving gloves" },
     "proportional": { "weight": 1.25, "volume": 1.25, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_wetsuit_gloves",
     "type": "ARMOR",
     "copy-from": "wetsuit_gloves",
-    "name": { "str": "pair of XS diving gloves", "str_pl": "pairs of XS diving gloves" },
+    "name": { "str": "pair of diving gloves", "str_pl": "pairs of diving gloves" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.75 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "wetsuit_gloves_thick",
@@ -1849,17 +1849,17 @@
     "id": "xl_wetsuit_gloves_thick",
     "type": "ARMOR",
     "copy-from": "wetsuit_gloves_thick",
-    "name": { "str": "pair of thick XL diving gloves", "str_pl": "pairs of thick XL diving gloves" },
+    "name": { "str": "pair of thick diving gloves", "str_pl": "pairs of thick diving gloves" },
     "proportional": { "weight": 1.25, "volume": 1.25, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_wetsuit_gloves_thick",
     "type": "ARMOR",
     "copy-from": "wetsuit_gloves_thick",
-    "name": { "str": "pair of thick XS diving gloves", "str_pl": "pairs of thick XS diving gloves" },
+    "name": { "str": "pair of thick diving gloves", "str_pl": "pairs of thick diving gloves" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.75 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "divemask_full_scuba_notready",

--- a/data/json/items/armor/torso_armor.json
+++ b/data/json/items/armor/torso_armor.json
@@ -24,19 +24,18 @@
   {
     "id": "xl_armor_cuirass",
     "type": "ARMOR",
-    "name": { "str": "XL bell cuirass", "str_pl": "XL bell cuirasses" },
+    "name": { "str": "bell cuirass", "str_pl": "bell cuirasses" },
     "copy-from": "armor_cuirass",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_armor_cuirass",
     "type": "ARMOR",
     "copy-from": "armor_cuirass",
-    "looks_like": "armor_cuirass",
-    "name": { "str": "XS bell cuirass", "str_pl": "XS bell cuirasses" },
+    "name": { "str": "bell cuirass", "str_pl": "bell cuirasses" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "cuirass_bronze",
@@ -63,18 +62,18 @@
   {
     "id": "xl_cuirass_bronze",
     "type": "ARMOR",
-    "name": { "str": "XL bronze cuirass", "str_pl": "XL bronze cuirasses" },
+    "name": { "str": "bronze cuirass", "str_pl": "bronze cuirasses" },
     "copy-from": "cuirass_bronze",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_cuirass_bronze",
     "type": "ARMOR",
-    "name": { "str": "XS bronze cuirass", "str_pl": "XS bronze cuirasses" },
+    "name": { "str": "bronze cuirass", "str_pl": "bronze cuirasses" },
     "copy-from": "cuirass_bronze",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "armor_lamellar",
@@ -117,19 +116,18 @@
   {
     "id": "xl_armor_lamellar",
     "type": "ARMOR",
-    "name": { "str": "XL leather lamellar cuirass", "str_pl": "XL leather lamellar cuirasses" },
+    "name": { "str": "leather lamellar cuirass", "str_pl": "leather lamellar cuirasses" },
     "copy-from": "armor_lamellar",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_armor_lamellar",
     "type": "ARMOR",
     "copy-from": "armor_lamellar",
-    "looks_like": "armor_lamellar",
-    "name": { "str": "XS leather lamellar cuirass", "str_pl": "XS leather lamellar cuirasses" },
+    "name": { "str": "leather lamellar cuirass", "str_pl": "leather lamellar cuirasses" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "armor_lamellar_lc",
@@ -180,20 +178,20 @@
   {
     "id": "xl_armor_lamellar_lc",
     "type": "ARMOR",
-    "name": { "str": "XL mild steel lamellar cuirass", "str_pl": "XL mild steel lamellar cuirasses" },
+    "name": { "str": "mild steel lamellar cuirass", "str_pl": "mild steel lamellar cuirasses" },
     "description": "A cuirass made of small strips of sheet metal laced together, something of an intermediary between chain mail and plate armor.  The perfect size for an orc or bipedal grizzly bear.",
     "copy-from": "armor_lamellar_lc",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_armor_lamellar_lc",
     "type": "ARMOR",
     "copy-from": "armor_lamellar_lc",
-    "name": { "str": "XS mild steel lamellar cuirass", "str_pl": "XS mild steel lamellar cuirasses" },
+    "name": { "str": "mild steel lamellar cuirass", "str_pl": "mild steel lamellar cuirasses" },
     "description": "A cuirass made of small strips of sheet metal laced together, something of an intermediary between chain mail and plate armor.  Perfectly sized for a particularly angry rat-person, yes-yes.",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "armor_lamellar_ch",
@@ -201,26 +199,25 @@
     "copy-from": "armor_lamellar_lc",
     "name": { "str": "hardened steel lamellar cuirass", "str_pl": "hardened steel lamellar cuirasses" },
     "description": "A cuirass made of small strips of sheet metal laced together, something of an intermediary between chain mail and plate armor.  This one has been hardened for extra protection.",
-    "looks_like": "armor_lamellar_lc",
     "replace_materials": { "lc_steel": "ch_steel" }
   },
   {
     "id": "xl_armor_lamellar_ch",
     "type": "ARMOR",
-    "name": { "str": "XL hardened steel lamellar cuirass", "str_pl": "XL hardened steel lamellar cuirasses" },
+    "name": { "str": "hardened steel lamellar cuirass", "str_pl": "hardened steel lamellar cuirasses" },
     "description": "A hardened cuirass made of small strips of sheet metal laced together, something of an intermediary between chain mail and plate armor.  Built larger for a minotaur guarding their labyrinth.",
     "copy-from": "armor_lamellar_ch",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_armor_lamellar_ch",
     "type": "ARMOR",
     "copy-from": "armor_lamellar_ch",
-    "name": { "str": "XS hardened steel lamellar cuirass", "str_pl": "XS hardened steel lamellar cuirasses" },
+    "name": { "str": "hardened steel lamellar cuirass", "str_pl": "hardened steel lamellar cuirasses" },
     "description": "A hardened cuirass made of small strips of sheet metal laced together, something of an intermediary between chain mail and plate armor.  Just the right size for a fantasy dwarf.",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "carpet_cuirass",
@@ -311,19 +308,18 @@
   {
     "id": "xl_armor_lorica",
     "type": "ARMOR",
-    "name": { "str_sp": "XL lorica segmentata" },
+    "name": { "str_sp": "lorica segmentata" },
     "copy-from": "armor_lorica",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "flags": [ "VARSIZE", "STURDY", "OVERSIZE", "OUTER" ]
+    "flags": [ "VARSIZE", "STURDY", "OVERSIZE", "PREFIX_XL", "OUTER" ]
   },
   {
     "id": "xs_armor_lorica",
     "type": "ARMOR",
     "copy-from": "armor_lorica",
-    "looks_like": "armor_lorica",
-    "name": { "str_sp": "XS lorica segmentata" },
+    "name": { "str_sp": "lorica segmentata" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "armor_thessalonian",
@@ -572,7 +568,7 @@
   {
     "abstract": "xl_chainmail_vest",
     "type": "ARMOR",
-    "name": { "str": "XL chainmail vest" },
+    "name": { "str": "chainmail vest" },
     "copy-from": "base_chainmail_vest",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
     "pocket_data": [
@@ -588,13 +584,13 @@
         "flag_restriction": [ "ABLATIVE_CHAINMAIL_TORSO" ]
       }
     ],
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "abstract": "xs_chainmail_vest",
     "type": "ARMOR",
     "copy-from": "base_chainmail_vest",
-    "name": { "str": "XS chainmail vest" },
+    "name": { "str": "chainmail vest" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
     "pocket_data": [
       {
@@ -609,7 +605,7 @@
         "flag_restriction": [ "ABLATIVE_CHAINMAIL_TORSO" ]
       }
     ],
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "chainmail_junk_vest",
@@ -631,14 +627,14 @@
     "copy-from": "xl_chainmail_vest",
     "replace_materials": { "steel": "lc_steel_chain" },
     "type": "ARMOR",
-    "name": { "str": "XL mild steel chainmail vest" }
+    "name": { "str": "mild steel chainmail vest" }
   },
   {
     "id": "xs_lc_chainmail_vest",
     "copy-from": "xs_chainmail_vest",
     "replace_materials": { "steel": "lc_steel_chain" },
     "type": "ARMOR",
-    "name": { "str": "XS mild steel chainmail vest" }
+    "name": { "str": "mild steel chainmail vest" }
   },
   {
     "id": "mc_chainmail_vest",
@@ -652,14 +648,14 @@
     "copy-from": "xl_chainmail_vest",
     "replace_materials": { "steel": "mc_steel_chain" },
     "type": "ARMOR",
-    "name": { "str": "XL medium steel chainmail vest" }
+    "name": { "str": "medium steel chainmail vest" }
   },
   {
     "id": "xs_mc_chainmail_vest",
     "copy-from": "xs_chainmail_vest",
     "replace_materials": { "steel": "mc_steel_chain" },
     "type": "ARMOR",
-    "name": { "str": "XS medium steel chainmail vest" }
+    "name": { "str": "medium steel chainmail vest" }
   },
   {
     "id": "hc_chainmail_vest",
@@ -673,14 +669,14 @@
     "copy-from": "xl_chainmail_vest",
     "replace_materials": { "steel": "hc_steel_chain" },
     "type": "ARMOR",
-    "name": { "str": "XL high steel chainmail vest" }
+    "name": { "str": "high steel chainmail vest" }
   },
   {
     "id": "xs_hc_chainmail_vest",
     "copy-from": "xs_chainmail_vest",
     "replace_materials": { "steel": "hc_steel_chain" },
     "type": "ARMOR",
-    "name": { "str": "XS high steel chainmail vest" }
+    "name": { "str": "high steel chainmail vest" }
   },
   {
     "id": "ch_chainmail_vest",
@@ -694,14 +690,14 @@
     "copy-from": "xl_chainmail_vest",
     "replace_materials": { "steel": "ch_steel_chain" },
     "type": "ARMOR",
-    "name": { "str": "XL hardened steel chainmail vest" }
+    "name": { "str": "hardened steel chainmail vest" }
   },
   {
     "id": "xs_ch_chainmail_vest",
     "copy-from": "xs_chainmail_vest",
     "replace_materials": { "steel": "ch_steel_chain" },
     "type": "ARMOR",
-    "name": { "str": "XS hardened steel chainmail vest" }
+    "name": { "str": "hardened steel chainmail vest" }
   },
   {
     "id": "qt_chainmail_vest",
@@ -715,14 +711,14 @@
     "copy-from": "xl_chainmail_vest",
     "replace_materials": { "steel": "qt_steel_chain" },
     "type": "ARMOR",
-    "name": { "str": "XL tempered steel chainmail vest" }
+    "name": { "str": "tempered steel chainmail vest" }
   },
   {
     "id": "xs_qt_chainmail_vest",
     "copy-from": "xs_chainmail_vest",
     "replace_materials": { "steel": "qt_steel_chain" },
     "type": "ARMOR",
-    "name": { "str": "XS tempered steel chainmail vest" }
+    "name": { "str": "tempered steel chainmail vest" }
   },
   {
     "id": "cloth_shirt_padded",
@@ -856,18 +852,18 @@
   {
     "id": "xl_cuirass_lightplate",
     "type": "ARMOR",
-    "name": { "str": "XL cuirass", "str_pl": "XL cuirasses" },
+    "name": { "str": "cuirass", "str_pl": "cuirasses" },
     "copy-from": "cuirass_lightplate",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "flags": [ "VARSIZE", "STURDY", "OVERSIZE", "OUTER" ]
+    "flags": [ "VARSIZE", "STURDY", "OVERSIZE", "PREFIX_XL", "OUTER" ]
   },
   {
     "id": "xs_cuirass_lightplate",
     "type": "ARMOR",
     "copy-from": "cuirass_lightplate",
-    "name": { "str": "XS cuirass", "str_pl": "XS cuirasses" },
+    "name": { "str": "cuirass", "str_pl": "cuirasses" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "cuirass_scrap",
@@ -904,19 +900,18 @@
   {
     "id": "xl_cuirass_scrap",
     "type": "ARMOR",
-    "name": { "str": "XL scrap cuirass", "str_pl": "XL scrap cuirasses" },
+    "name": { "str": "scrap cuirass", "str_pl": "scrap cuirasses" },
     "copy-from": "cuirass_scrap",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_cuirass_scrap",
     "type": "ARMOR",
     "copy-from": "cuirass_scrap",
-    "looks_like": "cuirass_scrap",
-    "name": { "str": "XS scrap cuirass", "str_pl": "XS scrap cuirasses" },
+    "name": { "str": "scrap cuirass", "str_pl": "scrap cuirasses" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "cuirass_tire",
@@ -942,19 +937,18 @@
   {
     "id": "xl_cuirass_tire",
     "type": "ARMOR",
-    "name": { "str": "XL tire cuirass", "str_pl": "XL tire cuirasses" },
+    "name": { "str": "tire cuirass", "str_pl": "tire cuirasses" },
     "copy-from": "cuirass_scrap",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "flags": [ "OVERSIZE", "OUTER", "NONCONDUCTIVE" ]
+    "flags": [ "OVERSIZE", "PREFIX_XL", "OUTER", "NONCONDUCTIVE" ]
   },
   {
     "id": "xs_cuirass_tire",
     "type": "ARMOR",
     "copy-from": "cuirass_tire",
-    "looks_like": "cuirass_tire",
-    "name": { "str": "XS tire cuirass", "str_pl": "XS tire cuirasses" },
+    "name": { "str": "tire cuirass", "str_pl": "tire cuirasses" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "fencing_jacket",
@@ -1249,7 +1243,6 @@
     "price_postapoc": "25 USD",
     "material": [ "rubber", "leather" ],
     "copy-from": "jacket_leather_mod",
-    "looks_like": "jacket_leather_mod",
     "color": "light_gray",
     "armor": [
       {
@@ -1519,7 +1512,6 @@
     "description": "An armored vest made from thick leather and metal plates which have been hardened for superb protection.",
     "price_postapoc": "20 USD",
     "copy-from": "vest_leather_mod",
-    "looks_like": "vest_leather_mod",
     "replace_materials": { "lc_steel": "ch_steel" }
   },
   {
@@ -1569,10 +1561,10 @@
   {
     "id": "xl_armor_lc_light_chestplate",
     "type": "ARMOR",
-    "name": { "str": "XL mild steel light chestplate" },
+    "name": { "str": "mild steel light chestplate" },
     "copy-from": "armor_lc_light_chestplate",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_mc_light_chestplate",
@@ -1585,10 +1577,10 @@
   {
     "id": "xl_armor_mc_light_chestplate",
     "type": "ARMOR",
-    "name": { "str": "XL medium steel light chestplate" },
+    "name": { "str": "medium steel light chestplate" },
     "copy-from": "armor_mc_light_chestplate",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_hc_light_chestplate",
@@ -1601,10 +1593,10 @@
   {
     "id": "xl_armor_hc_light_chestplate",
     "type": "ARMOR",
-    "name": { "str": "XL high steel light chestplate" },
+    "name": { "str": "high steel light chestplate" },
     "copy-from": "armor_hc_light_chestplate",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_ch_light_chestplate",
@@ -1617,10 +1609,10 @@
   {
     "id": "xl_armor_ch_light_chestplate",
     "type": "ARMOR",
-    "name": { "str": "XL hardened light chestplate" },
+    "name": { "str": "hardened light chestplate" },
     "copy-from": "armor_ch_light_chestplate",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_qt_light_chestplate",
@@ -1633,10 +1625,10 @@
   {
     "id": "xl_armor_qt_light_chestplate",
     "type": "ARMOR",
-    "name": { "str": "XL tempered light chestplate" },
+    "name": { "str": "tempered light chestplate" },
     "copy-from": "armor_qt_light_chestplate",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_lc_chestplate",
@@ -1685,10 +1677,10 @@
   {
     "id": "xl_armor_lc_chestplate",
     "type": "ARMOR",
-    "name": { "str": "XL mild steel chestplate" },
+    "name": { "str": "mild steel chestplate" },
     "copy-from": "armor_lc_chestplate",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_mc_chestplate",
@@ -1701,10 +1693,10 @@
   {
     "id": "xl_armor_mc_chestplate",
     "type": "ARMOR",
-    "name": { "str": "XL medium steel chestplate" },
+    "name": { "str": "medium steel chestplate" },
     "copy-from": "armor_mc_chestplate",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_hc_chestplate",
@@ -1717,10 +1709,10 @@
   {
     "id": "xl_armor_hc_chestplate",
     "type": "ARMOR",
-    "name": { "str": "XL high steel chestplate" },
+    "name": { "str": "high steel chestplate" },
     "copy-from": "armor_hc_chestplate",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_ch_chestplate",
@@ -1733,10 +1725,10 @@
   {
     "id": "xl_armor_ch_chestplate",
     "type": "ARMOR",
-    "name": { "str": "XL hardened chestplate" },
+    "name": { "str": "hardened chestplate" },
     "copy-from": "armor_ch_chestplate",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_qt_chestplate",
@@ -1749,10 +1741,10 @@
   {
     "id": "xl_armor_qt_chestplate",
     "type": "ARMOR",
-    "name": { "str": "XL tempered chestplate" },
+    "name": { "str": "tempered chestplate" },
     "copy-from": "armor_qt_chestplate",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_lc_heavy_chestplate",
@@ -1801,10 +1793,10 @@
   {
     "id": "xl_armor_lc_heavy_chestplate",
     "type": "ARMOR",
-    "name": { "str": "XL mild steel heavy chestplate" },
+    "name": { "str": "mild steel heavy chestplate" },
     "copy-from": "armor_lc_heavy_chestplate",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_mc_heavy_chestplate",
@@ -1817,10 +1809,10 @@
   {
     "id": "xl_armor_mc_heavy_chestplate",
     "type": "ARMOR",
-    "name": { "str": "XL medium steel heavy chestplate" },
+    "name": { "str": "medium steel heavy chestplate" },
     "copy-from": "armor_mc_heavy_chestplate",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_hc_heavy_chestplate",
@@ -1833,10 +1825,10 @@
   {
     "id": "xl_armor_hc_heavy_chestplate",
     "type": "ARMOR",
-    "name": { "str": "XL high steel heavy chestplate" },
+    "name": { "str": "high steel heavy chestplate" },
     "copy-from": "armor_hc_heavy_chestplate",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_ch_heavy_chestplate",
@@ -1849,10 +1841,10 @@
   {
     "id": "xl_armor_ch_heavy_chestplate",
     "type": "ARMOR",
-    "name": { "str": "XL hardened heavy chestplate" },
+    "name": { "str": "hardened heavy chestplate" },
     "copy-from": "armor_ch_heavy_chestplate",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_qt_heavy_chestplate",
@@ -1865,10 +1857,10 @@
   {
     "id": "xl_armor_qt_heavy_chestplate",
     "type": "ARMOR",
-    "name": { "str": "XL tempered heavy chestplate" },
+    "name": { "str": "tempered heavy chestplate" },
     "copy-from": "armor_qt_heavy_chestplate",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "survivor_adhoc_leather_shirt",
@@ -2036,19 +2028,18 @@
   {
     "id": "xl_armor_larmor_chest",
     "type": "ARMOR",
-    "name": { "str": "XL leather armor cuirass", "str_pl": "XL leather armor cuirasses" },
+    "name": { "str": "leather armor cuirass", "str_pl": "leather armor cuirasses" },
     "copy-from": "armor_larmor_chest",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "armor_larmor_chest_xs",
     "type": "ARMOR",
     "copy-from": "armor_larmor_chest",
-    "looks_like": "cuirass_bronze",
-    "name": { "str": "XS leather armor cuirass", "str_pl": "XS leather armor cuirasses" },
+    "name": { "str": "leather armor cuirass", "str_pl": "leather armor cuirasses" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "lc_mirror_armor",
@@ -2084,19 +2075,18 @@
   {
     "id": "xl_lc_mirror_armor",
     "type": "ARMOR",
-    "name": { "str": "XL mild steel mirror armor", "str_pl": "sets of XL mild steel mirror armor" },
+    "name": { "str": "mild steel mirror armor", "str_pl": "sets of mild steel mirror armor" },
     "copy-from": "cuirass_lightplate",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_lc_mirror_armor",
     "type": "ARMOR",
     "copy-from": "lc_mirror_armor",
-    "looks_like": "lc_mirror_armor",
-    "name": { "str": "XS mild steel mirror armor", "str_pl": "sets of XS mild steel mirror armor" },
+    "name": { "str": "mild steel mirror armor", "str_pl": "sets of mild steel mirror armor" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "mc_mirror_armor",
@@ -2109,19 +2099,18 @@
   {
     "id": "xl_mc_mirror_armor",
     "type": "ARMOR",
-    "name": { "str": "XL medium steel mirror armor", "str_pl": "sets of XL medium steel mirror armor" },
+    "name": { "str": "medium steel mirror armor", "str_pl": "sets of medium steel mirror armor" },
     "copy-from": "mc_mirror_armor",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_mc_mirror_armor",
     "type": "ARMOR",
     "copy-from": "mc_mirror_armor",
-    "looks_like": "mc_mirror_armor",
-    "name": { "str": "XS medium steel mirror armor", "str_pl": "sets of XS medium steel mirror armor" },
+    "name": { "str": "medium steel mirror armor", "str_pl": "sets of medium steel mirror armor" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "hc_mirror_armor",
@@ -2134,19 +2123,18 @@
   {
     "id": "xl_hc_mirror_armor",
     "type": "ARMOR",
-    "name": { "str": "XL high steel mirror armor", "str_pl": "sets of XL high steel mirror armor" },
+    "name": { "str": "high steel mirror armor", "str_pl": "sets of high steel mirror armor" },
     "copy-from": "hc_mirror_armor",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_hc_mirror_armor",
     "type": "ARMOR",
     "copy-from": "hc_mirror_armor",
-    "looks_like": "hc_mirror_armor",
-    "name": { "str": "XS high steel mirror armor", "str_pl": "sets of XS high steel mirror armor" },
+    "name": { "str": "high steel mirror armor", "str_pl": "sets of high steel mirror armor" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "ch_mirror_armor",
@@ -2159,19 +2147,18 @@
   {
     "id": "xl_ch_mirror_armor",
     "type": "ARMOR",
-    "name": { "str": "XL hardened steel mirror armor", "str_pl": "sets of XL hardened steel mirror armor" },
+    "name": { "str": "hardened steel mirror armor", "str_pl": "sets of hardened steel mirror armor" },
     "copy-from": "ch_mirror_armor",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_ch_mirror_armor",
     "type": "ARMOR",
     "copy-from": "ch_mirror_armor",
-    "looks_like": "ch_mirror_armor",
-    "name": { "str": "XS hardened steel mirror armor", "str_pl": "sets of XS hardened steel mirror armor" },
+    "name": { "str": "hardened steel mirror armor", "str_pl": "sets of hardened steel mirror armor" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "qt_mirror_armor",
@@ -2184,18 +2171,17 @@
   {
     "id": "xl_qt_mirror_armor",
     "type": "ARMOR",
-    "name": { "str": "XL tempered steel mirror armor", "str_pl": "sets of XL tempered steel mirror armor" },
+    "name": { "str": "tempered steel mirror armor", "str_pl": "sets of tempered steel mirror armor" },
     "copy-from": "qt_mirror_armor",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_qt_mirror_armor",
     "type": "ARMOR",
     "copy-from": "qt_mirror_armor",
-    "looks_like": "qt_mirror_armor",
-    "name": { "str": "XS tempered steel mirror armor", "str_pl": "sets of XS tempered steel mirror armor" },
+    "name": { "str": "tempered steel mirror armor", "str_pl": "sets of tempered steel mirror armor" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   }
 ]

--- a/data/json/items/armor/torso_clothes.json
+++ b/data/json/items/armor/torso_clothes.json
@@ -104,13 +104,13 @@
     "id": "waist_apron_long_xl",
     "copy-from": "waist_apron_long",
     "type": "ARMOR",
-    "name": { "str": "XL long waist apron" },
-    "extend": { "flags": [ "OVERSIZE" ] },
+    "name": { "str": "long waist apron" },
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] },
     "proportional": { "weight": 1.5, "volume": 1.5 },
     "variants": [
       {
         "id": "maid_apron_xl",
-        "name": { "str": "XL maid long waist apron" },
+        "name": { "str": "maid long waist apron" },
         "description": "It's colored white with black frilly decorations, commonly used with a maid dress or alone for nighttime activities.",
         "append": true
       }
@@ -120,13 +120,13 @@
     "id": "waist_apron_long_xs",
     "copy-from": "waist_apron_long",
     "type": "ARMOR",
-    "name": { "str": "XS long waist apron" },
-    "extend": { "flags": [ "UNDERSIZE" ] },
+    "name": { "str": "long waist apron" },
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] },
     "proportional": { "weight": 0.5, "volume": 0.5 },
     "variants": [
       {
         "id": "maid_apron_xs",
-        "name": { "str": "XS maid long waist apron" },
+        "name": { "str": "maid long waist apron" },
         "description": "It's colored white with black frilly decorations, commonly used with a maid dress or alone for nighttime activities.",
         "append": true
       }
@@ -237,13 +237,13 @@
     "id": "waist_apron_short_xl",
     "copy-from": "waist_apron_short",
     "type": "ARMOR",
-    "name": { "str": "XL short waist apron" },
-    "extend": { "flags": [ "OVERSIZE" ] },
+    "name": { "str": "short waist apron" },
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] },
     "proportional": { "weight": 1.5, "volume": 1.5 },
     "variants": [
       {
         "id": "maid_apron_xl",
-        "name": { "str": "XL maid short waist apron" },
+        "name": { "str": "maid short waist apron" },
         "description": "It's colored white with black frilly decorations, commonly used with a maid dress or alone for nighttime activities.",
         "append": true
       }
@@ -253,13 +253,13 @@
     "id": "waist_apron_short_xs",
     "copy-from": "waist_apron_short",
     "type": "ARMOR",
-    "name": { "str": "XS short waist apron" },
-    "extend": { "flags": [ "UNDERSIZE" ] },
+    "name": { "str": "short waist apron" },
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] },
     "proportional": { "weight": 0.5, "volume": 0.5 },
     "variants": [
       {
         "id": "maid_apron_xs",
-        "name": { "str": "XS maid short waist apron" },
+        "name": { "str": "maid short waist apron" },
         "description": "It's colored white with black frilly decorations, commonly used with a maid dress or alone for nighttime activities.",
         "append": true
       }
@@ -361,13 +361,13 @@
     "id": "apron_cotton_xl",
     "copy-from": "apron_cotton",
     "type": "ARMOR",
-    "name": { "str": "XL cotton apron" },
-    "extend": { "flags": [ "OVERSIZE" ] },
+    "name": { "str": "cotton apron" },
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] },
     "proportional": { "weight": 1.5, "volume": 1.5 },
     "variants": [
       {
         "id": "maid_apron_xl",
-        "name": { "str": "XL maid apron" },
+        "name": { "str": "maid apron" },
         "description": "It's colored white with black frilly decorations, commonly used with a maid dress or alone for nighttime activities.",
         "append": true
       }
@@ -377,13 +377,13 @@
     "id": "apron_cotton_xs",
     "copy-from": "apron_cotton",
     "type": "ARMOR",
-    "name": { "str": "XS cotton apron" },
-    "extend": { "flags": [ "UNDERSIZE" ] },
+    "name": { "str": "cotton apron" },
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] },
     "proportional": { "weight": 0.5, "volume": 0.5 },
     "variants": [
       {
         "id": "maid_apron_xs",
-        "name": { "str": "XS maid apron" },
+        "name": { "str": "maid apron" },
         "description": "It's colored white with black frilly decorations, commonly used with a maid dress or alone for nighttime activities.",
         "append": true
       }
@@ -1149,16 +1149,16 @@
     "id": "maid_dress_xl",
     "copy-from": "maid_dress",
     "type": "ARMOR",
-    "name": { "str_sp": "XL French maid clothes" },
-    "extend": { "flags": [ "OVERSIZE" ] },
+    "name": { "str_sp": "French maid clothes" },
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] },
     "proportional": { "weight": 1.5, "volume": 1.5 }
   },
   {
     "id": "maid_dress_xs",
     "copy-from": "maid_dress",
     "type": "ARMOR",
-    "name": { "str_sp": "XS French maid clothes" },
-    "extend": { "flags": [ "UNDERSIZE" ] },
+    "name": { "str_sp": "French maid clothes" },
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] },
     "proportional": { "weight": 0.5, "volume": 0.5 }
   },
   {
@@ -1209,16 +1209,16 @@
     "id": "maid_dress_short_xl",
     "copy-from": "maid_dress_short",
     "type": "ARMOR",
-    "name": { "str_sp": "XL short French maid clothes" },
-    "extend": { "flags": [ "OVERSIZE" ] },
+    "name": { "str_sp": "short French maid clothes" },
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] },
     "proportional": { "weight": 1.5, "volume": 1.5 }
   },
   {
     "id": "maid_dress_short_xs",
     "copy-from": "maid_dress_short",
     "type": "ARMOR",
-    "name": { "str_sp": "XS short French maid clothes" },
-    "extend": { "flags": [ "UNDERSIZE" ] },
+    "name": { "str_sp": "short French maid clothes" },
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] },
     "proportional": { "weight": 0.5, "volume": 0.5 }
   },
   {

--- a/data/json/items/armor/undergarment.json
+++ b/data/json/items/armor/undergarment.json
@@ -27,19 +27,19 @@
   {
     "id": "xl_arm_warmers",
     "type": "ARMOR",
-    "name": { "str": "pair of XL arm warmers", "str_pl": "pairs of XL arm warmers" },
+    "name": { "str": "pair of arm warmers", "str_pl": "pairs of arm warmers" },
     "weight": "49 g",
     "volume": "350 ml",
     "copy-from": "arm_warmers",
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_arm_warmers",
     "type": "ARMOR",
     "copy-from": "arm_warmers",
-    "name": { "str": "pair of XS arm warmers", "str_pl": "pairs of XS arm warmers" },
+    "name": { "str": "pair of arm warmers", "str_pl": "pairs of arm warmers" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "bellyband",
@@ -292,17 +292,17 @@
     "id": "xl_binder_top",
     "type": "ARMOR",
     "copy-from": "binder_top",
-    "name": { "str": "XL binder" },
+    "name": { "str": "binder" },
     "proportional": { "weight": 1.5, "volume": 1.5, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_binder_top",
     "type": "ARMOR",
     "copy-from": "binder_top",
-    "name": { "str": "XS binder" },
+    "name": { "str": "binder" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "boxer_briefs",
@@ -325,19 +325,19 @@
   {
     "id": "xlboxer_briefs",
     "type": "ARMOR",
-    "name": { "str": "XL boxer briefs", "str_pl": "pairs of XL boxer briefs" },
+    "name": { "str": "boxer briefs", "str_pl": "pairs of boxer briefs" },
     "weight": "50 g",
     "volume": "350 ml",
     "copy-from": "boxer_briefs",
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xsboxer_briefs",
     "type": "ARMOR",
     "copy-from": "boxer_briefs",
-    "name": { "str": "XS boxer briefs", "str_pl": "pairs of XS boxer briefs" },
+    "name": { "str": "boxer briefs", "str_pl": "pairs of boxer briefs" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "boxer_shorts",
@@ -378,19 +378,19 @@
   {
     "id": "xlboxer_shorts",
     "type": "ARMOR",
-    "name": { "str": "XL boxer shorts", "str_pl": "pairs of XL boxer shorts" },
+    "name": { "str": "boxer shorts", "str_pl": "pairs of boxer shorts" },
     "weight": "72 g",
     "volume": "500 ml",
     "copy-from": "boxer_shorts",
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xsboxer_shorts",
     "type": "ARMOR",
     "copy-from": "boxer_shorts",
-    "name": { "str": "XS boxer shorts", "str_pl": "pairs of XS boxer shorts" },
+    "name": { "str": "boxer shorts", "str_pl": "pairs of boxer shorts" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "boy_shorts",
@@ -431,19 +431,19 @@
   {
     "id": "xlboy_shorts",
     "type": "ARMOR",
-    "name": { "str": "XL boy shorts", "str_pl": "pairs of XL boy shorts" },
+    "name": { "str": "boy shorts", "str_pl": "pairs of boy shorts" },
     "weight": "72 g",
     "volume": "500 ml",
     "copy-from": "boy_shorts",
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xsboy_shorts",
     "type": "ARMOR",
     "copy-from": "boy_shorts",
-    "name": { "str": "XS boy shorts", "str_pl": "pairs of XS boy shorts" },
+    "name": { "str": "boy shorts", "str_pl": "pairs of boy shorts" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "bra",
@@ -467,17 +467,17 @@
     "id": "xl_bra",
     "type": "ARMOR",
     "copy-from": "bra",
-    "name": { "str": "XL bra" },
+    "name": { "str": "bra" },
     "proportional": { "weight": 1.5, "volume": 1.5, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_bra",
     "type": "ARMOR",
     "copy-from": "bra",
-    "name": { "str": "XS bra" },
+    "name": { "str": "bra" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "briefs",
@@ -758,7 +758,7 @@
   {
     "id": "leg_warmers_xl",
     "type": "ARMOR",
-    "name": { "str": "pair of XL leg warmers", "str_pl": "pairs of XL leg warmers" },
+    "name": { "str": "pair of leg warmers", "str_pl": "pairs of leg warmers" },
     "description": "Large, soft, snug cloth sleeves to keep your exotic anatomy warm.",
     "weight": "90 g",
     "volume": "750 ml",
@@ -770,7 +770,7 @@
     "color": "light_gray",
     "warmth": 20,
     "material_thickness": 2,
-    "flags": [ "VARSIZE", "SKINTIGHT", "OVERSIZE" ],
+    "flags": [ "VARSIZE", "SKINTIGHT", "OVERSIZE", "PREFIX_XL" ],
     "armor": [
       {
         "encumbrance": 7,
@@ -785,9 +785,9 @@
     "id": "leg_warmers_xs",
     "type": "ARMOR",
     "copy-from": "leg_warmers",
-    "name": { "str": "pair of XS leg warmers", "str_pl": "pairs of XS leg warmers" },
+    "name": { "str": "pair of leg warmers", "str_pl": "pairs of leg warmers" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "long_underpants",
@@ -912,19 +912,19 @@
   {
     "id": "xlsports_bra",
     "type": "ARMOR",
-    "name": { "str": "XL sports bra" },
+    "name": { "str": "sports bra" },
     "weight": "160 g",
     "volume": "750 ml",
     "copy-from": "sports_bra",
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xssports_bra",
     "type": "ARMOR",
     "copy-from": "sports_bra",
-    "name": { "str": "XS sports bra" },
+    "name": { "str": "sports bra" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "tank_top",

--- a/data/json/items/melee/unarmed_weapons.json
+++ b/data/json/items/melee/unarmed_weapons.json
@@ -47,18 +47,18 @@
   {
     "id": "xl_cestus",
     "type": "ARMOR",
-    "name": { "str": "XL cestus", "str_pl": "XL cesti" },
+    "name": { "str": "cestus", "str_pl": "cesti" },
     "copy-from": "cestus",
     "proportional": { "weight": 1.5, "volume": 1.5 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_cestus",
     "type": "ARMOR",
-    "name": { "str": "XS cestus", "str_pl": "XS cesti" },
+    "name": { "str": "cestus", "str_pl": "cesti" },
     "copy-from": "cestus",
     "proportional": { "weight": 0.75, "volume": 0.75 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "type": "ARMOR",
@@ -87,18 +87,18 @@
   {
     "id": "xl_knuckle_brass",
     "type": "ARMOR",
-    "name": { "str": "pair of XL brass knuckles", "str_pl": "pairs of XL brass knuckles" },
+    "name": { "str": "pair of brass knuckles", "str_pl": "pairs of brass knuckles" },
     "copy-from": "knuckle_brass",
     "proportional": { "weight": 1.5, "volume": 1.5 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_knuckle_brass",
     "type": "ARMOR",
-    "name": { "str": "pair of XS brass knuckles", "str_pl": "pairs of XS brass knuckles" },
+    "name": { "str": "pair of brass knuckles", "str_pl": "pairs of brass knuckles" },
     "copy-from": "knuckle_brass",
     "proportional": { "weight": 0.75, "volume": 0.75 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "type": "ARMOR",
@@ -127,18 +127,18 @@
   {
     "id": "xl_knuckle_nail",
     "type": "ARMOR",
-    "name": { "str": "pair of XL nail knuckles", "str_pl": "pairs of XL nail knuckles" },
+    "name": { "str": "pair of nail knuckles", "str_pl": "pairs of nail knuckles" },
     "copy-from": "knuckle_nail",
     "proportional": { "weight": 1.5, "volume": 1.5 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_knuckle_nail",
     "type": "ARMOR",
-    "name": { "str": "pair of XS nail knuckles", "str_pl": "pairs of XS nail knuckles" },
+    "name": { "str": "pair of nail knuckles", "str_pl": "pairs of nail knuckles" },
     "copy-from": "knuckle_nail",
     "proportional": { "weight": 0.75, "volume": 0.75 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "type": "ARMOR",
@@ -167,18 +167,18 @@
   {
     "id": "xl_knuckle_steel",
     "type": "ARMOR",
-    "name": { "str": "pair of XL scrap knuckles", "str_pl": "pairs of XL scrap knuckles" },
+    "name": { "str": "pair of scrap knuckles", "str_pl": "pairs of scrap knuckles" },
     "copy-from": "knuckle_steel",
     "proportional": { "weight": 1.5, "volume": 1.5 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_knuckle_steel",
     "type": "ARMOR",
-    "name": { "str": "pair of XS scrap knuckles", "str_pl": "pairs of XS scrap knuckles" },
+    "name": { "str": "pair of scrap knuckles", "str_pl": "pairs of scrap knuckles" },
     "copy-from": "knuckle_steel",
     "proportional": { "weight": 0.75, "volume": 0.75 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "type": "ARMOR",
@@ -209,18 +209,18 @@
   {
     "id": "xl_knuckle_steel_forged",
     "type": "ARMOR",
-    "name": { "str": "pair of XL steel knuckles", "str_pl": "pairs of XL steel knuckles" },
+    "name": { "str": "pair of steel knuckles", "str_pl": "pairs of steel knuckles" },
     "copy-from": "knuckle_steel_forged",
     "proportional": { "weight": 1.5, "volume": 1.5 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_knuckle_steel_forged",
     "type": "ARMOR",
-    "name": { "str": "pair of XS steel knuckles", "str_pl": "pairs of XS steel knuckles" },
+    "name": { "str": "pair of steel knuckles", "str_pl": "pairs of steel knuckles" },
     "copy-from": "knuckle_steel_forged",
     "proportional": { "weight": 0.75, "volume": 0.75 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "gloves_studded",
@@ -278,18 +278,18 @@
   {
     "id": "xl_gloves_studded",
     "type": "ARMOR",
-    "name": { "str": "pair of XL studded gloves", "str_pl": "pairs of XL studded gloves" },
+    "name": { "str": "pair of studded gloves", "str_pl": "pairs of studded gloves" },
     "copy-from": "gloves_studded",
     "proportional": { "weight": 1.5, "volume": 1.5 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_gloves_studded",
     "type": "ARMOR",
-    "name": { "str": "pair of XS studded gloves", "str_pl": "pairs of XS studded gloves" },
+    "name": { "str": "pair of studded gloves", "str_pl": "pairs of studded gloves" },
     "copy-from": "gloves_studded",
     "proportional": { "weight": 0.75, "volume": 0.75 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "knuckle_impact",
@@ -320,18 +320,18 @@
   {
     "id": "xl_knuckle_impact",
     "type": "ARMOR",
-    "name": { "str_sp": "XL impact knuckles" },
+    "name": { "str_sp": "impact knuckles" },
     "copy-from": "knuckle_impact",
     "proportional": { "weight": 1.5, "volume": 1.5 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_knuckle_impact",
     "type": "ARMOR",
-    "name": { "str_sp": "XS impact knuckles" },
+    "name": { "str_sp": "impact knuckles" },
     "copy-from": "knuckle_impact",
     "proportional": { "weight": 0.75, "volume": 0.75 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "knuckle_skewer",
@@ -355,17 +355,17 @@
   {
     "id": "xl_knuckle_skewer",
     "type": "ARMOR",
-    "name": { "str_sp": "XL skewer knuckles" },
+    "name": { "str_sp": "skewer knuckles" },
     "copy-from": "knuckle_skewer",
     "proportional": { "weight": 1.5, "volume": 1.5 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "xs_knuckle_skewer",
     "type": "ARMOR",
-    "name": { "str_sp": "XS skewer knuckles" },
+    "name": { "str_sp": "skewer knuckles" },
     "copy-from": "knuckle_skewer",
     "proportional": { "weight": 0.75, "volume": 0.75 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   }
 ]

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -21,7 +21,7 @@
   {
     "id": "arm_xlsplint",
     "type": "ARMOR",
-    "name": { "str": "arm splint XL", "str_pl": "arm splints XL" },
+    "name": { "str": "arm splint" },
     "description": "A tool to help set arm bones and hold them in place.  It is specifically designed to fit Huge survivors.",
     "copy-from": "arm_splint",
     "looks_like": "arm_splint",
@@ -30,12 +30,12 @@
     "price": "250 USD",
     "price_postapoc": "50 cent",
     "material": [ "wood", "cotton" ],
-    "flags": [ "OVERSIZE", "WATER_FRIENDLY", "OUTER", "SPLINT" ]
+    "flags": [ "OVERSIZE", "PREFIX_XL", "WATER_FRIENDLY", "OUTER", "SPLINT" ]
   },
   {
     "id": "arm_xs_splint",
     "type": "ARMOR",
-    "name": { "str": "arm splint XS", "str_pl": "arm splints XS" },
+    "name": { "str": "arm splint" },
     "description": "A tool to help set arm bones and hold them in place.  It is specifically designed to fit Tiny survivors.",
     "copy-from": "arm_splint",
     "looks_like": "arm_splint",
@@ -43,7 +43,7 @@
     "volume": "500 ml",
     "price": "150 USD",
     "price_postapoc": "50 cent",
-    "flags": [ "UNDERSIZE", "WATER_FRIENDLY", "OUTER", "SPLINT" ]
+    "flags": [ "UNDERSIZE", "PREFIX_XS", "WATER_FRIENDLY", "OUTER", "SPLINT" ]
   },
   {
     "id": "tourniquet_upper",
@@ -68,25 +68,25 @@
   {
     "id": "tourniquet_upper_XL",
     "type": "ARMOR",
-    "name": { "str": "tourniquet (arm XL)", "str_pl": "tourniquets (arm XL)" },
+    "name": { "str": "tourniquet (arm)", "str_pl": "tourniquets (arm)" },
     "description": "A first aid device used to apply pressure to a limb or extremity in order to limit blood flow.  Should be employed only to manage heavy bleeding, because prolonged use will harm the limb.  It can be adjusted in size to fit different limbs.",
     "copy-from": "tourniquet_upper",
     "looks_like": "tourniquet_upper",
     "sided": true,
     "use_action": { "target": "tourniquet_upper_XS", "msg": "You adjust the tourniquet.", "menu_text": "Adjust", "type": "transform" },
-    "flags": [ "WATER_FRIENDLY", "OUTER", "TOURNIQUET", "OVERSIZE" ]
+    "flags": [ "WATER_FRIENDLY", "OUTER", "TOURNIQUET", "OVERSIZE", "PREFIX_XL" ]
   },
   {
     "id": "tourniquet_upper_XS",
     "type": "ARMOR",
-    "name": { "str": "tourniquet (arm XS)", "str_pl": "tourniquets (arm XS)" },
+    "name": { "str": "tourniquet (arm)", "str_pl": "tourniquets (arm)" },
     "description": "A first aid device used to apply pressure to a limb or extremity in order to limit blood flow.  Should be employed only to manage heavy bleeding, because prolonged use will harm the limb.  It can be adjusted in size to fit different limbs.",
     "copy-from": "tourniquet_upper",
     "looks_like": "tourniquet_upper",
     "covers": [ "arm_l", "arm_r" ],
     "sided": true,
     "use_action": { "target": "tourniquet_lower", "msg": "You adjust the tourniquet.", "menu_text": "Adjust", "type": "transform" },
-    "flags": [ "WATER_FRIENDLY", "OUTER", "TOURNIQUET", "UNDERSIZE" ]
+    "flags": [ "WATER_FRIENDLY", "OUTER", "TOURNIQUET", "UNDERSIZE", "PREFIX_XS" ]
   },
   {
     "id": "tourniquet_lower",
@@ -104,24 +104,24 @@
   {
     "id": "tourniquet_lower_XL",
     "type": "ARMOR",
-    "name": { "str": "tourniquet (leg XL)", "str_pl": "tourniquets (leg XL)" },
+    "name": { "str": "tourniquet (leg)", "str_pl": "tourniquets (leg)" },
     "description": "A first aid device used to apply pressure to a limb or extremity in order to limit blood flow.  Should be employed only to manage heavy bleeding, because prolonged use will harm the limb.  It can be adjusted in size to fit different limbs.",
     "copy-from": "tourniquet_lower",
     "looks_like": "tourniquet_lower",
     "sided": true,
     "use_action": { "target": "tourniquet_lower_XS", "msg": "You adjust the tourniquet.", "menu_text": "Adjust", "type": "transform" },
-    "flags": [ "WATER_FRIENDLY", "OUTER", "TOURNIQUET", "OVERSIZE", "ALLOWS_TAIL" ]
+    "flags": [ "WATER_FRIENDLY", "OUTER", "TOURNIQUET", "OVERSIZE", "PREFIX_XL", "ALLOWS_TAIL" ]
   },
   {
     "id": "tourniquet_lower_XS",
     "type": "ARMOR",
-    "name": { "str": "tourniquet (leg XS)", "str_pl": "tourniquets (leg XS)" },
+    "name": { "str": "tourniquet (leg)", "str_pl": "tourniquets (leg)" },
     "description": "A first aid device used to apply pressure to a limb or extremity in order to limit blood flow.  Should be employed only to manage heavy bleeding, because prolonged use will harm the limb.  It can be adjusted in size to fit different limbs.",
     "copy-from": "tourniquet_lower",
     "looks_like": "tourniquet_lower",
     "sided": true,
     "use_action": { "target": "tourniquet_upper", "msg": "You adjust the tourniquet.", "menu_text": "Adjust", "type": "transform" },
-    "flags": [ "WATER_FRIENDLY", "OUTER", "TOURNIQUET", "UNDERSIZE", "ALLOWS_TAIL" ]
+    "flags": [ "WATER_FRIENDLY", "OUTER", "TOURNIQUET", "UNDERSIZE", "PREFIX_XS", "ALLOWS_TAIL" ]
   },
   {
     "id": "makeshift_blindfold",
@@ -316,7 +316,7 @@
   {
     "id": "leg_xlsplint",
     "type": "ARMOR",
-    "name": { "str": "leg splint XL", "str_pl": "leg splints XL" },
+    "name": { "str": "leg splint" },
     "description": "A tool to help set leg bones and hold them in place.  It is specifically designed to fit Huge people.",
     "copy-from": "leg_splint",
     "weight": "1000 g",
@@ -324,19 +324,19 @@
     "price": "250 USD",
     "price_postapoc": "50 cent",
     "material": [ "wood", "cotton" ],
-    "flags": [ "OVERSIZE", "WATER_FRIENDLY", "OUTER", "SPLINT", "ALLOWS_TAIL" ]
+    "flags": [ "OVERSIZE", "PREFIX_XL", "WATER_FRIENDLY", "OUTER", "SPLINT", "ALLOWS_TAIL" ]
   },
   {
     "id": "leg_xs_splint",
     "type": "ARMOR",
-    "name": { "str": "leg splint XS", "str_pl": "leg splints XS" },
+    "name": { "str": "leg splint" },
     "description": "A tool to help set leg bones and hold them in place.  It is specifically designed to fit Tiny people.",
     "copy-from": "leg_splint",
     "weight": "250 g",
     "volume": "500 ml",
     "price": "250 USD",
     "price_postapoc": "50 cent",
-    "flags": [ "UNDERSIZE", "WATER_FRIENDLY", "OUTER", "SPLINT", "ALLOWS_TAIL" ]
+    "flags": [ "UNDERSIZE", "PREFIX_XS", "WATER_FRIENDLY", "OUTER", "SPLINT", "ALLOWS_TAIL" ]
   },
   {
     "id": "miner_hat",
@@ -1820,9 +1820,9 @@
     "category": "clothing",
     "symbol": "[",
     "color": "dark_gray",
-    "name": { "str": "XL rebreather mask" },
+    "name": { "str": "rebreather mask" },
     "description": "A mask worn over your mouth which, when loaded with the proper filters, recycles your exhaled breath for rebreathing while underwater.  This model has been expanded substantially and can accommodate exotic anatomy.  Use it to turn it on.",
-    "flags": [ "WATER_FRIENDLY", "OVERSIZE" ],
+    "flags": [ "WATER_FRIENDLY", "OVERSIZE", "PREFIX_XL" ],
     "price": "250 USD",
     "price_postapoc": "5 USD",
     "material": [ "plastic", "aluminum" ],
@@ -1856,10 +1856,10 @@
     "id": "rebreather_xl_on",
     "copy-from": "rebreather_xl",
     "type": "TOOL_ARMOR",
-    "name": { "str": "XL rebreather mask (on)", "str_pl": "XL rebreather masks (on)" },
+    "name": { "str": "rebreather mask (on)", "str_pl": "rebreather masks (on)" },
     "material": [ "plastic", "aluminum" ],
     "description": "A mask worn over your mouth which, when loaded with the proper filters, recycles your exhaled breath for rebreathing while underwater.  This model has been expanded substantially and can accommodate exotic anatomy.  It is turned on, and continually consuming its filter.  Use it to turn it off.",
-    "flags": [ "WATER_FRIENDLY", "REBREATHER", "OVERSIZE", "TRADER_AVOID" ],
+    "flags": [ "WATER_FRIENDLY", "REBREATHER", "OVERSIZE", "PREFIX_XL", "TRADER_AVOID" ],
     "turns_per_charge": 60,
     "revert_to": "rebreather_xl",
     "use_action": {
@@ -1878,9 +1878,9 @@
     "category": "clothing",
     "symbol": "[",
     "color": "dark_gray",
-    "name": { "str": "XS rebreather mask" },
+    "name": { "str": "rebreather mask" },
     "description": "A mask worn over your mouth which, when loaded with the proper filters, recycles your exhaled breath for rebreathing while underwater.  This model has been shrunk dramatically to fit a smaller face.  Use it to turn it on.",
-    "flags": [ "WATER_FRIENDLY", "UNDERSIZE" ],
+    "flags": [ "WATER_FRIENDLY", "UNDERSIZE", "PREFIX_XS" ],
     "price": "250 USD",
     "price_postapoc": "5 USD",
     "material": [ "plastic", "aluminum" ],
@@ -1915,9 +1915,9 @@
     "id": "rebreather_xs_on",
     "copy-from": "rebreather_xs",
     "type": "TOOL_ARMOR",
-    "name": { "str": "XS rebreather mask (on)", "str_pl": "XS rebreather masks (on)" },
+    "name": { "str": "rebreather mask (on)", "str_pl": "rebreather masks (on)" },
     "description": "A mask worn over your mouth which, when loaded with the proper filters, recycles your exhaled breath for rebreathing while underwater.  This model has been shrunk dramatically to fit a smaller face.  It is turned on, and continually consuming its filter.  Use it to turn it off.",
-    "flags": [ "WATER_FRIENDLY", "REBREATHER", "UNDERSIZE", "TRADER_AVOID" ],
+    "flags": [ "WATER_FRIENDLY", "REBREATHER", "UNDERSIZE", "PREFIX_XS", "TRADER_AVOID" ],
     "turns_per_charge": 60,
     "revert_to": "rebreather_xs",
     "use_action": { "type": "transform", "menu_text": "Turn off", "msg": "Your %s deactivates.", "target": "rebreather_xs" },
@@ -1996,7 +1996,7 @@
   {
     "id": "mask_gas_xl",
     "type": "TOOL_ARMOR",
-    "name": { "str": "XL gas mask" },
+    "name": { "str": "gas mask" },
     "category": "clothing",
     "description": "A rather roomy mask with filters attached, designed to accommodate exotic anatomy.  Provides excellent protection from smoke, tear gas, and other contaminants.  It must be prepared before use.",
     "weight": "1397 g",
@@ -2026,12 +2026,12 @@
     "ammo": "gasfilter_m",
     "use_action": [ "GASMASK_ACTIVATE" ],
     "tick_action": [ "GASMASK" ],
-    "flags": [ "OVERSIZE", "SLEEP_IGNORE" ]
+    "flags": [ "OVERSIZE", "PREFIX_XL", "SLEEP_IGNORE" ]
   },
   {
     "id": "mask_gas_xs",
     "type": "TOOL_ARMOR",
-    "name": { "str": "XS gas mask" },
+    "name": { "str": "gas mask" },
     "category": "clothing",
     "description": "A rather small gas mask that covers the face and eyes.  Provides excellent protection from smoke, tear gas, and other contaminants.  It must be prepared before use.",
     "weight": "470 g",
@@ -2061,7 +2061,7 @@
     "ammo": "gasfilter_m",
     "use_action": [ "GASMASK_ACTIVATE" ],
     "tick_action": [ "GASMASK" ],
-    "flags": [ "VARSIZE", "UNDERSIZE", "SLEEP_IGNORE" ]
+    "flags": [ "VARSIZE", "UNDERSIZE", "PREFIX_XS", "SLEEP_IGNORE" ]
   },
   {
     "id": "mask_gas_half",
@@ -2147,18 +2147,18 @@
     "type": "TOOL_ARMOR",
     "copy-from": "mask_fsurvivor",
     "looks_like": "mask_fsurvivor",
-    "name": { "str": "XL survivor firemask" },
+    "name": { "str": "survivor firemask" },
     "proportional": { "weight": 1.25, "volume": 1.25, "price": 0.5 },
-    "flags": [ "VARSIZE", "STURDY", "OVERSIZE", "SUN_GLASSES", "SLEEP_IGNORE", "PADDED", "UNRESTRICTED" ]
+    "flags": [ "VARSIZE", "STURDY", "OVERSIZE", "PREFIX_XL", "SUN_GLASSES", "SLEEP_IGNORE", "PADDED", "UNRESTRICTED" ]
   },
   {
     "id": "mask_fsurvivorxs",
     "type": "TOOL_ARMOR",
     "copy-from": "mask_fsurvivor",
     "looks_like": "mask_fsurvivor",
-    "name": { "str": "XS survivor firemask" },
+    "name": { "str": "survivor firemask" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "flags": [ "VARSIZE", "STURDY", "SUN_GLASSES", "SLEEP_IGNORE", "UNDERSIZE", "PADDED", "UNRESTRICTED" ]
+    "flags": [ "VARSIZE", "STURDY", "SUN_GLASSES", "SLEEP_IGNORE", "UNDERSIZE", "PREFIX_XS", "PADDED", "UNRESTRICTED" ]
   },
   {
     "id": "mask_bunker",
@@ -2262,18 +2262,18 @@
     "type": "TOOL_ARMOR",
     "copy-from": "mask_hsurvivor",
     "looks_like": "mask_hsurvivor",
-    "name": { "str": "XL heavy survivor mask" },
+    "name": { "str": "heavy survivor mask" },
     "proportional": { "weight": 1.25, "volume": 1.25, "price": 0.5 },
-    "flags": [ "VARSIZE", "STURDY", "OVERSIZE", "SUN_GLASSES", "SLEEP_IGNORE", "PADDED", "UNRESTRICTED" ]
+    "flags": [ "VARSIZE", "STURDY", "OVERSIZE", "PREFIX_XL", "SUN_GLASSES", "SLEEP_IGNORE", "PADDED", "UNRESTRICTED" ]
   },
   {
     "id": "mask_hsurvivorxs",
     "type": "TOOL_ARMOR",
     "copy-from": "mask_hsurvivor",
     "looks_like": "mask_hsurvivor",
-    "name": { "str": "XS heavy survivor mask" },
+    "name": { "str": "heavy survivor mask" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "flags": [ "VARSIZE", "STURDY", "SUN_GLASSES", "SLEEP_IGNORE", "UNDERSIZE", "PADDED", "UNRESTRICTED" ]
+    "flags": [ "VARSIZE", "STURDY", "SUN_GLASSES", "SLEEP_IGNORE", "UNDERSIZE", "PREFIX_XS", "PADDED", "UNRESTRICTED" ]
   },
   {
     "id": "mask_lsurvivor",
@@ -2318,18 +2318,18 @@
     "type": "TOOL_ARMOR",
     "copy-from": "mask_lsurvivor",
     "looks_like": "mask_lsurvivor",
-    "name": { "str": "XL survivor half mask" },
+    "name": { "str": "survivor half mask" },
     "proportional": { "weight": 1.25, "volume": 1.25, "price": 0.5 },
-    "flags": [ "VARSIZE", "STURDY", "OVERSIZE", "SUN_GLASSES", "SLEEP_IGNORE", "UNRESTRICTED" ]
+    "flags": [ "VARSIZE", "STURDY", "OVERSIZE", "PREFIX_XL", "SUN_GLASSES", "SLEEP_IGNORE", "UNRESTRICTED" ]
   },
   {
     "id": "mask_lsurvivorxs",
     "type": "TOOL_ARMOR",
     "copy-from": "mask_lsurvivor",
     "looks_like": "mask_lsurvivor",
-    "name": { "str": "XS survivor half mask" },
+    "name": { "str": "survivor half mask" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "flags": [ "VARSIZE", "STURDY", "SUN_GLASSES", "SLEEP_IGNORE", "UNDERSIZE", "UNRESTRICTED" ]
+    "flags": [ "VARSIZE", "STURDY", "SUN_GLASSES", "SLEEP_IGNORE", "UNDERSIZE", "PREFIX_XS", "UNRESTRICTED" ]
   },
   {
     "id": "mask_survivor",
@@ -2380,18 +2380,18 @@
     "type": "TOOL_ARMOR",
     "copy-from": "mask_survivor",
     "looks_like": "mask_survivor",
-    "name": { "str": "XL survivor mask" },
+    "name": { "str": "survivor mask" },
     "proportional": { "weight": 1.25, "volume": 1.25, "price": 0.5 },
-    "flags": [ "VARSIZE", "STURDY", "OVERSIZE", "SUN_GLASSES", "SLEEP_IGNORE", "PADDED", "UNRESTRICTED" ]
+    "flags": [ "VARSIZE", "STURDY", "OVERSIZE", "PREFIX_XL", "SUN_GLASSES", "SLEEP_IGNORE", "PADDED", "UNRESTRICTED" ]
   },
   {
     "id": "mask_survivorxs",
     "type": "TOOL_ARMOR",
     "copy-from": "mask_survivor",
     "looks_like": "mask_survivor",
-    "name": { "str": "XS survivor mask" },
+    "name": { "str": "survivor mask" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "flags": [ "VARSIZE", "STURDY", "SUN_GLASSES", "SLEEP_IGNORE", "UNDERSIZE", "PADDED", "UNRESTRICTED" ]
+    "flags": [ "VARSIZE", "STURDY", "SUN_GLASSES", "SLEEP_IGNORE", "UNDERSIZE", "PREFIX_XS", "PADDED", "UNRESTRICTED" ]
   },
   {
     "id": "goggles_nv",
@@ -2620,10 +2620,10 @@
     "type": "TOOL_ARMOR",
     "copy-from": "mask_h20survivor",
     "looks_like": "mask_h20survivor",
-    "name": { "str": "XL survivor divemask" },
+    "name": { "str": "survivor divemask" },
     "description": "A custom-built, armored rebreather mask that covers the face and eyes.  Provides excellent protection from harm as well providing breathing gas while underwater.  Use it to turn it on.",
     "proportional": { "weight": 1.25, "volume": 1.25, "price": 1.5 },
-    "flags": [ "VARSIZE", "STURDY", "WATER_FRIENDLY", "SWIM_GOGGLES", "OVERSIZE" ],
+    "flags": [ "VARSIZE", "STURDY", "WATER_FRIENDLY", "SWIM_GOGGLES", "OVERSIZE", "PREFIX_XL" ],
     "use_action": {
       "type": "transform",
       "msg": "You activate your %s.",
@@ -2638,7 +2638,7 @@
     "type": "TOOL_ARMOR",
     "copy-from": "mask_h20survivor",
     "looks_like": "mask_h20survivor",
-    "name": { "str": "XS survivor divemask" },
+    "name": { "str": "survivor divemask" },
     "description": "A custom-built, armored rebreather mask that covers the face and eyes.  Provides excellent protection from harm as well providing breathing gas while underwater.  Use it to turn it on.",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
     "use_action": {
@@ -2649,15 +2649,15 @@
       "need_charges": 1,
       "need_charges_msg": "The %s's filter is used up."
     },
-    "flags": [ "VARSIZE", "STURDY", "WATER_FRIENDLY", "SWIM_GOGGLES", "UNDERSIZE" ]
+    "flags": [ "VARSIZE", "STURDY", "WATER_FRIENDLY", "SWIM_GOGGLES", "UNDERSIZE", "PREFIX_XS" ]
   },
   {
     "id": "mask_h20survivorxl_on",
     "copy-from": "mask_h20survivorxl",
     "type": "TOOL_ARMOR",
-    "name": { "str": "XL survivor divemask (on)", "str_pl": "XL survivor divemasks (on)" },
+    "name": { "str": "survivor divemask (on)", "str_pl": "survivor divemasks (on)" },
     "description": "A custom-built, armored rebreather mask that covers the face and eyes regardless of your state of mutation.  Provides excellent protection from harm as well providing breathing gas while underwater.  It is turned on, and continually consuming its filter.  Use it to turn it off.",
-    "flags": [ "VARSIZE", "STURDY", "WATER_FRIENDLY", "REBREATHER", "SWIM_GOGGLES", "OVERSIZE", "TRADER_AVOID" ],
+    "flags": [ "VARSIZE", "STURDY", "WATER_FRIENDLY", "REBREATHER", "SWIM_GOGGLES", "OVERSIZE", "PREFIX_XL", "TRADER_AVOID" ],
     "turns_per_charge": 60,
     "revert_to": "mask_h20survivorxl",
     "use_action": {
@@ -2674,10 +2674,10 @@
     "type": "TOOL_ARMOR",
     "copy-from": "mask_h20survivor",
     "looks_like": "mask_h20survivor",
-    "name": { "str": "XS survivor divemask (on)", "str_pl": "XS survivor divemasks (on)" },
+    "name": { "str": "survivor divemask (on)", "str_pl": "survivor divemasks (on)" },
     "description": "A custom-built, armored rebreather mask that covers the face and eyes.  Provides excellent protection from harm as well providing breathing gas while underwater.  Use it to turn it on.",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "flags": [ "VARSIZE", "STURDY", "WATER_FRIENDLY", "REBREATHER", "SWIM_GOGGLES", "UNDERSIZE", "TRADER_AVOID" ],
+    "flags": [ "VARSIZE", "STURDY", "WATER_FRIENDLY", "REBREATHER", "SWIM_GOGGLES", "UNDERSIZE", "PREFIX_XS", "TRADER_AVOID" ],
     "turns_per_charge": 60,
     "revert_to": "mask_h20survivorxs",
     "use_action": {

--- a/doc/JSON_FLAGS.md
+++ b/doc/JSON_FLAGS.md
@@ -219,6 +219,8 @@ Some armor flags, such as `WATCH` and `ALARMCLOCK` are compatible with other ite
 - ```PERSONAL``` This item goes in the personal aura layer, intended for metaphysical effects.
 - ```POCKETS``` Increases warmth for hands if the player's hands are cold and the player is wielding nothing.
 - ```POWERARMOR_COMPATIBLE``` Makes item compatible with power armor despite other parameters causing failure.
+- ```PREFIX_XL``` Adds the XL prefix to the item name.
+- ```PREFIX_XS``` Adds the XS prefix to the item name.
 - ```PSYSHIELD_PARTIAL``` 25% chance to protect against `fear_paralyze` monster attack when worn.
 - ```RAD_PROOF``` This piece of clothing completely protects you from radiation.
 - ```RAD_RESIST``` This piece of clothing partially (75%) protects you from radiation.


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "Dynamically compose some item names through suffixes/prefixes in JSON tags"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Part of #70352
Many items have separate names that require separate translation.
#71702 made it possible to dynamically add suffixes and prefixes to item names through `item_prefix` and `item_suffix` in JSON tags.
We can try to use this system as a solution (at least temporary)
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Instead of an issue, I created a PR, the first commit contains an example of how this is done. If the PR gets approval, I will complete it.

New tags are created in `data/json/flags.json` with the specified prefixes/suffixes and these flags are added to the desired items. Unnecessary parts are removed from item names, or rather the `name` is copied from the base object (it is not yet possible to completely remove the `name` field, see #71199).
See additional context for details of how this may affect translations.

---
1. XL/XS prefixes

For most items it is simply as described above. Paired items are named somewhat inconsistently. For this PR, the second option is preferable, since it can be replaced with a prefix:
https://github.com/CleverRaven/Cataclysm-DDA/blob/9eaa5d442581542cb536a8133b7e8252ac0faa69/data/json/items/armor/arms_armor.json#L139
https://github.com/CleverRaven/Cataclysm-DDA/blob/9eaa5d442581542cb536a8133b7e8252ac0faa69/data/json/items/armor/brigandine.json#L727
Therefore, paired things can also be brought to this system.

The only exception I've seen is:
https://github.com/CleverRaven/Cataclysm-DDA/blob/9eaa5d442581542cb536a8133b7e8252ac0faa69/data/json/items/tool_armor.json#L24
Should we bring the splints to a general prefix form?

---
2. (on)/(off) etc. [will be in another PR, not this one]

This may be worth breaking into a second part for this PR. The items here have even more inconsistent suffixes. Some items are (off) by default, and when enabled this suffix disappears.
https://github.com/CleverRaven/Cataclysm-DDA/blob/9eaa5d442581542cb536a8133b7e8252ac0faa69/data/mods/Magiclysm/items/caster_level_boosters.json#L112
https://github.com/CleverRaven/Cataclysm-DDA/blob/9eaa5d442581542cb536a8133b7e8252ac0faa69/data/mods/Magiclysm/items/caster_level_boosters.json#L139

Some are the opposite.
https://github.com/CleverRaven/Cataclysm-DDA/blob/9eaa5d442581542cb536a8133b7e8252ac0faa69/data/json/items/tool_armor.json#L2533
https://github.com/CleverRaven/Cataclysm-DDA/blob/9eaa5d442581542cb536a8133b7e8252ac0faa69/data/json/items/tool_armor.json#L2591

Some have suffixes in each state.
https://github.com/CleverRaven/Cataclysm-DDA/blob/9eaa5d442581542cb536a8133b7e8252ac0faa69/data/json/items/tool/lighting.json#L189
https://github.com/CleverRaven/Cataclysm-DDA/blob/9eaa5d442581542cb536a8133b7e8252ac0faa69/data/json/items/tool/lighting.json#L223

Activated items add "active" before the name, and in mods it is more common to have "(active)" after the name.
https://github.com/CleverRaven/Cataclysm-DDA/blob/9eaa5d442581542cb536a8133b7e8252ac0faa69/data/json/items/tool/explosives.json#L145
https://github.com/CleverRaven/Cataclysm-DDA/blob/9eaa5d442581542cb536a8133b7e8252ac0faa69/data/json/items/tool/explosives.json#L172

It is also worth bringing to one style. Without a suffix when turned off and with a suffix when turned on?

The bigger problem is that there are many different suffixes and you need to create a separate flag for each. We can still change only the most frequent ones, and then we can get by with 2-3 flags: (on)/(active)/(raised)?

---
3. How much will this reduce the number of translated strings?
Approximate numbers
800 - "XL/XS item"
250 - "pair of XL/XS items"
160 - "XL/XS pair of items"
110 - "item (on)"
43  - "item (off)"
40  - "active item"
20  - "item (active)"
37  - "item (raised)"
1460 (size 1210 + state 250)
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
This will make the translation less flexible, and using tags for this doesn't sound right. I have already mentioned that I see this PR as a temporary solution until something better comes along. The alternative is to reject this PR, leave everything as it is and wait.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
![Снимок экрана_2024-03-01_22-55-13](https://github.com/CleverRaven/Cataclysm-DDA/assets/99945024/fb58e847-5085-4cd3-9a41-68c2d1abc9ef)
![Снимок экрана_2024-03-02_10-54-48](https://github.com/CleverRaven/Cataclysm-DDA/assets/99945024/aee154a6-4526-45a2-bb84-1533db81cbc9)

The flags are also translatable.
```
#. ~ This is custom prefix added to item name. "XL_PREFIX"
#: data/json/flags.json
msgid "XL "
msgstr ""

#. ~ This is custom prefix added to item name. "XS_PREFIX"
#: data/json/flags.json
msgid "XS "
msgstr ""
```
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
It will not work to add these suffixes to existing `OVERSIZED`, `UNDERSIZED` tags. A lot of items (~1/3 of the total) have no other variants (duffel bag) or use these flags as a limit on one equipped item (lit cigarette).

<details><summary>Several examples of translations</summary>
<p>

Inconsistent translations often come across. I don’t know for sure, but maybe it won’t be a big misdeed to replace all this with prefixes, anyway, I think the pros outweigh the possible cons. Especially considering that most languages have translations of 30-60% of the text

pt_BR.po
```
msgid "XL Kevlar vest"
msgid_plural "XL Kevlar vests"
msgstr[0] "colete de Kevlar extra-grande"
msgstr[1] "coletes de Kevlar GG"

msgid "pair of XL biosilicified chitin boots"
msgstr[0] "par de bota de quitina biosilicificada XL"
```

ja.po
```
msgid "XL rebreather mask (on)"
msgstr[0] "XLリブリーザーマスク(オン)"

msgid "pair of XL hard arm guards"
msgstr[0] "XLハードアームガード"
```

zh_CN.po
```
msgid "XL rebreather mask (on)"
msgstr[0] "呼吸器面罩（XL）（开）"

msgid "pair of XL chitin arm guards"
msgstr[0] "甲壳护臂（XL）"
```

de.po
```
msgid "XL Kevlar vest"
msgstr[0] "Kevlar Weste XL"

msgid "XL rebreather mask (on)"
msgstr[0] "Große Kreislaufatemgerätsmaske (an)"

msgid "XL survivor firemask"
msgstr[0] "XL Überlebendenfeuerschutzmaske"

msgid "pair of XL Kevlar gambeson sleeves"
msgstr[0] "Paar XL Kevlar-Gambesonärmel"
```

es_AR.po
```
msgid "XL rebreather mask (on)"
msgstr[0] "máscara rebreather XL (on)"

msgid "XL tempered heavy arm guard"
msgstr[0] "guardabrazo XL pesado templado"

msgid "pair of XL light gloves"
msgstr[0] "par de guantes XL ligeros"
```

fr.po
```
msgid "XL rebreather mask (on)"
msgstr[0] "masque recycleur d'air XL (activé)"

msgid "pair of XL light gloves"
msgstr[0] "paire de gants fins XL"
```

</p>
</details> 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->