### PR TITLE
Fungal enemies should not be able to revive

### DIFF
--- a/data/json/monsters/fungus_zombie.json
+++ b/data/json/monsters/fungus_zombie.json
@@ -449,7 +449,7 @@
     "special_attacks": [ { "id": "bite_humanoid", "cooldown": 5, "min_mul": 0.7 }, { "id": "scratch_humanoid" }, [ "FUNGUS", 170 ] ],
     "death_drops": "default_zombie_death_drops",
     "burn_into": "mon_zombie_scorched",
-    "flags": [ "SEES", "HEARS", "STUMBLES", "WARM", "BASHES", "GROUP_BASH", "POISON", "NO_BREATHE", "REVIVES", "PUSH_MON", "FILTHY" ],
+    "flags": [ "SEES", "HEARS", "STUMBLES", "WARM", "BASHES", "GROUP_BASH", "POISON", "NO_BREATHE", "PUSH_MON", "FILTHY" ],
     "armor": { "bash": 5, "cut": 2, "bullet": 1, "electric": 2 }
   },
   {
@@ -495,7 +495,6 @@
       "GROUP_BASH",
       "POISON",
       "NO_BREATHE",
-      "REVIVES",
       "PUSH_MON",
       "FILTHY",
       "ATTACK_LOWER"
@@ -532,7 +531,7 @@
     "special_attacks": [ [ "FUNGUS", 200 ], { "id": "bite_humanoid", "cooldown": 5 }, { "id": "scratch_humanoid" } ],
     "death_drops": "default_zombie_death_drops",
     "burn_into": "mon_zombie_scorched",
-    "flags": [ "SEES", "HEARS", "STUMBLES", "WARM", "BASHES", "GROUP_BASH", "POISON", "NO_BREATHE", "REVIVES", "PUSH_MON", "FILTHY" ],
+    "flags": [ "SEES", "HEARS", "STUMBLES", "WARM", "BASHES", "GROUP_BASH", "POISON", "NO_BREATHE", "PUSH_MON", "FILTHY" ],
     "armor": { "bash": 5, "cut": 3, "bullet": 2, "electric": 2 }
   },
   {
@@ -569,7 +568,7 @@
       "//": "cloth as any other zombie (always), additional items from group hive (sometimes)"
     },
     "burn_into": "mon_zombie_scorched",
-    "flags": [ "SEES", "HEARS", "STUMBLES", "WARM", "BASHES", "GROUP_BASH", "POISON", "NO_BREATHE", "REVIVES", "PUSH_MON", "FILTHY" ],
+    "flags": [ "SEES", "HEARS", "STUMBLES", "WARM", "BASHES", "GROUP_BASH", "POISON", "NO_BREATHE", "PUSH_MON", "FILTHY" ],
     "armor": { "bash": 6, "cut": 8, "bullet": 6, "electric": 1 }
   },
   {
@@ -658,7 +657,7 @@
     "harvest": "zombie_animal_mushroom",
     "special_attacks": [ [ "FUNGUS", 230 ], { "id": "bite_humanoid", "cooldown": 5 }, { "id": "scratch_humanoid" } ],
     "death_drops": "mon_dog_death_drops",
-    "flags": [ "SEES", "HEARS", "STUMBLES", "WARM", "BASHES", "GROUP_BASH", "POISON", "NO_BREATHE", "REVIVES", "PUSH_MON" ],
+    "flags": [ "SEES", "HEARS", "STUMBLES", "WARM", "BASHES", "GROUP_BASH", "POISON", "NO_BREATHE", "PUSH_MON" ],
     "armor": { "electric": 1 }
   },
   {
@@ -690,7 +689,7 @@
     "bleed_rate": 0,
     "harvest": "zombie_animal_mushroom",
     "special_attacks": [ [ "FUNGUS", 160 ] ],
-    "flags": [ "SEES", "HEARS", "STUMBLES", "WARM", "BASHES", "GROUP_BASH", "POISON", "NO_BREATHE", "REVIVES", "PUSH_MON", "FILTHY" ],
+    "flags": [ "SEES", "HEARS", "STUMBLES", "WARM", "BASHES", "GROUP_BASH", "POISON", "NO_BREATHE", "PUSH_MON", "FILTHY" ],
     "armor": { "bash": 6, "cut": 4, "bullet": 3, "electric": 2 }
   },
   {
@@ -723,7 +722,7 @@
     "bleed_rate": 0,
     "harvest": "zombie_animal_mushroom",
     "special_attacks": [ [ "FUNGUS", 190 ], { "type": "leap", "cooldown": 20, "max_range": 5 } ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "WARM", "BASHES", "POISON", "NO_BREATHE", "REVIVES", "FILTHY" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "WARM", "BASHES", "POISON", "NO_BREATHE", "FILTHY" ],
     "armor": { "bash": 1, "electric": 1 }
   },
   {
@@ -755,7 +754,7 @@
     "bleed_rate": 0,
     "harvest": "zombie_animal_mushroom",
     "special_attacks": [ [ "FUNGUS", 160 ] ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "BASHES", "NO_BREATHE", "REVIVES" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "BASHES", "NO_BREATHE"],
     "armor": { "bash": 5, "cut": 1, "electric": 2 }
   },
   {
@@ -808,7 +807,7 @@
     "bleed_rate": 0,
     "harvest": "zombie_animal_mushroom",
     "special_attacks": [ [ "FUNGUS", 210 ] ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "WARM", "POISON", "NO_BREATHE", "REVIVES", "FILTHY" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "WARM", "POISON", "NO_BREATHE", "FILTHY" ],
     "armor": { "bash": 1, "cut": 3, "electric": 1 }
   },
   {
@@ -841,7 +840,7 @@
     "bleed_rate": 0,
     "harvest": "zombie_animal_mushroom",
     "special_attacks": [ [ "FUNGUS", 180 ] ],
-    "flags": [ "SEES", "HEARS", "STUMBLES", "WARM", "BASHES", "GROUP_BASH", "POISON", "NO_BREATHE", "REVIVES", "PUSH_MON", "FILTHY" ],
+    "flags": [ "SEES", "HEARS", "STUMBLES", "WARM", "BASHES", "GROUP_BASH", "POISON", "NO_BREATHE", "PUSH_MON", "FILTHY" ],
     "armor": { "bash": 5, "cut": 4, "electric": 1 }
   }
 ]

--- a/data/json/monsters/fungus_zombie.json
+++ b/data/json/monsters/fungus_zombie.json
@@ -754,7 +754,7 @@
     "bleed_rate": 0,
     "harvest": "zombie_animal_mushroom",
     "special_attacks": [ [ "FUNGUS", 160 ] ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "BASHES", "NO_BREATHE"],
+    "flags": [ "SEES", "HEARS", "SMELLS", "BASHES", "NO_BREATHE" ],
     "armor": { "bash": 5, "cut": 1, "electric": 2 }
   },
   {


### PR DESCRIPTION
A lot of the newer fungal monsters revived like blob zombies despite this never being the case for older fungal monsters.

I removed the revive flag from all newer fungal monsters so they are no longer mismatched with their older peers.

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing another guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "New fungal enemies should not revive"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
None of the older fungal zombies were capable of reviving however the revive tag was not removed when the newer fungal forms were created, this creates inconsistency regarding the behavior of dead fungals.

This change restores consistency among fungal enemies by ensuring none of them are capable of revivification. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Removed the "Revives" flag from all fungals that have it.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
None
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded up my test world, killed all the fungal monsters, none of them were capable of reviving and no issues cropped up.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
