### PR TITLE
(Fix for tests) Assign valid IDs to NPCs used during testing

### DIFF
--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -338,7 +338,8 @@ void avatar::set_active_mission( mission &cur_mission )
 {
     const auto iter = std::find( active_missions.begin(), active_missions.end(), &cur_mission );
     if( iter == active_missions.end() ) {
-        debugmsg( "new active mission %d is not in the active_missions list", cur_mission.get_id() );
+        debugmsg( "new active mission %s is not in the active_missions list",
+                  cur_mission.mission_id().c_str() );
     } else {
         active_mission = &cur_mission;
     }
@@ -366,7 +367,8 @@ void avatar::on_mission_finished( mission &cur_mission )
     }
     const auto iter = std::find( active_missions.begin(), active_missions.end(), &cur_mission );
     if( iter == active_missions.end() ) {
-        debugmsg( "completed mission %d was not in the active_missions list", cur_mission.get_id() );
+        debugmsg( "completed mission %s was not in the active_missions list",
+                  cur_mission.mission_id().c_str() );
     } else {
         active_missions.erase( iter );
     }
@@ -394,7 +396,8 @@ void avatar::remove_active_mission( mission &cur_mission )
     cur_mission.remove_active_world_mission( cur_mission );
     const auto iter = std::find( active_missions.begin(), active_missions.end(), &cur_mission );
     if( iter == active_missions.end() ) {
-        debugmsg( "removed mission %d was not in the active_missions list", cur_mission.get_id() );
+        debugmsg( "removed mission %s was not in the active_missions list",
+                  cur_mission.mission_id().c_str() );
     } else {
         active_missions.erase( iter );
     }

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -257,6 +257,9 @@ standard_npc::standard_npc( const std::string &name, const tripoint &pos,
 {
     this->name = name;
     set_pos_only( pos );
+    if( !getID().is_valid() ) {
+        setID( g->assign_npc_id() );
+    }
 
     str_cur = std::max( s_str, 0 );
     str_max = std::max( s_str, 0 );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/8139343413/job/22242297663?pr=72106#step:17:78 looks like this was broken by the morale test I added in #72018

#### Describe the solution
Change error reporting so we can figure out what mission this is even supposed to be. The integer id is not useful

~~(After we figure it out) fix the actual cause~~ --> Assign all NPCs, even test NPCs, valid IDs. Then when the test NPC dies and its ID is checked for various things (like failing missions), no unintended interactions happen.

#### Describe alternatives you've considered


#### Testing
Wait to see if `GCC 9, Curses, LTO ` builds and tests pass on it

#### Additional context
While this resolves a bug with `standard_npc` which prevents the error from occurring, it does not actually address the root cause of the error. The actual error is `(~[slow] ~[.],starting_items)=> (continued from above) ERROR : src/avatar.cpp:369 [void avatar::on_mission_finished(mission&)] completed mission MISSION_CAMP_LEADERSHIP_CHANGE was not in the active_missions list`. But the mission should be in the active_missions list. Still, the primary purpose here is to make sure the tests pass, and if we can do that by fixing a bug with test data (standard_npc is used only for tests) then that shall suffice.