### PR TITLE
Mansion Escape balance update

### DIFF
--- a/data/json/effects_on_condition/scenario_specific_eocs.json
+++ b/data/json/effects_on_condition/scenario_specific_eocs.json
@@ -68,7 +68,8 @@
       { "run_eocs": "EOC_SPAWN_MANSION_MONSTERS" },
       {
         "u_run_monster_eocs": [ { "id": "EOC_BANISH_MONSTERS_AROUND_PLAYER", "effect": { "run_eocs": "EOC_BANISH_SELF" } } ],
-        "monster_range": 6
+        "mtype_ids": [ "mon_zombie", "mon_feral_fancy_rapier", "mon_feral_fancy_rapier_fake", "mon_feral_maid_knife" ],
+        "monster_range": 10
       }
     ]
   },
@@ -111,7 +112,7 @@
       {
         "u_spawn_monster": "GROUP_MANSION_START",
         "group": true,
-        "real_count": 20,
+        "real_count": 15,
         "min_radius": 0,
         "max_radius": 36,
         "target_var": { "u_val": "mansion_centre" },

--- a/data/json/effects_on_condition/scenario_specific_eocs.json
+++ b/data/json/effects_on_condition/scenario_specific_eocs.json
@@ -95,13 +95,14 @@
         "monster_range": 36
       },
       {
-        "npc_run_monster_eocs": [
-          {
-            "id": "EOC_BANISH_MANSION_CIVILIANS",
-            "effect": { "run_eocs": "EOC_BANISH_SELF" }
-          }
+        "npc_run_monster_eocs": [ { "id": "EOC_BANISH_MANSION_CIVILIANS", "effect": { "run_eocs": "EOC_BANISH_SELF" } } ],
+        "mtype_ids": [
+          "mon_civilian_panic",
+          "mon_civilian_parent",
+          "mon_civilian_police",
+          "mon_civilian_stationary",
+          "mon_civilian_zombiefighter"
         ],
-        "mtype_ids": [ "mon_civilian_panic", "mon_civilian_parent", "mon_civilian_police", "mon_civilian_stationary", "mon_civilian_zombiefighter" ],
         "monster_range": 50
       }
     ]
@@ -141,7 +142,12 @@
           "id": "EOC_SEX_LAIR_SPAWNS",
           "condition": { "and": [ { "u_near_om_location": "mansion_boarded_t2d_start" }, { "math": [ "rand(2)", "==", "0" ] } ] },
           "effect": [
-            { "u_spawn_monster": "mon_zombie_resort_dancer", "real_count": { "math": [ "1 + rand(1)" ] }, "min_radius": 3, "max_radius": 5 },
+            {
+              "u_spawn_monster": "mon_zombie_resort_dancer",
+              "real_count": { "math": [ "1 + rand(1)" ] },
+              "min_radius": 3,
+              "max_radius": 5
+            },
             { "u_message": "What was that sound?", "type": "warning", "popup": true }
           ]
         }
@@ -151,7 +157,12 @@
           "id": "EOC_PANICROOM_SPAWNS",
           "condition": { "and": [ { "u_near_om_location": "mansion_boarded_t2_start" }, { "math": [ "rand(1)", "==", "0" ] } ] },
           "effect": [
-            { "u_spawn_monster": "GROUP_SCENARIO_PANICROOM", "group": true, "real_count": { "math": [ "1 + rand(1)" ] }, "max_radius": 2 },
+            {
+              "u_spawn_monster": "GROUP_SCENARIO_PANICROOM",
+              "group": true,
+              "real_count": { "math": [ "1 + rand(1)" ] },
+              "max_radius": 2
+            },
             { "u_message": "Is there someone else in here?", "type": "warning", "popup": true }
           ]
         }

--- a/data/json/effects_on_condition/scenario_specific_eocs.json
+++ b/data/json/effects_on_condition/scenario_specific_eocs.json
@@ -50,6 +50,7 @@
     "type": "effect_on_condition",
     "id": "scenario_mansion_pursuit",
     "eoc_type": "SCENARIO_SPECIFIC",
+    "//": "EOC_BANISH_MANSION_MONSTERS is not triggering/working at the moment.",
     "effect": [
       {
         "u_location_variable": { "u_val": "mansion_centre" },
@@ -68,9 +69,9 @@
       { "run_eocs": "EOC_SPAWN_MANSION_MONSTERS" },
       {
         "u_run_monster_eocs": [ { "id": "EOC_BANISH_MONSTERS_AROUND_PLAYER", "effect": { "run_eocs": "EOC_BANISH_SELF" } } ],
-        "mtype_ids": [ "mon_zombie", "mon_feral_fancy_rapier", "mon_feral_fancy_rapier_fake", "mon_feral_maid_knife" ],
-        "monster_range": 10
-      }
+        "monster_range": 12
+      },
+      { "run_eocs": "EOC_SPAWN_MANSION_MONSTERS_NEAR_PLAYER" }
     ]
   },
   {
@@ -92,6 +93,16 @@
           }
         ],
         "monster_range": 36
+      },
+      {
+        "npc_run_monster_eocs": [
+          {
+            "id": "EOC_BANISH_MANSION_CIVILIANS",
+            "effect": { "run_eocs": "EOC_BANISH_SELF" }
+          }
+        ],
+        "mtype_ids": [ "mon_civilian_panic", "mon_civilian_parent", "mon_civilian_police", "mon_civilian_stationary", "mon_civilian_zombiefighter" ],
+        "monster_range": 50
       }
     ]
   },
@@ -105,7 +116,7 @@
         "group": true,
         "real_count": 1,
         "min_radius": 0,
-        "max_radius": 36,
+        "max_radius": 18,
         "target_var": { "u_val": "mansion_centre" },
         "indoor_only": true
       },
@@ -116,6 +127,41 @@
         "min_radius": 0,
         "max_radius": 36,
         "target_var": { "u_val": "mansion_centre" },
+        "indoor_only": true
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_SPAWN_MANSION_MONSTERS_NEAR_PLAYER",
+    "//": "Spawn mansion monsters near the player, either for lore or as weak obstacles.",
+    "effect": [
+      {
+        "run_eocs": {
+          "id": "EOC_SEX_LAIR_SPAWNS",
+          "condition": { "and": [ { "u_near_om_location": "mansion_boarded_t2d_start" }, { "math": [ "rand(2)", "==", "0" ] } ] },
+          "effect": [
+            { "u_spawn_monster": "mon_zombie_resort_dancer", "real_count": { "math": [ "1 + rand(1)" ] }, "min_radius": 3, "max_radius": 5 },
+            { "u_message": "What was that sound?", "type": "warning", "popup": true }
+          ]
+        }
+      },
+      {
+        "run_eocs": {
+          "id": "EOC_PANICROOM_SPAWNS",
+          "condition": { "and": [ { "u_near_om_location": "mansion_boarded_t2_start" }, { "math": [ "rand(1)", "==", "0" ] } ] },
+          "effect": [
+            { "u_spawn_monster": "GROUP_SCENARIO_PANICROOM", "group": true, "real_count": { "math": [ "1 + rand(1)" ] }, "max_radius": 2 },
+            { "u_message": "Is there someone else in here?", "type": "warning", "popup": true }
+          ]
+        }
+      },
+      {
+        "u_spawn_monster": "GROUP_MANSION_PURSUERS",
+        "group": true,
+        "real_count": 5,
+        "min_radius": 10,
+        "max_radius": 16,
         "indoor_only": true
       }
     ]

--- a/data/json/mapgen/mansion.json
+++ b/data/json/mapgen/mansion.json
@@ -41,7 +41,7 @@
         "!": { "item": "crate_stack", "chance": 100 },
         "q": { "item": "tool_common_stack", "chance": 100 }
       },
-      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 17, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 2, 21 ], "y": [ 17, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -85,7 +85,7 @@
         "K": { "item": "crate_cleaning", "chance": 100 },
         "I": { "item": "table_foyer", "chance": 40 }
       },
-      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -133,7 +133,7 @@
       },
       "furniture": { "&": "f_sofa" },
       "items": { " ": { "item": "clutter_mansion", "chance": 2 }, "c": { "item": "suit_of_armor", "chance": 100 } },
-      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 17, 21 ], "density": 0.15 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 2, 21 ], "y": [ 17, 21 ], "density": 0.15 } ]
     }
   },
   {
@@ -187,7 +187,7 @@
         "?": { "item": "wetbar_fridge", "chance": 80 },
         "1": { "item": "wetbar_stack", "chance": 100 }
       },
-      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 14, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 2, 21 ], "y": [ 14, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -232,7 +232,7 @@
         "s": { "item": "table_foyer", "chance": 40 },
         "c": { "item": "suit_of_armor", "chance": 100 }
       },
-      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -513,7 +513,7 @@
         "!": { "item": "crate_stack", "chance": 100 },
         "$": { "item": "creepy", "chance": 25 }
       },
-      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 12 ], "density": 0.1 } ],
+      "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 2, 21 ], "y": [ 2, 12 ], "density": 0.1 } ],
       "place_monster": [ { "monster": "mon_zombie_resort_dancer", "x": [ 5, 19 ], "y": [ 16, 18 ], "repeat": [ 1, 2 ] } ]
     }
   },
@@ -564,7 +564,7 @@
         "s": { "item": "nightstand", "chance": 40 },
         "d": { "item": "dresser_stack", "chance": 100 }
       },
-      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -619,7 +619,7 @@
         { "group": "corpse_mansion", "x": [ 10, 12 ], "y": [ 5, 7 ], "chance": 50, "repeat": [ 0, 2 ] },
         { "item": "television", "x": 12, "y": 17, "chance": 100 }
       ],
-      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 10, 13 ], "y": [ 6, 10 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 10, 13 ], "y": [ 6, 10 ], "density": 0.1 } ]
     }
   },
   {
@@ -679,7 +679,7 @@
         ",": { "item": "clutter_bathroom", "chance": 15 },
         "I": { "item": "vanity", "chance": 30 }
       },
-      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 11 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 2, 21 ], "y": [ 2, 11 ], "density": 0.1 } ]
     }
   },
   {
@@ -732,7 +732,7 @@
         "x": { "item": "a_television", "chance": 100 },
         "c": { "item": "suit_of_armor", "chance": 100 }
       },
-      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 12 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 2, 21 ], "y": [ 2, 12 ], "density": 0.1 } ]
     }
   },
   {
@@ -786,7 +786,7 @@
         { "item": "stereo", "x": 4, "y": 4, "chance": 100 },
         { "item": "television", "x": 14, "y": 9, "chance": 100 }
       ],
-      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 11 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 2, 21 ], "y": [ 2, 11 ], "density": 0.1 } ]
     }
   },
   {
@@ -839,7 +839,7 @@
         "&": { "item": "table_wine", "chance": 100, "repeat": [ 1, 4 ] },
         ".": { "item": "clutter_basement", "chance": 1 }
       },
-      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 12 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 2, 21 ], "y": [ 2, 12 ], "density": 0.1 } ]
     }
   },
   {
@@ -890,7 +890,7 @@
         "J": { "item": "table_sideboard", "chance": 35 },
         "x": { "item": "table_livingroom", "chance": 35 }
       },
