### PR TITLE
Stacks of items on the ground render either the last-dropped favorite item or the largest item.

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -472,7 +472,7 @@ void tileset_cache::loader::create_textures_from_tile_atlas( const SDL_Surface_P
     for( tiles_pixel_color_entry &entry : tile_values_data ) {
         std::vector<texture> *tile_values = std::get<0>( entry );
         color_pixel_function_pointer color_pixel_function = get_color_pixel_function( std::get<1>
-                ( entry ) );
+            ( entry ) );
         if( !color_pixel_function ) {
             // TODO: Move it inside apply_color_filter.
             copy_surface_to_texture( tile_atlas, offset, *tile_values );
@@ -934,26 +934,26 @@ void tileset_cache::loader::process_variations_after_loading(
     for( auto &v : vs ) {
         // in a given variation, erase any invalid sprite ids
         v.obj.erase(
-            std::remove_if(
-                v.obj.begin(),
-                v.obj.end(),
+             std::remove_if(
+                 v.obj.begin(),
+                 v.obj.end(),
         [&]( int id ) {
             return id >= offset || id < 0;
         } ),
         v.obj.end()
-        );
+         );
     }
     // erase any variations with no valid sprite ids left
     vs.erase(
-        std::remove_if(
-            vs.begin(),
-            vs.end(),
+          std::remove_if(
+              vs.begin(),
+              vs.end(),
     [&]( const weighted_object<int, std::vector<int>> &o ) {
         return o.obj.empty();
     }
-        ),
+          ),
     vs.end()
-    );
+      );
     // populate the bookkeeping table used for selecting sprite variations
     vs.precalc();
 }
@@ -1365,9 +1365,9 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
     here.prev_o = o;
 
     you.prepare_map_memory_region(
-        here.getglobal( tripoint( min_mm_reg, center.z ) ),
-        here.getglobal( tripoint( max_mm_reg, center.z ) )
-    );
+           here.getglobal( tripoint( min_mm_reg, center.z ) ),
+           here.getglobal( tripoint( max_mm_reg, center.z ) )
+       );
 
     //set up a default tile for the edges outside the render area
     visibility_type offscreen_type = visibility_type::HIDDEN;
