### PR TITLE
Implemented drawing of CJK characters with ImGui screens

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -158,13 +158,41 @@ RGBTuple color_loader<RGBTuple>::from_rgb( const int r, const int g, const int b
 }
 #else
 #include "sdl_utils.h"
+#include "sdl_font.h"
+#include "font_loader.h"
+#include "wcwidth.h"
 #include <imgui/imgui_impl_sdl2.h>
 #include <imgui/imgui_impl_sdlrenderer2.h>
 
-SDL_Renderer *cataimgui::client::sdl_renderer = nullptr;
-SDL_Window *cataimgui::client::sdl_window = nullptr;
+struct CataImFont : public ImFont {
+    std::unordered_map<ImU32, unsigned char> sdlColorsToCata;
+    const cataimgui::client &imclient;
+    const std::unique_ptr<Font> &cata_font;
+    CataImFont( const cataimgui::client &imclient, const std::unique_ptr<Font> &cata_font ) :
+        imclient( imclient ), cata_font( cata_font ) {
+    }
 
-cataimgui::client::client()
+    // this function QUEUES a character to be drawn
+    bool CanRenderFallbackChar( const char *s_begin, const char *s_end ) const override {
+        return s_begin != nullptr && s_end != nullptr;
+    }
+
+    int GetFallbackCharWidth( const char *s_begin, const char *s_end,
+                              const float scale ) const override {
+        return cata_font->width * utf8_width( std::string( s_begin, s_end ) ) * int( scale );
+    }
+
+    int GetFallbackCharWidth( ImWchar c, const float scale ) const override {
+        return cata_font->width * mk_wcwidth( c ) * scale;
+    }
+};
+static CataImFont *activeFont;
+
+cataimgui::client::client( const SDL_Renderer_Ptr &sdl_renderer, const SDL_Window_Ptr &sdl_window,
+                           const GeometryRenderer_Ptr &sdl_geometry ) :
+    sdl_renderer( sdl_renderer ),
+    sdl_window( sdl_window ),
+    sdl_geometry( sdl_geometry )
 {
     IMGUI_CHECKVERSION();
     ImGui::CreateContext();
@@ -177,8 +205,39 @@ cataimgui::client::client()
 
     // Setup Dear ImGui style
     ImGui::StyleColorsDark();
-    ImGui_ImplSDL2_InitForSDLRenderer( sdl_window, sdl_renderer );
-    ImGui_ImplSDLRenderer2_Init( sdl_renderer );
+    ImGui_ImplSDL2_InitForSDLRenderer( sdl_window.get(), sdl_renderer.get() );
+    ImGui_ImplSDLRenderer2_Init( sdl_renderer.get() );
+}
+
+void cataimgui::client::load_fonts( const std::unique_ptr<Font> &cata_font,
+                                    const std::array<SDL_Color, color_loader<SDL_Color>::COLOR_NAMES_COUNT> &windowsPalette )
+{
+    ImGuiIO &io = ImGui::GetIO();
+    if( ImGui::GetIO().FontDefault == nullptr ) {
+        std::vector<std::string> typefaces;
+        ensure_unifont_loaded( typefaces );
+
+        ImFontConfig cfg;
+        cfg.DstFont = activeFont = new CataImFont( *this, cata_font );
+        for( size_t index = 0; index < color_loader<SDL_Color>::COLOR_NAMES_COUNT; index++ ) {
+            SDL_Color sdlCol = windowsPalette[index];
+            ImU32 rgb = sdlCol.b << 16 | sdlCol.g << 8 | sdlCol.r;
+            activeFont->sdlColorsToCata[rgb] = index;
+        }
+        io.FontDefault = io.Fonts->AddFontFromFileTTF( typefaces[0].c_str(), cata_font->height, &cfg,
+                         io.Fonts->GetGlyphRangesDefault() );
+        io.Fonts->Fonts[0] = cfg.DstFont;
+        ImGui_ImplSDLRenderer2_SetFallbackGlyphDrawCallback( [&]( const ImFontGlyphToDraw & glyph ) {
+            std::string uni_string = std::string( glyph.uni_str );
+            point p( int( glyph.pos.x ), int( glyph.pos.y - 5 ) );
+            unsigned char col = 0;
+            auto it = activeFont->sdlColorsToCata.find( glyph.col & 0xFFFFFF );
+            if( it != activeFont->sdlColorsToCata.end() ) {
+                col = it->second;
+            }
+            cata_font->OutputChar( sdl_renderer, sdl_geometry, glyph.uni_str, p, col );
+        } );
+    }
 }
 
 cataimgui::client::~client()

