### PR TITLE
[MoM] Rework Revitalizing Meditation

### DIFF
--- a/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
+++ b/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
@@ -1172,8 +1172,8 @@ Powers causing telepathic damage have a 5% chance to down the target, a 33% chan
 *Target*: Self<br />
 *Duration*: Instant<br />
 *Stamina Cost*: 8000<br />
-*Channeling Time*: 1 hour<br />
-*Effects*: Sink deep into meditation and increase the speed of healing hundreds of times. When the channeling time ends, the psion heals from 3 to 8 damage to every body part, plus 0.5 to 2 per power level.<br />
+*Channeling Time*: 5 seconds<br />
+*Effects*: Sink deep into meditation and greatly increase healing speed. While meditating, the psion heals 4 times faster, plus 0.75 times per power level. In addition, broken limbs heal 2 times faster, plus 0.25 times per power level.<br />
 *Prerequisites*: Damage Balancing 6, Allay Infection 5<br />
 
 ## Lacerating Touch 

--- a/data/mods/MindOverMatter/effects/effects_psionic.json
+++ b/data/mods/MindOverMatter/effects/effects_psionic.json
@@ -1868,7 +1868,7 @@
               ]
             }
           },
-          { "value": "REGEN_HP_AWAKE", "multiply": 0.85 }
+          { "value": "REGEN_HP_AWAKE", "multiply": 1 }
         ]
       }
     ]

--- a/data/mods/MindOverMatter/effects/effects_psionic.json
+++ b/data/mods/MindOverMatter/effects/effects_psionic.json
@@ -1845,6 +1845,36 @@
   },
   {
     "type": "effect_type",
+    "id": "effect_vitakin_healing_trance",
+    "name": [ "Revitalizing Meditation" ],
+    "desc": [ "Thanks to your meditations you are healing much more quickly" ],
+    "rating": "good",
+    "enchantments": [
+      {
+        "values": [
+          {
+            "value": "REGEN_HP",
+            "multiply": {
+              "math": [
+                "( ( u_spell_level('vita_healing_trance') * 0.75 ) + 4 ) * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling"
+              ]
+            }
+          },
+          {
+            "value": "MENDING_MODIFIER",
+            "multiply": {
+              "math": [
+                "( ( u_spell_level('vita_healing_trance') * 0.25 ) + 1 ) * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling"
+              ]
+            }
+          },
+          { "value": "REGEN_HP_AWAKE", "multiply": 0.85 }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_type",
     "id": "effect_vitakin_hurt",
     "name": [ "Enervating Touch" ],
     "desc": [ "This reduces monsters' regeneration.  It's a bug if you have it." ],

--- a/data/mods/MindOverMatter/powers/vitakinesis.json
+++ b/data/mods/MindOverMatter/powers/vitakinesis.json
@@ -419,7 +419,7 @@
     "id": "vita_healing_trance",
     "type": "SPELL",
     "name": "[Ψ]Revitalizing Meditation",
-    "description": "Enter a trance state and heal your injuries",
+    "description": "Enter a trance state and heal your injuries many times faster than they would heal naturally.",
     "message": "You exit your trance and your wounds feel less painful.",
     "teachable": false,
     "valid_targets": [ "self" ],
@@ -428,21 +428,12 @@
     "flags": [ "PSIONIC", "CONCENTRATE", "SILENT", "NO_HANDS", "NO_LEGS", "RANDOM_DAMAGE" ],
     "difficulty": 6,
     "max_level": { "math": [ "int_to_level(1)" ] },
-    "effect": "attack",
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_VITAKIN_HEALING_TRANCE",
     "shape": "blast",
-    "min_damage": {
-      "math": [
-        "( (u_spell_level('vita_healing_trance') * -0.5) - 3) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
-      ]
-    },
-    "max_damage": {
-      "math": [
-        "( (u_spell_level('vita_healing_trance') * -2) - 8) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
-      ]
-    },
     "energy_source": "STAMINA",
     "base_energy_cost": 8000,
-    "base_casting_time": 360000
+    "base_casting_time": 500
   },
   {
     "id": "vita_attack_touch",

--- a/data/mods/MindOverMatter/powers/vitakinesis_eoc.json
+++ b/data/mods/MindOverMatter/powers/vitakinesis_eoc.json
@@ -209,6 +209,29 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_VITAKIN_HEALING_TRANCE",
+    "effect": [
+      { "u_assign_activity": "ACT_VITAKIN_HEALING_TRANCE_MEDITATE", "duration": "2400 minutes" },
+      { "u_add_effect": "effect_vitakin_healing_trance", "duration": "2400 minutes" }
+    ]
+  },
+  {
+    "id": "ACT_VITAKIN_HEALING_TRANCE_MEDITATE",
+    "type": "activity_type",
+    "activity_level": "NO_EXERCISE",
+    "verb": "meditating",
+    "based_on": "time",
+    "can_resume": false,
+    "rooted": true,
+    "completion_eoc": "EOC_VITAKIN_HEALING_TRANCE_REMOVE"
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_VITAKIN_HEALING_TRANCE_REMOVE",
+    "effect": [ { "u_lose_effect": "effect_vitakin_healing_trance" } ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_VITAKIN_CURE_DISEASE_CHECKS",
     "condition": { "u_has_effect": "effect_vita_cure_disease" },
     "effect": [


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Rework Revitalizing Meditation"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Revitalizing Meditation had the same problem as Wakeful Rest used to--it feels more like a spell than a psionic power. You spend an hour "casting" it, and then at the end you get a bunch of HP back. So, it's time to rework it the same way.

This is also makes it more distinct from Anabolic Rejuvenation.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Change it from an hour-long channel that insta-grants HP at the end to a 5 second channel that starts a meditation. While meditating, you heal 4x faster + 0.75 times per power level, and your limbs mend twice as fast plus 0.25 times per power level. This means that it's affected by anything else that affects your healing speed--Fast/Very Fast Healer or the opposite mutations, bandaging/disinfecting, etc., so you can stack all your powers (Staunch Wound + Allay Infection + Revitalizing Meditation) to heal extremely fast.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Checked the power, it works as intended, and heals faster than sleep. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
