### PR TITLE
[Magiclysm] Technomancer Binoculars Spell

### DIFF
--- a/data/mods/Magiclysm/Spells/technomancer.json
+++ b/data/mods/Magiclysm/Spells/technomancer.json
@@ -856,5 +856,51 @@
         "true_eocs": [ { "id": "EOC_TECHNOMANCER_POWER_LINKAGE_ITEM", "effect": [ { "npc_set_flag": "USE_UPS" } ] } ]
       }
     ]
+  },
+  {
+    "id": "technomancer_far_sight",
+    "type": "SPELL",
+    "name": "Zoom Lens",
+    "description": "By etching tiny runes on a lens of great quality and infusing it with their magic, the caster can use the lens to see further than even the finest mundane binoculars.  Unfortunately, the arrangement is unstable and the lens will disintegrate after a time.",
+    "valid_targets": [ "self" ],
+    "effect": "spawn_item",
+    "effect_str": "technomancer_far_sight_lens",
+    "components": "spell_components_technomancer_far_sight",
+    "shape": "blast",
+    "flags": [ "SOMATIC", "CONCENTRATE", "VERBAL" ],
+    "extra_effects": [ { "id": "eoc_summon_setup" } ],
+    "spell_class": "TECHNOMANCER",
+    "difficulty": 6,
+    "min_duration": { "math": [ "summoning_proficiency_bonus_calculate(360000)" ] },
+    "max_duration": { "math": [ "summoning_proficiency_bonus_calculate(1440000)" ] },
+    "duration_increment": { "math": [ "summoning_proficiency_bonus_calculate(72000)" ] },
+    "energy_source": "MANA",
+    "base_casting_time": 60000,
+    "base_energy_cost": { "math": [ "summoning_proficiency_negate_calculate(600)" ] },
+    "final_energy_cost": { "math": [ "summoning_proficiency_negate_calculate(300)" ] },
+    "energy_increment": { "math": [ "summoning_proficiency_negate_calculate(-20)" ] }
+    "max_level": 15
+    "learn_spells": { "technomancer_far_sight_plus": 15 }
+  },
+  {
+    "id": "technomancer_far_sight_plus",
+    "type": "SPELL",
+    "name": "Enhanced Zoom Lens",
+    "description": "This lens can see farther than ever!  Now you know this spell like the back of your hand, and have started to design your own version.",
+    "valid_targets": [ "self" ],
+    "flags": [ "SOMATIC", "CONCENTRATE", "VERBAL", "NO_FAIL" ],
+    "extra_effects": [ { "id": "eoc_summon_setup" } ],
+    "effect": "spawn_item",
+    "effect_str": "technomancer_far_sight_lens",
+    "shape": "blast",
+    "base_casting_time": 60000,
+    "base_energy_cost": { "math": [ "summoning_proficiency_negate_calculate(300)" ] },
+    "min_duration": { "math": [ "summoning_proficiency_bonus_calculate(1440000)" ] },
+    "max_duration": { "math": [ "summoning_proficiency_bonus_calculate(8640000)" ] },
+    "duration_increment": { "math": [ "summoning_proficiency_bonus_calculate(288000)" ] },
+    "difficulty": 9,
+    "max_level": 25,
+    "spell_class": "TECHNOMANCER",
+    "energy_source": "MANA"
   }
 ]

--- a/data/mods/Magiclysm/Spells/technomancer.json
+++ b/data/mods/Magiclysm/Spells/technomancer.json
@@ -892,6 +892,7 @@
     "extra_effects": [ { "id": "eoc_summon_setup" } ],
     "effect": "spawn_item",
     "effect_str": "technomancer_far_sight_lens",
+    "components": "spell_components_technomancer_far_sight",
     "shape": "blast",
     "base_casting_time": 60000,
     "base_energy_cost": { "math": [ "summoning_proficiency_negate_calculate(300)" ] },