--- a/src/cata_imgui.h
+++ b/src/cata_imgui.h
@@ -10,12 +10,14 @@ struct input_event;
 struct item_info_data;
 
 #if defined(WIN32) || defined(TILES)
-struct SDL_Renderer;
-struct SDL_Window;
+#include "sdl_geometry.h"
+#include "sdl_wrappers.h"
+#include "color_loader.h"
 #endif
 
 struct point;
 class ImVec2;
+class Font;
 
 namespace cataimgui
 {
@@ -44,7 +46,14 @@ enum class dialog_result {
 class client
 {
     public:
+#if !(defined(TILES) || defined(WIN32))
         client();
+#else
+        client( const SDL_Renderer_Ptr &sdl_renderer, const SDL_Window_Ptr &sdl_window,
+                const GeometryRenderer_Ptr &sdl_geometry );
+        void load_fonts( const std::unique_ptr<Font> &cata_font,
+                         const std::array<SDL_Color, color_loader<SDL_Color>::COLOR_NAMES_COUNT> &windowsPalette );
+#endif
         ~client();
 
         void new_frame();
@@ -55,8 +64,9 @@ class client
         void upload_color_pair( int p, int f, int b );
         void set_alloced_pair_count( short count );
 #else
-        static struct SDL_Renderer *sdl_renderer;
-        static struct SDL_Window *sdl_window;
+        const SDL_Renderer_Ptr &sdl_renderer;
+        const SDL_Window_Ptr &sdl_window;
+        const GeometryRenderer_Ptr &sdl_geometry;
 #endif
 };
 

--- a/src/sdl_font.h
+++ b/src/sdl_font.h
@@ -85,7 +85,8 @@ class CachedTTFFont : public Font
                          unsigned char color, float opacity = 1.0f ) override;
 
     protected:
-        SDL_Texture_Ptr create_glyph( const SDL_Renderer_Ptr &renderer, const std::string &ch, int color );
+        SDL_Texture_Ptr create_glyph( const SDL_Renderer_Ptr &renderer, const std::string &ch,
+                                      int &ch_width, int color );
 
         TTF_Font_Ptr font;
         // Maps (character code, color) to SDL_Texture*

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -425,12 +425,7 @@ static void WinCreate()
         geometry = std::make_unique<DefaultGeometryRenderer>();
     }
 
-    cataimgui::client::sdl_renderer = renderer.get();
-    cataimgui::client::sdl_window = window.get();
-    imclient = std::make_unique<cataimgui::client>();
-
-    //io.Fonts->AddFontDefault();
-    //io.Fonts->Build();
+    imclient = std::make_unique<cataimgui::client>( renderer, window, geometry );
 }
 
 static void WinDestroy()
@@ -3688,7 +3683,7 @@ void catacurses::init_interface()
                    windowsPalette, fl.overmap_typeface, fl.overmap_fontsize, fl.fontblending );
     stdscr = newwin( get_terminal_height(), get_terminal_width(), point_zero );
     //newwin calls `new WINDOW`, and that will throw, but not return nullptr.
-
+    imclient->load_fonts( font, windowsPalette );
 #if defined(__ANDROID__)
     // Make sure we initialize preview_terminal_width/height to sensible values
     preview_terminal_width = TERMINAL_WIDTH * fontwidth;

--- a/src/third-party/imgui/imgui.h
+++ b/src/third-party/imgui/imgui.h
@@ -142,6 +142,7 @@ struct ImFontAtlas;                 // Runtime data for multiple fonts, bake mul
 struct ImFontBuilderIO;             // Opaque interface to a font builder (stb_truetype or FreeType).
 struct ImFontConfig;                // Configuration data when adding a font or merging fonts
 struct ImFontGlyph;                 // A single font glyph (code point + coordinates within in ImFontAtlas + offset)
