### PR TITLE
Maybe fix overmap test (disable geography scaling for tests)

### DIFF
--- a/data/core/game_balance.json
+++ b/data/core/game_balance.json
@@ -303,7 +303,7 @@
   {
     "type": "EXTERNAL_OPTION",
     "name": "OVERMAP_GEOGRAPHY_CHANGE",
-    "info": "Controls whether or not density of forests and urban areas will be modified with distance from the 0,0 overmap. False disables this scaling completely.",
+    "info": "Controls whether or not density of forests and urban areas will be modified with distance from the 0,0 overmap.  False disables this scaling completely.",
     "stype": "bool",
     "value": true
   },

--- a/data/core/game_balance.json
+++ b/data/core/game_balance.json
@@ -302,6 +302,13 @@
   },
   {
     "type": "EXTERNAL_OPTION",
+    "name": "OVERMAP_GEOGRAPHY_CHANGE",
+    "info": "Controls whether or not density of forests and urban areas will be modified with distance from the 0,0 overmap. False disables this scaling completely.",
+    "stype": "bool",
+    "value": true
+  },
+  {
+    "type": "EXTERNAL_OPTION",
     "name": "OVERMAP_FOREST_INCREASE_NORTH",
     "info": "Rate at which forest coverage of the map increases to the North, based on regional map settings thresholds.  0=no increase.",
     "stype": "float",

--- a/data/mods/TEST_DATA/game_balance.json
+++ b/data/mods/TEST_DATA/game_balance.json
@@ -1,0 +1,9 @@
+[
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "OVERMAP_GEOGRAPHY_CHANGE",
+    "info": "Controls whether or not density of forests and urban areas will be modified with distance from the 0,0 overmap. False disables this scaling completely.",
+    "stype": "bool",
+    "value": true
+  }
+]

--- a/data/mods/TEST_DATA/game_balance.json
+++ b/data/mods/TEST_DATA/game_balance.json
@@ -4,6 +4,6 @@
     "name": "OVERMAP_GEOGRAPHY_CHANGE",
     "info": "Controls whether or not density of forests and urban areas will be modified with distance from the 0,0 overmap.  False disables this scaling completely.",
     "stype": "bool",
-    "value": true
+    "value": false
   }
 ]

--- a/data/mods/TEST_DATA/game_balance.json
+++ b/data/mods/TEST_DATA/game_balance.json
@@ -2,7 +2,7 @@
   {
     "type": "EXTERNAL_OPTION",
     "name": "OVERMAP_GEOGRAPHY_CHANGE",
-    "info": "Controls whether or not density of forests and urban areas will be modified with distance from the 0,0 overmap. False disables this scaling completely.",
+    "info": "Controls whether or not density of forests and urban areas will be modified with distance from the 0,0 overmap.  False disables this scaling completely.",
     "stype": "bool",
     "value": true
   }

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -5333,17 +5333,19 @@ void overmap::calculate_forestosity()
     float western_forest_increase = get_option<float>( "OVERMAP_FOREST_INCREASE_WEST" );
     float southern_forest_increase = get_option<float>( "OVERMAP_FOREST_INCREASE_SOUTH" );
     const point_abs_om this_om = pos();
