### PR TITLE
Added 3-finger gestures to Android

### DIFF
--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -1803,6 +1803,10 @@ static float second_finger_down_x = -1.0f; // in pixels
 static float second_finger_down_y = -1.0f; // in pixels
 static float second_finger_curr_x = -1.0f; // in pixels
 static float second_finger_curr_y = -1.0f; // in pixels
+static float third_finger_down_x = -1.0f; // in pixels
+static float third_finger_down_y = -1.0f; // in pixels
+static float third_finger_curr_x = -1.0f; // in pixels
+static float third_finger_curr_y = -1.0f; // in pixels
 // when did the first finger start touching the screen? 0 if not touching, otherwise the time in milliseconds.
 static uint32_t finger_down_time = 0;
 // the last time we repeated input for a finger hold, 0 if not touching, otherwise the time in milliseconds.
@@ -1813,6 +1817,8 @@ static uint32_t last_tap_time = 0;
 static uint32_t ac_back_down_time = 0;
 // has a second finger touched the screen while the first was touching?
 static bool is_two_finger_touch = false;
+// has a third finger touched the screen while the first and second were touching?
+static bool is_three_finger_touch = false;
 // did this touch start on a quick shortcut?
 static bool is_quick_shortcut_touch = false;
 static bool quick_shortcuts_toggle_handled = false;
@@ -2341,7 +2347,8 @@ void draw_virtual_joystick()
         SDL_GetTicks() - finger_down_time <= static_cast<uint32_t>
         ( get_option<int>( "ANDROID_INITIAL_DELAY" ) ) ||
         is_quick_shortcut_touch ||
-        is_two_finger_touch ) {
+        is_two_finger_touch ||
+        is_three_finger_touch ) {
         return;
     }
 
@@ -2825,7 +2832,8 @@ static void CheckMessages()
         }
 
         // Handle repeating inputs from touch + holds
