### PR TITLE
Replace alot of raw strings in faction_camp.cpp and make use of static const where appropriate

### DIFF
--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -107,7 +107,7 @@ static const oter_type_str_id oter_type_field( "field" );
 static const oter_type_str_id oter_type_forest( "forest" );
 static const oter_type_str_id oter_type_forest_thick( "forest_thick" );
 static const oter_type_str_id oter_type_forest_trail( "forest_trail" );
-static const oter_type_str_id oter_type_forest_water( "forest_water" );
+static const oter_type_str_id oter_type_forest_trail_intersection( "forest_trail_intersection" );
 static const oter_type_str_id oter_type_rural_road( "rural_road" );
 static const oter_type_str_id oter_type_rural_road_forest( "rural_road_forest" );
 static const oter_type_str_id oter_type_special_forest( "special_forest" );
@@ -2405,13 +2405,14 @@ static void change_cleared_terrain( tripoint_abs_omt forest )
         const std::unordered_map<oter_type_str_id, oter_type_str_id> clear_cut_conversion = {
             { oter_type_forest, oter_type_field },
             { oter_type_forest_thick, oter_type_field },
-            { oter_type_special_forest, oter_type_field },
-            { oter_type_special_forest_thick, oter_type_field },
             { oter_type_forest_trail, oter_type_field },
-            { oter_type_rural_road_forest, oter_type_rural_road }
+            { oter_type_forest_trail_intersection, oter_type_field },
+            { oter_type_rural_road_forest, oter_type_rural_road },
+            { oter_type_special_forest, oter_type_field },
+            { oter_type_special_forest_thick, oter_type_field }
         };
-        auto converted_it = clear_cut_conversion.find( omt_trees->get_type_id() );
 