-      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -1001,7 +1001,7 @@
         "`": { "item": "clutter_gym", "chance": 2 },
         "%": { "item": "locker_gym", "chance": 40 }
       },
-      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 14 ], "y": [ 2, 9 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 2, 14 ], "y": [ 2, 9 ], "density": 0.1 } ]
     }
   },
   {
@@ -1054,7 +1054,7 @@
         "R": { "item": "mansion_bookcase", "chance": 100 },
         "&": { "item": "mansion_bookcase", "chance": 20 }
       },
-      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -1109,7 +1109,7 @@
         "&": { "item": "mansion_guns", "chance": 50, "repeat": [ 2, 3 ] },
         "∞": { "item": "mansion_guns", "chance": 50, "repeat": [ 2, 3 ] }
       },
-      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 4, 21 ], "y": [ 2, 9 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 4, 21 ], "y": [ 2, 9 ], "density": 0.1 } ]
     }
   },
   {
@@ -1176,7 +1176,7 @@
         "!": { "item": "crate_stack", "chance": 100 },
         "x": { "item": "a_television", "chance": 100 }
       },
-      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 12 ], "density": 0.1 } ],
+      "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 2, 21 ], "y": [ 2, 12 ], "density": 0.1 } ],
       "place_vehicles": [ { "vehicle": "laundry_cart", "x": [ 14, 15 ], "y": [ 0, 6 ], "chance": 100 } ]
     }
   },
@@ -1233,7 +1233,7 @@
         ")": { "item": "bed", "chance": 30 },
         "∞": { "item": "mansion_guns", "chance": 20 }
       },
-      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -1300,7 +1300,7 @@
         ",": { "item": "clutter_bathroom", "chance": 10 },
         "D": { "item": "dresser_servant", "chance": 45 }
       },
-      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 7 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 2, 21 ], "y": [ 2, 7 ], "density": 0.1 } ]
     }
   },
   {
@@ -1358,7 +1358,7 @@
         "s": { "item": "snacks_fancy", "chance": 35 },
         "n": { "item": "mansion_ammo", "chance": 40 }
       },
-      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 12 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 2, 21 ], "y": [ 2, 12 ], "density": 0.1 } ]
     }
   },
   {
@@ -1412,7 +1412,7 @@
         { "item": "metal_RPG_die", "x": 2, "y": 3, "chance": 10 },
         { "item": "RPG_die", "x": [ 1, 2 ], "y": [ 2, 3 ], "chance": 90, "repeat": [ 1, 4 ] }
       ],
-      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -1465,7 +1465,7 @@
         "F": { "item": "fridgesnacks", "chance": 45 },
         "f": { "item": "wetbar_stack", "chance": 100 }
       },
-      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 8 ], "y": [ 2, 11 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 2, 8 ], "y": [ 2, 11 ], "density": 0.1 } ]
     }
   },
   {
@@ -1549,7 +1549,7 @@
         "C": { "item": "garden_shed", "chance": 40 },
         "G": { "item": "snacks_fancy", "chance": 20 }
       },
-      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -1654,7 +1654,7 @@
       },
       "//": "Flavor spawn group for panic rooms with a different configuration of monsters for better story-telling.",
       "place_monsters": [
-        { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 },
+        { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 },
         { "monster": "GROUP_PANICROOM", "x": [ 9, 14 ], "y": [ 9, 14 ], "density": 0.1 }
       ]
     }
@@ -1708,7 +1708,7 @@
         "f": { "item": "table_ballroom", "chance": 35 },
         "c": { "item": "suit_of_armor", "chance": 100 }
       },
-      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -1799,7 +1799,7 @@
         "&": { "item": "hardware_bulk", "chance": 30 },
         "N": { "item": "construction_worker", "chance": 35 }
       },
-      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -1864,7 +1864,7 @@
         "F": { "item": "vending_drink", "chance": 45 },
         "w": { "item": "sports", "chance": 35 }
       },
-      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -1958,7 +1958,7 @@
         "?": { "item": "fridgesnacks", "chance": 45 },
         "!": { "item": "crate_stack", "chance": 100 }
       },
-      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 8 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 2, 21 ], "y": [ 2, 8 ], "density": 0.1 } ]
     }
   },
   {
@@ -2038,7 +2038,7 @@
           "y": 15
         }
       ],
-      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -2089,7 +2089,7 @@
         " ": { "item": "clutter_mansion", "chance": 1 },
         "-": { "item": "clutter_mansion", "chance": 1 }
       },
-      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 7 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 2, 21 ], "y": [ 2, 7 ], "density": 0.1 } ]
     }
   },
   {
@@ -2244,7 +2244,7 @@
         "1": { "item": "wetbar_stack", "chance": 100 },
         "l": { "item": "snacks_fancy", "chance": 30 }
       },
-      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 9, 21 ], "y": [ 17, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 9, 21 ], "y": [ 17, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -2284,7 +2284,7 @@
       "terrain": { " ": "t_soil", ".": "t_thconc_floor", "]": "t_sewage_pipe", ")": "t_sewage_pump" },
       "furniture": { "=": "f_machinery_old", "&": "f_table", "?": "f_generator_broken", "!": [ "f_crate_c", "f_cardboard_box" ] },
       "items": { ".": { "item": "clutter_basement", "chance": 1 }, "!": { "item": "crate_stack", "chance": 100 } },
-      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 8, 21 ], "y": [ 8, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 8, 21 ], "y": [ 8, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -2341,7 +2341,7 @@
         "J": { "item": "wetbar_stack", "chance": 100 },
         "l": { "item": "table_livingroom", "chance": 30 }
       },
-      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -2401,7 +2401,7 @@
         ",": { "item": "clutter_bathroom", "chance": 10 },
         "i": { "item": "wetbar_counter", "chance": 30 }
       },
-      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 9, 21 ], "y": [ 9, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 9, 21 ], "y": [ 9, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -2445,7 +2445,7 @@
         "!": { "item": "crate_stack", "chance": 100 },
         "x": { "item": "a_television", "chance": 100 }
       },
-      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 8, 21 ], "y": [ 8, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 8, 21 ], "y": [ 8, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -2498,7 +2498,7 @@
         "R": { "item": "mansion_bookcase", "chance": 100 },
         ")": { "item": "table_livingroom", "chance": 30 }
       },
-      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -2558,7 +2558,7 @@
         "s": { "item": "snacks_fancy", "chance": 20 },
         "∞": { "item": "mansion_guns", "chance": 100 }
       },
-      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 15, 21 ], "y": [ 9, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 15, 21 ], "y": [ 9, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -2624,7 +2624,7 @@
         "!": { "item": "crate_stack", "chance": 100 },
         "x": { "item": "a_television", "chance": 100 }
       },
-      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 13, 21 ], "y": [ 7, 21 ], "density": 0.1 } ],
+      "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 13, 21 ], "y": [ 7, 21 ], "density": 0.1 } ],
       "place_vehicles": [ { "vehicle": "laundry_cart", "x": [ 13, 18 ], "y": [ 8, 9 ], "chance": 50 } ]
     }
   },
@@ -2673,7 +2673,7 @@
         "R": { "item": "mansion_bookcase", "chance": 100 },
         "s": { "item": "nightstand", "chance": 35 }
       },
-      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -2724,7 +2724,7 @@
         ",": { "item": "softdrugs", "chance": 40 },
         "?": { "item": "dresser_servant", "chance": 45 }
       },
-      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 18, 21 ], "y": [ 8, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 18, 21 ], "y": [ 8, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -2779,7 +2779,7 @@
         "&": { "item": "table_wine", "chance": 100, "repeat": [ 1, 4 ] },
         ".": { "item": "clutter_basement", "chance": 1 }
       },
-      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 11, 21 ], "y": [ 8, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 11, 21 ], "y": [ 8, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -2830,7 +2830,7 @@
         ".": { "item": "clutter_yard", "chance": 1 },
         "r": { "item": "table_sideboard", "chance": 40 }
       },
-      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ],
+      "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ],
       "place_vehicles": [ { "vehicle": "cannon_3in", "x": 18, "y": 3, "chance": 1 } ]
     }
   },
@@ -2893,7 +2893,7 @@
         "-": { "item": "clutter_bedroom", "chance": 2 },
         "I": { "item": "nightstand", "chance": 40 }
       },
-      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 8, 21 ], "y": [ 12, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 8, 21 ], "y": [ 12, 21 ], "density": 0.1 } ]
     }
   }
 ]

--- a/data/json/mapgen/mansion.json
+++ b/data/json/mapgen/mansion.json
@@ -41,7 +41,7 @@
         "!": { "item": "crate_stack", "chance": 100 },
         "q": { "item": "tool_common_stack", "chance": 100 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 17, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 17, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -85,7 +85,7 @@
         "K": { "item": "crate_cleaning", "chance": 100 },
         "I": { "item": "table_foyer", "chance": 40 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -133,7 +133,7 @@
       },
       "furniture": { "&": "f_sofa" },
       "items": { " ": { "item": "clutter_mansion", "chance": 2 }, "c": { "item": "suit_of_armor", "chance": 100 } },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 17, 21 ], "density": 0.15 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 17, 21 ], "density": 0.15 } ]
     }
   },
   {
@@ -187,7 +187,7 @@
         "?": { "item": "wetbar_fridge", "chance": 80 },
         "1": { "item": "wetbar_stack", "chance": 100 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 14, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 14, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -232,7 +232,7 @@
         "s": { "item": "table_foyer", "chance": 40 },
         "c": { "item": "suit_of_armor", "chance": 100 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -498,13 +498,22 @@
           { "item": "tailorbooks", "chance": 60, "repeat": [ 0, 1 ] },
           { "item": "SUS_tailoring_fasteners", "chance": 30, "repeat": [ 2, 6 ] }
         ],
+        "f": [
+          { "item": "snacks_fancy", "chance": 65, "repeat": [ 1, 2 ] },
+          { "item": "table_sideboard", "chance": 40, "repeat": [ 2, 3 ] }
+        ],
+        "D": [ { "item": "sex_lair", "chance": 75, "repeat": [ 2, 3 ] }, { "item": "ss_merch_1", "chance": 55, "repeat": [ 2, 3 ] } ],
+        "d": [
+          { "item": "clothing_fancy", "chance": 75, "repeat": [ 2, 3 ] },
+          { "item": "beauty", "chance": 75, "repeat": [ 2, 3 ] }
+        ],
+        "h": [ { "item": "backroom", "chance": 55, "repeat": [ 1, 2 ] }, { "item": "tools_lighting", "chance": 100 } ],
         ".": { "item": "clutter_basement", "chance": 1 },
         "=": { "item": "sex_lair", "chance": 25, "repeat": [ 2, 4 ] },
         "!": { "item": "crate_stack", "chance": 100 },
-        "D": { "item": "sex_lair", "chance": 55, "repeat": [ 2, 6 ] },
-        "d": { "item": "sex_lair", "chance": 55, "repeat": [ 2, 6 ] }
+        "$": { "item": "creepy", "chance": 25 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 12 ], "density": 0.1 } ],
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 12 ], "density": 0.1 } ],
       "place_monster": [ { "monster": "mon_zombie_resort_dancer", "x": [ 5, 19 ], "y": [ 16, 18 ], "repeat": [ 1, 2 ] } ]
     }
   },
