### PR TITLE
Refactor camp hunting function

### DIFF
--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -286,6 +286,7 @@ class basecamp
          * if skill is higher, an item or corpse is spawned
          */
         void hunting_results( int skill, const mission_id &miss_id, int attempts, int difficulty );
+        void make_corpse_from_group( std::vector<MonsterGroupResult> group );
         inline const tripoint_abs_ms &get_dumping_spot() const {
             return dumping_spot;
         }

--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -286,7 +286,7 @@ class basecamp
          * if skill is higher, an item or corpse is spawned
          */
         void hunting_results( int skill, const mission_id &miss_id, int attempts, int difficulty );
-        void make_corpse_from_group( std::vector<MonsterGroupResult> group );
+        void make_corpse_from_group( const std::vector<MonsterGroupResult> &group );
         inline const tripoint_abs_ms &get_dumping_spot() const {
             return dumping_spot;
         }

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -4727,12 +4727,15 @@ void basecamp::hunting_results( int skill, const mission_id &miss_id, int attemp
         }
     }
 
-    auto base_group_results = MonsterGroupManager::GetResultFromGroup( GROUP_CAMP_HUNTING,
-                              &results_from_base_group );
-    auto mission_group_results = MonsterGroupManager::GetResultFromGroup( mission_specific_group,
-                                 &results_from_mission_group );
+    make_corpse_from_group( MonsterGroupManager::GetResultFromGroup( GROUP_CAMP_HUNTING,
+                            &results_from_base_group ) );
+    make_corpse_from_group( MonsterGroupManager::GetResultFromGroup( mission_specific_group,
+                            &results_from_mission_group ) );
+}
 
