### PR TITLE
[Xedra Evolved] Add Homullus mutations

### DIFF
--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -906,6 +906,20 @@
   },
   {
     "type": "effect_type",
+    "id": "telepathic_ignorance",
+    "//": "id is hardcoded, used by the Homullus spell A Face in the Crowd",
+    "name": [ "" ],
+    "desc": [ "" ]
+  },
+  {
+    "type": "effect_type",
+    "id": "telepathic_ignorance_self",
+    "//": "id is hardcoded, used by the Homullus spell A Face in the Crowd",
+    "name": [ "" ],
+    "desc": [ "" ]
+  },
+  {
+    "type": "effect_type",
     "id": "effect_salamander_levitation",
     "name": [ "Smoke-Walking" ],
     "desc": [ "You are walking through the air." ],

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_eocs.json
@@ -104,6 +104,13 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_HOMULLUS_GAIN_BIONIC_POWER_IN_CITIES",
+    "recurrence": "30 seconds",
+    "condition": { "or": [ { "u_has_any_trait": [ "HOMULLUS_GAIN_BIONIC_POWER", "HOMULLUS_GAIN_BIONIC_POWER_AND_MANA" ] } ] },
+    "effect": [ { "math": [ "u_val('power')", "+=", "energy('1 kJ') + (energy('1 kJ') * u_has_trait('THRESH_HOMULLUS'))" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "HOMULLUS_MIGRATE_TO_MIMIMIZED_MUTATIONS",
     "//": "For pre-existing homullus characters that don't have the mutation blocker mutation.",
     "eoc_type": "EVENT",

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_eocs.json
@@ -74,6 +74,16 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_HOMULLUS_RUNNING_GIVE_STAMINA",
+    "eoc_type": "EVENT",
+    "required_event": "avatar_moves",
+    "condition": {
+      "and": [ { "u_has_trait": "HOMULLUS_THE_HUNTER2" }, { "compare_string": [ "run", { "context_val": "movement_mode" } ] } ]
+    },
+    "effect": [ { "math": [ "u_val('stamina')", "+=", "rng(40,65)" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_HOMULLUS_INVISIBLE_TO_HUMANS",
     "condition": {
       "or": [

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_eocs.json
@@ -35,6 +35,14 @@
                 { "u_near_om_location": "dirt_road", "range": 3 },
                 { "u_near_om_location": "subway", "range": 3 }
               ]
+            },
+            {
+              "or": [
+                { "not": { "u_at_om_location": "field" } },
+                { "not": { "u_at_om_location": "forest" } },
+                { "not": { "u_at_om_location": "forest_thick" } },
+                { "not": { "u_at_om_location": "forest_water" } }
+              ]
             }
           ]
         }

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_eocs.json
@@ -37,7 +37,7 @@
               ]
             },
             {
-              "or": [
+              "and": [
                 { "not": { "u_at_om_location": "field" } },
                 { "not": { "u_at_om_location": "forest" } },
                 { "not": { "u_at_om_location": "forest_thick" } },

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_eocs.json
@@ -41,6 +41,7 @@
                 { "not": { "u_at_om_location": "field" } },
                 { "not": { "u_at_om_location": "forest" } },
                 { "not": { "u_at_om_location": "forest_thick" } },
+                { "not": { "u_at_om_location": "forest_water" } },
                 { "not": { "u_at_om_location": "forest_water" } }
               ]
             }
@@ -53,7 +54,14 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_HOMULLUS_INVISIBLE_TO_HUMANS",
-    "condition": { "or": [ "u_is_npc", { "or": [ { "u_has_species": "FERAL" }, { "u_has_species": "HUMAN" } ] } ] },
+    "condition": {
+      "or": [
+        "u_is_npc",
+        {
+          "or": [ { "u_has_species": "FERAL" }, { "and": [ { "not": { "u_has_species": "ZOMBIE" } }, { "u_has_species": "HUMAN" } ] } ]
+        }
+      ]
+    },
     "effect": [
       {
         "u_add_effect": "telepathic_ignorance",

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_eocs.json
@@ -42,7 +42,8 @@
                 { "not": { "u_at_om_location": "forest" } },
                 { "not": { "u_at_om_location": "forest_thick" } },
                 { "not": { "u_at_om_location": "forest_water" } },
-                { "not": { "u_at_om_location": "forest_water" } }
+                { "not": { "u_at_om_location": "lake_surface" } },
+                { "not": { "u_at_om_location": "river_center" } }
               ]
             }
           ]
@@ -50,6 +51,26 @@
       ]
     },
     "effect": [  ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_HOMULLUS_NO_TRACE_ON",
+    "condition": { "not": { "u_has_trait": "NO_TRACE_YET_I_WISH_active" } },
+    "effect": [ { "u_add_trait": "NO_TRACE_YET_I_WISH_active" }, { "u_message": "Your body stops producing scent.", "type": "good" } ],
+    "false_effect": [
+      { "u_lose_trait": "NO_TRACE_YET_I_WISH_active" },
+      { "u_message": "Your body begins producing scent.", "type": "neutral" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_HOMULLUS_BACKSTAGE_ON",
+    "condition": { "not": { "u_has_trait": "HOMULLUS_BACKSTAGE_active" } },
+    "effect": [
+      { "u_add_trait": "HOMULLUS_BACKSTAGE_active" },
+      { "u_message": "You seem to fade into the background.", "type": "good" }
+    ],
+    "false_effect": [ { "u_lose_trait": "HOMULLUS_BACKSTAGE_active" }, { "u_message": "You become more noticeable.", "type": "neutral" } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_eocs.json
@@ -1,6 +1,49 @@
 [
   {
     "type": "effect_on_condition",
+    "id": "EOC_HOMULLUS_IN_CIVILIZATION_CHECKER_CONDITION",
+    "//": "map_in_city cannot check talker location directly, so this is a substitute for enchantment conditions until that is possible.",
+    "condition": {
+      "or": [
+        {
+          "or": [
+            { "u_near_om_location": "FACTION_CAMP_ANY", "range": 6 },
+            { "u_near_om_location": "evac_center_18", "range": 6 },
+            { "u_near_om_location": "isolated_road_field_0", "range": 6 },
+            { "u_near_om_location": "lumbermill_0_0_ocu", "range": 6 },
+            { "u_near_om_location": "ranch_camp_41", "range": 6 },
+            { "u_near_om_location": "godco_5", "range": 6 },
+            { "u_near_om_location": "smallscrapyard_ocu", "range": 4 },
+            { "u_near_om_location": "robofachq_surface_entrance", "range": 6 }
+          ]
+        },
+        {
+          "and": [
+            {
+              "or": [
+                { "u_near_om_location": "road_curved", "range": 3 },
+                { "u_near_om_location": "road_four_way", "range": 3 },
+                { "u_near_om_location": "road_tee", "range": 3 },
+                { "u_near_om_location": "road_straight", "range": 3 },
+                { "u_near_om_location": "road_end", "range": 3 },
+                { "u_near_om_location": "road_sw", "range": 3 },
+                { "u_near_om_location": "road_ne", "range": 3 },
+                { "u_near_om_location": "road_ew", "range": 3 },
+                { "u_near_om_location": "road_ns", "range": 3 },
+                { "u_near_om_location": "road_nesw", "range": 3 },
+                { "u_near_om_location": "road", "range": 3 },
+                { "u_near_om_location": "dirt_road", "range": 3 },
+                { "u_near_om_location": "subway", "range": 3 }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "effect": [  ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_HOMULLUS_DREAMWALKER_GAIN_DREAMDROSS",
     "eoc_type": "EVENT",
     "required_event": "character_wakes_up",

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_eocs.json
@@ -2,7 +2,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_HOMULLUS_IN_CIVILIZATION_CHECKER_CONDITION",
-    "//": "map_in_city cannot check talker location directly, so this is a substitute for enchantment conditions until that is possible.",
+    "//": "map_in_city cannot check talker location directly, so this is a substitute for enchantment conditions until that is possible.  It does work on random roads in the middle of nowhere, but that's not such a bad thing.",
     "condition": {
       "or": [
         {
@@ -49,6 +49,19 @@
       ]
     },
     "effect": [  ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_HOMULLUS_INVISIBLE_TO_HUMANS",
+    "condition": { "or": [ "u_is_npc", { "or": [ { "u_has_species": "FERAL" }, { "u_has_species": "HUMAN" } ] } ] },
+    "effect": [
+      {
+        "u_add_effect": "telepathic_ignorance",
+        "duration": {
+          "math": [ "( 6000 + (u_spell_level('homullus_invisible_to_humans_spell') * 3000) ) * scaling_factor(u_val('intelligence') )" ]
+        }
+      }
+    ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_mutation_spells.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_mutation_spells.json
@@ -1,5 +1,64 @@
 [
   {
+    "id": "homullus_invisible_to_humans_spell",
+    "type": "SPELL",
+    "name": "A Face in the Crowd",
+    "description": "Though the teeming masses of humanity are gone, the Homullus can evoke their anonymizing essence with magick, rendering them invisible to any humans affected by the spell.",
+    "valid_targets": [ "hostile", "ally" ],
+    "spell_class": "HOMULLUS",
+    "flags": [ "VERBAL", "SOMATIC", "NO_HANDS", "IGNORE_WALLS" ],
+    "teachable": false,
+    "difficulty": 6,
+    "max_level": { "math": [ "int_to_level(1)" ] },
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_HOMULLUS_INVISIBLE_TO_HUMANS",
+    "extra_effects": [ { "id": "homullus_invisible_to_humans_spell_self", "hit_self": true } ],
+    "shape": "blast",
+    "min_duration": {
+      "math": [ "( 6000 + (u_spell_level('homullus_invisible_to_humans_spell') * 3000) ) * scaling_factor(u_val('intelligence') )" ]
+    },
+    "max_duration": {
+      "math": [ "( 6000 + (u_spell_level('homullus_invisible_to_humans_spell') * 3000) ) * scaling_factor(u_val('intelligence') )" ]
+    },
+    "min_aoe": {
+      "math": [
+        "min( ( ( (u_spell_level('homullus_invisible_to_humans_spell') * 1) + 3) * (scaling_factor(u_val('intelligence') ) ) ), 25)"
+      ]
+    },
+    "max_aoe": {
+      "math": [
+        "min( ( ( (u_spell_level('homullus_invisible_to_humans_spell') * 1) + 3) * (scaling_factor(u_val('intelligence') ) ) ), 25)"
+      ]
+    },
+    "energy_source": "MANA",
+    "base_energy_cost": 400,
+    "final_energy_cost": 200,
+    "energy_increment": -10,
+    "base_casting_time": 250,
+    "final_casting_time": 75,
+    "casting_time_increment": -5
+  },
+  {
+    "id": "homullus_invisible_to_humans_spell_self",
+    "type": "SPELL",
+    "name": "A Face in the Crowd Self",
+    "description": "Puts an effect on you so anyone affected by A Face in the Crowd knows to ignore you.  It's a bug if you have this directly.",
+    "message": "",
+    "spell_class": "HOMULLUS",
+    "teachable": false,
+    "valid_targets": [ "self" ],
+    "flags": [ "SILENT", "NO_HANDS", "NO_LEGS" ],
+    "effect": "attack",
+    "effect_str": "telepathic_ignorance_self",
+    "shape": "blast",
+    "min_duration": {
+      "math": [ "( 6000 + (u_spell_level('homullus_invisible_to_humans_spell') * 3000) ) * scaling_factor(u_val('intelligence') )" ]
+    },
+    "max_duration": {
+      "math": [ "( 6000 + (u_spell_level('homullus_invisible_to_humans_spell') * 3000) ) * scaling_factor(u_val('intelligence') )" ]
+    }
+  },
+  {
     "id": "homullus_cultivate_goblin_fruit",
     "type": "SPELL",
     "name": "Discover Goblin Fruit",

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_mutations.json
@@ -128,6 +128,36 @@
   },
   {
     "type": "mutation",
+    "id": "HOMULLUS_GAIN_BIONIC_POWER",
+    "name": "Echoes of the Streets",
+    "points": 5,
+    "visibility": 0,
+    "ugliness": 0,
+    "description": "Though much of humanity has died, their echoes remain in the places they once called home.  The Homullus can draw on those echoes to restore their bionic power.",
+    "changes_to": [ "HOMULLUS_GAIN_BIONIC_POWER_AND_MANA" ],
+    "prereqs": [ "HOMULLUS_CBM_MANA_1" ],
+    "category": [ "HOMULLUS" ]
+  },
+  {
+    "type": "mutation",
+    "id": "HOMULLUS_GAIN_BIONIC_POWER_AND_MANA",
+    "name": "The Pulse of the Invisible",
+    "points": 8,
+    "visibility": 0,
+    "ugliness": 0,
+    "description": "Though much of humanity has died, their echoes remain in the places they once called home.  The Homullus can draw on those echoes to restore their bionic power and mana.",
+    "prereqs": [ "HOMULLUS_GAIN_BIONIC_POWER" ],
+    "category": [ "HOMULLUS" ],
+    "threshreq": [ "THRESH_HOMULLUS" ],
+    "enchantments": [
+      {
+        "condition": { "test_eoc": "EOC_HOMULLUS_IN_CIVILIZATION_CHECKER_CONDITION" },
+        "values": [ { "value": "REGEN_MANA", "multiply": 0.25 } ]
+      }
+    ]
+  },
+  {
+    "type": "mutation",
     "id": "HOMULLUS_CITY_STRIDER",
     "name": { "str": "City Strider" },
     "points": 3,
@@ -179,31 +209,7 @@
     "category": [ "HOMULLUS" ],
     "enchantments": [
       {
-        "condition": {
-          "or": [
-            { "u_near_om_location": "road_curved", "range": 3 },
-            { "u_near_om_location": "road_four_way", "range": 3 },
-            { "u_near_om_location": "road_tee", "range": 3 },
-            { "u_near_om_location": "road_straight", "range": 3 },
-            { "u_near_om_location": "road_end", "range": 3 },
-            { "u_near_om_location": "road_sw", "range": 3 },
-            { "u_near_om_location": "road_ne", "range": 3 },
-            { "u_near_om_location": "road_ew", "range": 3 },
-            { "u_near_om_location": "road_ns", "range": 3 },
-            { "u_near_om_location": "road_nesw", "range": 3 },
-            { "u_near_om_location": "road", "range": 3 },
-            { "u_near_om_location": "dirt_road", "range": 3 },
-            { "u_near_om_location": "subway", "range": 3 },
-            { "u_near_om_location": "FACTION_CAMP_ANY", "range": 6 },
-            { "u_near_om_location": "evac_center_18", "range": 6 },
-            { "u_near_om_location": "isolated_road_field_0", "range": 6 },
-            { "u_near_om_location": "lumbermill_0_0_ocu", "range": 6 },
-            { "u_near_om_location": "ranch_camp_41", "range": 6 },
-            { "u_near_om_location": "godco_5", "range": 6 },
-            { "u_near_om_location": "smallscrapyard_ocu", "range": 4 },
-            { "u_near_om_location": "robofachq_surface_entrance", "range": 6 }
-          ]
-        },
+        "condition": { "test_eoc": "EOC_HOMULLUS_IN_CIVILIZATION_CHECKER_CONDITION" },
         "values": [ { "value": "CRAFTING_SPEED_MULTIPLIER", "multiply": -0.15 } ]
       }
     ]
@@ -221,31 +227,7 @@
     "category": [ "HOMULLUS" ],
     "enchantments": [
       {
-        "condition": {
-          "or": [
-            { "u_near_om_location": "road_curved", "range": 3 },
-            { "u_near_om_location": "road_four_way", "range": 3 },
-            { "u_near_om_location": "road_tee", "range": 3 },
-            { "u_near_om_location": "road_straight", "range": 3 },
-            { "u_near_om_location": "road_end", "range": 3 },
-            { "u_near_om_location": "road_sw", "range": 3 },
-            { "u_near_om_location": "road_ne", "range": 3 },
-            { "u_near_om_location": "road_ew", "range": 3 },
-            { "u_near_om_location": "road_ns", "range": 3 },
-            { "u_near_om_location": "road_nesw", "range": 3 },
-            { "u_near_om_location": "road", "range": 3 },
-            { "u_near_om_location": "dirt_road", "range": 3 },
-            { "u_near_om_location": "subway", "range": 3 },
-            { "u_near_om_location": "FACTION_CAMP_ANY", "range": 6 },
-            { "u_near_om_location": "evac_center_18", "range": 6 },
-            { "u_near_om_location": "isolated_road_field_0", "range": 6 },
-            { "u_near_om_location": "lumbermill_0_0_ocu", "range": 6 },
-            { "u_near_om_location": "ranch_camp_41", "range": 6 },
-            { "u_near_om_location": "godco_5", "range": 6 },
-            { "u_near_om_location": "smallscrapyard_ocu", "range": 4 },
-            { "u_near_om_location": "robofachq_surface_entrance", "range": 6 }
-          ]
-        },
+        "condition": { "test_eoc": "EOC_HOMULLUS_IN_CIVILIZATION_CHECKER_CONDITION" },
         "skills": [
           { "value": "electronics", "add": 1 },
           { "value": "fabrication", "add": 1 },
@@ -264,36 +246,12 @@
     "visibility": 0,
     "ugliness": 0,
     "description": "Though they had no claws or fangs or armored skin, humanity mastered the world through their tools.  When near civilization, your crafting speed and ability are greatly increased.",
-    "prereqs": [ "HOMULLUS_CRAFTING_BONUS_3" ],
+    "prereqs": [ "HOMULLUS_CRAFTING_BONUS_2" ],
     "category": [ "HOMULLUS" ],
     "threshreq": [ "THRESH_HOMULLUS" ],
     "enchantments": [
       {
-        "condition": {
-          "or": [
-            { "u_near_om_location": "road_curved", "range": 3 },
-            { "u_near_om_location": "road_four_way", "range": 3 },
-            { "u_near_om_location": "road_tee", "range": 3 },
-            { "u_near_om_location": "road_straight", "range": 3 },
-            { "u_near_om_location": "road_end", "range": 3 },
-            { "u_near_om_location": "road_sw", "range": 3 },
-            { "u_near_om_location": "road_ne", "range": 3 },
-            { "u_near_om_location": "road_ew", "range": 3 },
-            { "u_near_om_location": "road_ns", "range": 3 },
-            { "u_near_om_location": "road_nesw", "range": 3 },
-            { "u_near_om_location": "road", "range": 3 },
-            { "u_near_om_location": "dirt_road", "range": 3 },
-            { "u_near_om_location": "subway", "range": 3 },
-            { "u_near_om_location": "FACTION_CAMP_ANY", "range": 6 },
-            { "u_near_om_location": "evac_center_18", "range": 6 },
-            { "u_near_om_location": "isolated_road_field_0", "range": 6 },
-            { "u_near_om_location": "lumbermill_0_0_ocu", "range": 6 },
-            { "u_near_om_location": "ranch_camp_41", "range": 6 },
-            { "u_near_om_location": "godco_5", "range": 6 },
-            { "u_near_om_location": "smallscrapyard_ocu", "range": 4 },
-            { "u_near_om_location": "robofachq_surface_entrance", "range": 6 }
-          ]
-        },
+        "condition": { "test_eoc": "EOC_HOMULLUS_IN_CIVILIZATION_CHECKER_CONDITION" },
         "skills": [
           { "value": "electronics", "add": 2 },
           { "value": "fabrication", "add": 2 },

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_mutations.json
@@ -88,6 +88,7 @@
     "description": "Upon gaining this ability the Homullus gains the ability to render themselves invisible to humans.",
     "category": [ "HOMULLUS" ],
     "prereqs": [ "HOMULLUS_SKIN_1" ],
+    "prereqs2": [ "BACKSTAGE" ],
     "spells_learned": [ [ "homullus_invisible_to_humans_spell", 1 ] ]
   },
   {
@@ -100,6 +101,64 @@
     "description": "Upon gaining this ability the Homullus gains the ability to find a goblin fruit when in the remnants of civilization.",
     "category": [ "HOMULLUS" ],
     "spells_learned": [ [ "homullus_cultivate_goblin_fruit", 1 ] ]
+  },
+  {
+    "type": "mutation",
+    "id": "NO_TRACE_YET_I_WISH",
+    "name": { "str": "No Trace Yet I Wish" },
+    "points": 0,
+    "visibility": 0,
+    "ugliness": 0,
+    "description": "The Homullus gains the ability to stop emitting scent at will.  They can use this to control when scent-tracking creatures will be able to find them.",
+    "category": [ "HOMULLUS" ],
+    "activated_is_setup": true,
+    "active": true,
+    "activated_eocs": [ "EOC_HOMULLUS_NO_TRACE_ON" ],
+    "deactivated_eocs": [ "EOC_HOMULLUS_NO_TRACE_ON" ]
+  },
+  {
+    "type": "mutation",
+    "id": "NO_TRACE_YET_I_WISH_active",
+    "name": { "str": "No Trace Yet I Wish (on)" },
+    "description": "You don't currently produce scent.",
+    "copy-from": "NO_TRACE_YET_I_WISH",
+    "valid": false,
+    "player_display": false,
+    "flags": [ "NO_SCENT" ]
+  },
+  {
+    "type": "mutation",
+    "id": "HOMULLUS_BACKSTAGE",
+    "name": { "str": "Backstage" },
+    "points": 0,
+    "visibility": -1,
+    "ugliness": 0,
+    "description": "At will, you can recede from the foreground of people's perceptions.  They will still notice you if you make yourself known.  Conversation with actual humans will be harder while this trait is active.",
+    "category": [ "HOMULLUS" ],
+    "prereqs": [ "NO_TRACE_YET_I_WISH" ],
+    "activated_is_setup": true,
+    "active": true,
+    "activated_eocs": [ "EOC_HOMULLUS_BACKSTAGE_ON" ],
+    "deactivated_eocs": [ "EOC_HOMULLUS_BACKSTAGE_ON" ]
+  },
+  {
+    "type": "mutation",
+    "id": "HOMULLUS_BACKSTAGE_active",
+    "name": { "str": "Backstage (on)" },
+    "description": "You have faded into the background.",
+    "copy-from": "HOMULLUS_BACKSTAGE",
+    "valid": false,
+    "player_display": false,
+    "anger_relations": [ [ "HUMAN", -50 ], [ "FERAL", -50 ] ],
+    "enchantments": [
+      {
+        "values": [
+          { "value": "SOCIAL_LIE", "add": -20 },
+          { "value": "SOCIAL_PERSUADE", "add": -20 },
+          { "value": "SOCIAL_INTIMIDATE", "add": -30 }
+        ]
+      }
+    ]
   },
   {
     "type": "mutation",

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_mutations.json
@@ -204,7 +204,7 @@
             { "u_near_om_location": "robofachq_surface_entrance", "range": 6 }
           ]
         },
-        "values": [ { "value": "CRAFTING_SPEED_MULTIPLIER", "multiply": -0.15 } ]
+        "values": [ { "value": "CRAFTING_SPEED_MULTIPLIER", "multiply": 0.15 } ]
       }
     ]
   },

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_mutations.json
@@ -88,7 +88,7 @@
     "description": "Upon gaining this ability the Homullus gains the ability to render themselves invisible to humans.",
     "category": [ "HOMULLUS" ],
     "prereqs": [ "HOMULLUS_SKIN_1" ],
-    "prereqs2": [ "BACKSTAGE" ],
+    "prereqs2": [ "HOMULLUS_BACKSTAGE" ],
     "spells_learned": [ [ "homullus_invisible_to_humans_spell", 1 ] ]
   },
   {
@@ -122,6 +122,7 @@
     "name": { "str": "No Trace Yet I Wish (on)" },
     "description": "You don't currently produce scent.",
     "copy-from": "NO_TRACE_YET_I_WISH",
+    "active": false,
     "valid": false,
     "player_display": false,
     "flags": [ "NO_SCENT" ]
@@ -147,6 +148,7 @@
     "name": { "str": "Backstage (on)" },
     "description": "You have faded into the background.",
     "copy-from": "HOMULLUS_BACKSTAGE",
+    "active": false,
     "valid": false,
     "player_display": false,
     "anger_relations": [ [ "HUMAN", -50 ], [ "FERAL", -50 ] ],

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_mutations.json
@@ -252,7 +252,7 @@
           { "value": "mechanics", "add": 1 },
           { "value": "tailor", "add": 1 }
         ],
-        "values": [ { "value": "CRAFTING_SPEED_MULTIPLIER", "multiply": -0.25 } ]
+        "values": [ { "value": "CRAFTING_SPEED_MULTIPLIER", "multiply": 0.25 } ]
       }
     ]
   },

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_mutations.json
@@ -80,6 +80,18 @@
   },
   {
     "type": "mutation",
+    "id": "HOMULLUS_INVISIBLE_TO_HUMANS",
+    "name": { "str": "A Face in the Crowd" },
+    "points": 3,
+    "visibility": 0,
+    "ugliness": 0,
+    "description": "Upon gaining this ability the Homullus gains the ability to render themselves invisible to humans.",
+    "category": [ "HOMULLUS" ],
+    "prereqs": [ "HOMULLUS_SKIN_1" ],
+    "spells_learned": [ [ "homullus_invisible_to_humans_spell", 1 ] ]
+  },
+  {
+    "type": "mutation",
     "id": "HOMULLUS_CULTIVATE_GOBLIN_FRUIT",
     "name": { "str": "Cultivate Goblin Fruit" },
     "points": 3,

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_mutations.json
@@ -169,6 +169,143 @@
   },
   {
     "type": "mutation",
+    "id": "HOMULLUS_CRAFTING_BONUS_1",
+    "name": { "str": "The Tool-Maker" },
+    "points": 3,
+    "visibility": 0,
+    "ugliness": 0,
+    "description": "Though they had no claws or fangs or armored skin, humanity mastered the world through their tools.  When near civilization, your crafting speed is increased.",
+    "changes_to": [ "HOMULLUS_CRAFTING_BONUS_2" ],
+    "category": [ "HOMULLUS" ],
+    "enchantments": [
+      {
+        "condition": {
+          "or": [
+            { "u_near_om_location": "road_curved", "range": 3 },
+            { "u_near_om_location": "road_four_way", "range": 3 },
+            { "u_near_om_location": "road_tee", "range": 3 },
+            { "u_near_om_location": "road_straight", "range": 3 },
+            { "u_near_om_location": "road_end", "range": 3 },
+            { "u_near_om_location": "road_sw", "range": 3 },
+            { "u_near_om_location": "road_ne", "range": 3 },
+            { "u_near_om_location": "road_ew", "range": 3 },
+            { "u_near_om_location": "road_ns", "range": 3 },
+            { "u_near_om_location": "road_nesw", "range": 3 },
+            { "u_near_om_location": "road", "range": 3 },
+            { "u_near_om_location": "dirt_road", "range": 3 },
+            { "u_near_om_location": "subway", "range": 3 },
+            { "u_near_om_location": "FACTION_CAMP_ANY", "range": 6 },
+            { "u_near_om_location": "evac_center_18", "range": 6 },
+            { "u_near_om_location": "isolated_road_field_0", "range": 6 },
+            { "u_near_om_location": "lumbermill_0_0_ocu", "range": 6 },
+            { "u_near_om_location": "ranch_camp_41", "range": 6 },
+            { "u_near_om_location": "godco_5", "range": 6 },
+            { "u_near_om_location": "smallscrapyard_ocu", "range": 4 },
+            { "u_near_om_location": "robofachq_surface_entrance", "range": 6 }
+          ]
+        },
+        "values": [ { "value": "CRAFTING_SPEED_MULTIPLIER", "multiply": -0.15 } ]
+      }
+    ]
+  },
+  {
+    "type": "mutation",
+    "id": "HOMULLUS_CRAFTING_BONUS_2",
+    "name": { "str": "The Innovator" },
+    "points": 3,
+    "visibility": 0,
+    "ugliness": 0,
+    "description": "Though they had no claws or fangs or armored skin, humanity mastered the world through their tools.  When near civilization, your crafting speed and ability are increased.",
+    "prereqs": [ "HOMULLUS_CRAFTING_BONUS_1" ],
+    "changes_to": [ "HOMULLUS_CRAFTING_BONUS_3" ],
+    "category": [ "HOMULLUS" ],
+    "enchantments": [
+      {
+        "condition": {
+          "or": [
+            { "u_near_om_location": "road_curved", "range": 3 },
+            { "u_near_om_location": "road_four_way", "range": 3 },
+            { "u_near_om_location": "road_tee", "range": 3 },
+            { "u_near_om_location": "road_straight", "range": 3 },
+            { "u_near_om_location": "road_end", "range": 3 },
+            { "u_near_om_location": "road_sw", "range": 3 },
+            { "u_near_om_location": "road_ne", "range": 3 },
+            { "u_near_om_location": "road_ew", "range": 3 },
+            { "u_near_om_location": "road_ns", "range": 3 },
+            { "u_near_om_location": "road_nesw", "range": 3 },
+            { "u_near_om_location": "road", "range": 3 },
+            { "u_near_om_location": "dirt_road", "range": 3 },
+            { "u_near_om_location": "subway", "range": 3 },
+            { "u_near_om_location": "FACTION_CAMP_ANY", "range": 6 },
+            { "u_near_om_location": "evac_center_18", "range": 6 },
+            { "u_near_om_location": "isolated_road_field_0", "range": 6 },
+            { "u_near_om_location": "lumbermill_0_0_ocu", "range": 6 },
+            { "u_near_om_location": "ranch_camp_41", "range": 6 },
+            { "u_near_om_location": "godco_5", "range": 6 },
+            { "u_near_om_location": "smallscrapyard_ocu", "range": 4 },
+            { "u_near_om_location": "robofachq_surface_entrance", "range": 6 }
+          ]
+        },
+        "skills": [
+          { "value": "electronics", "add": 1 },
+          { "value": "fabrication", "add": 1 },
+          { "value": "mechanics", "add": 1 },
+          { "value": "tailor", "add": 1 }
+        ],
+        "values": [ { "value": "CRAFTING_SPEED_MULTIPLIER", "multiply": -0.25 } ]
+      }
+    ]
+  },
+  {
+    "type": "mutation",
+    "id": "HOMULLUS_CRAFTING_BONUS_3",
+    "name": { "str": "The Builder of Cities" },
+    "points": 3,
+    "visibility": 0,
+    "ugliness": 0,
+    "description": "Though they had no claws or fangs or armored skin, humanity mastered the world through their tools.  When near civilization, your crafting speed and ability are greatly increased.",
+    "prereqs": [ "HOMULLUS_CRAFTING_BONUS_3" ],
+    "category": [ "HOMULLUS" ],
+    "threshreq": [ "THRESH_HOMULLUS" ],
+    "enchantments": [
+      {
+        "condition": {
+          "or": [
+            { "u_near_om_location": "road_curved", "range": 3 },
+            { "u_near_om_location": "road_four_way", "range": 3 },
+            { "u_near_om_location": "road_tee", "range": 3 },
+            { "u_near_om_location": "road_straight", "range": 3 },
+            { "u_near_om_location": "road_end", "range": 3 },
+            { "u_near_om_location": "road_sw", "range": 3 },
+            { "u_near_om_location": "road_ne", "range": 3 },
+            { "u_near_om_location": "road_ew", "range": 3 },
+            { "u_near_om_location": "road_ns", "range": 3 },
+            { "u_near_om_location": "road_nesw", "range": 3 },
+            { "u_near_om_location": "road", "range": 3 },
+            { "u_near_om_location": "dirt_road", "range": 3 },
+            { "u_near_om_location": "subway", "range": 3 },
+            { "u_near_om_location": "FACTION_CAMP_ANY", "range": 6 },
+            { "u_near_om_location": "evac_center_18", "range": 6 },
+            { "u_near_om_location": "isolated_road_field_0", "range": 6 },
+            { "u_near_om_location": "lumbermill_0_0_ocu", "range": 6 },
+            { "u_near_om_location": "ranch_camp_41", "range": 6 },
+            { "u_near_om_location": "godco_5", "range": 6 },
+            { "u_near_om_location": "smallscrapyard_ocu", "range": 4 },
+            { "u_near_om_location": "robofachq_surface_entrance", "range": 6 }
+          ]
+        },
+        "skills": [
+          { "value": "electronics", "add": 2 },
+          { "value": "fabrication", "add": 2 },
+          { "value": "mechanics", "add": 2 },
+          { "value": "tailor", "add": 2 }
+        ],
+        "values": [ { "value": "CRAFTING_SPEED_MULTIPLIER", "multiply": -0.35 } ]
+      }
+    ]
+  },
+  {
+    "type": "mutation",
     "id": "HOMULLUS_EXPANDED_MUTATIONS",
     "name": "Mimicry of Biology",
     "points": 10,

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_mutations.json
@@ -300,7 +300,7 @@
           { "value": "mechanics", "add": 2 },
           { "value": "tailor", "add": 2 }
         ],
-        "values": [ { "value": "CRAFTING_SPEED_MULTIPLIER", "multiply": -0.35 } ]
+        "values": [ { "value": "CRAFTING_SPEED_MULTIPLIER", "multiply": 0.35 } ]
       }
     ]
   },

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_mutations.json
@@ -270,6 +270,29 @@
   },
   {
     "type": "mutation",
+    "id": "HOMULLUS_THE_HUNTER",
+    "name": { "str": "Endurance Hunter" },
+    "points": 2,
+    "description": "Early humans chased prey for miles before it dropped dead from exhaustion, and the Homullus is heir to that legacy.  You have 33% more stamina.",
+    "types": [ "METABOLISM" ],
+    "prereqs": [ "HOMULLUS_CITY_STRIDER" ],
+    "changes_to": [ "HOMULLUS_THE_HUNTER2" ],
+    "category": [ "HOMULLUS" ],
+    "enchantments": [ { "values": [ { "value": "MAX_STAMINA", "multiply": 0.33 } ] } ]
+  },
+  {
+    "type": "mutation",
+    "id": "HOMULLUS_EAT_DEMIHUMANS",
+    "name": { "str": "The Top of the Food Chain" },
+    "points": 5,
+    "description": "Early humans chased prey for miles before it dropped dead from exhaustion, and the Homullus is heir to that legacy.  You have 33% more stamina and you can run for much longer before tiring.",
+    "prereqs": [ "HOMULLUS_THE_HUNTER", "HOMULLUS_THE_HUNTER2" ],
+    "category": [ "HOMULLUS" ],
+    "threshreq": [ "THRESH_HOMULLUS" ],
+    "flags": [ "STRICT_HUMANITARIAN" ]
+  },
+  {
+    "type": "mutation",
     "id": "HOMULLUS_CRAFTING_BONUS_1",
     "name": { "str": "The Tool-Maker" },
     "points": 3,
@@ -361,6 +384,18 @@
     "allowed_category": [ "HOMULLUS" ],
     "changes_to": [ "HOMULLUS_EXPANDED_MUTATIONS" ],
     "category": [ "HOMULLUS" ]
+  },
+  {
+    "type": "mutation",
+    "id": "HOMULLUS_THE_HUNTER2",
+    "name": { "str": "Running to Marathon" },
+    "points": 2,
+    "description": "Early humans chased prey for miles before it dropped dead from exhaustion, and the Homullus is heir to that legacy.  You have 33% more stamina and you can run for much longer before tiring.",
+    "types": [ "METABOLISM" ],
+    "prereqs": [ "HOMULLUS_THE_HUNTER" ],
+    "category": [ "HOMULLUS" ],
+    "threshreq": [ "THRESH_HOMULLUS" ],
+    "enchantments": [ { "values": [ { "value": "MAX_STAMINA", "multiply": 0.33 } ] } ]
   },
   {
     "type": "mutation",

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_mutations.json
@@ -151,7 +151,7 @@
     "active": false,
     "valid": false,
     "player_display": false,
-    "anger_relations": [ [ "HUMAN", -50 ], [ "FERAL", -50 ] ],
+    "anger_relations": [ [ "HUMAN", -100 ], [ "FERAL", -100 ] ],
     "enchantments": [
       {
         "values": [
@@ -345,6 +345,7 @@
     "prereqs": [ "HOMULLUS_CRAFTING_BONUS_2" ],
     "category": [ "HOMULLUS" ],
     "threshreq": [ "THRESH_HOMULLUS" ],
+    "//": "This should also reduce Construction times once there's some way to do so.",
     "enchantments": [
       {
         "condition": { "test_eoc": "EOC_HOMULLUS_IN_CIVILIZATION_CHECKER_CONDITION" },

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_spell_learning_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_spell_learning_eocs.json
@@ -4,7 +4,14 @@
     "id": "EOC_HOMULLUS_SPELL_EXPERIENCE_INCREASER",
     "//": "Must be in a city or a faction camp",
     "recurrence": [ "6 h", "36 h" ],
-    "condition": { "and": [ { "u_has_trait": "HOMULLUS" }, { "u_has_trait": "HOMULLUS_CULTIVATE_GOBLIN_FRUIT" } ] },
+    "condition": {
+      "and": [
+        { "u_has_trait": "HOMULLUS" },
+        {
+          "u_has_any_trait": [ "HOMULLUS_INVISIBLE_TO_HUMANS", "HOMULLUS_CULTIVATE_GOBLIN_FRUIT", "PARACLESIAN_MAKE_GOSSAMER" ]
+        }
+      ]
+    },
     "deactivate_condition": { "not": { "u_has_trait": "HOMULLUS" } },
     "effect": [
       {
@@ -43,15 +50,54 @@
     "//": "This is a separate EoC to allow looping through until it finds a spell the Homullus knows. Probability is [11-Difficulty]",
     "condition": {
       "or": [
-        {
-          "and": [
-            { "math": [ "u_spell_level('paraclesian_spell_make_gossamer')", ">=", "0" ] },
-            { "math": [ "u_spell_level('paraclesian_spell_make_gossamer')", "<", "8" ] }
-          ]
-        }
+        { "math": [ "u_spell_level('homullus_invisible_to_humans_spell')", "<", "int_to_level(1)" ] },
+        { "math": [ "u_spell_level('homullus_cultivate_goblin_fruit')", "<", "int_to_level(1)" ] },
+        { "math": [ "u_spell_level('paraclesian_spell_make_gossamer')", "<", "8" ] }
       ]
     },
-    "effect": { "weighted_list_eocs": [ [ "EOC_LEVELER_HOMULLUS_MAKE_GOSSAMER", 4 ] ] }
+    "effect": {
+      "weighted_list_eocs": [
+        [ "EOC_LEVELER_HOMULLUS_INVISIBLE_TO_HUMANS", 5 ],
+        [ "EOC_LEVELER_HOMULLUS_CULTIVATE_GOBLIN_FRUIT", 3 ],
+        [ "EOC_LEVELER_HOMULLUS_MAKE_GOSSAMER", 4 ]
+      ]
+    }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_LEVELER_HOMULLUS_INVISIBLE_TO_HUMANS",
+    "condition": {
+      "and": [
+        { "math": [ "u_spell_level('homullus_invisible_to_humans_spell')", ">=", "0" ] },
+        { "math": [ "u_spell_level('homullus_invisible_to_humans_spell')", "<", "int_to_level(1)" ] }
+      ]
+    },
+    "effect": [
+      {
+        "u_message": "Your time spent surrounded by the remnants of civilization has increased your facility with your fae magicks.",
+        "type": "good"
+      },
+      { "math": [ "u_spell_exp('homullus_invisible_to_humans_spell')", "+=", "paraclesian_passive_spell_exp(1)" ] }
+    ],
+    "false_effect": [ { "run_eocs": "EOC_HOMULLUS_SPELL_EXPERIENCE_INCREASER_SELECTOR" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_LEVELER_HOMULLUS_CULTIVATE_GOBLIN_FRUIT",
+    "condition": {
+      "and": [
+        { "math": [ "u_spell_level('homullus_cultivate_goblin_fruit')", ">=", "0" ] },
+        { "math": [ "u_spell_level('homullus_cultivate_goblin_fruit')", "<", "int_to_level(1)" ] }
+      ]
+    },
+    "effect": [
+      {
+        "u_message": "Your time spent surrounded by the remnants of civilization has increased your facility with your fae magicks.",
+        "type": "good"
+      },
+      { "math": [ "u_spell_exp('homullus_cultivate_goblin_fruit')", "+=", "paraclesian_passive_spell_exp(1)" ] }
+    ],
+    "false_effect": [ { "run_eocs": "EOC_HOMULLUS_SPELL_EXPERIENCE_INCREASER_SELECTOR" } ]
   },
   {
     "type": "effect_on_condition",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing another guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Xedra Evolved] Add Homullus mutations"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

It's definitely harder for me to come up with ideas for a fae spirit of humanity than the elements, but I have a few.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the following traits:

PASSIVE:

- The Tool-Maker: When near civilization, reduces crafting speed by 15%. Changes to:
- The Innovator: When near civilization, reduces crafting speed by 25% and adds +1 to the mechanics, electronics, fabrication, and tailoring skills. 
- Endurance Hunter: Like the early humans who pursued prey until it collapsed from exhaustion, the Homullus has a great reserve of energy. Gain 33% more stamina (_Requires City Strider_)
- Echoes of the Streets: When in civilization, the homullus regenerates 1 bionic power every 30 seconds [2 every 30 seconds if post-threshold] (_Requires Cybernetic Adaptation_).
- The Top of the Food Chain: Just as humanity ate nearly anything in their quest to survive, the Homullus may eat anything not human. (Requires Endurance Hunter or Running to Marathon)

ACTIVE:

- No Trace Yet I Wish: At will, the Homullus may stop emitting scent (original idea by Maleclypse in #69066). 
- Backstage: At will, the Homullus may fade into the background, becoming much less noticeable to human enemies. However, their conversation ability with humans suffers due to their obscurity (lower chance on persuade, lie, and intimidate while active). (_Requires No Trace Yet I Wish_) (original idea by Maleclypse in #69066)

SPELL-GRANTING:

- A Face in the Crowd: When this spell is cast, all humans in a radius can no longer see the Homullus. (Requires Mannequin Skin and Backstage)

POST-THRESHOLD:

- The Builder of Cities: When near civilization, reduces crafting speed by 35% and adds +2 to the mechanics, electronics, fabrication, and tailoring skills.  (_Changed from The Innovator_)
- The Pulse of the Invisible: When in civilization, the homullus regenerates 2 bionic power every 30 seconds and regenerates mana 25% faster (_changed from Echoes of the Streets_).
- Running to Marathon: Humanity can run for longer than nearly anything else on the planet. Gain 33% increased Stamina and gain a great portion of Stamina back per move while running.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Everything works.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
