### PR TITLE
Unified logging and made it tree top aware

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6404,14 +6404,9 @@ void chop_tree_activity_actor::finish( player_activity &act, Character &who )
             }
         }
     }
-    const tripoint to = pos + 3 * direction.xy() + point( rng( -1, 1 ), rng( -1, 1 ) );
-    std::vector<tripoint> tree = line_to( pos, to, rng( 1, 8 ) );
-    for( const tripoint &elem : tree ) {
-        here.batter( elem, 300, 5 );
-        here.ter_set( elem, ter_t_trunk );
-    }
 
-    here.ter_set( pos, ter_t_stump );
+    here.cut_down_tree( tripoint_bub_ms( pos ), direction.xy() );
+
     who.add_msg_if_player( m_good, _( "You finish chopping down a tree." ) );
     // sound of falling tree
     here.collapse_at( pos, false, true, false );

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -170,6 +170,7 @@ static const ter_str_id ter_t_improvised_shelter( "t_improvised_shelter" );
 static const ter_str_id ter_t_moss( "t_moss" );
 static const ter_str_id ter_t_open_air( "t_open_air" );
 static const ter_str_id ter_t_sand( "t_sand" );
+static const ter_str_id ter_t_stump( "t_stump" );
 static const ter_str_id ter_t_tree_young( "t_tree_young" );
 static const ter_str_id ter_t_treetop( "t_treetop" );
 static const ter_str_id ter_t_trunk( "t_trunk" );
@@ -4829,21 +4830,8 @@ int om_cutdown_trees( const tripoint_abs_omt &omt_tgt, int chance, bool estimate
             }
             // get a random number that is either 1 or -1
             point dir( 3 * ( 2 * rng( 0, 1 ) - 1 ) + rng( -1, 1 ), 3 * rng( -1, 1 ) + rng( -1, 1 ) );
-            tripoint to = p + tripoint( dir, omt_tgt.z() );
-            std::vector<tripoint> tree = line_to( p, to, rng( 1, 8 ) );
-            for( tripoint &elem : tree ) {
-                target_bay.destroy( elem );
-                target_bay.ter_set( elem, ter_t_trunk );
-            }
-            target_bay.ter_set( p, ter_t_dirt );
-            for( int z = p.z + 1; z <= OVERMAP_HEIGHT; z++ ) {
-                const tripoint up_tree = tripoint{ p.xy(), z};
-                if( target_bay.ter( up_tree ) == ter_t_treetop ) {
-                    target_bay.ter_set( up_tree, ter_t_open_air );
-                } else {
-                    break;
-                }
-            }
+
+            target_bay.cut_down_tree( tripoint_omt_ms( p ), dir );
             harvested++;
         }
     }
