### PR TITLE
A bunch of random item reworks: 12

### DIFF
--- a/data/json/items/comestibles/other.json
+++ b/data/json/items/comestibles/other.json
@@ -649,15 +649,17 @@
     "id": "napkin",
     "name": { "str": "napkin" },
     "category": "spare_parts",
-    "weight": "3 g",
+    "weight": "1360 mg",
+    "//1": "Calculated from cocktail napkins with roughly average (13lb/500sheets) thickness. 100in^2 * 13lb / 864in^2 = 1.5lb => 1.5lb / 500 = 0.003lb per napkin.",
     "color": "white",
     "symbol": "`",
     "description": "A napkin.  Can be used for fires.",
     "price": 0,
     "price_postapoc": 0,
     "material": [ "paper" ],
-    "volume": "5 ml",
-    "flags": [ "TINDER" ]
+    "volume": "3 ml",
+    "flags": [ "TINDER" ],
+    "//2": "Based on https://www.sizes.com/home/napkins.htm"
   },
   {
     "type": "GENERIC",

--- a/data/json/items/containers/containers.json
+++ b/data/json/items/containers/containers.json
@@ -2197,12 +2197,13 @@
     "looks_like": "bottle_plastic",
     "description": "A standard plastic jug used for milk and household cleaning chemicals.  Some may be factory-sealed to increase shelf life.",
     "ascii_picture": "jug_plastic",
-    "weight": "190 g",
-    "volume": "3825 ml",
+    "weight": "160 g",
+    "volume": "4402 ml",
+    "//1": "Calculated as a cylinder of 6in diameter and 9.5in height, to account for it getting thinner near the top.",
     "longest_side": "28 cm",
-    "price": 0,
+    "price": "10 USD",
     "price_postapoc": 10,
-    "to_hit": 1,
+    "to_hit": { "grip": "none", "length": "hand", "surface": "any", "balance": "clumsy" },
     "material": [ "plastic" ],
     "symbol": ")",
     "color": "light_cyan",
@@ -2217,7 +2218,8 @@
         "sealed_data": { "spoil_multiplier": 0.5 }
       }
     ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "flags": [ "COLLAPSE_CONTENTS" ],
+    "//2": "Based on https://www.amazon.com/dp/B07GC1VJ9T"
   },
   {
     "id": "fuel_tin",

--- a/data/json/items/containers/containers.json
+++ b/data/json/items/containers/containers.json
@@ -454,12 +454,13 @@
     "looks_like": "bottle_plastic",
     "description": "A watertight glass bottle, holds 750 ml of liquid.",
     "ascii_picture": "bottle_glass",
-    "weight": "450 g",
-    "volume": "953 ml",
-    "longest_side": "276 mm",
-    "price": 0,
+    "weight": "511 g",
+    "volume": "1082 ml",
+    "//1": "Calculated as a cylinder of 2.9in diameter and 10in height, to account for it getting thinner near the top.",
+    "longest_side": "29 cm",
+    "price": "2 USD",
     "price_postapoc": 10,
-    "to_hit": 1,
+    "to_hit": { "grip": "none", "length": "hand", "surface": "any", "balance": "clumsy" },
     "material": [ "glass" ],
     "symbol": ")",
     "color": "cyan",
@@ -476,7 +477,8 @@
     ],
     "qualities": [ [ "BOIL", 1 ] ],
     "flags": [ "COLLAPSE_CONTENTS" ],
