### PR TITLE
Automatically learn proficiencies on load if XP is greater than required

### DIFF
--- a/src/proficiency.cpp
+++ b/src/proficiency.cpp
@@ -555,13 +555,6 @@ void proficiency_set::deserialize( const JsonObject &jsobj )
     jsobj.read( "learning", learning );
 }
 
-void proficiency_set::deserialize_legacy( const JsonArray &jo )
-{
-    for( const std::string prof : jo ) {
-        known.insert( proficiency_id( prof ) );
-    }
-}
-
 void learning_proficiency::serialize( JsonOut &jsout ) const
 {
     jsout.start_object();

--- a/src/proficiency.h
+++ b/src/proficiency.h
@@ -156,7 +156,6 @@ class proficiency_set
 
         void serialize( JsonOut &jsout ) const;
         void deserialize( const JsonObject &jsobj );
-        void deserialize_legacy( const JsonArray &jo );
 };
 
 struct learning_proficiency {

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -735,14 +735,7 @@ void Character::load( const JsonObject &data )
     data.read( "healthy_mod", daily_health );
     data.read( "health_tally", health_tally );
 
-    // Remove check after 0.F
-    if( savegame_loading_version >= 30 ) {
-        if( data.has_array( "proficiencies" ) ) {
-            _proficiencies->deserialize_legacy( data.get_array( "proficiencies" ) );
-        } else {
-            data.read( "proficiencies", _proficiencies );
-        }
-    }
+    data.read( "proficiencies", _proficiencies );
 
     //energy
     data.read( "stim", stim );

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -737,6 +737,13 @@ void Character::load( const JsonObject &data )
 
     data.read( "proficiencies", _proficiencies );
 
+    // If the proficiency XP required has changed such that a proficiency is now known
+    for( const proficiency_id &prof : _proficiencies->learning_profs() ) {
+        if( _proficiencies->pct_practiced_time( prof ) >= prof->time_to_learn() ) {
+            _proficiencies->learn( prof );
+        }
+    }
+
     //energy
     data.read( "stim", stim );
     data.read( "stamina", stamina );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
https://github.com/CleverRaven/Cataclysm-DDA/pull/72693#issuecomment-2038352503

#### Describe the solution
Remove old migration code and add a check that learns any proficiencies with >= 100% XP.

#### Testing
Edit a save to make a proficiency have over 100% XP. Load, and the proficiency does not list as over 100% XP, but is instead in the known list.