### PR TITLE
Add a gun-less variant of mansion safe item group and use it in the resort.

### DIFF
--- a/data/json/itemgroups/Locations_MapExtras/mansion.json
+++ b/data/json/itemgroups/Locations_MapExtras/mansion.json
@@ -84,6 +84,22 @@
     ]
   },
   {
+    "id": "mansion_safe_nogun",
+    "type": "item_group",
+    "subtype": "collection",
+    "items": [
+      [ "diamond", 20 ],
+      { "item": "money_bundle_twenty", "prob": 50, "count": [ 1, 5 ] },
+      { "item": "money_bundle_fifty", "prob": 50, "count": [ 1, 5 ] },
+      { "item": "money_bundle_hundred", "prob": 20, "count": [ 1, 2 ] },
+      { "group": "stash_drugs", "prob": 5 },
+      [ "file", 70 ],
+      { "group": "jewelry_front", "prob": 40 },
+      { "group": "costume_jewelry_vampire", "prob": 5 },
+      { "group": "costume_jewelry_dark", "prob": 5 }
+    ]
+  },
+  {
     "id": "mansion_gunsafe",
     "type": "item_group",
     "subtype": "collection",

--- a/data/json/itemgroups/Locations_MapExtras/mansion.json
+++ b/data/json/itemgroups/Locations_MapExtras/mansion.json
@@ -84,7 +84,7 @@
     ]
   },
   {
-    "id": "mansion_safe_nogun",
+    "id": "mansion_safe_nogun"
     "type": "item_group",
     "subtype": "collection",
     "items": [

--- a/data/json/itemgroups/Locations_MapExtras/mansion.json
+++ b/data/json/itemgroups/Locations_MapExtras/mansion.json
@@ -84,7 +84,7 @@
     ]
   },
   {
-    "id": "mansion_safe_nogun"
+    "id": "mansion_safe_nogun",
     "type": "item_group",
     "subtype": "collection",
     "items": [

--- a/data/json/mapgen_palettes/private_resort.json
+++ b/data/json/mapgen_palettes/private_resort.json
@@ -45,7 +45,7 @@
     "toilets": { "$": {  } },
     "items": {
       "$": { "item": "stash_drugs", "chance": 75 },
-      "Y": { "item": "mansion_safe", "chance": 100, "repeat": [ 3, 8 ] },
+      "Y": { "item": "mansion_safe_nogun", "chance": 100, "repeat": [ 3, 8 ] },
       "l": { "item": "trash", "chance": 66, "repeat": [ 1, 3 ] },
       "e": { "item": "SUS_office_desk", "chance": 50 },
       "K": { "item": "unisex_coat_rack", "chance": 33, "repeat": [ 1, 3 ] },


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
While tracking down the source of some excessively common gun spawns I found that a ton of guns were spawning in the safe deposit boxes in the resort.  Looks like "mansion_safe" is being used as a standin for "rich people stuff".

#### Describe the solution
Add a variant of the mansion_safe item group without guns and apply it to the resort.

#### Describe alternatives you've considered
There could be a special gun lockup placement as well (with much smaller numbers of guns).
The mansion_safe group isn't really a great match for this kind of thing and a replacement would be good, but this was the minimal change to fix the immediate problem I was having.

#### Testing
Generated some resorts and no guns, yay.