### PR TITLE
Made tinymap load take a tripoint_abs_omt parameter instead of untyped tripoint

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10589,12 +10589,12 @@ void Character::place_corpse()
 void Character::place_corpse( const tripoint_abs_omt &om_target )
 {
     tinymap bay;
-    bay.load( project_to<coords::sm>( om_target ), false );
+    bay.load( om_target, false );
     point fin( rng( 1, SEEX * 2 - 2 ), rng( 1, SEEX * 2 - 2 ) );
     // This makes no sense at all. It may find a random tile without furniture, but
     // if the first try to find one fails, it will go through all tiles of the map
     // and essentially select the last one that has no furniture.
-    // Q: Why check for furniture? (Check for passable or can-place-items seems more useful.)
+    // Q: Why check for furniture? (Check for passable or can-place-items seems more useful.) A: Furniture blocks revival?
     // Q: Why not grep a random point out of all the possible points (e.g. via random_entry)?
     // Q: Why use furn_str_id instead of f_null?
     // TODO: fix it, see above.

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -721,12 +721,14 @@ void zone_data::refresh_display() const
     const tripoint_abs_ms start = bounds.first;
     const tripoint_abs_ms end = bounds.second;
 
-    const tripoint_abs_sm sm_start_pos = coords::project_to<coords::sm>( start );
-    const tripoint_abs_sm sm_end_pos = coords::project_to<coords::sm>( end );
-    const tripoint_rel_ms start_remainder = get_start_point() - coords::project_to < coords::ms >
-                                            ( sm_start_pos );
-    const tripoint_rel_ms end_remainder = get_end_point() - coords::project_to < coords::ms >
-                                          ( sm_end_pos );
+    const tripoint_abs_omt omt_start_pos = coords::project_to<coords::omt>( start );
+    const tripoint_abs_omt omt_end_pos = coords::project_to<coords::omt>( end );
+    const tripoint_omt_ms start_remainder = tripoint_omt_ms( ( get_start_point() - coords::project_to
+                                            < coords::ms >
+                                            ( omt_start_pos ) ).raw() );
+    const tripoint_omt_ms end_remainder = tripoint_omt_ms( ( get_end_point() - coords::project_to
+                                          < coords::ms >
+                                          ( omt_end_pos ) ).raw() );
 
     zone_type_id type = this->get_type();
 
@@ -740,20 +742,20 @@ void zone_data::refresh_display() const
     }
 
     if( field != fd_null ) {
-        tripoint start_sm;
-        tripoint end_sm;
+        tripoint_omt_ms start_ms;
+        tripoint_omt_ms end_ms;
 
-        for( int i = sm_start_pos.x(); i <= sm_end_pos.x(); i++ ) {
-            for( int k = sm_start_pos.y(); k <= sm_end_pos.y(); k++ ) {
+        for( int i = omt_start_pos.x(); i <= omt_end_pos.x(); i++ ) {
+            for( int k = omt_start_pos.y(); k <= omt_end_pos.y(); k++ ) {
                 //  We assume the Z coordinate will remain fixed
-                update_tmap.load( { i, k, sm_start_pos.z() }, false );
+                update_tmap.load( tripoint_abs_omt{ i, k, omt_start_pos.z() }, false );
 
-                start_sm = tripoint( i > sm_start_pos.x() ? 0 : start_remainder.x(),
-                                     k > sm_start_pos.y() ? 0 : start_remainder.y(), start_remainder.z() );
-                end_sm = tripoint( i < sm_end_pos.x() ? MAPSIZE : end_remainder.x(),
-                                   k < sm_end_pos.y() ? MAPSIZE : end_remainder.y(), end_remainder.z() );
+                start_ms = tripoint_omt_ms( i > omt_start_pos.x() ? 0 : start_remainder.x(),
+                                            k > omt_start_pos.y() ? 0 : start_remainder.y(), start_remainder.z() );
+                end_ms = tripoint_omt_ms( i < omt_end_pos.x() ? SEEX * 2 - 1 : end_remainder.x(),
+                                          k < omt_end_pos.y() ? SEEY * 2 - 1 : end_remainder.y(), end_remainder.z() );
 
-                for( tripoint pt : update_tmap.points_in_rectangle( start_sm, end_sm ) ) {
+                for( tripoint_omt_ms pt : update_tmap.points_in_rectangle( start_ms, end_ms ) ) {
                     if( is_displayed ) {
                         update_tmap.add_field( pt, field, 1, time_duration::from_turns( 0 ), false );
                     } else {

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1561,9 +1561,9 @@ void construct::done_digormine_stair( const tripoint_bub_ms &p, bool dig,
 {
     map &here = get_map();
     const tripoint_abs_ms abs_pos = here.getglobal( p );
-    const tripoint_abs_sm pos_sm = project_to<coords::sm>( abs_pos );
+    const tripoint_abs_omt pos_omt = project_to<coords::omt>( abs_pos );
     tinymap tmpmap;
-    tmpmap.load( pos_sm + tripoint_below, false );
+    tmpmap.load( pos_omt + tripoint_below, false );
     const tripoint local_tmp = tmpmap.getlocal( abs_pos );
 
     bool dig_muts = player_character.has_trait( trait_PAINRESIST_TROGLO ) ||
@@ -1654,9 +1654,9 @@ void construct::done_mine_upstair( const tripoint_bub_ms &p, Character &player_c
 {
     map &here = get_map();
     const tripoint_abs_ms abs_pos = here.getglobal( p );
-    const tripoint_abs_sm pos_sm = project_to<coords::sm>( abs_pos );
+    const tripoint_abs_omt pos_omt = project_to<coords::omt>( abs_pos );
     tinymap tmpmap;
-    tmpmap.load( pos_sm + tripoint_above, false );
+    tmpmap.load( pos_omt + tripoint_above, false );
     const tripoint local_tmp = tmpmap.getlocal( abs_pos );
 
     if( tmpmap.ter( local_tmp ) == t_lava ) {

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -3408,10 +3408,9 @@ void debug()
             if( mx_choice >= 0 && mx_choice < static_cast<int>( mx_str.size() ) ) {
                 const tripoint_abs_omt where_omt( ui::omap::choose_point( true ) );
                 if( where_omt != overmap::invalid_tripoint ) {
-                    tripoint_abs_sm where_sm = project_to<coords::sm>( where_omt );
                     tinymap mx_map;
-                    mx_map.load( where_sm, false );
-                    MapExtras::apply_function( mx_str[mx_choice], mx_map, where_sm );
+                    mx_map.load( where_omt, false );
+                    MapExtras::apply_function( mx_str[mx_choice], mx_map, where_omt );
                     g->load_npcs();
                     here.invalidate_map_cache( here.get_abs_sub().z() );
                 }

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -2003,7 +2003,7 @@ void editmap::mapgen_preview( const real_coords &tc, uilist &gmenu )
 vehicle *editmap::mapgen_veh_query( const tripoint_abs_omt &omt_tgt )
 {
     tinymap target_bay;
-    target_bay.load( project_to<coords::sm>( omt_tgt ), false );
+    target_bay.load( omt_tgt, false );
 
     std::vector<vehicle *> possible_vehicles;
     for( int x = 0; x < 2; x++ ) {
@@ -2042,7 +2042,7 @@ bool editmap::mapgen_veh_destroy( const tripoint_abs_omt &omt_tgt, vehicle *car_
 {
     map &here = get_map();
     tinymap target_bay;
-    target_bay.load( project_to<coords::sm>( omt_tgt ), false );
+    target_bay.load( omt_tgt, false );
     for( int x = 0; x < 2; x++ ) {
         for( int y = 0; y < 2; y++ ) {
             submap *destsm = target_bay.get_submap_at_grid( { x, y, target.z } );

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -793,10 +793,8 @@ void emp_blast( const tripoint &p )
 
 void nuke( const tripoint_abs_omt &p )
 {
-    const tripoint_abs_sm pos_sm = project_to<coords::sm>( p );
-
     tinymap tmpmap;
-    tmpmap.load( pos_sm, false );
+    tmpmap.load( p, false );
 
     item mininuke( itype_mininuke_act );
     mininuke.set_flag( json_flag_ACTIVATE_ON_PLACE );

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -2168,7 +2168,7 @@ void basecamp::scan_pseudo_items()
         tripoint_abs_omt tile = tripoint_abs_omt( omt_pos.x() + expansion.first.x,
                                 omt_pos.y() + expansion.first.y, omt_pos.z() );
         tinymap expansion_map;
-        expansion_map.load( project_to<coords::sm>( tile ), false );
+        expansion_map.load( tile, false );
 
         tripoint mapmin = tripoint( 0, 0, omt_pos.z() );
         tripoint mapmax = tripoint( 2 * SEEX - 1, 2 * SEEY - 1, omt_pos.z() );
@@ -2687,7 +2687,7 @@ void basecamp::start_relay_hide_site( const mission_id &miss_id, float exertion_
 
         //Check items in improvised shelters at hide site
         tinymap target_bay;
-        target_bay.load( project_to<coords::sm>( forest ), false );
+        target_bay.load( forest, false );
 
         units::volume total_import_volume;
         units::mass total_import_mass;
@@ -3548,7 +3548,7 @@ static std::pair<size_t, std::string> farm_action( const tripoint_abs_omt &omt_t
 
     // farm_map is what the area actually looks like
     tinymap farm_map;
-    farm_map.load( project_to<coords::sm>( omt_tgt ), false );
+    farm_map.load( omt_tgt, false );
     // farm_json is what the area should look like according to jsons (loaded on demand)
     std::unique_ptr<fake_map> farm_json;
     tripoint mapmin = tripoint( 0, 0, omt_tgt.z() );
@@ -4449,7 +4449,7 @@ bool basecamp::survey_field_return( const mission_id &miss_id )
     }
 
     tinymap target;
-    target.load( project_to<coords::sm>( where ), false );
+    target.load( where, false );
     int mismatch_tiles = 0;
     tripoint mapmin = tripoint( 0, 0, where.z() );
     tripoint mapmax = tripoint( 2 * SEEX - 1, 2 * SEEY - 1, where.z() );
@@ -4732,7 +4732,7 @@ int om_harvest_ter( npc &comp, const tripoint_abs_omt &omt_tgt, const ter_id &t,
 {
     const ter_t &ter_tgt = t.obj();
     tinymap target_bay;
-    target_bay.load( project_to<coords::sm>( omt_tgt ), false );
+    target_bay.load( omt_tgt, false );
     int harvested = 0;
     int total = 0;
     tripoint mapmin = tripoint( 0, 0, omt_tgt.z() );
@@ -4776,7 +4776,7 @@ int om_cutdown_trees( const tripoint_abs_omt &omt_tgt, int chance, bool estimate
                       bool force_cut_trunk )
 {
     tinymap target_bay;
-    target_bay.load( project_to<coords::sm>( omt_tgt ), false );
+    target_bay.load( omt_tgt, false );
     int harvested = 0;
     int total = 0;
     tripoint mapmin = tripoint( 0, 0, omt_tgt.z() );
@@ -4822,7 +4822,7 @@ mass_volume om_harvest_itm( const npc_ptr &comp, const tripoint_abs_omt &omt_tgt
                             bool take )
 {
     tinymap target_bay;
-    target_bay.load( project_to<coords::sm>( omt_tgt ), false );
+    target_bay.load( omt_tgt, false );
     units::mass harvested_m = 0_gram;
     units::volume harvested_v = 0_ml;
     units::mass total_m = 0_gram;
@@ -4999,7 +4999,7 @@ bool om_set_hide_site( npc &comp, const tripoint_abs_omt &omt_tgt,
 {
     tinymap target_bay;
 
-    target_bay.load( project_to<coords::sm>( omt_tgt ), false );
+    target_bay.load( omt_tgt, false );
     target_bay.ter_set( relay_site_stash, t_improvised_shelter );
     for( drop_location it : itms_rem ) {
         item *i = it.first.get_item();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1122,7 +1122,7 @@ vehicle *game::place_vehicle_nearby(
         for( const tripoint_abs_omt &goal : overmap_buffer.find_all( omt_origin, find_params ) ) {
             // try place vehicle there.
             tinymap target_map;
-            target_map.load( project_to<coords::sm>( goal ), false );
+            target_map.load( goal, false );
             const tripoint tinymap_center( SEEX, SEEY, goal.z() );
             static constexpr std::array<units::angle, 4> angles = {{
                     0_degrees, 90_degrees, 180_degrees, 270_degrees

--- a/src/magic_teleporter_list.cpp
+++ b/src/magic_teleporter_list.cpp
@@ -65,10 +65,9 @@ static std::optional<tripoint> find_valid_teleporters_omt( const tripoint_abs_om
 {
     // this is the top left hand square of the global absolute coordinate
     // of the overmap terrain we want to try to teleport to.
-    // an OMT is SEEX * SEEY in size
-    const tripoint_abs_sm sm_pt = project_to<coords::sm>( omt_pt );
+    // an OMT is (2 * SEEX) * (2 * SEEY) in size
     tinymap checker;
-    checker.load( sm_pt, true );
+    checker.load( omt_pt, true );
     for( const tripoint &p : checker.points_on_zlevel() ) {
         if( checker.has_flag_furn( ter_furn_flag::TFLAG_TRANSLOCATOR, p ) ) {
             return checker.getabs( p );
@@ -80,8 +79,7 @@ static std::optional<tripoint> find_valid_teleporters_omt( const tripoint_abs_om
 bool teleporter_list::place_avatar_overmap( Character &you, const tripoint_abs_omt &omt_pt ) const
 {
     tinymap omt_dest;
-    tripoint_abs_sm sm_dest = project_to<coords::sm>( omt_pt );
-    omt_dest.load( sm_dest, true );
+    omt_dest.load( omt_pt, true );
     std::optional<tripoint> global_dest = find_valid_teleporters_omt( omt_pt );
     if( !global_dest ) {
         return false;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -9027,6 +9027,15 @@ tripoint_range<tripoint> tinymap::points_in_rectangle(
     return map::points_in_rectangle( from, to );
 }
 
+tripoint_range<tripoint_omt_ms> tinymap::points_in_rectangle(
+    const tripoint_omt_ms &from, const tripoint_omt_ms &to ) const
+{
+    const tripoint_range<tripoint> preliminary_result = map::points_in_rectangle( from.raw(),
+            to.raw() );
+    return tripoint_range<tripoint_omt_ms>( tripoint_omt_ms( preliminary_result.min() ),
+                                            tripoint_omt_ms( preliminary_result.max() ) );
+}
+
 tripoint_range<tripoint> tinymap::points_in_radius(
     const tripoint &center, size_t radius, size_t radiusz ) const
 {

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -452,7 +452,7 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
 
     tinymap m;
     if( bridge_at_north && road_at_south ) {
-        m.load( project_to<coords::sm>( abs_omt + point_south ), false );
+        m.load( abs_omt + point_south, false );
 
         //Sandbag block at the left edge
         line_furn( &m, f_sandbag_half, point( 3, 4 ), point( 3, 7 ) );
@@ -553,7 +553,7 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
     }
 
     if( bridge_at_south && road_at_north ) {
-        m.load( project_to<coords::sm>( abs_omt + point_north ), false );
+        m.load( abs_omt + point_north, false );
         //Two horizontal lines of sandbags
         line_furn( &m, f_sandbag_half, point( 5, 15 ), point( 10, 15 ) );
         line_furn( &m, f_sandbag_half, point( 13, 15 ), point( 18, 15 ) );
@@ -656,7 +656,7 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
     }
 
     if( bridge_at_west && road_at_east ) {
-        m.load( project_to<coords::sm>( abs_omt + point_east ), false );
+        m.load( abs_omt + point_east, false );
         //Draw walls of first tent
         square_furn( &m, f_canvas_wall, point( 0, 3 ), point( 4, 13 ) );
 
@@ -803,7 +803,7 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
     }
 
     if( bridge_at_east && road_at_west ) {
-        m.load( project_to<coords::sm>( abs_omt + point_west ), false );
+        m.load( abs_omt + point_west, false );
         //Spawn military cargo truck blocking the entry
         m.add_vehicle( vehicle_prototype_military_cargo_truck, tripoint( 15, 11, abs_sub.z ),
                        270_degrees, 70, 1 );
@@ -2091,7 +2091,7 @@ static bool mx_city_trap( map &/*m*/, const tripoint &abs_sub )
     const tripoint_abs_omt road_omt = random_entry( valid_omt, city_center_omt );
 
     tinymap compmap;
-    compmap.load( project_to<coords::sm>( road_omt ), false );
+    compmap.load( road_omt, false );
 
     const tripoint trap_center = { SEEX + rng( -5, 5 ), SEEY + rng( -5, 5 ), abs_sub.z };
     bool empty_3x3_square = false;
@@ -2148,7 +2148,7 @@ static bool mx_fungal_zone( map &/*m*/, const tripoint &abs_sub )
     const tripoint_abs_omt &park_omt = random_entry( valid_omt, city_center_omt );
 
     tinymap fungal_map;
-    fungal_map.load( project_to<coords::sm>( park_omt ), false );
+    fungal_map.load( park_omt, false );
 
     // Then find suitable location for fungal spire to spawn (grass, dirt etc)
     const tripoint submap_center = { SEEX, SEEY, abs_sub.z };
@@ -2253,7 +2253,7 @@ void apply_function( const map_extra_id &id, map &m, const tripoint_abs_sm &abs_
     overmap_buffer.add_extra( project_to<coords::omt>( abs_sub ), id );
 }
 
-void apply_function( const map_extra_id &id, tinymap &m, const tripoint_abs_sm &abs_sub )
+void apply_function( const map_extra_id &id, tinymap &m, const tripoint_abs_omt &abs_omt )
 {
     bool applied_successfully = false;
 
@@ -2262,18 +2262,18 @@ void apply_function( const map_extra_id &id, tinymap &m, const tripoint_abs_sm &
         case map_extra_method::map_extra_function: {
             const map_extra_pointer mx_func = get_function( map_extra_id( extra.generator_id ) );
             if( mx_func != nullptr ) {
-                applied_successfully = mx_func( *m.cast_to_map(), abs_sub.raw() );
+                applied_successfully = mx_func( *m.cast_to_map(), project_to<coords::sm>( abs_omt ).raw() );
             }
             break;
         }
         case map_extra_method::mapgen: {
-            mapgendata dat( project_to<coords::omt>( abs_sub ), *m.cast_to_map(), 0.0f, calendar::turn,
+            mapgendata dat( abs_omt, *m.cast_to_map(), 0.0f, calendar::turn,
                             nullptr );
             applied_successfully = run_mapgen_func( extra.generator_id, dat );
             break;
         }
         case map_extra_method::update_mapgen: {
-            mapgendata dat( project_to<coords::omt>( abs_sub ), *m.cast_to_map(), 0.0f,
+            mapgendata dat( abs_omt, *m.cast_to_map(), 0.0f,
                             calendar::start_of_cataclysm, nullptr );
             applied_successfully =
                 run_mapgen_update_func( update_mapgen_id( extra.generator_id ), dat );
@@ -2288,7 +2288,7 @@ void apply_function( const map_extra_id &id, tinymap &m, const tripoint_abs_sm &
         return;
     }
 
-    overmap_buffer.add_extra( project_to<coords::omt>( abs_sub ), id );
+    overmap_buffer.add_extra( abs_omt, id );
 }
 
 FunctionMap all_functions()

--- a/src/map_extras.h
+++ b/src/map_extras.h
@@ -86,9 +86,9 @@ map_extra_pointer get_function( const map_extra_id &name );
 FunctionMap all_functions();
 std::vector<map_extra_id> get_all_function_names();
 
-void apply_function( const map_extra_id &, map &, const tripoint_abs_sm & );
+void apply_function( const map_extra_id &, map &, const tripoint_abs_sm &abs_omt );
 void apply_function( const map_extra_id &, tinymap &,
-                     const tripoint_abs_sm & ); // TODO: Convert to tripoint_abs_omt
+                     const tripoint_abs_omt & );
 
 void load( const JsonObject &jo, const std::string &src );
 void check_consistency();

--- a/src/map_extras.h
+++ b/src/map_extras.h
@@ -86,9 +86,9 @@ map_extra_pointer get_function( const map_extra_id &name );
 FunctionMap all_functions();
 std::vector<map_extra_id> get_all_function_names();
 
-void apply_function( const map_extra_id &, map &, const tripoint_abs_sm &abs_omt );
-void apply_function( const map_extra_id &, tinymap &,
-                     const tripoint_abs_omt & );
+void apply_function( const map_extra_id &id, map &m, const tripoint_abs_sm &abs_sub );
+void apply_function( const map_extra_id &id, tinymap &m,
+                     const tripoint_abs_omt &abs_omt );
 
 void load( const JsonObject &jo, const std::string &src );
 void check_consistency();

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -7687,9 +7687,8 @@ bool update_mapgen_function_json::update_map(
 
     std::unique_ptr<tinymap> p_update_tmap = std::make_unique<tinymap>();
     tinymap &update_tmap = *p_update_tmap;
-    const tripoint_abs_sm sm_pos = project_to<coords::sm>( omt_pos );
 
-    update_tmap.load( sm_pos, true );
+    update_tmap.load( omt_pos, true );
     update_tmap.rotate( 4 - rotation );
     update_tmap.mirror( mirror_horizontal, mirror_vertical );
 
@@ -7700,7 +7699,7 @@ bool update_mapgen_function_json::update_map(
     update_tmap.mirror( mirror_horizontal, mirror_vertical );
     update_tmap.rotate( rotation );
 
-    if( get_map().inbounds( project_to<coords::ms>( sm_pos ) ) ) {
+    if( get_map().inbounds( project_to<coords::ms>( omt_pos ) ) ) {
         // trigger main map cleanup
         p_update_tmap.reset();
         // trigger new traps, etc
@@ -7826,9 +7825,8 @@ bool apply_construction_marker( const update_mapgen_id &update_mapgen_id,
 
     std::unique_ptr<tinymap> p_update_tmap = std::make_unique<tinymap>();
     tinymap &update_tmap = *p_update_tmap;
-    const tripoint_abs_sm sm_pos = project_to<coords::sm>( omt_pos );
 
-    update_tmap.load( sm_pos, true );
+    update_tmap.load( omt_pos, true );
     update_tmap.rotate( 4 - rotation );
     update_tmap.mirror( mirror_horizontal, mirror_vertical );
 
@@ -7846,7 +7844,7 @@ bool apply_construction_marker( const update_mapgen_id &update_mapgen_id,
         if( update_function->second.funcs()[0]->update_map( fake_md ) ) {
             for( const tripoint &pos : tmp_map.points_on_zlevel( fake_map::fake_map_z ) ) {
                 ter_id ter_at_pos = tmp_map.ter( pos );
-                const tripoint level_pos = tripoint( pos.xy(), sm_pos.z() );
+                const tripoint level_pos = tripoint( pos.xy(), omt_pos.z() );
 
                 if( ter_at_pos != t_grass || tmp_map.has_furn( level_pos ) ) {
                     if( apply ) {

--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -1552,7 +1552,7 @@ void talk_function::field_plant( npc &p, const std::string &place )
     const tripoint_abs_omt site = overmap_buffer.find_closest(
                                       player_character.global_omt_location(), place, 20, false );
     tinymap bay;
-    bay.load( project_to<coords::sm>( site ), false );
+    bay.load( site, false );
     for( const tripoint &plot : bay.points_on_zlevel() ) {
         if( bay.ter( plot ) == t_dirtmound ) {
             empty_plots++;
@@ -1624,7 +1624,7 @@ void talk_function::field_harvest( npc &p, const std::string &place )
     std::vector<itype_id> seed_types;
     std::vector<itype_id> plant_types;
     std::vector<std::string> plant_names;
-    bay.load( project_to<coords::sm>( site ), false );
+    bay.load( site, false );
     for( const tripoint &plot : bay.points_on_zlevel() ) {
         map_stack items = bay.i_at( plot );
         if( bay.furn( plot ) == furn_f_plant_harvest && !items.empty() ) {
@@ -2208,7 +2208,7 @@ bool talk_function::companion_om_combat_check( const std::vector<npc_ptr> &group
     tripoint_abs_sm sm_tgt = project_to<coords::sm>( om_tgt );
 
     tinymap target_bay;
-    target_bay.load( sm_tgt, false );
+    target_bay.load( om_tgt, false );
     std::vector< monster * > monsters_around;
     for( int x = 0; x < 2; x++ ) {
         for( int y = 0; y < 2; y++ ) {
@@ -2767,7 +2767,7 @@ std::set<item> talk_function::loot_building( const tripoint_abs_omt &site,
         const oter_str_id &looted_replacement )
 {
     tinymap bay;
-    bay.load( project_to<coords::sm>( site ), false );
+    bay.load( site, false );
     creature_tracker &creatures = get_creature_tracker();
     std::set<item> return_items;
     for( const tripoint &p : bay.points_on_zlevel() ) {

--- a/src/mission_start.cpp
+++ b/src/mission_start.cpp
@@ -163,7 +163,7 @@ void mission_start::place_npc_software( mission *miss )
     overmap_buffer.reveal( place, 6 );
 
     tinymap compmap;
-    compmap.load( project_to<coords::sm>( place ), false );
+    compmap.load( place, false );
     tripoint comppoint;
 
     oter_id oter = overmap_buffer.ter( place );
@@ -205,7 +205,7 @@ void mission_start::place_deposit_box( mission *miss )
     overmap_buffer.reveal( site, 2 );
 
     tinymap compmap;
-    compmap.load( project_to<coords::sm>( site ), false );
+    compmap.load( site, false );
     std::vector<tripoint> valid;
     for( const tripoint &p : compmap.points_on_zlevel() ) {
         if( compmap.ter( p ) == t_floor ) {
@@ -340,7 +340,7 @@ void static create_lab_consoles(
                                         otype, -1, miss, false, 4, place );
 
         tinymap compmap;
-        compmap.load( project_to<coords::sm>( om_place ), false );
+        compmap.load( om_place, false );
 
         tripoint comppoint = find_potential_computer_point( compmap );
 

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -3910,14 +3910,18 @@ talk_effect_fun_t::func f_revert_location( const JsonObject &jo, std::string_vie
         // maptile is 4 submaps so queue up 4 submap reverts
         const tripoint_abs_sm revert_sm_base = project_to<coords::sm>( omt_pos );
 
-        tinymap tm;
-        tm.load( omt_pos,
-                 true ); // This creates the submaps if they didn't already exist, so we know they're valid in the loop.
-
         for( int x = 0; x < 2; x++ ) {
             for( int y = 0; y < 2; y++ ) {
                 const tripoint_abs_sm revert_sm = revert_sm_base + point( x, y );
                 submap *sm = MAPBUFFER.lookup_submap( revert_sm );
+                if( sm == nullptr ) {
+                    tinymap tm;
+                    // This creates the submaps if they didn't already exist.
+                    // Note that all four submaps are loaded/created by this
+                    // call, so the submap lookup can fail at most once.
+                    tm.load( omt_pos, true );
+                    sm = MAPBUFFER.lookup_submap( revert_sm );
+                }
                 get_timed_events().add( timed_event_type::REVERT_SUBMAP, tif, -1,
                                         project_to<coords::ms>( revert_sm ), 0, "",
                                         sm->get_revert_submap(), key.evaluate( d ) );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -3103,7 +3103,7 @@ void map_add_item( item &it, tripoint_abs_ms target_pos )
         get_map().add_item_or_charges( get_map().getlocal( target_pos ), it );
     } else {
         tinymap target_bay;
-        target_bay.load( project_to<coords::sm>( target_pos ), false );
+        target_bay.load( project_to<coords::omt>( target_pos ), false );
         target_bay.add_item_or_charges( target_bay.getlocal( target_pos ), it );
     }
 }
@@ -3908,22 +3908,23 @@ talk_effect_fun_t::func f_revert_location( const JsonObject &jo, std::string_vie
         time_point tif = calendar::turn + dov_time_in_future.evaluate( d ) + 1_seconds;
         // Timed events happen before the player turn and eocs are during so we add a second here to sync them up using the same variable
         // maptile is 4 submaps so queue up 4 submap reverts
+        const tripoint_abs_sm revert_sm_base = project_to<coords::sm>( omt_pos );
+
+        tinymap tm;
+        tm.load( omt_pos,
+                 true ); // This creates the submaps if they didn't already exist, so we know they're valid in the loop.
+
         for( int x = 0; x < 2; x++ ) {
             for( int y = 0; y < 2; y++ ) {
-                tripoint_abs_sm revert_sm = project_to<coords::sm>( omt_pos );
-                revert_sm += point( x, y );
+                const tripoint_abs_sm revert_sm = revert_sm_base + point( x, y );
                 submap *sm = MAPBUFFER.lookup_submap( revert_sm );
-                if( sm == nullptr ) {
-                    tinymap tm;
-                    tm.load( revert_sm, true );
-                    sm = MAPBUFFER.lookup_submap( revert_sm );
-                }
                 get_timed_events().add( timed_event_type::REVERT_SUBMAP, tif, -1,
                                         project_to<coords::ms>( revert_sm ), 0, "",
                                         sm->get_revert_submap(), key.evaluate( d ) );
-                get_map().invalidate_map_cache( omt_pos.z() );
             }
         }
+
+        get_map().invalidate_map_cache( omt_pos.z() );
     };
 }
 

--- a/src/start_location.cpp
+++ b/src/start_location.cpp
@@ -283,9 +283,8 @@ tripoint_abs_omt start_location::find_player_initial_location( const city &origi
 void start_location::prepare_map( const tripoint_abs_omt &omtstart ) const
 {
     // Now prepare the initial map (change terrain etc.)
-    const tripoint_abs_sm player_location = project_to<coords::sm>( omtstart );
     tinymap player_start;
-    player_start.load( player_location, false );
+    player_start.load( omtstart, false );
     prepare_map( player_start );
     player_start.save();
 }
@@ -443,9 +442,8 @@ void start_location::place_player( avatar &you, const tripoint_abs_omt &omtstart
 void start_location::burn( const tripoint_abs_omt &omtstart, const size_t count,
                            const int rad ) const
 {
-    const tripoint_abs_sm player_location = project_to<coords::sm>( omtstart );
     tinymap m;
-    m.load( player_location, false );
+    m.load( omtstart, false );
     m.build_outside_cache( m.get_abs_sub().z() );
     point player_pos = get_player_character().pos().xy();
     const point u( player_pos.x % HALF_MAPSIZE_X, player_pos.y % HALF_MAPSIZE_Y );
@@ -471,11 +469,10 @@ void start_location::burn( const tripoint_abs_omt &omtstart, const size_t count,
 void start_location::add_map_extra( const tripoint_abs_omt &omtstart,
                                     const map_extra_id &map_extra ) const
 {
-    const tripoint_abs_sm player_location = project_to<coords::sm>( omtstart );
     tinymap m;
-    m.load( player_location, false );
+    m.load( omtstart, false );
 
-    MapExtras::apply_function( map_extra, m, player_location );
+    MapExtras::apply_function( map_extra, m, omtstart );
 
     m.save();
 }
@@ -513,9 +510,8 @@ void start_location::handle_heli_crash( avatar &you ) const
 static void add_monsters( const tripoint_abs_omt &omtstart, const mongroup_id &type,
                           float expected_points )
 {
-    const tripoint_abs_sm spawn_location = project_to<coords::sm>( omtstart );
     tinymap m;
-    m.load( spawn_location, false );
+    m.load( omtstart, false );
     // map::place_spawns internally multiplies density by rng(10, 50)
     const float density = expected_points / ( ( 10 + 50 ) / 2.0 );
     m.place_spawns( type, 1, point_zero, point( SEEX * 2 - 1, SEEY * 2 - 1 ), density );

--- a/src/timed_event.cpp
+++ b/src/timed_event.cpp
@@ -275,9 +275,10 @@ void timed_event::actualize()
                 fake_spell summoning( spell_dks_summon_alrp, true, 12 );
                 summoning.get_spell( player_character ).cast_all_effects( dispatcher, spot );
             } else {
+                const tripoint_abs_omt omt_point = project_to<coords::omt>( map_point );
                 tinymap mx_map;
-                mx_map.load( map_point, false );
-                MapExtras::apply_function( map_extra_mx_dsa_alrp, mx_map, map_point );
+                mx_map.load( omt_point, false );
+                MapExtras::apply_function( map_extra_mx_dsa_alrp, mx_map, omt_point );
                 g->load_npcs();
                 here.invalidate_map_cache( map_point.z() );
             }

--- a/tests/map_extra_test.cpp
+++ b/tests/map_extra_test.cpp
@@ -35,7 +35,7 @@ TEST_CASE( "mx_minefield_real_spawn", "[map_extra][overmap][!mayfail]" )
     // For every single bridge we found, run mapgen (which will select and apply a map extra).
     for( const tripoint_abs_omt &p : bridges ) {
         tinymap tm;
-        tm.load( project_to<coords::sm>( p ), false );
+        tm.load( p, false );
     }
 
     // Get all of the map extras that have been generated.
@@ -73,7 +73,7 @@ TEST_CASE( "mx_minefield_theoretical_spawn", "[map_extra][overmap]" )
                     road );
 
         tinymap tm;
-        tm.load( project_combine( om.pos(), project_to<coords::sm>( center ) ), false );
+        tm.load( project_combine( om.pos(), center ), false );
 
         const map_extra_pointer mx_func = MapExtras::get_function( map_extra_mx_minefield );
 

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -125,7 +125,7 @@ TEST_CASE( "tinymap_bounds_checking" )
     clear_map();
     tinymap m;
     tripoint_abs_sm point_away_from_real_map( get_map().get_abs_sub() + point( MAPSIZE_X, 0 ) );
-    m.load( project_to<coords::omt>( point_away_from_real_map + point( 1, 0 ) ),
+    m.load( project_to<coords::omt>( point_away_from_real_map + point_east ),
             false ); // Add submap to ensure to OMT lies beyond the reality bubble
     for( int x = -1; x <= SEEX * 2; ++x ) {
         for( int y = -1; y <= SEEY * 2; ++y ) {

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -125,7 +125,8 @@ TEST_CASE( "tinymap_bounds_checking" )
     clear_map();
     tinymap m;
     tripoint_abs_sm point_away_from_real_map( get_map().get_abs_sub() + point( MAPSIZE_X, 0 ) );
-    m.load( point_away_from_real_map, false );
+    m.load( project_to<coords::omt>( point_away_from_real_map + point( 1, 0 ) ),
+            false ); // Add submap to ensure to OMT lies beyond the reality bubble
     for( int x = -1; x <= SEEX * 2; ++x ) {
         for( int y = -1; y <= SEEY * 2; ++y ) {
             for( int z = -OVERMAP_DEPTH - 1; z <= OVERMAP_HEIGHT + 1; ++z ) {

--- a/tests/mapgen_helpers.cpp
+++ b/tests/mapgen_helpers.cpp
@@ -11,7 +11,7 @@ void common_mapgen_prep( tripoint_abs_omt const &pos, fprep_t const &prep )
 {
     if( prep ) {
         tinymap tm;
-        tm.load( project_to<coords::sm>( pos ), true );
+        tm.load( pos, true );
         prep( *tm.cast_to_map() );
     }
 }
@@ -26,7 +26,7 @@ void manual_update_mapgen( tripoint_abs_omt const &pos, update_mapgen_id const &
 void manual_nested_mapgen( tripoint_abs_omt const &pos, nested_mapgen_id const &id )
 {
     tinymap tm;
-    tm.load( project_to<coords::sm>( pos ), true );
+    tm.load( pos, true );
     mapgendata md( pos, *tm.cast_to_map(), 0.0f, calendar::turn, nullptr );
     const auto &ptr = nested_mapgens[id].funcs().pick();
     ( *ptr )->nest( md, point_zero, "test" );

--- a/tests/mapgen_remove_vehicles_test.cpp
+++ b/tests/mapgen_remove_vehicles_test.cpp
@@ -78,7 +78,7 @@ void remote_test( vehicle *veh, tripoint const &test_loc, F const &fmg, ID const
     check_vehicle_still_works( *veh );
 
     tinymap tm;
-    tm.load( project_to<coords::sm>( this_test_omt ), true );
+    tm.load( this_test_omt, true );
     REQUIRE( tm.get_vehicles().empty() );
 }
 

--- a/tests/overmap_test.cpp
+++ b/tests/overmap_test.cpp
@@ -349,7 +349,7 @@ TEST_CASE( "overmap_terrain_coverage", "[overmap][slow]" )
         CAPTURE( oter_type_id );
         const std::string msg = capture_debugmsg_during( [pos, &num_generated_since_last_clear]() {
             tinymap tm;
-            tm.load( project_to<coords::sm>( pos ), false );
+            tm.load( pos, false );
 
             // Periodically clear the generated maps to save memory
             if( ++num_generated_since_last_clear >= 64 ) {

--- a/tests/vehicle_split_test.cpp
+++ b/tests/vehicle_split_test.cpp
@@ -94,7 +94,7 @@ TEST_CASE( "conjoined_vehicles", "[vehicle]" )
 TEST_CASE( "crater_crash", "[vehicle]" )
 {
     tinymap here;
-    tripoint_abs_sm map_location( 60, 60, 0 );
+    tripoint_abs_omt map_location( 30, 30, 0 );
     here.load( map_location, true );
     here.add_vehicle( vehicle_prototype_car, { 14, 11, here.get_abs_sub().z() }, 45_degrees );
     const tripoint end{ 20, 20, 0 };
@@ -114,7 +114,7 @@ TEST_CASE( "split_vehicle_during_mapgen", "[vehicle]" )
 
     tinymap tm;
     // Wherever the main map is, create this tinymap outside its bounds.
-    tm.load( here.get_abs_sub() + tripoint( 20, 20, 0 ), false );
+    tm.load( project_to<coords::omt>( here.get_abs_sub() ) + tripoint_rel_omt( 10, 10, 0 ), false );
     wipe_map_terrain( tm.cast_to_map() );
     REQUIRE( tm.get_vehicles().empty() );
     tripoint vehicle_origin{ 14, 14, 0 };


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary

none

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Part of the effort to make coordinate usage typed. In this step the tinymap 'load' operation is made to take a tripoint_abs_omt coordinate.

An effect of the change is that it's now guaranteed to align with the overmap terrain tiles.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Change the 'load' operation profile and then fix all the places where it's used. Most cases were straightforward as they were already based off of tripoint_abs_omt coordinates that were then transformed to untyped tripoints representing tripoint_abs_sm.
A few cases required a bit more work to ensure they weren't requiring submap alignment that was misaligned with the omt they resided in.

A couple of test cases were based on an offset from the current map, which can be misaligned with their omt, but comments indicated the purpose of the offset was simply to ensure the tinymap used in the test wasn't overlapping with the used map.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

One change had an iteration over the submaps within the omt under processing with a tinymap loaded to ensure the generation of the submap of interest if it didn't exist. The changed code loads the tinymap regardless. An alternative would be to retain the previous logic that only loads the tinymap when the submap was missing, but instead load the tinymap based on the omt rather than the (possibly offset) submap. That would ensure all the relevant submaps would be generated only if any was missing.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Minimal, as there shouldn't be any changes to any game logic.
Loaded a save and created a couple of very large zones and displayed them (as the operation with the largest change involved changing the logic for zone display from being submap based to being overmap terrain tile based, which probably is insignificantly faster as it involves fewer tinymap load calls).

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Wasn't able to find an operation to perform necessary type casting from tripoint_rel_ms to tripoint_omt_ms (subtracting the anchor point of an omt from the absolute ms coordinate of a feature within it results in a tripoint_rel_ms even though a human can see the more specific type is applicable in this case), and so ended up with a rather ugly transformation via .raw(). There are 'make_unchecked' operations, but I only found one for going from tripoint_omt_ms to tripoint_rel_ms, but not in the other direction.
This may become a problem if typed usage gets mandatory. Of course, I may have failed to locate the appropriate operation or how to wrangle 'make_unchecked'.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
