### PR TITLE
Ability to disassemble flags into sheets + fix cotton sheet yield from regular sheet

### DIFF
--- a/data/json/recipes/recipe_deconstruction.json
+++ b/data/json/recipes/recipe_deconstruction.json
@@ -2333,7 +2333,39 @@
     "activity_level": "NO_EXERCISE",
     "time": "12 s",
     "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "sheet_cotton", 12 ] ] ]
+    "components": [ [ [ "sheet_cotton", 11 ] ] ]
+  },
+  {
+    "result": "national_flag",
+    "type": "uncraft",
+    "activity_level": "NO_EXERCISE",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "sheet", 7 ] ], [ [ "sheet_cotton", 6 ] ] ]
+  },
+  {
+    "result": "pride_flag",
+    "type": "uncraft",
+    "activity_level": "NO_EXERCISE",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "sheet", 7 ] ], [ [ "sheet_cotton", 6 ] ] ]
+  },
+  {
+    "result": "american_flag",
+    "type": "uncraft",
+    "activity_level": "NO_EXERCISE",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "sheet", 7 ] ], [ [ "sheet_cotton", 6 ] ] ]
+  },
+  {
+    "result": "state_flag",
+    "type": "uncraft",
+    "activity_level": "NO_EXERCISE",
+    "time": "30 s",
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "sheet", 7 ] ], [ [ "sheet_cotton", 6 ] ] ]
   },
   {
     "result": "sheet_cotton_patchwork",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Closes #72094. Flags, despite being perfectly rectangular, cannot be salvaged into sheets & must be broken all the way down into patches then stitched back up.

Also, sheets disassembled into one greater number of cotton sheets than its mass could contain. 😛 

#### Describe the solution

Every flag variation can be disassembled into 7 sheets & 6 cotton sheets (3200g flag wt. /420g sheet wt. = 7.6 sheets, the .6 giving 6.8 38g cotton sheets).

Sheets disassemble into only 11 cotton sheets.

#### Describe alternatives you've considered

Disassembling into 84 cotton sheets instead.

#### Testing

Spawned one of each flag, ~~got mauled by angry New Englanders for desecration~~ disassembled each flag.

#### Additional context

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/99621099/2bbde3ec-75d3-4315-a875-b0fc55f02a4c)
