### PR TITLE
Basecamp recipes can specify parameters and om_terrain_match_type

### DIFF
--- a/data/json/recipes/basecamps/recipe_groups.json
+++ b/data/json/recipes/basecamps/recipe_groups.json
@@ -11,14 +11,8 @@
           "field",
           "rural_road",
           "dirt_road_farm_parking",
-          "farmland_straight",
-          "farmland_turn",
-          "farmland_turn_inside",
-          "farmland_U",
-          "hayfield_straight",
-          "hayfield_turnL",
-          "hayfield_turnR",
-          "hayfield_end"
+          { "om_terrain": "farmland", "om_terrain_match_type": "PREFIX" },
+          { "om_terrain": "hayfield", "om_terrain_match_type": "PREFIX" }
         ]
       },
       {
@@ -28,14 +22,8 @@
           "field",
           "rural_road",
           "dirt_road_farm_parking",
-          "farmland_straight",
-          "farmland_turn",
-          "farmland_turn_inside",
-          "farmland_U",
-          "hayfield_straight",
-          "hayfield_turnL",
-          "hayfield_turnR",
-          "hayfield_end"
+          { "om_terrain": "farmland", "om_terrain_match_type": "PREFIX" },
+          { "om_terrain": "hayfield", "om_terrain_match_type": "PREFIX" }
         ]
       },
       { "id": "faction_base_firestation_0", "description": "Firestation Base", "om_terrains": [ "fire_station" ] },
@@ -140,14 +128,8 @@
           "field",
           "rural_road",
           "dirt_road_farm_parking",
