### PR TITLE
[Xedra Evolved] Update Mien of the Mannequin + Backstage

### DIFF
--- a/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_eocs.json
@@ -205,13 +205,78 @@
     "condition": { "not": { "u_has_trait": "HOMULLUS_DOLL_FORM_TRAITS" } },
     "effect": [
       { "u_add_trait": "HOMULLUS_DOLL_FORM_TRAITS" },
-      { "run_eocs": "EOC_HOMULLUS_DOLL_FORM_ANGER_RELATIONS" },
+      { "run_eocs": [ "EOC_HOMULLUS_DOLL_FORM_ANGER_RELATIONS", "EOC_HOMULLUS_DOLL_FORM_MOVEMENT_RESETTER" ] },
       { "u_message": "Your limbs stiffen and your skin takes on an even more waxen appearance.", "type": "good" }
     ],
     "false_effect": [
       { "u_lose_trait": "HOMULLUS_DOLL_FORM_TRAITS" },
       { "u_lose_trait": "HOMULLUS_DOLL_FORM_ANGER_RELATIONS" },
       { "u_message": "A small semblance of life returns to you.", "type": "neutral" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_HOMULLUS_DOLL_FORM_MOVEMENT_COUNTER",
+    "condition": { "math": [ "u_doll_form_movement", ">", "0" ] },
+    "effect": [ { "math": [ "u_doll_form_movement", "-=", "1" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_HOMULLUS_DOLL_FORM_MOVEMENT_COUNTER_ZERO_CHECKER",
+    "recurrence": "1 s",
+    "condition": { "u_has_trait": "HOMULLUS_DOLL_FORM_TRAITS" },
+    "effect": [
+      {
+        "run_eocs": {
+          "id": "EOC_HOMULLUS_DOLL_FORM_MOVEMENT_COUNTER_ZERO_CHECKER_2",
+          "condition": {
+            "and": [ { "math": [ "u_doll_form_movement", "==", "0" ] }, { "u_has_trait": "HOMULLUS_DOLL_FORM_ANGER_RELATIONS_ATTACKER" } ]
+          },
+          "effect": [ { "run_eocs": "EOC_HOMULLUS_DOLL_FORM_ANGER_RELATIONS_REGAIN" } ]
+        }
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_HOMULLUS_DOLL_FORM_MOVEMENT_SET_TO_ZERO",
+    "eoc_type": "EVENT",
+    "required_event": "avatar_moves",
+    "condition": { "u_has_trait": "HOMULLUS_DOLL_FORM_TRAITS" },
+    "effect": [ { "run_eocs": "EOC_HOMULLUS_DOLL_FORM_MOVEMENT_RESETTER" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_HOMULLUS_DOLL_FORM_MOVEMENT_RESETTER",
+    "condition": { "math": [ "u_monsters_nearby('radius': 45, 'attitude': 'both')", "==", "0" ] },
+    "effect": [ { "math": [ "u_doll_form_movement", "=", "0" ] }, { "run_eocs": "EOC_HOMULLUS_DOLL_FORM_ANGER_RELATIONS_REGAIN" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_HOMULLUS_DOLL_FORM_MOVEMENT_INCREASING",
+    "eoc_type": "EVENT",
+    "required_event": "avatar_moves",
+    "condition": { "and": [ { "u_has_trait": "HOMULLUS_DOLL_FORM_TRAITS" }, { "math": [ "u_doll_form_movement", "<=", "1000" ] } ] },
+    "effect": [ { "math": [ "u_doll_form_movement", "+=", "rand(10)" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_HOMULLUS_DOLL_FORM_MOVEMENT_BREAK_CHECKER",
+    "eoc_type": "EVENT",
+    "required_event": "avatar_moves",
+    "condition": {
+      "and": [
+        { "u_has_trait": "HOMULLUS_DOLL_FORM_TRAITS" },
+        { "math": [ "u_doll_form_movement", ">", "0" ] },
+        { "x_in_y_chance": { "x": { "math": [ "u_doll_form_movement" ] }, "y": 1000 } }
+      ]
+    },
+    "effect": [
+      {
+        "u_message": "As you take another step, you notice hostile eyes turn toward you.  They don't see you as just a doll now.",
+        "type": "bad"
+      },
+      { "run_eocs": "EOC_HOMULLUS_DOLL_FORM_ANGER_RELATIONS_LOSE" }
     ]
   },
   {
@@ -226,11 +291,7 @@
     "eoc_type": "EVENT",
     "required_event": "character_melee_attacks_monster",
     "condition": { "and": [ { "u_has_trait": "HOMULLUS_DOLL_FORM_ANGER_RELATIONS" }, { "u_has_trait": "THRESH_HOMULLUS" } ] },
-    "effect": [
-      { "u_add_trait": "HOMULLUS_DOLL_FORM_ANGER_RELATIONS_ATTACKER" },
-      { "u_lose_trait": "HOMULLUS_DOLL_FORM_ANGER_RELATIONS" },
-      { "queue_eocs": "EOC_HOMULLUS_DOLL_FORM_ANGER_RELATIONS_REGAIN", "time_in_future": 240 }
-    ]
+    "effect": [ { "run_eocs": "EOC_HOMULLUS_DOLL_FORM_ANGER_RELATIONS_LOSE" } ]
   },
   {
     "type": "effect_on_condition",
@@ -238,11 +299,7 @@
     "eoc_type": "EVENT",
     "required_event": "character_melee_attacks_character",
     "condition": { "and": [ { "u_has_trait": "HOMULLUS_DOLL_FORM_ANGER_RELATIONS" }, { "u_has_trait": "THRESH_HOMULLUS" } ] },
-    "effect": [
-      { "u_add_trait": "HOMULLUS_DOLL_FORM_ANGER_RELATIONS_ATTACKER" },
-      { "u_lose_trait": "HOMULLUS_DOLL_FORM_ANGER_RELATIONS" },
-      { "queue_eocs": "EOC_HOMULLUS_DOLL_FORM_ANGER_RELATIONS_REGAIN", "time_in_future": 240 }
-    ]
+    "effect": [ { "run_eocs": "EOC_HOMULLUS_DOLL_FORM_ANGER_RELATIONS_LOSE" } ]
   },
   {
     "type": "effect_on_condition",
@@ -250,11 +307,7 @@
     "eoc_type": "EVENT",
     "required_event": "character_ranged_attacks_monster",
     "condition": { "and": [ { "u_has_trait": "HOMULLUS_DOLL_FORM_ANGER_RELATIONS" }, { "u_has_trait": "THRESH_HOMULLUS" } ] },
-    "effect": [
-      { "u_add_trait": "HOMULLUS_DOLL_FORM_ANGER_RELATIONS_ATTACKER" },
-      { "u_lose_trait": "HOMULLUS_DOLL_FORM_ANGER_RELATIONS" },
-      { "queue_eocs": "EOC_HOMULLUS_DOLL_FORM_ANGER_RELATIONS_REGAIN", "time_in_future": 240 }
-    ]
+    "effect": [ { "run_eocs": "EOC_HOMULLUS_DOLL_FORM_ANGER_RELATIONS_LOSE" } ]
   },
   {
     "type": "effect_on_condition",
@@ -262,10 +315,16 @@
     "eoc_type": "EVENT",
     "required_event": "character_ranged_attacks_character",
     "condition": { "and": [ { "u_has_trait": "HOMULLUS_DOLL_FORM_ANGER_RELATIONS" }, { "u_has_trait": "THRESH_HOMULLUS" } ] },
+    "effect": [ { "run_eocs": "EOC_HOMULLUS_DOLL_FORM_ANGER_RELATIONS_LOSE" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_HOMULLUS_DOLL_FORM_ANGER_RELATIONS_LOSE",
+    "condition": { "and": [ { "u_has_trait": "HOMULLUS_DOLL_FORM_ANGER_RELATIONS" }, { "u_has_trait": "HOMULLUS_DOLL_FORM_TRAITS" } ] },
     "effect": [
-      { "u_add_trait": "HOMULLUS_DOLL_FORM_ANGER_RELATIONS_ATTACKER" },
       { "u_lose_trait": "HOMULLUS_DOLL_FORM_ANGER_RELATIONS" },
-      { "queue_eocs": "EOC_HOMULLUS_DOLL_FORM_ANGER_RELATIONS_REGAIN", "time_in_future": 240 }
+      { "u_add_trait": "HOMULLUS_DOLL_FORM_ANGER_RELATIONS_ATTACKER" },
+      { "queue_eocs": "EOC_HOMULLUS_DOLL_FORM_ANGER_RELATIONS_REGAIN", "time_in_future": [ 180, 360 ] }
     ]
   },
   {

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_eocs.json
@@ -218,7 +218,7 @@
     "type": "effect_on_condition",
     "id": "EOC_HOMULLUS_DOLL_FORM_MOVEMENT_COUNTER",
     "condition": { "math": [ "u_doll_form_movement", ">", "0" ] },
-    "effect": [ { "math": [ "u_doll_form_movement", "-=", "1" ] } ]
+    "effect": [ { "math": [ "u_doll_form_movement", "-=", "rand(3) + 1" ] } ]
   },
   {
     "type": "effect_on_condition",
@@ -257,7 +257,7 @@
     "eoc_type": "EVENT",
     "required_event": "avatar_moves",
     "condition": { "and": [ { "u_has_trait": "HOMULLUS_DOLL_FORM_TRAITS" }, { "math": [ "u_doll_form_movement", "<=", "1000" ] } ] },
-    "effect": [ { "math": [ "u_doll_form_movement", "+=", "rand(10)" ] } ]
+    "effect": [ { "math": [ "u_doll_form_movement", "+=", "rand(10) + 2" ] } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_mutations.json
@@ -531,7 +531,7 @@
       }
     ],
     "vitamin_rates": [ [ "vitC", -900 ], [ "iron", -900 ], [ "calcium", -900 ] ],
-    "flags": [ "BLEED_IMMUNE " ]
+    "flags": [ "BLEED_IMMUNE" ]
   },
   {
     "type": "mutation",

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_mutations.json
@@ -198,7 +198,7 @@
     "active": false,
     "valid": false,
     "player_display": false,
-    "anger_relations": [ [ "HUMAN", -100 ], [ "FERAL", -100 ] ],
+    "anger_relations": [ [ "HUMAN", -50 ], [ "FERAL", -50 ] ],
     "enchantments": [
       {
         "values": [
@@ -501,6 +501,7 @@
     "active": true,
     "activated_is_setup": true,
     "activated_eocs": [ "EOC_HOMULLUS_DOLL_FORM_ON" ],
+    "processed_eocs": [ "EOC_HOMULLUS_DOLL_FORM_MOVEMENT_COUNTER" ],
     "deactivated_eocs": [ "EOC_HOMULLUS_DOLL_FORM_ON" ]
   },
   {
@@ -529,13 +530,14 @@
         "values": [ { "value": "MOVE_COST", "multiply": 2.5 } ]
       }
     ],
-    "vitamin_rates": [ [ "vitC", -900 ], [ "iron", -900 ], [ "calcium", -900 ] ]
+    "vitamin_rates": [ [ "vitC", -900 ], [ "iron", -900 ], [ "calcium", -900 ] ],
+    "flags": [ "BLEED_IMMUNE " ]
   },
   {
     "type": "mutation",
     "id": "HOMULLUS_DOLL_FORM_ANGER_RELATIONS",
     "name": { "str": "Mannequin Form Anger Relations" },
-    "description": "Anger relations are here in a separate mutation so that they're removed on attacking a target.",
+    "description": "Anger relations are here in a separate mutation so that they're removed on attacking a target or moving too quickly.",
     "points": 2,
     "valid": false,
     "player_display": false,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing another guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Xedra Evolved] Update Mien of the Mannequin + Backstage"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Over Shabbat, I realized that my implementation of Mien of the Mannequin would make it so that a Homullus could just walk into a secure lab facility, unbothered by any enemies, loot everything, and leave, which is fun once but removes all challenge from the game after that, so I needed to handle that. And I came back to a ping about how Backstage made zombies not attack the Homullus when it was on, so I needed to fix that too.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Reduce the anger relations in Backstage so that zombies (which also have the `HUMAN` species) are still angry but ferals are not.

Edit Mien of the Mannequin to provide an invisible counter that goes up when you move--between 3 to 12 per step. Every turn, you lose 1-4 from this counter, and every time you move, there's a [counter] in 1000 chance that enemies realize you're _not_ just part of the scenery and attack. The objective is thus to move a bit, wait, move a bit, wait...just like a horror movie mannequin so the zombies will be like "That's odd...wasn't that mannequin in the corner last time I looked at it?"

If you're ever in a place where there's no monsters within 45 tiles, the counter resets to 0. If the counter is ever zero, you regain your indifference from monsters.   It's theoretically possible to just let monsters attack you while you lie limp until they lose interest, but this is obviously a high-risk strategy. 

Finally, Homullus are immune to bleeding while Mien of the Mannequin is active. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Everything works.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
