### PR TITLE
Arsonist should buy Merch at full value

### DIFF
--- a/data/json/npcs/refugee_center/surface_visitors/NPC_arsonist.json
+++ b/data/json/npcs/refugee_center/surface_visitors/NPC_arsonist.json
@@ -45,6 +45,11 @@
     "bonus_aggression": { "rng": [ 0, 1 ] },
     "bonus_collector": { "rng": [ 0, 2 ] },
     "shopkeeper_item_group": "NC_ARSONIST_STOCK",
+    "shopkeeper_price_rules":  [
+      { "item": "FMCNote", "fixed_adj": 0 },
+      { "item": "money_strap_FMCNote", "fixed_adj": 0 },
+      { "item": "money_bundle_FMCNote", "fixed_adj": 0 }
+    ],
     "carry_override": "NC_ARSONIST_STOCK",
     "worn_override": "NC_ARSONIST_worn",
     "skills": [

--- a/data/json/npcs/refugee_center/surface_visitors/NPC_arsonist.json
+++ b/data/json/npcs/refugee_center/surface_visitors/NPC_arsonist.json
@@ -45,7 +45,7 @@
     "bonus_aggression": { "rng": [ 0, 1 ] },
     "bonus_collector": { "rng": [ 0, 2 ] },
     "shopkeeper_item_group": "NC_ARSONIST_STOCK",
-    "shopkeeper_price_rules":  [
+    "shopkeeper_price_rules": [
       { "item": "FMCNote", "fixed_adj": 0 },
       { "item": "money_strap_FMCNote", "fixed_adj": 0 },
       { "item": "money_bundle_FMCNote", "fixed_adj": 0 }


### PR DESCRIPTION
#### Summary

Balance "Arsonist should buy Merch at full value"

#### Purpose of change

The arsonist in the refugee center was buying Merch from the player at a discount (determined by social skill and intelligence) because the arsonist is technically not part of the free_merchants. I think she should value Merch at full price because she lives in the refugee center and regularly trades with free_merchants.

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/52621858/f3356a4b-fd74-453b-b6fc-dc58f215cbc6)

#### Describe the solution

Add shopkeeper_price_rules to NC_ARSONIST

#### Describe alternatives you've considered

Set the faction of arsonist to free_merchants - I did not do this because I do not know what NPC faction affects besides trading prices

#### Testing

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/52621858/edcf937e-7e47-4791-8a44-d4000b5317b2)
