### PR TITLE
Favorite-ammo Overhaul

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -2572,6 +2572,13 @@
   },
   {
     "type": "keybinding",
+    "name": "Select default ammo for wielded item",
+    "category": "DEFAULTMODE",
+    "id": "select_default_ammo",
+    "bindings": [ { "input_method": "keyboard_any", "key": "F3" } ]
+  },
+  {
+    "type": "keybinding",
     "name": "Drop item",
     "category": "DEFAULTMODE",
     "id": "drop",

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -253,6 +253,8 @@ std::string action_ident( action_id act )
             return "cast_spell";
         case ACTION_SELECT_FIRE_MODE:
             return "select_fire_mode";
+        case ACTION_SELECT_DEFAULT_AMMO:
+            return "select_default_ammo";
         case ACTION_UNLOAD_CONTAINER:
             return "unload_container";
         case ACTION_DROP:
@@ -963,6 +965,7 @@ action_id handle_action_menu()
             REGISTER_ACTION( ACTION_RELOAD_WIELDED );
             REGISTER_ACTION( ACTION_CAST_SPELL );
             REGISTER_ACTION( ACTION_SELECT_FIRE_MODE );
+            REGISTER_ACTION( ACTION_SELECT_DEFAULT_AMMO );
             REGISTER_ACTION( ACTION_THROW );
             REGISTER_ACTION( ACTION_FIRE_BURST );
             REGISTER_ACTION( ACTION_PICK_STYLE );

--- a/src/action.h
+++ b/src/action.h
@@ -182,6 +182,8 @@ enum action_id : int {
     ACTION_FIRE_BURST,
     /** Change fire mode of the current weapon */
     ACTION_SELECT_FIRE_MODE,
+    /** Change default ammo for current weapon */
+    ACTION_SELECT_DEFAULT_AMMO,
     /** Cast a spell (only if any spells are known) */
     ACTION_CAST_SPELL,
     /** Open the insert-item menu */

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -402,6 +402,7 @@ void aim_activity_actor::serialize( JsonOut &jsout ) const
     jsout.member( "snap_to_target", snap_to_target );
     jsout.member( "shifting_view", shifting_view );
     jsout.member( "initial_view_offset", initial_view_offset );
+    jsout.member( "loaded_RAS_weapon", loaded_RAS_weapon );
     jsout.member( "aborted", aborted );
     jsout.member( "reload_requested", reload_requested );
     jsout.member( "abort_if_no_targets", abort_if_no_targets );
@@ -424,6 +425,7 @@ std::unique_ptr<activity_actor> aim_activity_actor::deserialize( JsonValue &jsin
     data.read( "snap_to_target", actor.snap_to_target );
     data.read( "shifting_view", actor.shifting_view );
     data.read( "initial_view_offset", actor.initial_view_offset );
+    data.read( "loaded_RAS_weapon", actor.loaded_RAS_weapon );
     data.read( "aborted", actor.aborted );
     data.read( "reload_requested", actor.reload_requested );
     data.read( "abort_if_no_targets", actor.abort_if_no_targets );
@@ -466,6 +468,7 @@ bool aim_activity_actor::load_RAS_weapon()
     const auto ammo_location_is_valid = [&]() -> bool {
         if( !you.ammo_location )
         {
+            you.ammo_location = item_location();
             return false;
         }
         if( !gun->can_reload_with( *you.ammo_location.get_item(), false ) )
@@ -499,6 +502,7 @@ bool aim_activity_actor::load_RAS_weapon()
     reload_time += ( sta_percent < 25 ) ? ( ( 25 - sta_percent ) * 2 ) : 0;
 
     you.mod_moves( -reload_time );
+    loaded_RAS_weapon = true;
     return true;
 }
 
@@ -507,7 +511,7 @@ void aim_activity_actor::unload_RAS_weapon()
     // Unload reload-and-shoot weapons to avoid leaving bows pre-loaded with arrows
     avatar &you = get_avatar();
     item_location weapon = get_weapon();
-    if( !weapon ) {
+    if( !weapon || !loaded_RAS_weapon ) {
         return;
     }
 
@@ -524,6 +528,7 @@ void aim_activity_actor::unload_RAS_weapon()
             you.set_moves( moves_before_unload );
         }
     }
+    loaded_RAS_weapon = false;
 }
 
 void autodrive_activity_actor::update_player_vehicle( Character &who )

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -55,6 +55,8 @@ class aim_activity_actor : public activity_actor
         bool snap_to_target = false;
         bool shifting_view = false;
         tripoint initial_view_offset;
+        /** RELOAD_AND_SHOOT weapon is kept loaded by the activity */
+        bool loaded_RAS_weapon = false;
         /** Target UI requested to abort aiming */
         bool aborted = false;
         /** if true abort if no targets are available when re-entering aiming ui after shooting */

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -9809,6 +9809,26 @@ void game::butcher()
     }
 }
 
