### PR TITLE
Add a screen reader mode option and implement on character creation screens

### DIFF
--- a/doc/USER_INTERFACE_AND_ACCESSIBILITY.md
+++ b/doc/USER_INTERFACE_AND_ACCESSIBILITY.md
@@ -40,15 +40,42 @@ text to show correctly.
 
 ## Compatibility with screen readers
 
-There are people who use screen readers to play Cataclysm DDA. In order for screen
-readers to announce the most important information in a UI, the terminal cursor has
-to be placed at the correct location. This information may be text such as selected
-item names in a list, etc, and the cursor has to be placed exactly at the beginning
-of the text for screen readers to announce it. (Note: from my test with an Ubuntu
-VM, if the cursor is placed after the end of the text, the cursor might be wrapped
-to the next line and cause the screen reader to announce the text incorrectly. It
-also seems to be easier for people to control the screen reader to read from the
-beginning of the text where the cursor is placed.)
+There are people who use screen readers to play Cataclysm DDA.  There are several
+things to keep in mind when checking the user interface for compatibility with
+screen readers.  These include:
+
+1. Screen reader mode:
+An option ("SCREEN_READER_MODE") has been added where the user can indicate that
+they are using a screen reader.  If a change to the UI to optimize for screen
+readers would be undesirable for other users, consider checking against
+"SCREEN_READER_MODE", and including the change when true.
+
+2. Text color:
+Text color is not announced by screen readers.  If key information is only
+communicated to the player through text color, that information will not be
+available to players using screen readers.  For example, a simple
+uilist where some options have been disabled:
+
+----------------------------------------------------------------------------
+|Execute which action?                                                     |
+|--------------------------------------------------------------------------|
+|<color_c_green>1</color> <color_c_light_gray>Cut up an item</color>       |
+|<color_c_green>f</color> <color_c_light_gray>Start a fire quickly</color> |
+|<color_c_dark_gray>h Use holster</color>                                  |
+----------------------------------------------------------------------------
+
+A screen reader user will only know that "Use holster" is unavailable when they
+attempt to use it.  When presenting information, consider hiding inaccessible
+options and adding text to confirm information conveyed by text color.  As an
+example, the display of food spoilage status:
+
+<color_c_light_blue>Acorns (fresh)</color>
+<color_c_yellow>Acorns (old)</color>
+
+3. Cursor placement
+In general, screen readers will start reading where the program has set the terminal
+cursor.  Thus, the cursor should be set to the beginning of the most important
+section of the UI.
 
 The recommended way to place the cursor is to use `ui_adaptor`. This ensures the
 desired cursor position is preserved when subsequent output code changes the
@@ -62,4 +89,122 @@ For debugging purposes, you can set the `DEBUG_CURSES_CURSOR` compile flag to
 always show the cursor in the terminal (currently only works with the curses
 build).
 
