### PR TITLE
refine calculations of WEAKNESS_TO_WATER

### DIFF
--- a/doc/MAGIC.md
+++ b/doc/MAGIC.md
@@ -896,7 +896,7 @@ Character status value  | Description
 `UGLINESS`              | Affects your `ugliness` stat, which affects NPCs' initial opinion of you.
 `VITAMIN_ABSORB_MOD`    | Increases amount of vitamins obtained from the food
 `VOMIT_MUL`             | Affects your chances to vomit.
-`WEAKNESS_TO_WATER`     | Amount of damage character gets when wet, once per minute; scales with wetness, being 50% wet deal only half of damage; negative values restore hp; flat number with default value of 0, so `multiply` is useful only in combination with `add`; Works with float numbers, so `"add": -0.3` would result in restoring 1 hp with 30% change, and 70% chance to do nothing
+`WEAKNESS_TO_WATER`     | Amount of damage character gets when wet, once per second; scales with wetness, being 50% wet deal only half of damage; negative values restore hp; flat number with default value of 0, so `multiply` is useful only in combination with `add`; Works with float numbers, so `"add": -0.3` would result in restoring 1 hp with 30% change, and 70% chance to do nothing
 `WEAPON_DISPERSION`     | Positive value increase the dispersion, negative decrease one.
 
 

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -223,7 +223,7 @@ void suffer::water_damage( Character &you )
     for( const std::pair<const bodypart_str_id, bodypart> &elem : you.get_body() ) {
         const float wetness_percentage = elem.second.get_wetness_percentage();
         float dmg_float = you.enchantment_cache->modify_value( enchant_vals::mod::WEAKNESS_TO_WATER,
-                          0 ) * wetness_percentage;
+                          0 ) * wetness_percentage / 100;
         const int dmg = roll_remainder( dmg_float );
         if( dmg > 0 ) {
             you.apply_damage( nullptr, elem.first, dmg );


### PR DESCRIPTION
#### Summary
Bugfixes "weakness to water do not disintegrate you anymore"
#### Purpose of change
in #72173 i fixed a few stuff related to WEAKNESS_TO_WATER, and changed it to tick once per second; i apparently miss that it scales with wetness not in format `being 50% wet deals 50% of the damage`, but `being 50% wet deals 50x more damage`
That is a big difference, and while there isn't much stuff that uses it (yet), i'll quickfix it to make more sense
#### Describe the solution
divide the result by 100, so 50% wetness deals only 50% of the damage; update the documents
#### Testing
I do not die instantly under the rain
#### Additional context
cc RedMisao
[Cataclysm_Dark_Days_Ahead_-_03B2540_2024-03-10_19-23-56.webm](https://github.com/CleverRaven/Cataclysm-DDA/assets/67688115/0ea9104d-2a2a-42a0-a3de-c0a73239f34e)