### PR TITLE
Truncate generated release notes for experimental releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  REPOSITORY_NAME: ${{ github.event.repository.name }}
 
 jobs:
   release:
@@ -38,11 +39,12 @@ jobs:
         run: |
           echo "tag_name=cdda-experimental-${{ steps.get-timestamp.outputs.time }}" >> $GITHUB_OUTPUT
           echo "release_name=Cataclysm-DDA experimental build ${{ steps.get-timestamp.outputs.time }}" >> $GITHUB_OUTPUT
+      - uses: actions/checkout@v4
       - name: Generate Release Notes
         id: generate-release-notes
         run: |
+          npm install @actions/github
           node build-scripts/generate-release-notes.js '${{ secrets.GITHUB_TOKEN }}' '${{ steps.generate_env_vars.outputs.tag_name }}' "$(git log -1 --format='%H')" > notes.txt
-      - uses: actions/checkout@v4
       - run: |
           gh release create ${{ steps.generate_env_vars.outputs.tag_name }} --notes-file notes.txt --prerelease --title "${{ steps.generate_env_vars.outputs.release_name }}" --target "$(git log -1 --format='%H')"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,9 +38,13 @@ jobs:
         run: |
           echo "tag_name=cdda-experimental-${{ steps.get-timestamp.outputs.time }}" >> $GITHUB_OUTPUT
           echo "release_name=Cataclysm-DDA experimental build ${{ steps.get-timestamp.outputs.time }}" >> $GITHUB_OUTPUT
+      - name: Generate Release Notes
+        id: generate-release-notes
+        run: |
+          node build-scripts/generate-release-notes.js '${{ secrets.GITHUB_TOKEN }}' '${{ steps.generate_env_vars.outputs.tag_name }}' "$(git log -1 --format='%H')" > notes.txt
       - uses: actions/checkout@v4
       - run: |
-          gh release create ${{ steps.generate_env_vars.outputs.tag_name }} --generate-notes --prerelease --title "${{ steps.generate_env_vars.outputs.release_name }}" --target "$(git log -1 --format='%H')"
+          gh release create ${{ steps.generate_env_vars.outputs.tag_name }} --notes-file notes.txt --prerelease --title "${{ steps.generate_env_vars.outputs.release_name }}" --target "$(git log -1 --format='%H')"
 
   builds:
     needs: release

--- a/build-scripts/generate-release-notes.js
+++ b/build-scripts/generate-release-notes.js
@@ -1,0 +1,75 @@
+// ./tools/scripts/generate-release-notes.js
+
+const github = require('@actions/github');
+
+/**
+ * Generates the release notes for a github release.
+ *
+ * Arguments:
+ * 1 - github_token
+ * 2 - new version
+ * 3 - commit SHA of new release
+ */
+const token = process.argv[2];
+const version = process.argv[3];
+const comittish = process.argv[4];
+
+async function main() {
+  const client = github.getOctokit(token);
+
+  const latestReleaseResponse = await client.request(
+    'GET /repos/{owner}/{repo}/releases/latest',
+    {
+      owner: 'CleverRaven',
+      repo: 'Cataclysm-DDA',
+      headers: {
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    }
+  );
+  const previousTag = latestReleaseResponse.data?.tag_name;
+
+  const response = await client.request(
+    'POST /repos/{owner}/{repo}/releases/generate-notes',
+    {
+      owner: 'CleverRaven',
+      repo: 'Cataclysm-DDA',
+      tag_name: version,
+      previous_tag_name: previousTag,
+      target_commitish: comittish,
+      headers: {
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    }
+  );
+
+  const noteSections = response.data.body?.split('\n\n');
+  const trimmedSections = [];
+  const githubNotesMaxCharLength = 125000;
+  const maxSectionLength = githubNotesMaxCharLength / noteSections.length;
+  for (let i = 0; i < noteSections.length; i++) {
+    if (noteSections[i].length > githubNotesMaxCharLength) {
+      const lastLineIndex =
+        noteSections[i].substring(0, maxSectionLength).split('\n').length - 1;
+      const trimmed =
+        noteSections[i]
+          .split('\n')
+          .slice(0, lastLineIndex - 1)
+          .join('\n') +
+        `\n... (+${
+          noteSections[i].split('\n').length - (lastLineIndex + 1)
+        } others)`;
+      trimmedSections.push(trimmed);
+      continue;
+    }
+
+    trimmedSections.push(noteSections[i]);
+  }
+
+  console.log(trimmedSections.join('\n\n'));
+}
+
+main().catch((e) => {
+  console.error(`Failed generating release notes with error: ${e}`);
+  process.exit(0);
+});

--- a/build-scripts/generate-release-notes.js
+++ b/build-scripts/generate-release-notes.js
@@ -13,6 +13,8 @@ const github = require('@actions/github');
 const token = process.argv[2];
 const version = process.argv[3];
 const comittish = process.argv[4];
+const repo = process.env.REPOSITORY_NAME
+const owner = process.env.GITHUB_REPOSITORY_OWNER
 
 async function main() {
   const client = github.getOctokit(token);
@@ -20,8 +22,8 @@ async function main() {
   const latestReleaseResponse = await client.request(
     'GET /repos/{owner}/{repo}/releases/latest',
     {
-      owner: 'CleverRaven',
-      repo: 'Cataclysm-DDA',
+      owner: owner,
+      repo: repo,
       headers: {
         'X-GitHub-Api-Version': '2022-11-28',
       },
@@ -32,8 +34,8 @@ async function main() {
   const response = await client.request(
     'POST /repos/{owner}/{repo}/releases/generate-notes',
     {
-      owner: 'CleverRaven',
-      repo: 'Cataclysm-DDA',
+      owner: owner,
+      repo: repo,
       tag_name: version,
       previous_tag_name: previousTag,
       target_commitish: comittish,


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Experimental release publishing started failing with the following error:
```
Run gh release create cdda-experimental-2024-03-19-1659 --generate-notes --prerelease --title "Cataclysm-DDA experimental build 2024-03-19-1659" --target "$(git log -1 --format='%H')"
HTTP 422: Validation Failed (https://api.github.com/repos/CleverRaven/Cataclysm-DDA/releases)
body is too long (maximum is 125000 characters)
Error: Process completed with exit code 1.
```
See: https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/8347107101/job/22845979624


#### Describe the solution
This follows the solution proposed here: https://github.com/orgs/community/discussions/63414
to manually retrieve the github release notes, but then truncate them to fit the release API limits before publishing.

#### Describe alternatives you've considered
Nuke the release notes?
Manually generate them?

#### Testing
GH being GH, I pretty much just need to push this and see if it starts working.

#### Additional context
I'm not a fan of js or YAML, ugh.