+        auto converted_it = clear_cut_conversion.find( omt_trees->get_type_id() );
         if( converted_it == clear_cut_conversion.end() ) {
             popup( _( "%s isn't a recognized terrain.  Please file a bug report." ), omt_trees.id().c_str() );
             return;
@@ -2433,10 +2434,8 @@ static void change_cleared_terrain( tripoint_abs_omt forest )
 
 void basecamp::start_cut_logs( const mission_id &miss_id, float exertion_level )
 {
-    std::vector<std::string> log_sources = { "forest", "forest_thick", "forest_trail", "rural_road_forest", "rural_road_turn_forest", "rural_road_turn1_forest", "rural_road_3way_forest",
-                                             "dirt_road_forest", "dirt_road_3way_forest", "dirt_road_turn_forest", "forest_trail_intersection", "special_forest", "special_forest_thick", "forest_trail_isolated", "forest_trail_end"
-                                           };
-    popup( _( "Forests are the only valid cutting locations, with forest dirt roads, forest rural roads, and trails being valid as well.  Note that it's likely both forest and field roads look exactly the same after having been cleared." ) );
+    std::vector<std::string> log_sources = { "forest", "forest_thick", "forest_trail",  "forest_trail_intersection", "rural_road_forest", "special_forest", "special_forest_thick" };
+    popup( _( "Forests, forest rural roads, and trails are the only valid cutting locations.  Note that it's likely both forest and field roads look exactly the same after having been cleared." ) );
     tripoint_abs_omt forest = om_target_tile( omt_pos, 1, 50, log_sources, ot_match_type::type );
     if( forest != tripoint_abs_omt( -999, -999, -999 ) ) {
         standard_npc sample_npc( "Temp" );
@@ -2472,10 +2471,8 @@ void basecamp::start_cut_logs( const mission_id &miss_id, float exertion_level )
 
 void basecamp::start_clearcut( const mission_id &miss_id, float exertion_level )
 {
-    std::vector<std::string> log_sources = { "forest", "forest_thick", "forest_trail", "rural_road_forest", "rural_road_turn_forest", "rural_road_turn1_forest", "rural_road_3way_forest",
-                                             "dirt_road_forest", "dirt_road_3way_forest", "dirt_road_turn_forest", "forest_trail_intersection", "special_forest", "special_forest_thick", "forest_trail_isolated", "forest_trail_end"
-                                           };
-    popup( _( "Forests are the only valid cutting locations, with forest dirt roads, forest rural roads, and trails being valid as well.  Note that it's likely both forest and field roads look exactly the same after having been cleared." ) );
+    std::vector<std::string> log_sources = { "forest", "forest_thick", "forest_trail",  "forest_trail_intersection", "rural_road_forest", "special_forest", "special_forest_thick" };
+    popup( _( "Forests, forest rural roads, and trails are the only valid cutting locations.  Note that it's likely both forest and field roads look exactly the same after having been cleared." ) );
     tripoint_abs_omt forest = om_target_tile( omt_pos, 1, 50, log_sources, ot_match_type::type );
     if( forest != tripoint_abs_omt( -999, -999, -999 ) ) {
         standard_npc sample_npc( "Temp" );

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -103,40 +103,15 @@ static const mongroup_id GROUP_CAMP_HUNTING( "GROUP_CAMP_HUNTING" );
 static const mongroup_id GROUP_CAMP_HUNTING_LARGE( "GROUP_CAMP_HUNTING_LARGE" );
 static const mongroup_id GROUP_CAMP_TRAPPING( "GROUP_CAMP_TRAPPING" );
 
-static const oter_str_id oter_dirt_road_3way_forest_east( "dirt_road_3way_forest_east" );
-static const oter_str_id oter_dirt_road_3way_forest_north( "dirt_road_3way_forest_north" );
-static const oter_str_id oter_dirt_road_3way_forest_south( "dirt_road_3way_forest_south" );
-static const oter_str_id oter_dirt_road_3way_forest_west( "dirt_road_3way_forest_west" );
-static const oter_str_id oter_dirt_road_forest_east( "dirt_road_forest_east" );
-static const oter_str_id oter_dirt_road_forest_north( "dirt_road_forest_north" );
-static const oter_str_id oter_dirt_road_forest_south( "dirt_road_forest_south" );
-static const oter_str_id oter_dirt_road_forest_west( "dirt_road_forest_west" );
-static const oter_str_id oter_dirt_road_turn_forest_east( "dirt_road_turn_forest_east" );
-static const oter_str_id oter_dirt_road_turn_forest_north( "dirt_road_turn_forest_north" );
-static const oter_str_id oter_dirt_road_turn_forest_south( "dirt_road_turn_forest_south" );
-static const oter_str_id oter_dirt_road_turn_forest_west( "dirt_road_turn_forest_west" );
-static const oter_str_id oter_forest( "forest" );
-static const oter_str_id oter_forest_thick( "forest_thick" );
-static const oter_str_id oter_rural_road_3way_forest_east( "rural_road_3way_forest_east" );
-static const oter_str_id oter_rural_road_3way_forest_north( "rural_road_3way_forest_north" );
-static const oter_str_id oter_rural_road_3way_forest_south( "rural_road_3way_forest_south" );
-static const oter_str_id oter_rural_road_3way_forest_west( "rural_road_3way_forest_west" );
-static const oter_str_id oter_rural_road_forest_east( "rural_road_forest_east" );
-static const oter_str_id oter_rural_road_forest_north( "rural_road_forest_north" );
-static const oter_str_id oter_rural_road_forest_south( "rural_road_forest_south" );
-static const oter_str_id oter_rural_road_forest_west( "rural_road_forest_west" );
-static const oter_str_id oter_rural_road_turn1_forest_east( "rural_road_turn1_forest_east" );
-static const oter_str_id oter_rural_road_turn1_forest_north( "rural_road_turn1_forest_north" );
-static const oter_str_id oter_rural_road_turn1_forest_south( "rural_road_turn1_forest_south" );
-static const oter_str_id oter_rural_road_turn1_forest_west( "rural_road_turn1_forest_west" );
-static const oter_str_id oter_rural_road_turn_forest_east( "rural_road_turn_forest_east" );
-static const oter_str_id oter_rural_road_turn_forest_north( "rural_road_turn_forest_north" );
-static const oter_str_id oter_rural_road_turn_forest_south( "rural_road_turn_forest_south" );
-static const oter_str_id oter_rural_road_turn_forest_west( "rural_road_turn_forest_west" );
-static const oter_str_id oter_special_forest( "special_forest" );
-static const oter_str_id oter_special_forest_thick( "special_forest_thick" );
-
+static const oter_type_str_id oter_type_field( "field" );
+static const oter_type_str_id oter_type_forest( "forest" );
+static const oter_type_str_id oter_type_forest_thick( "forest_thick" );
 static const oter_type_str_id oter_type_forest_trail( "forest_trail" );
+static const oter_type_str_id oter_type_forest_water( "forest_water" );
+static const oter_type_str_id oter_type_rural_road( "rural_road" );
+static const oter_type_str_id oter_type_rural_road_forest( "rural_road_forest" );
+static const oter_type_str_id oter_type_special_forest( "special_forest" );
+static const oter_type_str_id oter_type_special_forest_thick( "special_forest_thick" );
 
 static const skill_id skill_bashing( "bashing" );
 static const skill_id skill_combat( "combat" );
@@ -2425,75 +2400,31 @@ static void change_cleared_terrain( tripoint_abs_omt forest )
 {
     if( om_cutdown_trees_est( forest ) < 5 ) {
         const oter_id &omt_trees = overmap_buffer.ter( forest );
-        const std::string omt_trees_string = static_cast<std::string>( omt_trees.id() );
 
-        if( omt_trees_string.find( "dirt_road" ) != std::string::npos ) {}
+        // Oter types before and after clear cutting, if value (after) is linear, key (before) should also be linear, otherwise any combination of rotatable/linear/not rotatable should work
+        const std::unordered_map<oter_type_str_id, oter_type_str_id> clear_cut_conversion = {
+            { oter_type_forest, oter_type_field },
+            { oter_type_forest_thick, oter_type_field },
+            { oter_type_special_forest, oter_type_field },
+            { oter_type_special_forest_thick, oter_type_field },
+            { oter_type_forest_trail, oter_type_field },
+            { oter_type_rural_road_forest, oter_type_rural_road }
+        };
+        auto converted_it = clear_cut_conversion.find( omt_trees->get_type_id() );
 
-        if( omt_trees.id() == oter_dirt_road_forest_north ) {
-            overmap_buffer.ter_set( forest, oter_id( "dirt_road_north" ) );
-        } else if( omt_trees.id() == oter_dirt_road_forest_east ) {
-            overmap_buffer.ter_set( forest, oter_id( "dirt_road_east" ) );
-        } else if( omt_trees.id() == oter_dirt_road_forest_south ) {
-            overmap_buffer.ter_set( forest, oter_id( "dirt_road_south" ) );
-        } else if( omt_trees.id() == oter_dirt_road_forest_west ) {
-            overmap_buffer.ter_set( forest, oter_id( "dirt_road_west" ) );
-        } else if( omt_trees.id() == oter_dirt_road_3way_forest_north ) {
-            overmap_buffer.ter_set( forest, oter_id( "dirt_road_3way_north" ) );
-        } else if( omt_trees.id() == oter_dirt_road_3way_forest_east ) {
-            overmap_buffer.ter_set( forest, oter_id( "dirt_road_3way_east" ) );
-        } else if( omt_trees.id() == oter_dirt_road_3way_forest_south ) {
-            overmap_buffer.ter_set( forest, oter_id( "dirt_road_3way_south" ) );
-        } else if( omt_trees.id() == oter_dirt_road_3way_forest_west ) {
-            overmap_buffer.ter_set( forest, oter_id( "dirt_road_3way_west" ) );
-        } else if( omt_trees.id() == oter_dirt_road_turn_forest_north ) {
-            overmap_buffer.ter_set( forest, oter_id( "dirt_road_turn_north" ) );
-        } else if( omt_trees.id() == oter_dirt_road_turn_forest_east ) {
-            overmap_buffer.ter_set( forest, oter_id( "dirt_road_turn_east" ) );
-        } else if( omt_trees.id() == oter_dirt_road_turn_forest_south ) {
-            overmap_buffer.ter_set( forest, oter_id( "dirt_road_turn_south" ) );
-        } else if( omt_trees.id() == oter_dirt_road_turn_forest_west ) {
-            overmap_buffer.ter_set( forest, oter_id( "dirt_road_turn_west" ) );
-        }
-
-        else if( omt_trees.id() == oter_forest || omt_trees.id() == oter_forest_thick ||
-                 omt_trees.id() == oter_special_forest || omt_trees.id() == oter_special_forest_thick ||
-                 omt_trees_string.find( "forest_trail" ) != std::string::npos ) {
-            overmap_buffer.ter_set( forest, oter_id( "field" ) );
-        } else if( omt_trees.id() == oter_rural_road_forest_north ) {
-            overmap_buffer.ter_set( forest, oter_id( "rural_road_north" ) );
-        } else if( omt_trees.id() == oter_rural_road_forest_east ) {
-            overmap_buffer.ter_set( forest, oter_id( "rural_road_east" ) );
-        } else if( omt_trees.id() == oter_rural_road_forest_south ) {
-            overmap_buffer.ter_set( forest, oter_id( "rural_road_south" ) );
-        } else if( omt_trees.id() == oter_rural_road_forest_west ) {
-            overmap_buffer.ter_set( forest, oter_id( "rural_road_west" ) );
-        } else if( omt_trees.id() == oter_rural_road_3way_forest_north ) {
-            overmap_buffer.ter_set( forest, oter_id( "rural_road_3way_north" ) );
-        } else if( omt_trees.id() == oter_rural_road_3way_forest_east ) {
-            overmap_buffer.ter_set( forest, oter_id( "rural_road_3way_east" ) );
-        } else if( omt_trees.id() == oter_rural_road_3way_forest_south ) {
-            overmap_buffer.ter_set( forest, oter_id( "rural_road_3way_south" ) );
-        } else if( omt_trees.id() == oter_rural_road_3way_forest_west ) {
-            overmap_buffer.ter_set( forest, oter_id( "rural_road_3way_west" ) );
-        } else if( omt_trees.id() == oter_rural_road_turn_forest_north ) {
-            overmap_buffer.ter_set( forest, oter_id( "rural_road_turn_north" ) );
-        } else if( omt_trees.id() == oter_rural_road_turn_forest_east ) {
-            overmap_buffer.ter_set( forest, oter_id( "rural_road_turn_east" ) );
-        } else if( omt_trees.id() == oter_rural_road_turn_forest_south ) {
-            overmap_buffer.ter_set( forest, oter_id( "rural_road_turn_south" ) );
-        } else if( omt_trees.id() == oter_rural_road_turn_forest_west ) {
-            overmap_buffer.ter_set( forest, oter_id( "rural_road_turn_west" ) );
-        } else if( omt_trees.id() == oter_rural_road_turn1_forest_north ) {
-            overmap_buffer.ter_set( forest, oter_id( "rural_road_turn1_north" ) );
-        } else if( omt_trees.id() == oter_rural_road_turn1_forest_east ) {
-            overmap_buffer.ter_set( forest, oter_id( "rural_road_turn1_east" ) );
-        } else if( omt_trees.id() == oter_rural_road_turn1_forest_south ) {
-            overmap_buffer.ter_set( forest, oter_id( "rural_road_turn1_south" ) );
-        } else if( omt_trees.id() == oter_rural_road_turn1_forest_west ) {
-            overmap_buffer.ter_set( forest, oter_id( "rural_road_turn1_west" ) );
-        } else {
+        if( converted_it == clear_cut_conversion.end() ) {
             popup( _( "%s isn't a recognized terrain.  Please file a bug report." ), omt_trees.id().c_str() );
             return;
+        } else {
+            const oter_type_str_id &oter_type_clearcut = converted_it->second;
+            oter_id oter_to_place;
+            // Maintain rotation
+            if( oter_type_clearcut->is_linear() ) {
+                oter_to_place = oter_type_clearcut->get_linear( omt_trees->get_line() );
+            } else {
+                oter_to_place = oter_type_clearcut->get_rotated( omt_trees->get_dir() );
+            }
+            overmap_buffer.ter_set( forest, oter_to_place );
         }
         popup( _( "The logged tile has been cleared and cannot be logged further after this mission." ),
                omt_trees.id().c_str() );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Faction camp clearcutting works on rural roads again"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fixes #72808

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Removes references to migrated omt ids
Swaps out the gross if else for a generalised map that works for all rotation types for easy future additions without needing extra logic

Could do with #72558 merging first so I can reuse it to set the parameters for the road type to be the same pre/post cut

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Using a set for the forest oters to convert to field without rotation handling and dealing with rural road and it's linear rotation as a special case which would be shorter and more efficient than the map

I want to replace several things using std::string s in place of ids with ids but I'll do that after this has merged rather than delaying the bugfix

Unhardcoding the std::unordered_map but that would require the above so log_sources uses the same check

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

None yet, faction camp testing is a PITA

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