+static item::reload_option favorite_ammo_or_select( avatar &u, item_location &loc, bool empty, bool prompt )
+{
+    if( u.ammo_location ) {
+        std::vector<item::reload_option> ammo_list;
+        if( u.list_ammo( loc, ammo_list, false ) ) {
+            const auto is_favorite_and_compatible = [&loc, &u]( const item::reload_option & opt ) {
+                return opt.ammo == u.ammo_location && loc->can_reload_with( *u.ammo_location.get_item(), false );
+            };
+            auto it = std::find_if( ammo_list.begin(), ammo_list.end(), is_favorite_and_compatible );
+            if( it != ammo_list.end() ) {
+                return *it;
+            }
+        }
+    }
+    else {
+        const_cast<item_location &>( u.ammo_location ) = item_location();
+    }
+    return u.select_ammo( loc, prompt, empty );
+}
+
 void game::reload( item_location &loc, bool prompt, bool empty )
 {
     // bows etc. do not need to reload. select favorite ammo for them instead
@@ -9871,10 +9891,7 @@ void game::reload( item_location &loc, bool prompt, bool empty )
         loc = item_location( loc, &loc->only_item() );
     }
 
-    item::reload_option opt = u.ammo_location &&
-                              loc->can_reload_with( *u.ammo_location.get_item(), false ) ?
-                              item::reload_option( &u, loc, u.ammo_location ) :
-                              u.select_ammo( loc, prompt, empty );
+    item::reload_option opt = favorite_ammo_or_select( u, loc, empty, prompt );
 
     if( opt.ammo.get_item() == nullptr || ( opt.ammo.get_item()->is_frozen_liquid() &&
                                             !u.crush_frozen_liquid( opt.ammo ) ) ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2491,6 +2491,7 @@ input_context get_default_mode_input_context()
     ctxt.register_action( "cast_spell" );
     ctxt.register_action( "fire_burst" );
     ctxt.register_action( "select_fire_mode" );
+    ctxt.register_action( "select_default_ammo" );
     ctxt.register_action( "drop" );
     ctxt.register_action( "unload_container" );
     ctxt.register_action( "drop_adj" );
@@ -9816,9 +9817,13 @@ void game::reload( item_location &loc, bool prompt, bool empty )
         if( !opt ) {
             return;
         } else if( u.ammo_location && opt.ammo == u.ammo_location ) {
+            u.add_msg_if_player( _( "Cleared ammo preferences for %s." ), loc->tname() );
             u.ammo_location = item_location();
-        } else {
+        } else if( u.has_item( *opt.ammo ) ) {
+            u.add_msg_if_player( _( "Selected %s as default ammo for %s." ), opt.ammo->tname(), loc->tname() );
             u.ammo_location = opt.ammo;
+        } else {
+            u.add_msg_if_player( _( "You need to keep that ammo on you to select it as default ammo." ) );
         }
         return;
     }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -9809,7 +9809,8 @@ void game::butcher()
     }
 }
 
