### PR TITLE
Typos fixed

### DIFF
--- a/data/json/items/fluff.json
+++ b/data/json/items/fluff.json
@@ -263,8 +263,8 @@
       },
       {
         "id": "jigsaw_20",
-        "name": { "str": "Mount Fiji jigsaw puzzle" },
-        "description": "A jigsaw puzzle cardboard box containing 1000 cardboard pieces that when connected together properly forms the horizontal view of Mount Fiji, at the Japanese island of Honshu.",
+        "name": { "str": "Mount Fuji jigsaw puzzle" },
+        "description": "A jigsaw puzzle cardboard box containing 1000 cardboard pieces that when connected together properly forms the horizontal view of Mount Fuji, at the Japanese island of Honshu.",
         "color": "blue",
         "weight": 20
       },

--- a/data/json/monsters/mutant.json
+++ b/data/json/monsters/mutant.json
@@ -271,7 +271,7 @@
   {
     "id": "mon_mutant_alpha_boss",
     "type": "MONSTER",
-    "name": { "str": "mutant child" },
+    "name": { "str": "mutant child", "str_pl": "mutant children" },
     "description": "A thin child with a shaved head, wearing a too-large white lab coat over a baggy orange jumpsuit.  They turn their head towards you with uncanny speed, and you're taken aback by the inhuman curiosity burning in their eyes.  Their angelic smile does very little to reassure you of their intentions.",
     "copy-from": "mon_mutant_alpha",
     "default_faction": "lab_mutant",

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5693,14 +5693,14 @@ void item::properties_info( std::vector<iteminfo> &info, const iteminfo_query *p
             } );
             if( any_encumb_increase ) {
                 info.emplace_back( "BASE",
-                                   _( "* This items pockets are <info>not rigid</info>.  Its"
+                                   _( "* This item's pockets are <info>not rigid</info>.  Its"
                                       " volume and encumbrance increase with contents." ) );
                 not_rigid = true;
             }
         }
         if( !not_rigid && !all_pockets_rigid() && !is_corpse() ) {
             info.emplace_back( "BASE",
-                               _( "* This items pockets are <info>not rigid</info>.  Its"
+                               _( "* This item's pockets are <info>not rigid</info>.  Its"
                                   " volume increases with contents." ) );
         }
     }

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -429,23 +429,23 @@ TEST_CASE( "item_rigidity", "[iteminfo][rigidity]" )
 
             CHECK( item_info_str( waterskin, rigidity ) ==
                    "--\n"
-                   "* This items pockets are <color_c_cyan>not rigid</color>."
+                   "* This item's pockets are <color_c_cyan>not rigid</color>."
                    "  Its volume and encumbrance increase with contents.\n" );
 
             CHECK( item_info_str( backpack, rigidity ) ==
                    "--\n"
-                   "* This items pockets are <color_c_cyan>not rigid</color>."
+                   "* This item's pockets are <color_c_cyan>not rigid</color>."
                    "  Its volume and encumbrance increase with contents.\n" );
 
             CHECK( item_info_str( quiver, rigidity ) ==
                    "--\n"
-                   "* This items pockets are <color_c_cyan>not rigid</color>."
+                   "* This item's pockets are <color_c_cyan>not rigid</color>."
                    "  Its volume and encumbrance increase with contents.\n" );
 
             // Non-armor item - volume increases, but not encumbrance
             CHECK( item_info_str( condom, rigidity ) ==
                    "--\n"
-                   "* This items pockets are <color_c_cyan>not rigid</color>."
+                   "* This item's pockets are <color_c_cyan>not rigid</color>."
                    "  Its volume increases with contents.\n" );
         }
 


### PR DESCRIPTION
#### Summary
None
Fixes two typos ('Mount Fiji' instead of 'Mount Fuji', 'items' instead of "item's") and an incorrect plural ('mutant childs' instead of 'mutant children'). 

#### Describe the solution

Simple .json edit. This is very minor, so no in-game testing was done.
