### PR TITLE
Pain is less painful

### DIFF
--- a/data/core/game_balance.json
+++ b/data/core/game_balance.json
@@ -106,6 +106,34 @@
   },
   {
     "type": "EXTERNAL_OPTION",
+    "name": "PAIN_PENALTY_MOD_STR",
+    "info": "Scales how much pain decrease your stat.  0.005 means 0.5% of stat loss per one unit of pain.",
+    "stype": "float",
+    "value": 0.005
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "PAIN_PENALTY_MOD_DEX",
+    "info": "Scales how much pain decrease your stat.  0.0075 means 0.75% of stat loss per one unit of pain.",
+    "stype": "float",
+    "value": 0.0075
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "PAIN_PENALTY_MOD_INT",
+    "info": "Scales how much pain decrease your stat.  0.01 means 1% of stat loss per one unit of pain.",
+    "stype": "float",
+    "value": 0.01
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "PAIN_PENALTY_MOD_PER",
+    "info": "Scales how much pain decrease your stat.  0.01 means 1% of stat loss per one unit of pain.",
+    "stype": "float",
+    "value": 0.01
+  },
+  {
+    "type": "EXTERNAL_OPTION",
     "name": "SPAWN_CITY_HORDE_THRESHOLD",
     "info": "Minimum city size to guarantee extra zombies are spawned in cities.  0 means all cities spawn extra zombies.  Negative values disable extra city zombies.",
     "stype": "int",

--- a/doc/MAGIC.md
+++ b/doc/MAGIC.md
@@ -866,10 +866,10 @@ Character status value  | Description
 `OVERKILL_DAMAGE`       | multiplies or contributes to the damage to an enemy corpse after death. The lower the number, the more damage caused.
 `OVERMAP_SIGHT`         | Increases the amount of overmap tiles you can see around.
 `PAIN`                  | When gaining pain the amount gained will be modified by this much.  You will still always gain at least 1 pain.
-`PAIN_PENALTY_MOD_STR`  | Amount of this stat you lose from pain. Default value is `(pain*0.007)*max_str`. Can't be lower than 0
-`PAIN_PENALTY_MOD_DEX`  | Amount of this stat you lose from pain. Default value is `(pain*0.007)*max_dex`. Can't be lower than 0
-`PAIN_PENALTY_MOD_INT`  | Amount of this stat you lose from pain. Default value is `(pain*0.01)*max_int`. Can't be lower than 0
-`PAIN_PENALTY_MOD_PER`  | Amount of this stat you lose from pain. Default value is `(pain*0.01)*max_per`. Can't be lower than 0
+`PAIN_PENALTY_MOD_STR`  | Amount of this stat you lose from pain. Default value is `(pain*0.005)*max_str`. Can't be lower than 1
+`PAIN_PENALTY_MOD_DEX`  | Amount of this stat you lose from pain. Default value is `(pain*0.0075)*max_dex`. Can't be lower than 1
+`PAIN_PENALTY_MOD_INT`  | Amount of this stat you lose from pain. Default value is `(pain*0.01)*max_int`. Can't be lower than 1
+`PAIN_PENALTY_MOD_PER`  | Amount of this stat you lose from pain. Default value is `(pain*0.01)*max_per`. Can't be lower than 1
 `PAIN_PENALTY_MOD_SPEED`| Amount of speed you lose from pain. Default value is `pain^0.7`. Can't be bigger than 50 speed.
 `PAIN_REMOVE`           | When pain naturally decreases every five minutes the chance of pain removal will be modified by this much.  You will still always have at least a chance to reduce pain.
 `PERCEPTION`            | Affects the perception stat.

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3186,8 +3186,9 @@ units::mass Character::weight_capacity() const
     // Get base capacity from creature,
     // then apply enchantment.
     units::mass ret = Creature::weight_capacity();
+    // Not using get_str() so pain won't decrease carrying capacity
     /** @EFFECT_STR increases carrying capacity */
-    ret += get_str() * 4_kilogram;
+    ret += ( get_str_base() + get_str_bonus() ) * 4_kilogram;
 
     ret = enchantment_cache->modify_value( enchant_vals::mod::CARRY_WEIGHT, ret );
 
@@ -12398,13 +12399,14 @@ stat_mod Character::get_pain_penalty() const
 {
     stat_mod ret;
     int pain = get_perceived_pain();
-    if( pain <= 0 ) {
+    // if less than 10 pain, do not apply any penalties
+    if( pain <= 10 ) {
         return ret;
     }
 
     // Int and per are penalized more, 100 pain to drop stat to zero vs 140-ish for str and dex
     float penalty_mod = pain * 0.01f;
-    float lesser_penalty_mod = pain * 0.007f;
+    float lesser_penalty_mod = pain * 0.005f;
 
 
     ret.strength = enchantment_cache->modify_value( enchant_vals::mod::PAIN_PENALTY_MOD_STR,
@@ -12421,10 +12423,11 @@ stat_mod Character::get_pain_penalty() const
 
 
     // Prevent negative penalties, there is better ways to give bonuses for pain
-    ret.strength = std::max( ret.strength, 0 );
-    ret.dexterity = std::max( ret.dexterity, 0 );
-    ret.intelligence = std::max( ret.intelligence, 0 );
-    ret.perception = std::max( ret.perception, 0 );
+    // Also not make character has 0 stats
+    ret.strength = std::max( ret.strength, 1 );
+    ret.dexterity = std::max( ret.dexterity, 1 );
+    ret.intelligence = std::max( ret.intelligence, 1 );
+    ret.perception = std::max( ret.perception, 1 );
 
 
     int speed_penalty = std::pow( pain, 0.7f );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -12405,22 +12405,23 @@ stat_mod Character::get_pain_penalty() const
         return ret;
     }
 
-    // Int and per are penalized more, 100 pain to drop stat to zero vs 140-ish for str and dex
-    float penalty_mod = pain * 0.01f;
-    float lesser_penalty_mod = pain * 0.005f;
+    float penalty_str = pain * get_option<float>( "PAIN_PENALTY_MOD_STR" );
+    float penalty_dex = pain * get_option<float>( "PAIN_PENALTY_MOD_DEX" );
+    float penalty_int = pain * get_option<float>( "PAIN_PENALTY_MOD_INT" );
+    float penalty_per = pain * get_option<float>( "PAIN_PENALTY_MOD_PER" );
 
 
     ret.strength = enchantment_cache->modify_value( enchant_vals::mod::PAIN_PENALTY_MOD_STR,
-                   get_str() * lesser_penalty_mod );
+                   get_str() * penalty_str );
 
     ret.dexterity = enchantment_cache->modify_value( enchant_vals::mod::PAIN_PENALTY_MOD_DEX,
-                    get_dex() * lesser_penalty_mod );
+                    get_dex() * penalty_dex );
 
     ret.intelligence = enchantment_cache->modify_value( enchant_vals::mod::PAIN_PENALTY_MOD_INT,
-                       get_int() * penalty_mod );
+                       get_int() * penalty_int );
 
     ret.perception = enchantment_cache->modify_value( enchant_vals::mod::PAIN_PENALTY_MOD_PER,
-                     get_per() * penalty_mod );
+                     get_per() * penalty_per );
 
 
     // Prevent negative penalties, there is better ways to give bonuses for pain

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3186,7 +3186,8 @@ units::mass Character::weight_capacity() const
     // Get base capacity from creature,
     // then apply enchantment.
     units::mass ret = Creature::weight_capacity();