+struct ImFontGlyphToDraw;
 struct ImFontGlyphRangesBuilder;    // Helper to build glyph ranges from text/string data
 struct ImColor;                     // Helper functions to create a color that can be converted to either u32 or float4 (*OBSOLETE* please avoid using)
 struct ImGuiContext;                // Dear ImGui context (opaque structure, unless including imgui_internal.h)
@@ -2569,6 +2570,7 @@ struct ImDrawList
     ImVector<ImDrawCmd>     CmdBuffer;          // Draw commands. Typically 1 command = 1 GPU draw call, unless the command is a callback.
     ImVector<ImDrawIdx>     IdxBuffer;          // Index buffer. Each command consume ImDrawCmd::ElemCount of those
     ImVector<ImDrawVert>    VtxBuffer;          // Vertex buffer.
+    ImVector<ImFontGlyphToDraw> FallbackGlyphs;
     ImDrawListFlags         Flags;              // Flags, you may poke into these to adjust anti-aliasing settings per-primitive.
 
     // [Internal, used while building lists]
@@ -2749,6 +2751,13 @@ struct ImFontGlyph
     float           AdvanceX;           // Distance to next character (= data from font + ImFontConfig::GlyphExtraSpacing.x baked in)
     float           X0, Y0, X1, Y1;     // Glyph corners
     float           U0, V0, U1, V1;     // Texture coordinates
+};
+
+struct ImFontGlyphToDraw
+{
+    char uni_str[7];
+    ImVec2 pos;
+    ImU32 col;
 };
 
 // Helper to build glyph ranges from text/string data. Feed your application strings/characters to it then call BuildRanges().
@@ -2939,10 +2948,10 @@ struct ImFont
 
     // Methods
     IMGUI_API ImFont();
-    IMGUI_API ~ImFont();
+    virtual IMGUI_API ~ImFont();
     IMGUI_API const ImFontGlyph*FindGlyph(ImWchar c) const;
     IMGUI_API const ImFontGlyph*FindGlyphNoFallback(ImWchar c) const;
-    float                       GetCharAdvance(ImWchar c) const     { return ((int)c < IndexAdvanceX.Size) ? IndexAdvanceX[(int)c] : FallbackAdvanceX; }
+    float                       GetCharAdvance(ImWchar c) const;
     bool                        IsLoaded() const                    { return ContainerAtlas != NULL; }
     const char*                 GetDebugName() const                { return ConfigData ? ConfigData->Name : "<unknown>"; }
 
@@ -2950,6 +2959,9 @@ struct ImFont
     // 'wrap_width' enable automatic word-wrapping across multiple lines to fit into given width. 0.0f to disable.
     IMGUI_API ImVec2            CalcTextSizeA(float size, float max_width, float wrap_width, const char* text_begin, const char* text_end = NULL, const char** remaining = NULL) const; // utf8
     IMGUI_API const char*       CalcWordWrapPositionA(float scale, const char* text, const char* text_end, float wrap_width) const;
+    virtual bool                CanRenderFallbackChar(const char *s_begin, const char *s_end) const;
+    virtual int                 GetFallbackCharWidth( const char* s_begin, const char* s_end, const float scale ) const;
+    virtual int                 GetFallbackCharWidth(ImWchar c, const float scale) const;
     IMGUI_API void              RenderChar(ImDrawList* draw_list, float size, const ImVec2& pos, ImU32 col, ImWchar c) const;
     IMGUI_API void              RenderText(ImDrawList* draw_list, float size, const ImVec2& pos, ImU32 col, const ImVec4& clip_rect, const char* text_begin, const char* text_end, float wrap_width = 0.0f, bool cpu_fine_clip = false) const;
 

--- a/src/third-party/imgui/imgui_draw.cpp
+++ b/src/third-party/imgui/imgui_draw.cpp
@@ -394,6 +394,7 @@ void ImDrawList::_ResetForNewFrame()
     CmdBuffer.resize(0);
     IdxBuffer.resize(0);
     VtxBuffer.resize(0);
