### PR TITLE
[CR] Reign in the damage from items dropped from height, with math

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -204,7 +204,6 @@ static const quality_id qual_LIFT( "LIFT" );
 static const skill_id skill_cooking( "cooking" );
 static const skill_id skill_melee( "melee" );
 static const skill_id skill_survival( "survival" );
-static const skill_id skill_throw( "throw" );
 static const skill_id skill_weapon( "weapon" );
 
 static const species_id species_ROBOT( "ROBOT" );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -14600,9 +14600,6 @@ bool item::on_drop( const tripoint &pos, map &m )
 
     avatar &player_character = get_avatar();
 
-    // set variable storing information of character dropping item
-    dropped_char_stats.throwing = player_character.get_skill_level( skill_throw );
-
     return type->drop_action && type->drop_action.call( &player_character, *this, pos );
 }
 

--- a/src/item.h
+++ b/src/item.h
@@ -176,10 +176,6 @@ template<>
 struct enum_traits<iteminfo::flags> {
     static constexpr bool is_flag_enum = true;
 };
-// Currently used to store the only throwing stats of character dropping this item. Default is -1
-struct dropped_by_character_stats {
-    float throwing;
-};
 
 iteminfo vol_to_info( const std::string &type, const std::string &left,
                       const units::volume &vol, int decimal_places = 2, bool lower_is_better = true );
@@ -235,8 +231,6 @@ class item : public visitable
         {}
 
         ~item() override;
-
-        struct dropped_by_character_stats dropped_char_stats = { -1.0f };
 
         /** Return a pointer-like type that's automatically invalidated if this
          * item is destroyed or assigned-to */

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2925,29 +2925,31 @@ void map::drop_items( const tripoint &p )
             // We use sqrt here because it trends back towards 1. Spectacularly low hit_mod will still have SOME chance to hit while
             // hits of >1 avoid_chance are not always going to strike the head
             creature_hit_chance /= sqrt( avoid_chance );
+            bodypart_id hit_part;
             if( creature_hit_chance < 15 ) {
-                add_msg_if_player_sees( creature_below->pos(), _( "Falling %s hits %s in the head!" ), i.tname(),
-                                        creature_below->get_name() );
-                creature_below->deal_damage( nullptr, bodypart_id( "head" ), damage_instance( damage_bash,
-                                             damage ) );
+                hit_part = creature_below->get_random_body_part_of_type( body_part_type::type::head );
             } else if( creature_hit_chance < 30 ) {
-                add_msg_if_player_sees( creature_below->pos(), _( "Falling %s hits %s in the torso!" ), i.tname(),
-                                        creature_below->get_name() );
-                creature_below->deal_damage( nullptr, bodypart_id( "torso" ), damage_instance( damage_bash,
-                                             damage ) );
-            } else if( creature_hit_chance < 65 ) {
-                add_msg_if_player_sees( creature_below->pos(), _( "Falling %s hits %s in the left arm!" ),
-                                        i.tname(), creature_below->get_name() );
-                creature_below->deal_damage( nullptr, bodypart_id( "arm_l" ), damage_instance( damage_bash,
-                                             damage ) );
+                hit_part = creature_below->get_random_body_part_of_type( body_part_type::type::torso );
+            } else if( creature_hit_chance < 90 ) {
+                hit_part = creature_below->get_random_body_part_of_type( body_part_type::type::arm );
             } else if( creature_hit_chance < 100 ) {
-                add_msg_if_player_sees( creature_below->pos(), _( "Falling %s hits %s in the right arm!" ),
-                                        i.tname(), creature_below->get_name() );
-                creature_below->deal_damage( nullptr, bodypart_id( "arm_r" ), damage_instance( damage_bash,
-                                             damage ) );
+                hit_part = creature_below->get_random_body_part_of_type( body_part_type::type::leg );
             } else {
                 add_msg_if_player_sees( creature_below->pos(), _( "Falling %s misses the %s!" ), i.tname(),
                                         creature_below->get_name() );
+            }
+            // Did we hit at all? Then run the message.
+            if( creature_hit_chance < 100 ) {
+                // For some reason bp_null is_valid???
+                if( hit_part.is_valid() ) {
+                    add_msg_if_player_sees( creature_below->pos(), _( "Falling %s hits %s in their %s for %i damage!" ),
+                                            i.tname(), creature_below->get_name(), hit_part->name, static_cast<int>( damage ) );
+                } else {
+                    add_msg_if_player_sees( creature_below->pos(), _( "Falling %s hits %s for %i damage!" ),
+                                            i.tname(), creature_below->get_name(), static_cast<int>( damage ) );
+                }
+                // FIXME: Hardcoded damage type!
+                creature_below->deal_damage( nullptr, hit_part, damage_instance( damage_bash, damage ) );
             }
         }
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2891,7 +2891,7 @@ void map::drop_items( const tripoint &p )
             height_fallen -= occupied_tile_fraction( creature_below->get_size() );
         }
         // in meters, assuming one z-level is ~2.5m.
