### PR TITLE
Magiclysm - single use 24 hour corpse wrapper

### DIFF
--- a/data/mods/Magiclysm/itemgroups/itemgroups.json
+++ b/data/mods/Magiclysm/itemgroups/itemgroups.json
@@ -1538,7 +1538,7 @@
         { "group": "potions_uncommon", "prob": 6 },
         { "group": "potions_rare", "prob": 3 },
         { "group": "potions_illegal", "prob": 1 },
-        { "item": "wrapped_corpse_holding_1", "prob": 2 , "count-min": 1, "count-max": 5}
+        { "item": "wrapped_corpse_holding_1", "prob": 2, "count-min": 1, "count-max": 5 }
       ]
     }
   },

--- a/data/mods/Magiclysm/itemgroups/itemgroups.json
+++ b/data/mods/Magiclysm/itemgroups/itemgroups.json
@@ -1261,7 +1261,7 @@
       {
         "distribution": [
           { "item": "golemcore", "prob": 20 },
-          { "item": "wrapped_corpse_holding_1", "prob": 2 , "count-min": 1, "count-max": 5},
+          { "item": "wrapped_corpse_holding_1", "prob": 2, "count-min": 1, "count-max": 5 },
           { "item": "animist_doll_skeleton", "prob": 10 },
           { "item": "animist_doll_zombie", "prob": 20 },
           { "item": "animist_doll_decayed_pouncer", "prob": 3 }

--- a/data/mods/Magiclysm/itemgroups/itemgroups.json
+++ b/data/mods/Magiclysm/itemgroups/itemgroups.json
@@ -1537,7 +1537,7 @@
         { "group": "potions_common", "prob": 12 },
         { "group": "potions_uncommon", "prob": 6 },
         { "group": "potions_rare", "prob": 3 },
-        { "group": "potions_illegal", "prob": 1 }
+        { "group": "potions_illegal", "prob": 1 },
         { "item": "wrapped_corpse_holding_1", "prob": 2 , "count-min": 1, "count-max": 5},
       ]
     }

--- a/data/mods/Magiclysm/itemgroups/itemgroups.json
+++ b/data/mods/Magiclysm/itemgroups/itemgroups.json
@@ -1538,7 +1538,7 @@
         { "group": "potions_uncommon", "prob": 6 },
         { "group": "potions_rare", "prob": 3 },
         { "group": "potions_illegal", "prob": 1 },
-        { "item": "wrapped_corpse_holding_1", "prob": 2 , "count-min": 1, "count-max": 5},
+        { "item": "wrapped_corpse_holding_1", "prob": 2 , "count-min": 1, "count-max": 5}
       ]
     }
   },

--- a/data/mods/Magiclysm/itemgroups/itemgroups.json
+++ b/data/mods/Magiclysm/itemgroups/itemgroups.json
@@ -643,7 +643,7 @@
       { "item": "mspider_box", "prob": 100, "charges-min": 3, "charges-max": 24 },
       { "item": "cauldron_demon_chitin", "prob": 20 },
       { "item": "fridge_holding_1", "prob": 12 },
-      { "item": "wrapped_corpse_holding_1", "prob": 50 , "count-min": 1, "count-max": 2},
+      { "item": "wrapped_corpse_holding_1", "prob": 50, "count-min": 1, "count-max": 2 },
       { "item": "bag_holding_1", "prob": 8 },
       { "item": "bag_holding_2", "prob": 1 },
       { "item": "cauldron_orichalcum", "prob": 100 },

--- a/data/mods/Magiclysm/itemgroups/itemgroups.json
+++ b/data/mods/Magiclysm/itemgroups/itemgroups.json
@@ -465,7 +465,8 @@
       },
       { "item": "bone_human", "prob": 60, "count-min": 1, "count-max": 5 },
       { "item": "denarius", "prob": 40, "count-min": 2, "count-max": 5 },
