### PR TITLE
NPCs can develop vitamin diseases

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -5129,11 +5129,6 @@ needs_rates Character::calc_needs_rates() const
                                 pos() ) ) - 32.5f ) / 40.0f );
     }
 
-    if( is_npc() ) {
-        rates.hunger *= 0.25f;
-        rates.thirst *= 0.25f;
-    }
-
     rates.hunger = enchantment_cache->modify_value( enchant_vals::mod::HUNGER, rates.hunger );
     rates.fatigue = enchantment_cache->modify_value( enchant_vals::mod::FATIGUE, rates.fatigue );
     rates.thirst = enchantment_cache->modify_value( enchant_vals::mod::THIRST, rates.thirst );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8561,8 +8561,8 @@ void Character::blossoms()
 
 void Character::update_vitamins( const vitamin_id &vit )
 {
-    if( is_npc() && vit->type() != vitamin_type::COUNTER ) {
-        return; // NPCs cannot develop vitamin diseases, bypass for special
+    if( !needs_food() ) {
+        return; // NPCs can only develop vitamin diseases if their needs are enabled
     }
 
     efftype_id def = vit.obj().deficiency();

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -645,8 +645,7 @@ int Character::vitamin_mod( const vitamin_id &vit, int qty )
 
 void Character::vitamins_mod( const std::map<vitamin_id, int> &vitamins )
 {
-    const bool npc_no_food = is_npc() && get_option<bool>( "NO_NPC_FOOD" );
-    if( !npc_no_food ) {
+    if( needs_food() ) {
         for( const std::pair<const vitamin_id, int> &vit : vitamins ) {
             vitamin_mod( vit.first, vit.second );
         }


### PR DESCRIPTION
#### Summary
Bugfixes "NPCs can develop vitamin diseases"

#### Purpose of change
Hey, remember all that work I did to make sure toxins worked in the larder? Yeah, NPCs were just... immune to that. They could get toxins, and the toxins would go up and down, but they could never get the resulting effects.

#### Describe the solution
Replace yet another random NPC exclusion with a check to needs_food().

In other words: NPCs can develop vitamin diseases, *but only with the default mod disabled*. Otherwise they continue to not require food, not get vitamin excess/deficiency effects, etc.

#### Describe alternatives you've considered
~~I really should go over all the character code for instances of is_avatar() and is_npc() because there's still these random hardcoded things shaking out which aren't even tied to the NO_NPC_FOOD external option.~~
Did that. Found out NPCs randomly required 1/4th as much food and water, regardless of mods or settings. Died inside a little. (Also removed their magic powers)

#### Testing
Before PR: NPC follower with 15k toxins never got "unnerving symptoms"
After PR: NPC follower with 15k toxins immediately got "unnerving symptoms", same as the player.

#### Additional context
