### PR TITLE
Improve spell checker tokenization and reporting

### DIFF
--- a/.github/workflows/text-changes-analyzer.yml
+++ b/.github/workflows/text-changes-analyzer.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install python3-pip gettext
-          sudo pip3 install polib pyspellchecker
+          sudo pip3 install polib pyspellchecker regex
       - name: "Checkout test merge commit"
         uses: actions/checkout@v4
       - name: "Compute base commit and test merge commit"

--- a/.github/workflows/text-changes-analyzer.yml
+++ b/.github/workflows/text-changes-analyzer.yml
@@ -59,6 +59,9 @@ jobs:
       - name: "Write text changes"
         run: |
           python3 ./tools/pot_diff.py ~/base.pot ~/merge.pot -j ~/pot_diff.json
+      - name: "Run spell checker unit tests"
+        run: |
+          python3 ./tools/spell_check_unit_test.py
       - name: "Spell check on text changes"
         run: |
           python3 ./tools/spell_check_pr.py -i ~/pot_diff.json > spell_check_output

--- a/tools/spell_check.py
+++ b/tools/spell_check.py
@@ -14,3 +14,7 @@ for entry in pofile:
     #         occurrences[word] = 1
     if typos:
         print(typos, "<=", entry.msgid.replace('\n', '\\n'))
+    if entry.msgid_plural:
+        typos = spell_check(entry.msgid_plural)
+        if typos:
+            print(typos, "<=", entry.msgid_plural.replace('\n', '\\n'))

--- a/tools/spell_check_pr.py
+++ b/tools/spell_check_pr.py
@@ -23,8 +23,7 @@ for message in diff["added"]:
     message = message.replace('\n', "\\n")
     for typo in typos:
         bold = "**" + typo + "**"
-        message = re.sub(re.escape(typo), lambda _: bold, message,
-                         flags=re.IGNORECASE)
+        message = re.sub(re.escape(typo), lambda _: bold, message)
     errors.append(message)
 if errors:
     print("Spell checker encountered unrecognized words in the in-game text"

--- a/tools/spell_check_pr.py
+++ b/tools/spell_check_pr.py
@@ -39,3 +39,26 @@ if errors:
           " this is inaccurate, or (optionally) you can also add the new words"
           " to `tools/spell_checker/dictionary.txt` so they will not trigger "
           "an alert next time.")
+    print()
+    print("<details>")
+    print("<summary>Hints for adding a new word to the dictionary</summary>")
+    print()
+    print("* If the word is normally in all lowercase, such as the noun "
+          "`word` or the verb `does`, add it in its lower-case form; if the "
+          "word is a proper noun, such as the surname `George`, add it in its "
+          "initial-caps form; if the word is an acronym or has special letter "
+          "case, such as the acronym `CDDA` or the unit `mW`, add it by "
+          "preserving the case of all the letters. A word in the dictionary "
+          "will also match its initial-caps form (if the word is in all "
+          "lowercase) and all-uppercase form, so a word should be added to "
+          "the dictionary in its normal letter case even if used in a "
+          "different letter case in a sentence.")
+    print("* For a word to be added to the dictionary, it should either be a "
+          "real, properly-spelled modern American English word, a foreign "
+          "loan word (including romanized foreign names), or a foreign or "
+          "made-up word that is used consistently and commonly enough in the "
+          "game. Intentional misspelling (including eye dialect) of a word "
+          "should not be added unless it has become a common terminology in "
+          "the game, because while someone may have a legitimate use for it, "
+          "another person may spell it that way accidentally.")
+    print("</details>")

--- a/tools/spell_check_pr.py
+++ b/tools/spell_check_pr.py
@@ -17,7 +17,7 @@ if not options.pot_diff:
 diff = json.load(open(options.pot_diff, "r"))
 errors = []
 for message in diff["added"]:
-    typos = spell_check(message)
+    typos = set(spell_check(message))
     if len(typos) == 0:
         continue
     message = message.replace('\n', "\\n")

--- a/tools/spell_check_unit_test.py
+++ b/tools/spell_check_unit_test.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+from spell_checker import unit_test__tokenizer
+
+
+unit_test__tokenizer()
+print("unit test completed")

