### PR TITLE
Remove legacy computer migration infrastructure, it's ancient

### DIFF
--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -4811,11 +4811,7 @@ void submap::store( JsonOut &jsout ) const
     }
     jsout.end_array();
 
-    if( legacy_computer ) {
-        // it's possible that no access to computers has been made and legacy_computer
-        // is not cleared
-        jsout.member( "computers", *legacy_computer );
-    } else if( !computers.empty() ) {
+    if( !computers.empty() ) {
         jsout.member( "computers" );
         jsout.start_array();
         for( const auto &elem : computers ) {
@@ -5105,11 +5101,6 @@ void submap::load( const JsonValue &jv, const std::string &member_name, int vers
                                                       tripoint_zero ) ).first;
                 computers_json.next_value().read( new_comp_it->second );
             }
-        } else {
-            // only load legacy data here, but do not update to std::map, since
-            // the terrain may not have been loaded yet.
-            legacy_computer = std::make_unique<computer>( "BUGGED_COMPUTER", -100, tripoint_zero );
-            legacy_computer->deserialize( jv );
         }
     } else if( member_name == "camp" ) {
         camp = std::make_unique<basecamp>();

--- a/src/submap.cpp
+++ b/src/submap.cpp
@@ -13,8 +13,6 @@
 #include "units.h"
 #include "vehicle.h"
 
-static const furn_str_id furn_f_console( "f_console" );
-
 void maptile_soa::swap_soa_tile( const point &p1, const point &p2 )
 {
     std::swap( ter[p1.x][p1.y], ter[p2.x][p2.y] );

--- a/src/submap.cpp
+++ b/src/submap.cpp
@@ -140,24 +140,9 @@ void submap::delete_signage( const point &p )
     }
 }
 
-void submap::update_legacy_computer()
-{
-    if( !is_uniform() && legacy_computer ) {
-        for( int x = 0; x < SEEX; ++x ) {
-            for( int y = 0; y < SEEY; ++y ) {
-                if( m->frn[x][y] == furn_f_console ) {
-                    computers.emplace( point( x, y ), *legacy_computer );
-                }
-            }
-        }
-        legacy_computer.reset();
-    }
-}
-
 bool submap::has_computer( const point &p ) const
 {
-    return !is_uniform() && ( computers.find( p ) != computers.end() ||
-                              ( legacy_computer && m->frn[p.x][p.y] == furn_f_console ) );
+    return !is_uniform() && computers.find( p ) != computers.end();
 }
 
 const computer *submap::get_computer( const point &p ) const
@@ -168,17 +153,11 @@ const computer *submap::get_computer( const point &p ) const
     if( it != computers.end() ) {
         return &it->second;
     }
-    if( !is_uniform() && legacy_computer && m->frn[p.x][p.y] == furn_f_console ) {
-        return legacy_computer.get();
-    }
     return nullptr;
 }
 
 computer *submap::get_computer( const point &p )
 {
-    // need to update to std::map first so modifications to the returned object
-    // only affects the exact point p
-    //update_legacy_computer();
     const auto it = computers.find( p );
     if( it != computers.end() ) {
         return &it->second;
@@ -188,7 +167,6 @@ computer *submap::get_computer( const point &p )
 
 void submap::set_computer( const point &p, const computer &c )
 {
-    //update_legacy_computer();
     const auto it = computers.find( p );
     if( it != computers.end() ) {
         it->second = c;
@@ -199,7 +177,6 @@ void submap::set_computer( const point &p, const computer &c )
 
 void submap::delete_computer( const point &p )
 {
-    update_legacy_computer();
     computers.erase( p );
 }
 

--- a/src/submap.h
+++ b/src/submap.h
@@ -313,12 +313,9 @@ class submap
     private:
         std::map<point_sm_ms, tile_data> ephemeral_data;
         std::map<point, computer> computers;
-        std::unique_ptr<computer> legacy_computer;
         std::unique_ptr<maptile_soa> m;
         ter_id uniform_ter = t_null;
         int temperature_mod = 0; // delta in F
-
-        void update_legacy_computer();
 
         static constexpr size_t elements = SEEX * SEEY;
 };


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
While trying to track down a mapgen bug I came to suspect this conversion infrastructure.
It didn't end up being the cause, but now that I'm looking it's really ancient so it's tome to go.

#### Describe the solution
Remove the migration code that was introduced in 0813ad46e45f47ccdab369cb270b2e627e9de9e5 over four years ago.