### PR TITLE
Make ImGui popup respond properly to 'h' and 'l' keys when highlighting selected option

### DIFF
--- a/src/popup.cpp
+++ b/src/popup.cpp
@@ -16,23 +16,22 @@
 
 class query_popup_impl : public cataimgui::window
 {
-        short keyboard_selected_option;
         short mouse_selected_option;
         size_t msg_width;
         query_popup *parent;
     public:
+        short keyboard_selected_option;
+
         explicit query_popup_impl( query_popup *parent ) : cataimgui::window( "QUERY_POPUP",
                     ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoScrollbar ) {
             msg_width = 400;
             this->parent = parent;
-            keyboard_selected_option = -1;
+            keyboard_selected_option = 0;
             mouse_selected_option = -1;
         }
 
         void on_resized() override;
-        int get_keyboard_selected_option() const {
-            return keyboard_selected_option;
-        }
+
         int get_mouse_selected_option() const {
             return mouse_selected_option;
         }
@@ -53,7 +52,6 @@ class query_popup_impl : public cataimgui::window
 void query_popup_impl::draw_controls()
 {
     mouse_selected_option = -1;
-    keyboard_selected_option = -1;
 
     for( const std::string &line : parent->folded_msg ) {
         nc_color col = parent->default_text_color;
@@ -72,16 +70,12 @@ void query_popup_impl::draw_controls()
             if( ImGui::IsItemHovered() ) {
                 mouse_selected_option = ind;
             }
-            if( ImGui::IsItemFocused() ) {
-                keyboard_selected_option = ind;
+            if( keyboard_selected_option == short( ind ) && ImGui::IsWindowFocused() ) {
+                ImGui::SetKeyboardFocusHere( -1 );
             }
             ImGui::SameLine();
         }
 
-        if( keyboard_selected_option == -1 && ImGui::IsWindowFocused() ) {
-            ImGui::SetKeyboardFocusHere( -1 );
-            keyboard_selected_option = parent->buttons.size() - 1;
-        }
     }
 }
 
@@ -544,6 +538,8 @@ query_popup::result query_popup::query_once_imgui()
         // Mouse movement and button
         ctxt.register_action( "SELECT" );
         ctxt.register_action( "MOUSE_MOVE" );
+        ctxt.register_action( "LEFT" );
+        ctxt.register_action( "RIGHT" );
     }
     if( anykey ) {
         ctxt.register_action( "ANY_INPUT" );
@@ -570,8 +566,8 @@ query_popup::result query_popup::query_once_imgui()
             // Left-click to confirm selection
             res.action = "CONFIRM";
             cur = size_t( impl->get_mouse_selected_option() );
-        } else if( res.action == "CONFIRM" && impl->get_keyboard_selected_option() != -1 ) {
-            cur = size_t( impl->get_keyboard_selected_option() );
+        } else if( res.action == "CONFIRM" && impl->keyboard_selected_option != -1 ) {
+            cur = size_t( impl->keyboard_selected_option );
         }
     } while(
         // Always ignore mouse movement
@@ -588,6 +584,14 @@ query_popup::result query_popup::query_once_imgui()
         if( cur < options.size() ) {
             res.wait_input = false;
             res.action = options[cur].action;
+        }
+    } else if( res.action == "LEFT" ) {
+        if( impl->keyboard_selected_option > 0 ) {
+            impl->keyboard_selected_option--;
+        }
+    } else if( res.action == "RIGHT" ) {
+        if( impl->keyboard_selected_option < short( buttons.size() - 1 ) ) {
+            impl->keyboard_selected_option++;
         }
     } else if( res.action == "HELP_KEYBINDINGS" ) {
         // Keybindings may have changed, regenerate the UI


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fixed issue where user could only change the selected option in the ImGui popup using the arrow keys or tab key"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes: #72599 
Fixes: #72093
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
ImGui popup was relying on ImGui's keyboard navigation, but because this isn't based on CDDA's keybindings, it leads to confusing situations where the bound keys don't work to, for instance, change the focused button in the popup.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
We could try and implement some infrastructure for tying ImGui's input handling to Cataclysm's own input system, but that would require lots of sleepless nights.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
From the main menu, delete a world, and verify that the correct buttons work to select the option in the popup, without buttons like tab changing the focus unexpectedly
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