--- a/tools/spell_checker/__init__.py
+++ b/tools/spell_checker/__init__.py
@@ -5,37 +5,41 @@ from spellchecker import SpellChecker
 import unicodedata
 
 
-_latin_and_diacritic = r"\p{Script=Latin}|[\u0300-\u036F\u1AB0-\u1AC0\u1DC0-\u1DFF\u20D0-\u20F0\uFE20-\uFE2D]"
+_latin_and_diacritic = (
+    r"\p{Script=Latin}"
+    r"|"
+    r"[\u0300-\u036F\u1AB0-\u1AC0\u1DC0-\u1DFF\u20D0-\u20F0\uFE20-\uFE2D]"
+)
 Tokenizer = regex.compile(
     r"(?<="
-        r"(?:" # a word can be after...
-            r"^" # ...the start of text...
-        r"|" # ...or...
-            r"""[\s\-'‘"“«\*&\(\[\{/>]""" # ...a valid starting delimiter
+        r"(?:"  # a word can be after...  # noqa: E131
+            r"^"  # ...the start of text...  # noqa: E131
+        r"|"  # ...or...
+            r"""[\s\-'‘"“«\*&\(\[\{/>]"""  # ...a valid starting delimiter
         r")"
-        r"[…]*" # ignore possible punctuations before a word
+        r"[…]*"  # ignore possible punctuations before a word
     r")"
     # a single letter is always considered a valid word and therefore not
     # tokenized
     r"(?:" +
         _latin_and_diacritic +
-    r")" # a word always starts with an letter...
+    r")"  # a word always starts with an letter...
     r"(?:" +
         _latin_and_diacritic +
-    r"|['‘’´])*" # ...can contain letters and apostrophes...
+    r"|['‘’´])*"  # ...can contain letters and apostrophes...
     r"(?:" +
         _latin_and_diacritic +
-    r")" # ...and always ends with an letter
+    r")"  # ...and always ends with an letter
     # exclude suffix `'s` and match the apostrophe as a delimiter later
     r"(?<!'[sS])"
     # note: staring and ending apostrophe cannot be distinguished from
     # starting and ending single quote so the former is not considered.
     r"(?="
-        r"[,\.\?!:;…]*" # ignore any punctuations after a word
-        r"(?:" # a word can be before...
-            r"$" # ...the end of text...
-        r"|" # ...or...
-            r"""[\s\-'’"”»\*\)\]\}/<]""" # ...a valid ending delimiter
+        r"[,\.\?!:;…]*"  # ignore any punctuations after a word
+        r"(?:"  # a word can be before...
+            r"$"  # ...the end of text...
+        r"|"  # ...or...
+            r"""[\s\-'’"”»\*\)\]\}/<]"""  # ...a valid ending delimiter
         r")"
     r")"
 )
@@ -60,8 +64,8 @@ def init_known_words(DefaultKnownWords, KnownWords):
             (default_dict, DefaultKnownWords), (custom_dict, KnownWords)]:
         for word in dictionary:
             # For words in full lower case, allow capitalization and all caps
-            # (e.g. word, Word, & WORD); for other words, allow the word itself and
-            # all caps (e.g. George & GEORGE or pH & PH)
+            # (e.g. word, Word, & WORD); for other words, allow the word itself
+            # and all caps (e.g. George & GEORGE or pH & PH)
             knownwords.add(word)
             if word == word.lower():
                 knownwords.add(word.capitalize())
