### PR TITLE
Fixing screen artifacts seen when ImGui keybindings UI is closed

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -435,7 +435,7 @@ class cataimgui::window_impl
                 ImVec2 imsize = ImGui::GetWindowSize();
                 imvec2_to_point( &impos, &catapos );
                 imvec2_to_point( &imsize, &catasize );
-                window_adaptor->position( catapos, catasize );
+                window_adaptor->position_absolute( catapos, catasize );
             } );
             window_adaptor->on_screen_resize( [this]( ui_adaptor & ) {
                 is_resized = true;

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -3788,12 +3788,6 @@ input_event input_manager::get_input_event( const keyboard_mode preferred_keyboa
     // we can skip screen update if `needupdate` is false to improve performance during mouse
     // move events.
     wnoutrefresh( catacurses::stdscr );
-    
-    // This statement is required when the screen is made very small
-    if( ui_adaptor::has_imgui() ) {
-        needupdate = true;
-    }
-
     if( needupdate ) {
         refresh_display();
     }

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -3788,6 +3788,7 @@ input_event input_manager::get_input_event( const keyboard_mode preferred_keyboa
     // we can skip screen update if `needupdate` is false to improve performance during mouse
     // move events.
     wnoutrefresh( catacurses::stdscr );
+    
     // This statement is required when the screen is made very small
     if( ui_adaptor::has_imgui() ) {
         needupdate = true;

--- a/src/ui_manager.cpp
+++ b/src/ui_manager.cpp
@@ -131,6 +131,15 @@ void ui_adaptor::position( const point &topleft, const point &size )
     ui_manager::invalidate( old_dimensions, false );
 }
 
+void ui_adaptor::position_absolute( const point &topleft, const point &size )
+{
+    const rectangle<point> old_dimensions = dimensions;
+    // ensure position is updated before calling invalidate
+    dimensions = rectangle<point>( topleft, topleft + size );
+    invalidated = true;
+    ui_manager::invalidate( old_dimensions, false );
+}
+
 void ui_adaptor::on_redraw( const redraw_callback_t &fun )
 {
     redraw_cb = fun;

--- a/src/ui_manager.h
+++ b/src/ui_manager.h
@@ -128,6 +128,11 @@ class ui_adaptor
          **/
         void position( const point &topleft, const point &size );
         /**
+         * like 'position', except topleft and size are given as
+         * pixels in tiled builds and console cells on curses builds
+         **/
+        void position_absolute( const point &topleft, const point &size );
+        /**
          * Set redraw and resize callbacks. The resize callback should
          * call `position` or `position_from_window` to set the size of the UI,
          * and (re-)calculate any UI data that is related to the screen size,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fixing screen artifacts left on the screen after closing keybindings UI"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes: #72065
Reverts: #72501
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Reverted a previous change related to forcing the screen to refresh while an ImGui UI is on the screen. the issue was that the UI window dimensions were wrong according to the ui_adaptor which caused confusion as to when certain parts of the screen should redraw.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Shrink CDDA screen down to, like, 640x480, open the keybindings screen, verify that the UI still redraws properly (responds to input), then close and verify there are no artifacts.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
