### PR TITLE
PR template: remove `don't delete HTML comments`; add Summary examples; grammar

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,13 @@
 <!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
 Leave the headings unless they don't apply to your PR.
 
-Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
+Please read carefully.
 Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
-The results of these can be either seen under the "Files changed" section of a PR or in the check's details.
+The results can be either seen under the "Files changed" section of a PR or in the check's details.
 
 Rules for suggested pull requests:
 - If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
-- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing another guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - may be a quote from a person who was affected by scope creep
+- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
 - Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool
 
 NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->
@@ -18,6 +18,12 @@ Category "Brief description"
 1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
 2. Replace the text inside the quotes with a brief description of your changes.
 Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
+Examples:
+1. None
+2. Features "In-game Armor sprite change"
+3. Interface "Show crafting failure chances in the crafting interface"
+4. Infrastructure "JSON-ize slot machines"
+5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
 For more on the meaning of each category, see:
 https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
 If approved and merged, your summary will be added to the project changelog:
@@ -41,7 +47,7 @@ If there is no related issue, explain here what issue, feature, or other concern
 
 #### Testing
 
-<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
+<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
 
 #### Additional context
 
@@ -49,6 +55,6 @@ If there is no related issue, explain here what issue, feature, or other concern
 
 
 <!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
-The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
-By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
+The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
+By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
 See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
I thought the tests on a PR would fail if the HTML comments were deleted.

from Discord @GuardianDll 
> it says this so first time contributors won't remove it without reading

I don't believe this will start happening now.

#### Describe the solution
Remove the sentence that led me to believe that.
Also, fix some grammar reported by Gramarly, so that the template isn't red for me.

#### Describe alternatives you've considered
N/A

#### Testing
I see that I am writing this PR with the new template!

I am assuming the PR tester will not throw any errors as I have removed HTML comments in this PR.

#### Additional context
N/A