### PR TITLE
Added roof bashing to 'indoors' terrain

### DIFF
--- a/data/json/furniture_and_terrain/terrain-floors-indoor.json
+++ b/data/json/furniture_and_terrain/terrain-floors-indoor.json
@@ -14,6 +14,7 @@
     "bash": {
       "sound": "SMASH!",
       "ter_set": "t_null",
+      "ter_set_bashed_from_above": "t_thconc_floor_no_roof",
       "str_min": 100,
       "str_max": 400,
       "str_min_supported": 150,
@@ -40,6 +41,7 @@
     "bash": {
       "sound": "SMASH!",
       "ter_set": "t_null",
+      "ter_set_bashed_from_above": "t_thconc_floor_no_roof",
       "str_min": 100,
       "str_max": 400,
       "str_min_supported": 150,
@@ -103,6 +105,7 @@
       "sound_vol": 16,
       "sound_fail_vol": 10,
       "ter_set": "t_thconc_y",
+      "ter_set_bashed_from_above": "t_thconc_floor_no_roof",
       "items": [ { "item": "glass_shard", "count": [ 8, 16 ] } ]
     },
     "shoot": { "chance_to_hit": 0, "reduce_damage": [ 0, 0 ], "reduce_damage_laser": [ 0, 0 ], "destroy_damage": [ 2, 8 ] }
@@ -128,6 +131,7 @@
       "sound_vol": 16,
       "sound_fail_vol": 10,
       "ter_set": "t_thconc_floor",
+      "ter_set_bashed_from_above": "t_thconc_floor_no_roof",
       "items": [ { "item": "glass_shard", "count": [ 8, 16 ] } ]
     },
     "shoot": { "chance_to_hit": 0, "reduce_damage": [ 0, 0 ], "reduce_damage_laser": [ 0, 0 ], "destroy_damage": [ 2, 8 ] }
@@ -154,6 +158,7 @@
       "sound_vol": 16,
       "sound_fail_vol": 10,
       "ter_set": "t_floor",
+      "ter_set_bashed_from_above": "t_floor_noroof",
       "items": [ { "item": "glass_shard", "count": [ 8, 16 ] } ]
     },
     "shoot": { "chance_to_hit": 0, "reduce_damage": [ 0, 0 ], "reduce_damage_laser": [ 0, 0 ], "destroy_damage": [ 2, 8 ] }
@@ -170,7 +175,14 @@
     "move_cost": 2,
     "roof": "t_rock_roof",
     "flags": [ "TRANSPARENT", "INDOORS", "COLLAPSES", "SUPPORTS_ROOF", "FLAT", "ROAD" ],
-    "bash": { "ter_set": "t_null", "str_min": 75, "str_max": 400, "str_min_supported": 100, "bash_below": true }
+    "bash": {
+      "ter_set": "t_null",
+      "ter_set_bashed_from_above": "t_brick_floor_noroof",
+      "str_min": 75,
+      "str_max": 400,
+      "str_min_supported": 100,
+      "bash_below": true
+    }
   },
   {
     "type": "terrain",
@@ -194,6 +206,7 @@
       "sound_vol": 16,
       "sound_fail_vol": 10,
       "ter_set": "t_dirtfloor",
+      "ter_set_bashed_from_above": "t_dirtfloor_no_roof",
       "items": [ { "item": "glass_shard", "count": [ 8, 16 ] } ]
     },
     "shoot": { "chance_to_hit": 0, "reduce_damage": [ 0, 0 ], "reduce_damage_laser": [ 0, 0 ], "destroy_damage": [ 2, 8 ] }
@@ -219,6 +232,7 @@
       "sound_vol": 16,
       "sound_fail_vol": 10,
       "ter_set": "t_metal_floor",
+      "ter_set_bashed_from_above": "t_metal_floor_no_roof",
       "items": [ { "item": "glass_shard", "count": [ 8, 16 ] } ]
     },
     "shoot": { "chance_to_hit": 0, "reduce_damage": [ 0, 0 ], "reduce_damage_laser": [ 0, 0 ], "destroy_damage": [ 2, 8 ] }
@@ -245,6 +259,7 @@
       "sound_vol": 16,
       "sound_fail_vol": 10,
       "ter_set": "t_strconc_floor",
+      "ter_set_bashed_from_above": "t_strconc_floor_no_roof",
       "items": [ { "item": "glass_shard", "count": [ 8, 16 ] } ]
     },
     "shoot": { "chance_to_hit": 0, "reduce_damage": [ 0, 0 ], "reduce_damage_laser": [ 0, 0 ], "destroy_damage": [ 2, 8 ] }
