### PR TITLE
Minor generic zombie balance edits 3

### DIFF
--- a/data/json/items/generic/skulls.json
+++ b/data/json/items/generic/skulls.json
@@ -27,6 +27,7 @@
     "name": { "str": "tainted human skull" },
     "description": "The stained skull of what was once a human being.  It is rotted and noticeably warped from its lively form.  Carrying this around probably isn't going to win you any friends.",
     "copy-from": "skull_abstract",
+    "looks_like": "skull_human",
     "snippet_category": "skull_human_tainted_desc"
   },
   {

--- a/data/json/monsters/zed_explosive.json
+++ b/data/json/monsters/zed_explosive.json
@@ -86,7 +86,6 @@
     },
     "flags": [
       "SEES",
-      "GOODHEARING",
       "SMELLS",
       "STUMBLES",
       "WARM",
@@ -323,7 +322,7 @@
     "name": "bombardier boomer",
     "description": "This zombie's exposed ribcage is encircled by swollen lungs and other organs.  You would prefer to be far away when they burst.",
     "default_faction": "zombie",
-    "bodytype": "blob",
+    "bodytype": "human",
     "species": [ "ZOMBIE", "HUMAN" ],
     "diff": 9,
     "volume": "108500 ml",
@@ -349,7 +348,7 @@
     ],
     "death_drops": { "subtype": "collection", "groups": [ [ "default_zombie_death_drops", 100 ], [ "explode_zed", 100 ] ] },
     "death_function": { "effect": { "id": "death_boomer", "hit_self": true }, "message": "The %s explodes!", "corpse_type": "NO_CORPSE" },
-    "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "WARM", "POISON", "NO_BREATHE", "REVIVES", "FILTHY" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "WARM", "POISON", "NO_BREATHE", "BASHES", "REVIVES", "FILTHY" ],
     "armor": { "bash": 10, "cut": 5, "bullet": 5, "electric": 2 }
   }
 ]

--- a/data/json/monsters/zed_misc.json
+++ b/data/json/monsters/zed_misc.json
@@ -1031,6 +1031,8 @@
     "name": { "str": "zombie necro-boomer" },
     "description": "At first this creature looks like nothing more than a grotesque and oleaginous husk, bloated and punctured by jet-black pustules.  When approached, its glowing red eyes and an aching grin take form; its skin tears and its guts teem with unmatched fecundity, as its gaze inspires fear of nothing less than cosmic, inhuman ecstasy.",
     "copy-from": "mon_zombie_necro",
+    "volume": "108500 ml",
+    "weight": "120 kg",
     "diff": 25,
     "death_drops": { "subtype": "collection", "groups": [ [ "default_zombie_death_drops", 65 ], [ "zed_dust", 100 ] ] },
     "death_function": {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Weirdness caught during the creation of #72534 that I was advised to PR separately for the ease of reviewing
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Change the necroboomer size to be the same as normal boomer - I assume it was lost when boomers had their size audited since it's in a separate file
- Give the tainted human skull a ``looks_like`` of a normal human skull
- Removed ``GOODHEARING`` from huge boomers - no idea why they had them but there does not appear to be any reason?
- Switched the bodtype for the bombardier boomer from ``blob`` to ``human`` - all boomers except for the glutton are ``human``, so this appears to have been a mistake during cargo culting?
- Added ``BASHES`` to the bombardier boomer
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Adding ``BASHES`` to the gasbags, but I think it sort of makes sense with them not having it since they pop after just coming close to a living being
- Switching harvestlists for the glutton and bombardier to ``exempt``, but ultimately this doesn't matter ingame so I can handle that in #72534
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
