### PR TITLE
Player snaps back if teleport fails

### DIFF
--- a/src/game.h
+++ b/src/game.h
@@ -948,6 +948,7 @@ class game
         void insert_item( drop_locations &targets );
         // Places the player at the specified point; hurts feet, lists items etc.
         point place_player( const tripoint &dest, bool quick = false );
+        void place_player_overmap( const tripoint_abs_ms &ms_dest, bool move_player = true );
         void place_player_overmap( const tripoint_abs_omt &om_dest, bool move_player = true );
         void perhaps_add_random_npc( bool ignore_spawn_timers_and_rates );
         static void display_om_pathfinding_progress( size_t open_set, size_t known_size );

--- a/tests/water_movement_test.cpp
+++ b/tests/water_movement_test.cpp
@@ -261,6 +261,8 @@ struct swim_scenario {
 static int swimming_steps( avatar &swimmer )
 {
     map &here = get_map();
+    // This shouldn't work.
+    avatar_action::move( swimmer, here, tripoint_west );
     const tripoint left = swimmer.pos();
     const tripoint right = left + tripoint_east;
     int steps = 0;

--- a/tests/water_movement_test.cpp
+++ b/tests/water_movement_test.cpp
@@ -274,10 +274,10 @@ static int swimming_steps( avatar &swimmer )
     while( swimmer.get_stamina() > 0 && !swimmer.has_effect( effect_winded ) && steps < STOP_STEPS ) {
         if( steps % 2 == 0 ) {
             REQUIRE( swimmer.pos() == left );
-            REQUIRE( avatar_action::move( swimmer, here, tripoint_east ) );
+            REQUIRE( avatar_action::move( swimmer, here, swimmer.pos() + tripoint_east ) );
         } else {
             REQUIRE( swimmer.pos() == right );
-            REQUIRE( avatar_action::move( swimmer, here, tripoint_west ) );
+            REQUIRE( avatar_action::move( swimmer, here, swimmer.pos() + tripoint_west ) );
         }
         ++steps;
         REQUIRE( swimmer.get_moves() < last_moves );

--- a/tests/water_movement_test.cpp
+++ b/tests/water_movement_test.cpp
@@ -262,9 +262,13 @@ static int swimming_steps( avatar &swimmer )
 {
     map &here = get_map();
     // This shouldn't work.
-    avatar_action::move( swimmer, here, tripoint_west );
+    CAPTURE( swimmer.pos() );
+    avatar_action::move( swimmer, here, swimmer.pos() + tripoint_west );
+    CAPTURE( swimmer.pos() );
     const tripoint left = swimmer.pos();
     const tripoint right = left + tripoint_east;
+    CAPTURE( left );
+    CAPTURE( right );
     int steps = 0;
     constexpr int STOP_STEPS = 9000;
     int last_moves = swimmer.get_speed();
@@ -274,10 +278,10 @@ static int swimming_steps( avatar &swimmer )
     while( swimmer.get_stamina() > 0 && !swimmer.has_effect( effect_winded ) && steps < STOP_STEPS ) {
         if( steps % 2 == 0 ) {
             REQUIRE( swimmer.pos() == left );
-            REQUIRE( avatar_action::move( swimmer, here, swimmer.pos() + tripoint_east ) );
+            REQUIRE( avatar_action::move( swimmer, here, right ) );
         } else {
             REQUIRE( swimmer.pos() == right );
-            REQUIRE( avatar_action::move( swimmer, here, swimmer.pos() + tripoint_west ) );
+            REQUIRE( avatar_action::move( swimmer, here, left ) );
         }
         ++steps;
         REQUIRE( swimmer.get_moves() < last_moves );

--- a/tests/water_movement_test.cpp
+++ b/tests/water_movement_test.cpp
@@ -144,6 +144,7 @@ TEST_CASE( "avatar_diving", "[diving]" )
 
     // Put us back at 0. We shouldn't have to do this but other tests are
     // making assumptions about what z-level they're on.
+    dummy.setpos( test_origin );
     g->vertical_shift( 0 );
 }
 

--- a/tests/water_movement_test.cpp
+++ b/tests/water_movement_test.cpp
@@ -118,7 +118,7 @@ TEST_CASE( "avatar_diving", "[diving]" )
 
     GIVEN( "avatar is underwater at z-2" ) {
         dummy.set_underwater( true );
-        dummy.setpos( test_origin + tripoint( 0, 0, -2 ) );
+        dummy.setpos( test_origin );
         g->vertical_shift( -2 );
 
         WHEN( "avatar dives down" ) {
@@ -144,7 +144,6 @@ TEST_CASE( "avatar_diving", "[diving]" )
 
     // Put us back at 0. We shouldn't have to do this but other tests are
     // making assumptions about what z-level they're on.
-    dummy.setpos( test_origin );
     g->vertical_shift( 0 );
 }
 

--- a/tests/water_movement_test.cpp
+++ b/tests/water_movement_test.cpp
@@ -144,7 +144,7 @@ TEST_CASE( "avatar_diving", "[diving]" )
 
     // Put us back at 0. We shouldn't have to do this but other tests are
     // making assumptions about what z-level they're on.
-    dummy.setpos( test_origin );
+    g->vertical_shift( 0 );
 }
 
 static const efftype_id effect_winded( "winded" );

--- a/tests/water_movement_test.cpp
+++ b/tests/water_movement_test.cpp
@@ -144,7 +144,7 @@ TEST_CASE( "avatar_diving", "[diving]" )
 
     // Put us back at 0. We shouldn't have to do this but other tests are
     // making assumptions about what z-level they're on.
-    g->vertical_shift( 0 );
+    dummy.setpos( test_origin );
 }
 
 static const efftype_id effect_winded( "winded" );
@@ -905,6 +905,7 @@ static std::map<std::string, swim_result> expected_results = {
 
 TEST_CASE( "check_swim_move_cost_and_distance_values", "[swimming][slow]" )
 {
+    clear_avatar();
     setup_test_lake();
 
     avatar &dummy = get_avatar();


### PR DESCRIPTION
#### Summary
Bugfixes "Additional code safety if player's long-range teleport fails"

#### Purpose of change
* Closes #54088

#### Describe the solution
Check the teleport succeeded by comparing the player's actual coordinates before to after. If they are the same, the teleport has failed somehow. Run map update again to shift all the coordinates back. Re-run the function to make sure we safely unload and then reload the map.

#### Describe alternatives you've considered


#### Testing
Video depicts an attempted teleport to a modified art_gallery which is packed with every square containing a monster.

https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/b282fffa-f171-4858-abef-45247bdbde82


#### Additional context

