### PR TITLE
adjust api endpoint used to retrieve previous release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
       - '.github/workflows/release.yml'
       - 'android/**'
       - 'build-data/**'
+      - 'build-scripts/generate-release-notes.js'
       - 'cataclysm-launcher'
       - 'data/**'
       - 'doc/**'

--- a/build-scripts/generate-release-notes.js
+++ b/build-scripts/generate-release-notes.js
@@ -20,7 +20,7 @@ async function main() {
   const client = github.getOctokit(token);
 
   const latestReleaseResponse = await client.request(
-    'GET /repos/{owner}/{repo}/releases/latest',
+    'GET /repos/{owner}/{repo}/releases',
     {
       owner: owner,
       repo: repo,
@@ -29,7 +29,7 @@ async function main() {
       },
     }
   );
-  const previousTag = latestReleaseResponse.data?.tag_name;
+  const previousTag = latestReleaseResponse.data?[0].tag_name;
 
   const response = await client.request(
     'POST /repos/{owner}/{repo}/releases/generate-notes',

--- a/build-scripts/generate-release-notes.js
+++ b/build-scripts/generate-release-notes.js
@@ -29,7 +29,16 @@ async function main() {
       },
     }
   );
-  const previousTag = latestReleaseResponse.data?[0].tag_name;
+
+  let previousTag = null;
+  if (latestResponse.data) {
+    for (const responseData of latestResponse.data) {
+      if (responseData.draft == false && responseData.prerelease == true) {
+        previousTag = responseData.tag_name;
+	break;
+      }
+    }
+  }
 
   const response = await client.request(
     'POST /repos/{owner}/{repo}/releases/generate-notes',


### PR DESCRIPTION
Since we leave experimental releases in prerelease state we need to retrieve it slightly differently.

#### Summary
None

#### Purpose of change
The example I was working from was relying on the previous release being fully published and marked latest. Uncollected in our repo this results in the changelog starting at the previous stable release

#### Describe the solution
Use the first element returned by the releases endpoint to determine the previous tag. 


#### Describe alternatives you've considered
Again,  burn the javascript.


#### Testing
Just need to run it again. 