### PR TITLE
Melee weapon attack move cost algorithm based on simple physical modeling

### DIFF
--- a/data/json/items/melee/bludgeons.json
+++ b/data/json/items/melee/bludgeons.json
@@ -1150,7 +1150,7 @@
     "weight": "3200 g",
     "volume": "3750 ml",
     "longest_side": "200 cm",
-    "to_hit": { "grip": "weapon", "length": "long", "surface": "any", "balance": "uneven" },
+    "to_hit": { "grip": "weapon", "length": "long", "surface": "any", "balance": "good" },
     "price_postapoc": 10000,
     "qualities": [ [ "COOK", 1 ] ],
     "category": "weapons",

--- a/data/json/items/melee/swords_and_blades.json
+++ b/data/json/items/melee/swords_and_blades.json
@@ -2026,7 +2026,7 @@
     "description": "A huge, curved, two-handed sword from Japan.  It is surprisingly light for its size.\n\nMade with medium steel and with a grip made of leather wrapped in steel wire, this weapon is comfortable in your hand, though the balance isn't perfect and the edge could be sharper.",
     "weight": "3002 g",
     "volume": "3250 ml",
-    "longest_side": "120 cm",
+    "longest_side": "150 cm",
     "symbol": "/",
     "color": "light_gray",
     "looks_like": "nodachi",

--- a/src/enums.h
+++ b/src/enums.h
@@ -491,4 +491,48 @@ struct enum_traits<link_state> {
     static constexpr link_state last = link_state::last;
 };
 
+enum class grip_val : int {
+    BAD = 0,
+    NONE = 1,
+    SOLID = 2,
+    WEAPON = 3,
+    LAST = 4
+};
+template<>
+struct enum_traits<grip_val> {
+    static constexpr grip_val last = grip_val::LAST;
+};
+enum class length_val : int {
+    HAND = 0,
+    SHORT = 1,
+    LONG = 2,
+    LAST = 3
+};
+template<>
+struct enum_traits<length_val> {
+    static constexpr length_val last = length_val::LAST;
+};
+enum class surface_val : int {
+    POINT = 0,
+    LINE = 1,
+    ANY = 2,
+    EVERY = 3,
+    LAST = 4
+};
+template<>
+struct enum_traits<surface_val> {
+    static constexpr surface_val last = surface_val::LAST;
+};
+enum class balance_val : int {
+    CLUMSY = 0,
+    UNEVEN = 1,
+    NEUTRAL = 2,
+    GOOD = 3,
+    LAST = 4
+};
+template<>
+struct enum_traits<balance_val> {
+    static constexpr balance_val last = balance_val::LAST;
+};
+
 #endif // CATA_SRC_ENUMS_H

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -7430,7 +7430,7 @@ int item::attack_time( const Character &you ) const
                    weapon_type == weapon_category_medium_swords;
         } );
         ret = base_move * std::sqrt( weight() * ( is_sword ? sword_factor : 1 ) / 1000_gram * std::pow(
-                                         ( double )( length() / 1_mm ) / 1000,
+                                         static_cast<double>( length() / 1_mm ) / 1000,
                                          2 ) / const_weild + 1 );
     }
     ret = calculate_by_enchantment_wield( you, ret, enchant_vals::mod::ITEM_ATTACK_SPEED,

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -3839,49 +3839,7 @@ void Item_factory::add_special_pockets( itype &def )
     }
 }
 
-enum class grip_val : int {
-    BAD = 0,
-    NONE = 1,
-    SOLID = 2,
-    WEAPON = 3,
-    LAST = 4
-};
-template<>
-struct enum_traits<grip_val> {
-    static constexpr grip_val last = grip_val::LAST;
-};
-enum class length_val : int {
-    HAND = 0,
-    SHORT = 1,
-    LONG = 2,
-    LAST = 3
-};
-template<>
-struct enum_traits<length_val> {
-    static constexpr length_val last = length_val::LAST;
-};
-enum class surface_val : int {
-    POINT = 0,
-    LINE = 1,
-    ANY = 2,
-    EVERY = 3,
-    LAST = 4
-};
-template<>
-struct enum_traits<surface_val> {
-    static constexpr surface_val last = surface_val::LAST;
-};
-enum class balance_val : int {
-    CLUMSY = 0,
-    UNEVEN = 1,
-    NEUTRAL = 2,
-    GOOD = 3,
-    LAST = 4
-};
-template<>
-struct enum_traits<balance_val> {
-    static constexpr balance_val last = balance_val::LAST;
-};
+
 
 namespace io
 {
@@ -4158,6 +4116,8 @@ void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std:
         bool was_loaded = false;
         mandatory( jo, was_loaded, "to_hit", temp );
         def.m_to_hit = temp.sum_values();
+        def.balance = temp.balance;
+        def.surface = temp.surface;
     }
     optional( jo, false, "variant_type", def.variant_kind, itype_variant_kind::generic );
     optional( jo, false, "variants", def.variants );

--- a/src/itype.h
+++ b/src/itype.h
@@ -1397,6 +1397,10 @@ struct itype {
 
         int m_to_hit = 0;  // To-hit bonus for melee combat; -5 to 5 is reasonable
 
+        surface_val surface = surface_val::ANY;
+
+        balance_val balance = balance_val::NEUTRAL;
+
         unsigned light_emission = 0;   // Exactly the same as item_tags LIGHT_*, this is for lightmap.
 
         nc_color color = c_white; // Color on the map (color.h)


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
To implement the algorithm discussed in #72648.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
The code was written in accordance with the discussion in #72648, and the constants in the algorithm were determined based on " 1.41 times the base time required for attacking with a 3kg lance" and "2 times the base time required for attacking with  zweihänder". The weight scaling factor for sword weapons was set to 0.75.
This is merely a demonstration, and the values might not be rational.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Test shows that the DPS of long spear weapons, short-handled hammer/axe weapons and swords in this model has been greatly improved, which is as expected. However the DPS of some individual weapons that are supposed to be cumbersome has also increased significantly. In this model, the length will be the greatest negative factor for non-thrusting weapons, and its influence is even greater than that of weight. For example, a 180cm zweihänder will be far weaker than a 120cm nodachi.

For the issue of DPS improvement in melee attack, consider balancing it by increasing the overall stamina consumption. Because currently, players can punch continuously about 160 times in about 104 seconds even in the early stage of the game. Even in the top boxing events, it is difficult to see such a long period of high-intensity attack. Or we can increase the base attack time.
For extremely long lance-like weapons, it is possible to consider further reducing close-range damage as a balance. 
For other unwieldy weapons, it is possible to consider using a newly added "balance" term or simply using the "to_hit" term to determine the quality correction factor.
Regarding the issue that length becomes a pure negative attribute, I haven't figured out an appropriate solution yet.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Run the test.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
In fact, the amount of code is not large, but it will have a profound impact on the game. I hope to receive more advice. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