-For more information and examples, please see the documentation in `ui_manager.h`.
+4. Window layout
+While setting the terminal cursor position is sufficient to set things up for
+screen readers in many cases, there are caveats to this.  Screen readers will also
+attempt to detect text changes.  If that text change is after the terminal cursor,
+the screen reader may skip over text.  As an example (terminal position noted
+by X):
+
+XEye color: amber
+
+changing into
+
+XEye color: blue
+
+The screen reader will only read the word "blue", even though the cursor is
+set to start reading at "Eye".
+
+Another complication is if the screen reader detects text changes above the
+terminal cursor.  As an example:
+
+Lifestyle: underpowered
+XStrength: 8
+
+changing into
+
+Lifestyle: weak
+XStrength: 9
+
+The screen reader will start reading at "weak".
+
+Behaviour like this means that screen readers struggle with certain common UI
+layouts.  Examples of how to implement SCREEN_READER_MODE in various UI layouts
+can be found in src/newcharacter.cpp.
+
+Note: In all following examples, the terminal cursor is marked "X".
+
+4a. List with additional information at the top or bottom:
+
+-----------------------------------------------------
+|Choose type of butchery:                           |
+|---------------------------------------------------|
+XB Quick butchery	6 minutes                   |
+|b Full butchery	39 minutes                  |
+|---------------------------------------------------|
+|This technique is used when you are in a hurry, but|
+|still want to harvest something from the corpse.   |
+-----------------------------------------------------
+Figure 4ai - List with details at the bottom, current configuration
+
+If the cursor is set at "Quick butchery", then the screen reader will read all of the
+other options before getting to the description of what "Quick butchery" entails.  The
+preferred layout in SCREEN_READER_MODE is the following:
+
+-----------------------------------------------------
+|Choose type of butchery:                           |
+|---------------------------------------------------|
+|                                                   |
+|                                                   |
+|---------------------------------------------------|
+XB Quick butchery       6 minutes                   |
+|This technique is used when you are in a hurry, but|
+-----------------------------------------------------
+Figure 4aii - List with details at the bottom, recommended "SCREEN_READER_MODE"
+
+That is:
+1. Add the currently-selected list entry to the detail pane at the bottom, and
+2. Disable display of the list of options.
+The screen reader user can then scroll through the list of available options, only
+hearing about the details of the currently-selected option.
+
+Hiding the list of options is necessary even when the cursor is set to point X.
+In addition to following the terminal cursor, screen readers will try to detect when
+text changes, and can be misled by scrolling text.  As an example:
+
+-----------------------------------------------------
+|Choose type of butchery:                           |
+|---------------------------------------------------|
+Yb Full butchery	39 minutes                  |
+|f Field dress corpse	5 minutes                   |
+|---------------------------------------------------|
+XThis technique is used to properly butcher a corpse|
+|and requires a rope & a tree or a butchering rack, |
+-----------------------------------------------------
+Figure 4aiii - List with details at the bottom with scrolling issues
+
+When the list scrolls, the text at the top changes, and the screen reader will
+'helpfully' start reading at point Y rather than the current cursor position X.
+
+4b. List with additional information at the side:
+
+_______________________________
+|List    | Details relating to|
+XItem 1  | item 1.  Lorem     |
+|Item 2  | ipsum              |
+|Item 3  |                    |
+|Item 4  |                    |
+|Item 5  |                    |
+-------------------------------
+Figure 4bi - List with details at the side, current configuration
+
+In this common layout, the screen reader is unable to differentiate between the two
+panes, and ends up reading the list interwoven with the details of the currently-selected
+item.  This is true whether the terminal cursor is set to the current item or to the top
+left of the details pane.
+
+The recommended layout in SCREEN_READER_MODE is the following:
+
+_______________________________
+|        | XItem 1            |
+|        | Details relating to|
+|        | item 1.  Lorem     |
+|        | ipsum              |
+|        |                    |
+|        |                    |
+-------------------------------
+Figure 4bii - List with details at the side, recommended "SCREEN_READER_MODE"
+
+That is:
+1. Add the currently-selected list entry to the detail pane at the side, and
+2. Disable display of the list of options.

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1511,7 +1511,7 @@ void set_traits( tab_manager &tabs, avatar &u, pool_type pool )
 {
     const int max_trait_points = get_option<int>( "MAX_TRAIT_POINTS" );
     const bool screen_reader_mode = get_option<bool>( "SCREEN_READER_MODE" );
-    std::string last_trait = ""; // Used in screen_reader_mode to ensure full trait name is read
+    std::string last_trait; // Used in screen_reader_mode to ensure full trait name is read
     // Track how many good / bad POINTS we have; cap both at MAX_TRAIT_POINTS
     int num_good = 0;
     int num_bad = 0;

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -2402,7 +2402,7 @@ void set_profession( tab_manager &tabs, avatar &u, pool_type pool )
         //Draw options
         calcStartPos( iStartPos, cur_id, iContentHeight, profs_length );
         const int end_pos = iStartPos + std::min( iContentHeight, profs_length );
-        std::string cur_prof_notes = "";
+        std::string cur_prof_notes;
         for( int i = iStartPos; i < end_pos; i++ ) {
             nc_color col;
             if( u.prof != &sorted_profs[i].obj() ) {

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -3458,7 +3458,7 @@ void set_scenario( tab_manager &tabs, avatar &u, pool_type pool )
         //Draw options
         calcStartPos( iStartPos, cur_id, iContentHeight, scens_length );
         const int end_pos = iStartPos + std::min( iContentHeight, scens_length );
-        std::string current_scenario_notes = "";
+        std::string current_scenario_notes;
         for( int i = iStartPos; i < end_pos; i++ ) {
             nc_color col;
             if( get_scenario() != sorted_scens[i] ) {

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1998,7 +1998,7 @@ static struct {
 } profession_sorter;
 
 static std::string assemble_profession_details( const avatar &u, const input_context &ctxt,
-        const std::vector<string_id<profession>> &sorted_profs, const int cur_id )
+        const std::vector<string_id<profession>> &sorted_profs, const int cur_id, const std::string &notes )
 {
     std::string assembled;
 
@@ -2009,8 +2009,12 @@ static std::string assemble_profession_details( const avatar &u, const input_con
     }, enumeration_conjunction::arrow );
     assembled += string_format( _( "Origin: %s" ), mod_src ) + "\n";
 
+    std::string profession_name = sorted_profs[cur_id]->gender_appropriate_name( u.male );
+    if( get_option<bool>( "SCREEN_READER_MODE" ) && !notes.empty() ) {
+        profession_name = profession_name.append( string_format( " - %s", notes ) );
+    }
     assembled += string_format( g_switch_msg( u ), ctxt.get_desc( "CHANGE_GENDER" ),
-                                sorted_profs[cur_id]->gender_appropriate_name( u.male ) ) + "\n";
+                                profession_name ) + "\n";
     assembled += string_format( dress_switch_msg(), ctxt.get_desc( "CHANGE_OUTFIT" ) ) + "\n";
 
     if( sorted_profs[cur_id]->get_requirement().has_value() ) {
@@ -2251,6 +2255,8 @@ void set_profession( tab_manager &tabs, avatar &u, pool_type pool )
     size_t iContentHeight = 0;
     int iStartPos = 0;
 
+    const bool screen_reader_mode = get_option<bool>( "SCREEN_READER_MODE" );
+
     ui_adaptor ui;
     catacurses::window w;
     catacurses::window w_details_pane;
@@ -2297,11 +2303,6 @@ void set_profession( tab_manager &tabs, avatar &u, pool_type pool )
 
         const bool cur_id_is_valid = cur_id >= 0 && static_cast<size_t>( cur_id ) < sorted_profs.size();
         if( cur_id_is_valid ) {
-            if( details_recalc ) {
-                details.set_text( assemble_profession_details( u, ctxt, sorted_profs, cur_id ) );
-                details_recalc = false;
-            }
-
             int netPointCost = sorted_profs[cur_id]->point_cost() - u.prof->point_cost();
             ret_val<void> can_afford = sorted_profs[cur_id]->can_afford( u, skill_points_left( u, pool ) );
             ret_val<void> can_pick = sorted_profs[cur_id]->can_pick();
@@ -2336,6 +2337,7 @@ void set_profession( tab_manager &tabs, avatar &u, pool_type pool )
         //Draw options
         calcStartPos( iStartPos, cur_id, iContentHeight, profs_length );
         const int end_pos = iStartPos + std::min( iContentHeight, profs_length );
+        std::string cur_prof_notes = "";
         for( int i = iStartPos; i < end_pos; i++ ) {
             nc_color col;
             if( u.prof != &sorted_profs[i].obj() ) {
@@ -2343,22 +2345,37 @@ void set_profession( tab_manager &tabs, avatar &u, pool_type pool )
                 if( cur_id_is_valid && sorted_profs[i] == sorted_profs[cur_id] &&
                     !sorted_profs[i]->can_pick().success() ) {
                     col = h_dark_gray;
+                    if( i == cur_id ) {
+                        cur_prof_notes = _( "unavailable" );
+                    }
                 } else if( cur_id_is_valid && sorted_profs[i] != sorted_profs[cur_id] &&
                            !sorted_profs[i]->can_pick().success() ) {
                     col = c_dark_gray;
+                    if( i == cur_id ) {
+                        cur_prof_notes = _( "unavailable" );
+                    }
                 } else {
                     col = ( cur_id_is_valid && sorted_profs[i] == sorted_profs[cur_id] ? COL_SELECT : c_light_gray );
                 }
             } else {
                 col = ( cur_id_is_valid &&
                         sorted_profs[i] == sorted_profs[cur_id] ? hilite( c_light_green ) : COL_SKILL_USED );
+                if( i == cur_id ) {
+                    cur_prof_notes = _( "active" );
+                }
             }
-            const point opt_pos( 2, iHeaderHeight + i - iStartPos );
-            if( i == cur_id ) {
-                ui.set_cursor( w, opt_pos );
+            if( screen_reader_mode ) {
+                // This list only clutters up the screen in screen reader mode
+            } else {
+                const point opt_pos( 2, iHeaderHeight + i - iStartPos );
+                mvwprintz( w, opt_pos, col,
+                           sorted_profs[i]->gender_appropriate_name( u.male ) );
             }
-            mvwprintz( w, opt_pos, col,
-                       sorted_profs[i]->gender_appropriate_name( u.male ) );
+        }
+
+        if( details_recalc && cur_id_is_valid ) {
+            details.set_text( assemble_profession_details( u, ctxt, sorted_profs, cur_id, cur_prof_notes ) );
+            details_recalc = false;
         }
 
         list_sb.offset_x( 0 )
@@ -2369,6 +2386,7 @@ void set_profession( tab_manager &tabs, avatar &u, pool_type pool )
         .apply( w );
 
         wnoutrefresh( w );
+        ui.set_cursor( w_details_pane, point_zero );
         details.draw( c_light_gray );
     } );
 
@@ -2410,6 +2428,9 @@ void set_profession( tab_manager &tabs, avatar &u, pool_type pool )
                 popup( can_pick.str() );
                 continue;
             }
+
+            // Selecting a profession will, under certain circumstances, change the detail text
+            details_recalc = true;
 
             // Remove traits from the previous profession
             for( const trait_and_var &old : u.prof->get_locked_traits() ) {

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -2738,7 +2738,7 @@ void set_hobbies( tab_manager &tabs, avatar &u, pool_type pool )
         //Draw options
         calcStartPos( iStartPos, cur_id, iContentHeight, hobbies_length );
         const int end_pos = iStartPos + std::min( iContentHeight, hobbies_length );
-        std::string cur_hob_notes = "";
+        std::string cur_hob_notes;
         for( int i = iStartPos; i < end_pos; i++ ) {
             nc_color col;
             if( u.hobbies.count( &sorted_hobbies[i].obj() ) != 0 ) {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1951,6 +1951,12 @@ void options_manager::add_options_interface()
              to_translation( "If true, highlight unread recipes to allow tracking of newly learned recipes." ),
              true
            );
+
+        add( "SCREEN_READER_MODE", page_id, to_translation( "Screen reader mode" ),
+             to_translation( "On supported UI screens, tweaks display of text to optimize for screen readers.  Targeted towards using the open-source screen reader 'orca' using curses for display." ),
+             // See doc/USER_INTERFACE_AND_ACCESSIBILITY.md for testing and implementation notes
+             false
+           );
     } );
 
     add_empty_line();

--- a/src/player_difficulty.cpp
+++ b/src/player_difficulty.cpp
@@ -379,11 +379,22 @@ std::string player_difficulty::difficulty_to_string( const avatar &u ) const
     std::string combat = get_combat_difficulty( n );
     std::string defense = get_defense_difficulty( n );
 
-    return string_format( "%s |  %s: %s  %s: %s  %s: %s  %s: %s  %s: %s",
-                          _( "Summary" ),
-                          _( "Lifestyle" ), genetics,
-                          _( "Knowledge" ), expertise,
-                          _( "Offense" ), combat,
-                          _( "Defense" ), defense,
-                          _( "Social" ), socials );
+    if( get_option<bool>( "SCREEN_READER_MODE" ) ) {
+        // Put value before label to ensure the screen reader reads the label when the value changes
+        return string_format( "%s |  %s %s,  %s %s,  %s %s,  %s %s,  %s %s",
+                              _( "Summary" ),
+                              genetics, _( "Lifestyle" ),
+                              expertise, _( "Knowledge" ),
+                              combat, _( "Offense" ),
+                              defense, _( "Defense" ),
+                              socials, _( "Social" ) );
+    } else {
+        return string_format( "%s |  %s: %s  %s: %s  %s: %s  %s: %s  %s: %s",
+                              _( "Summary" ),
+                              _( "Lifestyle" ), genetics,
+                              _( "Knowledge" ), expertise,
+                              _( "Offense" ), combat,
+                              _( "Defense" ), defense,
+                              _( "Social" ), socials );
+    }
 }

--- a/src/player_difficulty.cpp
+++ b/src/player_difficulty.cpp
@@ -381,7 +381,7 @@ std::string player_difficulty::difficulty_to_string( const avatar &u ) const
 
     if( get_option<bool>( "SCREEN_READER_MODE" ) ) {
         // Put value before label to ensure the screen reader reads the label when the value changes
-        return string_format( "%s |  %s %s,  %s %s,  %s %s,  %s %s,  %s %s",
+        return string_format( "%s | %s %s, %s %s, %s %s, %s %s, %s %s",
                               _( "Summary" ),
                               genetics, _( "Lifestyle" ),
                               expertise, _( "Knowledge" ),


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing another guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Add a screen reader mode option and implement on character creation screens"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Screen readers are officially supported in Cataclysm, but even when the recommendations from [the documentation](https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/USER_INTERFACE_AND_ACCESSIBILITY.md#compatibility-with-screen-readers) have been followed, certain UI screens are extremely difficult to navigate when using a screen reader.  Making the learning curve even steeper is the fact that the character creation screens are among the hardest to use.
Goes a fair way to fixing #65577

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
1. Expand the documentation for how screen readers behave.  Given that they will a) try to detect new text, and b) are not necessarily capable of identifying the borders used in our UI screens, there are many circumstances where setting the terminal cursor position is not sufficient.
2. Add an option under accessibility settings to identify that the player is using a screen reader
3. Modify the display of the character creation screens (everything except the Description pane, which would be a fair bit more complicated) to optimize display for screen readers when SCREEN_READER_MODE is active.

Recommendations are detailed in the updated documentation/the TESTING section below, but generally speaking:
1. If information is _only_ conveyed via text colour, add an explicit text note
2. Move information from headers/lists to the big pane of text
3. Try to avoid displaying/changing text that would disrupt getting to the information the player needs
4. If text hasn't changed, but you want to make sure the screen reader reads it anyway, inserting a space before the text tricks the screen reader into thinking its new (Watch some of the trait names in the testing section below).

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
The first priority with this was ensuring that all necessary information is conveyed to players using screen readers.
After that, it's a matter of minimizing how annoying it is to get that information while also minimizing the amount of additional code.  
Maintaining a completely separate draw stack for SCREEN_READER_MODE is unfeasible, so I made no attempt to resize/move windows.  
Also, I wanted to avoid having screen reader-specific controls, so, I did not, for instance, add the ability to tab between the list of options and the details of the selected option.
I've tried to keep the changes to ~2 if statements per UI screen with notes about _why_ this text needs to be moved/hidden in SCREEN_READER_MODE.

Also, at some point these screens will need to be converted to ImGui.  The general logic for optimizing for a screen reader should remain the same.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
In theory, this PR only results in changes when SCREEN_READER_MODE is active.  I spent a bit of time navigating with it off, and did not spot any changes. 

**Points screen**
Before:
https://github.com/CleverRaven/Cataclysm-DDA/assets/89038572/1851cb71-2579-458f-8a22-b8be73581e4a
Issues include:
- There is no indication as to what option is currently active
- The list of options is interwoven with the description of the currently-selected option
- Text common between the options doesn't get read when scrolling

After:
https://github.com/CleverRaven/Cataclysm-DDA/assets/89038572/597aa677-cf17-4c54-8fdb-4cc5276096aa
Remaining issues include:
 - Upon confirming a selection, the screen reader doesn't automatically note that the option is now active

**Scenario screen**
Before:
https://gist.github.com/assets/89038572/6f78052d-6765-4b3b-8b1a-0579b0a3ea42
Issues include:
- There is no indication as to what scenario is currently active
- The list of options is interwoven with the description of the currently-selected option
- Text common between the options doesn't get read when scrolling

After:
https://gist.github.com/assets/89038572/3a03a33d-3479-4f72-9b3f-a335074026fc
Remaining issues include:
 - The "player difficulty" summary in the header will read out first if confirming a selection changes things
 - There's a whole lot of keybinding hint repetition before you get to the meat of the scenario changes

**Profession screen**
Before:
https://gist.github.com/assets/89038572/c800748d-fada-43bb-9050-558e30eb2a32
Issues include:
- There is no indication as to what profession is currently active
- The list of options is interwoven with the description of the currently-selected option
- Text common between the options doesn't get read when scrolling

After:
https://gist.github.com/assets/89038572/2218b99f-cf16-4ab7-8979-fece672b9053

**Background screen**
Before:
https://gist.github.com/assets/89038572/0b652dec-e08b-4837-b65d-58e1a8430e20
Issues include:
- There is no indication as to what backgrounds are currently active
- The list of options is interwoven with the description of the currently-selected option
- Text common between the options doesn't get read when scrolling

After:
https://gist.github.com/assets/89038572/66b8969f-6a98-4b2e-be25-2e9ab24d6da7

**Stats screen**
Before:
https://gist.github.com/assets/89038572/8fe5e04d-33aa-4e48-a0d1-04238d692521
Issues include:
- The list of stats is interwoven with the description of the currently-selected stat
- You can only infer which stat is currently selected

After:
https://gist.github.com/assets/89038572/a12c93a4-0bbd-4465-87c1-e5d81655243f

**Traits screen**
Before:
https://gist.github.com/assets/89038572/c03c7bc3-0983-439f-b411-93070435f3d3
Issues include:
- When the list of traits scrolls, it starts reading the list rather than the description
- There's no indication what traits are currently active or unavailable
 
After:
https://gist.github.com/assets/89038572/582c1d74-0d60-4b68-83ff-b4246cfc1a18
Remaining issues include:
 - If activating a trait causes the 'difficulty' summary to change, it reads that first.  Then it reads the scrollbars.

**Skills screen**
Before:
https://gist.github.com/assets/89038572/811fe236-5fd3-454c-98f1-d98563b24e16
Issues include:
- You have to wait for it to reach the skill in the list before learning what your current skill level is
- The list of options is interwoven with the description of the currently-selected option
- Text common between the skills doesn't get read when scrolling

After:
https://gist.github.com/assets/89038572/b367554e-10de-4068-a427-9f645d5b7016
Remaining issues include:
- Text common between the skills doesn't get read when scrolling
- The "player difficulty" summary in the header will read out first if confirming a selection changes things
- The list of crafting recipes takes a very long time to read

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
These changes were made working with Orca ([v45.2](https://archlinux.org/packages/extra/any/orca/)), as that's the most readily-available screen reader for use with Cataclysm on Linux.  I _believe_ the changes and the examples included in the documentation will also be beneficial to anyone using a different screen reader, but I am unable to test that.

If I understand my settings correctly, the voice used in the test recordings is the default voice from the [festival](https://archlinux.org/packages/extra/x86_64/festival/) package of voices.

I'm not sure if doc/USER_INTERFACE_AND_ACCESSIBILITY was the best location for my various diagrams and examples about how Orca reads the game UIs, but I wanted to get those down _somewhere_.

Thanks to @DoctorBoomstick for assistance in navigating Orca and some playtesting.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
