### PR TITLE
Remove .40 from 610

### DIFF
--- a/data/json/items/gun/10mm.json
+++ b/data/json/items/gun/10mm.json
@@ -4,14 +4,14 @@
     "copy-from": "pistol_revolver",
     "looks_like": "sw_619",
     "type": "GUN",
-    "name": { "str": "10mm/.40 revolver" },
-    "description": "A classic six-shooter revolver chambered for 10mm and .40 rounds.",
+    "name": { "str": "10mm revolver" },
+    "description": "A classic six-shooter revolver chambered for 10mm rounds.",
     "variant_type": "gun",
     "variants": [
       {
         "id": "sw_610",
         "name": { "str": "S&W 610 revolver" },
-        "description": "The Smith and Wesson 610 is a classic six-shooter revolver chambered for 10mm rounds, or for S&W's own .40 round."
+        "description": "The Smith and Wesson 610 is a classic six-shooter revolver chambered for 10mm rounds."
       }
     ],
     "ascii_picture": "sw_610",
@@ -26,7 +26,7 @@
     "material": [ "steel", "wood" ],
     "symbol": "(",
     "color": "dark_gray",
-    "ammo": [ "10mm", "40" ],
+    "ammo": [ "10mm" ],
     "dispersion": 320,
     "durability": 8,
     "blackpowder_tolerance": 56,
@@ -35,7 +35,7 @@
       {
         "pocket_type": "MAGAZINE",
         "rigid": true,
-        "ammo_restriction": { "10mm": 6, "40": 6 },
+        "ammo_restriction": { "10mm": 6 },
         "allowed_speedloaders": [ "40_speedloader6" ]
       }
     ],

--- a/data/json/items/magazine/10mm.json
+++ b/data/json/items/magazine/10mm.json
@@ -5,7 +5,7 @@
     "looks_like": "38_speedloader",
     "type": "MAGAZINE",
     "name": { "str": "10mm 6-round speedloader" },
-    "description": "This speedloader can hold 6 rounds of .40 S&W or 10mm Auto and quickly reload a compatible revolver.",
+    "description": "This speedloader can hold 6 rounds of 10mm Auto and quickly reload a compatible revolver.",
     "weight": "28 g",
     "volume": "25 ml",
     "price": 1500,
@@ -13,9 +13,9 @@
     "material": [ "plastic", "steel" ],
     "symbol": "#",
     "color": "light_gray",