@@ -555,7 +564,7 @@
         "s": { "item": "nightstand", "chance": 40 },
         "d": { "item": "dresser_stack", "chance": 100 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -602,7 +611,7 @@
         "~": { "item": "clutter_bathroom", "chance": 10 },
         ")": { "item": "bed", "chance": 40 },
         "R": { "item": "mansion_bookcase", "chance": 100 },
-        "6": { "item": "panic_room", "chance": 65, "repeat": [ 2, 6 ] },
+        "6": { "item": "panic_room", "chance": 75, "repeat": [ 2, 6 ] },
         "I": { "item": "nightstand", "chance": 40 },
         "d": { "item": "dresser_stack", "chance": 100 }
       },
@@ -610,7 +619,7 @@
         { "group": "corpse_mansion", "x": [ 10, 12 ], "y": [ 5, 7 ], "chance": 50, "repeat": [ 0, 2 ] },
         { "item": "television", "x": 12, "y": 17, "chance": 100 }
       ],
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 10, 13 ], "y": [ 6, 10 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 10, 13 ], "y": [ 6, 10 ], "density": 0.1 } ]
     }
   },
   {
@@ -670,7 +679,7 @@
         ",": { "item": "clutter_bathroom", "chance": 15 },
         "I": { "item": "vanity", "chance": 30 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 11 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 11 ], "density": 0.1 } ]
     }
   },
   {
@@ -723,7 +732,7 @@
         "x": { "item": "a_television", "chance": 100 },
         "c": { "item": "suit_of_armor", "chance": 100 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 12 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 12 ], "density": 0.1 } ]
     }
   },
   {
@@ -777,7 +786,7 @@
         { "item": "stereo", "x": 4, "y": 4, "chance": 100 },
         { "item": "television", "x": 14, "y": 9, "chance": 100 }
       ],
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 11 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 11 ], "density": 0.1 } ]
     }
   },
   {
@@ -830,7 +839,7 @@
         "&": { "item": "table_wine", "chance": 100, "repeat": [ 1, 4 ] },
         ".": { "item": "clutter_basement", "chance": 1 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 12 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 12 ], "density": 0.1 } ]
     }
   },
   {
@@ -881,7 +890,7 @@
         "J": { "item": "table_sideboard", "chance": 35 },
         "x": { "item": "table_livingroom", "chance": 35 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -992,7 +1001,7 @@
         "`": { "item": "clutter_gym", "chance": 2 },
         "%": { "item": "locker_gym", "chance": 40 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 14 ], "y": [ 2, 9 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 14 ], "y": [ 2, 9 ], "density": 0.1 } ]
     }
   },
   {
@@ -1045,7 +1054,7 @@
         "R": { "item": "mansion_bookcase", "chance": 100 },
         "&": { "item": "mansion_bookcase", "chance": 20 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -1100,7 +1109,7 @@
         "&": { "item": "mansion_guns", "chance": 50, "repeat": [ 2, 3 ] },
         "∞": { "item": "mansion_guns", "chance": 50, "repeat": [ 2, 3 ] }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 4, 21 ], "y": [ 2, 9 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 4, 21 ], "y": [ 2, 9 ], "density": 0.1 } ]
     }
   },
   {
@@ -1167,7 +1176,7 @@
         "!": { "item": "crate_stack", "chance": 100 },
         "x": { "item": "a_television", "chance": 100 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 12 ], "density": 0.1 } ],
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 12 ], "density": 0.1 } ],
       "place_vehicles": [ { "vehicle": "laundry_cart", "x": [ 14, 15 ], "y": [ 0, 6 ], "chance": 100 } ]
     }
   },
@@ -1224,7 +1233,7 @@
         ")": { "item": "bed", "chance": 30 },
         "∞": { "item": "mansion_guns", "chance": 20 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -1291,7 +1300,7 @@
         ",": { "item": "clutter_bathroom", "chance": 10 },
         "D": { "item": "dresser_servant", "chance": 45 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 7 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 7 ], "density": 0.1 } ]
     }
   },
   {
@@ -1349,7 +1358,7 @@
         "s": { "item": "snacks_fancy", "chance": 35 },
         "n": { "item": "mansion_ammo", "chance": 40 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 12 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 12 ], "density": 0.1 } ]
     }
   },
   {
@@ -1403,7 +1412,7 @@
         { "item": "metal_RPG_die", "x": 2, "y": 3, "chance": 10 },
         { "item": "RPG_die", "x": [ 1, 2 ], "y": [ 2, 3 ], "chance": 90, "repeat": [ 1, 4 ] }
       ],
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -1456,7 +1465,7 @@
         "F": { "item": "fridgesnacks", "chance": 45 },
         "f": { "item": "wetbar_stack", "chance": 100 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 8 ], "y": [ 2, 11 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 8 ], "y": [ 2, 11 ], "density": 0.1 } ]
     }
   },
   {
@@ -1540,7 +1549,7 @@
         "C": { "item": "garden_shed", "chance": 40 },
         "G": { "item": "snacks_fancy", "chance": 20 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -1643,9 +1652,10 @@
         "J": { "item": "hardware_bulk", "chance": 30 },
         "q": { "item": "hardware_plumbing", "chance": 40 }
       },
+      "//": "Flavor spawn group for panic rooms with a different configuration of monsters for better story-telling.",
       "place_monsters": [
-        { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 },
-        { "monster": "GROUP_ZOMBIE", "x": [ 9, 14 ], "y": [ 9, 14 ], "density": 0.1 }
+        { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 },
+        { "monster": "GROUP_PANICROOM", "x": [ 9, 14 ], "y": [ 9, 14 ], "density": 0.1 }
       ]
     }
   },
@@ -1698,7 +1708,7 @@
         "f": { "item": "table_ballroom", "chance": 35 },
         "c": { "item": "suit_of_armor", "chance": 100 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -1789,7 +1799,7 @@
         "&": { "item": "hardware_bulk", "chance": 30 },
         "N": { "item": "construction_worker", "chance": 35 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -1854,7 +1864,7 @@
         "F": { "item": "vending_drink", "chance": 45 },
         "w": { "item": "sports", "chance": 35 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -1948,7 +1958,7 @@
         "?": { "item": "fridgesnacks", "chance": 45 },
         "!": { "item": "crate_stack", "chance": 100 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 8 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 8 ], "density": 0.1 } ]
     }
   },
   {
@@ -2028,7 +2038,7 @@
           "y": 15
         }
       ],
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -2079,7 +2089,7 @@
         " ": { "item": "clutter_mansion", "chance": 1 },
         "-": { "item": "clutter_mansion", "chance": 1 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 7 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 7 ], "density": 0.1 } ]
     }
   },
   {
@@ -2234,7 +2244,7 @@
         "1": { "item": "wetbar_stack", "chance": 100 },
         "l": { "item": "snacks_fancy", "chance": 30 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 9, 21 ], "y": [ 17, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 9, 21 ], "y": [ 17, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -2274,7 +2284,7 @@
       "terrain": { " ": "t_soil", ".": "t_thconc_floor", "]": "t_sewage_pipe", ")": "t_sewage_pump" },
       "furniture": { "=": "f_machinery_old", "&": "f_table", "?": "f_generator_broken", "!": [ "f_crate_c", "f_cardboard_box" ] },
       "items": { ".": { "item": "clutter_basement", "chance": 1 }, "!": { "item": "crate_stack", "chance": 100 } },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 8, 21 ], "y": [ 8, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 8, 21 ], "y": [ 8, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -2331,7 +2341,7 @@
         "J": { "item": "wetbar_stack", "chance": 100 },
         "l": { "item": "table_livingroom", "chance": 30 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -2391,7 +2401,7 @@
         ",": { "item": "clutter_bathroom", "chance": 10 },
         "i": { "item": "wetbar_counter", "chance": 30 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 9, 21 ], "y": [ 9, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 9, 21 ], "y": [ 9, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -2435,7 +2445,7 @@
         "!": { "item": "crate_stack", "chance": 100 },
         "x": { "item": "a_television", "chance": 100 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 8, 21 ], "y": [ 8, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 8, 21 ], "y": [ 8, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -2488,7 +2498,7 @@
         "R": { "item": "mansion_bookcase", "chance": 100 },
         ")": { "item": "table_livingroom", "chance": 30 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -2548,7 +2558,7 @@
         "s": { "item": "snacks_fancy", "chance": 20 },
         "∞": { "item": "mansion_guns", "chance": 100 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 15, 21 ], "y": [ 9, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 15, 21 ], "y": [ 9, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -2614,7 +2624,7 @@
         "!": { "item": "crate_stack", "chance": 100 },
         "x": { "item": "a_television", "chance": 100 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 13, 21 ], "y": [ 7, 21 ], "density": 0.1 } ],
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 13, 21 ], "y": [ 7, 21 ], "density": 0.1 } ],
       "place_vehicles": [ { "vehicle": "laundry_cart", "x": [ 13, 18 ], "y": [ 8, 9 ], "chance": 50 } ]
     }
   },
@@ -2663,7 +2673,7 @@
         "R": { "item": "mansion_bookcase", "chance": 100 },
         "s": { "item": "nightstand", "chance": 35 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -2714,7 +2724,7 @@
         ",": { "item": "softdrugs", "chance": 40 },
         "?": { "item": "dresser_servant", "chance": 45 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 18, 21 ], "y": [ 8, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 18, 21 ], "y": [ 8, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -2769,7 +2779,7 @@
         "&": { "item": "table_wine", "chance": 100, "repeat": [ 1, 4 ] },
         ".": { "item": "clutter_basement", "chance": 1 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 11, 21 ], "y": [ 8, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 11, 21 ], "y": [ 8, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -2820,7 +2830,7 @@
         ".": { "item": "clutter_yard", "chance": 1 },
         "r": { "item": "table_sideboard", "chance": 40 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ],
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ],
       "place_vehicles": [ { "vehicle": "cannon_3in", "x": 18, "y": 3, "chance": 1 } ]
     }
   },
@@ -2883,7 +2893,7 @@
         "-": { "item": "clutter_bedroom", "chance": 2 },
         "I": { "item": "nightstand", "chance": 40 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 8, 21 ], "y": [ 12, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 8, 21 ], "y": [ 12, 21 ], "density": 0.1 } ]
     }
   }
 ]

--- a/data/json/mapgen/mansion_boarded.json
+++ b/data/json/mapgen/mansion_boarded.json
@@ -40,7 +40,7 @@
         "K": { "item": "crate_cleaning", "chance": 100 },
         "I": { "item": "table_foyer", "chance": 40 }
       },
-      "place_monster": [ { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 0, 23 ], "y": [ 12, 23 ], "chance": 65, "repeat": [ 2, 3 ] } ]
+      "place_monster": [ { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 0, 23 ], "y": [ 12, 23 ], "chance": 25, "repeat": [ 1, 2 ] } ]
     }
   },
   {
@@ -89,7 +89,7 @@
       },
       "furniture": { "&": "f_sofa" },
       "items": { " ": { "item": "clutter_mansion", "chance": 2 }, "c": { "item": "suit_of_armor", "chance": 100 } },
