### PR TITLE
Retain hole construction

### DIFF
--- a/data/json/furniture_and_terrain/terrain-migo.json
+++ b/data/json/furniture_and_terrain/terrain-migo.json
@@ -54,7 +54,7 @@
       "str_max": 700,
       "sound": "boom!",
       "sound_fail": "whack!",
-      "ter_set": "t_null",
+      "ter_set": "t_floor_resin",
       "items": [ { "item": "resin_chunk", "count": [ 10, 40 ] } ]
     }
   },

--- a/data/json/furniture_and_terrain/terrain-migo.json
+++ b/data/json/furniture_and_terrain/terrain-migo.json
@@ -54,7 +54,8 @@
       "str_max": 700,
       "sound": "boom!",
       "sound_fail": "whack!",
-      "ter_set": "t_floor_resin",
+      "ter_set": "t_null",
+      "ter_set_bashed_from_above": "t_platform_resin",
       "items": [ { "item": "resin_chunk", "count": [ 10, 40 ] } ]
     }
   },

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -107,7 +107,6 @@ static const ter_str_id ter_t_open_air( "t_open_air" );
 static const ter_str_id ter_t_pit( "t_pit" );
 static const ter_str_id ter_t_ramp_down_high( "t_ramp_down_high" );
 static const ter_str_id ter_t_ramp_down_low( "t_ramp_down_low" );
-static const ter_str_id ter_t_region_soil( "t_region_soil" );
 static const ter_str_id ter_t_rock_floor( "t_rock_floor" );
 static const ter_str_id ter_t_sand( "t_sand" );
 static const ter_str_id ter_t_stairs_down( "t_stairs_down" );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #72758, i.e. the closing over of a constructed hole into a roofed room below on a save/load cycle.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add code on hole construction to check what the terrain below is and transform it into the corresponding terrain resulting from smashing the roof if the terrain below is a roofed one.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Completely new JSON support data. Using the bashing data is probably good enough.
- Hope someone can tell me how to extract region terrain data in a non stupidly convoluted manner.
- Bring out the heavy machinery and change map.ter_set() to do whatever is needed when a tile with a roof is added or removed, as well as take care of the removal of a roof and replacing it with open air. This would also require the replacement of many, possibly most, tinymaps with smallmaps (to get access to the Z levels above/below), which could have performance implications. I'm getting more and more convinced that is the direction in which we'll need to go, but it's definitely not going to fit in a 500 line change limit. It might be possible to do gradually by having the ter_set operation ignore the additional Z level stuff if called by a smallmap, and thus rely on the flaky add_roofs code during the transition (after all, that's what's done currently).

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Using a copy of the save from the bug report as a base:
- Teleport to the burned down evac shelter.
- Wait until the companion finishes digging.
- Verify that examining the hole shows a hole with dirt beneath.
- Save/load to verify the hole isn't closed up.
- Quit.
- Delete the save copy and copy the save again.
- Teleport to the shelter.
- Go down the stairs and debug change the tile beneath the tile worked on to t_floor_resin.
- Go back up and wait for the companion to finish.
- Examine the hole, and verify it just tells you there's a resin floor below (there's no description difference between the two types of floor).
- Go down the stairs and debug examine the resin tile and verify it's actually t_platform_resin.
- Save/load to verify the hole isn't closed up.
 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Important notes:
- The only terrains that supported roof bashing are soil and rock, neither of which actually have roofs.
- The field for roof bashing is set to whatever ordinary bashing results in. This, unfortunately, is usually t_null.
- This PR adds roof bashing to t_floor_resin both as a proof of concept and as a means to test the change.
- The fallback when (roof) bashing data is t_null (almost all cases, unfortunately) is t_rock_floor if below z = -1, and region soil otherwise. There's a need for a significant amount of JSON work to provide JSON data to make bashing yield more reasonable results. This probably includes the definition of roof less versions of roofed terrain.
- This leads to the reason for the selection of mi-go resin as the example transformation. That is a case where there's already a suitable roof less floor provided, and so a minimum need for additional JSON. If I was to try to do the similar thing for the linoleum floor present (apart from not testing the t_null case), I'd have to define a roof less version of the tile (plus the cascade resulting from it being colored), a construction definition for it (and the others), as well as probably change the construction process to first create the roof less version and then go on to the roofed one (unless the linoleum is an addition to e.g. concrete, in which case there would have to be both a construction on roof less concrete (which I think exists) and roofed concrete, as well as the construction of the roofed version from the roofless one. There's a lot of JSON (and testing) work to implement everything properly...
- This PR ONLY addresses the case of actively constructing a hole. There are other cases that should benefit from the same kind of treatment:
  - the collapsed tower  opening holes in the ground that are closed on save/load.
  -  zombies smashing up basements.
  - Explosions exposing structures beneath (haven't seen issues with this myself, but probably haven't seen uncovered structures...).
  - May also be relevant to burning building collapses (haven't seen issues with this myself, I think).

Also, I suffer from the view not being properly updated, i.e. the 3D view visually displays the terrain that was below before the conversion, while looking at it ('x') displays the correct terrain below. I've tried various map cache updates and invalidation calls, but none work. The appropriate call probably is located elsewhere. However, I need help to find where to look for it. It can be noted that the visual display is corrected after a save/load cycle, but isn't corrected by moving away (outside of reality bubble range) and then return. 

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
