### PR TITLE
make amigara death drop stuff near the character

### DIFF
--- a/data/json/effects_on_condition/misc_effect_on_condition.json
+++ b/data/json/effects_on_condition/misc_effect_on_condition.json
@@ -64,7 +64,8 @@
     "id": "EOC_last_amigara_death",
     "condition": { "math": [ "u_monsters_nearby('mon_amigara_horror')", "<", "1" ] },
     "effect": [
-      { "mapgen_update": "amigara_death" },
+      { "u_location_variable": { "context_val": "my_loc" }, "max_radius": 2, "passable_only": true },
+      { "map_spawn_item": "amigara_drops", "use_item_group": true, "loc": { "context_val": "my_loc" } },
       { "u_lose_effect": "effect_amigara" },
       {
         "u_message": "As the last of the horrors fell dead, you notice a strange thing popped up from nowhere and dropped on the ground.",

--- a/data/json/mapgen/nested/aux_nested.json
+++ b/data/json/mapgen/nested/aux_nested.json
@@ -427,12 +427,6 @@
   {
     "type": "mapgen",
     "method": "json",
-    "update_mapgen_id": "amigara_death",
-    "object": { "place_items": [ { "item": "amigara_drops", "x": 11, "y": 12, "chance": 100 } ] }
-  },
-  {
-    "type": "mapgen",
-    "method": "json",
     "nested_mapgen_id": "8x8_hole",
     "object": {
       "mapgensize": [ 8, 8 ],


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Someone noted amigara stuff dropped in another room, because of how amigara EoC worked
#### Describe the solution
Make EoC spawn item near the player, always
#### Testing
TBD