### PR TITLE
Magiclysm - Added a deep storage freezer for a single body

### DIFF
--- a/data/mods/Magiclysm/itemgroups/itemgroups.json
+++ b/data/mods/Magiclysm/itemgroups/itemgroups.json
@@ -642,6 +642,7 @@
       { "item": "mspider_box", "prob": 100, "charges-min": 3, "charges-max": 24 },
       { "item": "cauldron_demon_chitin", "prob": 20 },
       { "item": "fridge_holding_1", "prob": 12 },
+      { "item": "fridge_holding_2", "prob": 2 },
       { "item": "bag_holding_1", "prob": 8 },
       { "item": "bag_holding_2", "prob": 1 },
       { "item": "cauldron_orichalcum", "prob": 100 },

--- a/data/mods/Magiclysm/items/containers.json
+++ b/data/mods/Magiclysm/items/containers.json
@@ -121,7 +121,7 @@
         "max_contains_volume": "1000 L",
         "max_contains_weight": "4850 kg",
         "max_item_length": "999 meter",
-        "spoil_multiplier": 0.01,
+        "spoil_multiplier": 0.05,
         "weight_multiplier": 5.0,
         "rigid": true
       }

--- a/data/mods/Magiclysm/items/containers.json
+++ b/data/mods/Magiclysm/items/containers.json
@@ -100,5 +100,31 @@
         "rigid": true
       }
     ]
+  },
+  {
+    "type": "GENERIC",
+    "id": "fridge_holding_2",
+    "category": "container",
+    "name": { "str": "hypergravity preservation box", "str_pl": "hypergravity preservation boxes" },
+    "description": "A box that takes gravity magic as a tool of preservation as far as it can go.  It makes the box even heavier, and more capacious, but you can only store a single item inside in nigh-perfect stasis.",
+    "weight": "160 kg",
+    "symbol": "E",
+    "color": "light_red",
+    "volume": "500 L",
+    "price": "8000 USD",
+    "flags": [ "TARDIS" ],
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "holster": true,
+        "moves": 6000,
+        "max_contains_volume": "1000 L",
+        "max_contains_weight": "4850 kg",
+        "max_item_length": "999 meter",
+        "spoil_multiplier": 0.01,
+        "weight_multiplier": 5.0,
+        "rigid": true
+      }
+    ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Added deep storage option for a single corpse"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

There's a few larger beasts out there that are nigh-impossible to butcher where you kill them. Your current choice is to quarter them or otherwise lose parts of the corpse in the name of portability. This provides a heavy, expensive, and bulky alternative, if you want all of your inconvenience up front in the form of hauling an expensive and awkward item out into the middle of nowhere to be ready for your hunt.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

This adds an even more awkward second tier of the magical gravity freezer. It's $8000 from the trader if he deigns to carry it, is 500L in size, 160kg empty, multiplies the weight of anything inside it by 5x, and can only carry a single item. With an adult dragon corpse inside, it weighs more than 10,000 kg. The only benefits are that it has enough internal capacity to hold an adult dragon corpse, and provides a .05 multiplier to decay, allowing a corpse to stay fresh inside for over a year. When not in use as a dragon storage device, it's also helpful for other large corpses you might want to break down at your base such as owlbear or moose, assuming you have a vehicle that has cargo capacity and can handle the weight.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Not doing it, but I like the idea of having more options for corpse management.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Spawned a dragon, killed a dragon, spawned the freezer, popped the body inside. Jumped a year into the future and saw that the body was still fresh. Jumped another year into the future and saw that the body was rotten, but not yet gone.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