-        if( !is_quick_shortcut_touch && !is_two_finger_touch && finger_down_time > 0 &&
+        if( !is_quick_shortcut_touch && !is_two_finger_touch && !is_three_finger_touch &&
+            finger_down_time > 0 &&
             ticks - finger_down_time > static_cast<uint32_t>
             ( get_option<int>( "ANDROID_INITIAL_DELAY" ) ) ) {
             if( ticks - finger_repeat_time > finger_repeat_delay ) {
@@ -2834,9 +2842,12 @@ static void CheckMessages()
                 // Prevent repeating inputs on the next call to this function if there is a fingerup event
                 while( SDL_PollEvent( &ev ) ) {
                     if( ev.type == SDL_FINGERUP ) {
-                        second_finger_down_x = second_finger_curr_x = finger_down_x = finger_curr_x = -1.0f;
-                        second_finger_down_y = second_finger_curr_y = finger_down_y = finger_curr_y = -1.0f;
+                        third_finger_down_x = third_finger_curr_x = second_finger_down_x = second_finger_curr_x =
+                                                  finger_down_x = finger_curr_x = -1.0f;
+                        third_finger_down_y = third_finger_curr_y = second_finger_down_y = second_finger_curr_y =
+                                                  finger_down_y = finger_curr_y = -1.0f;
                         is_two_finger_touch = false;
+                        is_three_finger_touch = false;
                         finger_down_time = 0;
                         finger_repeat_time = 0;
                         // let the next call decide if needupdate should be true
@@ -2848,7 +2859,8 @@ static void CheckMessages()
         }
 
         // If we received a first tap and not another one within a certain period, this was a single tap, so trigger the input event
-        if( !is_quick_shortcut_touch && !is_two_finger_touch && last_tap_time > 0 &&
+        if( !is_quick_shortcut_touch && !is_two_finger_touch && !is_three_finger_touch &&
+            last_tap_time > 0 &&
             ticks - last_tap_time >= static_cast<uint32_t>
             ( get_option<int>( "ANDROID_INITIAL_DELAY" ) ) ) {
             // Single tap
@@ -3189,7 +3201,8 @@ static void CheckMessages()
                     finger_curr_x = ev.tfinger.x * WindowWidth;
                     finger_curr_y = ev.tfinger.y * WindowHeight;
 
-                    if( get_option<bool>( "ANDROID_VIRTUAL_JOYSTICK_FOLLOW" ) && !is_two_finger_touch ) {
+                    if( get_option<bool>( "ANDROID_VIRTUAL_JOYSTICK_FOLLOW" ) && !is_two_finger_touch &&
+                        !is_three_finger_touch ) {
                         // If we've moved too far from joystick center, offset joystick center automatically
                         float delta_x = finger_curr_x - finger_down_x;
                         float delta_y = finger_curr_y - finger_down_y;
@@ -3206,6 +3219,9 @@ static void CheckMessages()
                 } else if( ev.tfinger.fingerId == 1 ) {
                     second_finger_curr_x = ev.tfinger.x * WindowWidth;
                     second_finger_curr_y = ev.tfinger.y * WindowHeight;
+                } else if( ev.tfinger.fingerId == 2 ) {
+                    third_finger_curr_x = ev.tfinger.x * WindowWidth;
+                    third_finger_curr_y = ev.tfinger.y * WindowHeight;
                 }
                 break;
             case SDL_FINGERDOWN:
@@ -3224,6 +3240,13 @@ static void CheckMessages()
                         second_finger_down_x = second_finger_curr_x = ev.tfinger.x * WindowWidth;
                         second_finger_down_y = second_finger_curr_y = ev.tfinger.y * WindowHeight;
                         is_two_finger_touch = true;
+                    }
+                } else if( ev.tfinger.fingerId == 2 ) {
+                    if( !is_quick_shortcut_touch ) {
+                        third_finger_down_x = third_finger_curr_x = ev.tfinger.x * WindowWidth;
+                        third_finger_down_y = third_finger_curr_y = ev.tfinger.y * WindowHeight;
+                        is_three_finger_touch = true;
+                        is_two_finger_touch = false;
                     }
                 }
                 break;
@@ -3317,14 +3340,81 @@ static void CheckMessages()
                                     }
                                 }
                             }
+                        } else if( is_three_finger_touch ) {
+                            // handle zoom in/out
+                            float x1 = ( finger_curr_x - finger_down_x );
+                            float y1 = ( finger_curr_y - finger_down_y );
+                            float d1 = std::sqrt( x1 * x1 + y1 * y1 );
+
+                            float x2 = ( second_finger_curr_x - second_finger_down_x );
+                            float y2 = ( second_finger_curr_y - second_finger_down_y );
+                            float d2 = std::sqrt( x2 * x2 + y2 * y2 );
+
+                            float x3 = ( third_finger_curr_x - third_finger_down_x );
+                            float y3 = ( third_finger_curr_y - third_finger_down_y );
+                            float d3 = std::sqrt( x3 * x3 + y3 * y3 );
+
+                            float longest_window_edge = std::max( WindowWidth, WindowHeight );
+
+                            if( std::max( d1, std::max( d2,
+                                                        d3 ) ) < get_option<float>( "ANDROID_DEADZONE_RANGE" ) * longest_window_edge ) {
+                                int three_tap_key = 0; //get_option<int>( "ANDROID_3_TAP_KEY" );
+                                if( three_tap_key == 0 ) { // not set
+                                    quick_shortcuts_enabled = !quick_shortcuts_enabled;
+
+                                    quick_shortcuts_toggle_handled = true;
+
+                                    // Display an Android toast message
+                                    {
+                                        JNIEnv *env = ( JNIEnv * )SDL_AndroidGetJNIEnv();
+                                        jobject activity = ( jobject )SDL_AndroidGetActivity();
+                                        jclass clazz( env->GetObjectClass( activity ) );
+                                        jstring toast_message = env->NewStringUTF( quick_shortcuts_enabled ? "Shortcuts visible" :
+                                                                "Shortcuts hidden" );
+                                        jmethodID method_id = env->GetMethodID( clazz, "toast", "(Ljava/lang/String;)V" );
+                                        env->CallVoidMethod( activity, method_id, toast_message );
+                                        env->DeleteLocalRef( activity );
+                                        env->DeleteLocalRef( clazz );
+                                    }
+                                } else {
+                                    last_input = input_event( three_tap_key, input_event_t::keyboard_char );
+                                }
+                            } else {
+                                float dot = ( x1 * x2 + y1 * y2 ) / ( d1 * d2 ); // dot product of two finger vectors, -1 to +1
+                                float dot2 = ( x1 * x3 + y1 * y3 ) / ( d1 * d3 ); // dot product of three finger vectors, -1 to +1
+                                if( dot > 0.0f &&
+                                    dot2 > 0.0f ) { // all fingers mostly heading in same direction, check for triple-finger swipe gesture
+                                    float dratio = d1 / d2;
+                                    const float dist_ratio = 0.3f;
+                                    if( dratio > dist_ratio &&
+                                        dratio < ( 1.0f /
+                                                   dist_ratio ) ) { // both fingers moved roughly the same distance, so it's a double-finger swipe!
+                                        float xavg = 0.5f * ( x1 + x2 );
+                                        float yavg = 0.5f * ( y1 + y2 );
+                                        if( xavg > 0 && xavg > std::abs( yavg ) ) {
+                                            last_input = input_event( '\t', input_event_t::keyboard_char );
+                                        } else if( xavg < 0 && -xavg > std::abs( yavg ) ) {
+                                            last_input = input_event( KEY_BTAB, input_event_t::keyboard_char );
+                                        } else if( yavg > 0 && yavg > std::abs( xavg ) ) {
+                                            last_input = input_event( KEY_NPAGE, input_event_t::keyboard_char );
+                                        } else {
+                                            last_input = input_event( KEY_PPAGE, input_event_t::keyboard_char );
+                                        }
+                                    }
+                                }
+                            }
+
                         } else if( ticks - finger_down_time <= static_cast<uint32_t>(
                                        get_option<int>( "ANDROID_INITIAL_DELAY" ) ) ) {
                             handle_finger_input( ticks );
                         }
                     }