--- a/data/mods/Magiclysm/Spells/technomancer.json
+++ b/data/mods/Magiclysm/Spells/technomancer.json
@@ -878,8 +878,8 @@
     "base_casting_time": 60000,
     "base_energy_cost": { "math": [ "summoning_proficiency_negate_calculate(600)" ] },
     "final_energy_cost": { "math": [ "summoning_proficiency_negate_calculate(300)" ] },
-    "energy_increment": { "math": [ "summoning_proficiency_negate_calculate(-20)" ] }
-    "max_level": 15
+    "energy_increment": { "math": [ "summoning_proficiency_negate_calculate(-20)" ] },
+    "max_level": 15,
     "learn_spells": { "technomancer_far_sight_plus": 15 }
   },
   {

--- a/data/mods/Magiclysm/effects/effects.json
+++ b/data/mods/Magiclysm/effects/effects.json
@@ -1333,7 +1333,8 @@
       { "u_remove_item_with": "armor_spirit" },
       { "u_remove_item_with": "magic_lamp" },
       { "u_remove_item_with": "technomancer_summoned_radio" },
-      { "u_remove_item_with": "technomancer_welder" }
+      { "u_remove_item_with": "technomancer_welder" },
+      { "u_remove_item_with": "technomancer_far_sight_lens" }
     ]
   },
   {

--- a/data/mods/Magiclysm/effects/effects.json
+++ b/data/mods/Magiclysm/effects/effects.json
@@ -1475,6 +1475,7 @@
       { "u_remove_item_with": "magic_lamp" },
       { "u_remove_item_with": "technomancer_summoned_radio" },
       { "u_remove_item_with": "technomancer_welder" },
+      { "u_remove_item_with": "technomancer_far_sight_lens" },
       { "u_remove_item_with": "druid_thorn_skin_item" },
       { "u_remove_item_with": "bonespear" },
       { "u_remove_item_with": "longsword_holy" },

--- a/data/mods/Magiclysm/itemgroups/spellbooks.json
+++ b/data/mods/Magiclysm/itemgroups/spellbooks.json
@@ -135,7 +135,8 @@
       [ "spell_scroll_flamesword", 35 ],
       [ "spell_scroll_force_jar", 30 ],
       [ "spell_scroll_flamebreath", 30 ],
-      [ "spell_scroll_thought_shield", 35 ]
+      [ "spell_scroll_thought_shield", 35 ],
+      [ "spell_scroll_technomancer_far_sight", 20 ]
     ]
   },
   {
@@ -297,7 +298,8 @@
       [ "basic_pyromancy", 50 ],
       [ "stat_up_spellbook", 45 ],
       [ "tome_of_wind", 45 ],
-      [ "tome_of_storms", 20 ]
+      [ "tome_of_storms", 20 ],
+      [ "pirate_spellbook", 20 ]
     ]
   },
   {

--- a/data/mods/Magiclysm/items/ethereal_items.json
+++ b/data/mods/Magiclysm/items/ethereal_items.json
@@ -1879,7 +1879,7 @@
     "id": "technomancer_far_sight_lens",
     "type": "GENERIC",
     "copy-from": "lens",
-    "name": { "str": "enchanted lens" },
+    "name": { "str": "enchanted lens", "str_pl": "enchanted lenses" },
     "description": "This lens has been etched with small symbols and infused with mana.  Holding it up to your eye allows you to see further than any mundane binoculars allow.",
     "flags": [ "ENHANCED_VISION", "TRADER_AVOID" ],
     "relic_data": { "passive_effects": [ { "id": "ench_technomancer_far_sight_lens" } ] }

--- a/data/mods/Magiclysm/items/ethereal_items.json
+++ b/data/mods/Magiclysm/items/ethereal_items.json
@@ -1874,5 +1874,14 @@
     "volume": "250 ml",
     "longest_side": "40 cm",
     "relic_data": { "passive_effects": [ { "id": "ench_luck_bone" } ] }
-  }
+  },
+  {
+    "id": "technomancer_far_sight_lens",
+    "type": "GENERIC",
+    "copy-from": "lens",
+    "name": { "str": "enchanted lens" },
+    "description": "This lens has been etched with small symbols and infused with mana.  Holding it up to your eye allows you to see further than any mundane binoculars allow.",
+    "flags": [ "ENHANCED_VISION", "TRADER_AVOID" ],
+    "relic_data": { "passive_effects": [ { "id": "ench_technomancer_far_sight_lens" } ] },
+  },
 ]

