### PR TITLE
NPCs will  prioritize wielding ranged weapons when allowed.

### DIFF
--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -4054,7 +4054,10 @@ bool npc::wield_better_weapon()
     const auto compare_weapon =
     [this, &weap, &best, &best_value, can_use_gun, use_silent]( const item & it ) {
         bool allowed = can_use_gun && it.is_gun() && ( !use_silent || it.is_silent() );
-        // According to this scoring mechanism, NPCs will always prioritize wielding guns if they have one. This is relatively reasonable, as players can issue commands to NPCs when they do not want them to use ranged weapons. Conversely, players cannot directly issue commands when they want NPCs to prioritize ranged weapons.
+        // According to unmodified evaluation score, NPCs almost always prioritize wielding guns if they have one.
+        // This is relatively reasonable, as players can issue commands to NPCs when we do not want them to use ranged weapons.
+        // Conversely, we cannot directly issue commands when we want NPCs to prioritize ranged weapons.
+        // Note that the scoring method here is different from the 'weapon_value' used elsewhere.
         double val_gun = allowed ? gun_value( it, it.shots_remaining( this ) ) : 0;
         add_msg_debug( debugmode::DF_NPC_ITEMAI,
                        "%s %s valued at <color_light_cyan>%1.2f as a ranged weapon to wield</color>.",

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -4054,14 +4054,16 @@ bool npc::wield_better_weapon()
     const auto compare_weapon =
     [this, &weap, &best, &best_value, can_use_gun, use_silent]( const item & it ) {
         bool allowed = can_use_gun && it.is_gun() && ( !use_silent || it.is_silent() );
-        double val;
-        if( !allowed ) {
-            val = weapon_value( it, 0 );
-        } else {
-            int ammo_count = it.shots_remaining( this );
-            val = weapon_value( it, ammo_count );
-        }
-
+        // According to this scoring mechanism, NPCs will always prioritize wielding guns if they have one. This is relatively reasonable, as players can issue commands to NPCs when they do not want them to use ranged weapons. Conversely, players cannot directly issue commands when they want NPCs to prioritize ranged weapons.
+        double val_gun = allowed ? gun_value( it, it.shots_remaining( this ) ) : 0;
+        add_msg_debug( debugmode::DF_NPC_ITEMAI,
+                       "%s %s valued at <color_light_cyan>%1.2f as a ranged weapon to wield</color>.",
+                       disp_name( true ), it.type->get_id().str(), val_gun );
+        double val_melee = melee_value( it );
+        add_msg_debug( debugmode::DF_NPC_ITEMAI,
+                       "%s %s valued at <color_light_cyan>%1.2f as a melee weapon to wield</color>.", disp_name( true ),
+                       it.type->get_id().str(), val_melee );
+        double val = std::max( val_gun, val_melee );
         bool using_same_type_bionic_weapon = is_using_bionic_weapon()
                                              && &it != &weap
                                              && it.type->get_id() == weap.type->get_id();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing another guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
When NPCs who are good at shooting are equipped with decent melee weapons to cope with insufficient ammunition, they will always wave the melee weapons while on standby, but when they encounter enemies, they will rush to take out their guns. This often leads to them being unable to fire at the enemy in a timely manner. The purpose of this PR is to improve this issue.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
In #69537, the value estimates of melee weapons and guns for NPCs have been modified so that the value of guns is no longer significantly higher than that of melee weapons.  This is generally reasonable, but it is reasonable for NPCs to prioritize wielding guns when standing guard, as players can directly command NPCs not to use guns, but cannot command NPCs not to use melee weapons.
Therefore, I believe that it is more reasonable to use the unmodified value when determining which weapon NPCs should wield, while continuing to use the modified value in other scenarios.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested in game.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
As Erk commented, the algorithm for evaluating the value of weapons may need to be completely reworked, and it is hoped that this issue will be thoroughly resolved in the future.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
