### PR TITLE
Fix ImGui keybindings screen not allowing the user to scroll the list upon opening

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -656,11 +656,11 @@ void cataimgui::window::clear_filter()
     }
 }
 
-void cataimgui::window::set_filter( const std::string &filter )
-{
-    // doesnt currently work, relies on API only available in newer ImGUi, because I can't have nice things
-    //ImGuiInputTextState* input_state = ImGui::GetInputTextState( p_impl->id );
-    //if( input_state ) {
-    //    input_state->ReloadUserBufAndSelectAll();
-    //}
-}
+//void cataimgui::window::set_filter( const std::string &filter )
+//{
+//    // doesnt currently work, relies on API only available in newer ImGUi, because I can't have nice things
+//    //ImGuiInputTextState* input_state = ImGui::GetInputTextState( p_impl->id );
+//    //if( input_state ) {
+//    //    input_state->ReloadUserBufAndSelectAll();
+//    //}
+//}

--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -599,3 +599,43 @@ cataimgui::bounds cataimgui::window::get_bounds()
 {
     return { -1.f, -1.f, -1.f, -1.f };
 }
+
+class cataimgui::filter_box_impl
+{
+    public:
+        ImGuiID id;
+};
+
+cataimgui::filter_box::filter_box()
+{
+    p_impl = new cataimgui::filter_box_impl();
+    p_impl->id = 0;
+    filter_text_impl[0] = '\0';
+}
+
+cataimgui::filter_box::~filter_box()
+{
+    delete p_impl;
+}
+
+void cataimgui::filter_box::draw()
+{
+    ImGui::InputText( "##FILTERBOX", filter_text_impl, std::extent_v< decltype( filter_text_impl )> );
+    if( !p_impl->id ) {
+        p_impl->id = GImGui->LastItemData.ID;
+    }
+}
+
+std::string cataimgui::filter_box::get_filter()
+{
+    return std::string( filter_text_impl );
+}
+
+void cataimgui::filter_box::set_filter( const std::string &filter )
+{
+    // doesnt currently work, relies on API only available in newer ImGUi, because I can't have nice things
+    //ImGuiInputTextState* input_state = ImGui::GetInputTextState( id );
+    //if( input_state ) {
+    //    input_state->ReloadUserBufAndSelectAll();
+    //}
+}

--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -465,7 +465,7 @@ class cataimgui::window_impl
 class cataimgui::filter_box_impl
 {
     public:
-        char text[255]; // NOLINT(modernize-avoid-c-arrays)
+        std::array<char, 255> text;
         ImGuiID id;
 };
 
@@ -627,9 +627,9 @@ void cataimgui::window::draw_filter( const input_context &ctxt, bool filtering_a
         action_button( "TEXT.CONFIRM", ctxt.get_button_text( "TEXT.CONFIRM", _( "OK" ) ) );
         ImGui::SameLine();
     }
-    ImGui::BeginDisabled( filtering_active );
-    ImGui::InputText( "##FILTERBOX", filter_impl->text,
-                      std::extent_v < decltype( filter_impl->text ) > );
+    ImGui::BeginDisabled( !filtering_active );
+    ImGui::InputText( "##FILTERBOX", filter_impl->text.data(),
+                      filter_impl->text.size() );
     ImGui::EndDisabled();
     if( !filter_impl->id ) {
         filter_impl->id = GImGui->LastItemData.ID;
@@ -639,7 +639,7 @@ void cataimgui::window::draw_filter( const input_context &ctxt, bool filtering_a
 std::string cataimgui::window::get_filter()
 {
     if( filter_impl ) {
-        return std::string( filter_impl->text );
+        return std::string( filter_impl->text.data() );
     } else {
         return std::string();
     }
@@ -655,12 +655,3 @@ void cataimgui::window::clear_filter()
         }
     }
 }
-
-//void cataimgui::window::set_filter( const std::string &filter )
-//{
-//    // doesnt currently work, relies on API only available in newer ImGUi, because I can't have nice things
-//    //ImGuiInputTextState* input_state = ImGui::GetInputTextState( p_impl->id );
-//    //if( input_state ) {
-//    //    input_state->ReloadUserBufAndSelectAll();
-//    //}
-//}