-static item::reload_option favorite_ammo_or_select( avatar &u, item_location &loc, bool empty, bool prompt )
+static item::reload_option favorite_ammo_or_select( avatar &u, item_location &loc, bool empty,
+        bool prompt )
 {
     if( u.ammo_location ) {
         std::vector<item::reload_option> ammo_list;
@@ -9822,8 +9823,7 @@ static item::reload_option favorite_ammo_or_select( avatar &u, item_location &lo
                 return *it;
             }
         }
-    }
-    else {
+    } else {
         const_cast<item_location &>( u.ammo_location ) = item_location();
     }
     return u.select_ammo( loc, prompt, empty );

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2475,7 +2475,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
                 if( weapon->gun_all_modes().size() > 1 ) {
                     weapon->gun_cycle_mode();
                 } else {
-                        add_msg( m_info, _( "Your %s has only one firing mode." ), weapon->tname() );
+                    add_msg( m_info, _( "Your %s has only one firing mode." ), weapon->tname() );
                 }
             }
             break;
@@ -2488,11 +2488,13 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
                 } else if( player_character.ammo_location && opt.ammo == player_character.ammo_location ) {
                     player_character.add_msg_if_player( _( "Cleared ammo preferences for %s." ), weapon->tname() );
                     player_character.ammo_location = item_location();
-                } else if ( player_character.has_item( *opt.ammo ) ) {
-                    player_character.add_msg_if_player( _( "Selected %s as default ammo for %s." ), opt.ammo->tname(), weapon->tname() );
+                } else if( player_character.has_item( *opt.ammo ) ) {
+                    player_character.add_msg_if_player( _( "Selected %s as default ammo for %s." ), opt.ammo->tname(),
+                                                        weapon->tname() );
                     player_character.ammo_location = opt.ammo;
                 } else {
-                    player_character.add_msg_if_player( _( "You need to keep that ammo on you to select it as default ammo." ) );
+                    player_character.add_msg_if_player(
+                        _( "You need to keep that ammo on you to select it as default ammo." ) );
                 }
             }
             break;

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2482,19 +2482,17 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
 
         case ACTION_SELECT_DEFAULT_AMMO:
             if( weapon && weapon->is_gun() && !weapon->is_gunmod() ) {
-                if( weapon->has_flag( flag_RELOAD_ONE ) || weapon->has_flag( flag_RELOAD_AND_SHOOT ) ) {
-                    item::reload_option opt = player_character.select_ammo( weapon, false );
-                    if( !opt ) {
-                        break;
-                    } else if( player_character.ammo_location && opt.ammo == player_character.ammo_location ) {
-                        player_character.add_msg_if_player( _( "Cleared ammo preferences for %s." ), weapon->tname() );
-                        player_character.ammo_location = item_location();
-                    } else if ( player_character.has_item( *opt.ammo ) ) {
-                        player_character.add_msg_if_player( _( "Selected %s as default ammo for %s." ), opt.ammo->tname(), weapon->tname() );
-                        player_character.ammo_location = opt.ammo;
-                    } else {
-                        player_character.add_msg_if_player( _( "You need to keep that ammo on you to select it as default ammo." ) );
-                    }
+                item::reload_option opt = player_character.select_ammo( weapon, false );
+                if( !opt ) {
+                    break;
+                } else if( player_character.ammo_location && opt.ammo == player_character.ammo_location ) {
+                    player_character.add_msg_if_player( _( "Cleared ammo preferences for %s." ), weapon->tname() );
+                    player_character.ammo_location = item_location();
+                } else if ( player_character.has_item( *opt.ammo ) ) {
+                    player_character.add_msg_if_player( _( "Selected %s as default ammo for %s." ), opt.ammo->tname(), weapon->tname() );
+                    player_character.ammo_location = opt.ammo;
+                } else {
+                    player_character.add_msg_if_player( _( "You need to keep that ammo on you to select it as default ammo." ) );
                 }
             }
             break;

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2471,19 +2471,29 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
         }
 
         case ACTION_SELECT_FIRE_MODE:
