### PR TITLE
Allows setting fixed special scoped parameters for start locations

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -850,6 +850,7 @@ bool game::start_game()
     const start_location &start_loc = u.random_start_location ? scen->random_start_location().obj() :
                                       u.start_location.obj();
     tripoint_abs_omt omtstart = overmap::invalid_tripoint;
+    std::vector<std::pair<std::string, std::string>> associated_parameters;
     const bool select_starting_city = get_option<bool>( "SELECT_STARTING_CITY" );
     do {
         if( select_starting_city ) {
@@ -857,9 +858,13 @@ bool game::start_game()
                 u.starting_city = random_entry( city::get_all() );
                 u.world_origin = u.starting_city->pos_om;
             }
-            omtstart = start_loc.find_player_initial_location( u.starting_city.value() );
+            auto ret = start_loc.find_player_initial_location( u.starting_city.value() );
+            omtstart = ret.first;
+            associated_parameters = ret.second;
         } else {
-            omtstart = start_loc.find_player_initial_location( u.world_origin.value_or( point_abs_om() ) );
+            auto ret = start_loc.find_player_initial_location( u.world_origin.value_or( point_abs_om() ) );
+            omtstart = ret.first;
+            associated_parameters = ret.second;
         }
         if( omtstart == overmap::invalid_tripoint ) {
 
@@ -872,6 +877,9 @@ bool game::start_game()
             }
         }
     } while( omtstart == overmap::invalid_tripoint );
+
+    // Set parameter(s) if specified in chosen start_loc
+    start_loc.set_parameters( omtstart, associated_parameters );
 
     start_loc.prepare_map( omtstart );
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -850,7 +850,7 @@ bool game::start_game()
     const start_location &start_loc = u.random_start_location ? scen->random_start_location().obj() :
                                       u.start_location.obj();
     tripoint_abs_omt omtstart = overmap::invalid_tripoint;