--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -607,15 +607,29 @@ cataimgui::bounds cataimgui::window::get_bounds()
     return { -1.f, -1.f, -1.f, -1.f };
 }
 
-void cataimgui::window::draw_filter_box()
+void cataimgui::window::draw_filter(bool filtering_active)
 {
     if( !filter_impl ) {
         filter_impl = std::make_unique<cataimgui::filter_box_impl>();
         filter_impl->id = 0;
         filter_impl->text[0] = '\0';
     }
+
+    if( !filtering_active ) {
+        action_button( "FILTER", "[/] Set" );
+        ImGui::SameLine();
+        action_button( "RESET_FILTER", "[r] Clear" );
+        ImGui::SameLine();
+    } else {
+        action_button( "QUIT", "[ESC] Cancel" );
+        ImGui::SameLine();
+        action_button( "TEXT.CONFIRM", "[RET] OK" );
+        ImGui::SameLine();
+    }
+    ImGui::BeginDisabled( filtering_active );
     ImGui::InputText( "##FILTERBOX", filter_impl->text,
-                      std::extent_v < decltype( filter_impl->text ) > );
+        std::extent_v < decltype(filter_impl->text) > );
+    ImGui::EndDisabled();
     if( !filter_impl->id ) {
         filter_impl->id = GImGui->LastItemData.ID;
     }

--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -10,6 +10,7 @@
 #include "input.h"
 #include "output.h"
 #include "ui_manager.h"
+#include "input_context.h"
 
 static ImGuiKey cata_key_to_imgui( int cata_key );
 
@@ -607,7 +608,7 @@ cataimgui::bounds cataimgui::window::get_bounds()
     return { -1.f, -1.f, -1.f, -1.f };
 }
 
-void cataimgui::window::draw_filter(bool filtering_active)
+void cataimgui::window::draw_filter( const input_context &ctxt, bool filtering_active )
 {
     if( !filter_impl ) {
         filter_impl = std::make_unique<cataimgui::filter_box_impl>();
@@ -616,19 +617,19 @@ void cataimgui::window::draw_filter(bool filtering_active)
     }
 
     if( !filtering_active ) {
-        action_button( "FILTER", "[/] Set" );
+        action_button( "FILTER", ctxt.get_button_text( "FILTER" ) );
         ImGui::SameLine();
-        action_button( "RESET_FILTER", "[r] Clear" );
+        action_button( "RESET_FILTER", ctxt.get_button_text( "RESET_FILTER" ) );
         ImGui::SameLine();
     } else {
-        action_button( "QUIT", "[ESC] Cancel" );
+        action_button( "QUIT", ctxt.get_button_text( "QUIT", _( "Cancel" ) ) );
         ImGui::SameLine();
-        action_button( "TEXT.CONFIRM", "[RET] OK" );
+        action_button( "TEXT.CONFIRM", ctxt.get_button_text( "TEXT.CONFIRM", _( "OK" ) ) );
         ImGui::SameLine();
     }
     ImGui::BeginDisabled( filtering_active );
     ImGui::InputText( "##FILTERBOX", filter_impl->text,
-        std::extent_v < decltype(filter_impl->text) > );
+                      std::extent_v < decltype( filter_impl->text ) > );
     ImGui::EndDisabled();
     if( !filter_impl->id ) {
         filter_impl->id = GImGui->LastItemData.ID;

--- a/src/cata_imgui.h
+++ b/src/cata_imgui.h
@@ -105,7 +105,6 @@ class window
         size_t str_width_to_pixels( size_t len );
         size_t str_height_to_pixels( size_t len );
         std::string get_filter();
-        //void set_filter( const std::string &filter );
         void clear_filter();
         void mark_resized();
 

--- a/src/cata_imgui.h
+++ b/src/cata_imgui.h
@@ -114,6 +114,18 @@ class window
         virtual void draw_controls() = 0;
 };
 
+class filter_box
+{
+        class filter_box_impl *p_impl;
+        char filter_text_impl[255]; // NOLINT(modernize-avoid-c-arrays)
+    public:
+        filter_box();
+        ~filter_box();
+        void draw();
+        std::string get_filter();
+        void set_filter( const std::string &filter );
+};
+
 #if !(defined(TILES) || defined(WIN32))
 void init_pair( int p, int f, int b );
 void load_colors();