-            if( weapon ) {
-                if( weapon->is_gun() && !weapon->is_gunmod() &&
-                    weapon->gun_all_modes().size() > 1 ) {
+            if( weapon && weapon->is_gun() && !weapon->is_gunmod() ) {
+                if( weapon->gun_all_modes().size() > 1 ) {
                     weapon->gun_cycle_mode();
-                } else if( weapon->has_flag( flag_RELOAD_ONE ) ||
-                           weapon->has_flag( flag_RELOAD_AND_SHOOT ) ) {
+                } else {
+                        add_msg( m_info, _( "Your %s has only one firing mode." ), weapon->tname() );
+                }
+            }
+            break;
+
+        case ACTION_SELECT_DEFAULT_AMMO:
+            if( weapon && weapon->is_gun() && !weapon->is_gunmod() ) {
+                if( weapon->has_flag( flag_RELOAD_ONE ) || weapon->has_flag( flag_RELOAD_AND_SHOOT ) ) {
                     item::reload_option opt = player_character.select_ammo( weapon, false );
                     if( !opt ) {
                         break;
                     } else if( player_character.ammo_location && opt.ammo == player_character.ammo_location ) {
+                        player_character.add_msg_if_player( _( "Cleared ammo preferences for %s." ), weapon->tname() );
                         player_character.ammo_location = item_location();
-                    } else {
+                    } else if ( player_character.has_item( *opt.ammo ) ) {
+                        player_character.add_msg_if_player( _( "Selected %s as default ammo for %s." ), opt.ammo->tname(), weapon->tname() );
                         player_character.ammo_location = opt.ammo;
+                    } else {
+                        player_character.add_msg_if_player( _( "You need to keep that ammo on you to select it as default ammo." ) );
                     }
                 }
             }


### PR DESCRIPTION
#### Summary
Interface "Favorite ammo Overhaul"

#### Purpose of change

When pressing `F` to change firing mode, if the gun has only 1 mode, and it's either RELOAD_AND_SHOOT (slings, bows) or RELOAD_ONE (shotguns, revolvers), the game will instead try to set default ammo for it. 
Same thing happens when pressing reload_item, reload_weapon, or reload_wielded_item, with RELOAD_AND_SHOOT weapon held.

But there are several bugs and inconveniences in this system.

If the shotgun has a second magazine (e.g. Kel-Tec KSG), it has a second firing mode, so the player loses the ability to select default ammo.

If the shotgun has only one magazine and one firing mode, select default ammo for it, then attach an underbarrel gunmod shotgun.
Normally, when the main magazine is filled up, you can then reload the underbarrel shotgun, but in this situation you are fobidden to do that, only "Can't reload the %s." is displayed.
Since that default ammo selection fallback from `F` key is disabled at this point, you can no longer reload the underbarrel shotgun, unless the default ammo is used up or dropped, or the gun is dropped once, which manually clears the ammo preferences.

Nothing prevented player from selecting an item on adjacent tiles as default ammo, and no matter how far you are from the tile where the ammo is, you have the ability to reload you gun with it (with a ridiculously long reloading time though). 
Once you save and quit the game, the item_location is lost, then you will get a debug message when trying to reload the gun, and in rare cases segfault can occur.

#### Describe the solution

Added a separate keybind  select_default_ammo (default hotkey is `F3`) for changing default gun ammo, and removed default ammo selection fallback from `F`.
Print messages when default_ammo is set, ammo preference is cleared, or trying to select inappropriate ammo.
If the player tries to switch firing mode, and the gun has only 1 mode, it'll say so.
Default ammo function now also works when using Kel-Tec KSG and so on. 
If the gun and attached gunmod(s) use different ammo, only the main ammo marked works.

Forbid selecting items outside player possession as default ammo, and future proof the code by resetting u.ammo_location whenever valididty check fails.

Also prevented the annoying "your bow isn't loaded" message from popping up when PC have sufficient arrow but can't fire the bow due to lack of str etc.

#### Describe alternatives you've considered

Limit the favorite ammo function to only affect RAS and RO weapons.

#### Testing

Spawn a kel-tec ksg shotgun, some 00 shot and birdshot, try setting favorite ammo and resetting it, and reloading in both condition.
Spawn a 6-round trenchgun, attach a modified masterkey shotgun to it, repeat the test.
Spawn a Remington 700 .30-06 rifle, some 30-06 FMJ and JSP, attach a modified masterkey shotgun to it, repeat the test.
Spawn an AUG assault rifle and a 10-round mag, try setting favorite mag and resetting it, and reloading in both condition.
Spawn a longbow and serveral kind of arrows, adjust the str of PC, try setting favorite ammo and resetting it, and reloading in both condition.
Everything works as intended.
Compiled and tested on win 10 and 11.

#### Additional context

N/A