### PR TITLE
Removes all hardcoded overmap_connection_id references

### DIFF
--- a/data/json/regional_map_settings.json
+++ b/data/json/regional_map_settings.json
@@ -310,6 +310,14 @@
       "river_floodplain_buffer_distance_min": 3,
       "river_floodplain_buffer_distance_max": 15
     },
+    "overmap_connection_settings": {
+      "intra_city_road_connection": "local_road",
+      "inter_city_road_connection": "local_road",
+      "trail_connection": "forest_trail",
+      "sewer_connection": "sewer_tunnel",
+      "subway_connection": "subway_tunnel",
+      "rail_connection": "local_railroad"
+    },
     "forest_mapgen_settings": {
       "forest": {
         "terrains": [ "forest", "special_forest" ],

--- a/data/mods/Backrooms/regional_map_settings.json
+++ b/data/mods/Backrooms/regional_map_settings.json
@@ -65,6 +65,14 @@
       "river_floodplain_buffer_distance_min": 0,
       "river_floodplain_buffer_distance_max": 0
     },
+    "overmap_connection_settings": {
+      "intra_city_road_connection": "local_road",
+      "inter_city_road_connection": "local_road",
+      "trail_connection": "forest_trail",
+      "sewer_connection": "sewer_tunnel",
+      "subway_connection": "subway_tunnel",
+      "rail_connection": "local_railroad"
+    },
     "forest_mapgen_settings": {
       "forest": {
         "sparseness_adjacency_factor": 3,

--- a/data/mods/No_Hope/regional_map_settings.json
+++ b/data/mods/No_Hope/regional_map_settings.json
@@ -283,6 +283,14 @@
       "river_floodplain_buffer_distance_min": 3,
       "river_floodplain_buffer_distance_max": 15
     },
+    "overmap_connection_settings": {
+      "intra_city_road_connection": "local_road",
+      "inter_city_road_connection": "local_road",
+      "trail_connection": "forest_trail",
+      "sewer_connection": "sewer_tunnel",
+      "subway_connection": "subway_tunnel",
+      "rail_connection": "local_railroad"
+    },
     "forest_mapgen_settings": {
       "forest": {
         "terrains": [ "forest", "special_forest" ],

--- a/data/mods/TEST_DATA/regions.json
+++ b/data/mods/TEST_DATA/regions.json
@@ -49,6 +49,14 @@
       "river_floodplain_buffer_distance_min": 1,
       "river_floodplain_buffer_distance_max": 6
     },
+    "overmap_connection_settings": {
+      "intra_city_road_connection": "local_road",
+      "inter_city_road_connection": "local_road",
+      "trail_connection": "forest_trail",
+      "sewer_connection": "sewer_tunnel",
+      "subway_connection": "subway_tunnel",
+      "rail_connection": "local_railroad"
+    },
     "forest_mapgen_settings": {
       "forest": {
         "sparseness_adjacency_factor": 3,

--- a/data/mods/TropiCataclysm/tropical_regional_map_settings.json
+++ b/data/mods/TropiCataclysm/tropical_regional_map_settings.json
@@ -336,6 +336,14 @@
       "river_floodplain_buffer_distance_min": 3,
       "river_floodplain_buffer_distance_max": 15
     },
+    "overmap_connection_settings": {
+      "intra_city_road_connection": "local_road",
+      "inter_city_road_connection": "local_road",
+      "trail_connection": "forest_trail",
+      "sewer_connection": "sewer_tunnel",
+      "subway_connection": "subway_tunnel",
+      "rail_connection": "local_railroad"
+    },
     "forest_mapgen_settings": {
       "forest": {
         "terrains": [ "forest", "special_forest" ],

--- a/data/mods/aftershock_exoplanet/region_settings.json
+++ b/data/mods/aftershock_exoplanet/region_settings.json
@@ -110,6 +110,14 @@
       "river_floodplain_buffer_distance_min": 3,
       "river_floodplain_buffer_distance_max": 15
     },
+    "overmap_connection_settings": {
+      "intra_city_road_connection": "local_road",
+      "inter_city_road_connection": "local_road",
+      "trail_connection": "forest_trail",
+      "sewer_connection": "sewer_tunnel",
+      "subway_connection": "subway_tunnel",
+      "rail_connection": "local_railroad"
+    },
     "forest_mapgen_settings": {
       "forest": {
         "sparseness_adjacency_factor": 9,

--- a/data/mods/classic_zombies/alberta_regional_map_settings.json
+++ b/data/mods/classic_zombies/alberta_regional_map_settings.json
@@ -269,6 +269,14 @@
       "river_floodplain_buffer_distance_min": 3,
       "river_floodplain_buffer_distance_max": 15
     },
+    "overmap_connection_settings": {
+      "intra_city_road_connection": "local_road",
+      "inter_city_road_connection": "local_road",
+      "trail_connection": "forest_trail",
+      "sewer_connection": "sewer_tunnel",
+      "subway_connection": "subway_tunnel",
+      "rail_connection": "local_railroad"
+    },
     "forest_mapgen_settings": {
       "forest": {
         "terrains": [ "forest", "special_forest" ],

--- a/data/mods/desert_region/desert_regional_map_settings.json
+++ b/data/mods/desert_region/desert_regional_map_settings.json
@@ -89,6 +89,14 @@
       "river_floodplain_buffer_distance_min": 3,
       "river_floodplain_buffer_distance_max": 15
     },
+    "overmap_connection_settings": {
+      "intra_city_road_connection": "local_road",
+      "inter_city_road_connection": "local_road",
+      "trail_connection": "forest_trail",
+      "sewer_connection": "sewer_tunnel",
+      "subway_connection": "subway_tunnel",
+      "rail_connection": "local_railroad"
+    },
     "forest_mapgen_settings": {
       "forest": {
         "terrains": [ "forest" ],

--- a/data/mods/rural_biome/rural_regional_map_settings.json
+++ b/data/mods/rural_biome/rural_regional_map_settings.json
@@ -206,6 +206,14 @@
       "river_floodplain_buffer_distance_min": 3,
       "river_floodplain_buffer_distance_max": 15
     },
+    "overmap_connection_settings": {
+      "intra_city_road_connection": "local_road",
+      "inter_city_road_connection": "local_road",
+      "trail_connection": "forest_trail",
+      "sewer_connection": "sewer_tunnel",
+      "subway_connection": "subway_tunnel",
+      "rail_connection": "local_railroad"
+    },
     "forest_mapgen_settings": {
       "forest": {
         "terrains": [ "forest" ],

--- a/doc/REGION_SETTINGS.md
+++ b/doc/REGION_SETTINGS.md
@@ -395,14 +395,14 @@ The **overmap_connection_settings** section defines the `overmap_connection_id`s
 
 ### Fields
 
-|          Identifier          |                                               Description                                                 |    Default     |
-| ---------------------------- | --------------------------------------------------------------------------------------------------------- | -------------- |
-| `intra_city_road_connection` | overmap_connection id used within cities. Should include locations for city_center and road_nesw_manhole. | local_road     |
-| `inter_city_road_connection` | overmap_connection id used between cities. Should include locations for the intra city terrains.          | local_road     |
-| `trail_connection`           | overmap_connection id used for forest trails.                                                             | forest_trail   |
-| `sewer_connection`           | overmap_connection id used for sewer connections.                                                         | sewer_tunnel   |
-| `subway_connection`          | overmap_connection id used for for both z-2 and z-4 subway connections.                                   | subway_tunnel  |
-| `rail_connection`            | overmap_connection id used for rail connections. ( Unused in vanilla as of 0.H )                          | local_railroad |
+|          Identifier          |                                                    Description                                                  |    Default     |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------------- | -------------- |
+| `intra_city_road_connection` | overmap_connection id used within cities. Should include locations for road, city_center and road_nesw_manhole. | local_road     |
+| `inter_city_road_connection` | overmap_connection id used between cities. Should include locations for the intra city terrains.                | local_road     |
+| `trail_connection`           | overmap_connection id used for forest trails.                                                                   | forest_trail   |
+| `sewer_connection`           | overmap_connection id used for sewer connections.                                                               | sewer_tunnel   |
+| `subway_connection`          | overmap_connection id used for for both z-2 and z-4 subway connections.                                         | subway_tunnel  |
+| `rail_connection`            | overmap_connection id used for rail connections. ( Unused in vanilla as of 0.H )                                | local_railroad |
 
 ### Example
 

--- a/doc/REGION_SETTINGS.md
+++ b/doc/REGION_SETTINGS.md
@@ -389,6 +389,32 @@ trailheads, and some general tuning of the actual trail width/position in mapgen
 }
 ```
 
+## Forest Trail Settings
+
+The **overmap_connection_settings** section defines the `overmap_connection_id`s used in hardcoded placement.
+
+### Fields
+
+|          Identifier          |                                               Description                                                 |    Default     |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------- | -------------- |
+| `intra_city_road_connection` | overmap_connection id used within cities. Should include locations for city_center and road_nesw_manhole. | local_road     |
+| `inter_city_road_connection` | overmap_connection id used between cities. Should include locations for the intra city terrains.          | local_road     |
+| `trail_connection`           | overmap_connection id used for forest trails.                                                             | forest_trail   |
+| `sewer_connection`           | overmap_connection id used for sewer connections.                                                         | sewer_tunnel   |
+| `subway_connection`          | overmap_connection id used for for both z-2 and z-4 subway connections.                                   | subway_tunnel  |
+| `rail_connection`            | overmap_connection id used for rail connections. ( Unused in vanilla as of 0.H )                          | local_railroad |
+
+### Example
+
+```json
+{
+	"overmap_connection_settings": {
+		"intra_city_road_connection": "cobbled_road",
+		"inter_city_road_connection": "rural_road"
+	}
+}
+```
+
 ## City
 
 The **city** section defines the possible overmap terrains and specials that may be used as

--- a/doc/REGION_SETTINGS.md
+++ b/doc/REGION_SETTINGS.md
@@ -395,14 +395,14 @@ The **overmap_connection_settings** section defines the `overmap_connection_id`s
 
 ### Fields
 
-|          Identifier          |                                                    Description                                                  |    Default     |
-| ---------------------------- | --------------------------------------------------------------------------------------------------------------- | -------------- |
-| `intra_city_road_connection` | overmap_connection id used within cities. Should include locations for road, city_center and road_nesw_manhole. | local_road     |
-| `inter_city_road_connection` | overmap_connection id used between cities. Should include locations for the intra city terrains.                | local_road     |
-| `trail_connection`           | overmap_connection id used for forest trails.                                                                   | forest_trail   |
-| `sewer_connection`           | overmap_connection id used for sewer connections.                                                               | sewer_tunnel   |
-| `subway_connection`          | overmap_connection id used for for both z-2 and z-4 subway connections.                                         | subway_tunnel  |
-| `rail_connection`            | overmap_connection id used for rail connections. ( Unused in vanilla as of 0.H )                                | local_railroad |
+|          Identifier          |                                                    Description                                                  |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `intra_city_road_connection` | overmap_connection id used within cities. Should include locations for road, city_center and road_nesw_manhole. |
+| `inter_city_road_connection` | overmap_connection id used between cities. Should include locations for the intra city terrains.                |
+| `trail_connection`           | overmap_connection id used for forest trails.                                                                   |
+| `sewer_connection`           | overmap_connection id used for sewer connections.                                                               |
+| `subway_connection`          | overmap_connection id used for for both z-2 and z-4 subway connections.                                         |
+| `rail_connection`            | overmap_connection id used for rail connections. ( Unused in vanilla as of 0.H )                                |
 
 ### Example
 

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -132,12 +132,6 @@ static const oter_type_str_id oter_type_slimepit_down( "slimepit_down" );
 static const oter_type_str_id oter_type_solid_earth( "solid_earth" );
 static const oter_type_str_id oter_type_sub_station( "sub_station" );
 
-static const overmap_connection_id overmap_connection_forest_trail( "forest_trail" );
-static const overmap_connection_id overmap_connection_local_railroad( "local_railroad" );
-static const overmap_connection_id overmap_connection_local_road( "local_road" );
-static const overmap_connection_id overmap_connection_sewer_tunnel( "sewer_tunnel" );
-static const overmap_connection_id overmap_connection_subway_tunnel( "subway_tunnel" );
-
 static const overmap_location_id overmap_location_land( "land" );
 static const overmap_location_id overmap_location_swamp( "swamp" );
 
@@ -3616,6 +3610,8 @@ bool overmap::generate_sub( const int z )
     for( city &i : goo_points ) {
         requires_sub |= build_slimepit( tripoint_om_omt( i.pos, z ), i.size );
     }
+    const overmap_connection_id &overmap_connection_sewer_tunnel =
+        settings->overmap_connection.sewer_connection;
     connect_closest_points( sewer_points, z, *overmap_connection_sewer_tunnel );
 
     // A third of overmaps have labs with a 1-in-2 chance of being subway connected.
@@ -3696,6 +3692,8 @@ bool overmap::generate_sub( const int z )
 
     subway_points.insert( subway_points.end(), subway_lab_train_points.begin(),
                           subway_lab_train_points.end() );
+    const overmap_connection_id &overmap_connection_subway_tunnel =
+        settings->overmap_connection.subway_connection;
     connect_closest_points( subway_points, z, *overmap_connection_subway_tunnel );
 
     for( auto &i : subway_points ) {
@@ -3705,7 +3703,8 @@ bool overmap::generate_sub( const int z )
     }
 
     // The first lab point is adjacent to a lab, set it a depot (as long as track was actually laid).
-    const auto create_train_depots = [this, z]( const oter_id & train_type,
+    const auto create_train_depots = [this, z,
+                                            overmap_connection_subway_tunnel]( const oter_id & train_type,
     const std::vector<point_om_omt> &train_points ) {
         bool is_first_in_pair = true;
         std::vector<point_om_omt> extra_route;
@@ -4482,6 +4481,8 @@ void overmap::place_forest_trails()
             }
 
             // Finally, connect all the points and make a forest trail out of them.
+            const overmap_connection_id &overmap_connection_forest_trail =
+                settings->overmap_connection.trail_connection;
             connect_closest_points( chosen_points, 0, *overmap_connection_forest_trail );
         }
     }
@@ -5096,7 +5097,9 @@ void overmap::place_roads( const overmap *north, const overmap *east, const over
     if( op_city_size <= 0 ) {
         return;
     }
-    std::vector<tripoint_om_omt> &roads_out = connections_out[overmap_connection_local_road];
+    const overmap_connection_id &overmap_connection_inter_city_road =
+        settings->overmap_connection.inter_city_road_connection;
+    std::vector<tripoint_om_omt> &roads_out = connections_out[overmap_connection_inter_city_road];
 
     // At least 3 exit points, to guarantee road continuity across overmaps
     if( roads_out.size() < 3 ) {
@@ -5158,7 +5161,7 @@ void overmap::place_roads( const overmap *north, const overmap *east, const over
     }
 
     // And finally connect them via roads.
-    connect_closest_points( road_points, 0, *overmap_connection_local_road );
+    connect_closest_points( road_points, 0, *overmap_connection_inter_city_road );
 }
 
 void overmap::place_railroads( const overmap *north, const overmap *east, const overmap *south,
@@ -5169,6 +5172,8 @@ void overmap::place_railroads( const overmap *north, const overmap *east, const 
     if( op_city_size <= 0 ) {
         return;
     }
+    const overmap_connection_id &overmap_connection_local_railroad =
+        settings->overmap_connection.rail_connection;
     std::vector<tripoint_om_omt> &railroads_out = connections_out[overmap_connection_local_railroad];
 
     // At least 3 exit points, to guarantee railroad continuity across overmaps
@@ -5476,7 +5481,9 @@ void overmap::place_cities()
                                      omts_per_city );
     }
 
-    const overmap_connection &local_road( *overmap_connection_local_road );
+    const overmap_connection_id &overmap_connection_intra_city_road =
+        settings->overmap_connection.intra_city_road_connection;
+    const overmap_connection &local_road( *overmap_connection_intra_city_road );
 
     // if there is only a single free tile, the probability of NOT finding it after MAX_PLACEMENT_ATTEMPTS attempts
     // is (1 - 1/(OMAPX * OMAPY))^MAX_PLACEMENT_ATTEMPTS ≈ 36% for the OMAPX=OMAPY=180 and MAX_PLACEMENT_ATTEMPTS=OMAPX * OMAPY

--- a/src/regional_settings.cpp
+++ b/src/regional_settings.cpp
@@ -595,7 +595,7 @@ void load_region_settings( const JsonObject &jo )
 
     load_overmap_ravine_settings( jo, new_region.overmap_ravine, strict, false );
 
-    load_overmap_connection_settings( jo, new_region.overmap_connection, false, false );
+    load_overmap_connection_settings( jo, new_region.overmap_connection, strict, false );
 
     load_region_terrain_and_furniture_settings( jo, new_region.region_terrain_and_furniture, strict,
             false );

--- a/src/regional_settings.cpp
+++ b/src/regional_settings.cpp
@@ -322,6 +322,33 @@ static void load_overmap_ravine_settings(
     }
 }
 
+static void load_overmap_connection_settings(
+    const JsonObject &jo, overmap_connection_settings &overmap_connection_settings, const bool strict,
+    const bool overlay )
+{
+    if( !jo.has_object( "overmap_connection_settings" ) ) {
+        if( strict ) {
+            jo.throw_error( "\"overmap_connection_settings\": { … } required for default" );
+        }
+    } else {
+        JsonObject overmap_connection_settings_jo = jo.get_object( "overmap_connection_settings" );
+        read_and_set_or_throw<overmap_connection_id>( overmap_connection_settings_jo, "trail_connection",
+                overmap_connection_settings.trail_connection, !overlay );
+        read_and_set_or_throw<overmap_connection_id>( overmap_connection_settings_jo, "sewer_connection",
+                overmap_connection_settings.sewer_connection, !overlay );
+        read_and_set_or_throw<overmap_connection_id>( overmap_connection_settings_jo, "subway_connection",
+                overmap_connection_settings.subway_connection, !overlay );
+        read_and_set_or_throw<overmap_connection_id>( overmap_connection_settings_jo, "rail_connection",
+                overmap_connection_settings.rail_connection, !overlay );
+        read_and_set_or_throw<overmap_connection_id>( overmap_connection_settings_jo,
+                "intra_city_road_connection",
+                overmap_connection_settings.intra_city_road_connection, !overlay );
+        read_and_set_or_throw<overmap_connection_id>( overmap_connection_settings_jo,
+                "inter_city_road_connection",
+                overmap_connection_settings.inter_city_road_connection, !overlay );
+    }
+}
+
 static void load_overmap_lake_settings( const JsonObject &jo,
                                         overmap_lake_settings &overmap_lake_settings,
                                         const bool strict, const bool overlay )
@@ -568,6 +595,8 @@ void load_region_settings( const JsonObject &jo )
 
     load_overmap_ravine_settings( jo, new_region.overmap_ravine, strict, false );
 
+    load_overmap_connection_settings( jo, new_region.overmap_connection, false, false );
+
     load_region_terrain_and_furniture_settings( jo, new_region.region_terrain_and_furniture, strict,
             false );
 
@@ -713,7 +742,11 @@ void apply_region_overlay( const JsonObject &jo, regional_settings &region )
 
     load_overmap_lake_settings( jo, region.overmap_lake, false, true );
 
+    load_overmap_ocean_settings( jo, region.overmap_ocean, false, true );
+
     load_overmap_ravine_settings( jo, region.overmap_ravine, false, true );
+
+    load_overmap_connection_settings( jo, region.overmap_connection, false, true );
 
     load_region_terrain_and_furniture_settings( jo, region.region_terrain_and_furniture, false, true );
 }

--- a/src/regional_settings.h
+++ b/src/regional_settings.h
@@ -233,6 +233,18 @@ struct overmap_ravine_settings {
     overmap_ravine_settings() = default;
 };
 
+struct overmap_connection_settings {
+    overmap_connection_id trail_connection = overmap_connection_id( "forest_trail" );
+    overmap_connection_id sewer_connection = overmap_connection_id( "sewer_tunnel" );
+    overmap_connection_id subway_connection = overmap_connection_id( "subway_tunnel" );
+    overmap_connection_id rail_connection = overmap_connection_id( "local_railroad" );
+    overmap_connection_id intra_city_road_connection = overmap_connection_id( "local_road" );
+    overmap_connection_id inter_city_road_connection = overmap_connection_id( "local_road" );
+
+    void finalize();
+    overmap_connection_settings() = default;
+};
+
 struct map_extras {
     unsigned int chance;
     weighted_int_list<map_extra_id> values;
@@ -275,6 +287,7 @@ struct regional_settings {
     overmap_lake_settings overmap_lake;
     overmap_ocean_settings overmap_ocean;
     overmap_ravine_settings overmap_ravine;
+    overmap_connection_settings overmap_connection;
     region_terrain_and_furniture_settings region_terrain_and_furniture;
 
     std::unordered_map<std::string, map_extras> region_extras;

--- a/src/regional_settings.h
+++ b/src/regional_settings.h
@@ -234,12 +234,12 @@ struct overmap_ravine_settings {
 };
 
 struct overmap_connection_settings {
-    overmap_connection_id trail_connection = overmap_connection_id( "forest_trail" );
-    overmap_connection_id sewer_connection = overmap_connection_id( "sewer_tunnel" );
-    overmap_connection_id subway_connection = overmap_connection_id( "subway_tunnel" );
-    overmap_connection_id rail_connection = overmap_connection_id( "local_railroad" );
-    overmap_connection_id intra_city_road_connection = overmap_connection_id( "local_road" );
-    overmap_connection_id inter_city_road_connection = overmap_connection_id( "local_road" );
+    overmap_connection_id trail_connection;
+    overmap_connection_id sewer_connection;
+    overmap_connection_id subway_connection;
+    overmap_connection_id rail_connection;
+    overmap_connection_id intra_city_road_connection;
+    overmap_connection_id inter_city_road_connection;
 
     void finalize();
     overmap_connection_settings() = default;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Hardcoded references bad
Allows mods/regions to have different connections for inter city vs intra city vs normal specials road connections, the former of which was impossible before while the latter required redefining every special to change it's connection
Is also useful for debugging city/inter city roads
Also fixes #72532 bc it's just a 1 line oversight and in the same file

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Adds a new region setting category for the connections with documentation explaining their uses and requirements
Replacing the intra city connections doesn't work perfectly because there's a few hardcoded references to the road oter so for example you can end up with two parallel adjacent roads, will look at making this more seamless in a future PR.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

I were going to have them default in region_settings.h and make the category optional so it needn't be defined anywhere unless being overridden but that kind of defeats the purpose of removing the references

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Used the test mod below to check both the new settings and overlay work correctly
```
[
  {
    "type": "MOD_INFO",
    "id": "testoverlay",
    "name": "testoverlay",
    "authors": [ "testoverlay" ],
    "maintainers": [ "testoverlay" ],
    "description": "testoverlay",
    "category": "rebalance",
    "dependencies": [ "dda" ]
  },
  {
    "type": "region_overlay",
    "regions": [ "all" ],
    "overmap_connection_settings": { "inter_city_road_connection": "z0_subway", "intra_city_road_connection": "z0_sewers" }
  },
  {
    "type": "overmap_connection",
    "id": "z0_sewers",
    "subtypes": [
      { "terrain": "sewer", "locations": [ "road", "z0_sewers" ], "basic_cost": 0, "flags": [ "ORTHOGONAL" ] },
      { "terrain": "sewer", "locations": [ "field" ], "basic_cost": 5 },
      { "terrain": "sewer", "locations": [ "forest" ], "basic_cost": 20 },
      { "terrain": "sewer", "locations": [ "swamp" ], "basic_cost": 40 },
      { "terrain": "sewer", "locations": [ "water" ], "basic_cost": 120 }
    ]
  },
  {
    "type": "overmap_connection",
    "id": "z0_subway",
    "subtypes": [
      { "terrain": "sewer", "locations": [ "z0_sewers" ], "basic_cost": 0, "flags": [ "ORTHOGONAL" ] },
      { "terrain": "subway", "locations": [ "field" ], "basic_cost": 5 },
      { "terrain": "subway", "locations": [ "forest" ], "basic_cost": 20 },
      { "terrain": "subway", "locations": [ "swamp" ], "basic_cost": 40 },
      { "terrain": "subway", "locations": [ "water" ], "basic_cost": 120 }
    ]
  },
  {
    "type": "overmap_connection",
    "id": "local_road",
    "subtypes": [
      { "terrain": "subway", "locations": [ "z0_subway" ], "basic_cost": 0, "flags": [ "ORTHOGONAL" ] },
      { "terrain": "sewer", "locations": [ "z0_sewers" ], "basic_cost": 0, "flags": [ "ORTHOGONAL" ] },
      { "terrain": "road", "locations": [ "road" ], "basic_cost": 0, "flags": [ "ORTHOGONAL" ] },
      { "terrain": "road", "locations": [ "field" ], "basic_cost": 5 },
      { "terrain": "road", "locations": [ "forest" ], "basic_cost": 20 },
      { "terrain": "road", "locations": [ "swamp" ], "basic_cost": 40 },
      { "terrain": "road_nesw_manhole", "locations": [  ] },
      { "terrain": "city_center", "locations": [ "field", "road" ] },
      { "terrain": "bridge", "locations": [ "water" ], "basic_cost": 120 },
      { "terrain": "bridgehead_ground", "locations": [ "water" ], "basic_cost": 120, "flags": [ "ORTHOGONAL" ] }
    ]
  },
  {
    "type": "overmap_location",
    "id": "z0_sewers",
    "terrains": [ "sewer", "city_center", "road_nesw_manhole" ]
  },
  {
    "type": "overmap_location",
    "id": "z0_subway",
    "terrains": [ "subway" ]
  }
]
```

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45432782/1044cc5f-c41d-4f83-a59f-de18ce11ed01)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

This could be used to yeet the SIDEWALK flag

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