-    for( MonsterGroupResult monster : base_group_results ) {
+void basecamp::make_corpse_from_group( std::vector<MonsterGroupResult> group )
+{
+    for( MonsterGroupResult monster : group ) {
         const mtype_id target = monster.name;
         item result = item::make_corpse( target, calendar::turn, "" );
         if( !result.is_null() ) {
@@ -4743,20 +4746,6 @@ void basecamp::hunting_results( int skill, const mission_id &miss_id, int attemp
             } while( num_to_spawn > 0 );
         }
     }
-
-    for( MonsterGroupResult monster : mission_group_results ) {
-        const mtype_id target = monster.name;
-        item result = item::make_corpse( target, calendar::turn, "" );
-        if( !result.is_null() ) {
-            int num_to_spawn = monster.pack_size;
-            do {
-                place_results( result );
-                num_to_spawn--;
-            } while( num_to_spawn > 0 );
-        }
-    }
-
-
 }
 
 int om_harvest_ter_est( npc &comp, const tripoint_abs_omt &omt_tgt, const ter_id &t, int chance )

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -4719,8 +4719,8 @@ void basecamp::hunting_results( int skill, const mission_id &miss_id, int attemp
 
     int results_from_base_group = 0;
     int results_from_mission_group = 0;
-    for( successful_hunts; successful_hunts > 0; successful_hunts-- ) {
-        if( rng( base_group_chance, total_chance ) ) {
+    for( ; successful_hunts > 0; successful_hunts-- ) {
+        if( x_in_y( base_group_chance, total_chance ) ) {
             results_from_base_group++;
         } else {
             results_from_mission_group++;

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -50,6 +50,7 @@
 #include "messages.h"
 #include "mission.h"
 #include "mission_companion.h"
+#include "mongroup.h"
 #include "npc.h"
 #include "npctalk.h"
 #include "omdata.h"
@@ -4694,29 +4695,68 @@ void basecamp::search_results( int skill, const item_group_id &group_id, int att
 void basecamp::hunting_results( int skill, const mission_id &miss_id, int attempts, int difficulty )
 {
     // corpses do not exist as discrete items, so we use monster groups instead
-    weighted_int_list<mtype_id> hunting_targets;
-    for( const MonsterGroupEntry &target : GROUP_CAMP_HUNTING->monsters ) {
-        hunting_targets.add( target.name, target.frequency );
-    }
+    int base_group_chance = GROUP_CAMP_HUNTING->freq_total;
+    int mission_specific_chance = 0;
+    mongroup_id mission_specific_group;
     if( miss_id.id == Camp_Trapping ) {
-        for( const MonsterGroupEntry &target : GROUP_CAMP_TRAPPING->monsters ) {
-            hunting_targets.add( target.name, target.frequency );
-        }
+        mission_specific_group = GROUP_CAMP_TRAPPING;
+        mission_specific_chance += GROUP_CAMP_TRAPPING->freq_total;
     } else if( miss_id.id == Camp_Hunting ) {
-        for( const MonsterGroupEntry &target : GROUP_CAMP_HUNTING_LARGE->monsters ) {
-            hunting_targets.add( target.name, target.frequency );
-        }
+        mission_specific_group = GROUP_CAMP_HUNTING_LARGE;
+        mission_specific_chance += GROUP_CAMP_HUNTING_LARGE->freq_total;
     }
+    const int total_chance = base_group_chance + mission_specific_chance;
+    int successful_hunts = 0;
     for( int i = 0; i < attempts; i++ ) {
         if( skill > rng( 0, difficulty ) ) {
-            // TODO: replace this with MonsterGroupManager::GetResultFromGroup
-            const mtype_id *target = hunting_targets.pick();
-            item result = item::make_corpse( *target, calendar::turn, "" );
-            if( !result.is_null() ) {
-                place_results( result );
-            }
+            successful_hunts++;
         }
     }
+
+    if( successful_hunts <= 0 ) {
+        return;
+    }
+
+    int results_from_base_group = 0;
+    int results_from_mission_group = 0;
+    for( successful_hunts; successful_hunts > 0; successful_hunts-- ) {
+        if( rng( base_group_chance, total_chance ) ) {
+            results_from_base_group++;
+        } else {
+            results_from_mission_group++;
+        }
+    }
+
+    auto base_group_results = MonsterGroupManager::GetResultFromGroup( GROUP_CAMP_HUNTING,
+                              &results_from_base_group );
+    auto mission_group_results = MonsterGroupManager::GetResultFromGroup( mission_specific_group,
+                                 &results_from_mission_group );
+
+    for( MonsterGroupResult monster : base_group_results ) {
+        const mtype_id target = monster.name;
+        item result = item::make_corpse( target, calendar::turn, "" );
+        if( !result.is_null() ) {
+            int num_to_spawn = monster.pack_size;
+            do {
+                place_results( result );
+                num_to_spawn--;
+            } while( num_to_spawn > 0 );
+        }
+    }
+
+    for( MonsterGroupResult monster : mission_group_results ) {
+        const mtype_id target = monster.name;
+        item result = item::make_corpse( target, calendar::turn, "" );
+        if( !result.is_null() ) {
+            int num_to_spawn = monster.pack_size;
+            do {
+                place_results( result );
+                num_to_spawn--;
+            } while( num_to_spawn > 0 );
+        }
+    }
+
+
 }
 
 int om_harvest_ter_est( npc &comp, const tripoint_abs_omt &omt_tgt, const ter_id &t, int chance )

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -4733,9 +4733,9 @@ void basecamp::hunting_results( int skill, const mission_id &miss_id, int attemp
                             &results_from_mission_group ) );
 }
 
-void basecamp::make_corpse_from_group( std::vector<MonsterGroupResult> group )
+void basecamp::make_corpse_from_group( const std::vector<MonsterGroupResult> &group )
 {
-    for( MonsterGroupResult monster : group ) {
+    for( const MonsterGroupResult &monster : group ) {
         const mtype_id target = monster.name;
         item result = item::make_corpse( target, calendar::turn, "" );
         if( !result.is_null() ) {


### PR DESCRIPTION
#### Summary
Bugfixes "Camp hunting doesn't bring back human corpses"

#### Purpose of change
* Fixes #70794

Also fixes another issue which was reported at some point but I can't find, regarding human corpses being accidentally brought back. Apparently "human" corpse is the default corpse item.

#### Describe the solution
Refactor the entire function to do some really stupid stuff. Get probability totals for both involved groups, roll our own dice, then call MonsterGroupManager::GetResultFromGroup for both groups.

I am actually kind of ashamed of this code but it should perfectly replicate what the old code did, but properly uses groups instead of going "uh no, that monster group isn't a real monster! [error and/or human corpse]"

#### Describe alternatives you've considered
Nuke GROUP_CAMP_HUNTING

#### Testing
Compiles, loads, animal (corpses) come back.

#### Additional context
It's their fault anyway. How dare you use a monster group like it's used anywhere else? Don't you know we don't support subgroups in jank land? (Well we do now)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/d1c18730-cb7a-43d0-aebf-8ba2fef5914e)
