### PR TITLE
Don't check always-assigned integer (interpreted as bool)

### DIFF
--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -2842,7 +2842,7 @@ static std::pair<int, bool> find_repair_difficulty( const itype &it )
 
     if( !it.materials.empty() ) {
         for( const auto &mats : it.materials ) {
-            if( mats.first->repair_difficulty() && difficulty < mats.first->repair_difficulty() ) {
+            if( difficulty < mats.first->repair_difficulty() ) {
                 difficulty = mats.first->repair_difficulty();
                 difficulty_defined = true;
             }


### PR DESCRIPTION
#### Summary
Bugfixes "Difficulty 0 materials are repaired at their intended difficulty level of 0, not 10"

#### Purpose of change
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/413e3766-d7d6-4200-abb9-540b4bcaff91)
This item has a repair_difficulty of 0 for both materials. Despite that, the repair_difficulty is 10, because...
https://github.com/CleverRaven/Cataclysm-DDA/blob/be1685d3bbd4f22948e10dc23969cb2132d42984/src/iuse_actor.cpp#L2874-L2877

and difficulty wasn't found earlier, because **a difficulty of 0 is interpreted as boolean false**:
https://github.com/CleverRaven/Cataclysm-DDA/blob/be1685d3bbd4f22948e10dc23969cb2132d42984/src/iuse_actor.cpp#L2845

#### Describe the solution
Don't check if repair_difficulty exists - it always does. Optional(the **function**) assigns a value of 0 if no json load is found.

#### Describe alternatives you've considered
wrap all optional loads in std::optional?

#### Testing
Difficulty 0
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/a095d70c-d147-446f-b89b-02675b688590)

#### Additional context
