### PR TITLE
Aftershock: New (and maybe the last) 7.5mm guns

### DIFF
--- a/data/mods/Aftershock/itemgroups/weapons/armories.json
+++ b/data/mods/Aftershock/itemgroups/weapons/armories.json
@@ -61,7 +61,7 @@
     "items": [
       { "group": "afs_civilian_ballistic_gun", "prob": 6 },
       { "group": "afs_any_ballistic_mag", "prob": 2 },
-      { "group": "afs_any_ballistic_ammo", "prob": 4 },
+      { "group": "afs_any_civilian_ballistic_ammo", "prob": 4 },
       { "group": "afs_shotgun_gunmod", "prob": 1 }
     ]
   },
@@ -93,6 +93,8 @@
       [ "afs_heavy_tactical_laser", 5 ],
       [ "afs_pam-41", 10 ],
       [ "afs_magnadrive_230k", 5 ],
+      [ "afs_marsec_t72", 2 ],
+      [ "afs_sr77", 10 ],
       [ "afs_gibs_shotgun", 20 ],
       [ "afs_raketa_shotgun", 20 ]
     ]

--- a/data/mods/Aftershock/itemgroups/weapons/balistic_gun_groups.json
+++ b/data/mods/Aftershock/itemgroups/weapons/balistic_gun_groups.json
@@ -29,7 +29,9 @@
       [ "afs_Accipitermg", 20 ],
       [ "afs_gibrifle", 40 ],
       [ "afs_shotgun", 15 ],
+      [ "afs_sr77", 10 ],
       [ "afs_25mm_goa", 5 ],
+      [ "afs_marsec_t72", 2 ],
       [ "afs_drotik_shotpistol", 5 ],
       [ "afs_shotgun_magnastorm", 5 ]
     ]
