### PR TITLE
Remove erroneous double quote

### DIFF
--- a/.github/summary-labels.yml
+++ b/.github/summary-labels.yml
@@ -39,4 +39,4 @@ labels:
 
   - label: "Translation"
     matcher:
-      body: "(\\s|^)#### Summary\\s*I18N +\".+\"\\s*(\n|$)""
+      body: "(\\s|^)#### Summary\\s*I18N +\".+\"\\s*(\n|$)"


### PR DESCRIPTION
This was breaking the labeller

#### Summary
None

#### Purpose of change
This seems to have been breaking the labeller, see
```
Run fuxingloh/multi-labeler@main
Error: YAMLException: bad indentation of a mapping entry (42:60)

 39 |  ... 
 40 |  ... 
 41 |  ... 
 42 |  ... ary\\s*I18N +\".+\"\\s*(\n|$)""
-----------------------------------------^
Error: bad indentation of a mapping entry (42:60)

 39 |  ... 
 40 |  ... 
 41 |  ... 
 42 |  ... ary\\s*I18N +\".+\"\\s*(\n|$)""
-----------------------------------------^
```
In e.g. https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/8351087539/job/22858794096?pr=72501

#### Describe the solution
Trim the quote
pay the sin tax

#### Describe alternatives you've considered
Burn down all the YAML

#### Testing
Merge it, what's it gonna do, break the labeller?