-                    second_finger_down_x = second_finger_curr_x = finger_down_x = finger_curr_x = -1.0f;
-                    second_finger_down_y = second_finger_curr_y = finger_down_y = finger_curr_y = -1.0f;
+                    third_finger_down_x = third_finger_curr_x = second_finger_down_x = second_finger_curr_x =
+                                              finger_down_x = finger_curr_x = -1.0f;
+                    third_finger_down_y = third_finger_curr_y = second_finger_down_y = second_finger_curr_y =
+                                              finger_down_y = finger_curr_y = -1.0f;
                     is_two_finger_touch = false;
+                    is_three_finger_touch = false;
                     finger_down_time = 0;
                     finger_repeat_time = 0;
                     needupdate = true; // ensure virtual joystick and quick shortcuts are updated properly
@@ -3335,6 +3425,13 @@ static void CheckMessages()
                         // is_two_finger_touch will be reset when first finger lifts (see above)
                         second_finger_curr_x = ev.tfinger.x * WindowWidth;
                         second_finger_curr_y = ev.tfinger.y * WindowHeight;
+                    }
+                } else if( ev.tfinger.fingerId == 2 ) {
+                    if( is_three_finger_touch ) {
+                        // on third finger release, just remember the x/y position so we can calculate delta once first finger is done
+                        // is_three_finger_touch will be reset when first finger lifts (see above)
+                        third_finger_curr_x = ev.tfinger.x * WindowWidth;
+                        third_finger_curr_y = ev.tfinger.y * WindowHeight;
                     }
                 }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing another guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Added support for three-finger gestures in Android"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes: #30468
I got annoyed that the 'quick shortcuts' menu didn't want to show up sometimes, and when it wouldn't work, stuff like the Options screen got extra hard to use because you couldn't press the Tab key. I also saw the aforementioned issue and thought this would be a nice QoL. This doesn't fix the shortcuts menu not showing up, something else is happening there.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
I looked at how two-finger gestures are implemented and followed that design, only needed to make a couple minor changes, like how for 3-finger, there is no need for pinch zoom.
Currently implemented:
3- finger tap: toggle quick shortcuts show/hide
swipe up: page up
swipe down: page down
swipe left: tab
swipe right: shift-tab
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Implement gesture inputs more gracefully, maybe come up with CDDA-specific keycodes to return, that we can then just fallback on the keybindings screen to configure.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded Android build on my Pixel 7, tested
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Two-finger swipe is configurable, but currently three-finger is not. Three-finger uses keys outside the normal printable range, and the options screen isn't built to handle that gracefully.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