@@ -87,7 +89,7 @@
     ]
   },
   {
-    "id": "afs_any_ballistic_ammo",
+    "id": "afs_any_civilian_ballistic_ammo",
     "type": "item_group",
     "subtype": "distribution",
     "items": [

--- a/data/mods/Aftershock/itemgroups/weapons/grenade_groups.json
+++ b/data/mods/Aftershock/itemgroups/weapons/grenade_groups.json
@@ -6,6 +6,10 @@
     "entries": [
       { "item": "afs_electroshock_grenade_1", "count-min": 1, "count-max": 3 },
       { "item": "grenade_cryo", "count-min": 1, "count-max": 3 },
+      { "item": "grenade", "count-min": 1, "count-max": 3 },
+      { "item": "afs_HE_grenade", "count-min": 1, "count-max": 3 },
+      { "item": "grenade_inc", "count-min": 1, "count-max": 3 },
+      { "item": "smokebomb", "count-min": 1, "count-max": 3 },
       { "item": "scrambler", "count-min": 1, "count-max": 3 },
       { "item": "grenade_emp", "count-min": 1, "count-max": 3 }
     ]

--- a/data/mods/Aftershock/items/grenades.json
+++ b/data/mods/Aftershock/items/grenades.json
@@ -72,6 +72,37 @@
     "extend": { "flags": [ "TRADER_AVOID" ] }
   },
   {
+    "id": "afs_HE_grenade",
+    "type": "TOOL",
+    "copy-from": "grenade_canister",
+    "looks_like": "grenade",
+    "name": "HE grenade",
+    "price": "450 USD",
+    "weight": "300 g",
+    "volume": "250 ml",
+    "description": "A high explosive grenade that deals most of its damage through a powerful shockwave.  Reduced shrapnel makes it much safer to use in open spaces.",
+    "use_action": {
+      "need_wielding": true,
+      "target": "afs_HE_grenade_act",
+      "msg": "You pull the pin on the grenade.",
+      "target_timer": "5 seconds",
+      "menu_text": "Pull pin",
+      "type": "transform"
+    },
+    "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "BOMB", "GRENADE" ]
+  },
+  {
+    "id": "afs_HE_grenade_act",
+    "type": "TOOL",
+    "copy-from": "afs_HE_grenade",
+    "name": "active HE grenade",
+    "looks_like": "grenade_act",
+    "description": "A high explosive grenade that deals most of its damage through a powerful shockwave.  It's currently active.",
+    "use_action": { "type": "message", "message": "You've already activated the %s, try throwing it instead." },
+    "countdown_action": { "type": "explosion", "explosion": { "power": 3000, "max_noise": 250, "distance_factor": 0.7 } },
+    "extend": { "flags": [ "TRADER_AVOID" ] }
+  },
+  {
     "id": "afs_electroshock_grenade_1",
     "type": "TOOL",
     "copy-from": "grenade_canister",

--- a/data/mods/Aftershock/items/gun/7.50mm.json
+++ b/data/mods/Aftershock/items/gun/7.50mm.json
@@ -3,7 +3,7 @@
     "id": "afs_marsec_t72",
     "type": "GUN",
     "copy-from": "sw629",
-    "name": { "str": "Marsec. T72 " },
+    "name": { "str": "Marsec. T72" },
     "description": "A massive, unwieldy revolver, using combined magnetic and chemical propulsion to fire 7.50mm rounds at energies that rival a sniping platform.  It additionally features a secondary barrel for a single 00 shot shell.\n\nThe T72 remains a relic of the early hyperspace era, meant to be used by and against the posthuman.  Its perhaps most notable for its use by fictional rebel figures than for any sort of actual combat effectiveness.",
     "weight": "2204 g",
     "volume": "1750 ml",
@@ -133,13 +133,13 @@
     "type": "GUN",
     "reload_noise_volume": 10,
     "name": { "str": "G&W SR-P77" },
-    "description": " Compact and powerful, the SR-77 serves as the current main firearm of UICA assault teams, having replaced the SR-P9 in the very last decade of the reclamation wars.  Designed for combat withing the tight confines of spacecraft and habitats, the SR-77 is a bullpup carbine with a top-mounted magazine and a high rate of fire.  Performance in open terrain is subpar.",
+    "description": "Compact and powerful, the SR-77 serves as the current main firearm of UICA assault teams, having replaced the SR-P9 in the very last decade of the reclamation wars.  Designed for combat withing the tight confines of spacecraft and habitats, the SR-77 is a bullpup carbine with a top-mounted magazine and a high rate of fire.  Performance in open terrain is subpar.",
     "variant_type": "gun",
     "variants": [
       {
         "id": "military",
         "name": { "str": "G&W SR-P77" },
-        "description": " Compact and powerful, the SR-77 serves as the current main firearm of UICA assault teams, having replaced the SR-P9 in the very last decade of the reclamation wars.  Designed for combat withing the tight confines of spacecraft and habitats, the SR-77 is a bullpup carbine with a top-mounted magazine and a high rate of fire.  Performance in open terrain is subpar.",
+        "description": "Compact and powerful, the SR-77 serves as the current main firearm of UICA assault teams, having replaced the SR-P9 in the very last decade of the reclamation wars.  Designed for combat withing the tight confines of spacecraft and habitats, the SR-77 is a bullpup carbine with a top-mounted magazine and a high rate of fire.  Performance in open terrain is subpar.",
         "weight": 3
       },
       {

--- a/data/mods/Aftershock/items/gun/7.50mm.json
+++ b/data/mods/Aftershock/items/gun/7.50mm.json
@@ -1,10 +1,41 @@
 [
   {
+    "id": "afs_marsec_t72",
+    "type": "GUN",
+    "copy-from": "sw629",
+    "name": { "str": "Marsec. T72 " },
+    "description": "A massive, unwieldy revolver, using combined magnetic and chemical propulsion to fire 7.50mm rounds at energies that rival a sniping platform.  It additionally features a secondary barrel for a single 00 shot shell.\n\nThe T72 remains a relic of the early hyperspace era, meant to be used by and against the posthuman.  Its perhaps most notable for its use by fictional rebel figures than for any sort of actual combat effectiveness.",
+    "weight": "2204 g",
+    "volume": "1750 ml",
+    "longest_side": "25 cm",
+    "price": "6400 USD",
+    "price_postapoc": "6400 USD",
+    "material": [ "superalloy", "ceramic" ],
+    "symbol": "(",
+    "color": "dark_gray",
+    "ammo": [ "afs_7.50mm" ],
+    "ranged_damage": { "damage_type": "bullet", "amount": -4 },
+    "dispersion": 175,
+    "durability": 9,
+    "min_strength": 16,
+    "clip_size": 9,
+    "flags": [ "WATERPROOF_GUN", "RELOAD_ONE", "NEVER_JAMS" ],
+    "pocket_data": [
+      {
+        "pocket_type": "MAGAZINE",
+        "holster": true,
+        "ammo_restriction": { "afs_7.50mm": 9 },
+        "allowed_speedloaders": [ "afs_marsect72_speedloader9" ]
+      }
+    ],
+    "built_in_mods": [ "afs_marsec_t72_shotgun" ]
+  },
+  {
     "id": "afs_landfall_gun",
     "type": "GUN",
     "copy-from": "rifle_22",
     "name": { "str": "landfall survival gun" },
-    "description": "A lightweight, bolt-action gun that is barely more than a 6.55mm barrel mounted within a flimsy metal assembly.  Cheaply made and outdated in all respects, it's only useful in the most extenuating of circumstances.",
+    "description": "A lightweight, bolt-action gun that is barely more than a 7.50mm barrel mounted within a flimsy metal assembly.  Cheaply made and outdated in all respects, it's only useful in the most extenuating of circumstances.",
     "price": 5000,
     "material": [ "steel", "plastic" ],
     "flags": [ "NEVER_JAMS", "RELOAD_EJECT" ],
@@ -95,5 +126,59 @@
     ],
     "melee_damage": { "bash": 12 },
     "weapon_category": [ "AUTOMATIC_RIFLES" ]
+  },
+  {
+    "id": "afs_sr77",
+    "copy-from": "fn_p90",
+    "type": "GUN",
+    "reload_noise_volume": 10,
+    "name": { "str": "G&W SR-P77" },
+    "description": " Compact and powerful, the SR-77 serves as the current main firearm of UICA assault teams, having replaced the SR-P9 in the very last decade of the reclamation wars.  Designed for combat withing the tight confines of spacecraft and habitats, the SR-77 is a bullpup carbine with a top-mounted magazine and a high rate of fire.  Performance in open terrain is subpar.",
+    "variant_type": "gun",
+    "variants": [
+      {
+        "id": "military",
+        "name": { "str": "G&W SR-P77" },
+        "description": " Compact and powerful, the SR-77 serves as the current main firearm of UICA assault teams, having replaced the SR-P9 in the very last decade of the reclamation wars.  Designed for combat withing the tight confines of spacecraft and habitats, the SR-77 is a bullpup carbine with a top-mounted magazine and a high rate of fire.  Performance in open terrain is subpar.",
+        "weight": 3
+      },
+      {
+        "id": "branded",
+        "name": { "str": "Gibson-77 Sentinel" },
+        "description": "A rare version of the m90-UASTA PDW built to its original private market specifications, featuring an ergonomic bullpup design and a large magazine capacity underneath a sleek white and chromed finish.  Actual combat performance is slightly improved over the more common military model, due to the use of higher-quality materials within the barrel and ETC ignition system.",
+        "weight": 0
+      }
+    ],
+    "ranged_damage": { "damage_type": "bullet", "amount": -10 },
+    "range": -4,
+    "weight": "2640 g",
+    "volume": "3817 ml",
+    "longest_side": "511 mm",
+    "barrel_length": "264 mm",
+    "price": 350000,
+    "price_postapoc": 3500,
+    "to_hit": -2,
+    "material": [ "superalloy", "plastic" ],
+    "symbol": "(",
+    "color": "light_gray",
+    "ammo": [ "afs_7.50mm" ],
+    "skill": "smg",
+    "dispersion": 260,
+    "durability": 10,
+    "min_cycle_recoil": 1350,
+    "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "AUTO", "burst", 5 ], [ "AUTO", "auto", 15 ] ],
+    "valid_mod_locations": [
+      [ "barrel", 1 ],
+      [ "brass catcher", 1 ],
+      [ "mechanism", 4 ],
+      [ "muzzle", 1 ],
+      [ "rail", 1 ],
+      [ "sights", 1 ],
+      [ "sling", 1 ],
+      [ "stock accessory", 2 ]
+    ],
+    "faults": [ "fault_gun_blackpowder", "fault_gun_dirt", "fault_gun_chamber_spent" ],
+    "pocket_data": [ { "magazine_well": "500 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "afs_sr77_45mag" ] } ],
+    "melee_damage": { "bash": 10 }
   }
 ]

--- a/data/mods/Aftershock/items/gun/shot.json
+++ b/data/mods/Aftershock/items/gun/shot.json
@@ -106,5 +106,23 @@
     ],
     "melee_damage": { "bash": 16 },
     "flags": [ "RELOAD_ONE", "RELOAD_EJECT", "NEVER_JAMS" ]
+  },
+  {
+    "id": "afs_marsec_t72_shotgun",
+    "copy-from": "underbarrel_base",
+    "type": "GUNMOD",
+    "name": { "str": "Marsec. T72 shotgun" },
+    "description": "The single round 00 bore barrel built at the center of the T72 revolver.  Can function as a backup in case the power pack of the main weapon is depleted.",
+    "volume": "250 ml",
+    "integral_volume": "0 ml",
+    "install_time": "0 s",
+    "material": [ "steel" ],
+    "symbol": ":",
+    "color": "light_red",
+    "location": "underbarrel",
+    "mod_targets": [ "pistol" ],
+    "gun_data": { "ammo": "shot", "skill": "shotgun", "range": -6, "dispersion": 600, "durability": 10, "reload": 150, "clip_size": 1 },
+    "flags": [ "RELOAD_ONE", "NO_UNLOAD", "IRREMOVABLE" ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "shot": 1 } } ]
   }
 ]