-        const double distance_to_fall = ( height_fallen ) * 2.5;
+        const double distance_to_fall = height_fallen * 2.5;
 
         // in meters per second (squared).
         const double gravity_acceleration_constant = 9.8;
@@ -2935,18 +2935,19 @@ void map::drop_items( const tripoint &p )
             } else if( creature_hit_chance < 100 ) {
                 hit_part = creature_below->get_random_body_part_of_type( body_part_type::type::leg );
             } else {
-                add_msg_if_player_sees( creature_below->pos(), _( "Falling %s misses the %s!" ), i.tname(),
-                                        creature_below->get_name() );
+                add_msg_if_player_sees( creature_below->pos(), _( "Falling %1$s misses %2$s!" ), i.tname(),
+                                        creature_below->disp_name() );
             }
             // Did we hit at all? Then run the message.
             if( creature_hit_chance < 100 ) {
-                // For some reason bp_null is_valid???
-                if( hit_part.is_valid() ) {
-                    add_msg_if_player_sees( creature_below->pos(), _( "Falling %s hits %s in their %s for %i damage!" ),
-                                            i.tname(), creature_below->get_name(), hit_part->name, static_cast<int>( damage ) );
+                if( hit_part.is_valid() && !creature_below->is_monster() ) {
+                    //~First positional argument: Item name. Second: Name of a person (e.g. "Jane") or player (e.g. "you"). Third: Body part name, accusative.
+                    add_msg_if_player_sees( creature_below->pos(), _(
+                                                "Falling %1$s hits %2$s on the %3$s for %4$i damage!" ),
+                                            i.tname(), creature_below->disp_name(), hit_part->accusative, static_cast<int>( damage ) );
                 } else {
-                    add_msg_if_player_sees( creature_below->pos(), _( "Falling %s hits %s for %i damage!" ),
-                                            i.tname(), creature_below->get_name(), static_cast<int>( damage ) );
+                    add_msg_if_player_sees( creature_below->pos(), _( "Falling %1$s hits %2$s for %3$i damage!" ),
+                                            i.tname(), creature_below->disp_name(), static_cast<int>( damage ) );
                 }
                 // FIXME: Hardcoded damage type!
                 creature_below->deal_damage( nullptr, hit_part, damage_instance( damage_bash, damage ) );


### PR DESCRIPTION
#### Summary
Balance "Damage from dropped items scales with kinetic energy"

#### Purpose of change
* Closes #67785

#### Describe the solution
Implemented @ampersand55's [suggestion of using kinetic energy](https://github.com/CleverRaven/Cataclysm-DDA/issues/67785#issuecomment-1687057324)... while game_balance.md specifically warns against using that as a comparison, the results seemed *reasonable enough* in repeat testing. Better than "wasp lands on you, you take 450 damage, do not pass go, do not collect 200 NPCs, go directly to dead". I personally think this is a good basis for future adjustments, although I will note it does give up the density calculation.

Implemented [my own](https://github.com/CleverRaven/Cataclysm-DDA/issues/67785#issuecomment-2017727959) reasoning that the first-z-level distance should be scaled by size of the impacted creature. This halves the **impact energy**(not the damage) for something falling on a medium-sized creature(default character size) 1 z-level above. For a creature in the huge class (occupies 100% of the tile) it completely nullifies it. If there's no distance for the object to gain speed as it falls, it just can't.

Completely removed the throwing skill adjustment, recalculated hit chance based on dodge differential of velocity at time of impact. Throwing skill and dropping an object 'real good' are just... not the same thing? How would you even get more skilled at this? Plus as noted by @Kamayana it [always used the player character](https://github.com/CleverRaven/Cataclysm-DDA/issues/67785#issuecomment-1694420967). I did not see any merit in maintaining this broken reasoning.

Ripped out the hardcoded messages claiming that hit monsters have limbs, used the bodypart accessors to get the actual body parts and message/damage them accordingly.

#### Describe alternatives you've considered
@Brambor had a pretty good point [in their comment](https://github.com/CleverRaven/Cataclysm-DDA/issues/67785#issuecomment-1692475026). I wanted to scale the damage according to dodge, so that basically any willful dodging ability meant a glancing hit from an object that wasn't the size of the tile. But by the point I got there I was tired of doing math, so I did the above instead.

#### Testing
I hit a lot of dogs(in the appendix) with rocks thrown at z+4

Before PR, damage from a 87.5kg wasp falling on a character from 1 z-level above:
` 5 * 87.5 * 1 * 1.1`
 `= 481.25 damage`
After PR, the same wasp falling on a default character from 1 z-level above:
`~1071.875J impact energy`
`= ~32.74 damage`

Before PR, damage from a 87.5kg wasp falling on a character from **10** z-level above:
` 5 * 87.5 * 1 * 1.1`
 `= 4812.5 damage`
After PR, the same wasp falling on a default character from **10** z-level above:
`~20,365J impact energy`
`= ~142.7 damage`

#### Additional context
@kevingranade I imagine you will have some opinion on this new iteration

Known issue:
none