-      [ "cauldron_orichalcum", 10 ],
+      { "item": "cauldron_orichalcum", "prob": 10 },
+      { "item": "wrapped_corpse_holding_1", "prob": 2, "count-min": 1, "count-max": 2},
       { "group": "tools_toolbox", "prob": 20 },
       { "group": "magic_plants_common", "prob": 40, "count-min": 1, "count-max": 14 },
       { "group": "magic_plants_uncommon", "prob": 20, "count-min": 1, "count-max": 8 },
@@ -642,6 +643,7 @@
       { "item": "mspider_box", "prob": 100, "charges-min": 3, "charges-max": 24 },
       { "item": "cauldron_demon_chitin", "prob": 20 },
       { "item": "fridge_holding_1", "prob": 12 },
+      { "item": "wrapped_corpse_holding_1", "prob": 50 , "count-min": 1, "count-max": 2},
       { "item": "bag_holding_1", "prob": 8 },
       { "item": "bag_holding_2", "prob": 1 },
       { "item": "cauldron_orichalcum", "prob": 100 },
@@ -1259,6 +1261,7 @@
       {
         "distribution": [
           { "item": "golemcore", "prob": 20 },
+          { "item": "wrapped_corpse_holding_1", "prob": 2 , "count-min": 1, "count-max": 5},
           { "item": "animist_doll_skeleton", "prob": 10 },
           { "item": "animist_doll_zombie", "prob": 20 },
           { "item": "animist_doll_decayed_pouncer", "prob": 3 }
@@ -1535,6 +1538,7 @@
         { "group": "potions_uncommon", "prob": 6 },
         { "group": "potions_rare", "prob": 3 },
         { "group": "potions_illegal", "prob": 1 }
+        { "item": "wrapped_corpse_holding_1", "prob": 2 , "count-min": 1, "count-max": 5},
       ]
     }
   },

--- a/data/mods/Magiclysm/itemgroups/itemgroups.json
+++ b/data/mods/Magiclysm/itemgroups/itemgroups.json
@@ -466,7 +466,7 @@
       { "item": "bone_human", "prob": 60, "count-min": 1, "count-max": 5 },
       { "item": "denarius", "prob": 40, "count-min": 2, "count-max": 5 },
       { "item": "cauldron_orichalcum", "prob": 10 },
-      { "item": "wrapped_corpse_holding_1", "prob": 2, "count-min": 1, "count-max": 2},
+      { "item": "wrapped_corpse_holding_1", "prob": 2, "count-min": 1, "count-max": 2 },
       { "group": "tools_toolbox", "prob": 20 },
       { "group": "magic_plants_common", "prob": 40, "count-min": 1, "count-max": 14 },
       { "group": "magic_plants_uncommon", "prob": 20, "count-min": 1, "count-max": 8 },

--- a/data/mods/Magiclysm/items/containers.json
+++ b/data/mods/Magiclysm/items/containers.json
@@ -95,24 +95,7 @@
       "type": "transform"
     }
   },
-  "description": "'Lucky Joe's Gentle Repose' single-use corpse wrappers. For when you want your body to be at its freshest! 24 hour guarantee!",
-  "weight": "25 g",
-  "volume": "25 ml",
-  "price_postapoc": "400 USD",
-  "material": [
-    "plastic"
-  ],
-  "symbol": ",",
-  "color": "pink",
-  "use_action": {
-    "target": "corpse_holding_1",
-    "target_timer": "86400 seconds",
-    "msg": "Upon opening the packet, the wrapper immediately starts to degrade. It should preserve a corpse for 24 hours, no more.",
-    "menu_text": "Unwrap wrapper",
-    "type": "transform"
-  }
-},
-    {
+  {
     "type": "GENERIC",
     "copy-from": "condom",
     "id": "corpse_holding_1",

--- a/data/mods/Magiclysm/items/containers.json
+++ b/data/mods/Magiclysm/items/containers.json
@@ -76,11 +76,24 @@
       }
     ]
   },
