### PR TITLE
Update COMPILING-MSYS.md to fix #72426

### DIFF
--- a/doc/COMPILING/COMPILING-MSYS.md
+++ b/doc/COMPILING/COMPILING-MSYS.md
@@ -80,7 +80,7 @@ git clone https://github.com/CleverRaven/Cataclysm-DDA.git ./Cataclysm-DDA
 
 ```bash
 cd Cataclysm-DDA
-make -j$((`nproc`+0)) CCACHE=1 RELEASE=1 MSYS2=1 DYNAMIC_LINKING=1 SDL=1 TILES=1 SOUND=1 LOCALIZE=1 LANGUAGES=all LINTJSON=0 ASTYLE=0 TESTS=0
+PATH="/ucrt64/bin:$PATH" make -j$((`nproc`+0)) CCACHE=1 RELEASE=1 MSYS2=1 DYNAMIC_LINKING=1 SDL=1 TILES=1 SOUND=1 LOCALIZE=1 LANGUAGES=all LINTJSON=0 ASTYLE=0 TESTS=0
 ```
 
 You will receive warnings about unterminated character constants; they do not impact the compilation as far as this writer is aware.


### PR DESCRIPTION
Small change i had to do in order to follow the howto. 

Essentially the g++ is not found otherwise