### PR TITLE
Sky islands - all roads lead to u_prevent_death

### DIFF
--- a/data/mods/Sky_Island/EOCs.json
+++ b/data/mods/Sky_Island/EOCs.json
@@ -269,6 +269,7 @@
     "eoc_type": "PREVENT_DEATH",
     "condition": { "u_has_item": "warphome" },
     "effect": [
+      "u_prevent_death",
       { "run_eocs": [ "EOC_homewardmote", "EOC_healall" ] },
       {
         "u_message": "Moments before your last breath leaves your body, the mote of warp essence on you jolts with a brilliant energy.  Its thin filament immediately snaps tight, reeling you home faster than you can process what it was that just saved your life.  The mote is spent, but you arrive home alive and well.",
@@ -283,6 +284,7 @@
     "//": "The player's death is now confirmed and not protected.  The true effect is when you die on the island, and the false effect is when you die out in the world.  Both make you incorporeal, which saves you from damage but also makes you drop all items behind, then heal you slightly to prevent death.",
     "condition": { "not": { "u_has_trait": "awayfromhome" } },
     "effect": [
+      "u_prevent_death",
       { "u_add_effect": "downed", "duration": 1 },
       { "u_add_effect": "incorporeal", "duration": 500 },
       { "run_eocs": [ "EOC_death_heal" ] },
@@ -292,6 +294,7 @@
       }
     ],
     "false_effect": [
+      "u_prevent_death",
       { "u_add_effect": "incorporeal", "duration": 1 },
       { "u_add_effect": "downed", "duration": 1 },
       { "run_eocs": [ "EOC_death_heal" ] },


### PR DESCRIPTION
#### Summary
Bugfixes "Can't die for real in sky islands (for real this time)"

#### Purpose of change
You are explicitly not supposed to die in sky islands

* Closes #72301

#### Describe the solution
So it turns out that eoc_type PREVENT_DEATH does not uh, actually prevent you from dying. It is merely a strong encouragement, and one of the last chances to trigger EOCs.

Actually tell the EOCs to stop you from dying. In all possible execution paths.

#### Describe alternatives you've considered
Hardcoding a game option for whether or not you can die would avoid this whole scripting mess, might even be preferable tbh.

#### Testing
I "died". A lot. But never truly dead! So it's hard to prove but I'm pretty sure it's working. Breakpoints were hit in character::prevent_death(), which otherwise wasn't called.

#### Additional context
The fact the eoc_type and actual effect are desynced is kind of wild, but 🤷 