-      "place_monster": [ { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 0, 23 ], "y": [ 17, 23 ], "chance": 65, "repeat": [ 2, 3 ] } ]
+      "place_monster": [ { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 0, 23 ], "y": [ 17, 23 ], "chance": 25, "repeat": [ 1, 2 ] } ]
     }
   },
   {
@@ -142,7 +142,7 @@
         "x": { "item": "a_television", "chance": 100 },
         "c": { "item": "suit_of_armor", "chance": 100 }
       },
-      "place_monster": [ { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 0, 23 ], "y": [ 0, 23 ], "chance": 65, "repeat": [ 2, 3 ] } ]
+      "place_monster": [ { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 0, 23 ], "y": [ 0, 23 ], "chance": 25, "repeat": [ 1, 2 ] } ]
     }
   },
   {
@@ -242,7 +242,7 @@
         "$": { "item": "creepy", "chance": 25 }
       },
       "place_monster": [
-        { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 2, 23 ], "y": [ 2, 12 ], "chance": 35, "repeat": [ 2, 3 ] },
+        { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 2, 23 ], "y": [ 2, 12 ], "chance": 15, "repeat": [ 1, 2 ] },
         { "monster": "mon_zombie_resort_dancer", "x": [ 5, 19 ], "y": [ 16, 18 ], "chance": 33, "repeat": [ 1, 2 ] }
       ],
       "place_zones": [ { "type": "ZONE_START_POINT", "faction": "your_followers", "x": [ 5, 10 ], "y": [ 16, 18 ] } ]
@@ -295,7 +295,7 @@
         "s": { "item": "nightstand", "chance": 40 },
         "d": { "item": "dresser_stack", "chance": 100 }
       },
-      "place_monster": [ { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 0, 23 ], "y": [ 0, 23 ], "chance": 65, "repeat": [ 2, 3 ] } ]
+      "place_monster": [ { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 0, 23 ], "y": [ 0, 23 ], "chance": 25, "repeat": [ 1, 2 ] } ]
     }
   },
   {
@@ -353,8 +353,8 @@
       ],
       "//": "Flavor spawn group for panic rooms with a different configuration of monsters for better story-telling.",
       "place_monster": [
-        { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 0, 23 ], "y": [ 12, 23 ], "chance": 35, "repeat": [ 2, 3 ] },
-        { "group": "GROUP_FANCY_PANICROOM", "x": [ 11, 13 ], "y": [ 6, 10 ], "chance": 65, "repeat": [ 1, 2 ] }
+        { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 0, 23 ], "y": [ 12, 23 ], "chance": 15, "repeat": [ 1, 2 ] },
+        { "group": "GROUP_PANICROOM", "x": [ 11, 13 ], "y": [ 6, 10 ], "chance": 65, "repeat": [ 1, 2 ] }
       ],
       "place_zones": [ { "type": "ZONE_START_POINT", "faction": "your_followers", "x": [ 10, 13 ], "y": [ 3, 4 ] } ]
     }
@@ -417,7 +417,7 @@
         ",": { "item": "clutter_bathroom", "chance": 15 },
         "I": { "item": "vanity", "chance": 30 }
       },
-      "place_monster": [ { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 0, 23 ], "y": [ 0, 11 ], "chance": 65, "repeat": [ 2, 3 ] } ]
+      "place_monster": [ { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 0, 23 ], "y": [ 0, 11 ], "chance": 25, "repeat": [ 1, 2 ] } ]
     }
   },
   {
@@ -472,7 +472,7 @@
         { "item": "stereo", "x": 4, "y": 4, "chance": 100 },
         { "item": "television", "x": 14, "y": 9, "chance": 100 }
       ],
-      "place_monster": [ { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 0, 23 ], "y": [ 0, 11 ], "chance": 65, "repeat": [ 2, 3 ] } ]
+      "place_monster": [ { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 0, 23 ], "y": [ 0, 11 ], "chance": 25, "repeat": [ 1, 2 ] } ]
     }
   },
   {
@@ -524,7 +524,7 @@
         "J": { "item": "table_sideboard", "chance": 35 },
         "x": { "item": "table_livingroom", "chance": 35 }
       },
-      "place_monster": [ { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 0, 23 ], "y": [ 0, 15 ], "chance": 65, "repeat": [ 2, 3 ] } ]
+      "place_monster": [ { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 0, 23 ], "y": [ 0, 15 ], "chance": 25, "repeat": [ 1, 2 ] } ]
     }
   },
   {
@@ -626,7 +626,7 @@
         "i": { "item": "pool_side", "chance": 30 },
         ",": { "item": "pool_side", "chance": 2 }
       },
-      "place_monster": [ { "group": "GROUP_ZOMBIE_POOL", "x": [ 9, 23 ], "y": [ 4, 23 ], "chance": 65, "repeat": [ 2, 3 ] } ]
+      "place_monster": [ { "group": "GROUP_ZOMBIE_POOL", "x": [ 9, 23 ], "y": [ 4, 23 ], "chance": 25, "repeat": [ 1, 2 ] } ]
     }
   },
   {
@@ -689,7 +689,7 @@
         "1": { "item": "wetbar_stack", "chance": 100 },
         "l": { "item": "snacks_fancy", "chance": 30 }
       },
-      "place_monster": [ { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 9, 23 ], "y": [ 17, 23 ], "chance": 65, "repeat": [ 2, 3 ] } ]
+      "place_monster": [ { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 9, 23 ], "y": [ 17, 23 ], "chance": 25, "repeat": [ 1, 2 ] } ]
     }
   },
   {
@@ -752,7 +752,7 @@
         "J": { "item": "wetbar_stack", "chance": 100 },
         "l": { "item": "table_livingroom", "chance": 30 }
       },
-      "place_monster": [ { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 6, 23 ], "y": [ 4, 23 ], "chance": 65, "repeat": [ 2, 3 ] } ]
+      "place_monster": [ { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 6, 23 ], "y": [ 4, 23 ], "chance": 25, "repeat": [ 1, 2 ] } ]
     }
   },
   {
@@ -813,7 +813,7 @@
         ",": { "item": "clutter_bathroom", "chance": 10 },
         "i": { "item": "wetbar_counter", "chance": 30 }
       },
-      "place_monster": [ { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 9, 23 ], "y": [ 9, 23 ], "chance": 65, "repeat": [ 2, 3 ] } ]
+      "place_monster": [ { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 9, 23 ], "y": [ 9, 23 ], "chance": 25, "repeat": [ 1, 2 ] } ]
     }
   },
   {
@@ -867,7 +867,7 @@
         "R": { "item": "mansion_bookcase", "chance": 100 },
         ")": { "item": "table_livingroom", "chance": 30 }
       },
-      "place_monster": [ { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 5, 23 ], "y": [ 6, 23 ], "chance": 65, "repeat": [ 2, 3 ] } ]
+      "place_monster": [ { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 5, 23 ], "y": [ 6, 23 ], "chance": 25, "repeat": [ 1, 2 ] } ]
     }
   },
   {
@@ -928,7 +928,7 @@
         "s": { "item": "snacks_fancy", "chance": 20 },
         "∞": { "item": "mansion_guns", "chance": 100 }
       },
-      "place_monster": [ { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 15, 23 ], "y": [ 9, 23 ], "chance": 65, "repeat": [ 2, 3 ] } ]
+      "place_monster": [ { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 15, 23 ], "y": [ 9, 23 ], "chance": 25, "repeat": [ 1, 2 ] } ]
     }
   },
   {
@@ -976,7 +976,7 @@
         "R": { "item": "mansion_bookcase", "chance": 100 },
         "s": { "item": "nightstand", "chance": 35 }
       },
-      "place_monster": [ { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 10, 23 ], "y": [ 6, 23 ], "chance": 65, "repeat": [ 2, 3 ] } ]
+      "place_monster": [ { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 10, 23 ], "y": [ 6, 23 ], "chance": 25, "repeat": [ 1, 2 ] } ]
     }
   },
   {
@@ -1028,7 +1028,7 @@
         ",": { "item": "softdrugs", "chance": 40 },
         "?": { "item": "dresser_servant", "chance": 45 }
       },
-      "place_monster": [ { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 18, 23 ], "y": [ 8, 23 ], "chance": 65, "repeat": [ 2, 3 ] } ]
+      "place_monster": [ { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 18, 23 ], "y": [ 8, 23 ], "chance": 25, "repeat": [ 1, 2 ] } ]
     }
   }
 ]

--- a/data/json/mapgen/mansion_boarded.json
+++ b/data/json/mapgen/mansion_boarded.json
@@ -40,7 +40,7 @@
         "K": { "item": "crate_cleaning", "chance": 100 },
         "I": { "item": "table_foyer", "chance": 40 }
       },
-      "place_monster": [ { "group": "GROUP_ZOMBIE", "x": [ 0, 23 ], "y": [ 12, 23 ], "chance": 65, "repeat": [ 3, 5 ] } ]
+      "place_monster": [ { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 0, 23 ], "y": [ 12, 23 ], "chance": 65, "repeat": [ 2, 3 ] } ]
     }
   },
   {
@@ -89,7 +89,7 @@
       },
       "furniture": { "&": "f_sofa" },
       "items": { " ": { "item": "clutter_mansion", "chance": 2 }, "c": { "item": "suit_of_armor", "chance": 100 } },
-      "place_monster": [ { "group": "GROUP_ZOMBIE", "x": [ 0, 23 ], "y": [ 17, 23 ], "chance": 65, "repeat": [ 3, 5 ] } ]
+      "place_monster": [ { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 0, 23 ], "y": [ 17, 23 ], "chance": 65, "repeat": [ 2, 3 ] } ]
     }
   },
   {
@@ -142,7 +142,7 @@
         "x": { "item": "a_television", "chance": 100 },
         "c": { "item": "suit_of_armor", "chance": 100 }
       },
-      "place_monster": [ { "group": "GROUP_ZOMBIE", "x": [ 0, 23 ], "y": [ 0, 23 ], "chance": 65, "repeat": [ 3, 5 ] } ]
+      "place_monster": [ { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 0, 23 ], "y": [ 0, 23 ], "chance": 65, "repeat": [ 2, 3 ] } ]
     }
   },
   {
@@ -226,15 +226,24 @@
           { "item": "tailorbooks", "chance": 60, "repeat": [ 0, 1 ] },
           { "item": "SUS_tailoring_fasteners", "chance": 30, "repeat": [ 2, 6 ] }
         ],
