### PR TITLE
Item groups can define crafted components for an item

### DIFF
--- a/data/json/itemgroups/SUS/lodge.json
+++ b/data/json/itemgroups/SUS/lodge.json
@@ -63,10 +63,15 @@
     "subtype": "collection",
     "entries": [
       { "item": "machete", "prob": 20 },
-      { "group": "preserved_food", "custom-flags": [ "CANNIBALISM" ], "prob": 30 },
+      {
+        "item": "meat_salted",
+        "components": [ "human_flesh", "salt" ],
+        "custom-flags": [ "CANNIBALISM" ],
+        "prob": 30
+      },
       { "group": "preserved_food", "prob": 20 },
       { "group": "dry_goods", "prob": 30 },
-      { "group": "dry_goods", "custom-flags": [ "CANNIBALISM" ], "prob": 60 },
+      { "item": "meat_smoked", "components": [ "human_flesh" ], "custom-flags": [ "CANNIBALISM" ], "prob": 60 },
       { "group": "pantry", "prob": 10 }
     ]
   }

--- a/data/mods/Magiclysm/worldgen/goblin_locations/orc_village.json
+++ b/data/mods/Magiclysm/worldgen/goblin_locations/orc_village.json
@@ -43,9 +43,21 @@
       { "item": "wastebread", "count-max": 8, "prob": 70 },
       { "item": "dry_fruit", "count-max": 8, "prob": 70 },
       { "item": "dry_veggy", "count-max": 8, "prob": 70 },
-      { "item": "meat_salted", "count-max": 3, "custom-flags": "CANNIBALISM", "prob": 50 },
+      {
+        "item": "meat_salted",
+        "components": [ "human_flesh", "salt" ],
+        "custom-flags": [ "CANNIBALISM" ],
+        "count-max": 3,
+        "prob": 50
+      },
       { "item": "meat_salted", "count-max": 8, "prob": 50 },
-      { "item": "meat_smoked", "count-max": 3, "custom-flags": "CANNIBALISM", "prob": 70 },
+      {
+        "item": "meat_smoked",
+        "components": [ "human_flesh" ],
+        "custom-flags": [ "CANNIBALISM" ],
+        "count-max": 3,
+        "prob": 70
+      },
       { "item": "meat_smoked", "count-max": 8, "prob": 50 }
     ]
   },

--- a/doc/ITEM_SPAWN.md
+++ b/doc/ITEM_SPAWN.md
@@ -89,6 +89,7 @@ Each entry can have more values (shown above as `...`).  They allow further prop
 "charges": <number>|<array>,
 "charges-min": <number>,
 "charges-max": <number>,
+"components": "<array>",
 "contents-item": "<item-id>" (can be a string or an array of strings),
 "contents-group": "<group-id>" (can be a string or an array of strings),
 "ammo-item": "<ammo-item-id>",
@@ -114,6 +115,8 @@ Each entry can have more values (shown above as `...`).  They allow further prop
 `custom-flags`: An array of flags that will be applied to this item.
 
 `variant`: A valid itype variant id for this item.
+
+`components`: Valid itype ids which are put into the item as its components, as may be done with in-game crafting. Note that there is no requirement for a matching recipe to exist, the components may be any existent item. You could define a spawned `hamburger` to have components of `[ "rock", "rock" ]` but it won't be good food... rocks contain no calories or nutrients!
 
 `event`: A reference to a holiday in the `holiday` enum. If specified, the entry only spawns during the specified real holiday. This works the same way as the seasonal title screens, where the holiday is checked against the current system's time. If the holiday matches, the item's spawn probability is taken from the `prob` field. Otherwise, the spawn probability becomes 0.
 

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -4947,6 +4947,15 @@ void Item_factory::add_entry( Item_group &ig, const JsonObject &obj, const std::
     } else {
         use_modifier |= load_sub_ref( modifier.container, obj, "container", ig );
     }
+    if( obj.has_array( "components" ) ) {
+        JsonArray ja = obj.get_array( "components" );
+        std::vector<itype_id> made_of;
+        for( auto sub : ja ) {
+            itype_id component = itype_id( sub );
+            made_of.emplace_back( component );
+        }
+        sptr->components_items = made_of;
+    }
     use_modifier |= load_sub_ref( modifier.contents, obj, "contents", ig );
     use_modifier |= load_str_arr( modifier.snippets, obj, "snippets" );
     if( obj.has_member( "sealed" ) ) {

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -232,6 +232,11 @@ item Single_item_creator::create_single_without_container( const time_point &bir
     }
     if( components_items ) {
         for( itype_id component_id : *components_items ) {
+            if( !component_id.is_valid() ) {
+                debugmsg( "Invalid components item %s in %s (could not find matching itype id)",
+                          component_id.c_str(), context() );
+                continue;
+            }
             item component = item( component_id, calendar::turn );
             tmp.components.add( component );
         }

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -230,6 +230,12 @@ item Single_item_creator::create_single_without_container( const time_point &bir
     if( one_in( 3 ) && tmp.has_flag( flag_VARSIZE ) ) {
         tmp.set_flag( flag_FIT );
     }
+    if( components_items ) {
+        for( itype_id component_id : *components_items ) {
+            item component = item( component_id, calendar::turn );
+            tmp.components.add( component );
+        }
+    }
     if( modifier ) {
         modifier->modify( tmp, "modifier for " + context() );
     } else {

--- a/src/item_group.h
+++ b/src/item_group.h
@@ -195,6 +195,10 @@ class Item_spawn_data
         std::optional<itype_id> container_item;
         std::optional<std::string> container_item_variant;
         overflow_behaviour on_overflow = overflow_behaviour::none;
+        /**
+         * These item(s) are spawned as components
+         */
+        std::optional<std::vector<itype_id>> components_items;
         bool sealed = true;
 
         struct relic_generator {
@@ -262,7 +266,6 @@ class Item_modifier
          */
         std::unique_ptr<Item_spawn_data> contents;
         bool sealed = true;
-
         /**
          * Custom flags to be added to the item.
          */


### PR DESCRIPTION
#### Summary
Features "Item groups can define crafted components for an item"

#### Purpose of change
Infrastructure to support #72224

Plus it allows additional storytelling. We could (as an extreme example) define the refugee centers' beggars' clothing as having `components` of `patchwork cotton sheets` or `rag` (or some other thing suitable to signal their status).

#### Describe the solution
Load itype_ids as we do elsewhere, made a new `item_components` and spawn items as appropriate. Put those components into the the item as the JSON asks. Throws an error on loading if you've asked for an invalid item type, and points you to the item group context that the error occurred in.

#### Describe alternatives you've considered
We could do some wacky shennigans by matching up recipes with the items, but especially for food there is a massive amount of recipes and I think it's better if we don't try to check the components *too* much. I think for mod content especially a modder might want to say "This is space chainmail, with components of superalloy sheet and crystallized mana", but they don't want to make a *recipe* for it, even a fake recipe.

#### Testing
It works properly in the orc village, and if hunting lodges were spawning items properly it would work there too.

#### Additional context
lmao #72326

All this effort to keep lodges un-broken and they were broken in the first place