### PR TITLE
Set proper overmap terrain for innawoods cave specials

### DIFF
--- a/data/mods/innawood/overmap/specials_kept.json
+++ b/data/mods/innawood/overmap/specials_kept.json
@@ -40,6 +40,19 @@
   },
   {
     "type": "overmap_special",
+    "id": "Cave w/ trail",
+    "overmaps": [
+      { "point": [ 0, 0, 0 ], "overmap": "cave_innawood" },
+      { "point": [ 0, 0, -1 ], "overmap": "cave_underground_innawood" }
+    ],
+    "connections": [ { "point": [ 0, -1, 0 ], "terrain": "forest_trail", "connection": "forest_trail" } ],
+    "locations": [ "forest" ],
+    "city_distance": [ 8, -1 ],
+    "occurrences": [ 0, 5 ],
+    "flags": [ "CLASSIC", "WILDERNESS" ]
+  },
+  {
+    "type": "overmap_special",
     "id": "Cave",
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "cave_innawood" },
@@ -47,8 +60,8 @@
     ],
     "locations": [ "forest" ],
     "city_distance": [ 8, -1 ],
-    "occurrences": [ 0, 10 ],
-    "flags": [ "WILDERNESS" ]
+    "occurrences": [ 0, 5 ],
+    "flags": [ "CLASSIC", "WILDERNESS" ]
   },
   {
     "type": "overmap_special",


### PR DESCRIPTION
#### Summary
Bugfixes "Set proper overmap terrain for innawoods cave specials"

#### Purpose of change

Regular cave specials (i.e. those with man-made furniture / items) are showing up in innawoods since #67470, which adds a new cave special (Cave w/ trail). This needs to be overridden in the innawoods mod with proper overmap terrains so the correct cave variants show up.

#### Describe the solution

Replace overmap terrains `cave` and `cave_underground` with `cave_innawood` and `cave_underground_innawood`, respectively.

#### Describe alternatives you've considered

None

#### Testing

Tested in game, generated some overmaps by teleporting. All generated caves are of the correct variants.

#### Additional context