+        "f": [
+          { "item": "snacks_fancy", "chance": 65, "repeat": [ 1, 2 ] },
+          { "item": "table_sideboard", "chance": 40, "repeat": [ 2, 3 ] }
+        ],
+        "D": [ { "item": "sex_lair", "chance": 75, "repeat": [ 2, 3 ] }, { "item": "ss_merch_1", "chance": 55, "repeat": [ 2, 3 ] } ],
+        "d": [
+          { "item": "clothing_fancy", "chance": 75, "repeat": [ 2, 3 ] },
+          { "item": "beauty", "chance": 75, "repeat": [ 2, 3 ] }
+        ],
+        "h": [ { "item": "backroom", "chance": 55, "repeat": [ 1, 2 ] }, { "item": "tools_lighting", "chance": 100 } ],
         ".": { "item": "clutter_basement", "chance": 1 },
         "=": { "item": "sex_lair", "chance": 25, "repeat": [ 2, 4 ] },
         "!": { "item": "crate_stack", "chance": 100 },
-        "D": { "item": "sex_lair", "chance": 55, "repeat": [ 2, 6 ] },
-        "d": { "item": "sex_lair", "chance": 55, "repeat": [ 2, 6 ] }
+        "$": { "item": "creepy", "chance": 25 }
       },
       "place_monster": [
-        { "group": "GROUP_ZOMBIE", "x": [ 2, 23 ], "y": [ 2, 12 ], "chance": 35, "repeat": [ 1, 4 ] },
-        { "monster": "mon_zombie_resort_dancer", "x": [ 5, 19 ], "y": [ 16, 18 ], "chance": 50, "repeat": [ 1, 2 ] }
+        { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 2, 23 ], "y": [ 2, 12 ], "chance": 35, "repeat": [ 2, 3 ] },
+        { "monster": "mon_zombie_resort_dancer", "x": [ 5, 19 ], "y": [ 16, 18 ], "chance": 33, "repeat": [ 1, 2 ] }
       ],
       "place_zones": [ { "type": "ZONE_START_POINT", "faction": "your_followers", "x": [ 5, 10 ], "y": [ 16, 18 ] } ]
     }
@@ -286,7 +295,7 @@
         "s": { "item": "nightstand", "chance": 40 },
         "d": { "item": "dresser_stack", "chance": 100 }
       },
-      "place_monster": [ { "group": "GROUP_ZOMBIE", "x": [ 0, 23 ], "y": [ 0, 23 ], "chance": 65, "repeat": [ 3, 5 ] } ]
+      "place_monster": [ { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 0, 23 ], "y": [ 0, 23 ], "chance": 65, "repeat": [ 2, 3 ] } ]
     }
   },
   {
@@ -334,7 +343,7 @@
         "~": { "item": "clutter_bathroom", "chance": 10 },
         ")": { "item": "bed", "chance": 40 },
         "R": { "item": "mansion_bookcase", "chance": 100 },
-        "6": { "item": "panic_room", "chance": 65, "repeat": [ 2, 6 ] },
+        "6": { "item": "panic_room", "chance": 75, "repeat": [ 2, 6 ] },
         "I": { "item": "nightstand", "chance": 40 },
         "d": { "item": "dresser_stack", "chance": 100 }
       },
@@ -342,9 +351,10 @@
         { "group": "corpse_mansion", "x": [ 10, 12 ], "y": [ 5, 7 ], "chance": 50, "repeat": [ 0, 2 ] },
         { "item": "television", "x": 12, "y": 17, "chance": 100 }
       ],
+      "//": "Flavor spawn group for panic rooms with a different configuration of monsters for better story-telling.",
       "place_monster": [
-        { "group": "GROUP_ZOMBIE", "x": [ 0, 23 ], "y": [ 12, 23 ], "chance": 35, "repeat": [ 1, 4 ] },
-        { "group": "GROUP_ZOMBIE", "x": [ 11, 13 ], "y": [ 6, 10 ], "chance": 65, "repeat": [ 1, 2 ] }
+        { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 0, 23 ], "y": [ 12, 23 ], "chance": 35, "repeat": [ 2, 3 ] },
+        { "group": "GROUP_FANCY_PANICROOM", "x": [ 11, 13 ], "y": [ 6, 10 ], "chance": 65, "repeat": [ 1, 2 ] }
       ],
       "place_zones": [ { "type": "ZONE_START_POINT", "faction": "your_followers", "x": [ 10, 13 ], "y": [ 3, 4 ] } ]
     }
@@ -407,7 +417,7 @@
         ",": { "item": "clutter_bathroom", "chance": 15 },
         "I": { "item": "vanity", "chance": 30 }
       },
-      "place_monster": [ { "group": "GROUP_ZOMBIE", "x": [ 0, 23 ], "y": [ 0, 11 ], "chance": 65, "repeat": [ 3, 5 ] } ]
+      "place_monster": [ { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 0, 23 ], "y": [ 0, 11 ], "chance": 65, "repeat": [ 2, 3 ] } ]
     }
   },
   {
@@ -462,7 +472,7 @@
         { "item": "stereo", "x": 4, "y": 4, "chance": 100 },
         { "item": "television", "x": 14, "y": 9, "chance": 100 }
       ],
-      "place_monster": [ { "group": "GROUP_ZOMBIE", "x": [ 0, 23 ], "y": [ 0, 11 ], "chance": 65, "repeat": [ 3, 5 ] } ]
+      "place_monster": [ { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 0, 23 ], "y": [ 0, 11 ], "chance": 65, "repeat": [ 2, 3 ] } ]
     }
   },
   {
@@ -514,7 +524,7 @@
         "J": { "item": "table_sideboard", "chance": 35 },
         "x": { "item": "table_livingroom", "chance": 35 }
       },
-      "place_monster": [ { "group": "GROUP_ZOMBIE", "x": [ 0, 23 ], "y": [ 0, 15 ], "chance": 65, "repeat": [ 3, 5 ] } ]
+      "place_monster": [ { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 0, 23 ], "y": [ 0, 15 ], "chance": 65, "repeat": [ 2, 3 ] } ]
     }
   },
   {
@@ -616,7 +626,7 @@
         "i": { "item": "pool_side", "chance": 30 },
         ",": { "item": "pool_side", "chance": 2 }
       },
-      "place_monster": [ { "group": "GROUP_ZOMBIE_POOL", "x": [ 9, 23 ], "y": [ 4, 23 ], "chance": 65, "repeat": [ 3, 5 ] } ]
+      "place_monster": [ { "group": "GROUP_ZOMBIE_POOL", "x": [ 9, 23 ], "y": [ 4, 23 ], "chance": 65, "repeat": [ 2, 3 ] } ]
     }
   },
   {
@@ -679,7 +689,7 @@
         "1": { "item": "wetbar_stack", "chance": 100 },
         "l": { "item": "snacks_fancy", "chance": 30 }
       },
-      "place_monster": [ { "group": "GROUP_ZOMBIE", "x": [ 9, 23 ], "y": [ 17, 23 ], "chance": 65, "repeat": [ 3, 5 ] } ]
+      "place_monster": [ { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 9, 23 ], "y": [ 17, 23 ], "chance": 65, "repeat": [ 2, 3 ] } ]
     }
   },
   {
@@ -742,7 +752,7 @@
         "J": { "item": "wetbar_stack", "chance": 100 },
         "l": { "item": "table_livingroom", "chance": 30 }
       },
-      "place_monster": [ { "group": "GROUP_ZOMBIE", "x": [ 6, 23 ], "y": [ 4, 23 ], "chance": 65, "repeat": [ 3, 5 ] } ]
+      "place_monster": [ { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 6, 23 ], "y": [ 4, 23 ], "chance": 65, "repeat": [ 2, 3 ] } ]
     }
   },
   {
@@ -803,7 +813,7 @@
         ",": { "item": "clutter_bathroom", "chance": 10 },
         "i": { "item": "wetbar_counter", "chance": 30 }
       },
-      "place_monster": [ { "group": "GROUP_ZOMBIE", "x": [ 9, 23 ], "y": [ 9, 23 ], "chance": 65, "repeat": [ 3, 5 ] } ]
+      "place_monster": [ { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 9, 23 ], "y": [ 9, 23 ], "chance": 65, "repeat": [ 2, 3 ] } ]
     }
   },
   {
@@ -857,7 +867,7 @@
         "R": { "item": "mansion_bookcase", "chance": 100 },
         ")": { "item": "table_livingroom", "chance": 30 }
       },
-      "place_monster": [ { "group": "GROUP_ZOMBIE", "x": [ 5, 23 ], "y": [ 6, 23 ], "chance": 65, "repeat": [ 3, 5 ] } ]
+      "place_monster": [ { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 5, 23 ], "y": [ 6, 23 ], "chance": 65, "repeat": [ 2, 3 ] } ]
     }
   },
   {
@@ -918,7 +928,7 @@
         "s": { "item": "snacks_fancy", "chance": 20 },
         "∞": { "item": "mansion_guns", "chance": 100 }
       },
-      "place_monster": [ { "group": "GROUP_ZOMBIE", "x": [ 15, 23 ], "y": [ 9, 23 ], "chance": 65, "repeat": [ 3, 5 ] } ]
+      "place_monster": [ { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 15, 23 ], "y": [ 9, 23 ], "chance": 65, "repeat": [ 2, 3 ] } ]
     }
   },
   {
@@ -966,7 +976,7 @@
         "R": { "item": "mansion_bookcase", "chance": 100 },
         "s": { "item": "nightstand", "chance": 35 }
       },
-      "place_monster": [ { "group": "GROUP_ZOMBIE", "x": [ 10, 23 ], "y": [ 6, 23 ], "chance": 65, "repeat": [ 3, 5 ] } ]
+      "place_monster": [ { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 10, 23 ], "y": [ 6, 23 ], "chance": 65, "repeat": [ 2, 3 ] } ]
     }
   },
   {
@@ -1018,7 +1028,7 @@
         ",": { "item": "softdrugs", "chance": 40 },
         "?": { "item": "dresser_servant", "chance": 45 }
       },
-      "place_monster": [ { "group": "GROUP_ZOMBIE", "x": [ 18, 23 ], "y": [ 8, 23 ], "chance": 65, "repeat": [ 3, 5 ] } ]
+      "place_monster": [ { "group": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 18, 23 ], "y": [ 8, 23 ], "chance": 65, "repeat": [ 2, 3 ] } ]
     }
   }
 ]

--- a/data/json/monstergroups/misc.json
+++ b/data/json/monstergroups/misc.json
@@ -65,10 +65,10 @@
     "name": "GROUP_MANSION_START",
     "//": "Nonsense ferals for the mansion escape challenge scenario, shouldn't be used for general spawns",
     "monsters": [
-      { "monster": "mon_feral_maid_broom", "weight": 400 },
-      { "monster": "mon_feral_maid_candlestick", "weight": 400 },
+      { "monster": "mon_feral_maid_broom", "weight": 600 },
+      { "monster": "mon_feral_maid_candlestick", "weight": 600 },
       { "monster": "mon_feral_maid_knife", "weight": 400 },
-      { "monster": "mon_feral_fancy_rapier", "weight": 300 },
+      { "monster": "mon_feral_fancy_rapier", "weight": 200 },
       { "monster": "mon_feral_fancy_rapier_fake", "weight": 300 }
     ]
   },

