### PR TITLE
Various fixes for bypassing NO_UNLOAD/NO_RELOAD

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -172,6 +172,7 @@ static const efftype_id effect_worked_on( "worked_on" );
 static const faction_id faction_your_followers( "your_followers" );
 
 static const flag_id json_flag_ALWAYS_AIMED( "ALWAYS_AIMED" );
+static const flag_id json_flag_NO_RELOAD( "NO_RELOAD" );
 
 static const furn_str_id furn_f_gunsafe_mj( "f_gunsafe_mj" );
 static const furn_str_id furn_f_safe_o( "f_safe_o" );
@@ -4541,6 +4542,10 @@ static ret_val<void> try_insert( item_location &holster, drop_location &holstere
 {
     item &it = *holstered_item.first;
     ret_val<void> ret = ret_val<void>::make_failure( _( "item can't be stored there" ) );
+
+    if( holster.get_item()->has_flag( json_flag_NO_RELOAD ) ) {
+        return ret_val<void>::make_failure( _( "destination can't be reloaded" ) );
+    }
 
     if( charges_added == nullptr ) {
         if( it.is_bucket_nonempty() ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -250,6 +250,7 @@ static const faction_id faction_your_followers( "your_followers" );
 
 static const flag_id json_flag_CONVECTS_TEMPERATURE( "CONVECTS_TEMPERATURE" );
 static const flag_id json_flag_LEVITATION( "LEVITATION" );
+static const flag_id json_flag_NO_RELOAD( "NO_RELOAD" );
 static const flag_id json_flag_SPLINT( "SPLINT" );
 
 static const furn_str_id furn_f_rope_up( "f_rope_up" );
@@ -1981,6 +1982,9 @@ static hint_rating rate_action_insert( const avatar &you, const item_location &l
         && loc.where() != item_location::type::map
         && !you.is_wielding( *loc ) ) {
 
+        return hint_rating::cant;
+    }
+    if( loc.get_item()->has_flag( json_flag_NO_RELOAD ) ) {
         return hint_rating::cant;
     }
     return hint_rating::good;

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -208,7 +208,7 @@ void pocket_favorite_callback::move_item( uilist *menu, item_pocket *selected_po
             // These make sure we exit back to the top level of the menu regardless of how the function was called.
             selector_menu.ret = -1;
             item_to_move = { nullptr, nullptr };
-			refresh_columns( menu );
+            refresh_columns( menu );
         }
 
         if( selector_menu.ret >= 0 ) {
@@ -1201,7 +1201,9 @@ bool item_contents::spill_contents( const tripoint &pos )
 {
     bool spilled = false;
     for( item_pocket &pocket : contents ) {
-        spilled = pocket.spill_contents( pos ) || spilled;
+        if( !pocket.get_pocket_data()->_no_unload ) {
+            spilled = pocket.spill_contents( pos ) || spilled;
+        }
     }
     return spilled;
 }

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -244,7 +244,7 @@ void pocket_favorite_callback::move_item( uilist *menu, item_pocket *selected_po
         ret_val<item_pocket::contain_code> contain = selected_pocket->can_contain( *item_to_move.first );
 
         bool cant_reload = false;
-        std::string reload_fail = "";
+        std::string reload_fail;
         if( selected_pocket->get_pocket_data()->_no_reload ) {
             cant_reload = true;
             reload_fail = _( "destination container can't be reloaded." );

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -203,6 +203,14 @@ void pocket_favorite_callback::move_item( uilist *menu, item_pocket *selected_po
             selector_menu.query();
         }
 
+        if( selected_pocket->get_pocket_data()->_no_unload ) {
+            popup( std::string( _( "Can't unload that." ) ), PF_GET_KEY );
+            // These make sure we exit back to the top level of the menu regardless of how the function was called.
+            selector_menu.ret = -1;
+            item_to_move = { nullptr, nullptr };
+			refresh_columns( menu );
+        }
+
         if( selector_menu.ret >= 0 ) {
             item_to_move = { item_list[selector_menu.ret], selected_pocket };
         }
@@ -234,12 +242,20 @@ void pocket_favorite_callback::move_item( uilist *menu, item_pocket *selected_po
     } else {
         // If no pockets are enabled, uilist allows scrolling through them, so we need to recheck
         ret_val<item_pocket::contain_code> contain = selected_pocket->can_contain( *item_to_move.first );
-        if( contain.success() ) {
+
+        bool cant_reload = false;
+        std::string reload_fail = "";
+        if( selected_pocket->get_pocket_data()->_no_reload ) {
+            cant_reload = true;
+            reload_fail = _( "destination container can't be reloaded." );
+        }
+
+        if( contain.success() && !cant_reload ) {
             // storage should mimick character inserting
             get_avatar().as_character()->store( selected_pocket, *item_to_move.first );
         } else {
             const std::string base_string = _( "Cannot put item in pocket because %s" );
-            popup( string_format( base_string, contain.str() ) );
+            popup( string_format( base_string, cant_reload ? reload_fail : contain.str() ) );
         }
         // reset the moved item
         item_to_move = { nullptr, nullptr };

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -65,6 +65,8 @@ static const ammotype ammo_NULL( "NULL" );
 static const damage_type_id damage_bash( "bash" );
 static const damage_type_id damage_bullet( "bullet" );
 
+static const flag_id json_flag_NO_RELOAD( "NO_RELOAD" );
+static const flag_id json_flag_NO_UNLOAD( "NO_UNLOAD" );
 
 static const gun_mode_id gun_mode_DEFAULT( "DEFAULT" );
 static const gun_mode_id gun_mode_MELEE( "MELEE" );
@@ -776,6 +778,18 @@ void Item_factory::finalize_post( itype &obj )
             } ) ) {
                 obj.repair.insert( tool );
             }
+        }
+    }
+
+    if( obj.has_flag( json_flag_NO_UNLOAD ) ) {
+        for( pocket_data &pocket : obj.pockets ) {
+            pocket._no_unload = true;
+        }
+    }
+
+    if( obj.has_flag( json_flag_NO_RELOAD ) ) {
+        for( pocket_data &pocket : obj.pockets ) {
+            pocket._no_reload = true;
         }
     }
 

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -544,6 +544,10 @@ class pocket_data
         itype_id default_magazine = itype_id::NULL_ID();
         // container's size and encumbrance does not change based on contents.
         bool rigid = false;
+        // Parent item of this pocket has flag NO_UNLOAD
+        bool _no_unload = false; // NOLINT(cata-serialize)
+        // Parent item of this pocket  has flag NO_RELOAD
+        bool _no_reload = false; // NOLINT(cata-serialize)
         // if true, the pocket cannot be used by the player
         bool forbidden = false;
 

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -80,6 +80,8 @@ static const efftype_id effect_poison( "poison" );
 static const efftype_id effect_stunned( "stunned" );
 static const efftype_id effect_teargas( "teargas" );
 
+static const flag_id json_flag_NO_UNLOAD( "NO_UNLOAD" );
+
 static const itype_id itype_rm13_armor_on( "rm13_armor_on" );
 static const itype_id itype_rock( "rock" );
 
@@ -985,11 +987,13 @@ void field_processor_fd_fire( const tripoint &p, field_entry &cur, field_proc_da
 
             if( destroyed ) {
                 // If we decided the item was destroyed by fire, remove it.
-                // But remember its contents, except for irremovable mods, if any
-                const std::list<item *> content_list = fuel->all_items_top();
-                for( item *it : content_list ) {
-                    if( !it->is_irremovable() ) {
-                        new_content.emplace_back( *it );
+                // But remember its contents, except for irremovable stuff, if any
+                if( !fuel->has_flag( json_flag_NO_UNLOAD ) ) {
+                    const std::list<item *> content_list = fuel->all_items_top();
+                    for( item *it : content_list ) {
+                        if( !it->is_irremovable() ) {
+                            new_content.emplace_back( *it );
+                        }
                     }
                 }
                 fuel = items_here.erase( fuel );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
These recent duct tape shenanigans have revealed many exploits for cheating containers.

#### Describe the solution
Fix them.

#### Describe alternatives you've considered
Awful in every way and doesn't work:
https://github.com/CleverRaven/Cataclysm-DDA/compare/master...RenechCDDA:Cataclysm-DDA:no_pocket_bypass

#### Testing
Pocket manager tells you you can't unload that (note: I was not able to figure out reloading with pocket manager, but the code suggests it should be possible so 🤷. Added a check for that to be sure)

Insert warns you can't insert stuff into NO_RELOAD items, both by greying out the option and explicitly failing when you try. (See additional context for a partial remaining issue)

Bashing containers into pieces destroys their contents if their contents can't be spilled

Fires similarly consume contents if the contents can't be unloaded

#### Additional context
Known issues:
You can still cheat insert items by inserting into a parent. When choosing between child pockets via item::fill_with it will choose pockets without respecting NO_RELOAD. I was not able to find a reasonable fix(image) for this that didn't potentially affect many, many other things. So I decided a partial fix was better than nothing.

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/1f388631-8056-4f75-bfe4-0221da5f1051)

