### PR TITLE
Fixing ImGui windows size issues and input issues

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -275,7 +275,8 @@ void cataimgui::client::process_input( void *input )
 bool cataimgui::client::auto_size_frame_active()
 {
     for( const ImGuiWindow *window : GImGui->Windows ) {
-        if( window->AutoFitFramesX > 0 || window->AutoFitFramesY > 0 ) {
+        if( ( window->ContentSize.x == 0 || window->ContentSize.y == 0 ) && ( window->AutoFitFramesX > 0 ||
+                window->AutoFitFramesY > 0 ) ) {
             return true;
         }
     }
@@ -485,8 +486,15 @@ cataimgui::window::window( const std::string &id_, int window_flags ) : window( 
     is_open = true;
 }
 
-
-cataimgui::window::~window() = default;
+cataimgui::window::~window()
+{
+    ImGui::ClearWindowSettings( id.c_str() );
+    p_impl.reset();
+    if( !ui_adaptor::has_imgui() ) {
+        ImGui::GetIO().ClearInputKeys();
+        GImGui->InputEventsQueue.resize( 0 );
+    }
+}
 
 bool cataimgui::window::is_bounds_changed()
 {

--- a/src/popup.cpp
+++ b/src/popup.cpp
@@ -19,6 +19,7 @@ class query_popup_impl : public cataimgui::window
         short mouse_selected_option;
         size_t msg_width;
         query_popup *parent;
+        short last_keyboard_selected_option;
     public:
         short keyboard_selected_option;
 
@@ -27,6 +28,7 @@ class query_popup_impl : public cataimgui::window
             msg_width = 400;
             this->parent = parent;
             keyboard_selected_option = 0;
+            last_keyboard_selected_option = -1;
             mouse_selected_option = -1;
         }
 
@@ -38,7 +40,7 @@ class query_popup_impl : public cataimgui::window
     protected:
         void draw_controls() override;
         cataimgui::bounds get_bounds() override {
-            return { -1.f, parent->ontop ? 0 : -1.f, -1.f, -1.f };
+            return { -1.f, parent->ontop ? 0 : -1.f, -1.f, -1.f};
         }
 };
 
@@ -52,29 +54,30 @@ void query_popup_impl::draw_controls()
     }
 
     if( !parent->buttons.empty() ) {
-        float x_pos = msg_width;
-        for( const query_popup::button &btn : parent->buttons ) {
-            x_pos -= ( str_width_to_pixels( remove_color_tags( btn.text ).length() ) +
-                       ( ImGui::GetStyle().FramePadding.x * 2 ) + ( ImGui::GetStyle().ItemSpacing.x ) );
-        }
-        ImGui::SetCursorPosX( x_pos );
+        size_t current_line = 0;
         for( size_t ind = 0; ind < parent->buttons.size(); ++ind ) {
+            ImGui::SetCursorPosX( float( parent->buttons[ind].pos.x ) );
             ImGui::Button( remove_color_tags( parent->buttons[ind].text ).c_str() );
             if( ImGui::IsItemHovered() ) {
                 mouse_selected_option = ind;
             }
-            if( keyboard_selected_option == short( ind ) && ImGui::IsWindowFocused() ) {
+            if( keyboard_selected_option != last_keyboard_selected_option &&
+                keyboard_selected_option == short( ind ) && ImGui::IsWindowFocused() ) {
                 ImGui::SetKeyboardFocusHere( -1 );
             }
-            ImGui::SameLine();
+            if( current_line == parent->buttons[ind].pos.y ) {
+                ImGui::SameLine();
+            }
+            current_line = parent->buttons[ind].pos.y;
         }
-
     }
 }
 
 void query_popup_impl::on_resized()
 {
-    constexpr size_t horz_padding = 2;
+    size_t frame_padding = size_t( ImGui::GetStyle().FramePadding.x * 2 );
+    size_t item_padding = size_t( ImGui::GetStyle().ItemSpacing.x );
+    size_t window_padding = size_t( ImGui::GetStyle().WindowPadding.x * 2 );
     // constexpr size_t vert_padding = 1;
     size_t max_line_width = str_width_to_pixels( FULL_SCREEN_WIDTH - 1 * 2 );
 
@@ -84,45 +87,50 @@ void query_popup_impl::on_resized()
     // Fold query buttons
     const auto &folded_query = query_popup::fold_query( parent->category, parent->pref_kbd_mode,
                                parent->options, max_line_width,
-                               horz_padding );
+                               frame_padding + item_padding );
 
     // Calculate size of message part
     msg_width = 0;
     for( const auto &line : parent->folded_msg ) {
-        msg_width = std::max( msg_width, get_text_width( line ) ); //utf8_width( line, true ) );
+        msg_width = std::max( msg_width,
+                              get_text_width( remove_color_tags( line ) ) ); //utf8_width( line, true ) );
     }
