### PR TITLE
Debug option to write file with list of cities located on current overmap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -234,6 +234,7 @@ Xcode/
 /tests/pch/tests-pch.hpp.pch
 /tests/catch/catch.hpp.gch
 /tests/catch/catch.hpp.pch
+cities.output
 weather.output
 
 # bundler local directories and files for jekyll site

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -244,6 +244,7 @@ std::string enum_to_string<debug_menu::debug_menu_index>( debug_menu::debug_menu
 		case debug_menu::debug_menu_index::NORMALIZE_BODY_STAT: return "NORMALIZE_BODY_STAT";
 		case debug_menu::debug_menu_index::SIX_MILLION_DOLLAR_SURVIVOR: return "SIX_MILLION_DOLLAR_SURVIVOR";
 		case debug_menu::debug_menu_index::EDIT_FACTION: return "EDIT_FACTION";
+		case debug_menu::debug_menu_index::WRITE_CITY_LIST: return "WRITE_CITY_LIST";
         // *INDENT-ON*
         case debug_menu::debug_menu_index::last:
             break;
@@ -491,6 +492,7 @@ static int info_uilist( bool display_all_entries = true )
             { uilist_entry( debug_menu_index::EDIT_GLOBAL_VARS, true, 'a', _( "Edit global v(a)rs" ) ) },
             { uilist_entry( debug_menu_index::TEST_MAP_EXTRA_DISTRIBUTION, true, 'e', _( "Test map extra list" ) ) },
             { uilist_entry( debug_menu_index::GENERATE_EFFECT_LIST, true, 'L', _( "Generate effect list" ) ) },
+            { uilist_entry( debug_menu_index::WRITE_CITY_LIST, true, 'C', _( "Write city list to cities.output" ) ) },
         };
         uilist_initializer.insert( uilist_initializer.begin(), debug_only_options.begin(),
                                    debug_only_options.end() );
@@ -3733,6 +3735,22 @@ void debug()
         case debug_menu_index::EDIT_FACTION:
             faction_edit_menu();
             break;
+
+        case debug_menu_index::WRITE_CITY_LIST: {
+            write_to_file( "cities.output", [&]( std::ostream & testfile ) {
+                overmap &cur_om = g->get_cur_om();
+                testfile << "name;size;pos_om;pos" << std::endl;
+                for( const city &c : cur_om.cities ) {
+                    testfile << c.name << ";"
+                             << c.size << ";"
+                             << c.pos_om.to_string() << ";"
+                             << c.pos.to_string()
+                             << std::endl;
+                }
+
+            }, "city_list" );
+            popup( string_format( _( "city list written to cities.output" ) ) );
+        }
 
         case debug_menu_index::last:
             return;

--- a/src/debug_menu.h
+++ b/src/debug_menu.h
@@ -104,6 +104,7 @@ enum class debug_menu_index : int {
     NORMALIZE_BODY_STAT,
     SIX_MILLION_DOLLAR_SURVIVOR,
     EDIT_FACTION,
+    WRITE_CITY_LIST,
     last
 };
 

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -2136,7 +2136,7 @@ void ui::omap::setup_cities_menu( uilist &cities_menu, std::vector<city> &cities
         cities_menu.desc_enabled = true;
         cities_menu.title = _( "Select a starting city" );
         for( const city &c : cities_container ) {
-            uilist_entry entry( c.database_id, true, -1, c.name,
+            uilist_entry entry( c.database_id, true, -1, string_format( _( "%s (size: %d)" ), c.name, c.size ),
                                 string_format(
                                     _( "Location: <color_white>%s</color>:<color_white>%s</color>" ),
                                     c.pos_om.to_string(), c.pos.to_string() ),


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fixes #72905

#### Testing

Use "Write city list to cities.output" option in debug menu and verify generated `cities.output` file.

#### Additional context

Debug option:

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/16213433/79344ab9-c391-4dbb-ac63-1602c19f7bcd)

Example of the `cities.output` file:

```
name;size;pos_om;pos
Prescott;4;(1,0);(115,16)
Mattapoisett;5;(1,0);(28,120)
Old Town;4;(1,0);(136,176)
Wells;2;(1,0);(92,11)
Byron;10;(1,0);(71,72)
Dudley;4;(1,0);(90,150)
Caratunk;2;(1,0);(16,101)
Templeton;4;(1,0);(146,26)
Jackson;2;(1,0);(82,123)
```

City sizes in city menu:

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/16213433/9aa88f5f-78bc-41ee-a808-dab5d775fc35)