-    "melee_damage": { "bash": 2 }
+    "melee_damage": { "bash": 2 },
+    "//2": "Based on https://www.amazon.com/dp/B09K2VQLZV"
   },
   {
     "id": "bottle_plastic",

--- a/data/json/items/generic/dining_kitchen.json
+++ b/data/json/items/generic/dining_kitchen.json
@@ -1312,12 +1312,15 @@
     "copy-from": "base_cookpot",
     "material": [ "steel" ],
     "color": "light_gray",
-    "weight": "728 g",
-    "volume": "1575 ml",
-    "longest_side": "21 cm",
+    "weight": "508 g",
+    "volume": "3205 ml",
+    "//1": "Calculated as a cylinder of 7.44in diameter and 4.5in height. Calculating it from package dimensions of the amazon listing would give ridiculous volume.",
+    "longest_side": "19 cm",
+    "price": "13 USD",
     "pocket_data": [ { "max_contains_volume": "1500 ml", "max_contains_weight": "2 kg", "watertight": true, "rigid": true } ],
     "delete": { "qualities": [ "COOK" ] },
-    "melee_damage": { "bash": 5 }
+    "melee_damage": { "bash": 5 },
+    "//2": "Based on https://www.amazon.com/dp/B0858VCYTB"
   },
   {
     "type": "GENERIC",

--- a/data/json/items/generic/dining_kitchen.json
+++ b/data/json/items/generic/dining_kitchen.json
@@ -565,8 +565,10 @@
     "symbol": "u",
     "description": "A piece of plastic tupperware with a matching watertight lid.  Holds 750 ml of liquid.",
     "copy-from": "base_plastic_dish",
-    "volume": "787 ml",
-    "longest_side": "17 cm",
+    "volume": "1463 ml",
+    "weight": "57 g",
+    "longest_side": "20 cm",
+    "price": "132 cent",
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -576,7 +578,9 @@
         "max_contains_weight": "1 kg"
       }
     ],
-    "qualities": [ [ "CONTAIN", 1 ] ]
+    "qualities": [ [ "CONTAIN", 1 ] ],
+    "to_hit": { "grip": "bad", "length": "hand", "surface": "any", "balance": "clumsy" },
+    "//": "Based on https://www.amazon.co.uk/dp/B097HTDRNZ"
   },
   {
     "id": "plastic_bowl_kids",

--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -453,7 +453,6 @@
         [ "bag_plastic", 10 ],
         [ "plastic_sheet_small", 10 ],
         [ "tumbler_plastic", 4 ],
-        [ "bowl_plastic", 4 ],
         [ "plastic_bowl_kids", 8 ],
         [ "sippy_cup", 4 ],
         [ "gasket_plastic", 1 ]

--- a/data/json/recipes/recipe_deconstruction.json
+++ b/data/json/recipes/recipe_deconstruction.json
@@ -2668,7 +2668,7 @@
     "type": "uncraft",
     "activity_level": "LIGHT_EXERCISE",
     "time": "1 s",
-    "components": [ [ [ "glass_shard", 3 ] ] ]
+    "components": [ [ [ "glass_shard", 6 ] ] ]
   },
   {
     "result": "flask_glass",

--- a/data/json/recipes/recipe_deconstruction.json
+++ b/data/json/recipes/recipe_deconstruction.json
@@ -3052,11 +3052,9 @@
     "result": "kettle",
     "type": "uncraft",
     "activity_level": "MODERATE_EXERCISE",
-    "skill_used": "fabrication",
-    "difficulty": 1,
     "time": "2 m",
-    "qualities": [ { "id": "SAW_M", "level": 1 } ],
-    "components": [ [ [ "sheet_metal_small", 3 ] ] ]
+    "qualities": [ { "id": "SAW_M", "level": 2 } ],
+    "components": [ [ [ "sheet_metal_small", 2 ] ] ]
   },
   {
     "result": "kiln_done",

--- a/data/json/recipes/recipe_others.json
+++ b/data/json/recipes/recipe_others.json
@@ -1703,7 +1703,7 @@
       [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ],
       [ [ "forge", 25 ] ]
     ],
