### PR TITLE
Assign default value of 1.0 for fault price modifiers, instead of 0

### DIFF
--- a/src/fault.cpp
+++ b/src/fault.cpp
@@ -103,7 +103,7 @@ void fault::load( const JsonObject &jo )
     optional( jo, false, "item_prefix", f.item_prefix_ );
     optional( jo, false, "fault_type", f.type_ );
     optional( jo, false, "flags", f.flags );
-    optional( jo, false, "price_modifier", f.price_modifier );
+    optional( jo, false, "price_modifier", f.price_modifier, 1.0 );
 
     if( !faults_all.emplace( f.id_, f ).second ) {
         jo.throw_error_at( "id", "parsed fault overwrites existing definition" );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
All guns with even a speck of dust were worth $0, because I forgot to assign a default price_modifier for faults (defaults to 0). My mistake made in #72142

#### Describe the solution
Set the default to 1.0, as intended.

#### Describe alternatives you've considered


#### Testing
Guns with fouling (fault) sell for the same price as guns without fouling, as intended. (Fouling has no price_modifier assigned)

#### Additional context