--- a/src/cata_imgui.h
+++ b/src/cata_imgui.h
@@ -78,6 +78,7 @@ void imvec2_to_point( ImVec2 *src, point *dest );
 class window
 {
         std::unique_ptr<class window_impl> p_impl;
+        std::unique_ptr<class filter_box_impl> filter_impl;
         bounds cached_bounds;
     protected:
         explicit window( int window_flags = 0 );
@@ -102,6 +103,9 @@ class window
         size_t get_text_height( const char *text );
         size_t str_width_to_pixels( size_t len );
         size_t str_height_to_pixels( size_t len );
+        std::string get_filter();
+        void set_filter( const std::string &filter );
+        void clear_filter();
         void mark_resized();
 
     protected:
@@ -112,18 +116,7 @@ class window
         std::string button_action;
         virtual bounds get_bounds();
         virtual void draw_controls() = 0;
-};
-
-class filter_box
-{
-        class filter_box_impl *p_impl;
-        char filter_text_impl[255]; // NOLINT(modernize-avoid-c-arrays)
-    public:
-        filter_box();
-        ~filter_box();
-        void draw();
-        std::string get_filter();
-        void set_filter( const std::string &filter );
+        void draw_filter_box();
 };
 
 #if !(defined(TILES) || defined(WIN32))

--- a/src/cata_imgui.h
+++ b/src/cata_imgui.h
@@ -18,6 +18,7 @@ struct item_info_data;
 struct point;
 class ImVec2;
 class Font;
+class input_context;
 
 namespace cataimgui
 {
@@ -116,7 +117,7 @@ class window
         std::string button_action;
         virtual bounds get_bounds();
         virtual void draw_controls() = 0;
-        void draw_filter(bool filtering_active);
+        void draw_filter( const input_context &ctxt, bool filtering_active );
 };
 
 #if !(defined(TILES) || defined(WIN32))

--- a/src/cata_imgui.h
+++ b/src/cata_imgui.h
@@ -105,7 +105,7 @@ class window
         size_t str_width_to_pixels( size_t len );
         size_t str_height_to_pixels( size_t len );
         std::string get_filter();
-        void set_filter( const std::string &filter );
+        //void set_filter( const std::string &filter );
         void clear_filter();
         void mark_resized();
 

--- a/src/cata_imgui.h
+++ b/src/cata_imgui.h
@@ -116,7 +116,7 @@ class window
         std::string button_action;
         virtual bounds get_bounds();
         virtual void draw_controls() = 0;
-        void draw_filter_box();
+        void draw_filter(bool filtering_active);
 };
 
 #if !(defined(TILES) || defined(WIN32))

--- a/src/input_context.cpp
+++ b/src/input_context.cpp
@@ -35,7 +35,7 @@
 #include "imgui/imgui.h"
 
 enum class kb_menu_status {
-    remove, reset, add, add_global, execute, show
+    remove, reset, add, add_global, execute, show, filter
 };
 
 class keybindings_ui : public cataimgui::window
@@ -48,8 +48,8 @@ class keybindings_ui : public cataimgui::window
         const nc_color unbound_key = c_light_red;
         const nc_color h_unbound_key = h_light_red;
         input_context *ctxt;
-        char filter_text_impl[255]; // NOLINT(modernize-avoid-c-arrays)
     public:
+        cataimgui::filter_box filter_box;
         // current status: adding/removing/reseting/executing/showing keybindings
         kb_menu_status status = kb_menu_status::show, last_status = kb_menu_status::execute;
 
@@ -61,7 +61,7 @@ class keybindings_ui : public cataimgui::window
         std::string hotkeys;
         int highlight_row_index = -1;
         size_t scroll_offset = 0;
-        std::string filter_text;
+        //std::string filter_text;
         keybindings_ui( bool permit_execute_action, input_context *parent );
         void init();
 
