### PR TITLE
Unhardcode RM13 use actions

### DIFF
--- a/data/json/item_actions.json
+++ b/data/json/item_actions.json
@@ -737,16 +737,6 @@
   },
   {
     "type": "item_action",
-    "id": "RM13ARMOR_OFF",
-    "name": { "str": "Turn on" }
-  },
-  {
-    "type": "item_action",
-    "id": "RM13ARMOR_ON",
-    "name": { "str": "Turn off" }
-  },
-  {
-    "type": "item_action",
     "id": "SEED",
     "name": { "str": "Consume" }
   },

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -1377,13 +1377,13 @@
     "charges_per_use": 1,
     "relic_data": { "passive_effects": [ { "id": "ench_climate_control_all" }, { "id": "ench_dampened_steps" } ] },
     "use_action": {
-		"type": "transform",
-		"msg": "You activate your RM13 combat armor.\nRivtech Model 13 RivOS v2.19:   ONLINE.\nCBRN defense system:            ONLINE.\nAcoustic dampening system:      ONLINE.\nThermal regulation system:      ONLINE.\nVision enhancement system:      ONLINE.\nElectro-reactive armor system:  ONLINE.\nAll systems nominal.",
-		"target": "rm13_armor_on",
-		"active": true,
-		"need_worn": true,
-		"need_charges": 1,
-		"need_charges_msg": "The RM13 combat armor's battery is dead."
+      "type": "transform",
+      "msg": "You activate your RM13 combat armor.\nRivtech Model 13 RivOS v2.19:   ONLINE.\nCBRN defense system:            ONLINE.\nAcoustic dampening system:      ONLINE.\nThermal regulation system:      ONLINE.\nVision enhancement system:      ONLINE.\nElectro-reactive armor system:  ONLINE.\nAll systems nominal.",
+      "target": "rm13_armor_on",
+      "active": true,
+      "need_worn": true,
+      "need_charges": 1,
+      "need_charges_msg": "The RM13 combat armor's battery is dead."
     },
     "warmth": 30,
     "environmental_protection": 10,

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -1376,7 +1376,15 @@
     "ammo": "battery",
     "charges_per_use": 1,
     "relic_data": { "passive_effects": [ { "id": "ench_climate_control_all" }, { "id": "ench_dampened_steps" } ] },
-    "use_action": [ "RM13ARMOR_OFF" ],
+    "use_action": {
+		"type": "transform",
+		"msg": "You activate your RM13 combat armor.\nRivtech Model 13 RivOS v2.19:   ONLINE.\nCBRN defense system:            ONLINE.\nAcoustic dampening system:      ONLINE.\nThermal regulation system:      ONLINE.\nVision enhancement system:      ONLINE.\nElectro-reactive armor system:  ONLINE.\nAll systems nominal.",
+		"target": "rm13_armor_on",
+		"active": true,
+		"need_worn": true,
+		"need_charges": 1,
+		"need_charges_msg": "The RM13 combat armor's battery is dead."
+    },
     "warmth": 30,
     "environmental_protection": 10,
     "material_thickness": 3,
@@ -1465,7 +1473,13 @@
     "material": [ "hyperweave_on", "carbide" ],
     "power_draw": "100 W",
     "revert_to": "rm13_armor",
-    "use_action": [ "RM13ARMOR_ON" ],
+    "use_action": {
+		"type": "transform",
+		"msg": "You deactivate your RM13 combat armor.\nRivOS v2.19 shutdown sequence initiated.\nShutting down.\nYour RM13 combat armor turns off.",
+		"target": "rm13_armor",
+		"active": true,
+		"need_worn": true
+    },
     "environmental_protection": 40,
     "qualities": [ [ "GLARE", 1 ] ],
     "material_thickness": 3,

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -1474,11 +1474,11 @@
     "power_draw": "100 W",
     "revert_to": "rm13_armor",
     "use_action": {
-		"type": "transform",
-		"msg": "You deactivate your RM13 combat armor.\nRivOS v2.19 shutdown sequence initiated.\nShutting down.\nYour RM13 combat armor turns off.",
-		"target": "rm13_armor",
-		"active": true,
-		"need_worn": true
+      "type": "transform",
+      "msg": "You deactivate your RM13 combat armor.\nRivOS v2.19 shutdown sequence initiated.\nShutting down.\nYour RM13 combat armor turns off.",
+      "target": "rm13_armor",
+      "active": true,
+      "need_worn": true
     },
     "environmental_protection": 40,
     "qualities": [ [ "GLARE", 1 ] ],

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -1852,8 +1852,6 @@ void Item_factory::init()
     add_iuse( "REMOTEVEH", &iuse::remoteveh );
     add_iuse( "REMOTEVEH_TICK", &iuse::remoteveh_tick );
     add_iuse( "REMOVE_ALL_MODS", &iuse::remove_all_mods );
