### PR TITLE
Unseal when items are removed but the pocket isn't emptied

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -11959,6 +11959,13 @@ bool item::use_amount( const itype_id &it, int &quantity, std::list<item> &used,
     }
 
     for( item *removed : removed_items ) {
+        // Handle cases where items are removed but the pocket isn't emptied
+        item *parent = this->find_parent( *removed );
+        for( item_pocket *pocket : parent->get_all_standard_pockets() ) {
+            if( pocket->has_item( *removed ) ) {
+                pocket->unseal();
+            }
+        }
         this->remove_item( *removed );
     }
 


### PR DESCRIPTION
#### Summary
Bugfixes "Crafting will unseal containers when contents are removed"

#### Purpose of change
* Closes #68923

item::on_contents_changed() only unseals when the pockets are **emptied**.

#### Describe the solution
Specifically track the item we're taking out, making sure to unseal *the specific pocket containing that item*, regardless if it empties the pocket. (It is at least mod-wise possible for items to have multiple pockets with independent sealed status and/or containing different items)

#### Describe alternatives you've considered
item::use_charges has an alternative implementation(below), but it's buried in a lambda.
https://github.com/CleverRaven/Cataclysm-DDA/blob/74771e195489cf73125afc53c2f0710a3c3583c1/src/item.cpp#L12238-L12241

#### Testing
https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/40070588-ebea-4a29-af41-fd8c3e00eccf



#### Additional context