@@ -4856,7 +4844,7 @@ int om_cutdown_trees( const tripoint_abs_omt &omt_tgt, int chance, bool estimate
     }
     // having cut down the trees, cut the trunks into logs
     for( const tripoint &p : target_bay.points_in_rectangle( mapmin, mapmax ) ) {
-        if( target_bay.ter( p ) == ter_t_trunk ) {
+        if( target_bay.ter( p ) == ter_t_trunk || target_bay.ter( p ) == ter_t_stump ) {
             target_bay.ter_set( p, ter_t_dirt );
             target_bay.spawn_item( p, itype_log, rng( 2, 3 ), 0, calendar::turn );
             harvested++;

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -168,11 +168,9 @@ static const ter_str_id ter_t_grass_long( "t_grass_long" );
 static const ter_str_id ter_t_grass_tall( "t_grass_tall" );
 static const ter_str_id ter_t_improvised_shelter( "t_improvised_shelter" );
 static const ter_str_id ter_t_moss( "t_moss" );
-static const ter_str_id ter_t_open_air( "t_open_air" );
 static const ter_str_id ter_t_sand( "t_sand" );
 static const ter_str_id ter_t_stump( "t_stump" );
 static const ter_str_id ter_t_tree_young( "t_tree_young" );
-static const ter_str_id ter_t_treetop( "t_treetop" );
 static const ter_str_id ter_t_trunk( "t_trunk" );
 
 static const trait_id trait_DEBUG_HS( "DEBUG_HS" );

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -4830,6 +4830,7 @@ int om_cutdown_trees( const tripoint_abs_omt &omt_tgt, int chance, bool estimate
             point dir( 3 * ( 2 * rng( 0, 1 ) - 1 ) + rng( -1, 1 ), 3 * rng( -1, 1 ) + rng( -1, 1 ) );
 
             target_bay.cut_down_tree( tripoint_omt_ms( p ), dir );
+            target_bay.collapse_at( p, true, true, false );
             harvested++;
         }
     }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -8559,23 +8559,10 @@ void map::cut_down_tree( tripoint_bub_ms p, point dir )
         return;
     }
 
-    int tree_height = 1;
+    const bool has_treetop = ter( p ).obj().roof &&
+                             ter( p + tripoint_above ).id() == ter( p ).obj().roof;
 
-    // There are several types of tree tops, but they all have the single support flag, something that is unlikely to be the case if something is
-    // "built" above a tree.
-    if( ter( p ).obj().roof && ter( p + tripoint_above ) != ter_t_open_air &&
-        ter( p + tripoint_above ).obj().has_flag( ter_furn_flag::TFLAG_SINGLE_SUPPORT ) ) {
-        tree_height = 2; // Both indicates the height and the presence of a tree top above.
-    }
-
-    // This code essentially assumes a tree height of 1 or 2, as the line of trunks probably gets
-    // too long if larger.
-    tripoint_bub_ms to = p + ( tree_height + 1 ) * dir + point( rng( -1, 1 ), rng( -1, 1 ) );
-    // If a treetopless tree ends up providing zero trunks, give it one anyway. This will hopefully
-    // stave of potential bug reports about logging resulting in no trunks.
-    if( to == p ) {
-        to = p + dir;
-    }
+    tripoint_bub_ms to = p + 3 * dir + point( rng( -1, 1 ), rng( -1, 1 ) );
 
     // TODO: make line_to type aware.
     std::vector<tripoint> tree = line_to( p.raw(), to.raw(), rng( 1, 8 ) );
@@ -8585,7 +8572,7 @@ void map::cut_down_tree( tripoint_bub_ms p, point dir )
     }
     ter_set( p, ter_t_stump );
 
-    if( tree_height == 2 ) {
+    if( has_treetop ) {
         ter_set( p + tripoint_above, ter_t_open_air );
     }
 }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -8546,7 +8546,6 @@ void map::produce_sap( const tripoint &p, const time_duration &time_since_last_a
     }
 }
 
-// This operation assumes trees have zero or one tree tops above. If that changes the logic has to change.
 void map::cut_down_tree( tripoint_bub_ms p, point dir )
 {
     if( !zlevels ) {
@@ -8559,8 +8558,6 @@ void map::cut_down_tree( tripoint_bub_ms p, point dir )
         return;
     }
 
-    const bool has_treetop = ter( p + tripoint_above ).id() == ter( p ).obj().roof;
-
     tripoint_bub_ms to = p + 3 * dir + point( rng( -1, 1 ), rng( -1, 1 ) );
 
     // TODO: make line_to type aware.
@@ -8570,10 +8567,6 @@ void map::cut_down_tree( tripoint_bub_ms p, point dir )
         ter_set( elem, ter_t_trunk );
     }
     ter_set( p, ter_t_stump );
-
-    if( has_treetop ) {
-        ter_set( p + tripoint_above, ter_t_open_air );
-    }
 }
 
 void map::rad_scorch( const tripoint &p, const time_duration &time_since_last_actualize )

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -8571,7 +8571,13 @@ void map::cut_down_tree( tripoint_bub_ms p, point dir )
 
     // This code essentially assumes a tree height of 1 or 2, as the line of trunks probably gets
     // too long if larger.
