### PR TITLE
Improved task activity feedback slightly

### DIFF
--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -86,6 +86,35 @@ enum class do_activity_reason : int {
 
 };
 
+const std::string do_activity_reason_string[int( do_activity_reason::NEEDS_DISASSEMBLE ) + 1] = {
+    "CAN_DO_CONSTRUCTION",
+    "CAN_DO_FETCH",
+    "NO_COMPONENTS",
+    "DONT_HAVE_SKILL",
+    "NO_ZONE",
+    "ALREADY_DONE",
+    "UNKNOWN_ACTIVITY",
+    "NEEDS_HARVESTING",
+    "NEEDS_PLANTING",
+    "NEEDS_TILLING",
+    "BLOCKING_TILE",
+    "NEEDS_BOOK_TO_LEARN",
+    "NEEDS_CHOPPING",
+    "NEEDS_TREE_CHOPPING",
+    "NEEDS_BIG_BUTCHERING",
+    "NEEDS_BUTCHERING",
+    "NEEDS_CUT_HARVESTING",
+    "ALREADY_WORKING",
+    "NEEDS_VEH_DECONST",
+    "NEEDS_VEH_REPAIR",
+    "WOULD_PREVENT_VEH_FLYING",
+    "NEEDS_MINING",
+    "NEEDS_MOP",
+    "NEEDS_FISHING",
+    "NEEDS_CRAFT",
+    "NEEDS_DISASSEMBLE"
+};
+
 struct activity_reason_info {
     //reason for success or fail
     do_activity_reason reason;

--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -86,7 +86,8 @@ enum class do_activity_reason : int {
 
 };
 
-const std::string do_activity_reason_string[int( do_activity_reason::NEEDS_DISASSEMBLE ) + 1] = {
+// Vector because of style demands => no built in consistency check when number of enum elements change.
+const std::vector<std::string> do_activity_reason_string = {
     "CAN_DO_CONSTRUCTION",
     "CAN_DO_FETCH",
     "NO_COMPONENTS",

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -2680,7 +2680,7 @@ static std::unordered_set<tripoint_abs_ms> generic_multi_activity_locations(
     }
     const bool post_dark_check = src_set.empty();
     if( !pre_dark_check && post_dark_check && !MOP_ACTIVITY ) {
-        you.add_msg_if_player( m_info, _( "It is too dark to do this activity." ) );
+        you.add_msg_if_player( m_info, _( "It is too dark to do the %s activity." ), act_id.c_str() );
     }
     return src_set;
 }
@@ -2730,9 +2730,21 @@ static requirement_check_result generic_multi_activity_check_requirement(
         reason == do_activity_reason::UNKNOWN_ACTIVITY ) {
         // we can discount this tile, the work can't be done.
         if( reason == do_activity_reason::DONT_HAVE_SKILL ) {
-            you.add_msg_if_player( m_info, _( "You don't have the skill for this task." ) );
+            if( zone ) {
+                you.add_msg_if_player( m_info, _( "You don't have the skill for the %s task at zone %s." ),
+                                       act_id.c_str(), zone->get_name() );
+            } else {
+                you.add_msg_if_player( m_info, _( "You don't have the skill for the %s task." ), act_id.c_str() );
+            }
         } else if( reason == do_activity_reason::BLOCKING_TILE ) {
-            you.add_msg_if_player( m_info, _( "There is something blocking the location for this task." ) );
+            if( zone ) {
+                you.add_msg_if_player( m_info,
+                                       _( "There is something blocking the location for the %s task at zone %s." ), act_id.c_str(),
+                                       zone->get_name() );
+            } else {
+                you.add_msg_if_player( m_info, _( "There is something blocking the location for the %s task." ),
+                                       act_id.c_str() );
+            }
         }
         return requirement_check_result::SKIP_LOCATION;
     } else if( reason == do_activity_reason::NO_COMPONENTS ||
@@ -2751,8 +2763,15 @@ static requirement_check_result generic_multi_activity_check_requirement(
         // we can do it, but we need to fetch some stuff first
         // before we set the task to fetch components - is it even worth it? are the components anywhere?
         if( you.is_npc() ) {
-            add_msg_if_player_sees( you, m_info, _( "%s is trying to find necessary items to do the job" ),
-                                    you.disp_name() );
+            if( zone ) {
+                add_msg_if_player_sees( you, m_info,
+                                        _( "%s is trying to find necessary items to do the %s job on zone %s, reason %s" ),
+                                        you.disp_name(), act_id.c_str(), zone->get_name(), do_activity_reason_string[int( reason )] );
+            } else {
+                add_msg_if_player_sees( you, m_info,
+                                        _( "%s is trying to find necessary items to do the %s job, reason %s" ),
+                                        you.disp_name(), act_id.c_str(), do_activity_reason_string[int( reason )] );
+            }
         }
         requirement_id what_we_need;
         std::vector<tripoint_bub_ms> loot_zone_spots;
@@ -2866,9 +2885,17 @@ static requirement_check_result generic_multi_activity_check_requirement(
         // is it even worth fetching anything if there isn't enough nearby?
         if( !are_requirements_nearby( tool_pickup ? loot_zone_spots : combined_spots, what_we_need, you,
                                       act_id, tool_pickup, src_loc ) ) {
-            you.add_msg_player_or_npc( m_info,
-                                       _( "The required items are not available to complete this task." ),
-                                       _( "The required items are not available to complete this task." ) );
+            if( zone ) {
+                you.add_msg_player_or_npc( m_info,
+                                           _( "The required items are not available to complete the %s task at zone %s." ), act_id.c_str(),
+                                           zone->get_name(),
+                                           _( "The required items are not available to complete the %s task at zone %s." ), act_id.c_str(),
+                                           zone->get_name() );
+            } else {
+                you.add_msg_player_or_npc( m_info,
+                                           _( "The required items are not available to complete the %s task." ), act_id.c_str(),
+                                           _( "The required items are not available to complete the %s task." ), act_id.c_str() );
+            }
             if( reason == do_activity_reason::NEEDS_VEH_DECONST ||
                 reason == do_activity_reason::NEEDS_VEH_REPAIR ) {
                 you.activity_vehicle_part_index = -1;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary

None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Marginally reduce head scratching when companions fail to perform tasks.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Improve existing feedback messages on task activities to include the task, zone, and deficiency the companion reports on.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Less code centric feedback by "translating" the constant names into English (and also translation to other languages). This makes it more readable to casual players and harder to tie the feedback to the internal state when trying to actually figure out what's (failing) going on.
- Somehow figure out how to report what the missing "materials" are. However, that info is buried elsewhere.
- Figure out how to give feedback as to what activity companions try to take up when orders are given.
- Figure out how to report when companions abandon tasks and provide feedback on why.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Limited to try to order a companion to perform construction activities when there are multiple zones available.
![Screenshot (328)](https://github.com/CleverRaven/Cataclysm-DDA/assets/22739822/8d5ae47f-b408-4418-9a4e-5fa8792ed130)
The image is after the first order.

In the testing the companion fails to perform bed constructions, then brings some materials for bed constructions a couple of times (with silent abortions in between), and then finally takes up workshelf construction (which may or may not be one started previously). The selection is presumably based on proximity, but there's no feedback...
This behavior is (approximately) the same as it was before the feedback changes, i.e. randomly complete failures to perform tasks, partial performance of tasks, and switching between different tasks where presumed placement determines whether a task that can actually be performed (or even progressed) is taken up when tasks that can be completed are available.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

It can be noted that the printing of the zone names would allow players who provide their zones with unique names (rather than using defaults) to identify exactly which zone the companion is trying to act on when there are multiple zones of the same type.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
