### PR TITLE
imgui demo_ui: no more delay (no more mouse wiggling)

### DIFF
--- a/src/input.h
+++ b/src/input.h
@@ -271,7 +271,7 @@ class input_manager
         void wait_for_any_key();
 
         /**
-         * Sets global input polling timeout as appropriate for the current interface system.
+         * Sets global input polling timeout in milliseconds as appropriate for the current interface system.
          * Use `input_context::(re)set_timeout()` when possible so timeout will be properly
          * reset when entering a new input context.
          */

--- a/src/input_context.h
+++ b/src/input_context.h
@@ -267,6 +267,7 @@ class input_context
          *
          * If the action is mouse input, returns "MOUSE".
          *
+         * @param timeout in milliseconds.
          * @return One of the input actions formerly registered with
          *         `register_action()`, or "ERROR" if an error happened.
          *

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -108,7 +108,7 @@ void demo_ui::run()
 
     while( is_open ) {
         ui_manager::redraw();
-        action = ctxt.handle_input();
+        action = ctxt.handle_input( 5 );
         if( action == "QUIT" ) {
             break;
         }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing another guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
No more mouse wiggling in ImGui demo!
Fix #72215

Experimentally determined the timeout is in milliseconds, so I wrote in the docs.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Set delay to 5. This allows for 200FPS (I get 70FPS) while not burning the PC like when I set it to 0.

Looking back, it was mentioned in the issue, but I didn't understand how to do it.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Set the delay to a different amount, like 16ms for 60 FPS. I feel like 50ms is too low, as it allows only 20FPS which might not be ideal for some animations (which are present in the ImGui demo).

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Inputs & Focus update instantly and as expected.
Plots work without the mouse wiggling.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I was working on #69831 and needed to fix the input delays. Since my starting point was ImGui demo, I came back to fix it.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
