### PR TITLE
Pickaxe_list and rope_natural relevant Fix

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -1897,7 +1897,7 @@
     "category": "CONSTRUCT",
     "required_skills": [ [ "fabrication", 3 ] ],
     "time": "30 m",
-    "tools": [ [ [ "pickaxe", -1 ], [ "bronze_pickaxe", -1 ], [ "jackhammer", 50 ], [ "elec_jackhammer", 660 ] ] ],
+    "tools": [ [ [ "pickaxe_list", 1, "LIST" ], [ "jackhammer", 50 ], [ "elec_jackhammer", 660 ] ] ],
     "pre_terrain": "t_brick_wall",
     "post_terrain": "t_embrasure_brick"
   },
@@ -1926,7 +1926,7 @@
     "category": "CONSTRUCT",
     "required_skills": [ [ "fabrication", 3 ] ],
     "time": "30 m",
-    "tools": [ [ [ "pickaxe", -1 ], [ "bronze_pickaxe", -1 ], [ "jackhammer", 50 ], [ "elec_jackhammer", 660 ] ] ],
+    "tools": [ [ [ "pickaxe_list", 1, "LIST" ], [ "jackhammer", 50 ], [ "elec_jackhammer", 660 ] ] ],
     "pre_terrain": "t_adobe_brick_wall",
     "post_terrain": "t_embrasure_adobe_brick"
   },
@@ -4765,13 +4765,14 @@
     "qualities": [
       [ { "id": "AXE", "level": 2 }, { "id": "SAW_W", "level": 1 } ],
       [ { "id": "HAMMER", "level": 2 } ],
-      [ { "id": "DIG", "level": 2 } ]
+      [ { "id": "DIG", "level": 2 } ],
+      [ { "id": "ROPE", "level": 2 } ]
     ],
     "tools": [
-      [ [ "pickaxe", -1 ], [ "bronze_pickaxe", -1 ], [ "jackhammer", 140 ], [ "elec_jackhammer", 1848 ] ],
+      [ [ "pickaxe_list", 1, "LIST" ], [ "jackhammer", 140 ], [ "elec_jackhammer", 1848 ] ],
       [ [ "rope_natural", 1, "LIST" ] ]
     ],
-    "components": [ [ [ "2x4", 18 ] ], [ [ "wood_beam", 2 ] ], [ [ "nails", 90, "LIST" ], [ "nuts_bolts", 90 ] ] ],
+    "components": [ [ [ "2x4", 18 ] ], [ [ "wood_beam", 2 ] ], [ [ "nails", 90, "LIST" ], [ "nuts_bolts", 90 ] ], [ [ "rope_natural", 1, "LIST" ] ] ],
     "byproducts": [ { "group": "digging_soil_loam_50L", "count": 40 } ],
     "activity_level": "EXTRA_EXERCISE",
     "pre_flags": "DIGGABLE",
@@ -4789,13 +4790,14 @@
     "qualities": [
       [ { "id": "AXE", "level": 2 }, { "id": "SAW_W", "level": 1 } ],
       [ { "id": "HAMMER", "level": 2 } ],
-      [ { "id": "DIG", "level": 2 } ]
+      [ { "id": "DIG", "level": 2 } ],
+      [ { "id": "ROPE", "level": 2 } ]
     ],
     "tools": [
-      [ [ "pickaxe", -1 ], [ "bronze_pickaxe", -1 ], [ "jackhammer", 160 ], [ "elec_jackhammer", 2112 ] ],
+      [ [ "pickaxe_list", 1, "LIST" ], [ "jackhammer", 160 ], [ "elec_jackhammer", 2112 ] ],
       [ [ "rope_natural", 1, "LIST" ] ]
     ],
-    "components": [ [ [ "2x4", 18 ] ], [ [ "wood_beam", 2 ] ], [ [ "nails", 90, "LIST" ], [ "nuts_bolts", 90 ] ] ],
+    "components": [ [ [ "2x4", 18 ] ], [ [ "wood_beam", 2 ] ], [ [ "nails", 90, "LIST" ], [ "nuts_bolts", 90 ] ], [ [ "rope_natural", 1, "LIST" ] ] ],
     "byproducts": [ { "group": "mining_rock" } ],
     "activity_level": "EXTRA_EXERCISE",
     "pre_special": "check_down_OK",