--- a/data/mods/Aftershock/items/magazine/7.50mm.json
+++ b/data/mods/Aftershock/items/magazine/7.50mm.json
@@ -33,5 +33,40 @@
     "reload_time": 200,
     "flags": [ "MAG_BULKY" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "afs_7.50mm": 100 } } ]
+  },
+  {
+    "id": "afs_marsect72_speedloader9",
+    "looks_like": "38_speedloader",
+    "type": "MAGAZINE",
+    "name": { "str": "Marsec. T72 7.50mm speedloader" },
+    "description": "A speedloader for the Marsec T72 revolver, holds 9 rounds of 7.50mm ammunition.",
+    "weight": "92 g",
+    "volume": "350 ml",
+    "price": 8000,
+    "price_postapoc": 250,
+    "material": [ "superalloy", "plastic" ],
+    "symbol": "#",
+    "color": "dark_gray",
+    "ammo_type": [ "afs_7.50mm" ],
+    "capacity": 9,
+    "flags": [ "SPEEDLOADER" ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "afs_7.50mm": 9 } } ]
+  },
+  {
+    "id": "afs_sr77_45mag",
+    "looks_like": "fnp90mag",
+    "type": "MAGAZINE",
+    "name": { "str": "SR-77 45-round magazine" },
+    "description": "A translucent 45-round box magazine, for use with the SR-77.",
+    "weight": "300 g",
+    "volume": "430 ml",
+    "longest_side": "266 mm",
+    "price": 9000,
+    "material": [ "plastic" ],
+    "symbol": "#",
+    "color": "light_gray",
+    "ammo_type": [ "afs_7.50mm" ],
+    "flags": [ "MAG_COMPACT" ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "afs_7.50mm": 45 } } ]
   }
 ]


### PR DESCRIPTION
#### Summary
Mods "Aftershock: New 7.5mm handcannon and PDW"

#### Purpose of change
This should finish up the mod's 7.5mm weapon line, unless some new ideas for guns come up.

#### Describe the solution

The new guns are:

Marsec. T72: A nine shot revolver with an extra barrel for 00 shot, functions just like the lemat revolver used to do. Requires 16 strenght to fire and is pretty massive. Should be the handcannon weapon for the whole mod (because doing this with 25mm is even more ridiculous)

SR-P77: A weird PDW that fires assault rifle bullets, it has higher capacity and lower size compared to the other mod assault rifle (SR-P9) but is less accurate at long range, and has lower range and damage. Counts as an SMG for skill purposes.

#### Testing
Bought and fired the guns.

#### Additional context
Consider obsoleting the rivtech revolver and the rest of the 8x40mm ammo from the mod. Its no longer serving a purpose here.