--- a/data/mods/Magiclysm/items/ethereal_items.json
+++ b/data/mods/Magiclysm/items/ethereal_items.json
@@ -1882,6 +1882,6 @@
     "name": { "str": "enchanted lens" },
     "description": "This lens has been etched with small symbols and infused with mana.  Holding it up to your eye allows you to see further than any mundane binoculars allow.",
     "flags": [ "ENHANCED_VISION", "TRADER_AVOID" ],
-    "relic_data": { "passive_effects": [ { "id": "ench_technomancer_far_sight_lens" } ] },
-  },
+    "relic_data": { "passive_effects": [ { "id": "ench_technomancer_far_sight_lens" } ] }
+  }
 ]

--- a/data/mods/Magiclysm/items/item_enchants.json
+++ b/data/mods/Magiclysm/items/item_enchants.json
@@ -194,7 +194,9 @@
     "values": [
       {
         "value": "OVERMAP_SIGHT",
-        "add": { "math": [ "(5 + (0.5 * u_spell_level('technomancer_far_sight')) + (1 * u_spell_level('technomancer_far_sight_plus')))" ] }
+        "add": {
+          "math": [ "(5 + (0.5 * u_spell_level('technomancer_far_sight')) + (1 * u_spell_level('technomancer_far_sight_plus')))" ]
+        }
       }
     ]
   }

--- a/data/mods/Magiclysm/items/item_enchants.json
+++ b/data/mods/Magiclysm/items/item_enchants.json
@@ -190,7 +190,7 @@
     "has": "HELD",
     "condition": "ALWAYS",
     "name": { "str": "Enhanced Vision" },
-    "description": "Looking through your enchanted lens allows you to see father than ever.",
+    "description": "Looking through your enchanted lens allows you to see farther than ever.",
     "values": [
       {
         "value": "OVERMAP_SIGHT",

--- a/data/mods/Magiclysm/items/item_enchants.json
+++ b/data/mods/Magiclysm/items/item_enchants.json
@@ -183,5 +183,19 @@
       { "value": "REGEN_MANA", "multiply": { "math": [ "rand(10) * 0.01" ] } },
       { "value": "REGEN_STAMINA", "multiply": { "math": [ "rand(10) * 0.01" ] } }
     ]
+  },
+  {
+    "type": "enchantment",
+    "id": "ench_technomancer_far_sight_lens",
+    "has": "HELD",
+    "condition": "ALWAYS",
+    "name": { "str": "Enhanced Vision" },
+    "description": "Looking through your enchanted lens allows you to see father than ever.",
+    "values": [
+      {
+        "value": "OVERMAP_SIGHT",
+        "add": { "math": [ "(5 + (1 * u_spell_level('technomancer_far_sight')) + (1 * u_spell_level('technomancer_far_sight_plus')))" ] }
+      }
+    ]
   }
 ]

--- a/data/mods/Magiclysm/items/item_enchants.json
+++ b/data/mods/Magiclysm/items/item_enchants.json
@@ -194,7 +194,7 @@
     "values": [
       {
         "value": "OVERMAP_SIGHT",
-        "add": { "math": [ "(5 + (1 * u_spell_level('technomancer_far_sight')) + (1 * u_spell_level('technomancer_far_sight_plus')))" ] }
+        "add": { "math": [ "(5 + (0.5 * u_spell_level('technomancer_far_sight')) + (1 * u_spell_level('technomancer_far_sight_plus')))" ] }
       }
     ]
   }

