### PR TITLE
Fixing ImGui popup size issue, and small input bug

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -266,6 +266,16 @@ void cataimgui::client::process_input( void *input )
 
 #endif
 
+bool cataimgui::client::auto_size_frame_active()
+{
+    for( const ImGuiWindow *window : GImGui->Windows ) {
+        if( window->AutoFitFramesX > 0 || window->AutoFitFramesY > 0 ) {
+            return true;
+        }
+    }
+    return false;
+}
+
 static ImGuiKey cata_key_to_imgui( int cata_key )
 {
     switch( cata_key ) {

--- a/src/cata_imgui.h
+++ b/src/cata_imgui.h
@@ -68,6 +68,7 @@ class client
         const SDL_Window_Ptr &sdl_window;
         const GeometryRenderer_Ptr &sdl_geometry;
 #endif
+        bool auto_size_frame_active();
 };
 
 void point_to_imvec2( point *src, ImVec2 *dest );

--- a/src/popup.cpp
+++ b/src/popup.cpp
@@ -588,10 +588,14 @@ query_popup::result query_popup::query_once_imgui()
     } else if( res.action == "LEFT" ) {
         if( impl->keyboard_selected_option > 0 ) {
             impl->keyboard_selected_option--;
+        } else {
+            impl->keyboard_selected_option = short( buttons.size() - 1 );
         }
     } else if( res.action == "RIGHT" ) {
         if( impl->keyboard_selected_option < short( buttons.size() - 1 ) ) {
             impl->keyboard_selected_option++;
+        } else {
+            impl->keyboard_selected_option = 0;
         }
     } else if( res.action == "HELP_KEYBINDINGS" ) {
         // Keybindings may have changed, regenerate the UI

--- a/src/popup.cpp
+++ b/src/popup.cpp
@@ -23,7 +23,7 @@ class query_popup_impl : public cataimgui::window
         short keyboard_selected_option;
 
         explicit query_popup_impl( query_popup *parent ) : cataimgui::window( "QUERY_POPUP",
-                    ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoScrollbar ) {
+                    ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_AlwaysAutoResize ) {
             msg_width = 400;
             this->parent = parent;
             keyboard_selected_option = 0;

--- a/src/popup.cpp
+++ b/src/popup.cpp
@@ -38,14 +38,7 @@ class query_popup_impl : public cataimgui::window
     protected:
         void draw_controls() override;
         cataimgui::bounds get_bounds() override {
-            float height = float( str_height_to_pixels( parent->folded_msg.size() ) ) +
-                           ( ImGui::GetStyle().ItemSpacing.y * 2 );
-            if( !parent->buttons.empty() ) {
-                height += float( str_height_to_pixels( 1 ) ) + ( ImGui::GetStyle().ItemInnerSpacing.y * 2 ) +
-                          ( ImGui::GetStyle().ItemSpacing.y * 2 );
-            }
-            return { -1.f, parent->ontop ? 0 : -1.f,
-                     float( msg_width ) + ( ImGui::GetStyle().WindowBorderSize * 2 ), height };
+            return { -1.f, parent->ontop ? 0 : -1.f, -1.f, -1.f };
         }
 };
 

--- a/src/ui_manager.cpp
+++ b/src/ui_manager.cpp
@@ -453,6 +453,12 @@ void ui_adaptor::redraw_invalidated( )
 
     imclient->end_frame();
     imgui_frame_started = false;
+
+    // if any ImGui window needed to calculate the size of its contents,
+    //  it needs an extra frame to draw. We do that here.
+    if( imclient->auto_size_frame_active() ) {
+        redraw_invalidated();
+    }
 }
 
 void ui_adaptor::screen_resized()


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fixing issue where popup doesn't size to fit its contents properly, and doesnt wrap the button selection navigation properly"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes: #72770
Fixes: #72769
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Input bug just needed a small change to wrap the selected index from the end of the list to the start, and vice versa. Sizing bug is more complex, it required a change in ui_adaptor::redraw_invalidated to perform another redraw, in order to allow ImGui screens with auto-sizing enabled to be shown on the first call to redraw_invalidated as the user would expect.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I could have just modified query_popup_impl::get_bounds to properly calculate the size to fix the sizing bug, but for the migration moving forward, not being able to auto-size windows is a big problem. Manually sizing ImGui windows is very tedious and involves knowing things like the padding between ImGui elements ahead of time, which is incredibly tedious.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Open the keybindings screen, try to change various keybindings, verify the popups show with the proper size. In the game, press 'D' to show the "drop where?" box, verify that it shows at the top of the screen and sized properly. Tried the EOC pasted in #72770 as well, verified the popup shows as the correct size.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