-    "ammo_type": [ "40", "10mm" ],
+    "ammo_type": [ "10mm" ],
     "flags": [ "SPEEDLOADER" ],
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "40": 6, "10mm": 6 } } ]
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "10mm": 6 } } ]
   },
   {
     "id": "glock_20mag",

--- a/tests/reloading_test.cpp
+++ b/tests/reloading_test.cpp
@@ -149,37 +149,37 @@ TEST_CASE( "reload_gun_with_casings", "[reload],[gun]" )
 {
 
     SECTION( "empty gun" ) {
-        item gun( "sw_610" );
+        item gun( "bond_410" );
 
         SECTION( "with one round" ) {
-            item ammo( "40sw" );
+            item ammo( "45colt_fmj" );
             test_reloading( gun, ammo );
         }
     }
 
     SECTION( "gun with casings and ammo" ) {
-        item gun( "sw_610" );
-        gun.put_in( item( "40sw", calendar::turn, 3 ), pocket_type::MAGAZINE );
-        gun.force_insert_item( item( "40_casing", calendar::turn, 3 ).set_flag( json_flag_CASING ),
+        item gun( "bond_410" );
+        gun.put_in( item( "45colt_fmj", calendar::turn, 3 ), pocket_type::MAGAZINE );
+        gun.force_insert_item( item( "45colt_casing", calendar::turn, 3 ).set_flag( json_flag_CASING ),
                                pocket_type::MAGAZINE );
 
         SECTION( "with one round" ) {
-            item ammo( "40sw" );
+            item ammo( "45colt_fmj" );
             test_reloading( gun, ammo );
         }
 
         SECTION( "with large stack of rounds" ) {
-            item ammo( "40sw", calendar::turn, 500 );
+            item ammo( "45colt_fmj", calendar::turn, 500 );
             test_reloading( gun, ammo );
         }
 
         SECTION( "with one ammo of different type" ) {
-            item ammo( "bp_40sw" );
+            item ammo( "45colt_cowboy" );
             test_reloading( gun, ammo );
         }
 
         SECTION( "with one ammo of different ammo type" ) {
-            item ammo( "10mm_fmj" );
+            item ammo( "410shot_000" );
             test_reloading( gun, ammo, false );
         }
 
@@ -190,17 +190,17 @@ TEST_CASE( "reload_gun_with_casings", "[reload],[gun]" )
     }
 
     SECTION( "full of casings" ) {
-        item gun( "sw_610" );
-        gun.force_insert_item( item( "40_casing", calendar::turn, 6 ).set_flag( json_flag_CASING ),
+        item gun( "bond_410" );
+        gun.force_insert_item( item( "45colt_casing", calendar::turn, 2 ).set_flag( json_flag_CASING ),
                                pocket_type::MAGAZINE );
 
         SECTION( "with one round" ) {
-            item ammo( "40sw" );
+            item ammo( "45colt_fmj" );
             test_reloading( gun, ammo );
         }
 
         SECTION( "with large stack of rounds" ) {
-            item ammo( "40sw", calendar::turn, 500 );
+            item ammo( "45colt_fmj", calendar::turn, 500 );
             test_reloading( gun, ammo );
         }
 
@@ -492,7 +492,7 @@ TEST_CASE( "speedloader_reloading", "[reload],[gun]" )
 
         SECTION( "partially empty speedloader" ) {
             item speedloader( "40_speedloader6" );
-            speedloader.put_in( item( "40sw", calendar::turn, 3 ), pocket_type::MAGAZINE );
+            speedloader.put_in( item( "10mm_fmj", calendar::turn, 3 ), pocket_type::MAGAZINE );
 
             REQUIRE( !speedloader.empty() );
             REQUIRE( !speedloader.is_magazine_full() );
@@ -502,7 +502,7 @@ TEST_CASE( "speedloader_reloading", "[reload],[gun]" )
 
         SECTION( "full speedloader" ) {
             item speedloader( "40_speedloader6" );
-            speedloader.put_in( item( "40sw", calendar::turn, 6 ), pocket_type::MAGAZINE );
+            speedloader.put_in( item( "10mm_fmj", calendar::turn, 6 ), pocket_type::MAGAZINE );
 
             REQUIRE( speedloader.is_magazine_full() );
 
@@ -522,7 +522,7 @@ TEST_CASE( "speedloader_reloading", "[reload],[gun]" )
 
     SECTION( "full gun" ) {
         item gun( "sw_610" );
-        gun.put_in( item( "40sw", calendar::turn, 6 ), pocket_type::MAGAZINE );
+        gun.put_in( item( "10mm_fmj", calendar::turn, 6 ), pocket_type::MAGAZINE );
         REQUIRE( gun.is_magazine_full() );
 
         SECTION( "empty speedloader" ) {
@@ -533,7 +533,7 @@ TEST_CASE( "speedloader_reloading", "[reload],[gun]" )
 
         SECTION( "partially empty speedloader" ) {
             item speedloader( "40_speedloader6" );
-            speedloader.put_in( item( "40sw", calendar::turn, 3 ), pocket_type::MAGAZINE );
+            speedloader.put_in( item( "10mm_fmj", calendar::turn, 3 ), pocket_type::MAGAZINE );
 
             REQUIRE( !speedloader.empty() );
             REQUIRE( !speedloader.is_magazine_full() );
@@ -543,7 +543,7 @@ TEST_CASE( "speedloader_reloading", "[reload],[gun]" )
 
         SECTION( "full speedloader" ) {
             item speedloader( "40_speedloader6" );
-            speedloader.put_in( item( "40sw", calendar::turn, 6 ), pocket_type::MAGAZINE );
+            speedloader.put_in( item( "10mm_fmj", calendar::turn, 6 ), pocket_type::MAGAZINE );
 
             REQUIRE( speedloader.is_magazine_full() );
 
@@ -563,7 +563,7 @@ TEST_CASE( "speedloader_reloading", "[reload],[gun]" )
 
     SECTION( "gun full of casings" ) {
         item gun( "sw_610" );
-        gun.force_insert_item( item( "40_casing", calendar::turn, 6 ).set_flag( json_flag_CASING ),
+        gun.force_insert_item( item( "10mm_casing", calendar::turn, 6 ).set_flag( json_flag_CASING ),
                                pocket_type::MAGAZINE );
 
         SECTION( "empty speedloader" ) {
@@ -574,7 +574,7 @@ TEST_CASE( "speedloader_reloading", "[reload],[gun]" )
 
         SECTION( "partially empty speedloader" ) {
             item speedloader( "40_speedloader6" );
-            speedloader.put_in( item( "40sw", calendar::turn, 3 ), pocket_type::MAGAZINE );
+            speedloader.put_in( item( "10mm_fmj", calendar::turn, 3 ), pocket_type::MAGAZINE );
 
             REQUIRE( !speedloader.empty() );
             REQUIRE( !speedloader.is_magazine_full() );
@@ -584,7 +584,7 @@ TEST_CASE( "speedloader_reloading", "[reload],[gun]" )
 
         SECTION( "full speedloader" ) {
             item speedloader( "40_speedloader6" );
-            speedloader.put_in( item( "40sw", calendar::turn, 6 ), pocket_type::MAGAZINE );
+            speedloader.put_in( item( "10mm_fmj", calendar::turn, 6 ), pocket_type::MAGAZINE );
 
             REQUIRE( speedloader.is_magazine_full() );
 
@@ -777,7 +777,7 @@ TEST_CASE( "reload_gun_with_integral_magazine", "[reload],[gun]" )
     // Make sure the player doesn't drop anything :P
     dummy.wear_item( item( "backpack", calendar::turn_zero ) );
 
-    item_location ammo = dummy.i_add( item( "40sw", calendar::turn_zero, item::default_charges_tag{} ) );
+    item_location ammo = dummy.i_add( item( "10mm_fmj", calendar::turn_zero, item::default_charges_tag{} ) );
     item_location gun = dummy.i_add( item( "sw_610", calendar::turn_zero, item::default_charges_tag{} ) );
 
     REQUIRE( dummy.has_item( *ammo ) );
@@ -918,7 +918,7 @@ TEST_CASE( "automatic_reloading_action", "[reload],[gun]" )
     }
 
     GIVEN( "a player armed with a revolver and ammo for it" ) {
-        item_location ammo = dummy.i_add( item( "40sw", calendar::turn_zero, 100 ) );
+        item_location ammo = dummy.i_add( item( "10mm_fmj", calendar::turn_zero, 100 ) );
         REQUIRE( ammo->is_ammo() );
 
         dummy.set_wielded_item( item( "sw_610", calendar::turn_zero, 0 ) );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Remove .40 from S&W 610"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The 610 can fire 10mm and 40 S&W, but the cylinder is machined in such a way that it can fire 10mm without a moonclip, but not .40 S&W and so without a moonclip, it would just push the 40 S&W cartridge into the cylinder. As moonclips currently do not function with reload eject, Tonk suggested to remove .40 S&W from the 610 entirely.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Removes .40 from 610, while you could still put 40 S&W in the speedloader I felt it would be confusing, which is also why any mentions of .40 was removed from the 610's description.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Tested locally, works fine.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Currently in draft as I figure out how to fix the tests (why is so much of it relying on the 610 darn)
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