-    // Not using get_str() so pain won't decrease carrying capacity
+    // Not using get_str() so pain and other temporary effects won't decrease carrying capacity;
+    // transiently reducing carry weight is unlikely to have any play impact besides being very annoying.
     /** @EFFECT_STR increases carrying capacity */
     ret += ( get_str_base() + get_str_bonus() ) * 4_kilogram;
 

--- a/tests/enchantments_test.cpp
+++ b/tests/enchantments_test.cpp
@@ -363,9 +363,9 @@ TEST_CASE( "Enchantment_PAIN_PENALTY_MOD_test", "[magic][enchantments]" )
     INFO( "Character has 50 pain, not affected by enchantments" );
     guy.set_pain( 50 );
     advance_turn( guy );
-    INFO( "Stats are: 6 str, 6 dex, 3 int, 3 per, 85 speed" );
+    INFO( "Stats are: 6 str, 5 dex, 3 int, 3 per, 85 speed" );
     REQUIRE( guy.get_str() == 6 );
-    REQUIRE( guy.get_dex() == 6 );
+    REQUIRE( guy.get_dex() == 5 );
     REQUIRE( guy.get_int() == 4 );
     REQUIRE( guy.get_per() == 4 );
     REQUIRE( guy.get_speed() == 85 );
@@ -375,7 +375,7 @@ TEST_CASE( "Enchantment_PAIN_PENALTY_MOD_test", "[magic][enchantments]" )
     guy.i_add( item( "test_PAIN_PENALTY_MOD_ench_item_1" ) );
     guy.recalculate_enchantment_cache();
     advance_turn( guy );
-    INFO( "Stats are: 4 str, 8 dex, 7 int, 0 per, 89 speed" );
+    INFO( "Stats are: 4 str, 7 dex, 7 int, 0 per, 89 speed" );
     REQUIRE( guy.get_str() == 4 );
     REQUIRE( guy.get_dex() == 8 );
     REQUIRE( guy.get_int() == 7 );

--- a/tests/enchantments_test.cpp
+++ b/tests/enchantments_test.cpp
@@ -377,7 +377,7 @@ TEST_CASE( "Enchantment_PAIN_PENALTY_MOD_test", "[magic][enchantments]" )
     advance_turn( guy );
     INFO( "Stats are: 4 str, 7 dex, 7 int, 0 per, 89 speed" );
     REQUIRE( guy.get_str() == 4 );
-    REQUIRE( guy.get_dex() == 8 );
+    REQUIRE( guy.get_dex() == 7 );
     REQUIRE( guy.get_int() == 7 );
     REQUIRE( guy.get_per() == 0 );
     REQUIRE( guy.get_speed() == 89 );


### PR DESCRIPTION
#### Summary
Balance "Pain was a bit too painful"
#### Purpose of change
Partially adress #72851
#### Describe the solution
Pain do not affect carrying capacity - doesn't add anything but inconvinience and double amount of speed penalty
Pain do not apply any penalties unless it's higher than 10
Strength lose 0.5% of stat per one pain unit (was 0.7 before, 143 pain to blackout vs 200 now)
Dexterity lose 0.75% of stat per one pain unit
Stats can not fall lower than 1 anymore 
Values are moved to external options so they can be modified globally
#### Testing
Spawned, debugged myself 10 pain, debugged myself 50 pain, seems okay
#### Additional context
Draft, because need to compile the game