--- a/data/json/monstergroups/misc.json
+++ b/data/json/monstergroups/misc.json
@@ -65,11 +65,18 @@
     "name": "GROUP_MANSION_START",
     "//": "Nonsense ferals for the mansion escape challenge scenario, shouldn't be used for general spawns",
     "monsters": [
-      { "monster": "mon_feral_maid_broom", "weight": 600 },
-      { "monster": "mon_feral_maid_candlestick", "weight": 600 },
-      { "monster": "mon_feral_maid_knife", "weight": 400 },
+      { "group": "GROUP_MANSION_PURSUERS", "weight": 1600 },
       { "monster": "mon_feral_fancy_rapier", "weight": 200 },
       { "monster": "mon_feral_fancy_rapier_fake", "weight": 300 }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_MANSION_PURSUERS",
+    "monsters": [
+      { "monster": "mon_feral_maid_broom", "weight": 600 },
+      { "monster": "mon_feral_maid_candlestick", "weight": 600 },
+      { "monster": "mon_feral_maid_knife", "weight": 400 }
     ]
   },
   {

--- a/data/json/monstergroups/zombies.json
+++ b/data/json/monstergroups/zombies.json
@@ -539,6 +539,41 @@
     ]
   },
   {
+    "name": "GROUP_PANICROOM",
+    "type": "monstergroup",
+    "//": "Flavor spawn group for panic rooms for better story-telling.  Improved chance of dogs, fancy dogs, and (still) breathing people and children.",
+    "monsters": [
+      { "monster": "mon_zombie_child", "weight": 180 },
+      { "monster": "mon_zombie", "weight": 120, "cost_multiplier": 2 },
+      { "group": "GROUP_CIVILIANS_STANDARD", "weight": 200 },
+      { "group": "GROUP_FERAL", "weight": 150, "cost_multiplier": 2 },
+      { "group": "GROUP_PET_DOGS", "weight": 100, "cost_multiplier": 2 },
+      { "monster": "mon_dog_rottweiler", "weight": 100, "cost_multiplier": 2 },
+      { "monster": "mon_dog_gpyrenees", "weight": 100, "cost_multiplier": 2 },
+      { "monster": "mon_zombie_dog", "weight": 20 }
+    ]
+  },
+  {
+    "name": "GROUP_FANCY_PANICROOM",
+    "type": "monstergroup",
+    "//": "Same as above, but with the fancy ferals thrown into the mix for the scenario.",
+    "monsters": [
+      { "monster": "mon_zombie_child", "weight": 250 },
+      { "monster": "mon_zombie", "weight": 20, "cost_multiplier": 2 },
+      { "group": "GROUP_CIVILIANS_STANDARD", "weight": 100 },
+      { "group": "GROUP_FERAL", "weight": 50, "cost_multiplier": 2 },
+      { "monster": "mon_feral_maid_broom", "weight": 20 },
+      { "monster": "mon_feral_maid_candlestick", "weight": 20 },
+      { "monster": "mon_feral_maid_knife", "weight": 20 },
+      { "monster": "mon_feral_fancy_rapier", "weight": 140, "cost_multiplier": 5 },
+      { "monster": "mon_feral_fancy_rapier_fake", "weight": 100, "cost_multiplier": 3 },
+      { "group": "GROUP_PET_DOGS", "weight": 100, "cost_multiplier": 2 },
+      { "monster": "mon_dog_rottweiler", "weight": 100, "cost_multiplier": 2 },
+      { "monster": "mon_dog_gpyrenees", "weight": 100, "cost_multiplier": 2 },
+      { "monster": "mon_zombie_dog", "weight": 20 }
+    ]
+  },
+  {
     "type": "monstergroup",
     "name": "GROUP_ZOMBULL_FROG_UPGRADE",
     "monsters": [

--- a/data/json/monstergroups/zombies.json
+++ b/data/json/monstergroups/zombies.json
@@ -558,19 +558,12 @@
     "type": "monstergroup",
     "//": "Same as above, but with the fancy ferals thrown into the mix for the scenario.",
     "monsters": [
-      { "monster": "mon_zombie_child", "weight": 250 },
-      { "monster": "mon_zombie", "weight": 20, "cost_multiplier": 2 },
-      { "group": "GROUP_CIVILIANS_STANDARD", "weight": 100 },
-      { "group": "GROUP_FERAL", "weight": 50, "cost_multiplier": 2 },
-      { "monster": "mon_feral_maid_broom", "weight": 20 },
-      { "monster": "mon_feral_maid_candlestick", "weight": 20 },
+      { "group": "GROUP_PANICROOM", "weight": 750 },
+      { "monster": "mon_feral_maid_broom", "weight": 15 },
+      { "monster": "mon_feral_maid_candlestick", "weight": 15 },
       { "monster": "mon_feral_maid_knife", "weight": 20 },
-      { "monster": "mon_feral_fancy_rapier", "weight": 140, "cost_multiplier": 5 },
-      { "monster": "mon_feral_fancy_rapier_fake", "weight": 100, "cost_multiplier": 3 },
-      { "group": "GROUP_PET_DOGS", "weight": 100, "cost_multiplier": 2 },
-      { "monster": "mon_dog_rottweiler", "weight": 100, "cost_multiplier": 2 },
-      { "monster": "mon_dog_gpyrenees", "weight": 100, "cost_multiplier": 2 },
-      { "monster": "mon_zombie_dog", "weight": 20 }
+      { "monster": "mon_feral_fancy_rapier", "weight": 120, "cost_multiplier": 5 },
+      { "monster": "mon_feral_fancy_rapier_fake", "weight": 80, "cost_multiplier": 3 }
     ]
   },
   {

--- a/data/json/monstergroups/zombies.json
+++ b/data/json/monstergroups/zombies.json
@@ -539,31 +539,26 @@
     ]
   },
   {
-    "name": "GROUP_PANICROOM",
+    "name": "GROUP_SCENARIO_PANICROOM",
     "type": "monstergroup",
-    "//": "Flavor spawn group for panic rooms for better story-telling.  Improved chance of dogs, fancy dogs, and (still) breathing people and children.",
+    "//": "Flavor spawn group for scenario panic rooms for better story-telling.  Improved chance of dogs, fancy dogs, and (still) breathing people and children.",
     "monsters": [
       { "monster": "mon_zombie_child", "weight": 180 },
-      { "monster": "mon_zombie", "weight": 120, "cost_multiplier": 2 },
       { "group": "GROUP_CIVILIANS_STANDARD", "weight": 200 },
-      { "group": "GROUP_FERAL", "weight": 150, "cost_multiplier": 2 },
       { "group": "GROUP_PET_DOGS", "weight": 100, "cost_multiplier": 2 },
       { "monster": "mon_dog_rottweiler", "weight": 100, "cost_multiplier": 2 },
-      { "monster": "mon_dog_gpyrenees", "weight": 100, "cost_multiplier": 2 },
-      { "monster": "mon_zombie_dog", "weight": 20 }
+      { "monster": "mon_dog_gpyrenees", "weight": 100, "cost_multiplier": 2 }
     ]
   },
   {
-    "name": "GROUP_FANCY_PANICROOM",
+    "name": "GROUP_PANICROOM",
     "type": "monstergroup",
-    "//": "Same as above, but with the fancy ferals thrown into the mix for the scenario.",
+    "//": "Same as above, but more lethal.",
     "monsters": [
-      { "group": "GROUP_PANICROOM", "weight": 750 },
-      { "monster": "mon_feral_maid_broom", "weight": 15 },
-      { "monster": "mon_feral_maid_candlestick", "weight": 15 },
-      { "monster": "mon_feral_maid_knife", "weight": 20 },
-      { "monster": "mon_feral_fancy_rapier", "weight": 120, "cost_multiplier": 5 },
-      { "monster": "mon_feral_fancy_rapier_fake", "weight": 80, "cost_multiplier": 3 }
+      { "monster": "mon_zombie", "weight": 120, "cost_multiplier": 2 },
+      { "group": "GROUP_SCENARIO_PANICROOM", "weight": 680 },
+      { "group": "GROUP_FERAL", "weight": 150, "cost_multiplier": 2 },
+      { "monster": "mon_zombie_dog", "weight": 20 }
     ]
   },
   {

--- a/data/json/monsters/feral_humans.json
+++ b/data/json/monsters/feral_humans.json
@@ -271,7 +271,10 @@
     "description": "Once a fancy servant of some rich family, this maniac walks around with a broom in hand, searching for a victim to sweep off this mortal coil.",
     "copy-from": "mon_feral_human_pipe",
     "melee_skill": 2,
-    "special_attacks": [ { "id": "feral_weapon_broom" } ],
+    "special_attacks": [ { "id": "feral_weapon_broom" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ], [ "PARROT_AT_DANGER", 0 ] ],
+    "extend": { "flags": [ "CLIMBS" ] },
+    "delete": { "flags": [ "BASHES", "GROUP_BASH" ] },
+    "//2": "Removed bashing and added CLIMBS to avoid them from trashing too much the mansion.",
     "death_drops": "feral_maids_death_drops_broom"
   },
   {
@@ -280,7 +283,7 @@
     "copy-from": "mon_feral_maid_broom",
     "name": { "str": "feral servant" },
     "description": "Once a fancy servant of some rich family, this maniac walks around with a candlestick in hand, ready to snuff out your life.",
-    "special_attacks": [ { "id": "feral_weapon_candlestick" } ],
+    "special_attacks": [ { "id": "feral_weapon_candlestick" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ], [ "PARROT_AT_DANGER", 0 ] ],
     "death_drops": "feral_maids_death_drops_candlestick"
   },
   {
@@ -290,7 +293,7 @@
     "name": { "str": "feral servant" },
     "description": "Once a fancy servant of some rich family, this maniac walks around with a knife in hand, searching for some victims to butcher.",
     "melee_skill": 3,
-    "special_attacks": [ { "id": "feral_weapon_knife_chef" } ],
+    "special_attacks": [ { "id": "feral_weapon_knife_chef" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ], [ "PARROT_AT_DANGER", 0 ] ],
     "death_drops": "feral_maids_death_drops_knife"
   },
   {
@@ -300,7 +303,7 @@
     "name": { "str": "well dressed feral" },
     "description": "Wearing fancy clothes and with a rapier in hand, this maniac was once a socialite.  They smile with madness and seem like they want to invite you to dinner.",
     "melee_skill": 4,
-    "special_attacks": [ { "id": "feral_weapon_rapier" } ],
+    "special_attacks": [ { "id": "feral_weapon_rapier" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ], [ "PARROT", 400 ] ],
     "death_drops": "feral_fancy_death_drops_rapier"
   },
   {
@@ -309,7 +312,7 @@
     "copy-from": "mon_feral_fancy_rapier",
     "name": { "str": "well dressed feral" },
     "description": "Wearing fancy clothes and with a rapier in hand, this maniac was once a socialite.  They smile with madness and seem like they want to invite you to dinner.",
-    "special_attacks": [ { "id": "feral_weapon_rapier_fake" } ],
+    "special_attacks": [ { "id": "feral_weapon_rapier_fake" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ], [ "PARROT", 400 ] ],
     "death_drops": "feral_fancy_death_drops_rapier_fake"
   },
   {
@@ -320,10 +323,14 @@
     "color": "i_magenta",
     "description": "Clad in ancient armor and with a mace in hand, this maniac walks around in search of their next prey.  You can see stains of dried blood all over their mace.",
     "melee_skill": 3,
-    "speed": 85,
-    "special_attacks": [ { "id": "feral_weapon_mace" } ],
+    "speed": 75,
+    "special_attacks": [ { "id": "feral_weapon_mace" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ], [ "PARROT", 600 ] ],
     "death_drops": "feral_armored_death_drops_mace",
-    "extend": { "weakpoint_sets": [ "wps_humanoid_body_armor", "wps_humanoid_open_helmet" ] },
+    "extend": {
+      "flags": [ "LOUDMOVES", "BASHES", "GROUP_BASH" ],
+      "weakpoint_sets": [ "wps_humanoid_body_armor", "wps_humanoid_open_helmet" ]
+    },
+    "delete": { "flags": [ "CLIMBS" ] },
     "//": "No synthetic armor proficiency because plate armor doesn't work the same as modern armor",
     "armor": { "bash": 20, "cut": 20, "stab": 15, "bullet": 12 }
   },
