### PR TITLE
[Xedra Evolved] Fix Arvore Commune with Nature scaling + add standard jmath post-threshold doubling

### DIFF
--- a/data/mods/Xedra_Evolved/jmath.json
+++ b/data/mods/Xedra_Evolved/jmath.json
@@ -68,5 +68,12 @@
     "id": "paraclesian_passive_spell_exp",
     "num_args": 1,
     "return": "u_skill('deduction') * 100 + _0"
+  },
+  {
+    "type": "jmath_function",
+    "id": "paraclesian_post_threshold_doubler",
+    "//": "Used to double various factors for a post-threshold bonus.  Should never more than double the initial input.",
+    "num_args": 1,
+    "return": "_0 + (1 * (u_has_trait('THRESH_ARVORE') + u_has_trait('THRESH_IERDE') + u_has_trait('THRESH_HOMULLUS') + u_has_trait('THRESH_SALAMANDER') + u_has_trait('THRESH_SYLPH') + u_has_trait('THRESH_UNDINE')) )"
   }
 ]

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_eocs.json
@@ -50,7 +50,11 @@
     "effect": [
       {
         "u_add_effect": "natures_commune",
-        "duration": { "math": [ "( 300 + (u_spell_level('arvore_commune_with_nature') * 165)) " ] }
+        "duration": {
+          "math": [
+            "( 600 + (u_spell_level('arvore_commune_with_nature') * 240)) * scaling_factor(u_val('perception') ) * paraclesian_post_threshold_doubler(1) "
+          ]
+        }
       },
       {
         "u_add_morale": "morale_forest_unity",
@@ -58,12 +62,12 @@
         "max_bonus": 15,
         "duration": {
           "math": [
-            "( 300 + (u_spell_level('arvore_commune_with_nature') * 165) ) * scaling_factor(u_val('perception') ) * paraclesian_post_threshold_doubler(1)"
+            "( 600 + (u_spell_level('arvore_commune_with_nature') * 240) ) * scaling_factor(u_val('perception') ) * paraclesian_post_threshold_doubler(1)"
           ]
         },
         "decay_start": {
           "math": [
-            "(( 300 + (u_spell_level('arvore_commune_with_nature') * 165) ) * scaling_factor(u_val('perception') ) *  paraclesian_post_threshold_doubler(1)) / 2"
+            "(( 600 + (u_spell_level('arvore_commune_with_nature') * 240) ) * scaling_factor(u_val('perception') ) *  paraclesian_post_threshold_doubler(1)) / 2"
           ]
         }
       }

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_eocs.json
@@ -56,8 +56,16 @@
         "u_add_morale": "morale_forest_unity",
         "bonus": 10,
         "max_bonus": 15,
-        "duration": { "math": [ "( 300 + (u_spell_level('arvore_commune_with_nature') * 165) )" ] },
-        "decay_start": { "math": [ "(( 300 + (u_spell_level('arvore_commune_with_nature') * 165) ) / 2)" ] }
+        "duration": {
+          "math": [
+            "( 300 + (u_spell_level('arvore_commune_with_nature') * 165) ) * scaling_factor(u_val('perception') ) * paraclesian_post_threshold_doubler(1)"
+          ]
+        },
+        "decay_start": {
+          "math": [
+            "(( 300 + (u_spell_level('arvore_commune_with_nature') * 165) ) * scaling_factor(u_val('perception') ) *  paraclesian_post_threshold_doubler(1)) / 2"
+          ]
+        }
       }
     ],
     "false_effect": [ { "u_message": "You must be surrounded by nature to commune with nature.", "type": "bad" } ]

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutation_spells.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutation_spells.json
@@ -219,12 +219,12 @@
     "energy_increment": -12,
     "min_duration": {
       "math": [
-        "( 30000 + (u_spell_level('arvore_commune_with_nature') * 16500) ) * scaling_factor(u_val('perception') ) * paraclesian_post_threshold_doubler(1)"
+        "( 60000 + (u_spell_level('arvore_commune_with_nature') * 24000) ) * scaling_factor(u_val('perception') ) * paraclesian_post_threshold_doubler(1)"
       ]
     },
     "max_duration": {
       "math": [
-        "( 30000 + (u_spell_level('arvore_commune_with_nature') * 16500) ) * scaling_factor(u_val('perception') ) * paraclesian_post_threshold_doubler(1)"
+        "( 60000 + (u_spell_level('arvore_commune_with_nature') * 24000 ) ) * scaling_factor(u_val('perception') ) * paraclesian_post_threshold_doubler(1)"
       ]
     },
     "learn_spells": { "arvore_summon_preservation_container": 6 }

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutation_spells.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutation_spells.json
@@ -217,9 +217,16 @@
     "base_energy_cost": 500,
     "final_energy_cost": 250,
     "energy_increment": -12,
-    "min_duration": 30000,
-    "max_duration": 1080000,
-    "duration_increment": 16500,
+    "min_duration": {
+      "math": [
+        "( 30000 + (u_spell_level('arvore_commune_with_nature') * 16500) ) * scaling_factor(u_val('perception') ) * paraclesian_post_threshold_doubler(1)"
+      ]
+    },
+    "max_duration": {
+      "math": [
+        "( 30000 + (u_spell_level('arvore_commune_with_nature') * 16500) ) * scaling_factor(u_val('perception') ) * paraclesian_post_threshold_doubler(1)"
+      ]
+    },
     "learn_spells": { "arvore_summon_preservation_container": 6 }
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing another guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Xedra Evolved] Fix Arvore Commune with Nature scaling + add standard jmath post-threshold doubling"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

While doing something else I noticed that Arvore's Commune with Nature spell didn't scale with their Perception, and then I thought it would be a good candidate for the "post-threshold, the effects double" thing I've done with some other Paraclesian powers, and that would be a good candidate for jmath.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Write a jmath equation to account for doubling: `"_0 + (1 * (u_has_trait('THRESH_ARVORE') + u_has_trait('THRESH_IERDE') + u_has_trait('THRESH_HOMULLUS') + u_has_trait('THRESH_SALAMANDER') + u_has_trait('THRESH_SYLPH') + u_has_trait('THRESH_UNDINE')) )"` Barring debug nonsense, no character should ever more than one of these, so the equation returns the input if the character isn't post-threshold and one plus the input if they are post-threshold.

Increase the duration of Commune with Nature and add Perception-based scaling to it, as well as the above equation. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Debugged my Perception ludicrously high, saw that the spell duration was likewise ludicrously high.

Swapped back and forth between threshold and not, saw that the spell doubled when post-threshold and then went back to normal when threshold was removed.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
