### PR TITLE
Enhanced debug backpack to carry liquids/gasses, utility use_action

### DIFF
--- a/data/json/items/armor/storage.json
+++ b/data/json/items/armor/storage.json
@@ -2833,6 +2833,11 @@
     "symbol": "[",
     "looks_like": "backpack",
     "color": "yellow",
+    "use_action": {
+      "type": "effect_on_conditions",
+      "description": "Seems like it could calm local conditions.",
+      "effect_on_conditions": [ "EOC_CANCEL_PORTAL_STORM" ]
+    },
     "pocket_data": [
       {
         "rigid": true,
@@ -2841,6 +2846,102 @@
         "max_contains_weight": "100000 kg",
         "moves": 1,
         "max_item_length": "1 km",
+        "weight_multiplier": 0.01,
+        "volume_multiplier": 0.01
+      },
+      {
+        "rigid": true,
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "100000 L",
+        "max_contains_weight": "100000 kg",
+        "moves": 1,
+        "max_item_length": "1 km",
+        "watertight": true,
+        "airtight": true,
+        "weight_multiplier": 0.01,
+        "volume_multiplier": 0.01
+      },
+      {
+        "rigid": true,
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "100000 L",
+        "max_contains_weight": "100000 kg",
+        "moves": 1,
+        "max_item_length": "1 km",
+        "watertight": true,
+        "airtight": true,
+        "weight_multiplier": 0.01,
+        "volume_multiplier": 0.01
+      },
+      {
+        "rigid": true,
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "100000 L",
+        "max_contains_weight": "100000 kg",
+        "moves": 1,
+        "max_item_length": "1 km",
+        "watertight": true,
+        "airtight": true,
+        "weight_multiplier": 0.01,
+        "volume_multiplier": 0.01
+      },
+      {
+        "rigid": true,
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "100000 L",
+        "max_contains_weight": "100000 kg",
+        "moves": 1,
+        "max_item_length": "1 km",
+        "watertight": true,
+        "airtight": true,
+        "weight_multiplier": 0.01,
+        "volume_multiplier": 0.01
+      },
+      {
+        "rigid": true,
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "100000 L",
+        "max_contains_weight": "100000 kg",
+        "moves": 1,
+        "max_item_length": "1 km",
+        "watertight": true,
+        "airtight": true,
+        "weight_multiplier": 0.01,
+        "volume_multiplier": 0.01
+      },
+      {
+        "rigid": true,
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "100000 L",
+        "max_contains_weight": "100000 kg",
+        "moves": 1,
+        "max_item_length": "1 km",
+        "watertight": true,
+        "airtight": true,
+        "weight_multiplier": 0.01,
+        "volume_multiplier": 0.01
+      },
+      {
+        "rigid": true,
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "100000 L",
+        "max_contains_weight": "100000 kg",
+        "moves": 1,
+        "max_item_length": "1 km",
+        "watertight": true,
+        "airtight": true,
+        "weight_multiplier": 0.01,
+        "volume_multiplier": 0.01
+      },
+      {
+        "rigid": true,
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "100000 L",
+        "max_contains_weight": "100000 kg",
+        "moves": 1,
+        "max_item_length": "1 km",
+        "watertight": true,
+        "airtight": true,
         "weight_multiplier": 0.01,
         "volume_multiplier": 0.01
       }

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -2875,16 +2875,9 @@ void debug()
     get_event_bus().send<event_type::uses_debug_menu>( *action );
 
     // Used for quick setup, constructed outside the switches to reduce duplicate code
-    std::vector<trait_id> setup_traits;
-    setup_traits.emplace_back( trait_DEBUG_BIONICS );
-    setup_traits.emplace_back( trait_DEBUG_CLAIRVOYANCE );
-    setup_traits.emplace_back( trait_DEBUG_CLOAK );
-    setup_traits.emplace_back( trait_DEBUG_HS );
-    setup_traits.emplace_back( trait_DEBUG_LS );
-    setup_traits.emplace_back( trait_DEBUG_MANA );
-    setup_traits.emplace_back( trait_DEBUG_NODMG );
-    setup_traits.emplace_back( trait_DEBUG_NOTEMP );
-    setup_traits.emplace_back( trait_DEBUG_SPEED );
+    std::vector<trait_id> setup_traits{trait_DEBUG_BIONICS, trait_DEBUG_CLAIRVOYANCE, trait_DEBUG_CLOAK,
+                                       trait_DEBUG_HS, trait_DEBUG_LS, trait_DEBUG_MANA, trait_DEBUG_NODMG,
+                                       trait_DEBUG_NOTEMP, trait_DEBUG_SPEED};
 
     avatar &player_character = get_avatar();
     map &here = get_map();


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Less friction when debugging = more ability to debug, more bugs squashed

#### Describe the solution
-Add 8 watertight+airtight pockets to the debug pocket universe. Since liquids/gasses cannot stack, unlike solids, they need a separate pocket for each stack you might want to carry. Rather than having to spawn a ton of empty containers, we can just stick that ability onto the existing debug item. I think 8 pockets is plenty enough for any purpose, but if we need more... well I guess we can add more later?

-Similarly, gave it an existing use_action to cancel ongoing portal storms. Portal storms activate **instantly** after debug changing time, and it's wasted more than a few of my minutes to debug spawn calming anomalies (sometimes repeatedly) to keep testing conditions static.

-During my first draft I also realized I could simplify the vector construction for setup_traits, used in debug quick setup. Cleaner code means future debugging additions will be easier, too!

#### Describe alternatives you've considered
My original approach was to add a debug trait to cancel out portal storms from ever starting, but that was *the only use case I could find* for such a trait(see branch name). It left me with a very bad impression if I ended up adding a debug trait which solely disabled portal storms and nothing else. I worried it might give players the incorrect impression that we want you to be able to turn off core parts of the game. 

I decided it was better to duplicate the use_action of the calming anomaly and stick it on a reusable debug item(debug pocket universe) which naturally is added to you during quick setup, but does not broadcast "MY SOLE PURPOSE IS TO TOGGLE PARTS OF THE GAME OFF". (Plus, reusing the existing logic to cancel ongoing portal storms is less likely to cause future bugs/give us invalid bug reports when players abuse debug functions)

#### Testing
Compiles, loads.

#### Additional context
