### PR TITLE
add !mayfail to overmap_terrain_coverage

### DIFF
--- a/tests/overmap_test.cpp
+++ b/tests/overmap_test.cpp
@@ -247,7 +247,7 @@ TEST_CASE( "mutable_overmap_placement", "[overmap][slow]" )
     }
 }
 
-TEST_CASE( "overmap_terrain_coverage", "[overmap][slow]" )
+TEST_CASE( "overmap_terrain_coverage", "[overmap][slow][!mayfail]" )
 {
     // The goal of this test is to generate a lot of overmaps, and count up how
     // many times we see each terrain, so that we can check that everything


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Functionality of overmap_terrain_coverage test is very important, but amount of fails it causes makes more harm, stopping most PRs from being properly autotested
#### Describe the solution
Add `[!mayfail]` to test tag list so it fails, the test will continue to run
#### Describe alternatives you've considered
Not doing it
#### Testing
Power of autotests