### PR TITLE
Remove the requirement to link with clangTidy

### DIFF
--- a/tools/clang-tidy-plugin/CMakeLists.txt
+++ b/tools/clang-tidy-plugin/CMakeLists.txt
@@ -55,7 +55,9 @@ if (CATA_CLANG_TIDY_EXECUTABLE)
 else ()
     set(CataAnalyzerName CataAnalyzerPlugin)
     add_library(${CataAnalyzerName} MODULE ${CataAnalyzerSrc})
-    target_link_libraries(${CataAnalyzerName} PRIVATE clangTidy)
+    if ("${CMAKE_SYSTEM_NAME}" MATCHES "Darwin")
+        target_link_options(${CataAnalyzerName} PRIVATE -undefined dynamic_lookup)
+    endif ()
 endif ()
 
 target_include_directories(${CataAnalyzerName} SYSTEM PRIVATE


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
A requirement to link against `clangTidy` was added as part of the transition to LLVM 17 (#71429), but it breaks the build against LLVM 17 for me locally.

#### Describe the solution
After some discussion below, it seems like @BrettDong and I have found an alternative solution that works for both of us.  I've updated this PR accordingly.

This has to do with a difference between the default linking behaviour on Linux and macOS.

#### Describe alternatives you've considered


#### Testing
This is the test.

#### Additional context