@@ -608,7 +608,6 @@ static const std::map<fallback_action, int> fallback_keys = {
 keybindings_ui::keybindings_ui( bool permit_execute_action,
                                 input_context *parent ) : cataimgui::window( "KEYBINDINGS", ImGuiWindowFlags_NoNav )
 {
-    filter_text_impl[0] = '\0';
     this->ctxt = parent;
 
     legend.push_back( colorize( _( "Unbound keys" ), unbound_key ) );
@@ -655,23 +654,26 @@ void keybindings_ui::draw_controls()
         ImGui::SetCursorPosX( str_width_to_pixels( width ) - ( get_text_width(
                                   button_text_no_color ) +
                               ( ImGui::GetStyle().FramePadding.x * 2 ) + ImGui::GetStyle().ItemSpacing.x ) );
+        ImGui::BeginDisabled( status == kb_menu_status::filter );
         action_button( buttons[legend_idx].first, button_text_no_color );
+        ImGui::EndDisabled();
     }
     for( ; legend_idx < legend.size(); legend_idx++ ) {
         draw_colored_text( legend[legend_idx], c_white );
     }
-    if( last_status != status && status == kb_menu_status::show ) {
+    if( last_status != status && status == kb_menu_status::filter ) {
         ImGui::SetKeyboardFocusHere( 0 );
     }
-    strncpy( filter_text_impl, filter_text.c_str(), filter_text.length() );
-    ImGui::InputText( "##NOLABEL", filter_text_impl, std::extent_v< decltype( filter_text_impl )>,
-                      status == kb_menu_status::show ? ImGuiInputTextFlags_None : ImGuiInputTextFlags_ReadOnly );
-    filter_text.assign( filter_text_impl );
+    ImGui::BeginDisabled( status != kb_menu_status::filter );
+    filter_box.draw();
+    ImGui::EndDisabled();
     ImGui::Separator();
+
+    if( last_status != status && status == kb_menu_status::show ) {
+        ImGui::SetNextWindowFocus();
+    }
     if( ImGui::BeginTable( "KB_KEYS", 2, ImGuiTableFlags_ScrollY ) ) {
-        if( last_status != status && status != kb_menu_status::show ) {
-            ImGui::SetKeyboardFocusHere( 0 );
-        }
+
         ImGui::TableSetupColumn( "Action Name",
                                  ImGuiTableColumnFlags_WidthStretch | ImGuiTableColumnFlags_NoSort );
         float keys_col_width = str_width_to_pixels( width ) - str_width_to_pixels( TERMX >= 100 ? 62 : 52 );
@@ -1303,6 +1305,8 @@ action_id input_context::display_menu_imgui( const bool permit_execute_action )
     ctxt.register_action( "PAGE_DOWN" );
     ctxt.register_action( "END" );
     ctxt.register_action( "HOME" );
+    ctxt.register_action( "FILTER" );
+    ctxt.register_action( "RESET_FILTER" );
     ctxt.register_action( "TEXT.INPUT_FROM_FILE" );
     if( permit_execute_action ) {
         ctxt.register_action( "EXECUTE" );
@@ -1357,13 +1361,19 @@ action_id input_context::display_menu_imgui( const bool permit_execute_action )
         }
 
         kb_menu.filtered_registered_actions = filter_strings_by_phrase( org_registered_actions,
-                                              kb_menu.filter_text );
+                                              kb_menu.filter_box.get_filter() );
 
         // In addition to the modifiable hotkeys, we also check for hardcoded
         // keys, e.g. '+', '-', '=', '.' in order to prevent the user from
         // entering an unrecoverable state.
-        if( action == "ADD_LOCAL"
-            || raw_input_char == fallback_keys.at( fallback_action::add_local ) ) {
+        if( kb_menu.status == kb_menu_status::filter ) {
+            if( action == "QUIT" ) {
+                kb_menu.filter_box.set_filter( "" );
+                kb_menu.status = kb_menu_status::show;
+            } else if( action == "TEXT.CONFIRM" ) {
+                kb_menu.status = kb_menu_status::show;
+            }
+        } else if( action == "ADD_LOCAL" ) {
             if( !kb_menu.filtered_registered_actions.empty() ) {
                 kb_menu.status = kb_menu_status::add;
             }
@@ -1391,11 +1401,15 @@ action_id input_context::display_menu_imgui( const bool permit_execute_action )
         } else if( action == "PAGE_UP" || action == "PAGE_DOWN" || action == "HOME" || action == "END" ) {
             continue; // do nothing - on tiles version for some reason this counts as pressing various alphabet keys
         } else if( action == "TEXT.CLEAR" ) {
-            kb_menu.filter_text.assign( "" );
+            kb_menu.filter_box.set_filter( "" );
             kb_menu.filtered_registered_actions = filter_strings_by_phrase( org_registered_actions,
                                                   "" );
         } else if( !kb_menu.get_is_open() ) {
             break;
+        } else if( action == "FILTER" ) {
+            kb_menu.status = kb_menu_status::filter;
+        } else if( action == "RESET_FILTER" ) {
+            kb_menu.filter_box.set_filter( "" );
         } else if( action == "QUIT" ) {
             if( kb_menu.status != kb_menu_status::show ) {
                 kb_menu.status = kb_menu_status::show;
@@ -1403,7 +1417,7 @@ action_id input_context::display_menu_imgui( const bool permit_execute_action )
                 break;
             }
         } else if( action == "TEXT.INPUT_FROM_FILE" ) {
-            kb_menu.filter_text += get_input_string_from_file();
+            kb_menu.filter_box.set_filter( kb_menu.filter_box.get_filter() + get_input_string_from_file() );
         } else if( action == "HELP_KEYBINDINGS" ) {
             // update available hotkeys in case they've changed
             kb_menu.hotkeys = ctxt.get_available_single_char_hotkeys( display_help_hotkeys );

--- a/src/input_context.cpp
+++ b/src/input_context.cpp
@@ -698,10 +698,10 @@ void keybindings_ui::draw_controls()
     for( ; legend_idx < legend.size(); legend_idx++ ) {
         draw_colored_text( legend[legend_idx], c_white );
     }
-    if( last_status != status && status == kb_menu_status::filter ) {
-        ImGui::SetKeyboardFocusHere( 0 );
-    }
     draw_filter( *ctxt, status == kb_menu_status::filter );
+    if( last_status != status && status == kb_menu_status::filter ) {
+        ImGui::SetKeyboardFocusHere( -1 );
+    }
     ImGui::Separator();
 
     if( last_status != status && status == kb_menu_status::show ) {
@@ -1452,9 +1452,6 @@ action_id input_context::display_menu_imgui( const bool permit_execute_action )
             } else {
                 break;
             }
-        } else if( action == "TEXT.INPUT_FROM_FILE" ) {
-            //kb_menu.set_filter( kb_menu.get_filter() + get_input_string_from_file() );
-            continue;
         } else if( action == "HELP_KEYBINDINGS" ) {
             // update available hotkeys in case they've changed
             kb_menu.hotkeys = ctxt.get_available_single_char_hotkeys( display_help_hotkeys );

--- a/src/input_context.cpp
+++ b/src/input_context.cpp
@@ -1453,7 +1453,8 @@ action_id input_context::display_menu_imgui( const bool permit_execute_action )
                 break;
             }
         } else if( action == "TEXT.INPUT_FROM_FILE" ) {
-            kb_menu.set_filter( kb_menu.get_filter() + get_input_string_from_file() );
+            //kb_menu.set_filter( kb_menu.get_filter() + get_input_string_from_file() );
+            continue;
         } else if( action == "HELP_KEYBINDINGS" ) {
             // update available hotkeys in case they've changed
             kb_menu.hotkeys = ctxt.get_available_single_char_hotkeys( display_help_hotkeys );

--- a/src/input_context.cpp
+++ b/src/input_context.cpp
@@ -663,20 +663,7 @@ void keybindings_ui::draw_controls()
     if( last_status != status && status == kb_menu_status::filter ) {
         ImGui::SetKeyboardFocusHere( 0 );
     }
-    if( status != kb_menu_status::filter ) {
-        action_button( "FILTER", "[/] Set" );
-        ImGui::SameLine();
-        action_button( "RESET_FILTER", "[r] Clear" );
-        ImGui::SameLine();
-    } else {
-        action_button( "QUIT", "[ESC] Cancel" );
-        ImGui::SameLine();
-        action_button( "TEXT.CONFIRM", "[RET] OK" );
-        ImGui::SameLine();
-    }
-    ImGui::BeginDisabled( status != kb_menu_status::filter );
-    draw_filter_box();
-    ImGui::EndDisabled();
+    draw_filter(status == kb_menu_status::filter);
     ImGui::Separator();
 
     if( last_status != status && status == kb_menu_status::show ) {

--- a/src/input_context.cpp
+++ b/src/input_context.cpp
@@ -320,6 +320,44 @@ std::string input_context::get_desc( const std::string &action_descriptor,
     return rval;
 }
 
+
+std::string input_context::get_button_text( const std::string &action_descriptor ) const
+{
+    std::string action_name = get_action_name( action_descriptor );
+    if( action_name.empty() ) {
+        action_name = action_descriptor;
+    }
+    return get_button_text( action_descriptor, action_name );
+}
+
+std::string input_context::get_button_text( const std::string &action_descriptor,
+        const std::string &action_text ) const
+{
+    if( action_descriptor == "ANY_INPUT" ) {
+        return ""; // what sort of crazy button would this be?
+    }
+
+    bool is_local = false;
+    const std::vector<input_event> &events = inp_mngr.get_input_for_action( action_descriptor,
+            category, &is_local );
+    if( events.empty() ) {
+        return action_text;
+    }
+
+    std::vector<input_event> inputs_to_show;
+    for( const input_event &event : events ) {
+        if( is_event_type_enabled( event.type ) ) {
+            inputs_to_show.push_back( event );
+        }
+    }
+
+    if( inputs_to_show.empty() ) {
+        return action_text;
+    } else {
+        return string_format( "[%s] %s", inputs_to_show[0].long_description(), action_text );
+    }
+}
+
 std::string input_context::get_desc(
     const std::string &action_descriptor,
     const std::string &text,
@@ -663,7 +701,7 @@ void keybindings_ui::draw_controls()
     if( last_status != status && status == kb_menu_status::filter ) {
         ImGui::SetKeyboardFocusHere( 0 );
     }
-    draw_filter(status == kb_menu_status::filter);
+    draw_filter( *ctxt, status == kb_menu_status::filter );
     ImGui::Separator();
 
     if( last_status != status && status == kb_menu_status::show ) {

--- a/src/input_context.h
+++ b/src/input_context.h
@@ -223,6 +223,27 @@ class input_context
                               const input_event_filter &evt_filter = allow_all_keys ) const;
 
         /**
+         * Get a description for the action parameter along with a printable hotkey
+         * for the description in the format [%s] %s
+         *
+         * @param action_descriptor The action descriptor for which to return
+         *                          a description of the bound keys.
+         */
+        std::string get_button_text( const std::string &action_descriptor ) const;
+
+        /**
+         * Get a description for the action parameter along with a printable hotkey
+         * for the description in the format [%s] %s
+         *
+         * @param action_descriptor The action descriptor for which to return
+         *                          a description of the bound keys.
+         *
+         * @param action_text The human readable description of the action.
+         */
+        std::string get_button_text( const std::string &action_descriptor,
+                                     const std::string &action_text ) const;
+
+        /**
          * Get a description based on `text`. If a bound key for `action_descriptor`
          * satisfying `evt_filter` is contained in `text`, surround the key with
          * brackets and change the case if necessary (e.g. "(Y)es"). Otherwise


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fixes ImGui keybindings UI not allowing the user to scroll"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes: #72598 
Fixes: #72066
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Implemented actions in the keybindings screen to switch to "filtering" mode and back. This breaks from the original behavior of the screen because ImGui does not behave well with having the user use the arrow keys to scroll one part of the screen while also having a text field accepting text input on another part of the screen. Only one control can truly have "focus" at a time and switching focus between elements in order to have user input apply in both places like the old screen, simply is not possible.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Modifying ImGui itself to allow programmatic focusing of elements be truly "seamless" so when a user presses an arrow key, have the scrollable element focus, or when they press an alphanumeric key, focus the text field. This is currently possible but at the cost of ImGui "eating" the input that the user makes that causes the focus switch. There is simply no way around it.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Turns out that modifying the text passed to the InputText field programmatically is a very annoying operation, and possibly requires a new version of ImGui in order to work properly.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