-    "components": [ [ [ "glass_shard", 3 ], [ "bottle_glass", 1 ], [ "flask_glass", 3 ], [ "test_tube", 6 ], [ "marble", 75 ] ] ]
+    "components": [ [ [ "glass_shard", 3 ], [ "flask_glass", 3 ], [ "test_tube", 6 ], [ "marble", 75 ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/tools/containers.json
+++ b/data/json/recipes/tools/containers.json
@@ -83,19 +83,6 @@
   {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
-    "result": "jug_plastic",
-    "category": "CC_OTHER",
-    "subcategory": "CSC_OTHER_CONTAINERS",
-    "skill_used": "fabrication",
-    "difficulty": 1,
-    "time": "30 m",
-    "autolearn": true,
-    "qualities": [ { "id": "CUT", "level": 2 } ],
-    "components": [ [ [ "duct_tape", 10 ] ], [ [ "bottle_plastic", 8 ], [ "bottle_bathroom", 8 ], [ "bottle_plastic_small", 16 ] ] ]
-  },
-  {
-    "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
     "result": "jerrycan",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_CONTAINERS",
@@ -683,9 +670,9 @@
     "autolearn": true,
     "book_learn": [ [ "plastics_book", 2 ] ],
     "proficiencies": [ { "proficiency": "prof_plasticworking" } ],
-    "tools": [ [ [ "surface_heat", 15, "LIST" ] ] ],
+    "tools": [ [ [ "surface_heat", 4, "LIST" ] ] ],
     "using": [ [ "plastic_molding", 1 ] ],
-    "components": [ [ [ "plastic_chunk", 15 ] ] ]
+    "components": [ [ [ "plastic_chunk", 4 ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/tools/containers.json
+++ b/data/json/recipes/tools/containers.json
@@ -432,7 +432,7 @@
       [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ],
       [ [ "forge", 75 ] ]
     ],
-    "components": [ [ [ "glass_shard", 3 ], [ "pipe_glass", 1 ], [ "flask_glass", 3 ], [ "test_tube", 6 ], [ "marble", 75 ] ] ]
+    "components": [ [ [ "glass_shard", 7 ], [ "pipe_glass", 4 ], [ "flask_glass", 11 ], [ "test_tube", 47 ], [ "marble", 171 ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/tools/containers.json
+++ b/data/json/recipes/tools/containers.json
@@ -160,7 +160,7 @@
     "autolearn": true,
     "proficiencies": [ { "proficiency": "prof_plasticworking" } ],
     "tools": [ [ [ "surface_heat", 2, "LIST" ] ] ],
-    "components": [ [ [ "plastic_chunk", 3 ] ] ]
+    "components": [ [ [ "plastic_chunk", 2 ] ] ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
You thought I was done?
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
<details>
<summary>PLASTIC TUPPERWARE</summary>

- Weight: 130g -> 57g
- Volume: 787ml -> 1463l
- Longest side: 17cm -> 20cm
- ``price_preapoc``: 4$ -> 1.32$
- ``to-hit`` values now use modifiers
- Removed it from the horrendous plastic chunk recipe that caused like a 400g mass voiding
- Lowered it's plastic requirement in the crafting recipe

</details>

<details>
<summary>KETTLE</summary>

- Weight: 728g -> 508g
- Volume: 1575ml -> 3205ml
- Longest side:  21cm -> 19cm
- ``price_preapoc``: 45$ -> 13$
- Audited its deconstruction recipe to match new mass, use level 2 metal sawing and no longer train fabrication

</details>

<details>
<summary>GALLON JUG</summary>

- Weight: 190g -> 160g
- Volume: 3825ml -> 4402ml (potentially too generous?)
- ``price_preapoc``: 0$ -> 10$
- ``to-hit`` values now use modifiers
- Removed the horrendous crafting recipe for it that involved duct taping bottles together
- Lowered the plastic requirements and energy cost for crafting it from raw plastic

</details>

<details>
<summary>GLASS BOTTLE</summary>

- Weight: 450g -> 511g
- Volume: 953ml -> 1082ml (potentially too generous?)
- ``price_preapoc``: 0$ -> 2$
- ``to-hit`` values now use modifiers
- Audited its deconstruction recipe to match the weight
- Removed it from the glass pipe recipe since it caused a big weight loss
- Audited its crafting recipe to match its weight

</details>

<details>
<summary>NAPKIN</summary>

- Weight: 3g -> 1.36g
- Volume: 5ml -> 3ml

</details>
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Caused by #71969, because now carrots are too big to fit inside our tupperware...
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
