### PR TITLE
fix clang tidy fails

### DIFF
--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -4948,7 +4948,7 @@ void Item_factory::add_entry( Item_group &ig, const JsonObject &obj, const std::
     if( obj.has_array( "components" ) ) {
         JsonArray ja = obj.get_array( "components" );
         std::vector<itype_id> made_of;
-        for( auto sub : ja ) {
+        for( JsonValue sub : ja ) {
             itype_id component = itype_id( sub );
             made_of.emplace_back( component );
         }


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
#72327 accidentally broke clang tidy test, and now it fails on every PR
#### Describe the solution
Apply clang suggestion
#### Additional context
```
Error: /home/runner/work/Cataclysm-DDA/Cataclysm-DDA/src/item_factory.cpp:4951:14: error: Avoid auto in declaration of 'sub'. [cata-almost-never-auto,-warnings-as-errors]
 4951 |         for( auto sub : ja ) {
      |              ^~~~
      |              JsonValue
```