### PR TITLE
Fix crafting item preferences

### DIFF
--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1777,29 +1777,8 @@ static bool construction_activity( Character &you, const zone_data * /*zone*/,
             comp_selection<item_comp> sel;
             sel.use_from = usage_from::both;
             sel.comp = comp;
-            std::list<item> empty_consumed = you.consume_items( sel, 1, is_preferred_crafting_component );
-
-            int left_to_consume = 0;
-
-            if( !empty_consumed.empty() && empty_consumed.front().count_by_charges() ) {
-                int consumed = 0;
-                for( item &itm : empty_consumed ) {
-                    consumed += itm.charges;
-                }
-                left_to_consume = comp.count - consumed;
-            } else if( empty_consumed.size() < static_cast<size_t>( comp.count ) ) {
-                left_to_consume = comp.count - empty_consumed.size();
-            }
-
-            if( left_to_consume > 0 ) {
-                comp_selection<item_comp> remainder = sel;
-                remainder.comp.count = 1;
-                std::list<item>used_consumed = you.consume_items( remainder,
-                                               left_to_consume, is_crafting_component );
-                empty_consumed.splice( empty_consumed.end(), used_consumed );
-            }
-
-            used.splice( used.end(), empty_consumed );
+            std::list<item> consumed = you.consume_items( sel, 1, is_crafting_component );
+            used.splice( used.end(), consumed );
         }
     }
     pc.components = used;

