### PR TITLE
Set rot when all components are rotten

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -510,12 +510,14 @@ static void inherit_rot_from_components( item &it )
         const time_duration shortest_lifespan = get_shortest_lifespan_from_components( it );
         if( shortest_lifespan > 0_turns && shortest_lifespan < it.get_shelf_life() ) {
             it.set_rot( it.get_shelf_life() - shortest_lifespan );
+            return;
         }
-    } else {
-        const item *most_rotten = get_most_rotten_component( it );
-        if( most_rotten ) {
-            it.set_relative_rot( most_rotten->get_relative_rot() );
-        }
+        // Fallthrough: shortest_lifespan <= 0_turns (all components are rotten)
+    }
+
+    const item *most_rotten = get_most_rotten_component( it );
+    if( most_rotten ) {
+        it.set_relative_rot( most_rotten->get_relative_rot() );
     }
 }
 


### PR DESCRIPTION
#### Summary
Bugfixes "Rotten food doesn't become fresh when crafted with"

#### Purpose of change
* Fixes #64967

The logic to inherit rot incorrectly assumed that the "lifespan" (time it's spent rotting - maximum time to rot) of a comestible would be a positive value. This is not correct for rotten components, which end up with a negative "lifespan".

#### Describe the solution
If all components are rotten (lifespan <= 0 turns), always set relative rot instead of not setting rot at all.

#### Describe alternatives you've considered


#### Testing
Test case "recipes_inherit_rot_of_components_properly" passes locally. Crafted from some rotten raw meat ingame, got rotten cooked meat.

#### Additional context
My claim in the linked issue that this was due to cooks_like was wrong.