### PR TITLE
2 plastic mask variants

### DIFF
--- a/data/json/items/armor/masks.json
+++ b/data/json/items/armor/masks.json
@@ -388,6 +388,20 @@
         "description": "It's a cheesy plastic zombie mask.  You miss when they were just fiction.",
         "weight": 15,
         "append": true
+      },
+      {
+        "id": "payday_plastic_mask",
+        "name": { "str": "plastic heister mask" },
+        "description": "It's a plastic mask of a certain heister who heists the loud way.",
+        "weight": 15,
+        "append": true
+      },
+      {
+        "id": "noface_plastic_mask",
+        "name": { "str": "plastic no-face mask" },
+        "description": "It's a plastic mask of a lonely spirit.",
+        "weight": 15,
+        "append": true
       }
     ]
   },


### PR DESCRIPTION


#### Summary
None

#### Purpose of change
Two more plastic mask variants cuz why not.

#### Describe the solution

- plastic heister mask
- plastic no-face mask

#### Describe alternatives you've considered

Keep it for myself

#### Testing

![Screenshot_2024-03-23_21-20-18_1](https://github.com/CleverRaven/Cataclysm-DDA/assets/78019001/4323aafd-9d8b-4a77-ad29-6e043ad0ddfe)

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