@@ -77,39 +81,44 @@ if not KnownWords:
 def unit_test__tokenizer():
     text_and_results = [
         ("I'm a test", ["I'm", "test"]),
-        ("Bahá'í", ["Bahá'í"]), # containing composed character á
-        ("Bahá'í", ["Bahá'í"]), # containing decomposed sequence á
+        ("Bahá'í", ["Bahá'í"]),  # containing composed character á
+        ("Bahá'í", ["Bahá'í"]),  # containing decomposed sequence á
         ("This is Megingjörð", ["This", "is", "Megingjörð"]),
         ("Test 测试", ["Test"]),
         ("\"This'll do!\"", ["This'll", "do"]),
         ("Someone's test case", ["Someone", "test", "case"]),
-        ("SOMEONE'S VERY IMPORTANT TEST", ["SOMEONE", "VERY", "IMPORTANT", "TEST"]),
+        ("SOMEONE'S VERY IMPORTANT TEST",
+            ["SOMEONE", "VERY", "IMPORTANT", "TEST"]),
         ("tic-tac-toe", ["tic", "tac", "toe"]),
         ("Ünicodé", ["Ünicodé"]),
         ("This apostrophe’s weird", ["This", "apostrophe’s", "weird"]),
         ("This apostrophe´s weird", ["This", "apostrophe´s", "weird"]),
         ("Foo i18n l10n bar", ["Foo", "bar"]),
-        ("Lorem 123 ipsum -- dolor ||| sit", ["Lorem", "ipsum", "dolor", "sit"]),
+        ("Lorem 123 ipsum -- dolor ||| sit",
+            ["Lorem", "ipsum", "dolor", "sit"]),
         ("Lorem", ["Lorem"]),
         ("Lorem ipsum dolor sit amet",
             ["Lorem", "ipsum", "dolor", "sit", "amet"]),
         ("'Lorem ipsum dolor sit amet, consectetur adipiscing elit'",
             ["Lorem", "ipsum", "dolor", "sit", "amet", "consectetur",
-                "adipiscing","elit"]),
-        ("Lorem, ipsum.  dolor?  sit!  amet.", ["Lorem", "ipsum", "dolor", "sit", "amet"]),
+                "adipiscing", "elit"]),
+        ("Lorem, ipsum.  dolor?  sit!  amet.",
+            ["Lorem", "ipsum", "dolor", "sit", "amet"]),
         ("Lorem ipsum, 'dolor?'  sit!?", ["Lorem", "ipsum", "dolor", "sit"]),
         ("Lorem: ipsum; dolor…", ["Lorem", "ipsum", "dolor"]),
         ('"Lorem"', ["Lorem"]),
         ("Lorem-ipsum", ["Lorem", "ipsum"]),
-        ("«Lorem ipsum»", ["Lorem", "ipsum"]), # used in some NPC dialogue
+        ("«Lorem ipsum»", ["Lorem", "ipsum"]),  # used in some NPC dialogue
         ("*Lorem ipsum*", ["Lorem", "ipsum"]),
-        ("&Lorem ipsum", ["Lorem", "ipsum"]), # used in some NPC dialogue
+        ("&Lorem ipsum", ["Lorem", "ipsum"]),  # used in some NPC dialogue
         ("…Lorem", ["Lorem"]),
         ("'…Lorem ipsum…'", ["Lorem", "ipsum"]),
         ("Lorem <ipsum> <color_yellow>dolor</color>", ["Lorem", "dolor"]),
         ("<global_val:<u_val:foobar>>", []),
-        ("Lorem (ipsum) [dolor sit] {amet}", ["Lorem", "ipsum", "dolor", "sit", "amet"]),
-        ("Lorem ipsum/dolor/sit amet", ["Lorem", "ipsum", "dolor", "sit", "amet"]),
+        ("Lorem (ipsum) [dolor sit] {amet}",
+            ["Lorem", "ipsum", "dolor", "sit", "amet"]),
+        ("Lorem ipsum/dolor/sit amet",
+            ["Lorem", "ipsum", "dolor", "sit", "amet"]),
         ("Lorem.ipsum.dolor", []),
         ("Lorem %1$s ipsum %2$d dolor!", ["Lorem", "ipsum", "dolor"])
     ]
@@ -118,7 +127,8 @@ def unit_test__tokenizer():
     for text, expected in text_and_results:
         result = list(Tokenizer.findall(text))
         if result != expected:
-            print(f"test case: {text}\nexpected: {expected}\nresult: {result}\n")
+            print(f"test case: {text}\n"
+                  f"expected: {expected}\nresult: {result}\n")
             fail = True
 
     if fail:

--- a/tools/spell_checker/__init__.py
+++ b/tools/spell_checker/__init__.py
@@ -4,6 +4,7 @@ import regex
 from spellchecker import SpellChecker
 
 
