### PR TITLE
Don't crash when forest mapgen requests groundcover from a biome with no groundcover

### DIFF
--- a/src/mapgen_functions.cpp
+++ b/src/mapgen_functions.cpp
@@ -932,7 +932,7 @@ void mapgen_forest( mapgendata &dat )
     // In order to feather (blend) this overmap tile with adjacent ones, the general composition thereof must be known.
     // This can be calculated once from dat.t_nesw, and stored here:
     std::array<const forest_biome *, 8> adjacent_biomes;
-    for( int d = 0; d < 7; d++ ) {
+    for( int d = 0; d <= 7; d++ ) {
         auto lookup = dat.region.forest_composition.biomes.find( dat.t_nesw[d]->get_type_id() );
         if( lookup != dat.region.forest_composition.biomes.end() ) {
             adjacent_biomes[d] = &( lookup->second );
@@ -1187,7 +1187,12 @@ void mapgen_forest( mapgendata &dat )
                 return *dat.region.default_groundcover.pick();
             default:
                 if( adjacent_biomes[feather_selection] != nullptr ) {
-                    return *adjacent_biomes[feather_selection]->groundcover.pick();
+                    const ter_id *cover = adjacent_biomes[feather_selection]->groundcover.pick();
+                    if( cover ) {
+                        return *cover;
+                    }
+                    // Adjacent biome has no groundcover, use the region default.
+                    return *dat.region.default_groundcover.pick();
                 } else {
                     return *dat.region.default_groundcover.pick();
                 }

--- a/src/regional_settings.cpp
+++ b/src/regional_settings.cpp
@@ -172,19 +172,29 @@ static void load_forest_mapgen_settings( const JsonObject &jo,
                 if( forest_biome_ter_keys.empty() ) {
                     forest_biome_jo.throw_error( "Biome is not associated with any terrains." );
                 }
-                std::string first_ter = forest_biome_ter_keys.get_string( 0 );
-                load_forest_biome( forest_biome_jo, forest_mapgen_settings.unfinalized_biomes[first_ter],
-                                   overlay );
-                for( size_t biome_ter_idx = 1; biome_ter_idx < forest_biome_ter_keys.size(); biome_ter_idx++ ) {
+                std::string default_ter_name = member.name();
+                auto default_ter_it = forest_mapgen_settings.unfinalized_biomes.find( default_ter_name );
+                if( default_ter_it == forest_mapgen_settings.unfinalized_biomes.end() ) {
+                    if( overlay ) {
+                        forest_biome_jo.throw_error( "Terrain " + default_ter_name +
+                                                     " is not defined, cannot be used for forest biome." );
+                    }
+                    default_ter_it = forest_mapgen_settings.unfinalized_biomes.emplace( default_ter_name, forest_biome{} ).first;
+                }
+                forest_biome &default_ter = default_ter_it->second;
+                load_forest_biome( forest_biome_jo, default_ter, overlay );
+                for( size_t biome_ter_idx = 0; biome_ter_idx < forest_biome_ter_keys.size(); biome_ter_idx++ ) {
+                    std::string biome_ter_name = forest_biome_ter_keys.get_string( biome_ter_idx );
+                    if( biome_ter_name == default_ter_name ) {
+                        continue;
+                    }
                     forest_mapgen_settings.unfinalized_biomes.insert( std::pair<std::string, forest_biome>
-                            ( forest_biome_ter_keys.get_string( biome_ter_idx ),
-                              forest_mapgen_settings.unfinalized_biomes[first_ter] ) );
+                            ( forest_biome_ter_keys.get_string( biome_ter_idx ), default_ter ) );
                 }
             } else {
                 load_forest_biome( forest_biome_jo, forest_mapgen_settings.unfinalized_biomes[member.name()],
                                    overlay );
             }
-
         }
     }
 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #72877, #72872. #72812 exposed that some forest mapgen code assumes adjacent biomes have groundcover. This is not true.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Patch the code to fallback to regional groundcover like the other fallback cases use, in case the chosen adjacent biome in the feathering algorithm does not have groundcover of its own.

Also, noticed the adjacent biomes array wasn't being fully populated, with the last entry being skipped due to an off by one error in the initialization loop. Fix that too.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Use one of the repro saves from the issue, it doesn't crash anymore when mapgenning an innawoods cave tile.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