-    const tripoint_bub_ms to = p + ( tree_height + 1 ) * dir + point( rng( -1, 1 ), rng( -1, 1 ) );
+    tripoint_bub_ms to = p + ( tree_height + 1 ) * dir + point( rng( -1, 1 ), rng( -1, 1 ) );
+    // If a treetopless tree ends up providing zero trunks, give it one anyway. This will hopefully
+    // stave of potential bug reports about logging resulting in no trunks.
+    if( to == p ) {
+        to = p + dir;
+    }
+
     // TODO: make line_to type aware.
     std::vector<tripoint> tree = line_to( p.raw(), to.raw(), rng( 1, 8 ) );
     for( tripoint &elem : tree ) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -8559,8 +8559,7 @@ void map::cut_down_tree( tripoint_bub_ms p, point dir )
         return;
     }
 
-    const bool has_treetop = ter( p ).obj().roof &&
-                             ter( p + tripoint_above ).id() == ter( p ).obj().roof;
+    const bool has_treetop = ter( p + tripoint_above ).id() == ter( p ).obj().roof;
 
     tripoint_bub_ms to = p + 3 * dir + point( rng( -1, 1 ), rng( -1, 1 ) );
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -188,7 +188,6 @@ static const ter_str_id ter_t_tree_pine( "t_tree_pine" );
 static const ter_str_id ter_t_tree_willow( "t_tree_willow" );
 static const ter_str_id ter_t_tree_willow_harvested( "t_tree_willow_harvested" );
 static const ter_str_id ter_t_tree_young( "t_tree_young" );
-static const ter_str_id ter_t_treetop( "t_treetop" );
 static const ter_str_id ter_t_trunk( "t_trunk" );
 static const ter_str_id ter_t_vat( "t_vat" );
 static const ter_str_id ter_t_wall_glass( "t_wall_glass" );

--- a/src/map.h
+++ b/src/map.h
@@ -1975,6 +1975,13 @@ class map
          * called the last time.
          */
         void produce_sap( const tripoint &p, const time_duration &time_since_last_actualize );
+    public:
+        /**
+        * Removes the tree at 'p' and produces a trunk_yield length line of trunks in the 'dir'
+        * direction from 'p', leaving a stump behind at 'p'.
+        */
+        void cut_down_tree( tripoint_bub_ms p, point dir );
+    protected:
         /**
          * Radiation-related plant (and fungus?) death.
          */
@@ -2399,6 +2406,11 @@ class tinymap : private map
     protected:
         tinymap( int mapsize, bool zlev ) : map( mapsize, zlev ) {};
 
+        // This operation cannot be used with tinymap due to a lack of zlevel support, but are carried through for use by smallmap.
+        void cut_down_tree( tripoint_omt_ms p, point dir ) {
+            map::cut_down_tree( tripoint_bub_ms( p.raw() ), dir );
+        };
+
     public:
         tinymap() : map( 2, false ) {}
         bool inbounds( const tripoint &p ) const override;
@@ -2652,6 +2664,9 @@ class smallmap : public tinymap
 {
     public:
         smallmap() : tinymap( 2, true ) {}
-        void add_roofs();
+
+        void cut_down_tree( tripoint_omt_ms p, point dir ) {
+            tinymap::cut_down_tree( p, dir );
+        };
 };
 #endif // CATA_SRC_MAP_H


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
- Place the tree felling logic in a single operation and use it where logging is performed.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- The unification results in camp logging bashing things on the ground rather than destroying them (bashing is what "manual" logging used).
- Corrected the camp logging to also process the tree stumps. They were simply erased before.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
- Hacked camp logging to log all trees rather than a random number (which always turned out to be small in the test environment) and then looking for levitating tree tops. This is what led to the discovery that there were several different types of treetops.
- Had the PC manually cut a tree with a tree top and verified the tree top was gone afterwards.
- Ordered a companion to cut trees in a logging zone and verified that the tree top was gone. Really redundant, as the code is the same as for the PC cutting.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
It turned out there wasn't really a need for new logic in the tree cutting itself, as collapse_at provides the logic to handle the tree tops. However, this also meant that the faction camp logging needed to use it.

I've kept myself in check and haven't tried to typify stuff, under the assumption that this is considered scope creep, so there's more (or at least different) untyped mess to clean up later.

Note that this PR has been modified to reflect the current status. Thus, talk about yield and some details have changed or been removed.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
