### PR TITLE
Throw error if recipe definition is missing any valid combinations

### DIFF
--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -1647,6 +1647,10 @@ deduped_requirement_data::deduped_requirement_data( const requirement_data &in,
             pending.push( { without_dupes, next.index + 1 } );
         }
 
+        if( alternatives_.empty() && pending.empty() ) {
+            debugmsg( "Recipe definition %s somehow has no valid recipes!", context.str() );
+        }
+
         // Because this algorithm is super-exponential in the worst case, add a
         // sanity check to prevent things getting too far out of control.
         // The worst case in the core game currently is boots_fur


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Resolves the second part of #65679

#### Describe the solution
Add a check at the end of checking for deduplicated recipes (when the total number of valid combinations are counted).

If there's no valid combinations at this point, there never will be and something has gone wrong. Loudly warn at the recipe definition instead of just failing silently.


#### Describe alternatives you've considered


#### Testing
Re-introduced the JSON error solved by #65761
Was successfully caught during loading, throwing the follow debugmsgs:
```
17:18:51.438 ERROR : \Cataclysm-DDA\src\requirements.cpp:1651 [deduped_requirement_data] Recipe definition V8_jarred somehow has no valid recipes!
17:19:00.668 ERROR : \Cataclysm-DDA\src\requirements.cpp:1651 [deduped_requirement_data] Recipe definition sauce_red_jarred_3l somehow has no valid recipes!
17:19:00.668 ERROR : \Cataclysm-DDA\src\requirements.cpp:1651 [deduped_requirement_data] Recipe definition sauce_red_jarred somehow has no valid recipes!
17:19:00.668 ERROR : \Cataclysm-DDA\src\requirements.cpp:1651 [deduped_requirement_data] Recipe definition can_tomato_jarred somehow has no valid recipes!
17:19:00.668 ERROR : \Cataclysm-DDA\src\requirements.cpp:1651 [deduped_requirement_data] Recipe definition can_tomato_jarred_3l somehow has no valid recipes!
17:19:00.668 ERROR : \Cataclysm-DDA\src\requirements.cpp:1651 [deduped_requirement_data] Recipe definition kompot_jarred_3l somehow has no valid recipes!
17:19:00.668 ERROR : \Cataclysm-DDA\src\requirements.cpp:1651 [deduped_requirement_data] Recipe definition jam_fruit_jarred somehow has no valid recipes!
17:19:00.668 ERROR : \Cataclysm-DDA\src\requirements.cpp:1651 [deduped_requirement_data] Recipe definition jam_fruit_jarred_3L somehow has no valid recipes!
17:19:00.668 ERROR : \Cataclysm-DDA\src\requirements.cpp:1651 [deduped_requirement_data] Recipe definition kompot_jarred somehow has no valid recipes!
```

#### Additional context
This does not actually resolve the issue of trying to load components as tools, nor does it warn for that specific occurrence, but it's a general catch-all for a situation that should never be possible. A generic canary is better than no canary.