--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -930,26 +930,7 @@ void basecamp_action_components::consume_components()
     }
     for( const comp_selection<item_comp> &sel : item_selections_ ) {
         std::list<item> empty_consumed = player_character.consume_items( target_map, sel, batch_size_,
-                                         is_preferred_crafting_component, src );
-        int left_to_consume = 0;
-
-        if( !empty_consumed.empty() && empty_consumed.front().count_by_charges() ) {
-            int consumed = 0;
-            for( item &itm : empty_consumed ) {
-                consumed += itm.charges;
-            }
-            left_to_consume = sel.comp.count * batch_size_ - consumed;
-        } else if( empty_consumed.size() < static_cast<size_t>( sel.comp.count ) * batch_size_ ) {
-            left_to_consume = static_cast<size_t>( sel.comp.count ) * batch_size_ - empty_consumed.size();
-        }
-
-        if( left_to_consume > 0 ) {
-            comp_selection<item_comp> remainder = sel;
-            remainder.comp.count = 1;
-            player_character.consume_items( target_map, remainder,
-                                            batch_size_ * static_cast<size_t>( sel.comp.count ) - empty_consumed.size(), is_crafting_component,
-                                            src );
-        }
+                                         is_crafting_component, src );
     }
     // this may consume pseudo-resources from fake items
     for( const comp_selection<tool_comp> &sel : tool_selections_ ) {

--- a/src/character.h
+++ b/src/character.h
@@ -3626,6 +3626,7 @@ class Character : public Creature, public visitable
         std::list<item> consume_items( map &m, const comp_selection<item_comp> &is, int batch,
                                        const std::function<bool( const item & )> &filter = return_true<item>,
                                        const std::vector<tripoint> &reachable_pts = {}, bool select_ind = false );
+        // Selects one entry in components using select_item_component and consumes those items.
         std::list<item> consume_items( const std::vector<item_comp> &components, int batch = 1,
                                        const std::function<bool( const item & )> &filter = return_true<item>,
                                        const std::function<bool( const itype_id & )> &select_ind = return_false<itype_id> );

--- a/src/character.h
+++ b/src/character.h
@@ -3625,9 +3625,6 @@ class Character : public Creature, public visitable
                                        const std::function<bool( const item & )> &filter = return_true<item>, bool select_ind = false );
         std::list<item> consume_items( map &m, const comp_selection<item_comp> &is, int batch,
                                        const std::function<bool( const item & )> &filter = return_true<item>,
-                                       const tripoint &origin = tripoint_zero, int radius = PICKUP_RANGE, bool select_ind = false );
-        std::list<item> consume_items( map &m, const comp_selection<item_comp> &is, int batch,
-                                       const std::function<bool( const item & )> &filter = return_true<item>,
                                        const std::vector<tripoint> &reachable_pts = {}, bool select_ind = false );
         std::list<item> consume_items( const std::vector<item_comp> &components, int batch = 1,
                                        const std::function<bool( const item & )> &filter = return_true<item>,

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1023,35 +1023,8 @@ void place_construction( std::vector<construction_group_str_id> const &groups )
     } else {
         // Use up the components
         for( const std::vector<item_comp> &it : con.requirements->get_components() ) {
-            for( const item_comp &comp : it ) {
-                comp_selection<item_comp> sel;
-                sel.use_from = usage_from::both;
-                sel.comp = comp;
-                std::list<item> empty_consumed = player_character.consume_items( sel, 1,
-                                                 is_preferred_crafting_component );
-
-                int left_to_consume = 0;
-
-                if( !empty_consumed.empty() && empty_consumed.front().count_by_charges() ) {
-                    int consumed = 0;
-                    for( item &itm : empty_consumed ) {
-                        consumed += itm.charges;
-                    }
-                    left_to_consume = comp.count - consumed;
-                } else if( empty_consumed.size() < static_cast<size_t>( comp.count ) ) {
-                    left_to_consume = comp.count - empty_consumed.size();
-                }
-
-                if( left_to_consume > 0 ) {
-                    comp_selection<item_comp> remainder = sel;
-                    remainder.comp.count = 1;
-                    std::list<item>used_consumed = player_character.consume_items( remainder,
-                                                   left_to_consume, is_crafting_component );
-                    empty_consumed.splice( empty_consumed.end(), used_consumed );
-                }
-
-                used.splice( used.end(), empty_consumed );
-            }
+            std::list<item> tmp = player_character.consume_items( it, 1, is_crafting_component );
+            used.splice( used.end(), tmp );
         }
     }
     pc.components = used;

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -342,36 +342,14 @@ bool craft_command::continue_prompt_liquids( const std::function<bool( const ite
 static std::list<item> sane_consume_items( const comp_selection<item_comp> &it, Character *crafter,
         int batch, const std::function<bool( const item & )> &filter )
 {
-    std::function<bool( const item & )> preferred_component_filter = [&filter]( const item & it ) {
-        return is_preferred_component( it ) && filter( it );
-    };
     map &m = get_map();
     const std::vector<pocket_data> it_pkt = it.comp.type->pockets;
     if( ( item::count_by_charges( it.comp.type ) && it.comp.count > 0 ) ||
     !std::any_of( it_pkt.begin(), it_pkt.end(), []( const pocket_data & p ) {
     return p.type == pocket_type::CONTAINER && p.watertight;
 } ) ) {
-        std::list<item> empty_consumed = crafter->consume_items( it, batch, preferred_component_filter );
-        int left_to_consume = 0;
-
-        if( !empty_consumed.empty() && empty_consumed.front().count_by_charges() ) {
-            int consumed = 0;
-            for( item &itm : empty_consumed ) {
-                consumed += itm.charges;
-            }
-            left_to_consume = it.comp.count * batch - consumed;
-        } else if( empty_consumed.size() < static_cast<size_t>( it.comp.count ) * batch ) {
-            left_to_consume = it.comp.count * batch - empty_consumed.size();
-        }
-
-        if( left_to_consume > 0 ) {
-            comp_selection<item_comp> remainder = it;
-            remainder.comp.count = 1;
-            std::list<item>used_consumed = crafter->consume_items( remainder,
-                                           left_to_consume, filter );
-            empty_consumed.splice( empty_consumed.end(), used_consumed );
-        }
-        return empty_consumed;
+        std::list<item> consumed = crafter->consume_items( it, batch, filter );
+        return consumed;
     }
 
     // Everything below only occurs for item components that are liquid containers

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -2028,7 +2028,7 @@ std::list<item> Character::consume_items( map &m, const comp_selection<item_comp
     int real_count = ( selected_comp.count > 0 ) ? selected_comp.count * batch : std::abs(
                          selected_comp.count );
 
-    // First try to get everything from the map, than (remaining amount) from player it two passes, first using preferred items and then remainder ones.
+    // First try to get everything from the map, then (remaining amount) from player in two passes, first using preferred items and then remainder ones.
     if( is.use_from & usage_from::map ) {
         if( by_charges ) {
             std::list<item> tmp = m.use_charges( reachable_pts, selected_comp.type, real_count,

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1995,13 +1995,7 @@ static void empty_buckets( Character &p )
 std::list<item> Character::consume_items( const comp_selection<item_comp> &is, int batch,
         const std::function<bool( const item & )> &filter, bool select_ind )
 {
-    return consume_items( get_map(), is, batch, filter, pos(), PICKUP_RANGE, select_ind );
-}
-
-std::list<item> Character::consume_items( map &m, const comp_selection<item_comp> &is, int batch,
-        const std::function<bool( const item & )> &filter, const tripoint &origin, int radius,
-        bool select_ind )
-{
+    map &m = get_map();
     std::list<item> ret;
 
     if( has_trait( trait_DEBUG_HS ) ) {
@@ -2009,7 +2003,7 @@ std::list<item> Character::consume_items( map &m, const comp_selection<item_comp
     }
     // populate a grid of spots that can be reached
     std::vector<tripoint> reachable_pts;
-    m.reachable_flood_steps( reachable_pts, origin, radius, 1, 100 );
+    m.reachable_flood_steps( reachable_pts, pos(), PICKUP_RANGE, 1, 100 );
     return consume_items( m, is, batch, filter, reachable_pts, select_ind );
 }
 
@@ -2017,6 +2011,10 @@ std::list<item> Character::consume_items( map &m, const comp_selection<item_comp
         const std::function<bool( const item & )> &filter, const std::vector<tripoint> &reachable_pts,
         bool select_ind )
 {
+    auto preferred_filter = [&filter]( const item & it ) {
+        return filter( it ) && is_preferred_component( it );
+    };
+
     std::list<item> ret;
 
     if( has_trait( trait_DEBUG_HS ) ) {
@@ -2029,28 +2027,58 @@ std::list<item> Character::consume_items( map &m, const comp_selection<item_comp
     // Count given to use_amount/use_charges, changed by those functions!
     int real_count = ( selected_comp.count > 0 ) ? selected_comp.count * batch : std::abs(
                          selected_comp.count );
-    // First try to get everything from the map, than (remaining amount) from player
+
+    // First try to get everything from the map, than (remaining amount) from player it two passes, first using preferred items and then remainder ones.
     if( is.use_from & usage_from::map ) {
         if( by_charges ) {
-            std::list<item> tmp = m.use_charges( reachable_pts, selected_comp.type, real_count, filter );
+            std::list<item> tmp = m.use_charges( reachable_pts, selected_comp.type, real_count,
+                                                 preferred_filter );
             ret.splice( ret.end(), tmp );
         } else {
-            std::list<item> tmp = m.use_amount( reachable_pts, selected_comp.type, real_count, filter,
+            std::list<item> tmp = m.use_amount( reachable_pts, selected_comp.type, real_count, preferred_filter,
                                                 select_ind );
             remove_ammo( tmp, *this );
             ret.splice( ret.end(), tmp );
         }
     }
+
     if( is.use_from & usage_from::player ) {
         if( by_charges ) {
-            std::list<item> tmp = use_charges( selected_comp.type, real_count, filter );
+            std::list<item> tmp = use_charges( selected_comp.type, real_count, preferred_filter );
             ret.splice( ret.end(), tmp );
         } else {
-            std::list<item> tmp = use_amount( selected_comp.type, real_count, filter, select_ind );
+            std::list<item> tmp = use_amount( selected_comp.type, real_count, preferred_filter, select_ind );
+            real_count -= tmp.size();  // The use_amount operation above doesn't deduct what's been used...
             remove_ammo( tmp, *this );
             ret.splice( ret.end(), tmp );
         }
     }
+
+    if( real_count > 0 ) {
+        if( is.use_from & usage_from::map ) {
+            if( by_charges ) {
+                std::list<item> tmp = m.use_charges( reachable_pts, selected_comp.type, real_count, filter );
+                ret.splice( ret.end(), tmp );
+            } else {
+                std::list<item> tmp = m.use_amount( reachable_pts, selected_comp.type, real_count, filter,
+                                                    select_ind );
+                remove_ammo( tmp, *this );
+                ret.splice( ret.end(), tmp );
+            }
+        }
+        if( is.use_from & usage_from::player ) {
+            if( by_charges ) {
+                std::list<item> tmp = use_charges( selected_comp.type, real_count, filter );
+                ret.splice( ret.end(), tmp );
+            } else {
+                std::list<item> tmp = use_amount( selected_comp.type, real_count, filter, select_ind );
+                real_count -= tmp.size();  // The use_amount operation above doesn't deduct what's been used...
+                remove_ammo( tmp, *this );
+                ret.splice( ret.end(), tmp );
+            }
+        }
+    }
+
     // Merge charges for items that stack with each other
     if( by_charges && ret.size() > 1 ) {
         for( auto outer = std::begin( ret ); outer != std::end( ret ); ++outer ) {

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -2045,6 +2045,9 @@ std::list<item> Character::consume_items( map &m, const comp_selection<item_comp
     if( is.use_from & usage_from::player ) {
         if( by_charges ) {
             std::list<item> tmp = use_charges( selected_comp.type, real_count, preferred_filter );
+            for( const item &it : tmp ) {
+                real_count -= it.charges;  // The use_charges operation above doesn't deduct what's been used...
+            }
             ret.splice( ret.end(), tmp );
         } else {
             std::list<item> tmp = use_amount( selected_comp.type, real_count, preferred_filter, select_ind );
@@ -2069,10 +2072,11 @@ std::list<item> Character::consume_items( map &m, const comp_selection<item_comp
         if( is.use_from & usage_from::player ) {
             if( by_charges ) {
                 std::list<item> tmp = use_charges( selected_comp.type, real_count, filter );
+                // The use_charges operation above doesn't deduct what's been used, but we're not going to use real_count again.
                 ret.splice( ret.end(), tmp );
             } else {
                 std::list<item> tmp = use_amount( selected_comp.type, real_count, filter, select_ind );
-                real_count -= tmp.size();  // The use_amount operation above doesn't deduct what's been used...
+                // The use_amount operation above doesn't deduct what's been used, but we're not going to use real_count again.
                 remove_ammo( tmp, *this );
                 ret.splice( ret.end(), tmp );
             }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -15159,11 +15159,6 @@ bool is_preferred_component( const item &component )
            !component.has_flag( flag_HIDDEN_HALLU );
 }
 
-bool is_preferred_crafting_component( const item &component )
-{
-    return is_preferred_component( component ) && is_crafting_component( component );
-}
-
 disp_mod_by_barrel::disp_mod_by_barrel() = default;
 void disp_mod_by_barrel::deserialize( const JsonObject &jo )
 {

--- a/src/item.h
+++ b/src/item.h
@@ -3290,11 +3290,6 @@ inline bool is_crafting_component( const item &component )
  */
 bool is_preferred_component( const item &component );
 
-/**
- * Filter for empty crafting components first pass searches
- */
-bool is_preferred_crafting_component( const item &component );
-
 #endif // CATA_SRC_ITEM_H
 
 struct disp_mod_by_barrel {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing another guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary

None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fix #72182

Change construction so that it both preferentially selects empty containers (and non poisonous food) while also asks the player to select items when there is more than one alternative.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

The original change to implement preferential item selection was fooled by the fact that the one originally used had item selection buried within itself, while the one used doesn't.
The solution was to revert the changes to the callers and modify the called operation to implement preferential selection.
This carries some risk, as the operation originally used is used in multiple locations, but the changes shouldn't affect the overall result of the call in terms of the number of items selected, just a selection of a more appropriate set, when possible. The other callers have been adjusted, in many cases by reverting the corresponding preferential item selection code (as it's now done further down the call chain).

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

The bug report save was used for testing:
- Cancelled the construction of a stockade wall and saw that all the items that were (incorrectly) used up in its construction were returned. That's the expected outcome, as the items used were stored in the task.
- Started a new stockade construction in the same place and verified I now had to select which item(s) to use.
- Stopped the construction and verified the selected items (plus the mandatory logs) were missing from the pile of returned materials.
- Cancelled the construction and verified the logs and the selected materials were returned.
- Debug spawned materials for two stoves (2 pipes + 2 60L tanks), plus debug set all skills to 10.
- Spawned clean water and filled a tank with it.
- Placed the empty tank at the PC's tile together with 1 pipe and the other pipe and tank on the tile to the SE.
- Constructed a stove and verified the pipe from the PC's tile and the empty tank from the tile to the SE were used in the construction, as well as the presence of the remaining tank and pipe (Verifying preferential item selection still works).
- Did essentially the same with 3 tanks and pipes, but using a construction zone with two stoves. In this case I dropped one pipe to the SE and held onto the two remaining ones. Confusion occurred when all three pipes were gone, leading to the detection of the non count reducing 'use_amount' call, fixing that, and redoing the testing from scratch.
- Crafted bird food with barley and bread available and verified I'm still prompted to select which one to use and that the other one remained.
- Varied the above theme with one item on the ground and the other in the inventory, as well as providing items of the same kind both on the ground and in the inventory and multiple items in the inventory.

Edit: The auto tests were good for something for a change. The balaclava test showed the inventory use_charges operation didn't deduct anything either (I thought I had looked at it and concluded it did).
Additional test:
- Spawn sewing kit and 4 cotton sheets.
- See that you can't make a balaclava despite having a full sewing kit. Shrug, as it didn't work with a pure master build either.
- Spawn 100 thread.
- Craft a balaclava and get interrupted by a damned goose. Check inventory to see you now correctly have 90 thread left (80 before the change, as 10 were deducted on each pass.)
- Started save again and spawned sewing kit, 8 cotton sheets, 100 thread and dropped half of the treads and sheets on the ground. Verified 2 sheets and 10 thread were deducted from the inventory and nothing from the ground.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I ran into a curve ball in the form of the inventory based version of `use_amount` NOT reducing the quantity parameter by the number of items returned, while the map using one does. This didn't affect the outcome previously as the inventory item selection was done only after the map one and wasn't used after that, but it did matter when a two pass selection was implemented.

Edit: The same issue is present with use_charges.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
