### PR TITLE
[MoM] Photokinetic gets it's welding glare protection

### DIFF
--- a/data/mods/MindOverMatter/items/psions_summon_items.json
+++ b/data/mods/MindOverMatter/items/psions_summon_items.json
@@ -300,6 +300,28 @@
     ]
   },
   {
+    "id": "integrated_photo_eyes",
+    "type": "ARMOR",
+    "category": "armor",
+    "name": { "str_sp": "photon regulation" },
+    "description": "With a little concentration, you can control the light your eyes accept.  Protects you from glare and welding arcs.",
+    "weight": "1 g",
+    "volume": "1 ml",
+    "material": [ "light" ],
+    "symbol": "[",
+    "color": "yellow",
+    "qualities": [ [ "GLARE", 1 ] ],
+    "flags": [ "INTEGRATED", "UNBREAKABLE", "SKINTIGHT", "SOFT", "WATER_FRIENDLY", "SUN_GLASSES", "NO_REPAIR", "NO_SALVAGE", "AURA" ],
+    "armor": [
+      {
+        "material": [ { "type": "light", "covered_by_mat": 100, "thickness": 0.1 } ],
+        "covers": [ "eyes" ],
+        "coverage": 100,
+        "encumbrance": 0
+      }
+    ]
+  },
+  {
     "id": "pyrokinetic_torch_weld",
     "type": "TOOL_ARMOR",
     "name": { "str": "[Ψ]incandescent lance" },

--- a/data/mods/MindOverMatter/materials.json
+++ b/data/mods/MindOverMatter/materials.json
@@ -28,5 +28,11 @@
     "dmg_adj": [ "marked", "chipped", "cracked", "shattered" ],
     "bash_dmg_verb": "chipped",
     "cut_dmg_verb": "scratched"
+  },
+  {
+    "type": "material",
+    "id": "light",
+    "name": "Light",
+    "copy-from": "sunlight"
   }
 ]

--- a/data/mods/MindOverMatter/mutations/psi_passives.json
+++ b/data/mods/MindOverMatter/mutations/psi_passives.json
@@ -83,6 +83,7 @@
     "points": 0,
     "description": "Your powers passively filter the amount of photons your eyes receive.",
     "flags": [ "FLASH_PROTECTION", "SEESLEEP", "GLARE_RESIST" ],
+    "integrated_armor": [ "integrated_photo_eyes" ],
     "player_display": true,
     "valid": false,
     "purifiable": false


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
I found i can't use welding tools despite PHOTO_EYES should give me some protection here
#### Describe the solution
Add glare protection photokinetic deserves
#### Describe alternatives you've considered
Make it a power
#### Testing
Spawned, welded few stuff
#### Additional context
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/67688115/152672de-20c3-4582-8049-897f9e7404ce)