-    {
-  "id": "wrapped_corpse_holding_1",
-  "type": "TOOL",
-  "name": {
-    "str": "wrapped corpse wrapper"
+  {
+    "id": "wrapped_corpse_holding_1",
+    "type": "TOOL",
+    "name": { "str": "wrapped corpse wrapper" },
+    "description": "'Lucky Joe's Gentle Repose' single-use corpse wrappers. For when you want your body to be at its freshest! 24 hour guarantee!",
+    "weight": "25 g",
+    "volume": "25 ml",
+    "price_postapoc": "400 USD",
+    "material": [ "plastic" ],
+    "symbol": ",",
+    "color": "pink",
+    "use_action": {
+      "target": "corpse_holding_1",
+      "target_timer": "86400 seconds",
+      "msg": "Upon opening the packet, the wrapper immediately starts to degrade. It should preserve a corpse for 24 hours, no more.",
+      "menu_text": "Unwrap wrapper",
+      "type": "transform"
+    }
   },
   "description": "'Lucky Joe's Gentle Repose' single-use corpse wrappers. For when you want your body to be at its freshest! 24 hour guarantee!",
   "weight": "25 g",

--- a/data/mods/Magiclysm/items/containers.json
+++ b/data/mods/Magiclysm/items/containers.json
@@ -76,7 +76,30 @@
       }
     ]
   },
-  {
+    {
+  "id": "wrapped_corpse_holding_1",
+  "type": "TOOL",
+  "name": {
+    "str": "wrapped corpse wrapper"
+  },
+  "description": "'Lucky Joe's Gentle Repose' single-use corpse wrappers. For when you want your body to be at its freshest! 24 hour guarantee!",
+  "weight": "25 g",
+  "volume": "25 ml",
+  "price_postapoc": "400 USD",
+  "material": [
+    "plastic"
+  ],
+  "symbol": ",",
+  "color": "pink",
+  "use_action": {
+    "target": "corpse_holding_1",
+    "target_timer": "86400 seconds",
+    "msg": "Upon opening the packet, the wrapper immediately starts to degrade. It should preserve a corpse for 24 hours, no more.",
+    "menu_text": "Unwrap wrapper",
+    "type": "transform"
+  }
+},
+    {
     "type": "GENERIC",
     "copy-from": "condom",
     "id": "corpse_holding_1",
@@ -84,14 +107,17 @@
     "name": { "str": "corpse wrapper" },
     "description": "'Lucky Joe's Gentle Repose' single-use corpse wrappers. For when you want your body to be at its freshest! 24 hour guarantee!",
     "weight": "5 g",
-    "price": "400 USD",
+    "countdown_action": {
+    "type": "explosion",
+    "explosion": { "power": 0 }
+},
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
         "moves": 4000,
         "holster": true,
         "max_contains_volume": "1000 L",
-        "max_contains_weight": "4000 kg",
+        "max_contains_weight": "4850 kg",
         "max_item_volume": "1000 L",
         "max_item_length": "999 meter",
         "spoil_multiplier": 0.001,

--- a/data/mods/Magiclysm/items/containers.json
+++ b/data/mods/Magiclysm/items/containers.json
@@ -78,6 +78,30 @@
   },
   {
     "type": "GENERIC",
+    "copy-from": "condom",
+    "id": "corpse_holding_1",
+    "category": "container",
+    "name": { "str": "corpse wrapper" },
+    "description": "'Lucky Joe's Gentle Repose' single-use corpse wrappers. For when you want your body to be at its freshest! 24 hour guarantee!",
+    "weight": "5 g",
+    "price": "400 USD",
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "moves": 4000,
+        "holster": true,
+        "max_contains_volume": "1000 L",
+        "max_contains_weight": "4000 kg",
+        "max_item_volume": "1000 L",
+        "max_item_length": "999 meter",
+        "spoil_multiplier": 0.001,
+        "volume_multiplier": 0.40,
+        "rigid": false
+      }
+    ]
+  },
+  {
+    "type": "GENERIC",
     "id": "fridge_holding_1",
     "category": "container",
     "name": { "str": "supergravity preservation box", "str_pl": "supergravity preservation boxes" },

--- a/data/mods/Magiclysm/items/containers.json
+++ b/data/mods/Magiclysm/items/containers.json
@@ -80,7 +80,7 @@
     "id": "wrapped_corpse_holding_1",
     "type": "TOOL",
     "name": { "str": "wrapped corpse wrapper" },
-    "description": "'Lucky Joe's Gentle Repose' single-use corpse wrappers. For when you want your body to be at its freshest! 24 hour guarantee!",
+    "description": "'Lucky Joe's Gentle Repose' single-use corpse wrappers.  For when you want your body to be at its freshest!  24 hour guarantee!",
     "weight": "25 g",
     "volume": "25 ml",
     "price_postapoc": "400 USD",
@@ -90,7 +90,7 @@
     "use_action": {
       "target": "corpse_holding_1",
       "target_timer": "86400 seconds",
-      "msg": "Upon opening the packet, the wrapper immediately starts to degrade. It should preserve a corpse for 24 hours, no more.",
+      "msg": "Upon opening the packet, the wrapper immediately starts to degrade.  It should preserve a corpse for 24 hours, no more.",
       "menu_text": "Unwrap wrapper",
       "type": "transform"
     }
@@ -101,7 +101,7 @@
     "id": "corpse_holding_1",
     "category": "container",
     "name": { "str": "corpse wrapper" },
-    "description": "'Lucky Joe's Gentle Repose' single-use corpse wrappers. For when you want your body to be at its freshest! 24 hour guarantee!",
+    "description": "'Lucky Joe's Gentle Repose' single-use corpse wrappers.  For when you want your body to be at its freshest!  24 hour guarantee!",
     "weight": "5 g",
     "countdown_action": { "type": "explosion", "explosion": { "power": 0 } },
     "pocket_data": [

--- a/data/mods/Magiclysm/items/containers.json
+++ b/data/mods/Magiclysm/items/containers.json
@@ -117,7 +117,7 @@
         "max_item_volume": "1000 L",
         "max_item_length": "999 meter",
         "spoil_multiplier": 0.001,
-        "volume_multiplier": 0.40,
+        "volume_multiplier": 0.4,
         "rigid": false
       }
     ]

