### PR TITLE
Fix config/font.json generation to append correct paths for Android

### DIFF
--- a/src/font_loader.cpp
+++ b/src/font_loader.cpp
@@ -15,7 +15,7 @@ void ensure_unifont_loaded( std::vector<std::string> &font_list )
 }
 
 // Fix for Android not loading Terminus, same as above but for Terminus
-void validate_terminus_path( std::vector<std::string> &font_list )
+static void validate_terminus_path( std::vector<std::string> &font_list )
 {
     const std::string terminus = PATH_INFO::fontdir() + "Terminus.ttf";
     if( std::find( font_list.begin(), font_list.end(), terminus ) == font_list.end() ) {

--- a/src/font_loader.cpp
+++ b/src/font_loader.cpp
@@ -1,3 +1,4 @@
+
 #include "font_loader.h"
 
 #if defined( TILES )
@@ -10,6 +11,15 @@ void ensure_unifont_loaded( std::vector<std::string> &font_list )
     const std::string unifont = PATH_INFO::fontdir() + "unifont.ttf";
     if( std::find( font_list.begin(), font_list.end(), unifont ) == font_list.end() ) {
         font_list.emplace_back( unifont );
+    }
+}
+
+// Fix for Android not loading Terminus, same as above but for Terminus
+void validate_terminus_path( std::vector<std::string> &font_list )
+{
+    const std::string terminus = PATH_INFO::fontdir() + "Terminus.ttf";
+    if( std::find( font_list.begin(), font_list.end(), terminus ) == font_list.end() ) {
+        font_list.emplace_back( terminus );
     }
 }
 
@@ -34,6 +44,9 @@ void font_loader::load_throws( const cata_path &path )
             config.read( "overmap_typeface", overmap_typeface );
         }
 
+        validate_terminus_path( typeface );
+        validate_terminus_path( map_typeface );
+        validate_terminus_path( overmap_typeface );
         ensure_unifont_loaded( typeface );
         ensure_unifont_loaded( map_typeface );
         ensure_unifont_loaded( overmap_typeface );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Android: Added correct path for default Terminus font"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #72922 

This is a really old Android bug, as was noted in https://www.reddit.com/r/cataclysmdda/comments/ppwq9f/cataclysm_dda_on_android_an_indepth_tweaking_guide/, nearly 3 years ago. This will let Android users see/use the bundled Terminus font by default, without having to jump through hoops replacing or editing files manually. Showing Terminus as the default makes a world of difference in how nice the game appears compared to unifont (see screenshots in attached issue and reddit post).

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Copied the function that adds the correct path to unifont (which works properly), adjusted for Terminus.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

This solution would force terminus to be added even if it was removed (to back of the list, but in front of unifont).  Perhaps a more elegant solution would be to craft a function that just validates and fixes an invalid path for any entry in the list only if the entry exists to begin with, while leaving the ensure_unifont_loaded function be the one that specifically adds unifont to the back if it doesn't exist.

(I don't know how to do this off the top of my head but pretty confident I could figure it out. Eventually.)

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
~~None.~~ I have no idea how to compile for Android. Help please and thanks.

Edit: compiled and tested on Windows, nothing looks out of the ordinary, the functions don't appear to change anything, as expected.
fonds.json result:
```
{
  "typeface": [ "data/font/Terminus.ttf", "data/font/unifont.ttf" ],
  "map_typeface": [ "data/font/Terminus.ttf", "data/font/unifont.ttf" ],
  "overmap_typeface": [ "data/font/Terminus.ttf", "data/font/unifont.ttf" ]
}
```
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Review appreciated, I have no c++ background and also don't know if this is the proper way to solve the issue. And as mentioned above not sure how to compile to test...
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