@@ -334,7 +341,7 @@
     "color": "i_magenta",
     "name": { "str": "armored feral" },
     "description": "Clad in ancient armor and with a battle axe in hand, this maniac walks around in search of their next prey.  You can see stains of dried blood all over their axe.",
-    "special_attacks": [ { "id": "feral_weapon_battleaxe" } ],
+    "special_attacks": [ { "id": "feral_weapon_battleaxe" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ], [ "PARROT", 600 ] ],
     "death_drops": "feral_armored_death_drops_battleaxe"
   },
   {

--- a/data/json/speech.json
+++ b/data/json/speech.json
@@ -2851,6 +2851,24 @@
   },
   {
     "type": "speech",
+    "speaker": [ "mon_feral_maid_broom", "mon_feral_maid_candlestick", "mon_feral_maid_knife" ],
+    "sound": "\"Lord, an intruder!\"",
+    "volume": 35
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_maid_broom", "mon_feral_maid_candlestick", "mon_feral_maid_knife" ],
+    "sound": "\"My lady, come see this one!\"",
+    "volume": 35
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_maid_broom", "mon_feral_maid_candlestick", "mon_feral_maid_knife" ],
+    "sound": "\"Master, I have one trapped!\"",
+    "volume": 35
+  },
+  {
+    "type": "speech",
     "speaker": [ "mon_feral_fancy_rapier", "mon_feral_fancy_rapier_fake", "mon_feral_armored_mace", "mon_feral_armored_battleaxe" ],
     "sound": "\"Where…\"",
     "volume": 5

--- a/data/json/speech.json
+++ b/data/json/speech.json
@@ -2725,7 +2725,7 @@
   },
   {
     "type": "speech",
-    "speaker": [ "mon_civilian_zombiefighter" ],
+    "speaker": [ "mon_civilian_zombiefighter", "mon_feral_maid_broom", "mon_feral_maid_candlestick", "mon_feral_maid_knife" ],
     "sound": "\"Die!\"",
     "volume": 30
   },
@@ -2788,6 +2788,132 @@
     "speaker": [ "mon_civilian_parent" ],
     "sound": "someone calling for their child.",
     "volume": 25
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_maid_broom", "mon_feral_maid_candlestick", "mon_feral_maid_knife" ],
+    "sound": "\"Here!\"",
+    "volume": 40
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_maid_broom", "mon_feral_maid_candlestick", "mon_feral_maid_knife" ],
+    "sound": "\"Here it is!\"",
+    "volume": 40
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_maid_broom", "mon_feral_maid_candlestick", "mon_feral_maid_knife" ],
+    "sound": "\"Found you!\"",
+    "volume": 30
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_maid_broom", "mon_feral_maid_candlestick", "mon_feral_maid_knife" ],
+    "sound": "\"You are trapped!\"",
+    "volume": 30
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_maid_broom" ],
+    "sound": "\"Time to take out the trash!\"",
+    "volume": 30
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_maid_candlestick" ],
+    "sound": "\"Time to turn off the lights!\"",
+    "volume": 30
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_maid_knife" ],
+    "sound": "\"Food is ready!\"",
+    "volume": 30
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_maid_knife" ],
+    "sound": "\"Today's menu is… You!\"",
+    "volume": 30
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_maid_knife" ],
+    "sound": "\"Looks like meat is back on the menu!\"",
+    "volume": 30
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_maid_broom", "mon_feral_maid_candlestick", "mon_feral_maid_knife" ],
+    "sound": "\"Come here!\"",
+    "volume": 30
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_fancy_rapier", "mon_feral_fancy_rapier_fake", "mon_feral_armored_mace", "mon_feral_armored_battleaxe" ],
+    "sound": "\"Where…\"",
+    "volume": 5
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_fancy_rapier", "mon_feral_fancy_rapier_fake" ],
+    "sound": "\"Look over there!\"",
+    "volume": 10
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_fancy_rapier", "mon_feral_fancy_rapier_fake" ],
+    "sound": "\"Come eat with me…\"",
+    "volume": 8
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_fancy_rapier", "mon_feral_fancy_rapier_fake" ],
+    "sound": "\"Come dance with me!\"",
+    "volume": 10
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_fancy_rapier", "mon_feral_fancy_rapier_fake" ],
+    "sound": "\"You can't hide forever…\"",
+    "volume": 8
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_fancy_rapier", "mon_feral_fancy_rapier_fake" ],
+    "sound": "\"Did you hear that?…\"",
+    "volume": 8
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_fancy_rapier", "mon_feral_fancy_rapier_fake" ],
+    "sound": "\"Another dead end!\"",
+    "volume": 10
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_armored_mace", "mon_feral_armored_battleaxe" ],
+    "sound": "the sound of metal dragged on the floor.",
+    "volume": 8
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_armored_mace", "mon_feral_armored_battleaxe" ],
+    "sound": "heavy but muffled breathing.",
+    "volume": 5
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_armored_mace", "mon_feral_armored_battleaxe" ],
+    "sound": "a strong swing of something in the air.",
+    "volume": 10
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_armored_mace", "mon_feral_armored_battleaxe" ],
+    "sound": "footsteps of something heavy and big.",
+    "volume": 8
   },
   {
     "type": "speech",

--- a/data/mods/No_Hope/Mapgen/mansion.json
+++ b/data/mods/No_Hope/Mapgen/mansion.json
@@ -41,7 +41,7 @@
         "!": { "item": "crate_stack", "chance": 20 },
         "q": { "item": "tool_common_stack", "chance": 20 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 17, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 17, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -85,7 +85,7 @@
         "K": { "item": "crate_cleaning", "chance": 20 },
         "I": { "item": "table_foyer", "chance": 40 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -133,7 +133,7 @@
       },
       "furniture": { "&": "f_sofa" },
       "items": { " ": { "item": "clutter_mansion", "chance": 2 }, "c": { "item": "suit_of_armor", "chance": 10 } },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 17, 21 ], "density": 0.15 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 17, 21 ], "density": 0.15 } ]
     }
   },
   {
@@ -187,7 +187,7 @@
         "?": { "item": "wetbar_fridge", "chance": 20 },
         "1": { "item": "wetbar_stack", "chance": 20 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 14, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 14, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -232,7 +232,7 @@
         "s": { "item": "table_foyer", "chance": 40 },
         "c": { "item": "suit_of_armor", "chance": 10 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -316,13 +316,22 @@
           { "item": "tailorbooks", "chance": 20, "repeat": [ 0, 1 ] },
           { "item": "SUS_tailoring_fasteners", "chance": 30, "repeat": [ 2, 6 ] }
         ],
+        "f": [
+          { "item": "snacks_fancy", "chance": 35 },
+          { "item": "table_sideboard", "chance": 20 }
+        ],
+        "D": [ { "item": "sex_lair", "chance": 35 }, { "item": "ss_merch_1", "chance": 25 } ],
+        "d": [
+          { "item": "clothing_fancy", "chance": 35 },
+          { "item": "beauty", "chance": 25 }
+        ],
+        "h": [ { "item": "backroom", "chance": 15 }, { "item": "tools_lighting", "chance": 25 } ],
         ".": { "item": "clutter_basement", "chance": 1 },
         "=": { "item": "sex_lair", "chance": 10 },
         "!": { "item": "crate_stack", "chance": 10 },
-        "D": { "item": "sex_lair", "chance": 15 },
-        "d": { "item": "sex_lair", "chance": 15 }
+        "$": { "item": "creepy", "chance": 5 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 12 ], "density": 0.1 } ],
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 12 ], "density": 0.1 } ],
       "place_monster": [ { "monster": "mon_zombie_resort_dancer", "x": [ 6, 19 ], "y": [ 16, 18 ], "repeat": [ 1, 2 ] } ]
     }
   },
@@ -373,7 +382,7 @@
         "s": { "item": "nightstand", "chance": 40 },
         "d": { "item": "dresser_stack", "chance": 20 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -428,7 +437,7 @@
         { "group": "corpse_mansion", "x": [ 10, 12 ], "y": [ 5, 7 ], "chance": 50, "repeat": [ 0, 2 ] },
         { "item": "television", "x": 12, "y": 17, "chance": 50 }
       ],
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 11, 14 ], "y": [ 6, 10 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 11, 14 ], "y": [ 6, 10 ], "density": 0.1 } ]
     }
   },
   {
@@ -488,7 +497,7 @@
         ",": { "item": "clutter_bathroom", "chance": 15 },
         "I": { "item": "vanity", "chance": 30 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 11 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 11 ], "density": 0.1 } ]
     }
   },
   {
@@ -541,7 +550,7 @@
         "x": { "item": "a_television", "chance": 50 },
         "c": { "item": "suit_of_armor", "chance": 10 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 12 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 12 ], "density": 0.1 } ]
     }
   },
   {
@@ -595,7 +604,7 @@
         { "item": "stereo", "x": 4, "y": 4, "chance": 50 },
         { "item": "television", "x": 14, "y": 9, "chance": 50 }
       ],
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 11 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 11 ], "density": 0.1 } ]
     }
   },
   {
@@ -648,7 +657,7 @@
         "&": { "item": "table_wine", "chance": 20, "repeat": [ 1, 4 ] },
         ".": { "item": "clutter_basement", "chance": 1 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 12 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 12 ], "density": 0.1 } ]
     }
   },
   {
@@ -744,7 +753,7 @@
         "R": { "item": "mansion_bookcase", "chance": 20 },
         "&": { "item": "mansion_bookcase", "chance": 20 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -799,7 +808,7 @@
         "&": { "item": "mansion_guns", "chance": 20, "repeat": [ 2, 3 ] },
         "∞": { "item": "mansion_guns", "chance": 20, "repeat": [ 2, 3 ] }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 4, 21 ], "y": [ 2, 9 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 4, 21 ], "y": [ 2, 9 ], "density": 0.1 } ]
     }
   },
   {
@@ -867,7 +876,7 @@
         "!": { "item": "crate_stack", "chance": 20 },
         "x": { "item": "a_television", "chance": 20 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 12 ], "density": 0.1 } ],
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 12 ], "density": 0.1 } ],
       "place_vehicles": [ { "vehicle": "laundry_cart", "x": [ 14, 15 ], "y": [ 0, 6 ], "chance": 100 } ]
     }
   },
