### PR TITLE
Fixing ImGUi keybindings screen processing keys pressed before it was shown

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -89,6 +89,9 @@ void cataimgui::client::set_alloced_pair_count( short count )
 
 void cataimgui::client::process_input( void *input )
 {
+    if( !any_window_shown() ) {
+        return;
+    }
     if( input ) {
         input_event *curses_input = static_cast<input_event *>( input );
         ImTui::mouse_event new_mouse_event = ImTui::mouse_event();
@@ -261,7 +264,9 @@ void cataimgui::client::end_frame()
 
 void cataimgui::client::process_input( void *input )
 {
-    ImGui_ImplSDL2_ProcessEvent( static_cast<const SDL_Event *>( input ) );
+    if( any_window_shown() ) {
+        ImGui_ImplSDL2_ProcessEvent( static_cast<const SDL_Event *>( input ) );
+    }
 }
 
 #endif
@@ -274,6 +279,18 @@ bool cataimgui::client::auto_size_frame_active()
         }
     }
     return false;
+}
+
+bool cataimgui::client::any_window_shown()
+{
+    bool any_window_shown = false;
+    for( const ImGuiWindow *window : GImGui->Windows ) {
+        if( window->Active && !window->Hidden ) {
+            any_window_shown = true;
+            break;
+        }
+    }
+    return any_window_shown;
 }
 
 static ImGuiKey cata_key_to_imgui( int cata_key )

--- a/src/cata_imgui.h
+++ b/src/cata_imgui.h
@@ -69,6 +69,7 @@ class client
         const GeometryRenderer_Ptr &sdl_geometry;
 #endif
         bool auto_size_frame_active();
+        bool any_window_shown();
 };
 
 void point_to_imvec2( point *src, ImVec2 *dest );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "fixed issue where ImGui processes input that happens with no ImGui screens visible"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes: #72447
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
When no ImGui screens are visible, do not process any input into ImGui.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
We could have some sort of boolean that is updated whenever a ui_adaptor is created or destroyed that determines if any ImGui screen is in the ui_adaptor list. That's more complex and has more moving parts than this.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Perform the sequence of inputs mentioned in the linked issue and verify the extra inputs are not sent to the keybindings screen
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