-    std::vector<std::pair<std::string, std::string>> associated_parameters;
+    std::unordered_map<std::string, std::string> associated_parameters;
     const bool select_starting_city = get_option<bool>( "SELECT_STARTING_CITY" );
     do {
         if( select_starting_city ) {

--- a/src/mapgendata.cpp
+++ b/src/mapgendata.cpp
@@ -86,12 +86,12 @@ mapgendata::mapgendata( const tripoint_abs_omt &over, map &mp, const float densi
             // so now is the time to generate the arguments
             if( std::optional<overmap_special_id> s = overmap_buffer.overmap_special_at( over ) ) {
                 const overmap_special &special = **s;
-                auto tmp = special.get_args( *this );
+                mapgen_arguments internally_set_args = special.get_args( *this );
                 if( overmap_buffer.externally_set_args ) {
-                    maybe_args->value().map.merge( tmp.map );
+                    maybe_args->value().map.merge( internally_set_args.map );
                     overmap_buffer.externally_set_args = false;
                 } else {
-                    *maybe_args = tmp;
+                    *maybe_args = internally_set_args;
                 }
                 mapgen_args_ = **maybe_args;
             } else {

--- a/src/mapgendata.cpp
+++ b/src/mapgendata.cpp
@@ -79,14 +79,20 @@ mapgendata::mapgendata( const tripoint_abs_omt &over, map &mp, const float densi
     set_neighbour( 6, direction::SOUTHWEST );
     set_neighbour( 7, direction::NORTHWEST );
     if( std::optional<mapgen_arguments> *maybe_args = overmap_buffer.mapgen_args( over ) ) {
-        if( *maybe_args ) {
+        if( *maybe_args && !overmap_buffer.externally_set_args ) {
             mapgen_args_ = **maybe_args;
         } else {
             // We are the first omt from this overmap_special to be generated,
             // so now is the time to generate the arguments
             if( std::optional<overmap_special_id> s = overmap_buffer.overmap_special_at( over ) ) {
                 const overmap_special &special = **s;
-                *maybe_args = special.get_args( *this );
+                auto tmp = special.get_args( *this );
+                if( overmap_buffer.externally_set_args ) {
+                    maybe_args->value().map.merge( tmp.map );
+                    overmap_buffer.externally_set_args = false;
+                } else {
+                    *maybe_args = tmp;
+                }
                 mapgen_args_ = **maybe_args;
             } else {
                 debugmsg( "mapgen params expected but no overmap special found for terrain %s",

--- a/src/overmapbuffer.h
+++ b/src/overmapbuffer.h
@@ -144,6 +144,8 @@ class overmapbuffer
     public:
         overmapbuffer();
 
+        bool externally_set_args = false;
+
         static cata_path terrain_filename( const point_abs_om & );
         static cata_path player_filename( const point_abs_om & );
 

--- a/src/start_location.cpp
+++ b/src/start_location.cpp
@@ -280,7 +280,7 @@ std::pair<tripoint_abs_omt, std::unordered_map<std::string, std::string>>
             auto it = std::find_if( _locations.begin(), _locations.end(),
                                     target_is_ot_match );
             if( it != _locations.end() ) {
-                valid.emplace_back( std::make_pair( p, *it ) );
+                valid.emplace_back( p, *it );
             }
         }
     }

--- a/src/start_location.h
+++ b/src/start_location.h
@@ -68,7 +68,7 @@ class start_location
          * Set any parameters assigned to the chosen start location
          */
         void set_parameters( const tripoint_abs_omt &omtstart,
-                             const std::vector<std::pair<std::string, std::string>> &parameters ) const;
+                             std::vector<std::pair<std::string, std::string>> parameters_to_set ) const;
         /**
          * Initialize the map at players start location using @ref prepare_map.
          * @param omtstart Global overmap terrain coordinates where the player is to be spawned.
@@ -112,8 +112,6 @@ class start_location
         std::set<std::string> _flags;
         start_location_placement_constraints constraints_;
 
-        void set_special_arg( const tripoint_abs_omt &omtstart,
-                              const std::string &param_name_to_set, const std::string &value_to_set ) const;
         void prepare_map( tinymap &m ) const;
 };
 

--- a/src/start_location.h
+++ b/src/start_location.h
@@ -27,6 +27,12 @@ struct start_location_placement_constraints {
     numeric_interval<int> allowed_z_levels{ -OVERMAP_DEPTH, OVERMAP_HEIGHT };
 };
 
+struct omt_types_parameters {
+    std::string omt;
+    ot_match_type omt_type;
+    std::vector<std::pair<std::string, std::string>> parameters;
+};
+
 class start_location
 {
     public:
@@ -39,7 +45,7 @@ class start_location
 
         std::string name() const;
         int targets_count() const;
-        std::pair<std::string, ot_match_type> random_target() const;
+        omt_types_parameters random_target() const;
         const std::set<std::string> &flags() const;
 
         /**
@@ -48,14 +54,21 @@ class start_location
          * It may return `overmap::invalid_tripoint` if no suitable starting location could be found
          * in the world.
          */
-        tripoint_abs_omt find_player_initial_location( const point_abs_om &origin ) const;
+        std::pair<tripoint_abs_omt, std::vector<std::pair<std::string, std::string>>>
+        find_player_initial_location( const point_abs_om &origin ) const;
         /**
          * Find a suitable start location on the overmap in specific city.
          * @return Global, absolute overmap terrain coordinates where the player should spawn.
          * It may return `overmap::invalid_tripoint` if no suitable starting location could be found
          * in the world.
          */
-        tripoint_abs_omt find_player_initial_location( const city &origin ) const;
+        std::pair<tripoint_abs_omt, std::vector<std::pair<std::string, std::string>>>
+        find_player_initial_location( const city &origin ) const;
+        /**
+         * Set any parameters assigned to the chosen start location
+         */
+        void set_parameters( const tripoint_abs_omt &omtstart,
+                             const std::vector<std::pair<std::string, std::string>> &parameters ) const;
         /**
          * Initialize the map at players start location using @ref prepare_map.
          * @param omtstart Global overmap terrain coordinates where the player is to be spawned.
@@ -95,10 +108,12 @@ class start_location
         bool can_belong_to_city( const tripoint_om_omt &p, const city &cit ) const;
     private:
         translation _name;
-        std::vector<std::pair<std::string, ot_match_type>> _omt_types;
+        std::vector<omt_types_parameters> _locations;
         std::set<std::string> _flags;
         start_location_placement_constraints constraints_;
 
+        void set_special_arg( const tripoint_abs_omt &omtstart,
+                              const std::string &param_name_to_set, const std::string &value_to_set ) const;
         void prepare_map( tinymap &m ) const;
 };
 

--- a/src/start_location.h
+++ b/src/start_location.h
@@ -30,7 +30,7 @@ struct start_location_placement_constraints {
 struct omt_types_parameters {
     std::string omt;
     ot_match_type omt_type;
-    std::vector<std::pair<std::string, std::string>> parameters;
+    std::unordered_map<std::string, std::string> parameters;
 };
 
 class start_location
@@ -54,21 +54,21 @@ class start_location
          * It may return `overmap::invalid_tripoint` if no suitable starting location could be found
          * in the world.
          */
-        std::pair<tripoint_abs_omt, std::vector<std::pair<std::string, std::string>>>
-        find_player_initial_location( const point_abs_om &origin ) const;
+        std::pair<tripoint_abs_omt, std::unordered_map<std::string, std::string>>
+                find_player_initial_location( const point_abs_om &origin ) const;
         /**
          * Find a suitable start location on the overmap in specific city.
          * @return Global, absolute overmap terrain coordinates where the player should spawn.
          * It may return `overmap::invalid_tripoint` if no suitable starting location could be found
          * in the world.
          */
-        std::pair<tripoint_abs_omt, std::vector<std::pair<std::string, std::string>>>
-        find_player_initial_location( const city &origin ) const;
+        std::pair<tripoint_abs_omt, std::unordered_map<std::string, std::string>>
+                find_player_initial_location( const city &origin ) const;
         /**
          * Set any parameters assigned to the chosen start location
          */
         void set_parameters( const tripoint_abs_omt &omtstart,
-                             std::vector<std::pair<std::string, std::string>> parameters_to_set ) const;
+                             const std::unordered_map<std::string, std::string> &parameters_to_set ) const;
         /**
          * Initialize the map at players start location using @ref prepare_map.
          * @param omtstart Global overmap terrain coordinates where the player is to be spawned.


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Closes #72479
Needed for #72561 and #72809

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

You can set singular or multiple parameters to singular values which then override those calculated normally when the mapdata is initialised, so you don't have to set every parameter. 
You can also use this to set a parameter to a 0 weight value for it to be start location only. 

set_parameters somewhat cargo cults overmap_ui's set_special_args used for debug setting parameters

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

The bool being stored in overmap_buffer is pretty gross but I couldn't see how to easily scope it otherwise

It still calcs the overridden parameters which is suboptimal but I didn't fancy attacking the function that spits them all out together

If I or someone else gets around to doing #72529 the functions will probably want moving to overmap_special but I didn't fancy trying to scope that for this

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Tested with #72561

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
