### PR TITLE
Prototypes can fill tanks with items that aren't ammo

### DIFF
--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -1613,7 +1613,8 @@ void vehicles::finalize_prototypes()
                     blueprint.get_tools( vp ).emplace_back( it, calendar::turn );
                 }
                 if( pt.fuel ) {
-                    vp.ammo_set( pt.fuel, vp.ammo_capacity( pt.fuel->ammo->type ) );
+                    vp.ammo_set( pt.fuel,
+                                 pt.fuel->ammo ? vp.ammo_capacity( pt.fuel->ammo->type ) : vp.item_capacity( pt.fuel ) );
                 }
             }
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -312,11 +312,11 @@ void vehicle::init_state( map &placed_on, int init_veh_fuel, int init_veh_status
 
     std::map<itype_id, double> fuels; // lets tanks of same fuel type have even contents
     const auto rng_fuel_amount = [&fuels, init_veh_fuel]( vehicle_part & vp, const itype_id & fuel ) {
-        if( !fuel || !fuel->ammo || !fuel->ammo->type ) {
+        if( !fuel ) {
             vp.ammo_unset(); // clear if no valid fuel
             return;
         }
-        const int max = vp.ammo_capacity( fuel->ammo->type );
+        const int max = vp.item_capacity( fuel );
         if( init_veh_fuel < 0 ) {
             // map.emplace(...).first returns iterator to the new or existing element
             const double roll = fuels.emplace( fuel, normal_roll( 0.3, 0.15 ) ).first->second;

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -307,6 +307,9 @@ struct vehicle_part {
         /** Maximum amount of fuel, charges or ammunition that can be contained by a part */
         int ammo_capacity( const ammotype &ammo ) const;
 
+        /** Maximum amount of fuel, charges or ammunition that can be contained by a part */
+        int item_capacity( const itype_id &stuffing_id ) const;
+
         /** Amount of fuel, charges or ammunition currently contained by a part */
         int ammo_remaining() const;
         int remaining_ammo_capacity() const;

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -275,6 +275,26 @@ int vehicle_part::ammo_capacity( const ammotype &ammo ) const
     return 0;
 }
 
+int vehicle_part::item_capacity( const itype_id &stuffing_id ) const
+{
+    const itype *stuffing = item::find_type( stuffing_id );
+    if( stuffing->ammo ) {
+        return ammo_capacity( stuffing->ammo->type );
+    }
+
+    int max_amount_volume = 0;
+    int max_amount_weight = stuffing->weight == 0_gram ? INT_MAX :
+                            static_cast<int>( base.get_total_weight_capacity() / stuffing->weight );
+
+    if( stuffing->count_by_charges() ) {
+        max_amount_volume = stuffing->charges_per_volume( base.get_total_capacity() );
+    } else {
+        max_amount_volume = base.get_total_capacity() / stuffing->volume;
+    }
+
+    return std::min( max_amount_volume, max_amount_weight );
+}
+
 int vehicle_part::ammo_remaining() const
 {
     if( is_tank() ) {
@@ -297,9 +317,9 @@ int vehicle_part::ammo_set( const itype_id &ammo, int qty )
     // We often check if ammo is set to see if tank is empty, if qty == 0 don't set ammo
     if( is_tank() && qty != 0 ) {
         const itype *ammo_itype = item::find_type( ammo );
-        if( ammo_itype && ammo_itype->ammo && ammo_itype->phase >= phase_id::LIQUID ) {
+        if( ammo_itype && ammo_itype->phase >= phase_id::LIQUID ) {
             base.clear_items();
-            const int limit = ammo_capacity( ammo_itype->ammo->type );
+            const int limit = item_capacity( ammo );
             // assuming "ammo" isn't really going into a magazine as this is a vehicle part
             const int amount = qty > 0 ? std::min( qty, limit ) : limit;
             base.put_in( item( ammo, calendar::turn, amount ), pocket_type::CONTAINER );


### PR DESCRIPTION
#### Summary
Infrastructure "Prototypes can fill tanks with items that aren't ammo"

#### Purpose of change
A player reported a crash on loading with an exported vehicle prototype. On further investigation, I discovered that prototype loading simply assumed that any defined `fuel` had a defined `ammo`. 

https://github.com/CleverRaven/Cataclysm-DDA/blob/4026ef1cfd91ec229cd183febca6a2f27d35015f/src/veh_type.cpp#L1615-L1616

This is definitely not always the case. `->ammo` returns nullptr, and this crashes in vehicle_part::ammo_capacity.

#### Describe the solution
Somewhat supplant vehicle_part::ammo_capacity with a new function, vehicle_part::item_capacity. item_capacity accepts an itype_id and forwards to ammo_capacity if the itype has ammo (just in case), otherwise does the usual math for how much can be stuffed in there and returns appropriately.

There is some duplication of code here, which isn't great. That could be resolved with the alternative...

#### Describe alternatives you've considered
Replacing lots of calls to vehicle_part::ammo_capacity with vehicle_part::item_capacity. Probably a good idea, but bigger potential for breakage or spaghetti. My focus here was cleaning up a crash.

#### Testing
Put this vehicle into your json:
```
{
  "id": "TESTME_NO_CRASH",
  "type": "vehicle",
  "name": "TESTME_NO_CRASH",
  "blueprint": [
    "─"
  ],
  "parts": [
    { "x": 0, "y": 0, "parts": [ "frame", { "part": "tank", "fuel": "mutagen" } ] }
  ],
  "items": [
    
  ],
  "zones": [
    
  ]
}
```

Load game without PR. Crash. Load game with PR. Vehicle can be spawned with tank filled appropriately.

#### Additional context
For some historical context: #54987

There might be a good reason why we always want an ammo type for our tank contents, but I have not been able to find one.