### PR TITLE
No crafting while driving

### DIFF
--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -140,6 +140,14 @@ static bool crafting_allowed( const Character &p, const recipe &rec )
         return false;
     }
 
+    if( p.is_driving() ) {
+        // One day, NPCs may be able to drive.
+        p.add_msg_player_or_npc( m_info,
+                                 _( "You can't craft while driving!" ),
+                                 _( "<npcname> refuses to violate road safety guidelines by crafting while driving!" ) );
+        return false;
+    }
+
     if( rec.category == "CC_BUILDING" ) {
         add_msg( m_info, _( "Overmap terrain building recipes are not implemented yet!" ) );
         return false;


### PR DESCRIPTION
#### Summary
Bugfixes "Can't craft while driving"

#### Purpose of change
You could craft while driving. Someone brought this up as an exploit.

#### Describe the solution
Nix it

#### Describe alternatives you've considered
We could do some sort of calculation of which limb(s) are being used (e.g. you only need your arms to row) and down-rate your manipulation score accordingly. This would allow extremely simple recipes like watching tea boil to be carried out while driving... although you still wouldn't be able to *control the vehicle* or *turn*.

But that's a ton of code for an incredibly niche case. This solution is just a reasonable restriction.

#### Testing
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/6a2f3171-114d-4470-a4c3-93f4ab794eb6)


#### Additional context
