### PR TITLE
[MoM] High levels of weariness (or brainworms) turn off your powers

### DIFF
--- a/data/mods/MindOverMatter/effectoncondition/eoc_misc.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_misc.json
@@ -209,7 +209,10 @@
         { "not": { "u_has_proficiency": "prof_concentration_master" } }
       ]
     },
-    "effect": [ { "run_eocs": [ "EOC_END_PSI_POWERS" ] } ]
+    "effect": [
+      { "u_message": "You are almost too tired to think, and can't concentrate on maintaining your powers", "type": "bad" },
+      { "run_eocs": [ "EOC_END_PSI_POWERS_MAINTAINED" ] }
+    ]
   },
   {
     "type": "effect_on_condition",
@@ -222,7 +225,7 @@
         { "compare_string": [ "pd_int_bad", { "context_val": "effect" } ] }
       ]
     },
-    "effect": [ { "run_eocs": [ "EOC_END_PSI_POWERS" ] } ]
+    "effect": [ { "run_eocs": [ "EOC_END_PSI_POWERS_MAINTAINED" ] } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/MindOverMatter/effectoncondition/eoc_misc.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_misc.json
@@ -178,7 +178,11 @@
         "run_eocs": [
           {
             "id": "EOC_PSIONICS_DAZED_ENDS_POWERS_2",
-            "condition": { "roll_contested": { "math": [ "u_val('intelligence') + u_skill('metaphysics')" ] }, "difficulty": 20, "die_size": 15 },
+            "condition": {
+              "roll_contested": { "math": [ "(u_val('intelligence') / 2) + u_skill('metaphysics') + concentration_trait_bonuses()" ] },
+              "difficulty": 20,
+              "die_size": 15
+            },
             "effect": [  ],
             "false_effect": [
               { "u_message": "Your head is swimming.  You can no longer maintain your powers!", "type": "bad" },
@@ -188,6 +192,37 @@
         ]
       }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PSIONICS_WEARINESS_ENDS_POWERS",
+    "eoc_type": "EVENT",
+    "required_event": "character_gains_effect",
+    "condition": {
+      "and": [
+        {
+          "or": [
+            { "compare_string": [ "weary_7", { "context_val": "effect" } ] },
+            { "compare_string": [ "weary_8", { "context_val": "effect" } ] }
+          ]
+        },
+        { "not": { "u_has_proficiency": "prof_concentration_master" } }
+      ]
+    },
+    "effect": [ { "run_eocs": [ "EOC_END_PSI_POWERS" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PSIONICS_MIND_PROBLEMS_ENDS_POWERS",
+    "eoc_type": "EVENT",
+    "required_event": "character_gains_effect",
+    "condition": {
+      "or": [
+        { "compare_string": [ "brainworms", { "context_val": "effect" } ] },
+        { "compare_string": [ "pd_int_bad", { "context_val": "effect" } ] }
+      ]
+    },
+    "effect": [ { "run_eocs": [ "EOC_END_PSI_POWERS" ] } ]
   },
   {
     "type": "effect_on_condition",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] High levels of weariness turn off your powers"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

When you get to Weariness level 7 or 8, you're so tired you can't use any psionics. However, that could lead to an edge case where if you had a power still running, you couldn't turn it off because you were too tired. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Make an event EoC that ends concentration when you reach Weariness 7 or 8, unless you have the Concentration (Master) proficiency. Also make it so that brainworms ends your concentration powers and rework the EoC that can turn off your powers when you are Dazed to de-emphasize Intelligence but take concentration traits into account. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Turned on some powers, dug a ditch, powers turned off. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
