### PR TITLE
Code clearing window was using global font instead of the font actual…

### DIFF
--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -1171,8 +1171,8 @@ static bool draw_window( Font_Ptr &font, const catacurses::window &w, const poin
         // only clearing those lines that are touched, we avoid
         // clearing lines that were already drawn in a previous
         // window but are untouched in this one.
-        geometry->rect( renderer, point( win->pos.x * fontwidth, ( win->pos.y + j ) * fontheight ),
-                        win->width * fontwidth, fontheight,
+        geometry->rect( renderer, point( win->pos.x * font->width, ( win->pos.y + j ) * font->height),
+                        win->width * font->width, font->height,
                         color_as_sdl( catacurses::black ) );
         update = true;
         win->line[j].touched = false;

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -1171,7 +1171,7 @@ static bool draw_window( Font_Ptr &font, const catacurses::window &w, const poin
         // only clearing those lines that are touched, we avoid
         // clearing lines that were already drawn in a previous
         // window but are untouched in this one.
-        geometry->rect( renderer, point( win->pos.x * font->width, ( win->pos.y + j ) * font->height),
+        geometry->rect( renderer, point( win->pos.x * font->width, ( win->pos.y + j ) * font->height ),
                         win->width * font->width, font->height,
                         color_as_sdl( catacurses::black ) );
         update = true;


### PR DESCRIPTION
…ly passed to draw_window

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix for ASCII terrain not clearing window correctly when using map font dimensions different than the global font"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I play in ASCII mode and after recent updates I noticed incorrect visual artifacts in unexplored areas in the half of the window to the right of my character. For example, if I open the map then close it, unexplored tiles in the affected area would still show the content from the map.

After some investigation it turns out that the code that draws the window is clearing it using global font dimensions, and because I was using a map font with double the width of the global font, only half my terrain window was being cleared correctly. Setting my map font to the same dimensions as the global font hides this problem.

To reproduce, start in ASCII mode with a map font that has dimensions different to the global font (a width or height that is twice the global highlights the problem quite well). Open the map and close it to see the problem. 

The issue does not happen when using tiles as far as I could see.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Modified the code to calculate clear rectangle based on the font passed to the draw_window method.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
None.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Manual testing to verify fix.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
None.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
