### PR TITLE
Get roofs generated for basecamps

### DIFF
--- a/src/map.h
+++ b/src/map.h
@@ -2242,9 +2242,7 @@ class map
          * After calling @ref load or @ref generate, it should only contain non-null pointers.
          * Use @ref getsubmap or @ref setsubmap to access it.
          */
-    protected:
         std::vector<submap *> grid;
-    private:
         /**
          * This vector contains an entry for each trap type, it has therefore the same size
          * as the traplist vector. Each entry contains a list of all point on the map that

--- a/src/map.h
+++ b/src/map.h
@@ -2242,7 +2242,9 @@ class map
          * After calling @ref load or @ref generate, it should only contain non-null pointers.
          * Use @ref getsubmap or @ref setsubmap to access it.
          */
+    protected:
         std::vector<submap *> grid;
+    private:
         /**
          * This vector contains an entry for each trap type, it has therefore the same size
          * as the traplist vector. Each entry contains a list of all point on the map that
@@ -2652,5 +2654,6 @@ class smallmap : public tinymap
 {
     public:
         smallmap() : tinymap( 2, true ) {}
+        void add_roofs();
 };
 #endif // CATA_SRC_MAP_H

--- a/src/map.h
+++ b/src/map.h
@@ -2396,10 +2396,10 @@ bool generate_uniform_omt( const tripoint_abs_sm &p, const oter_id &terrain_type
 class tinymap : private map
 {
         friend class editmap;
-protected:
-    tinymap(int mapsize, bool zlev) : map(mapsize, zlev) {};
+    protected:
+        tinymap( int mapsize, bool zlev ) : map( mapsize, zlev ) {};
 
-public:
+    public:
         tinymap() : map( 2, false ) {}
         bool inbounds( const tripoint &p ) const override;
         bool inbounds( const tripoint_omt_ms &p ) const;
@@ -2650,7 +2650,7 @@ class fake_map : public tinymap
 */
 class smallmap : public tinymap
 {
-public:
-    smallmap() : tinymap(2, true) {}
+    public:
+        smallmap() : tinymap( 2, true ) {}
 };
 #endif // CATA_SRC_MAP_H

--- a/src/map.h
+++ b/src/map.h
@@ -2396,7 +2396,10 @@ bool generate_uniform_omt( const tripoint_abs_sm &p, const oter_id &terrain_type
 class tinymap : private map
 {
         friend class editmap;
-    public:
+protected:
+    tinymap(int mapsize, bool zlev) : map(mapsize, zlev) {};
+
+public:
         tinymap() : map( 2, false ) {}
         bool inbounds( const tripoint &p ) const override;
         bool inbounds( const tripoint_omt_ms &p ) const;
@@ -2636,5 +2639,18 @@ class fake_map : public tinymap
         explicit fake_map( const ter_id &ter_type = t_dirt );
         ~fake_map() override;
         static constexpr int fake_map_z = -OVERMAP_DEPTH;
+};
+
+/**
+* Smallmap is similar to tinymap in that it covers a single overmap terrain (OMT) tile, but differs
+* from it in that it covers all Z levels, not just a single one. It's intended usage is for cases
+* where you need to operate on an OMT, but cannot guarantee you needs are restricted to a single
+* Z level.
+* The smallmap's natural relative reference system is the tripoint_omt_ms one.
+*/
+class smallmap : public tinymap
+{
+public:
+    smallmap() : tinymap(2, true) {}
 };
 #endif // CATA_SRC_MAP_H

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -7688,8 +7688,8 @@ bool update_mapgen_function_json::update_map(
         return false;
     }
 
-    std::unique_ptr<tinymap> p_update_tmap = std::make_unique<tinymap>();
-    tinymap &update_tmap = *p_update_tmap;
+    std::unique_ptr<smallmap> p_update_tmap = std::make_unique<smallmap>();
+    smallmap &update_tmap = *p_update_tmap;
 
     update_tmap.load( omt_pos, true );
     update_tmap.rotate( 4 - rotation );
@@ -7826,8 +7826,8 @@ bool apply_construction_marker( const update_mapgen_id &update_mapgen_id,
     mapgendata fake_md( base_fake_md, args );
     fake_md.skip = { mapgen_phase::zones };
 
-    std::unique_ptr<tinymap> p_update_tmap = std::make_unique<tinymap>();
-    tinymap &update_tmap = *p_update_tmap;
+    std::unique_ptr<smallmap> p_update_tmap = std::make_unique<smallmap>();
+    smallmap &update_tmap = *p_update_tmap;
 
     update_tmap.load( omt_pos, true );
     update_tmap.rotate( 4 - rotation );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary

None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #70603, i.e. get basecamp roofs generated when they previously went AWOL.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Introduce smallmap, an OMT size map that contains all Z levels, as opposed to the previously existing tinymap.
- Use that map in conjunction with basecamp construction to properly trigger the magic that adds roofs onto constructed walls and ceilings.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
There are lots of places where the potential usage of a smallmap rather than a tinymap ought to be investigated:
- faction_camp operation scan_pseudo_items could be made 3D aware and thus look for items in basements and upper floors.
- faction_camp operation om_cutdown_trees: There have recently been work done to make trees span multiple Z levels. It ought to be checked whether the tree cutting clears out the stuff on the upper levels, as tinymap can't affect them. Also, the code might need to be updated to have the yield affected by the 3D height of the tree (don't know if regular tree cutting has been modified to do that either).
- debug_menu operation debug's MAP_EXTRA segment might benefit from an examination of whether it is and should remain a truly 2D action.
- editmap operation draw_main_ui_overlay may benefit for an examination of whether it is and should remain fully 2D.
- editmap operation mapgen_preview may benefit from a similar examination.
- mission_companion operation talk_function::loot_building might benefit from a determination of whether it should support 3D (basement and upper floors) as expanded functionality.
- Continue to try to device an operation that only adds the roof magic to the modified map. My attempts have all blown up because the code thinks map::grid is empty. I'm tired of failing with this, though.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Order companions to create a chicken coop in a livestock 2 expansion, debug wait, finish the job, and walk up to the roof to see whether a roof is generated, or the old behavior of showing the walls and floor on the level below remains.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
The roof addition magic is buried in the map::load call chain, and is only triggered if zlevels is true (as for map and smallmap, but, crucially, not for tinymap).

I've used smallmap for the main processing of the operation as well, because there's code intended to deal with cave-ins in case support is removed, but that code never triggers because zlevels = false causes it to silently fail to do anything.

Renamed the variables to indicate the type used, rather than the type used previously. Results in more "changes", but should lead to less confusion going forward.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