@@ -4809,7 +4811,7 @@
     "category": "DIG",
     "required_skills": [ [ "fabrication", 0 ] ],
     "time": "70 m",
-    "tools": [ [ [ "pickaxe", -1 ], [ "bronze_pickaxe", -1 ] ] ],
+    "tools": [ [ [ "pickaxe_list", 1, "LIST" ] ] ],
     "activity_level": "EXTRA_EXERCISE",
     "pre_terrain": "t_wall_resin_cage",
     "post_terrain": "t_floor_resin",
@@ -4881,10 +4883,11 @@
     "qualities": [
       [ { "id": "AXE", "level": 2 }, { "id": "SAW_W", "level": 1 } ],
       [ { "id": "HAMMER", "level": 2 } ],
-      [ { "id": "DIG", "level": 2 } ]
+      [ { "id": "DIG", "level": 2 } ],
+      [ { "id": "ROPE", "level": 2 } ]
     ],
     "tools": [
-      [ [ "pickaxe", -1 ], [ "bronze_pickaxe", -1 ], [ "jackhammer", 160 ], [ "elec_jackhammer", 2112 ] ],
+      [ [ "pickaxe_list", 1, "LIST" ], [ "jackhammer", 160 ], [ "elec_jackhammer", 2112 ] ],
       [
         "miner_hat",
         "hat_hard",
@@ -4894,11 +4897,10 @@
         "helmet_riot",
         "tac_helmet",
         "miner_hat_on"
-      ],
-      [ [ "rope_natural", 1, "LIST" ] ]
+      ]
     ],
     "//": "Helmets are essential because you're digging up and things may fall on you.",
-    "components": [ [ [ "2x4", 18 ] ], [ [ "wood_beam", 2 ] ], [ [ "nails", 90, "LIST" ], [ "nuts_bolts", 90 ] ] ],
+    "components": [ [ [ "2x4", 18 ] ], [ [ "wood_beam", 2 ] ], [ [ "nails", 90, "LIST" ], [ "nuts_bolts", 90 ] ], [ [ "rope_natural", 1, "LIST" ] ] ],
     "pre_special": "check_up_OK",
     "pre_terrain": "t_rock",
     "post_special": "done_mine_upstair",
@@ -6906,7 +6908,7 @@
     "qualities": [ [ { "id": "DIG", "level": 2 } ] ],
     "required_skills": [ [ "survival", 3 ] ],
     "time": "300 m",
-    "tools": [ [ [ "pickaxe", -1 ], [ "bronze_pickaxe", -1 ], [ "jackhammer", 140 ], [ "elec_jackhammer", 1848 ] ] ],
+    "tools": [ [ [ "pickaxe_list", 1, "LIST" ], [ "jackhammer", 140 ], [ "elec_jackhammer", 1848 ] ] ],
     "byproducts": [ { "group": "mining_rock" } ],
     "pre_terrain": "t_rock_floor",
     "post_terrain": "t_pit",
@@ -7748,7 +7750,7 @@
     "components": [ [ [ "2x4", 4 ] ], [ [ "nails", 16, "LIST" ] ] ],
     "pre_terrain": "t_rock_roof",
     "post_terrain": "t_skylight_frame",
-    "tools": [ [ [ "pickaxe", -1 ], [ "bronze_pickaxe", -1 ], [ "jackhammer", 50 ], [ "elec_jackhammer", 660 ] ] ]
+    "tools": [ [ [ "pickaxe_list", 1, "LIST" ], [ "jackhammer", 50 ], [ "elec_jackhammer", 660 ] ] ]
   },
   {
     "type": "construction",

--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -4797,7 +4797,12 @@
       [ [ "pickaxe_list", 1, "LIST" ], [ "jackhammer", 160 ], [ "elec_jackhammer", 2112 ] ],
       [ [ "rope_natural", 1, "LIST" ] ]
     ],
