### PR TITLE
Add Large Wooden Bowl recipe 

### DIFF
--- a/data/json/items/containers/containers.json
+++ b/data/json/items/containers/containers.json
@@ -709,7 +709,7 @@
     "looks_like": "bowl_plastic",
     "description": "A large crude-looking wooden bowl which holds liquid.",
     "ascii_picture": "bowl_wood",
-    "weight": "48 g",
+    "weight": "88 g",
     "volume": "550 ml",
     "price": 100,
     "price_postapoc": 10,

--- a/data/json/items/containers/containers.json
+++ b/data/json/items/containers/containers.json
@@ -702,6 +702,33 @@
     "qualities": [ [ "CONTAIN", 1 ] ]
   },
   {
+    "id": "bowl_wood_large",
+    "type": "GENERIC",
+    "category": "container",
+    "name": { "str": "large wooden bowl" },
+    "looks_like": "bowl_plastic",
+    "description": "A large crude-looking wooden bowl which holds liquid.",
+    "ascii_picture": "bowl_wood",
+    "weight": "48 g",
+    "volume": "550 ml",
+    "price": 100,
+    "price_postapoc": 10,
+    "material": [ "wood" ],
+    "symbol": ")",
+    "color": "brown",
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "watertight": true,
+        "rigid": true,
+        "open_container": true,
+        "max_contains_volume": "500 ml",
+        "max_contains_weight": "3 kg"
+      }
+    ],
+    "qualities": [ [ "CONTAIN", 1 ] ]
+  },
+  {
     "id": "bowl_coconut",
     "type": "GENERIC",
     "category": "container",

--- a/data/json/recipes/tools/containers.json
+++ b/data/json/recipes/tools/containers.json
@@ -829,6 +829,20 @@
     "components": [ [ [ "2x4", 1 ] ] ]
   },
   {
+    "result": "bowl_wood_large",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_CONTAINERS",
+    "skill_used": "fabrication",
+    "difficulty": 1,
+    "time": "35 m",
+    "autolearn": true,
+    "qualities": [ { "id": "CUT", "level": 2 } ],
+    "proficiencies": [ { "proficiency": "prof_carving" } ],
+    "components": [ [ [ "2x4", 2 ] ] ]
+  },
+  {
     "result": "bowl_skull",
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",

--- a/data/json/recipes/tools/containers.json
+++ b/data/json/recipes/tools/containers.json
@@ -840,7 +840,7 @@
     "autolearn": true,
     "qualities": [ { "id": "CUT", "level": 2 } ],
     "proficiencies": [ { "proficiency": "prof_carving" } ],
-    "components": [ [ [ "2x4", 2 ] ] ]
+    "components": [ [ [ "2x4", 1 ] ] ]
   },
   {
     "result": "bowl_skull",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Adding a Larger Wooden Bowl"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Im playing a very cozy playthrough in a cabin, and I was making woods meat soup, but it always makes (2) of the item. So I thought why not and make a larger version of the wooden bowl that just holds double of what a normal wooden bowl holds.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adds ability to make a larger wooden bowl that can be used as a larger container than a normal wooden bowl.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not really any. Just thought i'd give it a shot.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Checked and made sure it worked right, its literally just a wooden bowl with increased volume and a slightly increased craft time and ingredients.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Worked exactly how I wanted and I no longer need 2 wooden bowls for my woods meat soup I made :)

Also this is my first time contributing, if I messed up somewhere or did something wrong please let me know.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
