### PR TITLE
Bug fix for swag bags and canvas bags

### DIFF
--- a/data/json/items/armor/storage.json
+++ b/data/json/items/armor/storage.json
@@ -2637,8 +2637,8 @@
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
-        "max_contains_volume": "25 L",
-        "max_contains_weight": "30 kg",
+        "max_contains_volume": "15 L",
+        "max_contains_weight": "15 kg",
         "max_item_length": "60 cm",
         "moves": 300
       }


### PR DESCRIPTION




#### Summary
Bugfixes "Keeps swag-bag limits to canvas bag"


#### Purpose of change

Fixes bug #72857  in where creating a swag bag with a canvas bag increased its  max weight and volume

#### Describe the solution

Changed max weight and volume of swag bag to canvas bag

#### Describe alternatives you've considered



#### Testing



#### Additional context



<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
