### PR TITLE
Adjust vehicle docs

### DIFF
--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -3341,7 +3341,7 @@ See also [VEHICLES_JSON.md](VEHICLES_JSON.md)
 "name": "Shopping Cart",                   // Display name, subject to i18n.
 "blueprint": "#",                          // Preview of vehicle - ignored by the code, so use only as documentation
 "parts": [                                 // Parts list
-    {"x": 0, "y": 0, "part": "box"},       // Part definition, positive x direction is to the left, positive y is to the right
+    {"x": 0, "y": 0, "part": "box"},       // Part definition, positive x direction is to the right, positive y is up
     {"x": 0, "y": 0, "part": "casters"}    // See vehicle_parts.json for part ids
 ]
                                            /* Important! Vehicle parts must be defined in the

--- a/doc/VEHICLES_JSON.md
+++ b/doc/VEHICLES_JSON.md
@@ -16,8 +16,8 @@ Vehicle prototypes are used to spawn stock vehicles. After a vehicle has been sp
     "o#o"
 ],
 "parts": [                                 // Parts list
-    { "x": 0, "y": 0, "parts": [ "frame" ] },   // Part definition, positive x direction is up,
-    { "x": 0, "y": 0, "parts": [ "seat" ] },    // positive y is to the right
+    { "x": 0, "y": 0, "parts": [ "frame" ] },   // Part definition, positive x direction is to the right,
+    { "x": 0, "y": 0, "parts": [ "seat" ] },    // positive y is up
     { "x": 0, "y": 0, "parts": [ "controls" ] }, // See vehicle_parts.json for part ids
     { "x": 1, "y": 1, "parts": [ "veh_tools_workshop", "tools": [ "welder" ] ] },  // spawn attached tools
     { "x": 0, "y": 1, "parts": [ "frame", "seat" ] },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing another guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Closes #72159
As far as I can tell, the confusion comes from the fact that some vehicles are defined as pointing "sideways" which would mean that having a positive y value sets the part to the left when looking at it from the vehicle's perspective, similarly a positive x value would then mean for it to go up.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Change the docs to be more in line with what I'd expect it to say, i.e. x value being horizontal, y value being vertical.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded the markdown locally, text was different
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Maybe if vehicles get multi-storied having y be north would be better? I'm unsure, it feels weird to refer to it like that.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
