### PR TITLE
Re-tweak one sentence in last delivery mission 

### DIFF
--- a/data/json/starting_missions.json
+++ b/data/json/starting_missions.json
@@ -722,7 +722,7 @@
     "id": "MISSION_LAST_DELIVERY",
     "type": "mission_definition",
     "name": { "str": "Deliver Your Cargo" },
-    "description": "You're not sure who orders takeout when the world's ending, but that doesn't matter.  Evacuation doesn't matter.  Nothing, indeed, matters, save for safely delivering your precious cargo to its destination: a remote mansion.  May Foodperson watch over you, soldier.",
+    "description": "You're not sure who orders takeout when the world's ending, but that doesn't matter.  Evacuation doesn't matter.  Nothing, indeed, matters, save for safely delivering your precious cargo to its destination: a remote mansion.",
     "goal": "MGOAL_GO_TO_TYPE",
     "destination": "mansion_c3",
     "difficulty": 1,


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
The sentence "May Foodperson watch over you, soldier." was removed in #71871. Said sentence was accidentally readded when #71702 got merged. This PR corrects that and removes that sentence once again

#### Describe the solution
Delete one sentence a second time

#### Describe alternatives you've considered
Letting a PR accidentally readd something that got removed

#### Testing
Made sure that the change did not cause any errors

#### Additional context
