### PR TITLE
Fix food fun reduction test not actually having any reduction

### DIFF
--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -4919,5 +4919,15 @@
     "//": "Do not use calcium, iron or vitamin C! Those are calculated as RDAs, and you only get 96% of the listed value! No, that doesn't make any sense! But that's how it is. So use a normal vitamin. This is for a camp test, not a vitamin test...",
     "vitamins": [ [ "mutant_toxin", 100 ], [ "mutagen", 200 ] ],
     "melee_damage": { "bash": 1 }
+  },
+  {
+    "type": "COMESTIBLE",
+    "id": "toastem_test",
+    "name": { "str": "toast-em" },
+    "copy-from": "toastem",
+    "//": "toastem copy with a different material + manual values so monotony penalty is sure to apply",
+    "material": [ "foodplace_foodstuff" ],
+    "fun": 20,
+    "monotony_penalty": 4
   }
 ]

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -3933,7 +3933,8 @@ CBMs can be defined like this:
 "healthy" : -2,             // Health effects (used for sickness chances)
 "addiction_potential" : 80, // Default strength for this item to cause addictions
 "addiction_type" : [ "crack", { "addiction": "cocaine", "potential": 5 } ], // Addiction types (if no potential is given, the "addiction_potential" field is used to determine the strength of that addiction)
-"monotony_penalty" : 0,     // (Optional, default: 2) Fun is reduced by this number for each one you've consumed in the last 48 hours.
+"monotony_penalty" : 0,     // (Optional, default: 2 or 0 depending on material) Fun is reduced by this number for each one you've consumed in the last 48 hours.
+                            // Comestibles with any material of junk food (id: "junk") default to 0. All other comestibles default to 2 when unspecified.
                             // Can't drop fun below 0, unless the comestible also has the "NEGATIVE_MONOTONY_OK" flag.
 "calories" : 0,             // Hunger satisfied (in kcal)
 "nutrition" : 0,            // Hunger satisfied (OBSOLETE)

--- a/tests/food_fun_for_test.cpp
+++ b/tests/food_fun_for_test.cpp
@@ -367,12 +367,15 @@ TEST_CASE( "fun_for_food_eaten_too_often", "[fun_for][food][monotony]" )
     std::pair<int, int> actual_fun;
 
     // A big box of tasty toast-ems
-    item toastem( "toastem", calendar::turn, 10 );
+    item toastem( "toastem_test", calendar::turn, 10 );
     REQUIRE( toastem.is_comestible() );
 
     // Base fun value and monotony penalty for toast-em
     int toastem_fun = toastem.get_comestible_fun();
     int toastem_penalty = toastem.get_comestible()->monotony_penalty;
+
+    REQUIRE( toastem_fun > 0 );
+    REQUIRE( toastem_penalty > 0 );
 
     // Will do 2 rounds of penalty testing, so base fun needs to be at least 2x that
     REQUIRE( toastem_fun > 2 * toastem_penalty );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
"fun_for_food_eaten_too_often" did not actually test anything useful. It checked if a scaling penalty was applied, but the penalty was 0.

#### Describe the solution
Actually check to make sure the penalty exists. 

Pad the test with some more sanity checking to make sure we're doing math that makes sense.

Use a copy of the test item for the test data mod to ensure this sort of shenanigans does not occur again.

#### Describe alternatives you've considered
I didn't even know we had a defineable "monotony_penalty", it seems nothing actually uses a manual definition.

Kind of wanted to go muck with it and make it better across the board, but my time is due for 0.H right now.

#### Testing
Test passes locally

#### Additional context
Also updated docs to explain when monotony doesn't apply, instead of just hiding it in the item factory.