### PR TITLE
Bypass prereq category check for overlapping mod content

### DIFF
--- a/data/mods/TEST_DATA/mutations.json
+++ b/data/mods/TEST_DATA/mutations.json
@@ -8,6 +8,7 @@
     "dummy": true,
     "category": [ "HUMAN" ],
     "cancels": [
+      "TEST_CONSISTENCY_CHECK",
       "TEST_ENCH_MUTATION",
       "TEST_GOOD1",
       "TEST_GOOD2",

--- a/data/mods/TEST_DATA/mutations.json
+++ b/data/mods/TEST_DATA/mutations.json
@@ -39,6 +39,15 @@
   },
   {
     "type": "mutation",
+    "id": "TEST_CONSISTENCY_CHECK",
+    "name": "Dummy Test Trait",
+    "points": 0,
+    "description": "Test trait to trip the consistency check: it shouldn't cause a load error since it overwrites a basegame trait.",
+    "prereqs": [ "WINGS_STUB" ],
+    "category": [ "INST_TEST" ]
+  },
+  {
+    "type": "mutation",
     "id": "TEST_TRIGGER",
     "name": { "str": "OR Test trigger" },
     "points": 1,

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -701,13 +701,15 @@ void mutation_branch::check_consistency()
             }
         }
 
+        // Suppress this check for trait/prereq combos from different mod sources
         for( const mutation_category_id &cat_id : mdata.category ) {
             if( !mdata.prereqs.empty() ) {
                 bool found = false;
                 for( const trait_id &prereq_id : mdata.prereqs ) {
                     const mutation_branch &prereq = prereq_id.obj();
                     found = found ||
-                            std::find( prereq.category.begin(), prereq.category.end(), cat_id ) != prereq.category.end();
+                            std::find( prereq.category.begin(), prereq.category.end(), cat_id ) != prereq.category.end() ||
+                            mdata.src.end()->second != prereq.src.end()->second;
                 }
                 if( !found ) {
                     debugmsg( "mutation %s is in category %s but none of its slot 1 prereqs have this category",
@@ -720,7 +722,8 @@ void mutation_branch::check_consistency()
                 for( const trait_id &prereq_id : mdata.prereqs2 ) {
                     const mutation_branch &prereq = prereq_id.obj();
                     found = found ||
-                            std::find( prereq.category.begin(), prereq.category.end(), cat_id ) != prereq.category.end();
+                            std::find( prereq.category.begin(), prereq.category.end(), cat_id ) != prereq.category.end() ||
+                            mdata.src.end()->second != prereq.src.end()->second;
                 }
                 if( !found ) {
                     debugmsg( "mutation %s is in category %s but none of its slot 2 prereqs have this category",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
The mutatation consistency check for in-category prereqs consistently trips over basegame traits that are modified by multiple mods in an inconsistent way, especially in the context of our `yolo what if all the mods` test run.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Check if the loaded trait and the prereq come from the same mod source, only trip the onload warning if so.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
Add an escape route for out of category prereqs in the case of differing sources, but I couldn't find a trivial way to do that without bloating mutate_towards even more.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
Added a dummy mutation to TEST_DATA requiring a test mod but of a different still-test category, error triggers.
Replaced the category with a basegame category, error is suppressed.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
Note that this only suppresses the on-load error to allow for unit test runs, when this happens ingame there is still a red warning letting you know you're cheating on your main primer.

With the explosion of system-capable JSON content mod (inter)compatibility will need a look down the line, but this is a quick fix to make me not have to fiddle with goddamn ravenfolk wings every time I touch limb stuff.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
