### PR TITLE
[MoM] Hounds of Tindalos can teleport lock you + follow you through teleports

### DIFF
--- a/data/mods/MindOverMatter/effectoncondition/eoc_on_power_use_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_on_power_use_events.json
@@ -952,7 +952,7 @@
     },
     "effect": [
       {
-        "u_message": "As you come out of the darkness and the cold of the teleport, you feel watching eyes on you and see wisps of swirling fog in the corners of your vision.  They're still on your trail.",
+        "u_message": "As you come out of the darkness and the cold of the teleport, you feel the prickling sensation of watching eyes and see wisps of swirling fog in the corners of your vision.  They're still on your trail.",
         "type": "bad"
       },
       { "u_add_effect": "tindrift", "duration": "1 day" }
@@ -979,7 +979,7 @@
     "//": "This is a separate EoC so you don't see the message until *after* you exit the Gateway",
     "effect": [
       {
-        "u_message": "As you come out of the darkness and the cold of the teleport, you feel watching eyes on you and see wisps of swirling fog in the corners of your vision.  They're still on your trail.",
+        "u_message": "As you come out of the darkness and the cold of the teleport, you feel the prickling sensation of watching eyes and see wisps of swirling fog in the corners of your vision.  They're still on your trail.",
         "type": "bad"
       },
       { "u_add_effect": "tindrift", "duration": "1 day" }

--- a/data/mods/MindOverMatter/effectoncondition/eoc_on_power_use_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_on_power_use_events.json
@@ -929,5 +929,60 @@
       ]
     },
     "effect": [ { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_TELEPORTER_THE_HOUNDS_FOLLOW",
+    "eoc_type": "EVENT",
+    "required_event": "spellcasting_finish",
+    "condition": {
+      "and": [
+        { "u_has_trait": "TELEPORTER" },
+        {
+          "or": [
+            { "compare_string": [ "teleport_blink", { "context_val": "spell" } ] },
+            { "compare_string": [ "teleport_phase", { "context_val": "spell" } ] },
+            { "compare_string": [ "teleport_transpose", { "context_val": "spell" } ] },
+            { "compare_string": [ "teleport_farstep", { "context_val": "spell" } ] }
+          ]
+        },
+        { "math": [ "u_monsters_nearby('mon_hound_tindalos', 'radius': 50)", ">", "0" ] },
+        { "not": { "u_has_flag": "TEEPSHIELD" } }
+      ]
+    },
+    "effect": [
+      {
+        "u_message": "As you come out of the darkness and the cold of the teleport, you feel watching eyes on you and see wisps of swirling fog in the corner of your vision.  They're still on your trail.",
+        "type": "bad"
+      },
+      { "u_add_effect": "tindrift", "duration": "1 day" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_TELEPORTER_THE_HOUNDS_FOLLOW_GATEWAY",
+    "eoc_type": "EVENT",
+    "required_event": "character_casts_spell",
+    "condition": {
+      "and": [
+        { "u_has_trait": "TELEPORTER" },
+        { "compare_string": [ "teleport_gateway", { "context_val": "spell" } ] },
+        { "math": [ "u_monsters_nearby('mon_hound_tindalos', 'radius': 50)", ">", "0" ] },
+        { "not": { "u_has_flag": "TEEPSHIELD" } }
+      ]
+    },
+    "effect": [ { "queue_eocs": "EOC_TELEPORTER_THE_HOUNDS_FOLLOW_GATEWAY_2", "time_in_future": 0 } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_TELEPORTER_THE_HOUNDS_FOLLOW_GATEWAY_2",
+    "//": "This is a separate EoC so you don't see the message until *after* you exit the Gateway",
+    "effect": [
+      {
+        "u_message": "As you come out of the darkness and the cold of the teleport, you feel watching eyes on you and see wisps of swirling fog in the corner of your vision.  They're still on your trail.",
+        "type": "bad"
+      },
+      { "u_add_effect": "tindrift", "duration": "1 day" }
+    ]
   }
 ]

--- a/data/mods/MindOverMatter/effectoncondition/eoc_on_power_use_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_on_power_use_events.json
@@ -952,7 +952,7 @@
     },
     "effect": [
       {
-        "u_message": "As you come out of the darkness and the cold of the teleport, you feel watching eyes on you and see wisps of swirling fog in the corner of your vision.  They're still on your trail.",
+        "u_message": "As you come out of the darkness and the cold of the teleport, you feel watching eyes on you and see wisps of swirling fog in the corners of your vision.  They're still on your trail.",
         "type": "bad"
       },
       { "u_add_effect": "tindrift", "duration": "1 day" }
@@ -979,7 +979,7 @@
     "//": "This is a separate EoC so you don't see the message until *after* you exit the Gateway",
     "effect": [
       {
-        "u_message": "As you come out of the darkness and the cold of the teleport, you feel watching eyes on you and see wisps of swirling fog in the corner of your vision.  They're still on your trail.",
+        "u_message": "As you come out of the darkness and the cold of the teleport, you feel watching eyes on you and see wisps of swirling fog in the corners of your vision.  They're still on your trail.",
         "type": "bad"
       },
       { "u_add_effect": "tindrift", "duration": "1 day" }

--- a/data/mods/MindOverMatter/effects/effects_edited.json
+++ b/data/mods/MindOverMatter/effects/effects_edited.json
@@ -30,7 +30,7 @@
   {
     "id": "tindrift",
     "type": "effect_type",
-    "immune_flags": [ "TEEPSHIELD", "TELESTOP" ]
+    "immune_flags": [ "TEEPSHIELD" ]
   },
   {
     "id": "attention",

--- a/data/mods/MindOverMatter/effects/effects_monster.json
+++ b/data/mods/MindOverMatter/effects/effects_monster.json
@@ -153,6 +153,16 @@
   },
   {
     "type": "effect_type",
+    "id": "effect_teleporting_lock",
+    "name": [ "Caught in the Angles" ],
+    "desc": [ "You feel a strange, inward force." ],
+    "apply_message": "You feel a strange, inward force.",
+    "remove_message": "The strange, inward force suddenly vanishes.",
+    "rating": "bad",
+    "flags": [ "TELEPORT_LOCK" ]
+  },
+  {
+    "type": "effect_type",
     "id": "effect_vitakinetic_health_down",
     "name": [ "Feeling Unwell" ],
     "desc": [ "You feel weak and shaky." ],

--- a/data/mods/MindOverMatter/monsters/monster_overrides.json
+++ b/data/mods/MindOverMatter/monsters/monster_overrides.json
@@ -221,14 +221,16 @@
     "id": "mon_hound_tindalos",
     "copy-from": "mon_hound_tindalos",
     "type": "MONSTER",
-    "extend": { "flags": [ "TEEP_IMMUNE" ] },
+    "extend": { "flags": [ "TEEP_IMMUNE", "TELEPORT_IMMUNE" ] },
+    "attack_effs": [ { "id": "effect_teleporting_lock", "duration": [ 5, 60 ], "chance": 50 } ],
     "armor": { "cut": 50, "bullet": 40, "electric": 1, "psi_telekinetic_damage": 50 }
   },
   {
     "id": "mon_hound_tindalos_afterimage",
     "copy-from": "mon_hound_tindalos_afterimage",
     "type": "MONSTER",
-    "extend": { "flags": [ "TEEP_IMMUNE" ] },
+    "extend": { "flags": [ "TEEP_IMMUNE", "TELEPORT_IMMUNE" ] },
+    "attack_effs": [ { "id": "effect_teleporting_lock", "duration": [ 5, 60 ], "chance": 50 } ],
     "armor": { "cut": 50, "bullet": 40, "electric": 1, "psi_telekinetic_damage": 50 }
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing another guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Hounds of Tindalos can teleport lock you"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Teleporter is among the most most powerful MoM paths and I've been careful not to try to limit that, since the whole _point_ of playing a teleporter is being able to teleport all around. That's why teleporters are immune to Teleglow, so they can use their powers without constantly being worried about being attacked by the Hounds.

But if the Hounds are _already_ on your trail, there should be consequences.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Attacks by the Hounds now have a 50% chance to TELEPORT_LOCK you for between 5 and 60 seconds, preventing you from using any teleporting powers that cause instant movement. I did this by adding an `"attack_effs"` to their regular attacks, so the balance and difficulty of the Hounds is otherwise unchanged. If you can't teleport, their new ability will have no effect.

Also, if you teleport when the Hounds are in range before they attack you, they'll sense the teleport (within 50 squares, their normal vision range), and follow you through the Nether. I did this by setting up EoCs that give you the `tindrift` effect when you come out of the teleport--the hardcoded handling of `tindrift` deals with the rest.

Telepathic Shield makes you immune to tindrift, and thus protects you from being followed.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Loaded up a game as an Itzcuauhtli Corps Liaison, spawned in some Hounds, let them attack me and tried to teleport away. I could not.

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/120433252/027b0f22-86b8-4804-a54b-0f7f2de9244e)

Uh oh:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/120433252/c4ed0c1e-578a-40d0-9b73-2f22896ca367)


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