--- a/data/mods/Magiclysm/items/spell_scrolls.json
+++ b/data/mods/Magiclysm/items/spell_scrolls.json
@@ -2031,5 +2031,14 @@
     "name": { "str": "Scroll of Power Linkage", "str_pl": "Scrolls of Power Linkage" },
     "description": "Enchant a tool to accept power wirelessly from a compatible source.",
     "use_action": { "type": "learn_spell", "spells": [ "technomancer_create_ups_connection" ] }
+  },
+  {
+    "type": "BOOK",
+    "copy-from": "spell_scroll",
+    "id": "spell_scroll_technomancer_far_sight",
+    "//": "Technomancer spell",
+    "name": { "str": "Scroll of Zoom Lens", "str_pl": "Scrolls of Zoom Lens" },
+    "description": "Enchant a lens with the ability to see beyond the horizon.",
+    "use_action": { "type": "learn_spell", "spells": [ "technomancer_far_sight" ] }
   }
 ]

--- a/data/mods/Magiclysm/items/spellbooks.json
+++ b/data/mods/Magiclysm/items/spellbooks.json
@@ -1365,5 +1365,29 @@
     "symbol": "?",
     "color": "red",
     "use_action": { "type": "learn_spell", "spells": [ "mana_upgrade_sensitivity_02" ] }
+  },
+  {
+    "id": "pirate_spellbook",
+    "type": "BOOK",
+    "category": "manuals",
+    "name": { "str": "Sail the High Seas with Sorcery on Your Side", "str_pl": "copies of Sail the High Seas with Sorcery on Your Side" },
+    "//": "3 Stormshaper spells, 1 Technomancer spell",
+    "description": "This romanticized book of dubious historical accuracy details how pirates used magic to their advantage while sailing.  From better telescopes to banks of fog to hide their approach, it seems that according to this author at least, piracy was a true terror to behold.",
+    "weight": "437 g",
+    "volume": "825 ml",
+    "price": 7000,
+    "material": [ "paper" ],
+    "looks_like": "cookbook",
+    "symbol": "?",
+    "color": "red",
+    "use_action": {
+      "type": "learn_spell",
+      "spells": [
+        "stormshaper_cloak_of_fog",
+        "storm_shipwrecker",
+        "air_bubble",
+        "technomancer_far_sight"
+      ]
+    }
   }
 ]

--- a/data/mods/Magiclysm/items/spellbooks.json
+++ b/data/mods/Magiclysm/items/spellbooks.json
@@ -1370,7 +1370,10 @@
     "id": "pirate_spellbook",
     "type": "BOOK",
     "category": "manuals",
-    "name": { "str": "Sail the High Seas with Sorcery on Your Side", "str_pl": "copies of Sail the High Seas with Sorcery on Your Side" },
+    "name": {
+      "str": "Sail the High Seas with Sorcery on Your Side",
+      "str_pl": "copies of Sail the High Seas with Sorcery on Your Side"
+    },
     "//": "3 Stormshaper spells, 1 Technomancer spell",
     "description": "This romanticized book of dubious historical accuracy details how pirates used magic to their advantage while sailing.  From better telescopes to banks of fog to hide their approach, it seems that according to this author at least, piracy was a true terror to behold.",
     "weight": "437 g",
@@ -1382,12 +1385,7 @@
     "color": "red",
     "use_action": {
       "type": "learn_spell",
-      "spells": [
-        "stormshaper_cloak_of_fog",
-        "storm_shipwrecker",
-        "air_bubble",
-        "technomancer_far_sight"
-      ]
+      "spells": [ "stormshaper_cloak_of_fog", "storm_shipwrecker", "air_bubble", "technomancer_far_sight" ]
     }
   }
 ]

--- a/data/mods/Magiclysm/requirements/spell_components.json
+++ b/data/mods/Magiclysm/requirements/spell_components.json
@@ -297,8 +297,8 @@
   },
   {
     "id": "spell_components_technomancer_far_sight",
-    "type": "requirement"
-    "//": "Lens, chisel, and mana focus for the Zoom Lens spell"
+    "type": "requirement",
+    "//": "Lens, chisel, and mana focus for the Zoom Lens spell",
     "qualities": [ { "id": "CHISEL", "level": 3 }, { "id": "MANA_FOCUS", "level": 1 } ],
     "components": [ [ [ "lens", 1 ] ] ]
   }