@@ -1601,8 +1601,8 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
 
                             // string overlay
                             here.overlay_strings_cache.emplace(
-                                tile_pos + quarter_tile,
-                                formatted_text( text, catacurses::black, direction::NORTH ) );
+                                    tile_pos + quarter_tile,
+                                    formatted_text( text, catacurses::black, direction::NORTH ) );
                         };
 
                         if( g->display_overlay_state( ACTION_DISPLAY_LIGHTING ) ) {
@@ -1709,7 +1709,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
         int cur_zlevel = draw_min_z;
         while( cur_zlevel <= center.z ) {
             const half_open_rectangle<point> &cur_any_tile_range = is_isometric()
-                    ? z_any_tile_range[center.z - cur_zlevel] : top_any_tile_range;
+                ? z_any_tile_range[center.z - cur_zlevel] : top_any_tile_range;
             // For each row
             for( int row = cur_any_tile_range.p_min.y; row < cur_any_tile_range.p_max.y; row ++ ) {
                 // Set base height for each tile
@@ -3276,7 +3276,7 @@ bool cata_tiles::draw_furniture( const tripoint &p, const lit_level ll, int &hei
             const auto furn = [&]( const tripoint & q, const bool invis ) -> furn_id {
                 const auto it = furniture_override.find( q );
                 return it != furniture_override.end() ? it->second :
-                ( !overridden || !invis ) ? here.furn( q ) : f_null;
+                                               ( !overridden || !invis ) ? here.furn( q ) : f_null;
             };
             const std::array<int, 4> neighborhood = {
                 static_cast<int>( furn( p + point_south, invisible[1] ) ),
@@ -3370,7 +3370,7 @@ bool cata_tiles::draw_trap( const tripoint &p, const lit_level ll, int &height_3
             const auto tr_at = [&]( const tripoint & q, const bool invis ) -> trap_id {
                 const auto it = trap_override.find( q );
                 return it != trap_override.end() ? it->second :
-                ( !overridden || !invis ) ? here.tr_at( q ).loadid : tr_null;
+                                          ( !overridden || !invis ) ? here.tr_at( q ).loadid : tr_null;
             };
             const std::array<int, 4> neighborhood = {
                 static_cast<int>( tr_at( p + point_south, invisible[1] ) ),
@@ -3473,8 +3473,7 @@ bool cata_tiles::draw_field_or_item( const tripoint &p, const lit_level ll, int 
                 auto has_field = [&]( field_type_id fld, const tripoint & q, const bool invis ) -> field_type_id {
                     // go through the fields and see if they are equal
                     field_type_id found = fd_null;
-                    for( std::pair<const field_type_id, field_entry> &this_fld : here.field_at( q ) )
-                    {
+                    for( std::pair<const field_type_id, field_entry> &this_fld : here.field_at( q ) ) {
                         if( this_fld.first == fld ) {
                             found = fld;
                         }
@@ -3579,7 +3578,7 @@ bool cata_tiles::draw_field_or_item( const tripoint &p, const lit_level ll, int 
             auto field_at = [&]( const tripoint & q, const bool invis ) -> field_type_id {
                 const auto it = field_override.find( q );
                 return it != field_override.end() ? it->second :
-                ( !fld_overridden || !invis ) ? here.field_at( q ).displayed_field_type() : fd_null;
+                                           ( !fld_overridden || !invis ) ? here.field_at( q ).displayed_field_type() : fd_null;
             };
             // for rotation information
             const std::array<int, 4> neighborhood = {
@@ -3648,7 +3647,7 @@ bool cata_tiles::draw_field_or_item( const tripoint &p, const lit_level ll, int 
                                                  0, layer_lit, layer_nv, height_3d, 0, variant, layer_var.offset );
 
                             // if the top item is already being layered don't draw it later
-                            if( i.typeId() == tile.get_uppermost_item().typeId() ) {
+                            if( i.typeId() == tile.get_most_visible_item().typeId() ) {
                                 drawtop = false;
                             }
 
@@ -3693,7 +3692,7 @@ bool cata_tiles::draw_field_or_item( const tripoint &p, const lit_level ll, int 
                                                      0, layer_lit, layer_nv, height_3d, 0, variant, layer_var.offset );
 
                                 // if the top item is already being layered don't draw it later
-                                if( i.typeId() == tile.get_uppermost_item().typeId() ) {
+                                if( i.typeId() == tile.get_most_visible_item().typeId() ) {
                                     drawtop = false;
                                 }
 
@@ -3715,7 +3714,9 @@ bool cata_tiles::draw_field_or_item( const tripoint &p, const lit_level ll, int 
                 hilite = std::get<2>( it_override->second );
                 it_type = item::find_type( it_id );
             } else if( !invisible[0] && here.sees_some_items( p, get_player_character() ) ) {
-                const item &itm = tile.get_uppermost_item();
+                // instead of just drawing the uppermost item, we draw the uppermost favorite item, and if there is none, we draw the item with the greatest volume.
+                const item &itm = tile.get_most_visible_item();
+
                 if( itm.has_itype_variant() ) {
                     variant = itm.itype_variant().id;
                 }
@@ -4717,8 +4718,8 @@ void cata_tiles::draw_sct_frame( std::multimap<point, formatted_text> &overlay_s
                                              full_text_length / 2;
 
                 overlay_strings.emplace(
-                    player_to_screen( iD + point( direction_offset, 0 ) ),
-                    formatted_text( sText, FG, direction ) );
+                                   player_to_screen( iD + point( direction_offset, 0 ) ),
+                                   formatted_text( sText, FG, direction ) );
             } else {
                 for( char &it : sText ) {
                     const std::string generic_id = get_ascii_tile_id( it, FG, -1 );
@@ -4818,7 +4819,7 @@ void cata_tiles::get_terrain_orientation( const tripoint &p, int &rota, int &sub
     const auto ter = [&]( const tripoint & q, const bool invis ) -> ter_id {
         const auto override = ter_override.find( q );
         return override != ter_override.end() ? override->second :
-        ( !overridden || !invis ) ? here.ter( q ) : t_null;
+                                       ( !overridden || !invis ) ? here.ter( q ) : t_null;
     };
 
     // get terrain at x,y
@@ -5238,7 +5239,7 @@ void cata_tiles::do_tile_loading_report()
 
     std::vector<map_extra_id> map_extra_ids = MapExtras::get_all_function_names();
     map_extra_ids.erase(
-        std::remove_if( map_extra_ids.begin(), map_extra_ids.end(),
+                     std::remove_if( map_extra_ids.begin(), map_extra_ids.end(),
     []( const map_extra_id & id ) {
         return !id->autonote;
     } ), map_extra_ids.end() );

--- a/src/submap.cpp
+++ b/src/submap.cpp
@@ -296,8 +296,6 @@ void submap::rotate( int turns )
     computers = rot_comp;
 }
 
-
-
 void submap::mirror( bool horizontally )
 {
     if( is_uniform() ) {

--- a/src/submap.cpp
+++ b/src/submap.cpp
@@ -296,6 +296,8 @@ void submap::rotate( int turns )
     computers = rot_comp;
 }
 
+
+
 void submap::mirror( bool horizontally )
 {
     if( is_uniform() ) {

--- a/src/submap.h
+++ b/src/submap.h
@@ -420,30 +420,35 @@ class maptile_impl
 
         /** Returns the uppermost favorite item if there is a favorite item. Otherwise, returns the item with the greatest volume.
         *
-        * Assumes there is at least one item.
+        * Requires that there is at least one item, otherwise throws.
         * Used to decide which item to render.
-        * TODO: might be slow enough to justify storing the most visible item for each tile? 
         */
-        const item &get_most_visible_item() const {
+        const item& get_most_visible_item() const {
+            
+            const cata::colony<item> & items = get_items();
 
-            const item *biggest_item = nullptr;
+            // make sure there is at least one item
+            if( items.size() == 0 ) {
+                throw std::runtime_error("Call to get_most_visible_item() with no visible item!\n");
+            }
+
+            const item *biggest_item = &*items.begin(); 
             units::volume biggest_volume = 0_ml;
 
-            // uppermost item is at end of the list, so iterate backwards so uppermost item is preferred
-            auto items = get_items();
-            // unsigned int i = get_items().size();
+            // uppermost item is at end of the list, so iterate backwards so uppermost (last dropped) item is preferred
             for( auto it = items.rbegin(); it != items.rend(); it++ ) {
-                const auto &item = *it;
+                const item &current_item = *it;
 
-                if( item.is_favorite ) {
-                    return item;
+                if( current_item.is_favorite ) {
+                    return current_item;
                 }
 
-                if( item.base_volume() > biggest_volume ) {
-                    biggest_item = &item;
-                    biggest_volume = item.base_volume();
+                if( current_item.base_volume() > biggest_volume ) {
+                    biggest_item = &current_item;
+                    biggest_volume = current_item.base_volume();
                 }
             }
+
             return *biggest_item;
         }
 

--- a/src/submap.h
+++ b/src/submap.h
@@ -420,35 +420,30 @@ class maptile_impl
 
         /** Returns the uppermost favorite item if there is a favorite item. Otherwise, returns the item with the greatest volume.
         *
-        * Requires that there is at least one item, otherwise throws.
+        * Assumes there is at least one item.
         * Used to decide which item to render.
+        * TODO: might be slow enough to justify storing the most visible item for each tile? 
         */
-        const item& get_most_visible_item() const {
-            
-            const cata::colony<item> & items = get_items();
+        const item &get_most_visible_item() const {
 
-            // make sure there is at least one item
-            if( items.size() == 0 ) {
-                throw std::runtime_error("Call to get_most_visible_item() with no visible item!\n");
-            }
-
-            const item *biggest_item = &*items.begin(); 
+            const item *biggest_item = nullptr;
             units::volume biggest_volume = 0_ml;
 
-            // uppermost item is at end of the list, so iterate backwards so uppermost (last dropped) item is preferred
+            // uppermost item is at end of the list, so iterate backwards so uppermost item is preferred
+            auto items = get_items();
+            // unsigned int i = get_items().size();
             for( auto it = items.rbegin(); it != items.rend(); it++ ) {
-                const item &current_item = *it;
+                const auto &item = *it;
 
-                if( current_item.is_favorite ) {
-                    return current_item;
+                if( item.is_favorite ) {
+                    return item;
                 }
 
-                if( current_item.base_volume() > biggest_volume ) {
-                    biggest_item = &current_item;
-                    biggest_volume = current_item.base_volume();
+                if( item.base_volume() > biggest_volume ) {
+                    biggest_item = &item;
+                    biggest_volume = item.base_volume();
                 }
             }
-
             return *biggest_item;
         }
 

--- a/src/submap.h
+++ b/src/submap.h
@@ -418,6 +418,35 @@ class maptile_impl
             return *std::prev( sm->get_items( pos() ).cend() );
         }
 
+        /** Returns the uppermost favorite item if there is a favorite item. Otherwise, returns the item with the greatest volume.
+        *
+        * Assumes there is at least one item.
+        * Used to decide which item to render.
+        * TODO: might be slow enough to justify storing the most visible item for each tile? 
+        */
+        const item &get_most_visible_item() const {
+
+            const item *biggest_item = nullptr;
+            units::volume biggest_volume = 0_ml;
+
+            // uppermost item is at end of the list, so iterate backwards so uppermost item is preferred
+            auto items = get_items();
+            // unsigned int i = get_items().size();
+            for( auto it = items.rbegin(); it != items.rend(); it++ ) {
+                const auto &item = *it;
+
+                if( item.is_favorite ) {
+                    return item;
+                }
+
+                if( item.base_volume() > biggest_volume ) {
+                    biggest_item = &item;
+                    biggest_volume = item.base_volume();
+                }
+            }
+            return *biggest_item;
+        }
+
         // Gets all items
         const cata::colony<item> &get_items() const {
             return sm->get_items( pos() );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Instead of rendering the last-dropped item on the ground, it renders the last-dropped favorite items on the ground, or the biggest item if no such favorite item."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Addresses #71637

Once, I lost my backpack in a lab and spent like an hour trying to find it because after dropping my backpack on a tile, I noticed I also had some broken glass in my pockets and decided to drop that too. Because the game rendered the glass instead of the backpack. it was a huge pain to find it. 

In general, it makes much more sense for bigger items to display in favor of smaller ones, and for favorite items to display in favor of non-favorite ones, and will prevent stuff like bullet casings covering up actually important items.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

In the code that renders dropped items, I replaced the calls to submap::get_uppermost_item() with a call to a new function, submap::get_most_visible_item(), which iterates through the items on that tile and returns the first (and therefore last dropped) favorite item or, failing that, the biggest item.

#### Describe alternatives you've considered

Marking the item as favorite and enabling creation of notes when a favorite item is dropped helps, but it doesn't give its exact position as well, and it doesn't change the fact that it's really weird/potentially deceptive for the last dropped item to render, even when you drop something tiny on something big.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

I walked around in a new game picking up and dropping various items in various orders, and strolling through the city. Worked as expected, and I did not notice any performance issues, even with thousands of items on the same tile.
I also ran all tests locally and saw no related issues.

#### Additional context

If this leads to performance issues with item rendering (given the O(n items on tile) time complexity), it would be pretty simple to just cache the most visible item on each tile, but I can't imagine this being an issue unless there are literally >1,000,000 items in view, in which case there are most likely already other performance issues.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
