### PR TITLE
(Infrastructure, not yet effective) NPCs consider allergies, cannibalism, and other things when eating from camp stores

### DIFF
--- a/data/json/items/comestibles/other.json
+++ b/data/json/items/comestibles/other.json
@@ -1409,6 +1409,41 @@
   {
     "type": "COMESTIBLE",
     "comestible_type": "FOOD",
+    "id": "camp_meal_small",
+    "name": { "str": "prepared meal (small)", "str_pl": "prepared meals (small)" },
+    "description": "I am an item used in faction camps. If you see this description, it is a bug.",
+    "weight": "250 g",
+    "volume": "250 ml",
+    "price": "100 cent",
+    "price_postapoc": "100 cent",
+    "material": [ "foodplace_foodstuff" ],
+    "symbol": "F",
+    "color": "brown",
+    "spoils_in": "300 days",
+    "calories": 0,
+    "flags": [ "DEBUG_ONLY" ]
+  },
+  {
+    "type": "COMESTIBLE",
+    "comestible_type": "FOOD",
+    "id": "camp_meal_medium",
+    "name": { "str": "prepared meal (medium)", "str_pl": "prepared meals (medium)" },
+    "weight": "600 g",
+    "volume": "600 ml",
+    "copy-from": "camp_meal_small"
+  },
+  {
+    "type": "COMESTIBLE",
+    "comestible_type": "FOOD",
+    "id": "camp_meal_large",
+    "name": { "str": "prepared meal (large)", "str_pl": "prepared meals (large)" },
+    "weight": "1200 g",
+    "volume": "1200 ml",
+    "copy-from": "camp_meal_small"
+  },
+  {
+    "type": "COMESTIBLE",
+    "comestible_type": "FOOD",
     "id": "press_cake",
     "name": { "str": "press cake" },
     "description": "Dry leftovers that remain after extracting the oil from nuts or seeds.",

--- a/data/json/items/comestibles/other.json
+++ b/data/json/items/comestibles/other.json
@@ -1411,7 +1411,7 @@
     "comestible_type": "FOOD",
     "id": "camp_meal_small",
     "name": { "str": "prepared meal (small)", "str_pl": "prepared meals (small)" },
-    "description": "I am an item used in faction camps. If you see this description, it is a bug.",
+    "description": "I am an item used in faction camps.  If you see this description, it is a bug.",
     "weight": "250 g",
     "volume": "250 ml",
     "price": "100 cent",

--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -242,6 +242,7 @@ class basecamp
         /// Helper, forwards to above
         void feed_workers( Character &worker, nutrients food, bool is_player_meal = false );
         void player_eats_meal();
+        item make_fake_food( nutrients to_use ) const;
         /// Takes all the food from the camp_food zone and increases the faction
         /// food_supply
         bool distribute_food();

--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -242,7 +242,7 @@ class basecamp
         /// Helper, forwards to above
         void feed_workers( Character &worker, nutrients food, bool is_player_meal = false );
         void player_eats_meal();
-        item make_fake_food( nutrients to_use ) const;
+        item make_fake_food( const nutrients &to_use ) const;
         /// Takes all the food from the camp_food zone and increases the faction
         /// food_supply
         bool distribute_food();

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -11,6 +11,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "activity_actor_definitions.h"
 #include "activity_type.h"
 #include "avatar.h"
 #include "basecamp.h"
@@ -1680,10 +1681,6 @@ void basecamp::player_eats_meal()
     int kcal_to_eat = 3000;
     Character &you = get_player_character();
     const int &food_available = fac()->food_supply.kcal();
-    if( you.stomach.contains() >= ( you.stomach.capacity( you ) / 2 ) ) {
-        popup( _( "You're way too full to eat a full meal right now." ) );
-        return;
-    }
     if( food_available <= 0 ) {
         popup( _( "You check storage for some food, but there is nothing but dust and cobwebs…" ) );
         return;
@@ -5542,14 +5539,56 @@ void basecamp::feed_workers( const std::vector<std::reference_wrapper <Character
     food /= num_workers;
     for( const auto &worker_reference : workers ) {
         Character &worker = worker_reference.get();
-        worker.add_msg_if_player( _( "You grab a prepared meal from storage and chow down." ) );
-        units::volume filling_vol = std::max( 0_ml,
-                                              worker.stomach.capacity( worker ) / 2 - worker.stomach.contains() );
-        worker.stomach.ingest( food_summary{
-            0_ml,
-            filling_vol,
-            food
-        } );
+        item food_item = make_fake_food( food );
+        // Handle allergies and other stuff
+        bool query_player = !worker.is_npc();
+        const ret_val<edible_rating> rating = worker.will_eat( food_item, query_player );
+        switch( rating.value() ) {
+            case EDIBLE:
+                worker.assign_activity( consume_activity_actor( food_item ) );
+                break;
+            case TOO_FULL:
+                worker.add_msg_player_or_npc( m_neutral,
+                                              _( "You are too full to eat right now, and put the meal back into storage." ),
+                                              _( "<npcname> is too full to eat right now, and puts the meal back into storage." ) );
+                camp_food_supply( food );
+                break;
+            case INEDIBLE:
+            case INEDIBLE_MUTATION:
+                debugmsg( "Always-edible food somehow inedible, please report this error." );
+                camp_food_supply( food );
+                break;
+            case ALLERGY:
+                worker.add_msg_if_npc( m_bad,
+                                       _( "%s takes one look at the food and declines, explaining they're allergic." ),
+                                       worker.get_name() );
+                camp_food_supply( food );
+                break;
+            case ALLERGY_WEAK:
+                worker.add_msg_if_npc( m_bad,
+                                       _( "%s takes a bite but spits it out.  It seems something in the food disagrees with them." ),
+                                       worker.get_name() );
+                camp_food_supply( food );
+                break;
+            case CANNIBALISM:
+                worker.add_msg_if_npc( m_bad,
+                                       _( "%s thanks you for the meal, but when they see what's in the meal their attitude suddenly changes." ),
+                                       worker.get_name() );
+                if( worker.is_npc() ) {
+                    worker.as_npc()->mutiny();
+                }
+                // Food specifically does not go back in the larder.
+                break;
+            case PARASITES:
+                // None of these should ever happen.
+                break;
+            case ROTTEN:
+                break;
+            case NAUSEA:
+                break;
+            case NO_TOOL:
+                break;
+        }
     }
 }
 
@@ -5567,6 +5606,22 @@ int basecamp::time_to_food( time_duration work, float exertion_level ) const
 
     return base_metabolic_rate * ( work_time * exertion_level + days * work_day_rest_hours * NO_EXERCISE
                                    + days * work_day_idle_hours * SLEEP_EXERCISE ) / 24;
+}
+
+item basecamp::make_fake_food( nutrients to_use ) const
+{
+    // This is dumb, but effective.
+    std::string food_id = "camp_meal_small";
+    if( to_use.kcal() > 3000 ) {
+        food_id = "camp_meal_large";
+    } else if( to_use.kcal() > 1000 ) {
+        food_id = "camp_meal_medium";
+    }
+    item food_item( food_id );
+    // Set the default nutritional of the item.
+    // This doesn't persist through save/load, but that's ok, we will be eating it immediately.
+    food_item.get_comestible()->default_nutrition = to_use;
+    return food_item;
 }
 
 static const npc &getAverageJoe()

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -5545,7 +5545,9 @@ void basecamp::feed_workers( const std::vector<std::reference_wrapper <Character
         const ret_val<edible_rating> rating = worker.will_eat( food_item, query_player );
         switch( rating.value() ) {
             case EDIBLE:
-                worker.assign_activity( consume_activity_actor( food_item ) );
+                // I'd like to use consume_activity_actor here, but our little trick with make_fake_food() requires that the
+                // item be consumed immediately.
+                worker.consume( food_item );
                 break;
             case TOO_FULL:
                 worker.add_msg_player_or_npc( m_neutral,

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -5574,7 +5574,7 @@ void basecamp::feed_workers( const std::vector<std::reference_wrapper <Character
                 break;
             case CANNIBALISM:
                 worker.add_msg_if_npc( m_bad,
-                                       _( "%s thanks you for the meal, but when they see what's in the meal their attitude suddenly changes." ),
+                                       _( "%s thanks you for the meal, but when they see what's in the meal their attitude suddenly changes!" ),
                                        worker.get_name() );
                 if( worker.is_npc() ) {
                     worker.as_npc()->mutiny();
@@ -5582,12 +5582,9 @@ void basecamp::feed_workers( const std::vector<std::reference_wrapper <Character
                 // Food specifically does not go back in the larder.
                 break;
             case PARASITES:
-                // None of these should ever happen.
-                break;
+            // None of these should ever happen.
             case ROTTEN:
-                break;
             case NAUSEA:
-                break;
             case NO_TOOL:
                 break;
         }
@@ -5610,7 +5607,7 @@ int basecamp::time_to_food( time_duration work, float exertion_level ) const
                                    + days * work_day_idle_hours * SLEEP_EXERCISE ) / 24;
 }
 
-item basecamp::make_fake_food( nutrients to_use ) const
+item basecamp::make_fake_food( const nutrients &to_use ) const
 {
     // This is dumb, but effective.
     std::string food_id = "camp_meal_small";


### PR DESCRIPTION
#### Summary
Balance "NPCs consider allergies, cannibalism, other issues before eating from camp larder"

#### Purpose of change
With #72224 it will be possible to track whether food put into camp storage contained human parts. Naturally, NPCs are mostly upstanding people that are unwilling to eat others. So they need to be able to think for themselves.

#### Describe the solution
When feeding workers, instantiate fake food item. Override that item's default nutrition with the food nutrients struct they previously had put right into their stomach.

Check character::will_eat to see if there's anything wrong with the food (player can force themself to eat anyway, NPCs will always decline)

If won't eat, re-add food to larder (add message for player so they know what's going on). Except if you try to feed human flesh to non-cannibals. Then they just plain revolt.

#### Describe alternatives you've considered
It would have been even neater if you could take the food back out of storage as an actual 'prepared meal' item that stayed preserved *and did rot over time*. But there's no reasonable way to do that, since overriding the default nutrition only lasts until the game closes. 

(Still I did consider making components of 1_kcal and 1_vitamin and inserting them into the food's components. But that is a TERRIBLE idea!)

#### Testing

https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/4d26ee8d-d8eb-43f1-81e1-7d02dbe3e21e



#### Additional context
Will have no practical effect until #72224 is merged, and then only for cannibalism.

Note that **as food is placed back in the larder on failure to eat** this has the potential for massive balance swings to how camps are made. A not hungry/allergic NPC will put the food back, meaning calories spent on upgrades are refunded (or at least that NPC's share).

But I personally am not opposed to the idea of that. 

If actual food costs don't match the labor costs of camp construction, then let the numbers fall where they may.