### PR TITLE
use item/tname instead of its raw name (nname) in recipe menu

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -14530,10 +14530,11 @@ std::string item::nname( const itype_id &id, unsigned int quantity )
     return t->nname( quantity );
 }
 
-std::string item::tname( const itype_id &id, unsigned int quantity )
+std::string item::tname( const itype_id &id, unsigned int quantity,
+                         const tname::segment_bitset const &segments )
 {
     item item_temp( id );
-    return item_temp.tname( quantity );
+    return item_temp.tname( quantity, segments );
 }
 
 bool item::count_by_charges( const itype_id &id )

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -14530,6 +14530,12 @@ std::string item::nname( const itype_id &id, unsigned int quantity )
     return t->nname( quantity );
 }
 
+std::string item::tname( const itype_id &id, unsigned int quantity )
+{
+    item item_temp( id );
+    return item_temp.tname( quantity );
+}
+
 bool item::count_by_charges( const itype_id &id )
 {
     const itype *t = find_type( id );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -14531,7 +14531,7 @@ std::string item::nname( const itype_id &id, unsigned int quantity )
 }
 
 std::string item::tname( const itype_id &id, unsigned int quantity,
-                         const tname::segment_bitset const &segments )
+                         const tname::segment_bitset &segments )
 {
     item item_temp( id );
     return item_temp.tname( quantity, segments );

--- a/src/item.h
+++ b/src/item.h
@@ -418,7 +418,8 @@ class item : public visitable
         std::string tname( unsigned int quantity = 1,
                            tname::segment_bitset const &segments = tname::default_tname ) const;
         std::string tname( unsigned int quantity, bool with_prefix ) const;
-        static std::string tname( const itype_id &id, unsigned int quantity = 1 );
+        static std::string tname( const itype_id &id, unsigned int quantity = 1,
+                                  tname::segment_bitset const &segments = tname::default_tname );
         std::string display_money( unsigned int quantity, unsigned int total,
                                    const std::optional<unsigned int> &selected = std::nullopt ) const;
         /**

--- a/src/item.h
+++ b/src/item.h
@@ -418,6 +418,7 @@ class item : public visitable
         std::string tname( unsigned int quantity = 1,
                            tname::segment_bitset const &segments = tname::default_tname ) const;
         std::string tname( unsigned int quantity, bool with_prefix ) const;
+        static std::string tname( const itype_id &id, unsigned int quantity = 1 );
         std::string display_money( unsigned int quantity, unsigned int total,
                                    const std::optional<unsigned int> &selected = std::nullopt ) const;
         /**

--- a/src/item_tname.h
+++ b/src/item_tname.h
@@ -108,11 +108,16 @@ constexpr uint64_t tname_conditional_bits =    // TODO: fine grain?
     1ULL << static_cast<size_t>( tname::segments::COMPONENTS ) |
     1ULL << static_cast<size_t>( tname::segments::TAGS ) |
     1ULL << static_cast<size_t>( tname::segments::VARS );
+constexpr uint64_t item_name_bits =    // item prefix + item name + item suffix
+    1ULL << static_cast<size_t>( tname::segments::CUSTOM_ITEM_PREFIX ) |
+    1ULL << static_cast<size_t>( tname::segments::TYPE ) |
+    1ULL << static_cast<size_t>( tname::segments::CUSTOM_ITEM_SUFFIX );
 constexpr segment_bitset default_tname( default_tname_bits );
 constexpr segment_bitset unprefixed_tname( default_tname_bits & ~tname_prefix_bits );
 constexpr segment_bitset tname_sort_key( default_tname_bits & ~tname_unsortable_bits );
 constexpr segment_bitset tname_contents( tname_contents_bits );
 constexpr segment_bitset tname_conditional( tname_conditional_bits );
+constexpr segment_bitset item_name( item_name_bits );
 
 } // namespace tname
 

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -1226,7 +1226,8 @@ std::string recipe::result_name( const bool decorated ) const
             name = iter_var->alt_name.translated();
         }
     } else {
-        name = item::nname( result_ );
+        item option( result_, calendar::turn_zero );
+        name = option.tname( 1, false );
     }
     if( decorated &&
         uistate.favorite_recipes.find( this->ident() ) != uistate.favorite_recipes.end() ) {

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -1226,8 +1226,7 @@ std::string recipe::result_name( const bool decorated ) const
             name = iter_var->alt_name.translated();
         }
     } else {
-        item option( result_, calendar::turn_zero );
-        name = option.tname( 1, false );
+        name = item::tname( result_, 1 );
     }
     if( decorated &&
         uistate.favorite_recipes.find( this->ident() ) != uistate.favorite_recipes.end() ) {

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -1226,7 +1226,7 @@ std::string recipe::result_name( const bool decorated ) const
             name = iter_var->alt_name.translated();
         }
     } else {
-        name = item::tname( result_, 1 );
+        name = item::tname( result_, 1, tname::item_name );
     }
     if( decorated &&
         uistate.favorite_recipes.find( this->ident() ) != uistate.favorite_recipes.end() ) {

--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -158,9 +158,9 @@ std::string tool_comp::to_string( const int batch, const int ) const
         //~ %1$s: tool name, %2$d: charge requirement
         return string_format( npgettext( "requirement", "%1$s (%2$d charge)", "%1$s (%2$d charges)",
                                          charge_total ),
-                              item( type ).tname( 1 ), charge_total );
+                              item::tname( type, 1 ), charge_total );
     } else {
-        return item( type ).tname( std::abs( count ) );
+        return item::tname( type, std::abs( count ) );
     }
 }
 

--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -158,9 +158,9 @@ std::string tool_comp::to_string( const int batch, const int ) const
         //~ %1$s: tool name, %2$d: charge requirement
         return string_format( npgettext( "requirement", "%1$s (%2$d charge)", "%1$s (%2$d charges)",
                                          charge_total ),
-                              item::nname( type ), charge_total );
+                              item( type ).tname( 1 ), charge_total );
     } else {
-        return item::nname( type, std::abs( count ) );
+        return item( type ).tname( std::abs( count ) );
     }
 }
 

--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -167,8 +167,8 @@ std::string tool_comp::to_string( const int batch, const int ) const
 std::string item_comp::to_string( const int batch, const int avail ) const
 {
     const int c = std::abs( count ) * batch;
-    const itype *type_ptr = item::find_type( type );
-    if( type_ptr->count_by_charges() ) {
+    const item item_temp = item( type );
+    if( item_temp.count_by_charges() ) {
         // Count-by-charge
 
         if( avail == item::INFINITE_CHARGES ) {
@@ -176,16 +176,16 @@ std::string item_comp::to_string( const int batch, const int avail ) const
             return string_format( npgettext( "requirement", "%2$d %1$s (have infinite)",
                                              "%2$d %1$s (have infinite)",
                                              c ),
-                                  type_ptr->nname( 1 ), c );
+                                  item_temp.tname( 1 ), c );
         } else if( avail > 0 ) {
             //~ %1$s: item name, %2$d: charge requirement, %3%d: available charges
             return string_format( npgettext( "requirement", "%2$d %1$s (have %3$d)",
                                              "%2$d %1$s (have %3$d)", c ),
-                                  type_ptr->nname( 1 ), c, avail );
+                                  item_temp.tname( 1 ), c, avail );
         } else {
             //~ %1$s: item name, %2$d: charge requirement
             return string_format( npgettext( "requirement", "%2$d %1$s", "%2$d %1$s", c ),
-                                  type_ptr->nname( 1 ), c );
+                                  item_temp.tname( 1 ), c );
         }
     } else {
         if( avail == item::INFINITE_CHARGES ) {
@@ -193,16 +193,16 @@ std::string item_comp::to_string( const int batch, const int avail ) const
             return string_format( npgettext( "requirement", "%2$d %1$s (have infinite)",
                                              "%2$d %1$s (have infinite)",
                                              c ),
-                                  type_ptr->nname( c ), c );
+                                  item_temp.tname( c ), c );
         } else if( avail > 0 ) {
             //~ %1$s: item name, %2$d: required count, %3%d: available count
             return string_format( npgettext( "requirement", "%2$d %1$s (have %3$d)",
                                              "%2$d %1$s (have %3$d)", c ),
-                                  type_ptr->nname( c ), c, avail );
+                                  item_temp.tname( c ), c, avail );
         } else {
             //~ %1$s: item name, %2$d: required count
             return string_format( npgettext( "requirement", "%2$d %1$s", "%2$d %1$s", c ),
-                                  type_ptr->nname( c ), c );
+                                  item_temp.tname( c ), c );
         }
     }
 }

--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -158,9 +158,9 @@ std::string tool_comp::to_string( const int batch, const int ) const
         //~ %1$s: tool name, %2$d: charge requirement
         return string_format( npgettext( "requirement", "%1$s (%2$d charge)", "%1$s (%2$d charges)",
                                          charge_total ),
-                              item::tname( type, 1 ), charge_total );
+                              item::tname( type, 1, tname::item_name ), charge_total );
     } else {
-        return item::tname( type, std::abs( count ) );
+        return item::tname( type, std::abs( count ), tname::item_name );
     }
 }
 
@@ -176,16 +176,16 @@ std::string item_comp::to_string( const int batch, const int avail ) const
             return string_format( npgettext( "requirement", "%2$d %1$s (have infinite)",
                                              "%2$d %1$s (have infinite)",
                                              c ),
-                                  item_temp.tname( 1 ), c );
+                                  item_temp.tname( 1, tname::item_name ), c );
         } else if( avail > 0 ) {
             //~ %1$s: item name, %2$d: charge requirement, %3%d: available charges
             return string_format( npgettext( "requirement", "%2$d %1$s (have %3$d)",
                                              "%2$d %1$s (have %3$d)", c ),
-                                  item_temp.tname( 1 ), c, avail );
+                                  item_temp.tname( 1, tname::item_name ), c, avail );
         } else {
             //~ %1$s: item name, %2$d: charge requirement
             return string_format( npgettext( "requirement", "%2$d %1$s", "%2$d %1$s", c ),
-                                  item_temp.tname( 1 ), c );
+                                  item_temp.tname( 1, tname::item_name ), c );
         }
     } else {
         if( avail == item::INFINITE_CHARGES ) {
@@ -193,16 +193,16 @@ std::string item_comp::to_string( const int batch, const int avail ) const
             return string_format( npgettext( "requirement", "%2$d %1$s (have infinite)",
                                              "%2$d %1$s (have infinite)",
                                              c ),
-                                  item_temp.tname( c ), c );
+                                  item_temp.tname( c, tname::item_name ), c );
         } else if( avail > 0 ) {
             //~ %1$s: item name, %2$d: required count, %3%d: available count
             return string_format( npgettext( "requirement", "%2$d %1$s (have %3$d)",
                                              "%2$d %1$s (have %3$d)", c ),
-                                  item_temp.tname( c ), c, avail );
+                                  item_temp.tname( c, tname::item_name ), c, avail );
         } else {
             //~ %1$s: item name, %2$d: required count
             return string_format( npgettext( "requirement", "%2$d %1$s", "%2$d %1$s", c ),
-                                  item_temp.tname( c ), c );
+                                  item_temp.tname( c, tname::item_name ), c );
         }
     }
 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing another guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "use item/tname instead of its raw name (nname) in recipe menu"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

#72114 seems to require this functionality. The item name in the recipe will be displayed as 'tname', allowing prefix+item name+suffix to be displayed correctly in the recipe menu.



<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Replace the names of item entries and requirements(tools and components) in the recipe, originally obtained using `nname`, with `tname`.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
None
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
```json
  {
    "id": "makeshift_machete",
    "type": "TOOL",
    "category": "weapons",
    "name": { "str": "makeshift machete" },
    "description": "A large blade with one end wrapped in duct tape to make a crude handle, making it easier to wield as a rough machete.",
    "weight": "581 g",
    "volume": "2 L",
    "longest_side": "50 cm",
    "price": 1000,
    "price_postapoc": 250,
    "to_hit": { "grip": "solid", "length": "short", "surface": "line", "balance": "neutral" },
    "material": [ "steel" ],
    "symbol": "/",
    "color": "light_gray",
    "qualities": [ [ "CUT", 2 ], [ "GRASS_CUT", 1 ], [ "BUTCHER", -27 ] ],
    "techniques": [ "WBLOCK_1" ],
    "flags": [ "SHEATH_SWORD", "TEST_PREFIX" ],
    "weapon_category": [ "SHORT_SWORDS" ],
    "melee_damage": { "cut": 16 }
  },
  {
    "id": "TEST_PREFIX",
    "type": "json_flag",
    "item_suffix": " (Test)"
  },
  {
    "type": "recipe",
    "activity_level": "LIGHT_EXERCISE",
    "result": "makeshift_machete",
    "category": "CC_WEAPON",
    "subcategory": "CSC_WEAPON_CUTTING",
    "skill_used": "fabrication",
    "time": "5 m",
    "reversible": true,
    "autolearn": true,
    "tools": [ [ [ "makeshift_machete", -1 ] ] ],
    "components": [ [ [ "makeshift_machete", 1 ] ], [ [ "blade", 1 ] ] ]
  }
```
<img width="448" alt="image" src="https://github.com/CleverRaven/Cataclysm-DDA/assets/81861009/f067474f-18e8-46c2-808a-df08195208b7">
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

It might also be necessary to perform the replacement from 'nname' to 'tname' in the construction menu. In any case, I'll go ahead and submit this PR.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
