### PR TITLE
Fix companions ceasing activities when PC enter Z level

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3060,6 +3060,13 @@ void Character::remove_mission_items( int mission_id )
 void Character::on_move( const tripoint_abs_ms &old_pos )
 {
     Creature::on_move( old_pos );
+    // Ugly to compare a tripoint_bub_ms with a tripoint_abs_ms, but the 'z' component
+    // is the same regardless of the x/y reference point.
+    if( this->pos_bub().z() != old_pos.z() ) {
+        // Make sure caches are rebuilt in a timely manner to ensure companions aren't
+        // caught in the "dark" because the caches aren't updated on their next move.
+        get_map().build_map_cache( this->pos_bub().z() );
+    }
     // In case we've moved out of range of lifting assist.
     if( using_lifting_assist ) {
         invalidate_weight_carried_cache();

--- a/tests/char_sight_test.cpp
+++ b/tests/char_sight_test.cpp
@@ -86,12 +86,10 @@ TEST_CASE( "light_and_fine_detail_vision_mod", "[character][sight][light][vision
 
     SECTION( "midnight with a new moon" ) {
         // yes, surprisingly, we need to test for this
-        tripoint const z_shift = GENERATE( tripoint_above, tripoint_zero );
-        dummy.setpos( dummy.pos() + z_shift );
-        CAPTURE( z_shift );
-
         calendar::turn = calendar::turn_zero;
-        here.build_map_cache( 0, false );
+        tripoint const z_shift = GENERATE( tripoint_above, tripoint_zero );
+        dummy.setpos( dummy.pos() + z_shift ); // This implicitly rebuilds the light map.
+        CAPTURE( z_shift );
         REQUIRE_FALSE( g->is_in_sunlight( dummy.pos() ) );
         REQUIRE( here.ambient_light_at( dummy.pos() ) == Approx( LIGHT_AMBIENT_MINIMAL ) );
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #72792, i.e. Companion crafting aborted whe PC enters the companion's Z level.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add a call to rebuild map caches when the PC changes Z level.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Using a save suffering from the bug report issue and verify it still happens when going down the stairs and then up again.
Modify the code and verify there is no visible effect on the crafting companion (still active) after having returned to the same Z level.
Waiting and verifying that the progress of a pair of heavy survivor boots in progress craft increases from 49% to 50% after waiting.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

The changes to the tests requires some explanations:
- The reason the test failed is that the implicit recalculation of the light map due to the change of Z levels was performed BEFORE the time was changed, so it was still daytime.
- The test probably didn't test anything useful, as it updated the light map for Z level 0, while 'dummy' was shifted up to Z level 1, whose light map remained unchanged (despite the claim that all Z levels are affected, only the specified Z level light map is updated, which presumably is why there is a Z level parameter to the call).
- I have no idea why the code wants to change the Z level of 'dummy'. I retained that since there might be some reason for it. However, as far as I can tell, you can remove the Z level juggling and restore the call to build_map_cache (as it's no longer called implicitly), keeping it a Z level 0. Testing that caused the test to pass.

This is presumably caused by the solution not to keep lighting information up to date on all Z levels for performance reasons, coupled with a delay in the update of the lighting conditions of the Z level the PC reaches to after the companions have evaluated their light levels for the turn. Companions are kept unaffected by the light level while the PC is on a different Z level by code that explicitly ignores it due to the performance issues involved in keeping it up to date.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