+_latin_and_diacritic = r"\p{Script=Latin}|[\u0300-\u036F\u1AB0-\u1AC0\u1DC0-\u1DFF\u20D0-\u20F0\uFE20-\uFE2D]"
 Tokenizer = regex.compile(
     r"(?<="
         r"(?:" # a word can be after...
@@ -15,9 +16,15 @@ Tokenizer = regex.compile(
     r")"
     # a single letter is always considered a valid word and therefore not
     # tokenized
-    r"\pL" # a word always starts with an letter...
-    r"(?:\pL|['‘’])*" # ...can contain letters and apostrophes...
-    r"\pL" # ...and always ends with an letter
+    r"(?:" +
+        _latin_and_diacritic +
+    r")" # a word always starts with an letter...
+    r"(?:" +
+        _latin_and_diacritic +
+    r"|['‘’´])*" # ...can contain letters and apostrophes...
+    r"(?:" +
+        _latin_and_diacritic +
+    r")" # ...and always ends with an letter
     # exclude suffix `'s` and match the apostrophe as a delimiter later
     r"(?<!'[sS])"
     # note: staring and ending apostrophe cannot be distinguished from
@@ -66,12 +73,17 @@ if not KnownWords:
 def unit_test__tokenizer():
     text_and_results = [
         ("I'm a test", ["I'm", "test"]),
+        ("Bahá'í", ["Bahá'í"]), # containing composed character á
+        ("Bahá'í", ["Bahá'í"]), # containing decomposed sequence á
+        ("This is Megingjörð", ["This", "is", "Megingjörð"]),
+        ("Test 测试", ["Test"]),
         ("\"This'll do!\"", ["This'll", "do"]),
         ("Someone's test case", ["Someone", "test", "case"]),
         ("SOMEONE'S VERY IMPORTANT TEST", ["SOMEONE", "VERY", "IMPORTANT", "TEST"]),
         ("tic-tac-toe", ["tic", "tac", "toe"]),
         ("Ünicodé", ["Ünicodé"]),
         ("This apostrophe’s weird", ["This", "apostrophe’s", "weird"]),
+        ("This apostrophe´s weird", ["This", "apostrophe´s", "weird"]),
         ("Foo i18n l10n bar", ["Foo", "bar"]),
         ("Lorem 123 ipsum -- dolor ||| sit", ["Lorem", "ipsum", "dolor", "sit"]),
         ("Lorem", ["Lorem"]),

--- a/tools/spell_checker/__init__.py
+++ b/tools/spell_checker/__init__.py
@@ -1,17 +1,43 @@
 #!/usr/bin/env python3
 import os
-import re
+import regex
 from spellchecker import SpellChecker
 
 
 Speller = SpellChecker()
-Tokenizer = re.compile(r'\w+')
+Tokenizer = regex.compile(
+    r"(?<="
+        r"(?:" # a word can be after...
+            r"^" # ...the start of text...
+        r"|" # ...or...
+            r"""[\s\-'‘"“«\*&\(\[\{/>]""" # ...a valid starting delimiter
+        r")"
+        r"[…]*" # ignore possible punctuations before a word
+    r")"
+    # a single letter is always considered a valid word and therefore not
+    # tokenized
+    r"\pL" # a word always starts with an letter...
+    r"(?:\pL|['‘’])*" # ...can contain letters and apostrophes...
+    r"\pL" # ...and always ends with an letter
+    # exclude suffix `'s` and match the apostrophe as a delimiter later
+    r"(?<!'[sS])"
+    # note: staring and ending apostrophe cannot be distinguished from
+    # starting and ending single quote so the former is not considered.
+    r"(?="
+        r"[,\.\?!:;…]*" # ignore any punctuations after a word
+        r"(?:" # a word can be before...
+            r"$" # ...the end of text...
+        r"|" # ...or...
+            r"""[\s\-'’"”»\*\)\]\}/<]""" # ...a valid ending delimiter
+        r")"
+    r")"
+)
 KnownWords = set()
 
 
 def init_known_words():
     dictionary = os.path.join(os.path.dirname(__file__), 'dictionary.txt')
-    with open(dictionary) as fp:
+    with open(dictionary, 'r', encoding='utf-8') as fp:
         for line in fp:
             line = line.rstrip('\n').rstrip('\r')
             KnownWords.add(line.split(' ')[0])

--- a/tools/spell_checker/__init__.py
+++ b/tools/spell_checker/__init__.py
@@ -2,6 +2,7 @@
 import os
 import regex
 from spellchecker import SpellChecker
+import unicodedata
 
 
 _latin_and_diacritic = r"\p{Script=Latin}|[\u0300-\u036F\u1AB0-\u1AC0\u1DC0-\u1DFF\u20D0-\u20F0\uFE20-\uFE2D]"
@@ -43,14 +44,17 @@ KnownWords = set()
 
 
 def init_known_words(DefaultKnownWords, KnownWords):
-    default_dict = SpellChecker(case_sensitive=True).word_frequency
+    default_dict = {
+        unicodedata.normalize('NFC', word) for word in
+        SpellChecker(case_sensitive=True).word_frequency
+    }
 
     custom_dict = set()
     dict_path = os.path.join(os.path.dirname(__file__), 'dictionary.txt')
     with open(dict_path, 'r', encoding='utf-8') as fp:
         for line in fp:
             line = line.rstrip('\n').rstrip('\r')
-            custom_dict.add(line)
+            custom_dict.add(unicodedata.normalize('NFC', line))
 
     for dictionary, knownwords in [
             (default_dict, DefaultKnownWords), (custom_dict, KnownWords)]:

--- a/tools/spell_checker/__init__.py
+++ b/tools/spell_checker/__init__.py
@@ -45,3 +45,49 @@ def init_known_words():
 
 if not KnownWords:
     init_known_words()
+
+
+def unit_test__tokenizer():
+    text_and_results = [
+        ("I'm a test", ["I'm", "test"]),
+        ("\"This'll do!\"", ["This'll", "do"]),
+        ("Someone's test case", ["Someone", "test", "case"]),
+        ("SOMEONE'S VERY IMPORTANT TEST", ["SOMEONE", "VERY", "IMPORTANT", "TEST"]),
+        ("tic-tac-toe", ["tic", "tac", "toe"]),
+        ("Ünicodé", ["Ünicodé"]),
+        ("This apostrophe’s weird", ["This", "apostrophe’s", "weird"]),
+        ("Foo i18n l10n bar", ["Foo", "bar"]),
+        ("Lorem 123 ipsum -- dolor ||| sit", ["Lorem", "ipsum", "dolor", "sit"]),
+        ("Lorem", ["Lorem"]),
+        ("Lorem ipsum dolor sit amet",
+            ["Lorem", "ipsum", "dolor", "sit", "amet"]),
+        ("'Lorem ipsum dolor sit amet, consectetur adipiscing elit'",
+            ["Lorem", "ipsum", "dolor", "sit", "amet", "consectetur",
+                "adipiscing","elit"]),
+        ("Lorem, ipsum.  dolor?  sit!  amet.", ["Lorem", "ipsum", "dolor", "sit", "amet"]),
+        ("Lorem ipsum, 'dolor?'  sit!?", ["Lorem", "ipsum", "dolor", "sit"]),
+        ("Lorem: ipsum; dolor…", ["Lorem", "ipsum", "dolor"]),
+        ('"Lorem"', ["Lorem"]),
+        ("Lorem-ipsum", ["Lorem", "ipsum"]),
+        ("«Lorem ipsum»", ["Lorem", "ipsum"]), # used in some NPC dialogue
+        ("*Lorem ipsum*", ["Lorem", "ipsum"]),
+        ("&Lorem ipsum", ["Lorem", "ipsum"]), # used in some NPC dialogue
+        ("…Lorem", ["Lorem"]),
+        ("'…Lorem ipsum…'", ["Lorem", "ipsum"]),
+        ("Lorem <ipsum> <color_yellow>dolor</color>", ["Lorem", "dolor"]),
+        ("<global_val:<u_val:foobar>>", []),
+        ("Lorem (ipsum) [dolor sit] {amet}", ["Lorem", "ipsum", "dolor", "sit", "amet"]),
+        ("Lorem ipsum/dolor/sit amet", ["Lorem", "ipsum", "dolor", "sit", "amet"]),
+        ("Lorem.ipsum.dolor", []),
+        ("Lorem %1$s ipsum %2$d dolor!", ["Lorem", "ipsum", "dolor"])
+    ]
+
+    fail = False
+    for text, expected in text_and_results:
+        result = list(Tokenizer.findall(text))
+        if result != expected:
+            print(f"test case: {text}\nexpected: {expected}\nresult: {result}\n")
+            fail = True
+
+    if fail:
+        raise RuntimeError("tokenizer test failed")

--- a/tools/spell_checker/gen_dictionary.py
+++ b/tools/spell_checker/gen_dictionary.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from . import Speller, Tokenizer
+from . import DefaultKnownWords, Tokenizer
 import os
 import polib
 
@@ -11,12 +11,14 @@ def gen_dictionary():
     dictionary = set()
     for entry in pofile:
         words = Tokenizer.findall(entry.msgid)
-        for word in Speller.unknown(words):
-            dictionary.add(word)
+        for word in words:
+            if word not in DefaultKnownWords:
+                dictionary.add(word)
         if entry.msgid_plural:
             words = Tokenizer.findall(entry.msgid_plural)
-            for word in Speller.unknown(words):
-                dictionary.add(word)
+            for word in words:
+                if word not in DefaultKnownWords:
+                    dictionary.add(word)
     dict_path = os.path.join(os.path.dirname(__file__), "dictionary.txt")
     with open(dict_path, "w", encoding="utf-8") as fp:
         for word in sorted(dictionary):

--- a/tools/spell_checker/gen_dictionary.py
+++ b/tools/spell_checker/gen_dictionary.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 from . import Speller, Tokenizer
-from .spell_checker import is_english, sanitize_message
 import os
 import polib
 
@@ -11,11 +10,10 @@ def gen_dictionary():
     pofile = polib.pofile(po_path)
     dictionary = set()
     for entry in pofile:
-        words = filter(is_english,
-                       Tokenizer.findall(sanitize_message(entry.msgid)))
+        words = Tokenizer.findall(entry.msgid)
         for word in Speller.unknown(words):
             dictionary.add(word)
     dict_path = os.path.join(os.path.dirname(__file__), "dictionary.txt")
-    with open(dict_path, "w") as fp:
+    with open(dict_path, "w", encoding="utf-8") as fp:
         for word in sorted(dictionary):
             print(word, file=fp)

--- a/tools/spell_checker/gen_dictionary.py
+++ b/tools/spell_checker/gen_dictionary.py
@@ -13,6 +13,10 @@ def gen_dictionary():
         words = Tokenizer.findall(entry.msgid)
         for word in Speller.unknown(words):
             dictionary.add(word)
+        if entry.msgid_plural:
+            words = Tokenizer.findall(entry.msgid_plural)
+            for word in Speller.unknown(words):
+                dictionary.add(word)
     dict_path = os.path.join(os.path.dirname(__file__), "dictionary.txt")
     with open(dict_path, "w", encoding="utf-8") as fp:
         for word in sorted(dictionary):

--- a/tools/spell_checker/gen_dictionary.py
+++ b/tools/spell_checker/gen_dictionary.py
@@ -24,5 +24,5 @@ def gen_dictionary():
                     dictionary.add(norm)
     dict_path = os.path.join(os.path.dirname(__file__), "dictionary.txt")
     with open(dict_path, "w", encoding="utf-8") as fp:
-        for word in sorted(dictionary):
+        for word in sorted(dictionary, key=lambda v: (v.lower(), v)):
             print(word, file=fp)

--- a/tools/spell_checker/gen_dictionary.py
+++ b/tools/spell_checker/gen_dictionary.py
@@ -2,6 +2,7 @@
 from . import DefaultKnownWords, Tokenizer
 import os
 import polib
+import unicodedata
 
 
 def gen_dictionary():
@@ -12,13 +13,15 @@ def gen_dictionary():
     for entry in pofile:
         words = Tokenizer.findall(entry.msgid)
         for word in words:
-            if word not in DefaultKnownWords:
-                dictionary.add(word)
+            norm = unicodedata.normalize('NFC', word)
+            if norm not in DefaultKnownWords:
+                dictionary.add(norm)
         if entry.msgid_plural:
             words = Tokenizer.findall(entry.msgid_plural)
             for word in words:
-                if word not in DefaultKnownWords:
-                    dictionary.add(word)
+                norm = unicodedata.normalize('NFC', word)
+                if norm not in DefaultKnownWords:
+                    dictionary.add(norm)
     dict_path = os.path.join(os.path.dirname(__file__), "dictionary.txt")
     with open(dict_path, "w", encoding="utf-8") as fp:
         for word in sorted(dictionary):

--- a/tools/spell_checker/spell_checker.py
+++ b/tools/spell_checker/spell_checker.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import re
-from . import Speller, Tokenizer, KnownWords
+from . import Tokenizer, KnownWords
 
 
 def not_in_known_words(word):
@@ -9,5 +9,5 @@ def not_in_known_words(word):
 
 def spell_check(message):
     words = Tokenizer.findall(message)
-    unknowns = filter(not_in_known_words, Speller.unknown(words))
+    unknowns = filter(not_in_known_words, words)
     return list(unknowns)

--- a/tools/spell_checker/spell_checker.py
+++ b/tools/spell_checker/spell_checker.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import re
 from . import Tokenizer, KnownWords
 import unicodedata
 

--- a/tools/spell_checker/spell_checker.py
+++ b/tools/spell_checker/spell_checker.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 import re
 from . import Tokenizer, KnownWords
+import unicodedata
 
 
 def not_in_known_words(word):
-    return word not in KnownWords
+    return unicodedata.normalize('NFC', word) not in KnownWords
 
 
 def spell_check(message):

--- a/tools/spell_checker/spell_checker.py
+++ b/tools/spell_checker/spell_checker.py
@@ -3,24 +3,11 @@ import re
 from . import Speller, Tokenizer, KnownWords
 
 
-def is_english(word):
-    for w in word:
-        if not ('a' <= w and w <= 'z'):
-            return False
-    return True
-
-
 def not_in_known_words(word):
     return word not in KnownWords
 
 
-def sanitize_message(message):
-    untagged = re.sub(r'<[0-9a-z_/]+>', '', message)
-    unformatted = re.sub(r'%[0-9lz\.\s$]*[scfd]', '', untagged)
-    return unformatted
-
-
 def spell_check(message):
-    words = filter(is_english, Tokenizer.findall(sanitize_message(message)))
+    words = Tokenizer.findall(message)
     unknowns = filter(not_in_known_words, Speller.unknown(words))
     return list(unknowns)


### PR DESCRIPTION
#### Summary
Infrastructure "Improve spell checker tokenization and reporting"

#### Purpose of change
The current spell checker does not handle words with apostrophes correctly. For example, in https://github.com/CleverRaven/Cataclysm-DDA/pull/72910#issuecomment-2044289265 it reports the `isn` in `isn't`.

The spell checker is also not case-sensitive, and it seems the default dictionary from `pyspellchecker` only contains non-proper-nouns.

#### Describe the solution
The spell checker's tokenizer is improved to consider apostrophe as part of a word, unless the apostrophe starts or ends a word or is followed by an `s` that ends the word. In the former case, it is difficult to distinguish the apostrophe from a single quote; in the latter case, the full word is genitive or an abbreviation of `xxx is/has`, so checking the part before `'s` should be enough.

The spell checker code now also takes the case of the word into account. For any all-lowercase word in the dictionary, the original, initial-caps, or all-uppercase form is considered correct; for any other word the original and all-uppercase form is considered correct.

#### Describe alternatives you've considered

#### Testing
Tested locally and was able to fix spelling mistakes in #72910 without getting a million reports on `isn`. The spell checker also distinguished words with different cases, so I was able to fix words with incorrect capitalization in #72910.

The spell checker github action is tested by running it on top of #72910 in this PR and results in https://github.com/CleverRaven/Cataclysm-DDA/pull/72924#issuecomment-2044634346. Words not in the dictionary are correctly reported, apostrophes are correctly handled, and capitalized/all-uppercase words are correctly handled. Note that it reports some correctly spelled words because the updated dictionary is not added in this PR.

#### Additional context
The updated dictionary contains a lot of changed lines so it will be submitted as a separate PR. This PR should be usable with the existing dictionary though.
