### PR TITLE
Add a check for duplicate recipe_ids on load

### DIFF
--- a/src/recipe.h
+++ b/src/recipe.h
@@ -86,6 +86,7 @@ struct practice_recipe_data {
 class recipe
 {
         friend class recipe_dictionary;
+        friend struct mod_tracker;
 
     private:
         itype_id result_ = itype_id::NULL_ID();
@@ -100,7 +101,7 @@ class recipe
         recipe();
 
         bool is_null() const {
-            return ident_.is_null();
+            return id.is_null();
         }
 
         explicit operator bool() const {
@@ -152,7 +153,7 @@ class recipe
         }
 
         const recipe_id &ident() const {
-            return ident_;
+            return id;
         }
 
         bool is_blacklisted() const {
@@ -306,7 +307,8 @@ class recipe
         void incorporate_build_reqs();
         void add_requirements( const std::vector<std::pair<requirement_id, int>> &reqs );
 
-        recipe_id ident_ = recipe_id::NULL_ID();
+        recipe_id id = recipe_id::NULL_ID();
+        std::vector<std::pair<recipe_id, mod_id>> src;
 
         /** Abstract recipes can be inherited from but are themselves disposed of at finalization */
         bool abstract = false;

--- a/src/recipe_dictionary.cpp
+++ b/src/recipe_dictionary.cpp
@@ -594,7 +594,7 @@ void recipe_dictionary::finalize()
         if( e->book && !recipe_dict.uncraft.count( rid ) && e->volume > 0_ml ) {
             int pages = e->volume / 12.5_ml;
             recipe &bk = recipe_dict.uncraft[rid];
-            bk.ident_ = rid;
+            bk.id = rid;
             bk.result_ = id;
             bk.reversible = true;
             bk.requirements_ = *requirement_data_uncraft_book * pages;

--- a/src/recipe_dictionary.cpp
+++ b/src/recipe_dictionary.cpp
@@ -18,6 +18,7 @@
 #include "itype.h"
 #include "make_static.h"
 #include "mapgen.h"
+#include "mod_manager.h"
 #include "output.h"
 #include "requirements.h"
 #include "skill.h"
@@ -435,7 +436,35 @@ recipe &recipe_dictionary::load( const JsonObject &jo, const std::string &src,
     }
 
     r.load( jo, src );
+    mod_tracker::assign_src( r, src );
     r.was_loaded = true;
+
+    // Check for duplicate recipe_ids before assigning it to the map
+    if( out.find( r.ident() ) != out.end() ) {
+        const std::string new_mod_src = enumerate_as_string( r.src, [](
+        const std::pair<recipe_id, mod_id> &source ) {
+            return string_format( "'%s'", source.second->name() );
+        }, enumeration_conjunction::arrow );
+        const std::string old_mod_src = enumerate_as_string( out[ r.ident() ].src, [](
+        const std::pair<recipe_id, mod_id> &source ) {
+            return string_format( "'%s'", source.second->name() );
+        }, enumeration_conjunction::arrow );
+
+        const std::string base_json = string_format( "'%s'", _( "Dark Days Ahead" ) );
+        if( old_mod_src == base_json && new_mod_src != base_json ) {
+            // Assume the mod developer knows what they're doing
+        } else if( old_mod_src == new_mod_src ) {
+            // Conflict within a single source. Throw an error:
+            debugmsg( "Unable to load recipe_id %1$s. A recipe with that id already exists.\nExisting recipe source: %2$s\nNew recipe source: %3$s",
+                      r.ident().str(), old_mod_src, new_mod_src );
+        } else {
+            // Conflict between mods, leave a warning for debugging
+            DebugLog( DebugLevel::D_WARNING,
+                      DC_ALL ) <<
+                               string_format( "Recipe_id conflict: %1$s is included in both %2$s and %3$s.  Only the latter recipe will be loaded",
+                                              r.ident().str(), old_mod_src, new_mod_src );
+        }
+    }
 
     return out[ r.ident() ] = std::move( r );
 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing another guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "Add a check for duplicate recipe_ids on load"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Multiple recipes can be defined in the json with the same recipe_id.  These recipe_ids are not checked for conflicts on load, which causes some recipes to silently fail to appear in-game.
Fixes #71768 
Fixes #63138

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
1. Update the recipe class to work with mod_tracker to track the source of each recipe (ident_ -> id)
2. Add a check on creation of recipes for duplicate recipe_ids.  Handle any duplicates like so:
- If the new recipe is defined by a mod and is overwriting the base definition, assume it's intentional and ignore it
- If the new recipe is defined by a mod and is overwriting a _different_ mod, add a note in the debug log so there's a way to check "Hey, why isn't x recipe from y mod showing up?"
- If both recipes are defined in the same mod, throw a debugmsg, because (based on #72002 and #72209) it's either lacking a suffix, a duplicate, or something that was intended to be a different recipe, but wasn't completed.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
~~Adding a check in the test suite for recipe conflicts?~~
~~Wouldn't really be as useful for many people who only modify the json, but it would probably be worthwhile to automatically check all the in-repo recipes before release~~
The current CI system appears to load each json file and catch the debugmsg thrown by this change.  Between that and throwing a debugmsg on loading the game, that should cover most use-cases.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
 - Loaded into Cataclysm and into worlds containing each of the in-repo mods with the check on, identifying a variety of conflicts.

 - Loaded into Cataclysm with several mods loaded, resulting in the debug log including a bunch of messages like this:
```
15:34:31.344 WARNING : Recipe_id conflict: fried_brain is included in both 'Innawood' and 'Aftershock'.  Only the latter recipe will be loaded
15:34:31.344 WARNING : Recipe_id conflict: grilled_sweetbread is included in both 'Innawood' and 'Aftershock'.  Only the latter recipe will be loaded
15:34:31.345 WARNING : Recipe_id conflict: thermometer is included in both 'Innawood' and 'Aftershock'.  Only the latter recipe will be loaded
```

 - I have _not_ tested any 3rd party mods, but I expect there are some in use that have recipe_id conflicts in their json.  This update will throw debugmsgs on loading any mod with conflicts.

~~There is no _automated_ test included, but if anyone has any ideas on how to set up a test to load the json from each in-repo mod, then it would probably be useful~~
No specific test suite is included, but it looks like any errors are caught by the all_mods check noted by mqrause below.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
 - The enumerate_as_string handling of the source _probably_ isn't necessary for recipes, but I based the infrastructure off of profession source handling and felt it was worth leaving in place

~~I'm holding this as a draft until #72209 is merged, because otherwise it'll throw debugmsgs on load for several in-repo mods~~
Now that the other PR is merged, I'm marking as ready for review.  Let's see if I need to rebase/if there are any other id conflicts I've missed.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