-
+    auto btn_padding = [&frame_padding, &item_padding]( size_t num_buttons ) {
+        return ( frame_padding * ( num_buttons - 1 ) ) + ( item_padding * ( num_buttons - 1 ) );
+    };
     // Calculate width with query buttons
     for( const auto &line : folded_query ) {
         if( !line.empty() ) {
             int button_width = 0;
             for( const auto &opt : line ) {
-                button_width += get_text_width( opt );
+                button_width += get_text_width( remove_color_tags( opt ) );
             }
-            msg_width = std::max( msg_width, button_width +
-                                  horz_padding * ( line.size() - 1 ) );
+            // extra item padding needed here to account for space left at the beginning of the window by ImGui
+            msg_width = std::max( msg_width, button_width + btn_padding( line.size() ) + item_padding );
         }
     }
-    msg_width = std::min( msg_width, max_line_width ) * 1.1; // add some margin
+    msg_width = std::min( msg_width, max_line_width );
 
     // Calculate height with query buttons & button positions
     parent->buttons.clear();
+    size_t line_idx = 0;
     if( !folded_query.empty() ) {
         for( const auto &line : folded_query ) {
             if( !line.empty() ) {
                 int button_width = 0;
                 for( const auto &opt : line ) {
-                    button_width += get_text_width( opt );
+                    button_width += get_text_width( remove_color_tags( opt ) );
                 }
                 // Right align.
                 // TODO: multi-line buttons
-                size_t button_x = std::max( size_t( 0 ), size_t( msg_width - button_width -
-                                            horz_padding * ( line.size() - 1 ) ) );
+                size_t button_x = std::max( size_t( 0 ),
+                                            size_t( msg_width - button_width - btn_padding( line.size() ) ) );
                 for( const auto &opt : line ) {
-                    parent->buttons.emplace_back( opt, point( button_x, 0 ) );
-                    button_x += get_text_width( opt ) + horz_padding;
+                    parent->buttons.emplace_back( opt, point( button_x, line_idx ) );
+                    button_x += get_text_width( remove_color_tags( opt ) ) + frame_padding + item_padding;
                 }
             }
+            line_idx++;
         }
     }
 }

--- a/src/popup.cpp
+++ b/src/popup.cpp
@@ -54,7 +54,7 @@ void query_popup_impl::draw_controls()
     }
 
     if( !parent->buttons.empty() ) {
-        size_t current_line = 0;
+        int current_line = 0;
         for( size_t ind = 0; ind < parent->buttons.size(); ++ind ) {
             ImGui::SetCursorPosX( float( parent->buttons[ind].pos.x ) );
             ImGui::Button( remove_color_tags( parent->buttons[ind].text ).c_str() );
@@ -77,7 +77,6 @@ void query_popup_impl::on_resized()
 {
     size_t frame_padding = size_t( ImGui::GetStyle().FramePadding.x * 2 );
     size_t item_padding = size_t( ImGui::GetStyle().ItemSpacing.x );
-    size_t window_padding = size_t( ImGui::GetStyle().WindowPadding.x * 2 );
     // constexpr size_t vert_padding = 1;
     size_t max_line_width = str_width_to_pixels( FULL_SCREEN_WIDTH - 1 * 2 );
 

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -3788,8 +3788,11 @@ input_event input_manager::get_input_event( const keyboard_mode preferred_keyboa
     // we can skip screen update if `needupdate` is false to improve performance during mouse
     // move events.
     wnoutrefresh( catacurses::stdscr );
+
     if( needupdate ) {
         refresh_display();
+    } else if( ui_adaptor::has_imgui() ) {
+        try_sdl_update();
     }
 
     if( inputdelay < 0 ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "fixing issues where ImGui popup changes size sporadically. Fix issue where keybindings filter box deactivates unexpectedly"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes: #72822
Popup had issues where opening different popups of various sizes caused the popup sizes to became tangled, so some popups become too small, and some become too large. I took the time while I was in there to tighten up the code that determines the size of the window, and moved all the sizing calculations into the resize callback for optimization.

Keybindings UI had an issue where, if you close another ImGui window with the 'escape' key, because input processing stops when ImGui UI is not on screen (by design) ImGui would think the Escape key is stuck down, causing the filter box to become deactivated after pressing the 'f' key.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
-After closing any ImGui window, clear the window settings for the window to make sure the size can't be shared
-After closing the last open ImGui window, clear ImGui's input queue of all characters waiting to be processed, and clear all active pressed key data.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Burn it all. To the ground.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
-Craft something. Verify the popup expands and contracts to fit its contents only as required
-Cancel the craft
-Press 'D'. Verify the popup asking where to drop has a normal size.
-Repeat the above a few times and make damn sure that popup never, ever, ever changes size

-Open keybindings UI
-Close it with the Escape key
-Open keybindings UI
-Press 'f' to bring up the filter
-Verify that a filter can be typed as normal
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
