### PR TITLE
NPCs are better at finding places to sleep, heavily prefer real beds

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -5710,8 +5710,8 @@ Character::comfort_response_t Character::base_comfort_value( const tripoint_bub_
                 }
             }
         }
-        if( ( fungaloid_cosplay && here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_FUNGUS, pos() ) ) ||
-            ( watersleep && here.has_flag_ter( ter_furn_flag::TFLAG_SWIMMABLE, pos() ) ) ) {
+        if( ( fungaloid_cosplay && here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_FUNGUS, p.raw() ) ) ||
+            ( watersleep && here.has_flag_ter( ter_furn_flag::TFLAG_SWIMMABLE, p.raw() ) ) ) {
             comfort += static_cast<int>( comfort_level::very_comfortable );
         }
     } else if( plantsleep ) {
@@ -11467,12 +11467,12 @@ int Character::sleep_spot( const tripoint_bub_ms &p ) const
 
     sleepy = enchantment_cache->modify_value( enchant_vals::mod::SLEEPY, sleepy );
 
-    if( watersleep && get_map().has_flag_ter( ter_furn_flag::TFLAG_SWIMMABLE, pos() ) ) {
+    if( watersleep && get_map().has_flag_ter( ter_furn_flag::TFLAG_SWIMMABLE, p.raw() ) ) {
         sleepy += 10; //comfy water!
     }
 
     if( has_trait( trait_CHLOROMORPH ) &&
-        get_map().has_flag_ter( ter_furn_flag::TFLAG_PLOWABLE, pos() ) ) {
+        get_map().has_flag_ter( ter_furn_flag::TFLAG_PLOWABLE, p.raw() ) ) {
         sleepy += 25; // It's time for a nice nap.
     }
 

--- a/src/npc.h
+++ b/src/npc.h
@@ -1138,6 +1138,7 @@ class npc : public Character
         npc_action address_needs( float danger );
         npc_action address_player();
         npc_action long_term_goal_action();
+        int evaluate_sleep_spot( tripoint_bub_ms p );
         // Returns true if did something and we should end turn
         bool scan_new_items();
         // Returns true if did wield it

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2043,13 +2043,16 @@ int npc::evaluate_sleep_spot( tripoint_bub_ms p )
 {
     // Base evaluation is based on ability to actually fall sleep there
     int sleep_eval = sleep_spot( p );
-    // ...but our snooty NPCs also want the closest thing to a real bed they can find.
-    units::temperature_delta ideal_bed_value = 2_C_delta;
-    const units::temperature_delta sleep_spot_value = floor_bedding_warmth( p.raw() );
-    if( sleep_spot_value < ideal_bed_value ) {
-        double bed_similarity = sleep_spot_value / ideal_bed_value;
-        // bed_similarity^2, exponentially diminishing the value of non-bed sleeping spots the more not-bed-like they are
-        sleep_eval *= pow( bed_similarity, 2 );
+    // Only evaluate further if the possible bed isn't already considered very comfortable.
+    // This opt-out is necessary to allow mutant NPCs to find desired non-bed sleeping spaces
+    if( sleep_eval < static_cast<int>( comfort_level::very_comfortable ) - 1 ) {
+        const units::temperature_delta ideal_bed_value = 2_C_delta;
+        const units::temperature_delta sleep_spot_value = floor_bedding_warmth( p.raw() );
+        if( sleep_spot_value < ideal_bed_value ) {
+            double bed_similarity = sleep_spot_value / ideal_bed_value;
+            // bed_similarity^2, exponentially diminishing the value of non-bed sleeping spots the more not-bed-like they are
+            sleep_eval *= pow( bed_similarity, 2 );
+        }
     }
     return sleep_eval;
 }

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -1626,16 +1626,18 @@ void npc::execute_action( npc_action action )
             // Find a nice spot to sleep
             tripoint_bub_ms best_spot = pos_bub();
             int best_sleepy = evaluate_sleep_spot( best_spot );
-            for( const tripoint_bub_ms &p : closest_points_first( pos_bub(), 6 ) ) {
+            for( const tripoint_bub_ms &p : closest_points_first( pos_bub(), ACTIVITY_SEARCH_DISTANCE ) ) {
                 if( !could_move_onto( p ) || !g->is_empty( p ) ) {
                     continue;
                 }
 
-                // TODO: Blankets when it's cold
-                const int sleepy = evaluate_sleep_spot( p );
-                if( sleepy > best_sleepy ) {
-                    best_sleepy = sleepy;
-                    best_spot = p;
+                // For non-mutants, very_comfortable-1 is the expected value of an ideal normal bed.
+                if( best_sleepy < static_cast<int>( comfort_level::very_comfortable ) - 1 ) {
+                    const int sleepy = evaluate_sleep_spot( p );
+                    if( sleepy > best_sleepy ) {
+                        best_sleepy = sleepy;
+                        best_spot = p;
+                    }
                 }
             }
             if( is_walking_with() ) {


### PR DESCRIPTION
#### Summary
Balance "Improved NPCs ability to find a good bed to sleep on"

#### Purpose of change
* Closes #71865

#### Describe the solution
Massively increase the search range for possible beds, counterbalance this by stopping the search if we've already found an ideal bed that can be used. The search radius extends outwards doing closest points first, so a NPC that sees a couch in the same room won't 'settle for less' until the search comes up empty for real beds.

NPCs down-rate evaluated places to sleep based on a comparison to the standard bed - bed or something better keeps the same rating, but improvised sleeping spots and the floor are downrated increasingly hardthe more makeshift they are. Mutant NPCs that **want** to sleep in exotic places opt-out of this and only consider comfort, the same as before. (But with the increased search radius from above)

#### Describe alternatives you've considered


#### Testing
Yes

#### Additional context
There's some overlap between a potential bed's `comfort` and `floor_bedding_warmth' that I'm not terribly happy with, but properly sorting those out or making them serve completely separate roles is outside the scope of my intended changes.