@@ -271,6 +286,7 @@
       "sound_vol": 16,
       "sound_fail_vol": 10,
       "ter_set": "t_linoleum_gray",
+      "ter_set_bashed_from_above": "t_linoleum_gray_no_roof",
       "items": [ { "item": "glass_shard", "count": [ 8, 16 ] } ]
     },
     "shoot": { "chance_to_hit": 0, "reduce_damage": [ 0, 0 ], "reduce_damage_laser": [ 0, 0 ], "destroy_damage": [ 2, 8 ] }
@@ -297,6 +313,7 @@
       "sound_vol": 16,
       "sound_fail_vol": 10,
       "ter_set": "t_linoleum_white",
+      "ter_set_bashed_from_above": "t_linoleum_white_no_roof",
       "items": [ { "item": "glass_shard", "count": [ 8, 16 ] } ]
     },
     "shoot": { "chance_to_hit": 0, "reduce_damage": [ 0, 0 ], "reduce_damage_laser": [ 0, 0 ], "destroy_damage": [ 2, 8 ] }
@@ -313,6 +330,7 @@
     "bash": {
       "sound": "SCRRRASH!",
       "ter_set": "t_null",
+      "ter_set_bashed_from_above": "t_null",
       "str_min": 100,
       "str_max": 400,
       "str_min_supported": 150,
@@ -334,6 +352,7 @@
     "bash": {
       "sound": "SMASH!",
       "ter_set": "t_null",
+      "ter_set_bashed_from_above": "t_strconc_floor_no_roof",
       "str_min": 150,
       "str_max": 400,
       "str_min_supported": 200,
@@ -362,6 +381,7 @@
     "bash": {
       "sound": "SMASH!",
       "ter_set": "t_null",
+      "ter_set_bashed_from_above": "t_strconc_floor_no_roof",
       "str_min": 150,
       "str_max": 400,
       "str_min_supported": 200,
@@ -384,6 +404,7 @@
     "bash": {
       "sound": "SCRRRASH!",
       "ter_set": "t_null",
+      "ter_set_bashed_from_above": "t_null",
       "str_min": 100,
       "str_max": 400,
       "str_min_supported": 150,
@@ -402,6 +423,7 @@
     "bash": {
       "sound": "SMASH!",
       "ter_set": "t_null",
+      "ter_set_bashed_from_above": "t_null",
       "str_min": 50,
       "str_max": 400,
       "str_min_supported": 100,
@@ -424,7 +446,14 @@
     "move_cost": 2,
     "roof": "t_rock_roof",
     "flags": [ "TRANSPARENT", "INDOORS", "COLLAPSES", "SUPPORTS_ROOF", "FLAT", "ROAD" ],
-    "bash": { "ter_set": "t_null", "str_min": 75, "str_max": 400, "str_min_supported": 100, "bash_below": true }
+    "bash": {
+      "ter_set": "t_null",
+      "ter_set_bashed_from_above": "t_rock_floor_no_roof",
+      "str_min": 75,
+      "str_max": 400,
+      "str_min_supported": 100,
+      "bash_below": true
+    }
   },
   {
     "type": "terrain",
@@ -439,7 +468,14 @@
     "move_cost": 2,
     "roof": "t_rock_roof",
     "flags": [ "TRANSPARENT", "INDOORS", "COLLAPSES", "SUPPORTS_ROOF", "FLAT", "ROAD" ],
-    "bash": { "ter_set": "t_null", "str_min": 75, "str_max": 400, "str_min_supported": 100, "bash_below": true }
+    "bash": {
+      "ter_set": "t_null",
+      "ter_set_bashed_from_above": "t_marble_floor_noroof",
+      "str_min": 75,
+      "str_max": 400,
+      "str_min_supported": 100,
+      "bash_below": true
+    }
   },
   {
     "type": "terrain",
@@ -452,7 +488,15 @@
     "connects_to": "ROCKFLOOR",
     "move_cost": 2,
     "roof": "t_warped_roof",
-    "flags": [ "TRANSPARENT", "INDOORS", "SUPPORTS_ROOF", "FLAT", "ROAD" ]
+    "flags": [ "TRANSPARENT", "INDOORS", "SUPPORTS_ROOF", "FLAT", "ROAD" ],
+    "bash": {
+      "ter_set": "t_null",
+      "ter_set_bashed_from_above": "t_floor_warped_noroof",
+      "str_min": 75,
+      "str_max": 400,
+      "str_min_supported": 100,
+      "bash_below": true
+    }
   },
   {
     "type": "terrain",
@@ -469,6 +513,7 @@
     "bash": {
       "sound": "thump",
       "ter_set": "t_null",
+      "ter_set_bashed_from_above": "t_metal_floor_no_roof",
       "str_min": 200,
       "str_max": 500,
       "str_min_supported": 200,
@@ -487,7 +532,6 @@
     "symbol": ".",
     "color": "light_cyan",
     "move_cost": 2,
-    "roof": "t_metal_roof",
     "flags": [ "TRANSPARENT", "INDOORS" ],
     "bash": {
       "sound": "thump",
@@ -518,6 +562,7 @@
     "bash": {
       "sound": "SMASH!",
       "ter_set": "t_null",
+      "ter_set_bashed_from_above": "t_floor_no_roof",
       "str_min": 50,
       "str_max": 400,
       "str_min_supported": 100,
@@ -538,6 +583,7 @@
     "bash": {
       "sound": "SMASH!",
       "ter_set": "t_null",
+      "ter_set_bashed_from_above": "t_dirtfloor_no_roof",
       "str_min": 50,
       "str_max": 400,
       "str_min_supported": 100,
@@ -563,6 +609,7 @@
       "str_max": 400,
       "sound": "SMASH!",
       "ter_set": "t_null",
+      "ter_set_bashed_from_above": "t_floor_metal_gangway",
       "str_min_supported": 100,
       "items": [ { "item": "steel_chunk", "count": [ 5, 11 ] } ]
     }
@@ -583,6 +630,7 @@
     "bash": {
       "sound": "SMASH!",
       "ter_set": "t_null",
+      "ter_set_bashed_from_above": "t_floor_no_roof",
       "str_min": 50,
       "str_max": 400,
       "str_min_supported": 100,
@@ -604,6 +652,7 @@
     "bash": {
       "sound": "SMASH!",
       "ter_set": "t_null",
+      "ter_set_bashed_from_above": "t_dirtfloor_no_roof",
       "str_min": 50,
       "str_max": 400,
       "str_min_supported": 100,
@@ -626,6 +675,7 @@
     "bash": {
       "sound": "SMASH!",
       "ter_set": "t_null",
+      "ter_set_bashed_from_above": "t_dirtfloor_no_roof",
       "str_min": 50,
       "str_max": 400,
       "str_min_supported": 100,
@@ -658,6 +708,7 @@
     "bash": {
       "sound": "SMASH!",
       "ter_set": "t_null",
+      "ter_set_bashed_from_above": "t_null",
       "str_min": 50,
       "str_max": 400,
       "str_min_supported": 100,
@@ -729,6 +780,7 @@
     "bash": {
       "sound": "SMASH!",
       "ter_set": "t_floor",
+      "ter_set_bashed_from_above": "t_floor_no_roof",
       "str_min": 5,
       "str_max": 15,
       "str_min_supported": 100,
@@ -805,6 +857,7 @@
     "bash": {
       "sound": "SMASH!",
       "ter_set": "t_floor",
+      "ter_set_bashed_from_above": "t_floor_no_roof",
       "str_min": 5,
       "str_max": 15,
       "str_min_supported": 100,
@@ -887,6 +940,7 @@
     "bash": {
       "sound": "SMASH!",
       "ter_set": "t_thconc_floor",
+      "ter_set_bashed_from_above": "t_thconc_floor_no_roof",
       "str_min": 5,
       "str_max": 15,
       "str_min_supported": 100,
@@ -959,6 +1013,7 @@
     "bash": {
       "sound": "SMASH!",
       "ter_set": "t_metal_floor",
+      "ter_set_bashed_from_above": "t_metal_floor_no_roof",
       "str_min": 5,
       "str_max": 15,
       "str_min_supported": 100,
@@ -1032,6 +1087,7 @@
     "bash": {
       "sound": "SMASH!",
       "ter_set": "t_strconc_floor",
+      "ter_set_bashed_from_above": "t_strconc_floor_no_roof",
       "str_min": 5,
       "str_max": 15,
       "str_min_supported": 100,
@@ -1104,6 +1160,7 @@
     "bash": {
       "sound": "SMASH!",
       "ter_set": "t_rock_floor",
+      "ter_set_bashed_from_above": "t_rock_floor_no_roof",
       "str_min": 5,
       "str_max": 15,
       "str_min_supported": 100,
@@ -1176,6 +1233,7 @@
     "bash": {
       "sound": "SMASH!",
       "ter_set": "t_floor_primitive",
+      "ter_set_bashed_from_above": "t_dirtfloor_no_roof",
       "str_min": 5,
       "str_max": 15,
       "str_min_supported": 100,
@@ -1252,6 +1310,7 @@
     "bash": {
       "sound": "SMASH!",
       "ter_set": "t_linoleum_gray",
+      "ter_set_bashed_from_above": "t_linoleum_gray_no_roof",
       "str_min": 5,
       "str_max": 15,
       "str_min_supported": 100,
@@ -1328,6 +1387,7 @@
     "bash": {
       "sound": "SMASH!",
       "ter_set": "t_linoleum_white",
+      "ter_set_bashed_from_above": "t_linoleum_white_no_roof",
       "str_min": 5,
       "str_max": 15,
       "str_min_supported": 100,
@@ -1402,6 +1462,7 @@
     "bash": {
       "sound": "SMASH!",
       "ter_set": "t_null",
+      "ter_set_bashed_from_above": "t_linoleum_white_no_roof",
       "str_min": 50,
       "str_max": 400,
       "str_min_supported": 100,
@@ -1423,6 +1484,7 @@
     "bash": {
       "sound": "SMASH!",
       "ter_set": "t_null",
+      "ter_set_bashed_from_above": "t_linoleum_gray_no_roof",
       "str_min": 50,
       "str_max": 400,
       "str_min_supported": 100,
@@ -1445,6 +1507,7 @@
       "str_max": 400,
       "str_min_supported": 100,
       "ter_set": "t_null",
+      "ter_set_bashed_from_above": "t_floor_noroof",
       "sound": "SMASH!",
       "items": [ { "item": "splinter", "count": [ 2, 8 ] }, { "item": "nail", "charges": [ 5, 10 ] } ]
     },
@@ -1499,7 +1562,8 @@
       "str_max": 200,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "ter_set": "t_dirt",
+      "ter_set": "t_null",
+      "ter_set_bashed_from_above": "t_floor_metal_gangway",
       "items": [ { "item": "pipe", "count": [ 1, 2 ] }, { "item": "scrap", "count": [ 1, 40 ] } ]
     }
   },
@@ -1518,6 +1582,7 @@
     "connects_to": "CONCRETE",
     "bash": {
       "ter_set": "t_null",
+      "ter_set_bashed_from_above": "t_concrete",
       "str_min": 50,
       "str_max": 400,
       "str_min_supported": 100,
@@ -1538,7 +1603,15 @@
     "looks_like": "t_dirt",
     "roof": "t_rock_roof",
     "flags": [ "TRANSPARENT", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "ROAD", "PLOWABLE", "DIGGABLE" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": {
+      "sound": "thump",
+      "ter_set": "t_null",
+      "ter_set_bashed_from_above": "t_dirtfloor_no_roof",
+      "str_min": 50,
+      "str_max": 100,
+      "str_min_supported": 100,
+      "bash_below": true
+    }
   },
   {
     "type": "terrain",
@@ -1554,7 +1627,15 @@
     "move_cost": 3,
     "roof": "t_rock_roof",
     "flags": [ "TRANSPARENT", "SUPPORTS_ROOF", "INDOORS", "FLAT", "DIGGABLE" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": {
+      "sound": "thump",
+      "ter_set": "t_null",
+      "ter_set_bashed_from_above": "t_sand",
+      "str_min": 50,
+      "str_max": 100,
+      "str_min_supported": 100,
+      "bash_below": true
+    }
   },
   {
     "type": "terrain",
@@ -1568,7 +1649,15 @@
     "move_cost": 3,
     "roof": "t_rock_roof",
     "flags": [ "TRANSPARENT", "SUPPORTS_ROOF", "INDOORS", "FLAT", "DIGGABLE" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": {
+      "sound": "thump",
+      "ter_set": "t_null",
+      "ter_set_bashed_from_above": "t_mud",
+      "str_min": 50,
+      "str_max": 100,
+      "str_min_supported": 100,
+      "bash_below": true
+    }
   },
   {
     "type": "terrain",
@@ -1582,7 +1671,15 @@
     "color": "light_green",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "SUPPORTS_ROOF", "INDOORS" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 40, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": {
+      "sound": "thump",
+      "ter_set": "t_null",
+      "ter_set_bashed_from_above": "t_moss",
+      "str_min": 40,
+      "str_max": 100,
+      "str_min_supported": 100,
+      "bash_below": true
+    }
   },
   {
     "type": "terrain",
@@ -1597,7 +1694,15 @@
     "move_cost": 2,
     "roof": "t_rock_roof",
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "SUPPORTS_ROOF", "INDOORS" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": {
+      "sound": "thump",
+      "ter_set": "t_null",
+      "ter_set_bashed_from_above": "t_clay",
+      "str_min": 50,
+      "str_max": 100,
+      "str_min_supported": 100,
+      "bash_below": true
+    }
   },
   {
     "type": "terrain",
@@ -1618,6 +1723,7 @@
       "sound": "splosh!",
       "sound_fail": "splosh!",
       "ter_set": "t_water_dp",
+      "ter_set_bashed_from_above": "t_claymound",
       "items": [ { "item": "clay_lump", "count": [ 6, 12 ] } ]
     }
   },
@@ -1639,7 +1745,8 @@
       "sound_fail": "slap!",
       "sound_vol": 8,
       "sound_fail_vol": 4,
-      "ter_set": "t_null"
+      "ter_set": "t_null",
+      "ter_set_bashed_from_above": "t_floor_paper_noroof"
     }
   },
   {

--- a/data/json/furniture_and_terrain/terrain-floors-indoor.json
+++ b/data/json/furniture_and_terrain/terrain-floors-indoor.json
@@ -223,7 +223,7 @@
     "move_cost": 2,
     "light_emitted": 120,
     "roof": "t_metal_roof",
-    "flags": [ "TRANSPARENT", "INDOORS", "FLAT", "ROAD" ],
+    "flags": [ "TRANSPARENT", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "ROAD" ],
     "bash": {
       "str_min": 4,
       "str_max": 12,
@@ -509,7 +509,7 @@
     "connects_to": "METALFLOOR",
     "move_cost": 2,
     "roof": "t_metal_roof",
-    "flags": [ "TRANSPARENT", "INDOORS", "FLAT", "ROAD" ],
+    "flags": [ "TRANSPARENT", "INDOORS", "COLLAPSES", "SUPPORTS_ROOF", "FLAT", "ROAD" ],
     "bash": {
       "sound": "thump",
       "ter_set": "t_null",
@@ -562,7 +562,7 @@
     "bash": {
       "sound": "SMASH!",
       "ter_set": "t_null",
-      "ter_set_bashed_from_above": "t_floor_no_roof",
+      "ter_set_bashed_from_above": "t_floor_noroof",
       "str_min": 50,
       "str_max": 400,
       "str_min_supported": 100,
@@ -630,7 +630,7 @@
     "bash": {
       "sound": "SMASH!",
       "ter_set": "t_null",
-      "ter_set_bashed_from_above": "t_floor_no_roof",
+      "ter_set_bashed_from_above": "t_floor_noroof",
       "str_min": 50,
       "str_max": 400,
       "str_min_supported": 100,
@@ -708,7 +708,7 @@
     "bash": {
       "sound": "SMASH!",
       "ter_set": "t_null",
-      "ter_set_bashed_from_above": "t_null",
+      "ter_set_bashed_from_above": "t_floor_noroof",
       "str_min": 50,
       "str_max": 400,
       "str_min_supported": 100,
@@ -780,7 +780,7 @@
     "bash": {
       "sound": "SMASH!",
       "ter_set": "t_floor",
-      "ter_set_bashed_from_above": "t_floor_no_roof",
+      "ter_set_bashed_from_above": "t_floor_noroof",
       "str_min": 5,
       "str_max": 15,
       "str_min_supported": 100,
@@ -857,7 +857,7 @@
     "bash": {
       "sound": "SMASH!",
       "ter_set": "t_floor",
-      "ter_set_bashed_from_above": "t_floor_no_roof",
+      "ter_set_bashed_from_above": "t_floor_noroof",
       "str_min": 5,
       "str_max": 15,
       "str_min_supported": 100,

--- a/data/json/furniture_and_terrain/terrain-floors-outdoors.json
+++ b/data/json/furniture_and_terrain/terrain-floors-outdoors.json
@@ -646,5 +646,45 @@
     "flags": [ "FLAT", "ROAD", "TRANSPARENT" ],
     "symbol": ".",
     "color": "white"
+  },
+  {
+    "type": "terrain",
+    "id": "t_brick_floor_noroof",
+    "name": "brick floor",
+    "description": "A relatively flat area made of tightly placed bricks with no ceiling above it.",
+    "symbol": ".",
+    "color": "light_red",
+    "connect_groups": "BRICKFLOOR",
+    "connects_to": "BRICKFLOOR",
+    "move_cost": 2,
+    "flags": [ "TRANSPARENT", "FLAT", "ROAD" ],
+    "bash": { "ter_set": "t_null", "str_min": 75, "str_max": 400, "str_min_supported": 100 }
+  },
+  {
+    "type": "terrain",
+    "id": "t_marble_floor_noroof",
+    "name": "marble floor",
+    "description": "A smooth and flat flooring made of marble tiles.  Beautiful and expensive, with no ceiling above.",
+    "looks_like": "t_rock_floor",
+    "symbol": ".",
+    "color": "light_gray",
+    "connect_groups": "MARBLEFLOOR",
+    "connects_to": "MARBLEFLOOR",
+    "move_cost": 2,
+    "flags": [ "TRANSPARENT", "FLAT", "ROAD" ],
+    "bash": { "ter_set": "t_null", "str_min": 75, "str_max": 400, "str_min_supported": 100 }
+  },
+  {
+    "type": "terrain",
+    "id": "t_floor_warped_noroof",
+    "name": "warped stone floor",
+    "description": "A rough stone floor.  Its patterns constantly shift as if your mind can't quite understand what it's really seeing  The ceiling is missing.",
+    "symbol": ".",
+    "color": "magenta",
+    "connect_groups": "ROCKFLOOR",
+    "connects_to": "ROCKFLOOR",
+    "move_cost": 2,
+    "roof": "t_warped_roof",
+    "flags": [ "TRANSPARENT", "FLAT", "ROAD" ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Partial address of #72765, i.e. support bashing of roofs resulting in somewhat reasonable roofless terrain as a result.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adding ter_set_bashed_from_above entries to all roofed terrain in terrain-floors-indoors.json as well as adding a few roofless terrains to terrain-floors-outdoors for usage.
Adjusted a couple of ter_set values to be more consistent as a bycatch (t_dirt is better represented by t_null for instance, as that should resolve into something that's reasonable for the location).

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Introducing a different mechanism than bashing for the transformation when a roof is removed as suggested by the suggestion.
- Introducing construction entries for the restoration of roofs.
- Introduction of additional roof less terrain, as some are transformations aren't too great (such as crappy metal roofed terrain being converted to a metal gangway, as a nice metal floor seemed a worse choice).
- Revamp of the construction process such that the roofless versions become steps in the construction process, so the roof is added at the end.
- Guerilla change to the construction process on top of roof less terrain where you can specify the kind of roof you want on a roof less terrain, and the process would generate the standard roofed terrain but with the selected roof on the tile above. Not sure if it's reasonable to implement from a technical perspective, though. It might not be well received by the main devs either.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
- Copied the modified JSON files elsewhere.
- Switched to master (and hacked in the missed include that's PR:ed) and compiled.
- Copied the saved JSON filed back (into "master").
- Saved a save where a companion is clearing a hole while the PC is standing in the basement below.

- Debug changed the terrain beneath the future hole to a terrain changed by this PR.
- Waited until clearing was done.
- Debug checked that the terrain below changed as expected (has to use debug as the terrain looks the same visually with the roof less version.
- Killed and loaded the save.
- Repeated the above for each changed terrain. For carpets only one color carpet was tested for each floor material as copy-from should ensure other colors behave the same.

Testing uncovered a few cases where terrain didn't specify roofs, as well as cases where the roof less terrain was misspelled (not exactly helped by the inconsistent nomenclature).

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

As mentioned, the implementation is an attempt at a best fit between existing roofed and unroofed terrain, with the introduction of new terrain in only a bare minimum of cases. Reviewers might want new roof less terrain for additional questionable matches.

Note that this PR is not contain everything that ought to be updated, only a single file. There's more that needs doing. However, it might be that further efforts may require the addition of new entries to terrain-floors-outdoors which will cause the incompetent conflict detection to consider it a "conflict" to add entries directly after the entries added here, so the next step should not be performed after this PR is merged (assuming it's approved).

Apart from the errors detected during testing, there are several suspect terrain definitions in the indoors file that don't have roofs. There's a whole suite of colored ones, for instance. Those were not touched by this PR, both because they're slightly out of scope, but mostly because I don't know if they should have roofs.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
