### PR TITLE
sort large PRs

### DIFF
--- a/.github/workflows/size-check.yml
+++ b/.github/workflows/size-check.yml
@@ -1,0 +1,44 @@
+name: Sort large PRs
+
+on:
+  pull_request_target:
+    branches:
+      - master
+    # TODO: make this work on synchronize, be smart about don't spam with
+    # warning message each push
+    types: [opened]
+    paths:
+      - 'data/**.json'
+      - '**.cpp'
+      - '**.h'
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  PR_NUMBER: ${{ github.event.pull_request.number }}
+
+jobs:
+  changed_files:
+    runs-on: ubuntu-latest
+    name: Warn and label
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: calculate changes
+        id: lines_changed
+        run: |
+          git remote add upstream https://github.com/CleverRaven/Cataclysm-DDA.git
+          git fetch --no-tags --prune --depth=1 upstream master
+
+          json_changed=$(git diff --numstat upstream/master..HEAD -- 'data/*.json' | awk '{sum+=$1+$2} END{print sum}')
+          echo "Debug: lines of data/*.json added or deleted: $json_changed"
+
+          cpp_changed=$(git diff --numstat upstream/master..HEAD -- '*.cpp' '*.h' | awk '{sum+=$1+$2} END{print sum}')
+          echo "Debug: lines of *.cpp and *.h added or deleted: $cpp_changed"
+
+          echo "json_changed=$json_changed" >> $GITHUB_OUTPUT
+          echo "cpp_changed=$cpp_changed" >> $GITHUB_OUTPUT
+
+      - if: ${{ steps.lines_changed.outputs.json_changed > 1000 || steps.lines_changed.outputs.cpp_changed > 300 }}
+        run: |
+          gh pr comment "$PR_NUMBER" --body "This is a large PR! Merging has been blocked until one of the project leads can take a look and approve it. That doesn't mean your PR is not wanted or that you've done anything wrong, this is a safety feature."
+          gh pr edit "$PR_NUMBER" --add-label "needs review"


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing another guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
this was a feature request on a comment on the recent upcoming review guide, based on one of the checklist items for PRs: try to avoid large PRs >300 loc of cpp source files and header files >1000 loc of json

* use git diff to get the amount of changes in a PR, note this is deletions + additions

* label pr that pass the loc limit with a label `needs review` and leave a comment courtesy of Erk
https://discord.com/channels/598523535169945603/598535827169083403/1217569735571537961

this is a draft because I want feedback on these two things, like yes/no to labeling of just comment on the PR
by the way it does not block anything, it says "Merging has been blocked" but it's just a bluff

one limitation this has is that it won't warn if the PR gets larger over time because that's a little more complicated, and I fear it would take quite some time to figure out

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
https://github.com/casswedson/Cataclysm-DDA/actions/runs/8288186147/job/22682229734?pr=144 running on https://github.com/casswedson/Cataclysm-DDA/pull/144
logic is good https://github.com/casswedson/Cataclysm-DDA/actions/runs/8288186147/job/22682229734?pr=144#step:3:1
github is being github again, and I can't quite test the labeling step cause it's not letting me access resources for whatever reason https://github.com/casswedson/Cataclysm-DDA/actions/runs/8288186147/job/22682229734?pr=144#step:4:1 other than that this baby is good to go

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