-    if( western_forest_increase != 0 && this_om.x() < 0 ) {
-        forest_size_adjust -= this_om.x() * western_forest_increase;
-    }
-    if( northern_forest_increase != 0 && this_om.y() < 0 ) {
-        forest_size_adjust -= this_om.y() * northern_forest_increase;
-    }
-    if( eastern_forest_increase != 0 && this_om.x() > 0 ) {
-        forest_size_adjust += this_om.x() * eastern_forest_increase;
-    }
-    if( southern_forest_increase != 0 && this_om.y() > 0 ) {
-        forest_size_adjust += this_om.y() * southern_forest_increase;
+    if( get_option<bool>( "OVERMAP_GEOGRAPHY_CHANGE" ) ) {
+        if( western_forest_increase != 0 && this_om.x() < 0 ) {
+            forest_size_adjust -= this_om.x() * western_forest_increase;
+        }
+        if( northern_forest_increase != 0 && this_om.y() < 0 ) {
+            forest_size_adjust -= this_om.y() * northern_forest_increase;
+        }
+        if( eastern_forest_increase != 0 && this_om.x() > 0 ) {
+            forest_size_adjust += this_om.x() * eastern_forest_increase;
+        }
+        if( southern_forest_increase != 0 && this_om.y() > 0 ) {
+            forest_size_adjust += this_om.y() * southern_forest_increase;
+        }
     }
     forestosity = forest_size_adjust * 25.0f;
     //debugmsg( "forestosity = %1.2f at OM %i, %i", forestosity, this_om.x(), this_om.y() );
@@ -5370,42 +5372,44 @@ void overmap::calculate_urbanity()
     float urbanity_adj = 0.0f;
 
     const point_abs_om this_om = pos();
-    if( northern_urban_increase != 0 && this_om.y() < 0 ) {
-        urbanity_adj -= this_om.y() * northern_urban_increase / 10.0f;
-        // add some falloff to the sides, keeping cities larger but breaking up the megacity a bit.
-        // Doesn't apply if we expect megacity in those directions as well.
-        if( this_om.x() < 0 && western_urban_increase == 0 ) {
-            urbanity_adj /=  std::max( this_om.x() / -2.0f, 1.0f );
+    if( get_option<bool>( "OVERMAP_GEOGRAPHY_CHANGE" ) ) {
+        if( northern_urban_increase != 0 && this_om.y() < 0 ) {
+            urbanity_adj -= this_om.y() * northern_urban_increase / 10.0f;
+            // add some falloff to the sides, keeping cities larger but breaking up the megacity a bit.
+            // Doesn't apply if we expect megacity in those directions as well.
+            if( this_om.x() < 0 && western_urban_increase == 0 ) {
+                urbanity_adj /=  std::max( this_om.x() / -2.0f, 1.0f );
+            }
+            if( this_om.x() > 0 && eastern_urban_increase == 0 ) {
+                urbanity_adj /=  std::max( this_om.x() / 2.0f, 1.0f );
+            }
         }
-        if( this_om.x() > 0 && eastern_urban_increase == 0 ) {
-            urbanity_adj /=  std::max( this_om.x() / 2.0f, 1.0f );
+        if( eastern_urban_increase != 0 && this_om.x() > 0 ) {
+            urbanity_adj += this_om.x() * eastern_urban_increase / 10.0f;
+            if( this_om.y() < 0 && northern_urban_increase == 0 ) {
+                urbanity_adj /=  std::max( this_om.y() / -2.0f, 1.0f );
+            }
+            if( this_om.y() > 0 && southern_urban_increase == 0 ) {
+                urbanity_adj /= std::max( this_om.y() / 2.0f, 1.0f );
+            }
         }
-    }
-    if( eastern_urban_increase != 0 && this_om.x() > 0 ) {
-        urbanity_adj += this_om.x() * eastern_urban_increase / 10.0f;
-        if( this_om.y() < 0 && northern_urban_increase == 0 ) {
-            urbanity_adj /=  std::max( this_om.y() / -2.0f, 1.0f );
+        if( western_urban_increase != 0 && this_om.x() < 0 ) {
+            urbanity_adj -= this_om.x() * western_urban_increase / 10.0f;
+            if( this_om.y() < 0 && northern_urban_increase == 0 ) {
+                urbanity_adj /=  std::max( this_om.y() / -2.0f, 1.0f );
+            }
+            if( this_om.y() > 0 && southern_urban_increase == 0 ) {
+                urbanity_adj /=  std::max( this_om.y() / 2.0f, 1.0f );
+            }
         }
-        if( this_om.y() > 0 && southern_urban_increase == 0 ) {
-            urbanity_adj /= std::max( this_om.y() / 2.0f, 1.0f );
-        }
-    }
-    if( western_urban_increase != 0 && this_om.x() < 0 ) {
-        urbanity_adj -= this_om.x() * western_urban_increase / 10.0f;
-        if( this_om.y() < 0 && northern_urban_increase == 0 ) {
-            urbanity_adj /=  std::max( this_om.y() / -2.0f, 1.0f );
-        }
-        if( this_om.y() > 0 && southern_urban_increase == 0 ) {
-            urbanity_adj /=  std::max( this_om.y() / 2.0f, 1.0f );
-        }
-    }
-    if( southern_urban_increase != 0 && this_om.y() > 0 ) {
-        urbanity_adj += this_om.y() * southern_urban_increase / 10.0f;
-        if( this_om.x() < 0 && western_urban_increase == 0 ) {
-            urbanity_adj /=  std::max( this_om.x() / -2.0f, 1.0f );
-        }
-        if( this_om.x() > 0 && eastern_urban_increase == 0 ) {
-            urbanity_adj /=  std::max( this_om.x() / 2.0f, 1.0f );
+        if( southern_urban_increase != 0 && this_om.y() > 0 ) {
+            urbanity_adj += this_om.y() * southern_urban_increase / 10.0f;
+            if( this_om.x() < 0 && western_urban_increase == 0 ) {
+                urbanity_adj /=  std::max( this_om.x() / -2.0f, 1.0f );
+            }
+            if( this_om.x() > 0 && eastern_urban_increase == 0 ) {
+                urbanity_adj /=  std::max( this_om.x() / 2.0f, 1.0f );
+            }
         }
     }
     urbanity = static_cast<int>( urbanity_adj );

--- a/tests/overmap_test.cpp
+++ b/tests/overmap_test.cpp
@@ -13,6 +13,7 @@
 #include "map.h"
 #include "mapbuffer.h"
 #include "omdata.h"
+#include "options.h"
 // #include "options_helpers.h"
 #include "output.h"
 #include "overmap.h"
@@ -263,6 +264,9 @@ TEST_CASE( "overmap_terrain_coverage", "[overmap][slow]" )
     std::unordered_map<oter_type_id, omt_stats> stats;
     point_abs_omt origin;
     map &main_map = get_map();
+
+    // Geography scaling is disabled when the TEST_DATA mod is loaded, this test performs very poorly otherwise.
+    REQUIRE( get_option<bool>( "OVERMAP_GEOGRAPHY_CHANGE" ) );
 
     for( const point_abs_omt &p : closest_points_first( origin, 0, 10 * OMAPX - 1 ) ) {
         // We need to avoid OMTs that overlap with the 'main' map, so we start at a

--- a/tests/overmap_test.cpp
+++ b/tests/overmap_test.cpp
@@ -266,7 +266,7 @@ TEST_CASE( "overmap_terrain_coverage", "[overmap][slow]" )
     map &main_map = get_map();
 
     // Geography scaling is disabled when the TEST_DATA mod is loaded, this test performs very poorly otherwise.
-    REQUIRE( get_option<bool>( "OVERMAP_GEOGRAPHY_CHANGE" ) );
+    REQUIRE( !get_option<bool>( "OVERMAP_GEOGRAPHY_CHANGE" ) );
 
     for( const point_abs_omt &p : closest_points_first( origin, 0, 10 * OMAPX - 1 ) ) {
         // We need to avoid OMTs that overlap with the 'main' map, so we start at a


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
`overmap_terrain_coverage` test fails, a LOT.

#### Describe the solution
Add external option `OVERMAP_GEOGRAPHY_CHANGE` which dictates whether these scalars apply at all

Turn the option to off (false) in the TEST_DATA mod, which is (should?) always loaded when the tests are running

#### Describe alternatives you've considered
https://github.com/CleverRaven/Cataclysm-DDA/compare/master...RenechCDDA:Cataclysm-DDA:maybe_fix_overmap_test

Previous attempt: Added new external option OVERMAPS_BEFORE_GEOGRAPHY_CHANGE, an option that serves as the cutoff where the geography changes kicks in: 10, as was previously expected. 

After discussion with the dev team, the PR you're reading was the requested approach.

#### Testing
Relying mostly on github tests at this point. The test fails so frequently that success in one PR means a lot

#### Additional context

