### PR TITLE
[Magiclysm] Technomancer Mapping Spell

### DIFF
--- a/data/mods/Magiclysm/Spells/technomancer.json
+++ b/data/mods/Magiclysm/Spells/technomancer.json
@@ -875,7 +875,7 @@
     "final_casting_time": { "math": [ "channeling_proficiency_negate_calculate(60000)" ] },
     "casting_time_increment": { "math": [ "channeling_proficiency_negate_calculate(-20000)" ] },
     "base_energy_cost": { "math": [ "channeling_proficiency_negate_calculate(1000)" ] },
-    "difficulty": 7,
+    "difficulty": 4,
     "energy_source": "MANA",
     "spell_class": "TECHNOMANCER"
   }

--- a/data/mods/Magiclysm/Spells/technomancer.json
+++ b/data/mods/Magiclysm/Spells/technomancer.json
@@ -856,5 +856,27 @@
         "true_eocs": [ { "id": "EOC_TECHNOMANCER_POWER_LINKAGE_ITEM", "effect": [ { "npc_set_flag": "USE_UPS" } ] } ]
       }
     ]
+  },
+  {
+    "type": "SPELL",
+    "name": "Ping Devices",
+    "id": "technomancer_reveal_world_map",
+    "description": "You send out a ping to any un- or less-secured devices in the area, then tediously collect the received data into something approximating a map of your surrounding area",
+    "valid_targets": [ "self" ],
+    "shape": "blast",
+    "effect": "map",
+    "min_aoe": 25,
+    "max_aoe": 55,
+    "aoe_increment": 2,
+    "flags": [ "NO_HANDS", "CONCENTRATE", "VERBAL" ],
+    "extra_effects": [ { "id": "eoc_channeling_setup" } ],
+    "max_level": 15,
+    "base_casting_time": { "math": [ "channeling_proficiency_negate_calculate(360000)" ] },
+    "final_casting_time": { "math": [ "channeling_proficiency_negate_calculate(60000)" ] },
+    "casting_time_increment": { "math": [ "channeling_proficiency_negate_calculate(-20000)" ] },
+    "base_energy_cost": { "math": [ "channeling_proficiency_negate_calculate(1000)" ] },
+    "difficulty": 7,
+    "energy_source": "MANA",
+    "spell_class": "TECHNOMANCER"
   }
 ]

--- a/data/mods/Magiclysm/itemgroups/itemgroups.json
+++ b/data/mods/Magiclysm/itemgroups/itemgroups.json
@@ -1354,7 +1354,8 @@
           { "item": "spell_scroll_technomancer_conjure_ups", "prob": 25 },
           { "item": "spell_scroll_technomancer_welder", "prob": 35 },
           { "item": "spell_scroll_technomancer_recharge_vehicle", "prob": 20 },
-          { "item": "spell_scroll_technomancer_create_ups_connection", "prob": 25 }
+          { "item": "spell_scroll_technomancer_create_ups_connection", "prob": 25 },
+          { "item": "spell_scroll_technomancer_reveal_world_map", "prob": 30
         ],
         "prob": 35
       },

--- a/data/mods/Magiclysm/itemgroups/itemgroups.json
+++ b/data/mods/Magiclysm/itemgroups/itemgroups.json
@@ -1355,7 +1355,7 @@
           { "item": "spell_scroll_technomancer_welder", "prob": 35 },
           { "item": "spell_scroll_technomancer_recharge_vehicle", "prob": 20 },
           { "item": "spell_scroll_technomancer_create_ups_connection", "prob": 25 },
-          { "item": "spell_scroll_technomancer_reveal_world_map", "prob": 30
+          { "item": "spell_scroll_technomancer_reveal_world_map", "prob": 30 }
         ],
         "prob": 35
       },

--- a/data/mods/Magiclysm/itemgroups/spellbooks.json
+++ b/data/mods/Magiclysm/itemgroups/spellbooks.json
@@ -135,7 +135,8 @@
       [ "spell_scroll_flamesword", 35 ],
       [ "spell_scroll_force_jar", 30 ],
       [ "spell_scroll_flamebreath", 30 ],
-      [ "spell_scroll_thought_shield", 35 ]
+      [ "spell_scroll_thought_shield", 35 ],
+      [ "spell_scroll_technomancer_reveal_world_map", 20]
     ]
   },
   {

--- a/data/mods/Magiclysm/itemgroups/spellbooks.json
+++ b/data/mods/Magiclysm/itemgroups/spellbooks.json
@@ -136,7 +136,7 @@
       [ "spell_scroll_force_jar", 30 ],
       [ "spell_scroll_flamebreath", 30 ],
       [ "spell_scroll_thought_shield", 35 ],
-      [ "spell_scroll_technomancer_reveal_world_map", 20]
+      [ "spell_scroll_technomancer_reveal_world_map", 20 ]
     ]
   },
   {

--- a/data/mods/Magiclysm/items/spell_scrolls.json
+++ b/data/mods/Magiclysm/items/spell_scrolls.json
@@ -2031,5 +2031,14 @@
     "name": { "str": "Scroll of Power Linkage", "str_pl": "Scrolls of Power Linkage" },
     "description": "Enchant a tool to accept power wirelessly from a compatible source.",
     "use_action": { "type": "learn_spell", "spells": [ "technomancer_create_ups_connection" ] }
+  },
+  {
+    "type": "BOOK",
+    "copy-from": "spell_scroll",
+    "id": "spell_scroll_technomancer_reveal_world_map",
+    "//": "Technomancer spell",
+    "name": { "str": "Scroll of Ping Devices", "str_pl": "Scrolls of Ping Devices" },
+    "description": "Send out a ping to devices in your area, to collect data and create a map of your surroundings",
+    "use_action": { "type": "learn_spell", "spells": [ "technomancer_reveal_world_map" ] }
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Technomancer map spell"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
At present, the only magiclysm class with a mapping spell was Earthshaper. This opens the ability up to all characters.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Added a spell that lets technomancers map areas, modeled after the earthshaper spell.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
There are a couple of ways I wanted to be able to do this. Making it use a pseudo-map like the earthshaper spell that only revealed MAN_MADE structures would have been great, but I didn't see a means of doing that and it would have been a nightmare to try and add every single viable location to a map. I also had thought it might be cool to place the map radius around the nearest radio tower rather than around the player, but I didn't see a way of doing that either. I'm sure it's not theoretically impossible to do those things, but it would take more skill at coding than I have, so this is what I got. 
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Spell casts properly, learns properly, and gives proficiencies properly. Spell scroll spawned properly in the item groups it was added to. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
While testing this I discovered that while the Novice Channeling proficiency correctly reduces cost and time to cast, Apprentice and Master seem to increase it again? I don't think that's an error with this PR given how I'm using the same math as every other spell, but it's worth looking into.  EDIT: Made a PR to fix it, ended up being much easier than I thought.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
