### PR TITLE
Allow migrating from deleted variants

### DIFF
--- a/data/json/obsoletion_and_migration_0.I/migration_items.json
+++ b/data/json/obsoletion_and_migration_0.I/migration_items.json
@@ -1213,6 +1213,13 @@
     "replace": "remington_870"
   },
   {
+    "id": "mossberg_500",
+    "type": "MIGRATION",
+    "from_variant": "mossberg_500_security",
+    "replace": "benelli_tsa",
+    "variant": "mossberg_500_security"
+  },
+  {
     "id": "bottle_suppressor",
     "type": "MIGRATION",
     "replace": "filter_suppressor"

--- a/src/item_factory.h
+++ b/src/item_factory.h
@@ -224,6 +224,9 @@ class Item_factory
          */
         void migrate_item( const itype_id &id, item &obj );
 
+        /** applies a migration to the item if one exists with the given from_variant */
+        void migrate_item_from_variant( item &obj, const std::string &from_variant );
+
         /**
          * Check if an item type is known to the Item_factory.
          * @param id Item type id (@ref itype::id).

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2875,7 +2875,11 @@ void item::io( Archive &archive )
     } );
     archive.io( "craft_data", craft_data_, decltype( craft_data_ )() );
     const auto ivload = [this]( const std::string & variant ) {
-        set_itype_variant( variant );
+        if( possible_itype_variant( variant ) ) {
+            set_itype_variant( variant );
+        } else {
+            item_controller->migrate_item_from_variant( *this, variant );
+        }
     };
     const auto ivsave = []( const itype_variant_data * iv ) {
         return iv->id;


### PR DESCRIPTION
#### Summary
Bugfixes "Fix migrating from item variants when the variant has been deleted" 

#### Purpose of change
Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/72607
Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/72602

#### Describe the solution
On loading a variant that is not a possible variant from the given item, try to search for a migration from that item with the variant that was loaded, and apply that migration if relevant.

Moved some code around so as to not duplicate it, which makes up most of the diff.

Also added a migration to fix https://github.com/CleverRaven/Cataclysm-DDA/issues/72602

#### Testing
Follow steps in https://github.com/CleverRaven/Cataclysm-DDA/issues/72607.