-    "components": [ [ [ "2x4", 18 ] ], [ [ "wood_beam", 2 ] ], [ [ "nails", 90, "LIST" ], [ "nuts_bolts", 90 ] ], [ [ "rope_natural", 1, "LIST" ] ] ],
+    "components": [
+      [ [ "2x4", 18 ] ],
+      [ [ "wood_beam", 2 ] ],
+      [ [ "nails", 90, "LIST" ], [ "nuts_bolts", 90 ] ],
+      [ [ "rope_natural", 1, "LIST" ] ]
+    ],
     "byproducts": [ { "group": "mining_rock" } ],
     "activity_level": "EXTRA_EXERCISE",
     "pre_special": "check_down_OK",

--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -4772,7 +4772,12 @@
       [ [ "pickaxe_list", 1, "LIST" ], [ "jackhammer", 140 ], [ "elec_jackhammer", 1848 ] ],
       [ [ "rope_natural", 1, "LIST" ] ]
     ],
-    "components": [ [ [ "2x4", 18 ] ], [ [ "wood_beam", 2 ] ], [ [ "nails", 90, "LIST" ], [ "nuts_bolts", 90 ] ], [ [ "rope_natural", 1, "LIST" ] ] ],
+    "components": [
+      [ [ "2x4", 18 ] ],
+      [ [ "wood_beam", 2 ] ],
+      [ [ "nails", 90, "LIST" ], [ "nuts_bolts", 90 ] ],
+      [ [ "rope_natural", 1, "LIST" ] ]
+    ],
     "byproducts": [ { "group": "digging_soil_loam_50L", "count": 40 } ],
     "activity_level": "EXTRA_EXERCISE",
     "pre_flags": "DIGGABLE",

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -124,7 +124,7 @@
     "id": "pickaxe_list",
     "type": "requirement",
     "//": "Pickaxe tools",
-    "tools": [ [ [ "pickaxe", -1 ] ], [ [ "bronze_pickaxe", -1 ] ] ]
+    "tools": [ [ [ "pickaxe", -1 ], [ "bronze_pickaxe", -1 ] ] ]
   },
   {
     "id": "serum_production_standard",

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -301,7 +301,7 @@
     "id": "mining_standard",
     "type": "requirement",
     "//": "mining",
-    "tools": [ [ [ "pickaxe", -1 ], [ "bronze_pickaxe", -1 ], [ "jackhammer", 300 ], [ "elec_jackhammer", 3960 ] ] ]
+    "tools": [ [ [ "pickaxe_list", 1, "LIST" ], [ "jackhammer", 300 ], [ "elec_jackhammer", 3960 ] ] ]
   },
   {
     "id": "bronzesmithing_tools",
@@ -341,8 +341,7 @@
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "CHISEL", "level": 2 }, { "id": "PRY", "level": 3 } ],
     "tools": [
       [
-        [ "pickaxe", -1 ],
-        [ "bronze_pickaxe", -1 ],
+        [ "pickaxe_list", 1, "LIST" ],
         [ "jackhammer", 140 ],
         [ "elec_jackhammer", 1848 ],
         [ "hammer_sledge", -1 ],
@@ -376,7 +375,7 @@
     "//": "Tools for removing road / sidewalk",
     "qualities": [ { "id": "PRY", "level": 3 } ],
     "tools": [
-      [ [ "pickaxe", -1 ], [ "bronze_pickaxe", -1 ], [ "jackhammer", 140 ], [ "elec_jackhammer", 1848 ] ],
+      [ [ "pickaxe_list", 1, "LIST" ], [ "jackhammer", 140 ], [ "elec_jackhammer", 1848 ] ],
       [ [ "masonrysaw_off", 100 ], [ "electric_masonrysaw_off", 1320 ] ]
     ]
   },

--- a/data/json/uncraft/generic.json
+++ b/data/json/uncraft/generic.json
@@ -29,7 +29,7 @@
     "activity_level": "MODERATE_EXERCISE",
     "skill_used": "fabrication",
     "time": "5 m",
-    "tools": [ [ [ "pickaxe_list", -1, "LIST" ], [ "jackhammer", 5 ], [ "elec_jackhammer", 66 ] ] ],
+    "tools": [ [ [ "pickaxe_list", 1, "LIST" ], [ "jackhammer", 5 ], [ "elec_jackhammer", 66 ] ] ],
     "components": [ [ [ "rock", 24 ] ] ]
   },
   {

--- a/data/mods/Magiclysm/requirements/crafting.json
+++ b/data/mods/Magiclysm/requirements/crafting.json
@@ -28,24 +28,6 @@
     "id": "pickaxe_list",
     "type": "requirement",
     "//": "Pickaxe tools",
-    "extend": { "tools": [ [ [ "pickaxe_plus_one", -1 ] ], [ [ "pickaxe_plus_two", -1 ], [ "eshaper_pickaxe", -1 ] ] ] }
-  },
-  {
-    "id": "mining_standard",
-    "type": "requirement",
-    "//": "mining",
-    "extend": { "tools": [ [ [ "pickaxe_plus_one", -1 ] ], [ [ "pickaxe_plus_two", -1 ], [ "eshaper_pickaxe", -1 ] ] ] }
-  },
-  {
-    "id": "concrete_removal_standard",
-    "type": "requirement",
-    "//": "Tools for removing concrete",
-    "extend": { "tools": [ [ [ "pickaxe_plus_one", -1 ] ], [ [ "pickaxe_plus_two", -1 ], [ "eshaper_pickaxe", -1 ] ] ] }
-  },
-  {
-    "id": "road_removal_standard",
-    "type": "requirement",
-    "//": "Tools for removing road / sidewalk",
-    "extend": { "tools": [ [ [ "pickaxe_plus_one", -1 ] ], [ [ "pickaxe_plus_two", -1 ], [ "eshaper_pickaxe", -1 ] ] ] }
+    "extend": { "tools": [ [ [ "pickaxe_plus_one", -1 ], [ "pickaxe_plus_two", -1 ], [ "eshaper_pickaxe", -1 ] ] ] }
   }
 ]

