### PR TITLE
Remove unnecessary roofs from steel mill for shadowcasting performance

### DIFF
--- a/data/json/mapgen/steel_mill/steel_mill_z1.json
+++ b/data/json/mapgen/steel_mill/steel_mill_z1.json
@@ -10,7 +10,7 @@
       [ "steel_mill_4_1", "steel_mill_4_2", "steel_mill_4_3", "steel_mill_rail_2" ]
     ],
     "object": {
-      "fill_ter": "t_thconc_floor",
+      "fill_ter": "t_thconc_floor_no_roof",
       "rows": [
         "vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv._______,,_______.vvvvvvvvvvvvvvvvvvvvvvvvvvv",
         "v..................................................._______,,_______...........................v",

--- a/data/json/mapgen_palettes/steel_mill_palette.json
+++ b/data/json/mapgen_palettes/steel_mill_palette.json
@@ -42,7 +42,7 @@
       "G": "t_grate",
       "2": "t_sai_box",
       "5": "t_switchgear_l",
-      "`": "t_thconc_y"
+      "`": "t_thconc_floor_no_roof"
     },
     "furniture": {
       "c": "f_console_broken",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
none
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Address #72508

There are many unnecessary roofs in the steel mill. Roofs mark map squares as `indoors`, thus weather sight penalty isn't applied on those squares' transparency values. But in this case, the map structure creates too much fluctuations in transparency, thus shadowcasting starts struggling.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Remove most roofs that are supposed to be `outdoors`.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
1. Improve shadowcasting performance: I tried and came to the conclusion that I'm not capable enough to do that.
2. Improve the algorithm of identifying whether a map square should be subject to sight penalty: this really should be done ( in hope of fixing #65205 ), but it takes time more than this simple solution.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Newly generated steel mills no longer suffer from degraded shadowcasting performance. Note that already explored steel mills aren't salvageable.

For comparison, below are pictures of the second floor of the steel mill, before and after the change.

before:
![orig](https://github.com/CleverRaven/Cataclysm-DDA/assets/22912139/d45d4519-660e-4f79-87c0-ef49494db0ee)


After:
![new](https://github.com/CleverRaven/Cataclysm-DDA/assets/22912139/079e3a82-3296-448b-a30e-f9c9708e2835)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
