### PR TITLE
Revert #71460 Altered Mindstates partially resist Flaming Eyes

### DIFF
--- a/data/json/monster_special_attacks/spells.json
+++ b/data/json/monster_special_attacks/spells.json
@@ -1188,35 +1188,6 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_STARE2",
-    "condition": {
-      "and": [
-        { "u_has_trait": "SCHIZOPHRENIC" },
-        { "not": { "u_has_effect": "took_thorazine" } },
-        { "x_in_y_chance": { "x": 2, "y": 3 } }
-      ]
-    },
-    "effect": [
-      {
-        "if": "player_see_u",
-        "then": { "u_message": "The <npc_name> quickly looks away from you.", "type": "warning" },
-        "else": { "u_message": "A chorus of whispers chatter raucously around you.", "type": "warning" }
-      }
-    ],
-    "false_effect": { "run_eocs": [ "EOC_STARE3" ] }
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_STARE3",
-    "condition": { "math": [ "rand(6) < u_effect_intensity('drunk')" ] },
-    "effect": [
-      { "u_message": "The world lurches drunkenly around you.", "type": "warning" },
-      { "u_add_effect": "stunned", "duration": 4 }
-    ],
-    "false_effect": { "run_eocs": [ "EOC_STARE4" ] }
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_STARE4",
     "condition": "player_see_npc",
     "effect": [
       { "u_message": "The <npc_name> stares at you, and you shudder.", "type": "bad" },

--- a/data/json/npcs/refugee_center/beggars/BEGGAR_2_Dino_Dave.json
+++ b/data/json/npcs/refugee_center/beggars/BEGGAR_2_Dino_Dave.json
@@ -203,43 +203,6 @@
     "id": "TALK_REFUGEE_BEGGAR_2_WEARING",
     "dynamic_line": "You ask me what I can see, but I don't tell you what you see.  Sometimes we have shields up, to protect ourselves.",
     "responses": [
-      { "text": "Shields?", "topic": "TALK_REFUGEE_BEGGAR_2_FLAMINGEYE" },
-      { "text": "What was that about cardboard?", "topic": "TALK_REFUGEE_BEGGAR_2_CARDBOARD" },
-      { "text": "Why are you sitting out here?", "topic": "TALK_REFUGEE_BEGGAR_2_REFUGEE" },
-      { "text": "I think I have to get going…", "topic": "TALK_DONE" }
-    ]
-  },
-  {
-    "type": "talk_topic",
-    "id": "TALK_REFUGEE_BEGGAR_2_FLAMINGEYE",
-    "dynamic_line": "Once I saw the full moon, and it was staring right at me - only it couldn't see me, because the sandman kept it away.  Understand?",
-    "responses": [
-      {
-        "condition": { "u_has_trait": "SCHIZOPHRENIC" },
-        "text": "[Kaluptic Psychosis] I think I do.  Are we the same?",
-        "topic": "TALK_REFUGEE_BEGGAR_2_FLAMINGEYE_YES"
-      },
-      { "text": "No, I don't.", "topic": "TALK_REFUGEE_BEGGAR_2_FLAMINGEYE_NO" },
-      { "text": "What was that about cardboard?", "topic": "TALK_REFUGEE_BEGGAR_2_CARDBOARD" },
-      { "text": "Why are you sitting out here?", "topic": "TALK_REFUGEE_BEGGAR_2_REFUGEE" },
-      { "text": "I think I have to get going…", "topic": "TALK_DONE" }
-    ]
-  },
-  {
-    "type": "talk_topic",
-    "id": "TALK_REFUGEE_BEGGAR_2_FLAMINGEYE_NO",
-    "dynamic_line": "That's OK, nobody's perfect, ha ha…",
-    "responses": [
-      { "text": "What was that about cardboard?", "topic": "TALK_REFUGEE_BEGGAR_2_CARDBOARD" },
-      { "text": "Why are you sitting out here?", "topic": "TALK_REFUGEE_BEGGAR_2_REFUGEE" },
-      { "text": "I think I have to get going…", "topic": "TALK_DONE" }
-    ]
-  },
-  {
-    "type": "talk_topic",
-    "id": "TALK_REFUGEE_BEGGAR_2_FLAMINGEYE_YES",
-    "dynamic_line": "Nobody's the same, not even twins.  But I'll tell you something.  The big eye looked at me.  When it did, it heard the voices, and it blinked.",
-    "responses": [
       { "text": "What was that about cardboard?", "topic": "TALK_REFUGEE_BEGGAR_2_CARDBOARD" },
       { "text": "Why are you sitting out here?", "topic": "TALK_REFUGEE_BEGGAR_2_REFUGEE" },
       { "text": "I think I have to get going…", "topic": "TALK_DONE" }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Drunkenness as a protective measure is a pernicious and dangerous concept and I will not be party to it.

Mental illness as a protective measure is also extremely problematic, and encouraging people to not take their medication is beyond the pale.

#### Describe the solution
Revert it.