### PR TITLE
[Bombastic Perks] Add more perks

### DIFF
--- a/data/mods/BombasticPerks/perkdata/grit_your_teeth.json
+++ b/data/mods/BombasticPerks/perkdata/grit_your_teeth.json
@@ -42,7 +42,7 @@
           ],
           "false_effect": [
             { "math": [ "u_grit_your_teeth_pain_value_removed", "=", "u_pain()" ] },
-            { "math": [ "u_pain()", "==", "0" ] },
+            { "math": [ "u_pain()", "=", "0" ] },
             { "queue_eocs": "EOC_PERK_GRIT_YOUR_TEETH_DEACTIVATE", "time_in_future": 180 }
           ]
         }
@@ -54,5 +54,14 @@
     "id": "EOC_PERK_GRIT_YOUR_TEETH_DEACTIVATE",
     "condition": { "u_has_effect": "effect_perk_grit_your_teeth_cooldown" },
     "effect": [ { "math": [ "u_pain()", "+=", "u_grit_your_teeth_pain_value_removed" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PERK_GRIT_YOUR_TEETH_BACKUP_REMOVE",
+    "eoc_type": "EVENT",
+    "required_event": "character_wakes_up",
+    "//": "A backup to remove the cooldown in case the character ends up with a million pain or something.",
+    "condition": { "u_has_effect": "effect_perk_grit_your_teeth_cooldown" },
+    "effect": [ { "u_lose_effect": "effect_perk_grit_your_teeth_cooldown" } ]
   }
 ]

--- a/data/mods/BombasticPerks/perkdata/grit_your_teeth.json
+++ b/data/mods/BombasticPerks/perkdata/grit_your_teeth.json
@@ -1,0 +1,58 @@
+[
+  {
+    "type": "effect_type",
+    "id": "effect_perk_grit_your_teeth_cooldown",
+    "//": "No name or description to hide effect",
+    "name": [ "" ],
+    "desc": [ "" ],
+    "rating": "bad"
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PERK_GRIT_YOUR_TEETH",
+    "condition": { "not": { "u_has_effect": "effect_perk_grit_your_teeth_cooldown" } },
+    "effect": [
+      { "math": [ "u_grit_your_teeth_pain_value", "=", "u_pain()" ] },
+      {
+        "u_add_effect": "effect_perk_grit_your_teeth_cooldown",
+        "duration": { "math": [ "u_grit_your_teeth_pain_value * 60" ] }
+      },
+      { "run_eocs": "EOC_PERK_GRIT_YOUR_TEETH_2" }
+    ],
+    "false_effect": [ { "u_message": "You need more time to collect yourself before you can grit your teeth again.", "type": "mixed" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PERK_GRIT_YOUR_TEETH_2",
+    "condition": { "math": [ "u_grit_your_teeth_pain_value", ">=", "62" ] },
+    "effect": [
+      { "math": [ "u_grit_your_teeth_pain_value_removed", "=", "u_pain() / 2" ] },
+      { "math": [ "u_pain()", "-=", "u_grit_your_teeth_pain_value_removed" ] },
+      { "queue_eocs": "EOC_PERK_GRIT_YOUR_TEETH_DEACTIVATE", "time_in_future": 180 }
+    ],
+    "false_effect": [
+      {
+        "run_eocs": {
+          "id": "EOC_PERK_GRIT_YOUR_TEETH_3",
+          "condition": { "math": [ "u_grit_your_teeth_pain_value", ">=", "30" ] },
+          "effect": [
+            { "math": [ "u_grit_your_teeth_pain_value_removed", "=", "30" ] },
+            { "math": [ "u_pain()", "-=", "u_grit_your_teeth_pain_value_removed" ] },
+            { "queue_eocs": "EOC_PERK_GRIT_YOUR_TEETH_DEACTIVATE", "time_in_future": 180 }
+          ],
+          "false_effect": [
+            { "math": [ "u_grit_your_teeth_pain_value_removed", "=", "u_pain()" ] },
+            { "math": [ "u_pain()", "==", "0" ] },
+            { "queue_eocs": "EOC_PERK_GRIT_YOUR_TEETH_DEACTIVATE", "time_in_future": 180 }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PERK_GRIT_YOUR_TEETH_DEACTIVATE",
+    "condition": { "u_has_effect": "effect_perk_grit_your_teeth_cooldown" },
+    "effect": [ { "math": [ "u_pain()", "+=", "u_grit_your_teeth_pain_value_removed" ] } ]
+  }
+]

--- a/data/mods/BombasticPerks/perkdata/moonstruck.json
+++ b/data/mods/BombasticPerks/perkdata/moonstruck.json
@@ -1,0 +1,109 @@
+[
+  {
+    "type": "effect_type",
+    "id": "effect_perk_moonstruck_full",
+    "name": [ "Moonstruck: Full Moon" ],
+    "desc": [ "Under the clear light of the full moon, you have unlocked your greatest potential." ],
+    "apply_message": "",
+    "rating": "good",
+    "max_duration": "1 days",
+    "enchantments": [
+      {
+        "values": [
+          { "value": "STRENGTH", "add": 3 },
+          { "value": "DEXTERITY", "add": 3 },
+          { "value": "INTELLIGENCE", "add": 3 },
+          { "value": "PERCEPTION", "add": 3 }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_perk_moonstruck_waxing",
+    "name": [ "Moonstruck: Waxing Moon" ],
+    "desc": [ "The silver light of the waxing moon enhances your prowess." ],
+    "apply_message": "",
+    "rating": "good",
+    "max_duration": "1 days",
+    "enchantments": [
+      {
+        "values": [
+          { "value": "STRENGTH", "add": 1 },
+          { "value": "DEXTERITY", "add": 1 },
+          { "value": "INTELLIGENCE", "add": 1 },
+          { "value": "PERCEPTION", "add": 1 }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_perk_moonstruck_new",
+    "name": [ "Moonstruck: New Moon" ],
+    "desc": [ "In the dark of the moon, you feel your vital essence weaken." ],
+    "apply_message": "",
+    "rating": "bad",
+    "max_duration": "1 days",
+    "enchantments": [
+      {
+        "values": [
+          { "value": "STRENGTH", "add": -2 },
+          { "value": "DEXTERITY", "add": -2 },
+          { "value": "INTELLIGENCE", "add": -2 },
+          { "value": "PERCEPTION", "add": -2 }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PERK_MOONSTRUCK",
+    "recurrence": [ "1 hours", "1 hours" ],
+    "condition": { "u_has_trait": "perk_moonstruck" },
+    "deactivate_condition": { "not": { "u_has_trait": "perk_moonstruck" } },
+    "effect": {
+      "run_eocs": [
+        {
+          "id": "EOC_PERK_MOONSTRUCK_2",
+          "condition": { "math": [ "moon_phase() == 4" ] },
+          "effect": [
+            { "u_lose_effect": "effect_perk_moonstruck_full" },
+            { "u_lose_effect": "effect_perk_moonstruck_waxing" },
+            { "u_lose_effect": "effect_perk_moonstruck_new" },
+            { "u_add_effect": "effect_perk_moonstruck_full", "duration": "2 hours" }
+          ],
+          "false_effect": {
+            "run_eocs": {
+              "id": "EOC_PERK_MOONSTRUCK_3",
+              "condition": { "and": [ { "math": [ "moon_phase() <= 3" ] }, { "math": [ "moon_phase() >= 1" ] } ] },
+              "effect": [
+                { "u_lose_effect": "effect_perk_moonstruck_full" },
+                { "u_lose_effect": "effect_perk_moonstruck_waxing" },
+                { "u_lose_effect": "effect_perk_moonstruck_new" },
+                { "u_add_effect": "effect_perk_moonstruck_waxing", "duration": "2 hours" }
+              ],
+              "false_effect": {
+                "run_eocs": {
+                  "id": "EOC_PERK_MOONSTRUCK_4",
+                  "condition": { "math": [ "moon_phase() == 0" ] },
+                  "effect": [
+                    { "u_lose_effect": "effect_perk_moonstruck_full" },
+                    { "u_lose_effect": "effect_perk_moonstruck_waxing" },
+                    { "u_lose_effect": "effect_perk_moonstruck_new" },
+                    { "u_add_effect": "effect_perk_moonstruck_new", "duration": "2 hours" }
+                  ],
+                  "false_effect": [
+                    { "u_lose_effect": "effect_perk_moonstruck_full" },
+                    { "u_lose_effect": "effect_perk_moonstruck_waxing" },
+                    { "u_lose_effect": "effect_perk_moonstruck_new" }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+]

--- a/data/mods/BombasticPerks/perkdata/undying_loyalty.json
+++ b/data/mods/BombasticPerks/perkdata/undying_loyalty.json
@@ -27,7 +27,7 @@
     "id": "perk_undying_loyalty_spell",
     "type": "SPELL",
     "name": "Undying Loyalty Spell",
-    "description": "The spell to activate the Undying Loyalty effect. It's a bug if you have it.",
+    "description": "The spell to activate the Undying Loyalty effect.  It's a bug if you have it.",
     "valid_targets": [ "ally" ],
     "flags": [ "SILENT", "NO_HANDS", "NO_LEGS", "NO_EXPLOSION_SFX" ],
     "effect": "attack",
@@ -54,7 +54,7 @@
     "desc": [ "You'll protect your allies no matter the cost." ],
     "apply_message": "",
     "rating": "good",
-    "show_in_info": "true",
+    "show_in_info": true,
     "max_duration": "1 minutes",
     "enchantments": [ { "values": [ { "value": "ARMOR_ALL", "multiply": -0.15 } ] } ]
   }

--- a/data/mods/BombasticPerks/perkdata/undying_loyalty.json
+++ b/data/mods/BombasticPerks/perkdata/undying_loyalty.json
@@ -1,0 +1,61 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PERK_UNDYING_LOYALTY",
+    "eoc_type": "EVENT",
+    "required_event": "character_takes_damage",
+    "condition": {
+      "and": [
+        { "u_has_trait": "perk_undying_loyalty" },
+        { "not": { "u_has_effect": "effect_perk_undying_loyalty_self" } },
+        { "not": { "u_has_any_trait": [ "PRED1", "PRED2", "PRED3", "PRED4", "SAPIOVORE" ] } },
+        { "math": [ "u_characters_nearby('radius': 15, 'attitude': 'allies')", ">", "0" ] },
+        {
+          "or": [
+            { "math": [ "u_hp('head') / u_hp_max('head')", "<=", "0.5" ] },
+            { "math": [ "u_hp('torso') / u_hp_max('torso')", "<=", "0.5" ] }
+          ]
+        }
+      ]
+    },
+    "effect": [
+      { "u_cast_spell": { "id": "perk_undying_loyalty_spell" } },
+      { "u_add_effect": "effect_perk_undying_loyalty_self", "duration": "5 minutes" }
+    ]
+  },
+  {
+    "id": "perk_undying_loyalty_spell",
+    "type": "SPELL",
+    "name": "Undying Loyalty Spell",
+    "description": "The spell to activate the Undying Loyalty effect. It's a bug if you have it.",
+    "valid_targets": [ "ally" ],
+    "flags": [ "SILENT", "NO_HANDS", "NO_LEGS", "NO_EXPLOSION_SFX" ],
+    "effect": "attack",
+    "effect_str": "effect_perk_undying_loyalty",
+    "shape": "blast",
+    "difficulty": 1,
+    "min_duration": 6000,
+    "max_duration": 6000,
+    "min_aoe": 15,
+    "max_aoe": 15
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_perk_undying_loyalty_self",
+    "//": "No name or description to hide effect",
+    "name": [ "" ],
+    "desc": [ "" ],
+    "rating": "bad"
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_perk_undying_loyalty",
+    "name": [ "Undying Loyalty" ],
+    "desc": [ "You'll protect your allies no matter the cost." ],
+    "apply_message": "",
+    "rating": "good",
+    "show_in_info": "true",
+    "max_duration": "1 minutes",
+    "enchantments": [ { "values": [ { "value": "ARMOR_ALL", "multiply": -0.15 } ] } ]
+  }
+]

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -665,6 +665,25 @@
         "topic": "TALK_PERK_MENU_SELECT"
       },
       {
+        "condition": { "not": { "u_has_trait": "perk_non_combatant" } },
+        "text": "Gain [<trait_name:perk_non_combatant>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_non_combatant>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:perk_non_combatant>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "perk_non_combatant", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Must have the Pacifist trait",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "u_has_trait": "PACIFIST" } }
+        ],
+        "topic": "TALK_PERK_MENU_SELECT"
+      },
+      {
         "condition": { "not": { "u_has_trait": "perk_troubleseeker" } },
         "text": "Gain [<trait_name:perk_troubleseeker>]",
         "effect": [

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -522,6 +522,30 @@
         "topic": "TALK_PERK_MENU_SELECT"
       },
       {
+        "condition": { "not": { "u_has_trait": "perk_grit_your_teeth" } },
+        "text": "Gain [<trait_name:perk_grit_your_teeth>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_grit_your_teeth>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:perk_grit_your_teeth>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "perk_grit_your_teeth", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Must have the Built Tough perk./n/nMust not have the Pain Sensitive, Hyperalgesia, or Extreme Hyperalgesia Traits",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          {
+            "set_condition": "perk_condition",
+            "condition": {
+              "and": [ { "u_has_trait": "perk_built_tough" }, { "not": { "u_has_any_trait": [ "MORE_PAIN", "MORE_PAIN2", "MORE_PAIN3" ] } } ]
+            }
+          }
+        ],
+        "topic": "TALK_PERK_MENU_SELECT"
+      },
+      {
         "condition": { "not": { "u_has_trait": "perk_recycler" } },
         "text": "Gain [<trait_name:perk_recycler>]",
         "effect": [

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -532,7 +532,7 @@
           },
           { "set_string_var": "perk_grit_your_teeth", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Must have the Built Tough perk./n/nMust not have the Pain Sensitive, Hyperalgesia, or Extreme Hyperalgesia Traits",
+            "set_string_var": "Must have the Built Tough perk.\n\nMust not have the Pain Sensitive, Hyperalgesia, or Extreme Hyperalgesia Traits",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -503,6 +503,33 @@
         "topic": "TALK_PERK_MENU_SELECT"
       },
       {
+        "condition": { "not": { "u_has_trait": "perk_undying_loyalty" } },
+        "text": "Gain [<trait_name:perk_undying_loyalty>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_undying_loyalty>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:perk_undying_loyalty>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "perk_undying_loyalty", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Must have the Extrovert or Sociable trait\n\nMust not have the Culler, Hunter, Predator, Apex Predator, or Sapiovore traits.",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          {
+            "set_condition": "perk_condition",
+            "condition": {
+              "and": [
+                { "or": [ { "u_has_trait": "SOCIAL1" }, { "u_has_trait": "SOCIAL2" } ] },
+                { "not": { "u_has_any_trait": [ "PRED1", "PRED2", "PRED3", "PRED4", "SAPIOVORE" ] } }
+              ]
+            }
+          }
+        ],
+        "topic": "TALK_PERK_MENU_SELECT"
+      },
+      {
         "condition": { "not": { "u_has_trait": "perk_tuck_and_roll" } },
         "text": "Gain [<trait_name:perk_tuck_and_roll>]",
         "effect": [

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -993,6 +993,25 @@
         "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
       },
       {
+        "condition": { "not": { "u_has_trait": "perk_moonstruck" } },
+        "text": "Gain [<trait_name:perk_moonstruck>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_moonstruck>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:perk_moonstruck>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "perk_moonstruck", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
+        ],
+        "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
+      },
+      {
         "condition": { "not": { "u_has_trait": "perk_skeleton" } },
         "text": "Gain [<trait_name:perk_skeleton>]",
         "effect": [

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -210,6 +210,17 @@
   },
   {
     "type": "mutation",
+    "id": "perk_undying_loyalty",
+    "name": {
+      "//~": "This is a pun, based on undying literally meaning 'does not die' but also the figurative meaning of an emotion that lasts forever.",
+      "str": "Undying Loyalty"
+    },
+    "points": 0,
+    "description": "You inspire your allies to protect you when you're seriously injured.  If attacked when your head or torso health are at 50% or lower, all allies within 15 meters will take 20% reduced damage for one minute.  This effect can only trigger once every five minutes.",
+    "category": [ "perk" ]
+  },
+  {
+    "type": "mutation",
     "id": "perk_tuck_and_roll",
     "name": { "str": "Tuck and Roll" },
     "points": 0,

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -331,6 +331,56 @@
   },
   {
     "type": "mutation",
+    "id": "perk_non_combatant",
+    "name": { "str": "Non-Combatant" },
+    "points": 0,
+    "description": "Hey, that's against the Geneva Convention!  When not wielding a weapon, or object that could be used as an improvised weapon, you take -15% reduced damage.",
+    "category": [ "perk" ],
+    "//": "u_has_weapon checks if you're wielding ANYTHNG, not a weapon specifically, hence the long condition below.",
+    "enchantments": [
+      {
+        "condition": {
+          "and": [
+            { "not": { "u_has_wielded_with_weapon_category": "AUTOMATIC_PISTOLS" } },
+            { "not": { "u_has_wielded_with_weapon_category": "SHIVS" } },
+            { "not": { "u_has_wielded_with_weapon_category": "QUARTERSTAVES" } },
+            { "not": { "u_has_wielded_with_weapon_category": "HOOKING_WEAPONRY" } },
+            { "not": { "u_has_wielded_with_weapon_category": "AUTOMATIC_RIFLES" } },
+            { "not": { "u_has_wielded_with_weapon_category": "KNIVES" } },
+            { "not": { "u_has_wielded_with_weapon_category": "MEDIUM_SWORDS" } },
+            { "not": { "u_has_wielded_with_weapon_category": "GREAT_HAMMERS" } },
+            { "not": { "u_has_wielded_with_weapon_category": "GREAT_AXES" } },
+            { "not": { "u_has_wielded_with_weapon_category": "MACES" } },
+            { "not": { "u_has_wielded_with_weapon_category": "SPEARS" } },
+            { "not": { "u_has_wielded_with_weapon_category": "FENCING_WEAPONRY" } },
+            { "not": { "u_has_wielded_with_weapon_category": "LONG_SWORDS" } },
+            { "not": { "u_has_wielded_with_weapon_category": "GREAT_SWORDS" } },
+            { "not": { "u_has_wielded_with_weapon_category": "BIONIC_WEAPONRY" } },
+            { "not": { "u_has_wielded_with_weapon_category": "SHORT_SWORDS" } },
+            { "not": { "u_has_wielded_with_weapon_category": "HAND_AXES" } },
+            { "not": { "u_has_wielded_with_weapon_category": "BATONS" } },
+            { "not": { "u_has_wielded_with_weapon_category": "FLAILS" } },
+            { "not": { "u_has_wielded_with_weapon_category": "POLEARMS" } },
+            { "not": { "u_has_wielded_with_weapon_category": "LONG_THRUSTING_SWORDS" } },
+            { "not": { "u_has_wielded_with_weapon_category": "BIONIC_SWORDS" } },
+            { "not": { "u_has_wielded_with_flag": "OLD_GUN" } },
+            { "not": { "u_has_wielded_with_flag": "NEVER_JAMS" } },
+            { "not": { "u_has_wielded_with_flag": "NON_FOULING" } },
+            { "not": { "u_has_wielded_with_flag": "RELOAD_AND_SHOOT" } },
+            { "not": { "u_has_wielded_with_flag": "RELOAD_EJECT" } },
+            { "not": { "u_has_wielded_with_flag": "RELOAD_ONE" } },
+            { "not": { "u_has_wielded_with_flag": "STR_DRAW" } },
+            { "not": { "u_has_wielded_with_flag": "DURABLE_MELEE" } },
+            { "not": { "u_has_wielded_with_flag": "BIONIC_WEAPON" } },
+            { "not": { "u_has_wielded_with_flag": "POLEARM" } }
+          ]
+        },
+        "values": [ { "value": "ARMOR_ALL", "multiply": -0.15 } ]
+      }
+    ]
+  },
+  {
+    "type": "mutation",
     "id": "perk_recycler",
     "name": { "str": "Recycler" },
     "points": 0,

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -109,22 +109,7 @@
     "points": 0,
     "description": "You're like a walking tank!  Take 5% less damage from all sources.",
     "category": [ "perk" ],
-    "enchantments": [
-      {
-        "condition": "ALWAYS",
-        "values": [
-          { "value": "ARMOR_ACID", "multiply": -0.05 },
-          { "value": "ARMOR_BASH", "multiply": -0.05 },
-          { "value": "ARMOR_BIO", "multiply": -0.05 },
-          { "value": "ARMOR_BULLET", "multiply": -0.05 },
-          { "value": "ARMOR_COLD", "multiply": -0.05 },
-          { "value": "ARMOR_CUT", "multiply": -0.05 },
-          { "value": "ARMOR_ELEC", "multiply": -0.05 },
-          { "value": "ARMOR_HEAT", "multiply": -0.05 },
-          { "value": "ARMOR_STAB", "multiply": -0.05 }
-        ]
-      }
-    ]
+    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "ARMOR_ALL", "multiply": -0.05 } ] } ]
   },
   {
     "type": "mutation",

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -236,7 +236,7 @@
     "description": "When you have to you can wipe the blood off your chin, grit your teeth, and get it done.  Use to reduce your pain by 30 or half (whichever is greater) for 3 minutes.\n\nThe cooldown on this perk scales based on your pain at the time you used it.",
     "category": [ "perk" ],
     "active": true,
-    "activated_is_setup": true,
+    "activated_is_setup": false,
     "activated_eocs": [ "EOC_PERK_GRIT_YOUR_TEETH" ]
   },
   {
@@ -422,7 +422,7 @@
     "id": "perk_frakenstein",
     "name": { "str": "Playing God" },
     "points": 0,
-    "description": "You've been dissecting critters since high school.  Last night a voice gave you an idea for how to bring them back to life activate the perk to gain insight into the nature of life itself!",
+    "description": "You've been dissecting critters since high school.  Last night a voice gave you an idea for how to bring them back to life.  Activate the perk to gain insight into the nature of life itself!",
     "category": [ "perk" ],
     "active": true,
     "activated_eocs": [ "EOC_frankenstein_insight" ]

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -234,6 +234,17 @@
   },
   {
     "type": "mutation",
+    "id": "perk_grit_your_teeth",
+    "name": { "str": "Grit Your Teeth" },
+    "points": 0,
+    "description": "When you have to you can wipe the blood off your chin, grit your teeth, and get it done.  Use to reduce your pain by 30 or half (whichever is greater) for 3 minutes.\n\nThe cooldown on this perk scales based on your pain at the time you used it.",
+    "category": [ "perk" ],
+    "active": true,
+    "activated_is_setup": true,
+    "activated_eocs": [ "EOC_PERK_GRIT_YOUR_TEETH" ]
+  },
+  {
+    "type": "mutation",
     "id": "perk_surgical_strikes",
     "name": { "str": "Surgical Strikes" },
     "points": 0,

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -634,6 +634,14 @@
   },
   {
     "type": "mutation",
+    "id": "perk_moonstruck",
+    "name": { "str": "Moonstruck" },
+    "points": 0,
+    "description": "You've always been greatly affected by the phases of the moon.  During a full moon, you gain a +3 bonus to all stats.  During a waxing moon, you gain a +1 bonus to all stats, and during a new moon, you suffer a -2 penalty to all stats.",
+    "category": [ "perk" ]
+  },
+  {
+    "type": "mutation",
     "id": "perk_ascetic_empowerment",
     "name": { "str": "Ascetic Empowerment" },
     "points": 0,

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -375,7 +375,7 @@
             { "not": { "u_has_wielded_with_flag": "POLEARM" } }
           ]
         },
-        "values": [ { "value": "ARMOR_ALL", "multiply": -0.15 } ]
+        "values": [ { "value": "ARMOR_ALL", "multiply": -0.25 } ]
       }
     ]
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Bombastic Perks] Add more perks"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Had yet more ideas for perks
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add some perks:

- Grit Your Teeth: Activate to reduce your current pain by 30 or by half (whichever is greater) for 3 minutes. When it ends, all previous pain returns. The cooldown is minutes equal to your pain at the time you used the perk. _Requires Built Tough; cannot have Pain Sensitive or its upgrades_
- Undying Loyalty: If you take damage when your torso or head is at 50% health or lower, and you have any allies with you, all nearby allies take 20% less damage for 1 minute. Can trigger no more than once per 5 minutes.  _Requires Extrovert, cannot have the various predatory mind mutations (Pack Hunter is allowed)_
- Non-combatant: Hey, that's against the Geneva Convention! You take 25% less damage when not wielding a weapon. _Requires Pacifist trait_

And one playstyle perk:
- Moonstruck: You are greatly affected by the phases of the moon. When the moon is full, you gain +3 to all stats. When the moon is waxing, you gain +1 to all stats, when the moon is waning, you gain no benefit, and during the new moon you suffer a -2 penalty to all stats.  (done as a recurring EoC that rechecks the buff every hour)

More to come.

I also changed the enchant on Built Tough to ARMOR_ALL, since it explicitly says it's supposed to reduce all damage by 5%.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Tested perks, they all require appropriate prerequisites and all work properly.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
