### PR TITLE
Dead NPCs give samples when dissected

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10473,6 +10473,9 @@ void Character::place_corpse()
     for( item *itm : tmp ) {
         body.force_insert_item( *itm, pocket_type::CONTAINER );
     }
+    // One sample, as you would get from dissecting any other human.
+    body.put_in( item( "human_sample" ), pocket_type::CORPSE );
+
     for( const bionic &bio : *my_bionics ) {
         if( item::type_is_defined( bio.info().itype() ) ) {
             item cbm( bio.id.str(), calendar::turn );
@@ -10513,6 +10516,9 @@ void Character::place_corpse( const tripoint_abs_omt &om_target )
     for( item *itm : tmp ) {
         body.force_insert_item( *itm, pocket_type::CONTAINER );
     }
+    // One sample, as you would get from dissecting any other human.
+    body.put_in( item( "human_sample" ), pocket_type::CORPSE );
+
     for( const bionic &bio : *my_bionics ) {
         if( item::type_is_defined( bio.info().itype() ) ) {
             body.put_in( item( bio.id.str(), calendar::turn ), pocket_type::CORPSE );


### PR DESCRIPTION
#### Summary
Balance "Dead NPCs give samples when dissected, like other humans"

#### Purpose of change
Supposedly "human" NPCs didn't have any human samples when you dissected them

#### Describe the solution
Improved ~~cylon~~ NPC disguise, they now come with a sample.

#### Describe alternatives you've considered
I tried to make it draw from the harvest group so that future json changes would be tracked automatically, but that was an absolute mess of code for future-proofing.
https://github.com/CleverRaven/Cataclysm-DDA/compare/master...RenechCDDA:Cataclysm-DDA:NPCs_drop_samples

#### Testing
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/d365c216-a17b-4649-975b-2e69610ec314)

#### Additional context
