### PR TITLE
Remove some duplicate map save directives that can break the map buffer

### DIFF
--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -2116,9 +2116,6 @@ static bool mx_city_trap( map &/*m*/, const tripoint &abs_sub )
         //... and a loudspeaker to attract zombies
         compmap.place_spawns( GROUP_TURRET_SPEAKER, 1, trap_center.xy(), trap_center.xy(), 1, true );
     }
-
-    compmap.save();
-
     return true;
 }
 
@@ -2170,9 +2167,6 @@ static bool mx_fungal_zone( map &/*m*/, const tripoint &abs_sub )
                              suitable_location.xy() + point_north_west,
                              suitable_location.xy() + point_south_east,
                              3, true );
-
-    fungal_map.save();
-
     return true;
 }
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
While doing some intensive mapgen testing I found that some map extras were occasionally triggering a memory leak when generating and deleting an OMT repeatedly. (this isn't exactly a normal use case, but fixing it is harmless so...).
I tracked it down to these, which are causing problems because they trigger map::save() twice on the same area, invalidating mapbuffer assumptions.

#### Describe the solution
Just remove the calls to map::save(), they're guaranteed to be handled by the caller.

#### Testing
This resolved my memory leak across a huge number of iterations.