### PR TITLE
[MoM] stop using premonition if you don't have premonition

### DIFF
--- a/data/mods/MindOverMatter/npcs/dialogue/portal_future_you.json
+++ b/data/mods/MindOverMatter/npcs/dialogue/portal_future_you.json
@@ -6,7 +6,12 @@
       {
         "text": "[Premonition] *Determine if the voice is a threat*",
         "topic": "TALK_PORTAL_STORM_DANGER_SENSE_FAIL",
-        "condition": { "math": [ "u_spell_level('clair_danger_sense')", "<=", "7" ] }
+        "condition": {
+          "and": [
+            { "math": [ "u_spell_level('clair_danger_sense')", "<=", "7" ] },
+            { "math": [ "u_spell_level('clair_danger_sense')", "!=", "-1" ] }
+          ]
+        }
       },
       {
         "text": "[Premonition 8+] *Determine if the voice is a threat*",


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Played the game, got this
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/67688115/747cdb62-620d-49d2-bef4-bd2c10a07500)
Realised i don't have premonition or clairsomething class at all
#### Describe the solution
Unlearned spells are considered to be level -1. Added check to portal dialogue so TALK_PORTAL_STORM_DANGER_SENSE_FAIL won't be triggered if you have clair_danger_sense not learned