@@ -935,7 +944,7 @@
         ",": { "item": "clutter_bathroom", "chance": 10 },
         "D": { "item": "dresser_servant", "chance": 45 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 7 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 7 ], "density": 0.1 } ]
     }
   },
   {
@@ -993,7 +1002,7 @@
         "s": { "item": "snacks_fancy", "chance": 35 },
         "n": { "item": "mansion_ammo", "chance": 40 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 12 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 12 ], "density": 0.1 } ]
     }
   },
   {
@@ -1047,7 +1056,7 @@
         { "item": "metal_RPG_die", "x": 2, "y": 3, "chance": 10 },
         { "item": "RPG_die", "x": [ 1, 2 ], "y": [ 2, 3 ], "chance": 90, "repeat": [ 1, 4 ] }
       ],
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -1100,7 +1109,7 @@
         "F": { "item": "fridgesnacks", "chance": 25 },
         "f": { "item": "wetbar_stack", "chance": 20 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 8 ], "y": [ 2, 11 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 8 ], "y": [ 2, 11 ], "density": 0.1 } ]
     }
   },
   {
@@ -1165,9 +1174,10 @@
         "J": { "item": "hardware_bulk", "chance": 30 },
         "q": { "item": "hardware_plumbing", "chance": 40 }
       },
+      "//": "Flavor spawn group for panic rooms with a different configuration of monsters for better story-telling.",
       "place_monsters": [
-        { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 },
-        { "monster": "GROUP_ZOMBIE", "x": [ 10, 15 ], "y": [ 9, 14 ], "density": 0.1 }
+        { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 },
+        { "monster": "GROUP_PANICROOM", "x": [ 10, 15 ], "y": [ 9, 14 ], "density": 0.1 }
       ]
     }
   },
@@ -1216,7 +1226,7 @@
         "f": { "item": "table_ballroom", "chance": 35 },
         "c": { "item": "suit_of_armor", "chance": 10 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -1269,7 +1279,7 @@
         "&": { "item": "hardware_bulk", "chance": 30 },
         "N": { "item": "construction_worker", "chance": 35 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -1335,7 +1345,7 @@
         "F": { "item": "vending_drink", "chance": 25 },
         "w": { "item": "sports", "chance": 35 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -1392,7 +1402,7 @@
         "?": { "item": "fridgesnacks", "chance": 45 },
         "!": { "item": "crate_stack", "chance": 20 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 8 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 8 ], "density": 0.1 } ]
     }
   },
   {
@@ -1472,7 +1482,7 @@
           "y": 15
         }
       ],
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -1577,7 +1587,7 @@
         "1": { "item": "wetbar_stack", "chance": 20 },
         "l": { "item": "snacks_fancy", "chance": 30 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 9, 21 ], "y": [ 17, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 9, 21 ], "y": [ 17, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -1617,7 +1627,7 @@
       "terrain": { " ": "t_soil", ".": "t_thconc_floor", "]": "t_sewage_pipe", ")": "t_sewage_pump" },
       "furniture": { "=": "f_machinery_old", "&": "f_table", "?": "f_generator_broken", "!": [ "f_crate_c", "f_cardboard_box" ] },
       "items": { ".": { "item": "clutter_basement", "chance": 1 }, "!": { "item": "crate_stack", "chance": 20 } },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 8, 21 ], "y": [ 8, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 8, 21 ], "y": [ 8, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -1674,7 +1684,7 @@
         "J": { "item": "wetbar_stack", "chance": 20 },
         "l": { "item": "table_livingroom", "chance": 30 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -1734,7 +1744,7 @@
         ",": { "item": "clutter_bathroom", "chance": 10 },
         "i": { "item": "wetbar_counter", "chance": 30 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 9, 21 ], "y": [ 9, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 9, 21 ], "y": [ 9, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -1778,7 +1788,7 @@
         "!": { "item": "crate_stack", "chance": 20 },
         "x": { "item": "a_television", "chance": 20 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 8, 21 ], "y": [ 8, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 8, 21 ], "y": [ 8, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -1832,7 +1842,7 @@
         "R": { "item": "mansion_bookcase", "chance": 20 },
         ")": { "item": "table_livingroom", "chance": 30 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -1892,7 +1902,7 @@
         "s": { "item": "snacks_fancy", "chance": 20 },
         "∞": { "item": "mansion_guns", "chance": 20 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 15, 21 ], "y": [ 9, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 15, 21 ], "y": [ 9, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -1959,7 +1969,7 @@
         "!": { "item": "crate_stack", "chance": 20 },
         "x": { "item": "a_television", "chance": 20 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 13, 21 ], "y": [ 7, 21 ], "density": 0.1 } ],
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 13, 21 ], "y": [ 7, 21 ], "density": 0.1 } ],
       "place_vehicles": [ { "vehicle": "laundry_cart", "x": [ 13, 18 ], "y": [ 8, 9 ], "chance": 50 } ]
     }
   },
@@ -2008,7 +2018,7 @@
         "R": { "item": "mansion_bookcase", "chance": 20 },
         "s": { "item": "nightstand", "chance": 35 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -2063,7 +2073,7 @@
         "&": { "item": "table_wine", "chance": 20, "repeat": [ 1, 4 ] },
         ".": { "item": "clutter_basement", "chance": 1 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 11, 21 ], "y": [ 8, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 11, 21 ], "y": [ 8, 21 ], "density": 0.1 } ]
     }
   },
   {
@@ -2127,7 +2137,7 @@
         "-": { "item": "clutter_bedroom", "chance": 2 },
         "I": { "item": "nightstand", "chance": 40 }
       },
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 8, 21 ], "y": [ 12, 21 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_VANILLA", "x": [ 8, 21 ], "y": [ 12, 21 ], "density": 0.1 } ]
     }
   }
 ]

--- a/data/mods/No_Hope/Mapgen/mansion.json
+++ b/data/mods/No_Hope/Mapgen/mansion.json
@@ -316,15 +316,9 @@
           { "item": "tailorbooks", "chance": 20, "repeat": [ 0, 1 ] },
           { "item": "SUS_tailoring_fasteners", "chance": 30, "repeat": [ 2, 6 ] }
         ],
-        "f": [
-          { "item": "snacks_fancy", "chance": 35 },
-          { "item": "table_sideboard", "chance": 20 }
-        ],
+        "f": [ { "item": "snacks_fancy", "chance": 35 }, { "item": "table_sideboard", "chance": 20 } ],
         "D": [ { "item": "sex_lair", "chance": 35 }, { "item": "ss_merch_1", "chance": 25 } ],
-        "d": [
-          { "item": "clothing_fancy", "chance": 35 },
-          { "item": "beauty", "chance": 25 }
-        ],
+        "d": [ { "item": "clothing_fancy", "chance": 35 }, { "item": "beauty", "chance": 25 } ],
         "h": [ { "item": "backroom", "chance": 15 }, { "item": "tools_lighting", "chance": 25 } ],
         ".": { "item": "clutter_basement", "chance": 1 },
         "=": { "item": "sex_lair", "chance": 10 },


### PR DESCRIPTION
#### Summary
Balance "Several balance changes to the Mansion Escape scenario and related monsters/spawns"

#### Purpose of change
There was a recent removal of the crossbow feral and confinement of the rest of the mansion ferals to scenario only, so I decided this was a good time to update and improve the balance of the scenario in question, there were also some problems with the recent confinement of the ferals, removing some flavor to the location, so I went around to recover that.

#### Describe the solution
Spawns:
- **Reduced** the current number of spawned **enemies** (dead or alive).
- There are now significantly **more servants than fancy people**, every fancy suit you see around needs at least 3 different people to boss around!
- Word has gone around that the mansion is actually not a police station or military base! Shocking! Those **zombie police officers and soldiers** that were already here have kindly taken the message and **departed from the premises**.
- The **most dangerous ferals** (The ones that can easily kill a newly made character) and zombies have decided to give you a head start and **will now avoid starting too close to you**r starting location, weaker enemies can still spawn close tough, you should be able to survive a little rough start. Armored ferals have reportedly decided to ignore the head start rule so be careful with them. 
- Added a little **more things to the safe zones** in the mansion (So you have a few more options at start), mainly affecting the sex lair in the basement so you have at least something to eat before starting your scavenging run outside the safety of those 4 walls.
- **Guaranteed source of light** in the basement, it could be anything so you could be unlucky and receive a flashlight with charge for 5 minutes, or a candle without matches (The masochist profession looks better now, right?).
- Restored the **panic room flavor monsters** (You can find a dog and a child hiding there, someone rich that managed to escape to the safe room, or even some random nobody that just had good luck!).

Monsters:
- The **feral servants will now call their masters** when they find you roaming the mansion halls! Be sure to avoid their notice or eliminate them before they have the chance to call for reinforcements.
- The **well dressed ferals will now** murmur for themselves, order their servants to search harder or **call you out** to come out of hiding, be sure to keep an ear open so you know where they are before they even know it!
- The **armored ferals** are now **too heavy for sneaking around** and will be easier to hear them coming if they are close enough.
- **Armored ferals will** sometimes swing their weapons around while imagining how they would crush you, the fools do not realize that **help**s **you find them**.
- The precious armor of the **armored ferals** weights them down too much, they could resist all your punches with it, but they **are now too slow to catch you** if you maneuver around them fast enough.
- The **servant and fancy ferals** now remember the value of their mansion! They **will now avoid bashing** that precious imported wood doors, or destroying their precious collection of wine, the servants would be fired if they did that! And the fancy people in suits actually paid for those items!
- **Armored ferals will still destroy anything** in their path, part of their job description they say.
- All **mansion ferals will now start to eat** the great **food** reserves of the mansion! Run for it before there is no more!

#### Describe alternatives you've considered
More/Less monsters, or more noise, but after much testing I feel the numbers are now in a good place.

#### Testing
Spawned several times with different numbers and let the game run for half a day to see the locations and groupings of the monsters (Currently they will still remain separated enough to serve as a warning line), teleported in front of a servant feral and waited some time to see the rest of the monsters come running to my location, teleported to a room next a well dressed feral and waited some time to hear the feral calling me out, teleported to a safe room and waited some hours to wait for any sounds, detected some sounds coming from monsters not too far away.

Teleported in front of a servant feral armed only with my trusted cudgel and no knowledge of combat, I managed to kill it before being surrounded by all sides by enemies hearing the calls of the servant I just killed and ended up mauled to death.

Tested with a real run of the game and I have to say it is really fun! You have to take care quickly of the feral servants you see, or run quickly, because they WILL summon their brethren and together they will maul you to death!

#### Additional context
I hope this update manages to make the scenario even more fun for players! It will somewhat decrease the difficulty of the start of the scenario but these changes should also complicate surviving for careless players who just rush towards every enemy they see.

Oh, and the boarded mansion of the scenario uses a monster group that does not include civilians because if too many were present all enemies tended to group in one or two locations, they can still very rarely spawn in the parts of the mansion that are not changed from the vanilla mansion.