### PR TITLE
Fix zlib old-style-cast build breakage

### DIFF
--- a/src/cata_utility.cpp
+++ b/src/cata_utility.cpp
@@ -399,7 +399,10 @@ std::string read_compressed_file_to_string( std::istream &fin )
     z_stream zs;
     memset( &zs, 0, sizeof( zs ) );
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
     if( inflateInit2( &zs, MAX_WBITS | 16 ) != Z_OK ) {
+#pragma GCC diagnostic pop
         throw std::runtime_error( "inflateInit failed while decompressing." );
     }
 


### PR DESCRIPTION
#### Summary
Build "Fix zlib old-style-cast build breakage"

#### Purpose of change

Unbreak the build on at least macOS Sonoma with Xcode 15.2 (15C500b) and zlib 1.3.1 from MacPorts; possibly also on other platform / compiler / zlib combinations:

```
clang++ -Isrc -isystem src/third-party -DMACOSX -DGIT_VERSION -DOSX_SDL2_LIBS -DTILES -DBACKTRACE -DUSE_HOME_DIR -Og -Werror -Wall -Wextra -Wformat-signedness -Wlogical-op -Wmissing-declarations -Wmissing-noreturn -Wnon-virtual-dtor -Wold-style-cast -Woverloaded-virtual -Wpedantic -Wsuggest-override -Wunused-macros -Wzero-as-null-pointer-constant -Wno-unknown-warning-option -Wno-dangling-reference -Wno-c++20-compat -Wredundant-decls  -g  -fsigned-char -stdlib=libc++ -std=c++17 -DIMGUI_DISABLE_OBSOLETE_KEYIO -mmacosx-version-min=10.13 -D_THREAD_SAFE -I/opt/local/include/SDL2 -I/opt/local/include -I/opt/local/include/opus -I/opt/local/include -I/opt/local/include/opus -I/opt/local/include -I/opt/local/include/SDL2 -DSDL_SOUND -I/opt/local/include/SDL2 -D_THREAD_SAFE -I/opt/local/include -MMD -MP -Winvalid-pch -include-pch pch/main-pch.hpp.pch -c src/cata_utility.cpp -o obj/tiles/cata_utility.o
src/cata_utility.cpp:402:9: error: use of old-style cast [-Werror,-Wold-style-cast]
    if( inflateInit2( &zs, MAX_WBITS | 16 ) != Z_OK ) {
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/local/include/zlib.h:1822:25: note: expanded from macro 'inflateInit2'
                        (int)sizeof(z_stream))
                        ^    ~~~~~~~~~~~~~~~~
1 error generated.
make: *** [obj/tiles/cata_utility.o] Error 1
```

#### Describe the solution

Disable `-Wold-style-cast` across the use of zlib's `inflateInit2` macro.

#### Describe alternatives you've considered

That macro uses a C style cast because it lives in a (C++-compatible) C header, so this isn't a bug in zlib, and even if it were, we'd still want to work around (hypothetically) broken zlib versions.

Considered removing either `-Werror` or `-Wold-style-cast` from the defaults, but felt that would be a more contentious change than locally disabling `-Wold-style-cast` (i.e. the footgunning seems intentional).

#### Testing

Before change: Build was broken.  After change: Build was fine.  Smoke-tested the resulting binaries and they seem fine.

#### Additional context

n/a