### PR TITLE
Rename cover ---> concealment

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6564,7 +6564,7 @@ void game::print_terrain_info( const tripoint &lp, const catacurses::window &w_l
     print_furniture_info( lp, w_look, column, line );
 
     // Cover percentage from terrain and furniture next.
-    fold_and_print( w_look, point( column, ++line ), max_width, c_light_gray, _( "Cover: %d%%" ),
+    fold_and_print( w_look, point( column, ++line ), max_width, c_light_gray, _( "Concealment: %d%%" ),
                     m.coverage( lp ) );
 
     if( m.has_flag( ter_furn_flag::TFLAG_TREE, lp ) ) {


### PR DESCRIPTION
#### Summary
Interface "Tile cover is now named concealment, because that's all it actually does."

#### Purpose of change
Many, many many people have confused terrain/furniture cover for interacting with projectiles. It does not interact with projectiles in any way.

#### Describe the solution
Change the display name to make it really obvious

#### Describe alternatives you've considered
I originally called it "Vision" and slapped a negative sign on it
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/f53d4a62-2645-4d50-a027-4de40a1e2f4b)


#### Testing
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/ba9d7dc5-c727-47af-a89f-f478520ead4a)


#### Additional context