-    add_iuse( "RM13ARMOR_OFF", &iuse::rm13armor_off );
-    add_iuse( "RM13ARMOR_ON", &iuse::rm13armor_on );
     add_iuse( "ROBOTCONTROL", &iuse::robotcontrol );
     add_iuse( "SEED", &iuse::seed );
     add_iuse( "SEWAGE", &iuse::sewage );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -2346,50 +2346,6 @@ std::optional<int> iuse::manage_exosuit( Character *p, item *it, const tripoint 
     return 0;
 }
 
-std::optional<int> iuse::rm13armor_off( Character *p, item *it, const tripoint & )
-{
-    // This allows it to turn on for a turn, because ammo_sufficient assumes non-tool non-weapons need zero ammo, for some reason.
-    if( !it->ammo_sufficient( p ) ) {
-        p->add_msg_if_player( m_info, _( "The RM13 combat armor's fuel cells are dead." ) );
-        return std::nullopt;
-    } else {
-        std::string oname = it->typeId().str() + "_on";
-        p->add_msg_if_player( _( "You activate your RM13 combat armor." ) );
-        p->add_msg_if_player( _( "Rivtech Model 13 RivOS v2.19:   ONLINE." ) );
-        p->add_msg_if_player( _( "CBRN defense system:            ONLINE." ) );
-        p->add_msg_if_player( _( "Acoustic dampening system:      ONLINE." ) );
-        p->add_msg_if_player( _( "Thermal regulation system:      ONLINE." ) );
-        p->add_msg_if_player( _( "Vision enhancement system:      ONLINE." ) );
-        p->add_msg_if_player( _( "Electro-reactive armor system:  ONLINE." ) );
-        p->add_msg_if_player( _( "All systems nominal." ) );
-        it->convert( itype_id( oname ), p ).active = true;
-        p->calc_encumbrance();
-        return 1;
-    }
-}
-
-std::optional<int> iuse::rm13armor_on( Character *p, item *it, const tripoint & )
-{
-    if( !p ) { // Normal use
-        debugmsg( "%s called action rm13armor_on that requires character but no character is present",
-                  it->typeId().str() );
-    } else { // Turning it off
-        std::string oname = it->typeId().str();
-        if( string_ends_with( oname, "_on" ) ) {
-            oname.erase( oname.length() - 3, 3 );
-        } else {
-            debugmsg( "no item type to turn it into (%s)!", oname );
-            return 0;
-        }
-        p->add_msg_if_player( _( "RivOS v2.19 shutdown sequence initiated." ) );
-        p->add_msg_if_player( _( "Shutting down." ) );
-        p->add_msg_if_player( _( "Your RM13 combat armor turns off." ) );
-        it->convert( itype_id( oname ), p ).active = false;
-        p->calc_encumbrance();
-    }
-    return 1;
-}
-
 std::optional<int> iuse::unpack_item( Character *p, item *it, const tripoint & )
 {
     if( p->cant_do_underwater() ) {

--- a/src/iuse.h
+++ b/src/iuse.h
@@ -166,8 +166,6 @@ std::optional<int> radio_off( Character *, item *, const tripoint & );
 std::optional<int> radio_on( Character *, item *, const tripoint & );
 std::optional<int> radio_tick( Character *, item *, const tripoint & );
 std::optional<int> remove_all_mods( Character *, item *, const tripoint & );
-std::optional<int> rm13armor_off( Character *, item *, const tripoint & );
-std::optional<int> rm13armor_on( Character *, item *, const tripoint & );
 std::optional<int> robotcontrol( Character *, item *, const tripoint & );
 std::optional<int> rpgdie( Character *, item *, const tripoint & );
 std::optional<int> seed( Character *, item *, const tripoint & );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "Unhardcoded RM13's use actions"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

For some reason, probably one of legacy, the RM13 has hardcoded use actions and activation strings. I don't really see why that has to be the case these days.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Remove unique use actions from both JSON and C++, migrate relevant content to the RM13's `use_action` blocks.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Not doing it?

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Implemented PR, compiled, generated new world and character. 
Put on RM13, activated it, message displayed as expected
Deactivated RM13, appropriate message displayed.
Let battery run out while active, appropriate message displayed.
Attempted to activate when battery was empty, appropriate string displayed in the `a`ctivate menu.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Side note: this is another one of those, "I have no idea what category to put this in" PRs so I've just put it in interface until someone tells me it should go elsewhere.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
