### PR TITLE
Add the option to open the ImGui demo from the main menu for debugging

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -436,7 +436,7 @@ void cataimgui::window::draw()
     }
     if( ImGui::Begin( id.c_str(), &is_open, window_flags ) ) {
         draw_controls();
-        if( p_impl->window_adaptor->is_on_top ) {
+        if( p_impl->window_adaptor->is_on_top && !force_to_back ) {
             ImGui::BringWindowToDisplayFront( ImGui::GetCurrentWindow() );
         }
     }

--- a/src/cata_imgui.h
+++ b/src/cata_imgui.h
@@ -92,6 +92,7 @@ class window
         void mark_resized();
 
     protected:
+        bool force_to_back = false;
         bool is_open;
         std::string id;
         int window_flags;

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -53,6 +53,69 @@
 #include "wcwidth.h"
 #include "worldfactory.h"
 
+#if !defined(__ANDROID__)
+#include "cata_imgui.h"
+#include "imgui/imgui.h"
+
+class demo_ui : public cataimgui::window
+{
+    public:
+        demo_ui();
+        void init();
+        void run();
+
+    protected:
+        void draw_controls() override;
+        cataimgui::bounds get_bounds() override;
+        void on_resized() override {
+            init();
+        };
+};
+
+demo_ui::demo_ui() : cataimgui::window( _( "ImGui Demo Screen" ) )
+{
+}
+
+cataimgui::bounds demo_ui::get_bounds()
+{
+    return { -1.f, -1.f, float( str_width_to_pixels( TERMX ) ), float( str_height_to_pixels( TERMY ) ) };
+}
+
+void demo_ui::draw_controls()
+{
+    ImGui::ShowDemoWindow();
+}
+
+void demo_ui::init()
+{
+    // The demo makes it's own screen.  Don't get in the way
+    force_to_back = true;
+}
+
+void demo_ui::run()
+{
+    init();
+
+    input_context ctxt( "HELP_KEYBINDINGS" );
+    ctxt.register_action( "QUIT" );
+    ctxt.register_action( "SELECT" );
+    ctxt.register_action( "MOUSE_MOVE" );
+    ctxt.register_action( "ANY_INPUT" );
+    ctxt.register_action( "HELP_KEYBINDINGS" );
+    std::string action;
+
+    ui_manager::redraw();
+
+    while( is_open ) {
+        ui_manager::redraw();
+        action = ctxt.handle_input();
+        if( action == "QUIT" ) {
+            break;
+        }
+    }
+}
+#endif
+
 static const mod_id MOD_INFORMATION_dda( "dda" );
 
 enum class main_menu_opts : int {
@@ -510,6 +573,11 @@ void main_menu::init_strings()
     vSettingsSubItems.emplace_back( pgettext( "Main Menu|Settings", "A<u|U>topickup" ) );
     vSettingsSubItems.emplace_back( pgettext( "Main Menu|Settings", "Sa<f|F>emode" ) );
     vSettingsSubItems.emplace_back( pgettext( "Main Menu|Settings", "Colo<r|R>s" ) );
+#if !defined(__ANDROID__)
+    if( get_options().has_option( "USE_IMGUI" ) && get_option<bool>( "USE_IMGUI" ) ) {
+        vSettingsSubItems.emplace_back( pgettext( "Main Menu|Settings", "<I|i>mGui Demo Screen" ) );
+    }
+#endif
 
     vSettingsHotkeys.clear();
     for( const std::string &item : vSettingsSubItems ) {
@@ -855,6 +923,13 @@ bool main_menu::opening_screen()
                         get_safemode().show();
                     } else if( sel2 == 4 ) { /// Colors
                         all_colors.show_gui();
+#if !defined(__ANDROID__)
+                    } else if( sel2 == 5 ) { /// ImGui demo
+                        if( get_options().has_option( "USE_IMGUI" ) && get_option<bool>( "USE_IMGUI" ) ) {
+                            demo_ui demo;
+                            demo.run();
+                        }
+#endif
                     }
                     break;
                 case main_menu_opts::WORLD:


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The new ImGui windows are a bit tricky to debug and modify because, until contributors (me, I'm talking about me) are familiar with the system, we need to go through a bit of a mental checklist:
- Is this a bug in my code?
- Is this a bug in cata_imgui?
- Is this a bug in ImGui?
- Is this how ImGui is supposed to display things?
- Am I using the wrong ImGui feature for this UI element?
- Can I even do that in ImGui?

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
One way to answer several of these questions is with quick access to the ImGui demo screen:
![Option_on_main_menu](https://github.com/CleverRaven/Cataclysm-DDA/assets/89038572/1358994c-5b43-470f-a724-4693cb4794ea)

![ImGui_Demo_Tiles](https://github.com/CleverRaven/Cataclysm-DDA/assets/89038572/fd1c61a4-223e-4083-8c95-5e6c6cea660b)

 - If it works in the demo screen, then the bug is probably on our end.
 - We get to see a bunch of different ImGui elements, and can refer to src/third-party/imgui/imgui_demo.cpp to see a specific example of how they're implemented.
 - There's an example of a minimum-viable cataimgui::window implementation that puts things on the screen

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Putting the demo screen under the debug menu
Then you need to load into the game to see it.  The main menu is much faster
- Hiding it behind another option so that only people working on the UI see it
Possible, perhaps even beneficial, but I haven't done it yet.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Does the demo screen work perfectly?  No, no it does not.
 - I needed to tweak the drawing code to give us a way to force things to the back, because otherwise it would be hidden behind a blank ui_adaptor window
 - Font loading for CJK characters is definitely broken (see #72162), as the example display widget doesn't work
![Current_font_loading_CJK](https://github.com/CleverRaven/Cataclysm-DDA/assets/89038572/f22a7e2d-b24a-4646-a739-659c0a38db39)
 - Curses is a bit twitchy, where the demo screen doesn't show up until after you resize the window
   - Also, the curses demo screen is gigantic and way off to the bottom right, suggesting that our window positioning/resizing isn't working
![ImGui_Demo_Curses](https://github.com/CleverRaven/Cataclysm-DDA/assets/89038572/cc9c39c1-7b7c-4442-b8f9-d9dbad0efd4d)
   - There seems to be an odd quirk where the window won't detect a mouse click unless you wiggle the mouse slightly

But this is _valuable information_ for debugging our own windows

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