-          "farmland_straight",
-          "farmland_turn",
-          "farmland_turn_inside",
-          "farmland_U",
-          "hayfield_straight",
-          "hayfield_turnL",
-          "hayfield_turnR",
-          "hayfield_end"
+          { "om_terrain": "farmland", "om_terrain_match_type": "PREFIX" },
+          { "om_terrain": "hayfield", "om_terrain_match_type": "PREFIX" }
         ]
       },
       {
@@ -157,14 +139,8 @@
           "field",
           "rural_road",
           "dirt_road_farm_parking",
-          "farmland_straight",
-          "farmland_turn",
-          "farmland_turn_inside",
-          "farmland_U",
-          "hayfield_straight",
-          "hayfield_turnL",
-          "hayfield_turnR",
-          "hayfield_end"
+          { "om_terrain": "farmland", "om_terrain_match_type": "PREFIX" },
+          { "om_terrain": "hayfield", "om_terrain_match_type": "PREFIX" }
         ]
       },
       {
@@ -174,14 +150,8 @@
           "field",
           "rural_road",
           "dirt_road_farm_parking",
-          "farmland_straight",
-          "farmland_turn",
-          "farmland_turn_inside",
-          "farmland_U",
-          "hayfield_straight",
-          "hayfield_turnL",
-          "hayfield_turnR",
-          "hayfield_end"
+          { "om_terrain": "farmland", "om_terrain_match_type": "PREFIX" },
+          { "om_terrain": "hayfield", "om_terrain_match_type": "PREFIX" }
         ]
       },
       {
@@ -191,14 +161,8 @@
           "field",
           "rural_road",
           "dirt_road_farm_parking",
-          "farmland_straight",
-          "farmland_turn",
-          "farmland_turn_inside",
-          "farmland_U",
-          "hayfield_straight",
-          "hayfield_turnL",
-          "hayfield_turnR",
-          "hayfield_end"
+          { "om_terrain": "farmland", "om_terrain_match_type": "PREFIX" },
+          { "om_terrain": "hayfield", "om_terrain_match_type": "PREFIX" }
         ]
       },
       {
@@ -208,14 +172,8 @@
           "field",
           "rural_road",
           "dirt_road_farm_parking",
-          "farmland_straight",
-          "farmland_turn",
-          "farmland_turn_inside",
-          "farmland_U",
-          "hayfield_straight",
-          "hayfield_turnL",
-          "hayfield_turnR",
-          "hayfield_end"
+          { "om_terrain": "farmland", "om_terrain_match_type": "PREFIX" },
+          { "om_terrain": "hayfield", "om_terrain_match_type": "PREFIX" }
         ]
       },
       {
@@ -225,14 +183,8 @@
           "field",
           "rural_road",
           "dirt_road_farm_parking",
-          "farmland_straight",
-          "farmland_turn",
-          "farmland_turn_inside",
-          "farmland_U",
-          "hayfield_straight",
-          "hayfield_turnL",
-          "hayfield_turnR",
-          "hayfield_end"
+          { "om_terrain": "farmland", "om_terrain_match_type": "PREFIX" },
+          { "om_terrain": "hayfield", "om_terrain_match_type": "PREFIX" }
         ]
       },
       {
@@ -242,14 +194,8 @@
           "field",
           "rural_road",
           "dirt_road_farm_parking",
-          "farmland_straight",
-          "farmland_turn",
-          "farmland_turn_inside",
-          "farmland_U",
-          "hayfield_straight",
-          "hayfield_turnL",
-          "hayfield_turnR",
-          "hayfield_end"
+          { "om_terrain": "farmland", "om_terrain_match_type": "PREFIX" },
+          { "om_terrain": "hayfield", "om_terrain_match_type": "PREFIX" }
         ]
       },
       {
@@ -259,14 +205,8 @@
           "field",
           "rural_road",
           "dirt_road_farm_parking",
-          "farmland_straight",
-          "farmland_turn",
-          "farmland_turn_inside",
-          "farmland_U",
-          "hayfield_straight",
-          "hayfield_turnL",
-          "hayfield_turnR",
-          "hayfield_end"
+          { "om_terrain": "farmland", "om_terrain_match_type": "PREFIX" },
+          { "om_terrain": "hayfield", "om_terrain_match_type": "PREFIX" }
         ]
       },
       {
@@ -276,14 +216,8 @@
           "field",
           "rural_road",
           "dirt_road_farm_parking",
-          "farmland_straight",
-          "farmland_turn",
-          "farmland_turn_inside",
-          "farmland_U",
-          "hayfield_straight",
-          "hayfield_turnL",
-          "hayfield_turnR",
-          "hayfield_end"
+          { "om_terrain": "farmland", "om_terrain_match_type": "PREFIX" },
+          { "om_terrain": "hayfield", "om_terrain_match_type": "PREFIX" }
         ]
       },
       {
@@ -293,14 +227,8 @@
           "field",
           "rural_road",
           "dirt_road_farm_parking",
-          "farmland_straight",
-          "farmland_turn",
-          "farmland_turn_inside",
-          "farmland_U",
-          "hayfield_straight",
-          "hayfield_turnL",
-          "hayfield_turnR",
-          "hayfield_end"
+          { "om_terrain": "farmland", "om_terrain_match_type": "PREFIX" },
+          { "om_terrain": "hayfield", "om_terrain_match_type": "PREFIX" }
         ]
       },
       {
@@ -310,14 +238,8 @@
           "field",
           "rural_road",
           "dirt_road_farm_parking",
-          "farmland_straight",
-          "farmland_turn",
-          "farmland_turn_inside",
-          "farmland_U",
-          "hayfield_straight",
-          "hayfield_turnL",
-          "hayfield_turnR",
-          "hayfield_end"
+          { "om_terrain": "farmland", "om_terrain_match_type": "PREFIX" },
+          { "om_terrain": "hayfield", "om_terrain_match_type": "PREFIX" }
         ]
       },
       {
@@ -327,14 +249,8 @@
           "field",
           "rural_road",
           "dirt_road_farm_parking",
-          "farmland_straight",
-          "farmland_turn",
-          "farmland_turn_inside",
-          "farmland_U",
-          "hayfield_straight",
-          "hayfield_turnL",
-          "hayfield_turnR",
-          "hayfield_end"
+          { "om_terrain": "farmland", "om_terrain_match_type": "PREFIX" },
+          { "om_terrain": "hayfield", "om_terrain_match_type": "PREFIX" }
         ]
       },
       {
@@ -344,14 +260,8 @@
           "field",
           "rural_road",
           "dirt_road_farm_parking",
-          "farmland_straight",
-          "farmland_turn",
-          "farmland_turn_inside",
-          "farmland_U",
-          "hayfield_straight",
-          "hayfield_turnL",
-          "hayfield_turnR",
-          "hayfield_end"
+          { "om_terrain": "farmland", "om_terrain_match_type": "PREFIX" },
+          { "om_terrain": "hayfield", "om_terrain_match_type": "PREFIX" }
         ]
       },
       {

--- a/doc/BASECAMP.md
+++ b/doc/BASECAMP.md
@@ -216,7 +216,6 @@ the needs must be autocalculated.
 ## Recipe groups
 Recipe groups serve two purposes: they indicate what recipes can produced by the camp after an upgrade mission is completed, and they indicate what upgrade paths are available and where camps can be placed.
 
-### Upgrade Paths and Expansions
 There are two special recipe groups, `"all_faction_base_types"` and `"all_faction_base_expansions"`.  They both look like this:
 ```json
   {
@@ -232,11 +231,56 @@ There are two special recipe groups, `"all_faction_base_types"` and `"all_factio
   },
 ```
 
-Each entry in the `"recipes"` array must be a dictionary with the `"id"`, `"description"`, and `"om_terrains"` fields.  `"id"` is the recipe `"id"` of the recipe that starts that basecamp or basecamp expansion upgrade path, and has to conform to the pattern `"faction_base_X_0"`, where X distinguishes the entry from the others, with the prefix and suffix required by the code.  `"description"` is a short name of the basecamp or basecamp expansion.  `"om_terrains"` is a list of overmap terrain ids which can be used as the basis for the basecamp or basecamp expansion.
+### Upgrade Paths and Expansions
 
-All recipes that start an upgrade path or expansion should have a blueprint requirement that can never be met, such as `"not_an_upgrade"`, to prevent them from showing up as available upgrades. Additionally, if you want to add an expansion, you must create an OMT with the same `id` as the expansion's `id`.
+All recipes that start an upgrade path or expansion should have a blueprint requirement that can never be met, such as `"not_an_upgrade"`, to prevent them from showing up as available upgrades.
+Additionally, if you want to add an expansion, you must create an OMT with the same `id` as the expansion's `id`.
+If the player attempts to start a basecamp on an overmap terrain that has two or more valid basecamp expansion paths, they will allowed to choose which path to start.
 
-If the player attempts to start a basecamp on an overmap terrain that has two or more valid basecamp expansion paths, she will allowed to choose which path to start.
+Each entry in the `"recipes"` array must be a dictionary with the `"id"`, `"description"`, and `"om_terrains"` fields.
+
+---- Field ---- | --------------------------------------------------------------------------------------------------------- Description --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+`"id"`          | Id of the recipe that starts that basecamp or basecamp expansion upgrade path, and has to conform to the pattern `"faction_base_X_0"`, where X distinguishes the entry from the others, with the prefix and suffix required by the code.                                                                                                          |
+`"description"` | The name shown in-game for the basecamp or basecamp expansion.                                                                                                                                                                                                                                                                                    |
+`"om_terrains"` | An array of overmap terrain ids which can be used as the basis for the basecamp or basecamp expansion. Individual entries can either be a string or an object containing `"om_terrain"` for the overmap terrain id, along with at least one of `"parameters"` and `"om_terrain_match_type"` (see [JSON_INFO.md](JSON_INFO.md#Starting-locations)) |
+
+
+#### Examples
+
+Camp that can be made anywhere
+
+```json
+    {
+        "id": "faction_base_barebones_0",
+        "description": "Barebones Camp",
+        "om_terrains": [ "ANY" ]
+    },
+```
+
+Camp that can be placed on any overmap terrain starting `farmland_` or `hayfield_` or that match `"farmland"` or `"hayfield"` exactly
+
+```json
+    {
+        "id": "faction_base_farmer_0",
+        "description": "Farmer Camp",
+        "om_terrains": [
+        { "om_terrain": "farmland", "om_terrain_match_type": "PREFIX" },
+        { "om_terrain": "hayfield", "om_terrain_match_type": "PREFIX" }
+        ]
+    },
+```
+
+Camp that can only be placed on `"omt_that_varies_in_shape"` if the parameter `"shape"` is set to either `"circle"` or `"circle_alt"` (but not say `"rectangle"` that would want different map updates)
+
+```json
+    {
+        "id": "faction_base_circle_0",
+        "description": "Farmer Camp",
+        "om_terrains": [
+        { "om_terrain": "omt_that_varies_in_shape", "parameters": { "shape": [ "circle", "circle_alt" ] }
+        ]
+    },
+```
 
 ## Sample basecamp upgrade path
 

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -5838,10 +5838,11 @@ String here contains the id of an overmap terrain type (see overmap_terrain.json
 
 If it is an object - it has following attributes:
 
- Identifier            | Description
----                    | ---
-`om_terrain`           | ID of overmap terrain which will be selected as the target. Mandatory.
-`om_terrain_match_type`| Matching rule to use with `om_terrain`. Defaults to TYPE. Details are below.
+     Identifier        |                                   Description                                           |
+---------------------- | --------------------------------------------------------------------------------------- |
+`om_terrain`           | ID of overmap terrain which will be selected as the target. Mandatory.                  |
+`om_terrain_match_type`| Optional. Matching rule to use with `om_terrain`. Defaults to TYPE. Details are below.  |
+`parameters`           | Optional. Parameter key/value pairs to set. Details are below.                          |
 
 
 `om_terrain_match_type` defaults to TYPE if unspecified, and has the following possible values:
@@ -5865,6 +5866,31 @@ If it is an object - it has following attributes:
 * `CONTAINS` - The provided string must be contained within the overmap terrain
   id, but may occur at the beginning, end, or middle and does not have any rules
   about underscore delimiting.
+
+`parameters` is an object containing one or more keys to set to a specific value provided, say to pick a safe variant of a map.
+The keys and values must be valid for the overmap terrains in question.
+This can also be used with 0 weight values to provide unique starting map variations that don't spawn normally.
+
+### Examples
+
+Any overmap terrain that is either `"shelter"` or begins with `shelter_`
+
+```json
+{
+    "om_terrain": "shelter",
+    "om_terrain_match_type": "PREFIX"
+}
+```
+
+Any overmap terrain that is either `"mansion"` or begins with `mansion_`, and forces the parameter `mansion_variant` to be set to `haunted_scenario_only`
+
+```json
+{
+    "om_terrain": "mansion",
+    "om_terrain_match_type": "PREFIX",
+    "parameters": { "mansion_variant": "haunted_scenario_only" }
+}
+```
 
 ## `city_sizes`
 (array of two integers)

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -975,7 +975,10 @@ conditional_t::func f_at_om_location( const JsonObject &jo, std::string_view mem
             return omt_str.find( "faction_base_camp" ) != std::string::npos;
         } else if( location_value == "FACTION_CAMP_START" ) {
             const std::optional<mapgen_arguments> *maybe_args = overmap_buffer.mapgen_args( omt_pos );
-            return !recipe_group::get_recipes_by_id( "all_faction_base_types", maybe_args, omt_ter ).empty();
+            if( !maybe_args ) {
+                return !recipe_group::get_recipes_by_id( "all_faction_base_types", omt_ter ).empty();
+            }
+            return !recipe_group::get_recipes_by_id( "all_faction_base_types", omt_ter, *maybe_args ).empty();
         } else {
             return oter_no_dir( omt_ter ) == location_value;
         }

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -974,7 +974,8 @@ conditional_t::func f_at_om_location( const JsonObject &jo, std::string_view mem
             // TODO: legacy check to be removed once primitive field camp OMTs have been purged
             return omt_str.find( "faction_base_camp" ) != std::string::npos;
         } else if( location_value == "FACTION_CAMP_START" ) {
-            return !recipe_group::get_recipes_by_id( "all_faction_base_types", omt_str ).empty();
+            const std::optional<mapgen_arguments> *maybe_args = overmap_buffer.mapgen_args( omt_pos );
+            return !recipe_group::get_recipes_by_id( "all_faction_base_types", maybe_args, omt_ter ).empty();
         } else {
             return oter_no_dir( omt_ter ) == location_value;
         }
@@ -991,6 +992,7 @@ conditional_t::func f_near_om_location( const JsonObject &jo, std::string_view m
         for( const tripoint_abs_omt &curr_pos : points_in_radius( omt_pos,
                 range.evaluate( d ) ) ) {
             const oter_id &omt_ter = overmap_buffer.ter( curr_pos );
+            const std::optional<mapgen_arguments> *maybe_args = overmap_buffer.mapgen_args( omt_pos );
             const std::string &omt_str = omt_ter.id().str();
             std::string location_value = location.evaluate( d );
 
@@ -1004,7 +1006,7 @@ conditional_t::func f_near_om_location( const JsonObject &jo, std::string_view m
                     return true;
                 }
             } else if( location_value  == "FACTION_CAMP_START" &&
-                       !recipe_group::get_recipes_by_id( "all_faction_base_types", omt_str ).empty() ) {
+                       !recipe_group::get_recipes_by_id( "all_faction_base_types", maybe_args, omt_ter, ).empty() ) {
                 return true;
             } else {
                 if( oter_no_dir( omt_ter ) == location_value ) {

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -975,10 +975,7 @@ conditional_t::func f_at_om_location( const JsonObject &jo, std::string_view mem
             return omt_str.find( "faction_base_camp" ) != std::string::npos;
         } else if( location_value == "FACTION_CAMP_START" ) {
             const std::optional<mapgen_arguments> *maybe_args = overmap_buffer.mapgen_args( omt_pos );
-            if( !maybe_args ) {
-                return !recipe_group::get_recipes_by_id( "all_faction_base_types", omt_ter ).empty();
-            }
-            return !recipe_group::get_recipes_by_id( "all_faction_base_types", omt_ter, *maybe_args ).empty();
+            return !recipe_group::get_recipes_by_id( "all_faction_base_types", omt_ter, maybe_args ).empty();
         } else {
             return oter_no_dir( omt_ter ) == location_value;
         }
@@ -1009,7 +1006,7 @@ conditional_t::func f_near_om_location( const JsonObject &jo, std::string_view m
                     return true;
                 }
             } else if( location_value  == "FACTION_CAMP_START" &&
-                       !recipe_group::get_recipes_by_id( "all_faction_base_types", maybe_args, omt_ter, ).empty() ) {
+                       !recipe_group::get_recipes_by_id( "all_faction_base_types", omt_ter, maybe_args ).empty() ) {
                 return true;
             } else {
                 if( oter_no_dir( omt_ter ) == location_value ) {

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -699,9 +699,8 @@ void talk_function::start_camp( npc &p )
 {
     const tripoint_abs_omt omt_pos = p.global_omt_location();
     const oter_id &omt_ref = overmap_buffer.ter( omt_pos );
-
-    const auto &pos_camps = recipe_group::get_recipes_by_id( "all_faction_base_types",
-                            omt_ref.id().c_str() );
+    const std::optional<mapgen_arguments> *maybe_args = overmap_buffer.mapgen_args( omt_pos );
+    const auto &pos_camps = recipe_group::get_recipes_by_id( "all_faction_base_types", maybe_args, omt_ref );
     if( pos_camps.empty() ) {
         popup( _( "You cannot build a camp here." ) );
         return;
@@ -1445,8 +1444,10 @@ void basecamp::get_available_missions( mission_data &mission_key, map &here )
             for( const auto &dir : base_camps::all_directions ) {
                 if( dir.first != base_camps::base_dir && expansions.find( dir.first ) == expansions.end() ) {
                     const oter_id &omt_ref = overmap_buffer.ter( omt_pos + dir.first );
-                    const auto &pos_expansions = recipe_group::get_recipes_by_id( "all_faction_base_expansions",
-                                                 omt_ref.id().c_str() );
+                    const std::optional<mapgen_arguments> *maybe_args = overmap_buffer.mapgen_args(
+                                omt_pos + dir.first );
+                    const auto &pos_expansions = recipe_group::get_recipes_by_id( "all_faction_base_expansions", maybe_args,
+                                                 omt_ref );
                     if( !pos_expansions.empty() ) {
                         possible_expansion_found = true;
                         break;
@@ -4528,8 +4529,9 @@ bool basecamp::survey_return( const mission_id &miss_id )
     }
 
     const oter_id &omt_ref = overmap_buffer.ter( where );
-    const auto &pos_expansions = recipe_group::get_recipes_by_id( "all_faction_base_expansions",
-                                 omt_ref.id().c_str() );
+    const std::optional<mapgen_arguments> *maybe_args = overmap_buffer.mapgen_args( where );
+    const auto &pos_expansions = recipe_group::get_recipes_by_id( "all_faction_base_expansions", maybe_args,
+                                 omt_ref );
     if( pos_expansions.empty() ) {
         popup( _( "You can't build any expansions in a %s." ), omt_ref.id().c_str() );
         if( query_yn(

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -700,7 +700,8 @@ void talk_function::start_camp( npc &p )
     const tripoint_abs_omt omt_pos = p.global_omt_location();
     const oter_id &omt_ref = overmap_buffer.ter( omt_pos );
     const std::optional<mapgen_arguments> *maybe_args = overmap_buffer.mapgen_args( omt_pos );
-    const auto &pos_camps = recipe_group::get_recipes_by_id( "all_faction_base_types", maybe_args, omt_ref );
+    const auto &pos_camps = recipe_group::get_recipes_by_id( "all_faction_base_types", omt_ref,
+                            maybe_args );
     if( pos_camps.empty() ) {
         popup( _( "You cannot build a camp here." ) );
         return;
@@ -1446,8 +1447,8 @@ void basecamp::get_available_missions( mission_data &mission_key, map &here )
                     const oter_id &omt_ref = overmap_buffer.ter( omt_pos + dir.first );
                     const std::optional<mapgen_arguments> *maybe_args = overmap_buffer.mapgen_args(
                                 omt_pos + dir.first );
-                    const auto &pos_expansions = recipe_group::get_recipes_by_id( "all_faction_base_expansions", maybe_args,
-                                                 omt_ref );
+                    const auto &pos_expansions = recipe_group::get_recipes_by_id( "all_faction_base_expansions",
+                                                 omt_ref, maybe_args );
                     if( !pos_expansions.empty() ) {
                         possible_expansion_found = true;
                         break;
@@ -4530,8 +4531,8 @@ bool basecamp::survey_return( const mission_id &miss_id )
 
     const oter_id &omt_ref = overmap_buffer.ter( where );
     const std::optional<mapgen_arguments> *maybe_args = overmap_buffer.mapgen_args( where );
-    const auto &pos_expansions = recipe_group::get_recipes_by_id( "all_faction_base_expansions", maybe_args,
-                                 omt_ref );
+    const auto &pos_expansions = recipe_group::get_recipes_by_id( "all_faction_base_expansions",
+                                 omt_ref, maybe_args );
     if( pos_expansions.empty() ) {
         popup( _( "You can't build any expansions in a %s." ), omt_ref.id().c_str() );
         if( query_yn(

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -6867,7 +6867,7 @@ dynamic_line_t::dynamic_line_t( const JsonObject &jo )
         };
     } else if( jo.get_bool( "list_faction_camp_sites", false ) ) {
         function = [&]( const dialogue & ) {
-            const auto &sites = recipe_group::get_recipes_by_id( "all_faction_base_types", "ANY" );
+            const auto &sites = recipe_group::get_recipes_by_id( "all_faction_base_types" );
             if( sites.empty() ) {
                 return std::string( _( "I can't think of a single place I can build a camp." ) );
             }

--- a/src/recipe_groups.cpp
+++ b/src/recipe_groups.cpp
@@ -121,8 +121,10 @@ std::map<recipe_id, translation> recipe_group::get_recipes_by_id( const std::str
     const recipe_group_data &group = recipe_groups_data.obj( group_id( id ) );
     for( const auto &recp : group.recipes ) {
         const auto &recp_terrain_it = group.om_terrains.find( recp.first );
-        if( !is_ot_match( recp_terrain_it->second.omt, omt_ter, recp_terrain_it->second.omt_type ) ) {
-            continue;
+        if( recp_terrain_it->second.omt != "ANY" ) {
+            if( !is_ot_match( recp_terrain_it->second.omt, omt_ter, recp_terrain_it->second.omt_type ) ) {
+                continue;
+            }
         }
         if( recp_terrain_it->second.parameters.empty() ) {
             all_rec.emplace( recp );
@@ -133,10 +135,12 @@ std::map<recipe_id, translation> recipe_group::get_recipes_by_id( const std::str
             for( const auto &key_value_set_pair : recp_terrain_it->second.parameters ) {
                 auto map_key_it = maybe_args->value().map.find( key_value_set_pair.first );
                 if( map_key_it == maybe_args->value().map.end() ) {
-                    debugmsg( "Parameter key %s in recipe %s not found for omt %s", key_value_set_pair.first, id, omt_ter.id().str() );
+                    debugmsg( "Parameter key %s in recipe %s not found for omt %s", key_value_set_pair.first, id,
+                              omt_ter.id().str() );
                     continue;
                 }
-                if( key_value_set_pair.second.find( map_key_it->second.get_string() ) == key_value_set_pair.second.end() ) {
+                if( key_value_set_pair.second.find( map_key_it->second.get_string() ) ==
+                    key_value_set_pair.second.end() ) {
                     parameters_matched = false;
                     break;
                 }

--- a/src/recipe_groups.cpp
+++ b/src/recipe_groups.cpp
@@ -101,45 +101,65 @@ std::map<recipe_id, translation> recipe_group::get_recipes_by_bldg( const std::s
     }
 }
 
-std::map<recipe_id, translation> recipe_group::get_recipes_by_id( const std::string &id, const std::optional<mapgen_arguments> *maybe_args,
-        const std::optional<oter_id> &omt_ter )
+std::map<recipe_id, translation> recipe_group::get_recipes_by_id( const std::string &id )
 {
     std::map<recipe_id, translation> all_rec;
     if( !recipe_groups_data.is_valid( group_id( id ) ) ) {
         return all_rec;
     }
     const recipe_group_data &group = recipe_groups_data.obj( group_id( id ) );
-    if( !omt_ter ) {
-        return group.recipes;
+    return group.recipes;
+}
+
+std::map<recipe_id, translation> recipe_group::get_recipes_by_id( const std::string &id,
+        const oter_id &omt_ter )
+{
+    std::map<recipe_id, translation> all_rec;
+    if( !recipe_groups_data.is_valid( group_id( id ) ) ) {
+        return all_rec;
     }
+    const recipe_group_data &group = recipe_groups_data.obj( group_id( id ) );
     for( const auto &recp : group.recipes ) {
         const auto &recp_terrain_it = group.om_terrains.find( recp.first );
-        if( !is_ot_match( recp_terrain_it->second.omt, *omt_ter, recp_terrain_it->second.omt_type ) ) {
-        continue;
+        if( is_ot_match( recp_terrain_it->second.omt, omt_ter, recp_terrain_it->second.omt_type ) ) {
+            all_rec.emplace( recp );
+        }
     }
-    if( recp_terrain_it->second.parameters.empty() ) {
-        all_rec.emplace( recp );
+    return all_rec;
+}
+
+std::map<recipe_id, translation> recipe_group::get_recipes_by_id( const std::string &id,
+        const oter_id &omt_ter, const mapgen_arguments &args )
+{
+    std::map<recipe_id, translation> all_rec;
+    if( !recipe_groups_data.is_valid( group_id( id ) ) ) {
+        return all_rec;
+    }
+    const recipe_group_data &group = recipe_groups_data.obj( group_id( id ) );
+    for( const auto &recp : group.recipes ) {
+        const auto &recp_terrain_it = group.om_terrains.find( recp.first );
+        if( !is_ot_match( recp_terrain_it->second.omt, omt_ter, recp_terrain_it->second.omt_type ) ) {
             continue;
         }
-        if( !!maybe_args ) {
+        if( recp_terrain_it->second.parameters.empty() ) {
+            all_rec.emplace( recp );
+            continue;
+        }
         std::set<std::string> keys_found;
         std::set<std::string> keys_matched;
         for( const auto &key_value_pair : recp_terrain_it->second.parameters ) {
-                keys_found.insert( key_value_pair.first );
-                auto map_key_it = *maybe_args->map.find( key_value_pair.first );
-                if( map_key_it == *maybe_args->map.end() ) {
-                    debugmsg( "Parameter key %s in recipe %s not found", key_value_pair.first, recipe_id.str() );
-                    continue;
-                }
-                if( key_value_pair.second == map_key_it.second.get_string() ) {
-                    keys_matched.insert( key_value_pair.first );
-                }
+            keys_found.insert( key_value_pair.first );
+            auto map_key_it = args.map.find( key_value_pair.first );
+            if( map_key_it == args.map.end() ) {
+                debugmsg( "Parameter key %s in recipe %s not found", key_value_pair.first, recipe_id.str() );
+                continue;
             }
-            if( keys_found == keys_matched ) {
-                all_rec.emplace( recp );
+            if( key_value_pair.second == map_key_it.second.get_string() ) {
+                keys_matched.insert( key_value_pair.first );
             }
-        } else {
-            debugmsg( "Parameter(s) expected for recipe %s but none found", recipe_id.str() );
+        }
+        if( keys_found == keys_matched ) {
+            all_rec.emplace( recp );
         }
     }
     return all_rec;

--- a/src/recipe_groups.h
+++ b/src/recipe_groups.h
@@ -19,8 +19,9 @@ void check();
 void reset();
 
 std::map<recipe_id, translation> get_recipes_by_bldg( const std::string &bldg );
-std::map<recipe_id, translation> get_recipes_by_id( const std::string &id, const std::optional<mapgen_arguments> *maybe_args,
-        const std::optional<oter_id> &omt_ter = std::nullopt );
+std::map<recipe_id, translation> get_recipes_by_id( const std::string &id );
+std::map<recipe_id, translation> get_recipes_by_id( const std::string &id, const oter_id &omt_ter );
+std::map<recipe_id, translation> get_recipes_by_id( const std::string &id, const oter_id &omt_ter, const mapgen_arguments &args );
 std::string get_building_of_recipe( const std::string &recipe );
 } // namespace recipe_group
 

--- a/src/recipe_groups.h
+++ b/src/recipe_groups.h
@@ -6,6 +6,7 @@
 #include <map>
 
 #include "type_id.h"
+#include "mapgendata.h"
 
 class JsonObject;
 class translation;
@@ -18,8 +19,8 @@ void check();
 void reset();
 
 std::map<recipe_id, translation> get_recipes_by_bldg( const std::string &bldg );
-std::map<recipe_id, translation> get_recipes_by_id( const std::string &id,
-        const std::string &om_terrain_id = "ANY" );
+std::map<recipe_id, translation> get_recipes_by_id( const std::string &id, const std::optional<mapgen_arguments> *maybe_args,
+        const std::optional<oter_id> &omt_ter = std::nullopt );
 std::string get_building_of_recipe( const std::string &recipe );
 } // namespace recipe_group
 

--- a/src/recipe_groups.h
+++ b/src/recipe_groups.h
@@ -20,8 +20,7 @@ void reset();
 
 std::map<recipe_id, translation> get_recipes_by_bldg( const std::string &bldg );
 std::map<recipe_id, translation> get_recipes_by_id( const std::string &id );
-std::map<recipe_id, translation> get_recipes_by_id( const std::string &id, const oter_id &omt_ter );
-std::map<recipe_id, translation> get_recipes_by_id( const std::string &id, const oter_id &omt_ter, const mapgen_arguments &args );
+std::map<recipe_id, translation> get_recipes_by_id( const std::string &id, const oter_id &omt_ter, const std::optional<mapgen_arguments> *maybe_args );
 std::string get_building_of_recipe( const std::string &recipe );
 } // namespace recipe_group
 

--- a/src/recipe_groups.h
+++ b/src/recipe_groups.h
@@ -20,7 +20,8 @@ void reset();
 
 std::map<recipe_id, translation> get_recipes_by_bldg( const std::string &bldg );
 std::map<recipe_id, translation> get_recipes_by_id( const std::string &id );
-std::map<recipe_id, translation> get_recipes_by_id( const std::string &id, const oter_id &omt_ter, const std::optional<mapgen_arguments> *maybe_args );
+std::map<recipe_id, translation> get_recipes_by_id( const std::string &id, const oter_id &omt_ter,
+        const std::optional<mapgen_arguments> *maybe_args );
 std::string get_building_of_recipe( const std::string &recipe );
 } // namespace recipe_group
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Needed for #72561, parameters can affects layouts of maps changing which basecamp recipes should be offered
om_match_type matching > just type matching
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Allows for parameter matching like `"om_terrains": [ { "om_terrain": "omt1", "parameters": { "param_key1": [ "allowed_value1", "allowed_value2" ] } } ]` to match omt1 if param_key1 is set to either allowed_value1 or allowed_value2

Allows for om_match_type matching like `"om_terrains": [ { "om_terrain": "omt1", "om_terrain_match_type": "PREFIX" } ]` tp match "omt1", "omt1_roof", "omt1_3_8" etc and applies it to existing recipes

Uses an overload instead of the defaulted "ANY" C++ argument in the function call so things don't get too hairy ("ANY" is still fine as a JSON om_terrain to match all omts)

Adds documentation for the new fields

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Tested parameter specification using #72561:

The evac shelter we're at has layout 24x24_shelter_1:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45432782/f543d75a-4a57-4fa2-b835-9cd8f49c0319)
Asking my good friend Gordon to start a camp offers the faction_base_shelter_1_0 camp and the bare bones camp but not faction_base_shelter_0 or faction_base_shelter_2_0 as expected
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45432782/23c05ecd-d136-4d70-aa74-0cf9af6f1d08)


Tested om_match_terrain_type by verifying the same basecamp recipes were offered before and after [9595812](https://github.com/CleverRaven/Cataclysm-DDA/pull/72642/commits/9595812392a6c8682f72c65ab671fe821b4ad9e5) while on `farmland_turn_inside`
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