--- a/data/mods/Magiclysm/items/containers.json
+++ b/data/mods/Magiclysm/items/containers.json
@@ -103,10 +103,7 @@
     "name": { "str": "corpse wrapper" },
     "description": "'Lucky Joe's Gentle Repose' single-use corpse wrappers. For when you want your body to be at its freshest! 24 hour guarantee!",
     "weight": "5 g",
-    "countdown_action": {
-    "type": "explosion",
-    "explosion": { "power": 0 }
-},
+    "countdown_action": { "type": "explosion", "explosion": { "power": 0 } },
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods  "Adds a consumable Magiclysm item to temporarily preserve a corpse"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Per the discussion regarding the deep freezer chest magical item, the need for corpse preservation & transport was recognized, but the form and format of the proposed solution wasn't in line with the general vision for new item creation. This is an expansion of the idea proposed by @I-am-Erk, to shift to a cheaper temporary consumable option. This corpse wrapper will delay decay for 24 hours after being taken out of its own wrapper, as well as applying a 40% reduction in size to enable the transport of large corpses in vehicles. It does not modify weight in any way. I put it in the general container item group, as well as the ones for general wizard and animist tools. Testing it on a revivable zombie corpse, it seems that the revival clock is one of the things delayed by the magic of the device, as all surrounding zombies killed at the same time revived while the one contained in the wrapper popped back out after 24 hours when the wrapper dissolved, and then revived only after no longer being contained.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
The wrapped corpse wrapper can be bought or found, and when unwrapped, gives you a capacious single-item wrapper that halts decay for 24 hours, whereupon it vanishes, dumping out the body.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

A larger, more permanent version that is more akin to a magical chest freezer. Larger vehicle freezers in the main game. Being able to use heat pumps in constructions to make a walk-in freezer.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Spawned the wrapped item, unwrapped it. Inserted an item. Waited 24 hours to see it vanish and dump out the corpse.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