--- a/data/mods/Magiclysm/requirements/spell_components.json
+++ b/data/mods/Magiclysm/requirements/spell_components.json
@@ -288,5 +288,18 @@
     "type": "requirement",
     "//": "Fuel oils for the Power Linkage spell",
     "components": [ [ [ "crude_lamp_oil", 120 ], [ "lamp_oil", 120 ], [ "gasoline", 120 ], [ "diesel", 120 ] ] ]
+  },
+  {
+    "id": "spell_components_create_ups_connection",
+    "type": "requirement",
+    "//": "Fuel oils for the Power Linkage spell",
+    "components": [ [ [ "crude_lamp_oil", 120 ], [ "lamp_oil", 120 ], [ "gasoline", 120 ], [ "diesel", 120 ] ] ]
+  },
+  {
+    "id": "spell_components_technomancer_far_sight",
+    "type": "requirement"
+    "//": "Lens, chisel, and mana focus for the Zoom Lens spell"
+    "qualities": [ { "id": "CHISEL", "level": 3 }, { "id": "MANA_FOCUS", "level": 1 } ],
+    "components": [ [ [ "lens", 1 ] ] ]
   }
 ]

--- a/data/mods/Magiclysm/requirements/spell_components.json
+++ b/data/mods/Magiclysm/requirements/spell_components.json
@@ -290,12 +290,6 @@
     "components": [ [ [ "crude_lamp_oil", 120 ], [ "lamp_oil", 120 ], [ "gasoline", 120 ], [ "diesel", 120 ] ] ]
   },
   {
-    "id": "spell_components_create_ups_connection",
-    "type": "requirement",
-    "//": "Fuel oils for the Power Linkage spell",
-    "components": [ [ [ "crude_lamp_oil", 120 ], [ "lamp_oil", 120 ], [ "gasoline", 120 ], [ "diesel", 120 ] ] ]
-  },
-  {
     "id": "spell_components_technomancer_far_sight",
     "type": "requirement",
     "//": "Lens, chisel, and mana focus for the Zoom Lens spell",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing another guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Adds Technomancer binoculars spell"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Giving technomancers some magitechnical means of replacing binoculars temporarily. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
After my previous attempt that was rejected for reasonable reasons, Maleclypse suggested a technomancer spell that gave better-than-binoculars overmap tile sight. This does that! 

I initially gave it one tile of sight per level of the spell but that was very powerful and while the difficulty and scarcity of the components might have balanced that, I didn't want to front-load the functionality so that there was no reason to level it. The plus version does give one tile per level, but given how difficult it'll be to level since it's impossible to study as a book and has scarce components, I figured that'd be fair. 

The components are as scarce as they are to make this something you have to actually be choosy about when to use. The spell lasts a long time so it holds up to a good few hours of exploration, without allowing you to set it and forget it every day. That's also why I decided against a permanent item made by a craft instead of a spell or something instead, along with the fact that I wanted it to scale in potency with spell level. I also thought the idea of tools being required for a technomancer spell just made sense, hence the chisel and mana focus requirement, since this is themed almost like a crafting recipe for a temporary item. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not adding this? Giving it less restrictive components? Making it an actual crafting recipe for a permanent item instead? I think I've addressed those thoughts above.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Both spells cast properly with required components, lens item spawned properly, sight range varied based on level of spell correctly, scroll and spellbook appeared in tests of the relevant item groups properly. Can't think of anything else to test here?
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
This is my second attempt at formulating a functional and thematic technomancer spell for some sort of overmap sight ability. I recognize the first attempt was not suitably interesting and distinct to make it make sense as an actual spell rather than just as my desires for mapping, and I hope I've fixed those problems with this attempt, but I can always edit it further if needed. Or stop trying to push the idea if that's desired too, I want to be clear that while I like and want this idea, I'm not trying to force it where it doesn't fit. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