+    FallbackGlyphs.resize(0);
     Flags = _Data->InitialFlags;
     memset(&_CmdHeader, 0, sizeof(_CmdHeader));
     _VtxCurrentIdx = 0;
@@ -3341,6 +3342,18 @@ const ImFontGlyph* ImFont::FindGlyph(ImWchar c) const
     return &Glyphs.Data[i];
 }
 
+float ImFont::GetCharAdvance(ImWchar c) const
+{
+    if((int)c < IndexAdvanceX.Size)
+    {
+        return IndexAdvanceX[(int)c];
+    }
+    else
+    {
+        return GetFallbackCharWidth(c, 1.f);
+    }
+}
+
 const ImFontGlyph* ImFont::FindGlyphNoFallback(ImWchar c) const
 {
     if (c >= (size_t)IndexLookup.Size)
@@ -3518,7 +3531,12 @@ ImVec2 ImFont::CalcTextSizeA(float size, float max_width, float wrap_width, cons
                 continue;
         }
 
-        const float char_width = ((int)c < IndexAdvanceX.Size ? IndexAdvanceX.Data[c] : FallbackAdvanceX) * scale;
+        float char_width = 0.f;
+        if( (int)c < IndexAdvanceX.Size ) {
+            char_width = IndexAdvanceX.Data[c] * scale;
+        } else {
+            char_width = GetFallbackCharWidth( prev_s, s, scale );
+        }
         if (line_width + char_width >= max_width)
         {
             s = prev_s;
@@ -3553,6 +3571,21 @@ void ImFont::RenderChar(ImDrawList* draw_list, float size, const ImVec2& pos, Im
     float y = IM_FLOOR(pos.y);
     draw_list->PrimReserve(6, 4);
     draw_list->PrimRectUV(ImVec2(x + glyph->X0 * scale, y + glyph->Y0 * scale), ImVec2(x + glyph->X1 * scale, y + glyph->Y1 * scale), ImVec2(glyph->U0, glyph->V0), ImVec2(glyph->U1, glyph->V1), col);
+}
+
+bool ImFont::CanRenderFallbackChar(const char *s_begin, const char *s_end) const
+{
+    return false;
+}
+
+int ImFont::GetFallbackCharWidth( const char* s_begin, const char* s_end, const float scale ) const 
+{
+    return FallbackAdvanceX * scale;
+}
+
+int ImFont::GetFallbackCharWidth(ImWchar c, const float scale) const
+{
+    return FallbackAdvanceX * scale;
 }
 
 // Note: as with every ImDrawList drawing function, this expects that the font atlas texture is bound.
@@ -3624,6 +3657,7 @@ void ImFont::RenderText(ImDrawList* draw_list, float size, const ImVec2& pos, Im
 
     while (s < text_end)
     {
+        const char* s_orig = s;
         if (word_wrap_enabled)
         {
             // Calculate how far we can render. Requires two passes on the string data but keeps the code simple and not intrusive for what's essentially an uncommon feature.
@@ -3666,6 +3700,10 @@ void ImFont::RenderText(ImDrawList* draw_list, float size, const ImVec2& pos, Im
             continue;
 
         float char_width = glyph->AdvanceX * scale;
+        if( glyph == FallbackGlyph ) {
+            char_width = GetFallbackCharWidth( s_orig, s, scale );
+        }
+
         if (glyph->Visible)
         {
             // We don't do a second finer clipping test on the Y axis as we've already skipped anything before clip_rect.y and exit once we pass clip_rect.w
@@ -3725,6 +3763,21 @@ void ImFont::RenderText(ImDrawList* draw_list, float size, const ImVec2& pos, Im
                 // Support for untinted glyphs
                 ImU32 glyph_col = glyph->Colored ? col_untinted : col;
 
+                if(glyph == FallbackGlyph)
+                {
+                    if(CanRenderFallbackChar(s_orig, s))
+                    {
+                        ImFontGlyphToDraw glyphToDraw;
+                        size_t len = s - s_orig;
+                        memcpy(glyphToDraw.uni_str, s_orig, len);
+                        glyphToDraw.uni_str[len] = 0;
+                        glyphToDraw.pos = { x1, y1 };
+                        glyphToDraw.col = glyph_col;
+                        draw_list->FallbackGlyphs.push_back(glyphToDraw);
+                    }
+                    glyph = NULL;
+                }
+                else
                 // We are NOT calling PrimRectUV() here because non-inlined causes too much overhead in a debug builds. Inlined here:
                 {
                     vtx_write[0].pos.x = x1; vtx_write[0].pos.y = y1; vtx_write[0].col = glyph_col; vtx_write[0].uv.x = u1; vtx_write[0].uv.y = v1;

--- a/src/third-party/imgui/imgui_impl_sdlrenderer2.cpp
+++ b/src/third-party/imgui/imgui_impl_sdlrenderer2.cpp
@@ -116,6 +116,13 @@ void ImGui_ImplSDLRenderer2_NewFrame()
         ImGui_ImplSDLRenderer2_CreateDeviceObjects();
 }
 
+std::function<void(const ImFontGlyphToDraw &)> drawFallbackGlyphCallback;
+
+void ImGui_ImplSDLRenderer2_SetFallbackGlyphDrawCallback(std::function<void(const ImFontGlyphToDraw &)> func)
+{
+    drawFallbackGlyphCallback = func;
+}
+
 void ImGui_ImplSDLRenderer2_RenderDrawData(ImDrawData* draw_data)
 {
 	ImGui_ImplSDLRenderer2_Data* bd = ImGui_ImplSDLRenderer2_GetBackendData();
@@ -203,6 +210,14 @@ void ImGui_ImplSDLRenderer2_RenderDrawData(ImDrawData* draw_data)
                     uv, (int)sizeof(ImDrawVert),
                     cmd_list->VtxBuffer.Size - pcmd->VtxOffset,
                     idx_buffer + pcmd->IdxOffset, pcmd->ElemCount, sizeof(ImDrawIdx));
+            }
+
+            if(drawFallbackGlyphCallback)
+            {
+                for(const ImFontGlyphToDraw &glyphToDraw : cmd_list->FallbackGlyphs)
+                {
+                    drawFallbackGlyphCallback(glyphToDraw);
+                }
             }
         }
     }

--- a/src/third-party/imgui/imgui_impl_sdlrenderer2.h
+++ b/src/third-party/imgui/imgui_impl_sdlrenderer2.h
@@ -12,6 +12,7 @@
 //  [X] Renderer: Large meshes support (64k+ vertices) with 16-bit indices.
 
 #pragma once
+#include <functional>
 #include "imgui.h"      // IMGUI_IMPL_API
 
 struct SDL_Renderer;
@@ -19,6 +20,7 @@ struct SDL_Renderer;
 IMGUI_IMPL_API bool     ImGui_ImplSDLRenderer2_Init(SDL_Renderer* renderer);
 IMGUI_IMPL_API void     ImGui_ImplSDLRenderer2_Shutdown();
 IMGUI_IMPL_API void     ImGui_ImplSDLRenderer2_NewFrame();
+IMGUI_IMPL_API void     ImGui_ImplSDLRenderer2_SetFallbackGlyphDrawCallback(std::function<void(const ImFontGlyphToDraw &)> func);
 IMGUI_IMPL_API void     ImGui_ImplSDLRenderer2_RenderDrawData(ImDrawData* draw_data);
 
 // Called by Init/NewFrame/Shutdown


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Implemented drawing of non-English characters in ImGui screens"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes: #72162
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Implemented a font "fallback" system in ImGui to allow CDDA to interrupt ImGui's drawing flow to draw glyphs using CDDA's Font::OutputChar method.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
There are open PRs in the ImGui repo that implement dynamic font atlases which could potentially solve this problem, but they seem far from being viable enough to be a better solution than this.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Changed the language to Chinese, opened up the keybindings screen, and verified that the screen displays properly
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
The 'x' and 'y' position that ImGui tries to draw at doesn't quite work for Cataclysm. I needed to modify those by magic numbers to make the font align properly. I'm still not sure why it's needed.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