--- a/data/mods/innawood/recipes/recipe_deconstruction.json
+++ b/data/mods/innawood/recipes/recipe_deconstruction.json
@@ -13,7 +13,7 @@
     "activity_level": "MODERATE_EXERCISE",
     "skill_used": "fabrication",
     "time": "5 m",
-    "tools": [ [ [ "pickaxe_list", -1, "LIST" ], [ "jackhammer", 1 ], [ "elec_jackhammer", 50 ] ] ],
+    "tools": [ [ [ "pickaxe_list", 1, "LIST" ] ], [ [ "jackhammer", 1 ] ], [ [ "elec_jackhammer", 50 ] ] ],
     "components": [ [ [ "rock", 24 ] ] ]
   },
   {

--- a/data/mods/innawood/recipes/recipe_deconstruction.json
+++ b/data/mods/innawood/recipes/recipe_deconstruction.json
@@ -13,7 +13,7 @@
     "activity_level": "MODERATE_EXERCISE",
     "skill_used": "fabrication",
     "time": "5 m",
-    "tools": [ [ [ "pickaxe_list", 1, "LIST" ] ], [ [ "jackhammer", 1 ] ], [ [ "elec_jackhammer", 50 ] ] ],
+    "tools": [ [ [ "pickaxe_list", 1, "LIST" ], [ "jackhammer", 1 ], [ "elec_jackhammer", 50 ] ] ],
     "components": [ [ [ "rock", 24 ] ] ]
   },
   {


### PR DESCRIPTION
#### Summary

Bugfixes "Pickaxe_list, and the bug 'Unable To Construct Dig Downstair'"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix https://github.com/CleverRaven/Cataclysm-DDA/issues/71381 and https://github.com/CleverRaven/Cataclysm-DDA/issues/72141, in addition to some minor bugs.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Pickaxe_list is not working properly, fixed it both in vanilla, Magiclysm and innawood. Now we can uncraft large rock with tools in pickaxe_list, and tools required are shown correctly in relevant construction recipes.

Requirements in constr_dig_downstair, constr_mine_downstair, and constr_mine_upstair are not well-defined, removed the rope_natural required in tools, added
`[ "rope_natural", 1, "LIST" ]`
to components and
`[ { "id": "ROPE", "level": 2 } ]`
to qualities required.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Not sure what's the purpose of the changes in stair construct recipes, so I add both solutions for now, please give me some advice on which one should be used. The in-game description suggests it as a component, but the words has not been changed since 0.G.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Manual testing to verify fix, nothing wrong when uncrafting large rock with pickaxe and construct dig downstair.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

None

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
