### PR TITLE
[Bombastic Perks] Add Stormwrought line of playstyle perks

### DIFF
--- a/data/mods/BombasticPerks/perkdata/stormwrought.json
+++ b/data/mods/BombasticPerks/perkdata/stormwrought.json
@@ -1,0 +1,128 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PERK_PORTAL_STORM_BIRD_MUTATOR",
+    "recurrence": [ "5 minutes", "30 minutes" ],
+    "condition": {
+      "and": [
+        {
+          "or": [ { "is_weather": "distant_portal_storm" }, { "is_weather": "portal_storm" }, { "is_weather": "close_portal_storm" } ]
+        },
+        { "u_has_trait": "perk_portal_storm_mutator_bird" },
+        { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_PORTAL_PROOF" },
+        "u_is_outside",
+        { "x_in_y_chance": { "x": 1, "y": 3 } }
+      ]
+    },
+    "deactivate_condition": { "not": { "u_has_trait": "perk_portal_storm_mutator_bird" } },
+    "effect": [
+      { "u_message": "Your whole body pulses in time with the raging storm.", "type": "info" },
+      { "u_mutate_category": "BIRD", "use_vitamins": false }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PERK_PORTAL_STORM_FELINE_MUTATOR",
+    "recurrence": [ "5 minutes", "30 minutes" ],
+    "condition": {
+      "and": [
+        {
+          "or": [ { "is_weather": "distant_portal_storm" }, { "is_weather": "portal_storm" }, { "is_weather": "close_portal_storm" } ]
+        },
+        { "u_has_trait": "perk_portal_storm_mutator_feline" },
+        { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_PORTAL_PROOF" },
+        "u_is_outside",
+        { "x_in_y_chance": { "x": 1, "y": 3 } }
+      ]
+    },
+    "deactivate_condition": { "not": { "u_has_trait": "perk_portal_storm_mutator_feline" } },
+    "effect": [
+      { "u_message": "Your whole body pulses in time with the raging storm.", "type": "info" },
+      { "u_mutate_category": "FELINE", "use_vitamins": false }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PERK_PORTAL_STORM_INSECT_MUTATOR",
+    "recurrence": [ "5 minutes", "30 minutes" ],
+    "condition": {
+      "and": [
+        {
+          "or": [ { "is_weather": "distant_portal_storm" }, { "is_weather": "portal_storm" }, { "is_weather": "close_portal_storm" } ]
+        },
+        { "u_has_trait": "perk_portal_storm_mutator_insect" },
+        { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_PORTAL_PROOF" },
+        "u_is_outside",
+        { "x_in_y_chance": { "x": 1, "y": 3 } }
+      ]
+    },
+    "deactivate_condition": { "not": { "u_has_trait": "perk_portal_storm_mutator_insect" } },
+    "effect": [
+      { "u_message": "Your whole body pulses in time with the raging storm.", "type": "info" },
+      { "u_mutate_category": "INSECT", "use_vitamins": false }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PERK_PORTAL_STORM_LUPINE_MUTATOR",
+    "recurrence": [ "5 minutes", "30 minutes" ],
+    "condition": {
+      "and": [
+        {
+          "or": [ { "is_weather": "distant_portal_storm" }, { "is_weather": "portal_storm" }, { "is_weather": "close_portal_storm" } ]
+        },
+        { "u_has_trait": "perk_portal_storm_mutator_lupine" },
+        { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_PORTAL_PROOF" },
+        "u_is_outside",
+        { "x_in_y_chance": { "x": 1, "y": 3 } }
+      ]
+    },
+    "deactivate_condition": { "not": { "u_has_trait": "perk_portal_storm_mutator_lupine" } },
+    "effect": [
+      { "u_message": "Your whole body pulses in time with the raging storm.", "type": "info" },
+      { "u_mutate_category": "LUPINE", "use_vitamins": false }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PERK_PORTAL_STORM_PLANT_MUTATOR",
+    "recurrence": [ "5 minutes", "30 minutes" ],
+    "condition": {
+      "and": [
+        {
+          "or": [ { "is_weather": "distant_portal_storm" }, { "is_weather": "portal_storm" }, { "is_weather": "close_portal_storm" } ]
+        },
+        { "u_has_trait": "perk_portal_storm_mutator_plant" },
+        { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_PORTAL_PROOF" },
+        "u_is_outside",
+        { "x_in_y_chance": { "x": 1, "y": 3 } }
+      ]
+    },
+    "deactivate_condition": { "not": { "u_has_trait": "perk_portal_storm_mutator_plant" } },
+    "effect": [
+      { "u_message": "Your whole body pulses in time with the raging storm.", "type": "info" },
+      { "u_mutate_category": "PLANT", "use_vitamins": false }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PERK_PORTAL_STORM_SPIDER_MUTATOR",
+    "recurrence": [ "5 minutes", "30 minutes" ],
+    "condition": {
+      "and": [
+        {
+          "or": [ { "is_weather": "distant_portal_storm" }, { "is_weather": "portal_storm" }, { "is_weather": "close_portal_storm" } ]
+        },
+        { "u_has_trait": "perk_portal_storm_mutator_spider" },
+        { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_PORTAL_PROOF" },
+        "u_is_outside",
+        { "x_in_y_chance": { "x": 1, "y": 3 } }
+      ]
+    },
+    "deactivate_condition": { "not": { "u_has_trait": "perk_portal_storm_mutator_spider" } },
+    "effect": [
+      { "u_message": "Your whole body pulses in time with the raging storm.", "type": "info" },
+      { "u_mutate_category": "SPIDER", "use_vitamins": false }
+    ]
+  }
+]

--- a/data/mods/BombasticPerks/perkdata/stormwrought.json
+++ b/data/mods/BombasticPerks/perkdata/stormwrought.json
@@ -18,7 +18,8 @@
     "effect": [
       { "u_message": "Your whole body pulses in time with the raging storm.", "type": "info" },
       { "math": [ "u_vitamin('mutagen_bird')", "+=", "450" ] },
-      { "math": [ "u_vitamin('mutagen')", "+=", "550" ] }
+      { "math": [ "u_vitamin('mutagen')", "+=", "550" ] },
+      { "u_mutate": 0 }
     ]
   },
   {
@@ -40,7 +41,8 @@
     "effect": [
       { "u_message": "Your whole body pulses in time with the raging storm.", "type": "info" },
       { "math": [ "u_vitamin('mutagen_feline')", "+=", "450" ] },
-      { "math": [ "u_vitamin('mutagen')", "+=", "550" ] }
+      { "math": [ "u_vitamin('mutagen')", "+=", "550" ] },
+      { "u_mutate": 0 }
     ]
   },
   {
@@ -62,7 +64,8 @@
     "effect": [
       { "u_message": "Your whole body pulses in time with the raging storm.", "type": "info" },
       { "math": [ "u_vitamin('mutagen_insect')", "+=", "450" ] },
-      { "math": [ "u_vitamin('mutagen')", "+=", "550" ] }
+      { "math": [ "u_vitamin('mutagen')", "+=", "550" ] },
+      { "u_mutate": 0 }
     ]
   },
   {
@@ -84,7 +87,8 @@
     "effect": [
       { "u_message": "Your whole body pulses in time with the raging storm.", "type": "info" },
       { "math": [ "u_vitamin('mutagen_lupine')", "+=", "450" ] },
-      { "math": [ "u_vitamin('mutagen')", "+=", "550" ] }
+      { "math": [ "u_vitamin('mutagen')", "+=", "550" ] },
+      { "u_mutate": 0 }
     ]
   },
   {
@@ -106,7 +110,8 @@
     "effect": [
       { "u_message": "Your whole body pulses in time with the raging storm.", "type": "info" },
       { "math": [ "u_vitamin('mutagen_plant')", "+=", "450" ] },
-      { "math": [ "u_vitamin('mutagen')", "+=", "550" ] }
+      { "math": [ "u_vitamin('mutagen')", "+=", "550" ] },
+      { "u_mutate": 0 }
     ]
   },
   {
@@ -128,7 +133,8 @@
     "effect": [
       { "u_message": "Your whole body pulses in time with the raging storm.", "type": "info" },
       { "math": [ "u_vitamin('mutagen_spider')", "+=", "450" ] },
-      { "math": [ "u_vitamin('mutagen')", "+=", "550" ] }
+      { "math": [ "u_vitamin('mutagen')", "+=", "550" ] },
+      { "u_mutate": 0 }
     ]
   }
 ]

--- a/data/mods/BombasticPerks/perkdata/stormwrought.json
+++ b/data/mods/BombasticPerks/perkdata/stormwrought.json
@@ -17,7 +17,8 @@
     "deactivate_condition": { "not": { "u_has_trait": "perk_portal_storm_mutator_bird" } },
     "effect": [
       { "u_message": "Your whole body pulses in time with the raging storm.", "type": "info" },
-      { "u_mutate_category": "BIRD", "use_vitamins": false }
+      { "math": [ "u_vitamin('mutagen_bird')", "+=", "450" ] },
+      { "math": [ "u_vitamin('mutagen')", "+=", "550" ] }
     ]
   },
   {
@@ -38,7 +39,8 @@
     "deactivate_condition": { "not": { "u_has_trait": "perk_portal_storm_mutator_feline" } },
     "effect": [
       { "u_message": "Your whole body pulses in time with the raging storm.", "type": "info" },
-      { "u_mutate_category": "FELINE", "use_vitamins": false }
+      { "math": [ "u_vitamin('mutagen_feline')", "+=", "450" ] },
+      { "math": [ "u_vitamin('mutagen')", "+=", "550" ] }
     ]
   },
   {
@@ -59,7 +61,8 @@
     "deactivate_condition": { "not": { "u_has_trait": "perk_portal_storm_mutator_insect" } },
     "effect": [
       { "u_message": "Your whole body pulses in time with the raging storm.", "type": "info" },
-      { "u_mutate_category": "INSECT", "use_vitamins": false }
+      { "math": [ "u_vitamin('mutagen_insect')", "+=", "450" ] },
+      { "math": [ "u_vitamin('mutagen')", "+=", "550" ] }
     ]
   },
   {
@@ -80,7 +83,8 @@
     "deactivate_condition": { "not": { "u_has_trait": "perk_portal_storm_mutator_lupine" } },
     "effect": [
       { "u_message": "Your whole body pulses in time with the raging storm.", "type": "info" },
-      { "u_mutate_category": "LUPINE", "use_vitamins": false }
+      { "math": [ "u_vitamin('mutagen_lupine')", "+=", "450" ] },
+      { "math": [ "u_vitamin('mutagen')", "+=", "550" ] }
     ]
   },
   {
@@ -101,7 +105,8 @@
     "deactivate_condition": { "not": { "u_has_trait": "perk_portal_storm_mutator_plant" } },
     "effect": [
       { "u_message": "Your whole body pulses in time with the raging storm.", "type": "info" },
-      { "u_mutate_category": "PLANT", "use_vitamins": false }
+      { "math": [ "u_vitamin('mutagen_plant')", "+=", "450" ] },
+      { "math": [ "u_vitamin('mutagen')", "+=", "550" ] }
     ]
   },
   {
@@ -122,7 +127,8 @@
     "deactivate_condition": { "not": { "u_has_trait": "perk_portal_storm_mutator_spider" } },
     "effect": [
       { "u_message": "Your whole body pulses in time with the raging storm.", "type": "info" },
-      { "u_mutate_category": "SPIDER", "use_vitamins": false }
+      { "math": [ "u_vitamin('mutagen_spider')", "+=", "450" ] },
+      { "math": [ "u_vitamin('mutagen')", "+=", "550" ] }
     ]
   }
 ]

--- a/data/mods/BombasticPerks/perkdata/stormwrought.json
+++ b/data/mods/BombasticPerks/perkdata/stormwrought.json
@@ -19,7 +19,9 @@
       { "u_message": "Your whole body pulses in time with the raging storm.", "type": "info" },
       { "math": [ "u_vitamin('mutagen_bird')", "+=", "450" ] },
       { "math": [ "u_vitamin('mutagen')", "+=", "550" ] },
-      { "u_mutate": 0 }
+      { "u_mutate": 0 },
+      { "math": [ "u_vitamin('mutagen_bird')", "-=", "350" ] },
+      { "math": [ "u_vitamin('mutagen')", "-=", "550" ] }
     ]
   },
   {
@@ -42,7 +44,9 @@
       { "u_message": "Your whole body pulses in time with the raging storm.", "type": "info" },
       { "math": [ "u_vitamin('mutagen_feline')", "+=", "450" ] },
       { "math": [ "u_vitamin('mutagen')", "+=", "550" ] },
-      { "u_mutate": 0 }
+      { "u_mutate": 0 },
+      { "math": [ "u_vitamin('mutagen_feline')", "-=", "350" ] },
+      { "math": [ "u_vitamin('mutagen')", "-=", "550" ] }
     ]
   },
   {
@@ -65,7 +69,9 @@
       { "u_message": "Your whole body pulses in time with the raging storm.", "type": "info" },
       { "math": [ "u_vitamin('mutagen_insect')", "+=", "450" ] },
       { "math": [ "u_vitamin('mutagen')", "+=", "550" ] },
-      { "u_mutate": 0 }
+      { "u_mutate": 0 },
+      { "math": [ "u_vitamin('mutagen_insect')", "-=", "350" ] },
+      { "math": [ "u_vitamin('mutagen')", "-=", "550" ] }
     ]
   },
   {
@@ -88,7 +94,9 @@
       { "u_message": "Your whole body pulses in time with the raging storm.", "type": "info" },
       { "math": [ "u_vitamin('mutagen_lupine')", "+=", "450" ] },
       { "math": [ "u_vitamin('mutagen')", "+=", "550" ] },
-      { "u_mutate": 0 }
+      { "u_mutate": 0 },
+      { "math": [ "u_vitamin('mutagen_lupine')", "-=", "350" ] },
+      { "math": [ "u_vitamin('mutagen')", "-=", "550" ] }
     ]
   },
   {
@@ -111,7 +119,9 @@
       { "u_message": "Your whole body pulses in time with the raging storm.", "type": "info" },
       { "math": [ "u_vitamin('mutagen_plant')", "+=", "450" ] },
       { "math": [ "u_vitamin('mutagen')", "+=", "550" ] },
-      { "u_mutate": 0 }
+      { "u_mutate": 0 },
+      { "math": [ "u_vitamin('mutagen_plant')", "-=", "350" ] },
+      { "math": [ "u_vitamin('mutagen')", "-=", "550" ] }
     ]
   },
   {
@@ -134,7 +144,9 @@
       { "u_message": "Your whole body pulses in time with the raging storm.", "type": "info" },
       { "math": [ "u_vitamin('mutagen_spider')", "+=", "450" ] },
       { "math": [ "u_vitamin('mutagen')", "+=", "550" ] },
-      { "u_mutate": 0 }
+      { "u_mutate": 0 },
+      { "math": [ "u_vitamin('mutagen_spider')", "-=", "350" ] },
+      { "math": [ "u_vitamin('mutagen')", "-=", "550" ] }
     ]
   }
 ]

--- a/data/mods/BombasticPerks/perkdata/stormwrought.json
+++ b/data/mods/BombasticPerks/perkdata/stormwrought.json
@@ -17,11 +17,11 @@
     "deactivate_condition": { "not": { "u_has_trait": "perk_portal_storm_mutator_bird" } },
     "effect": [
       { "u_message": "Your whole body pulses in time with the raging storm.", "type": "info" },
-      { "math": [ "u_vitamin('mutagen_bird')", "+=", "450" ] },
-      { "math": [ "u_vitamin('mutagen')", "+=", "550" ] },
+      { "math": [ "u_vitamin('mutagen_bird')", "+=", "2500" ] },
+      { "math": [ "u_vitamin('mutagen')", "+=", "1000" ] },
       { "u_mutate": 0 },
-      { "math": [ "u_vitamin('mutagen_bird')", "-=", "350" ] },
-      { "math": [ "u_vitamin('mutagen')", "-=", "550" ] }
+      { "math": [ "u_vitamin('mutagen_bird')", "-=", "2500" ] },
+      { "math": [ "u_vitamin('mutagen')", "-=", "1000" ] }
     ]
   },
   {
@@ -42,11 +42,11 @@
     "deactivate_condition": { "not": { "u_has_trait": "perk_portal_storm_mutator_feline" } },
     "effect": [
       { "u_message": "Your whole body pulses in time with the raging storm.", "type": "info" },
-      { "math": [ "u_vitamin('mutagen_feline')", "+=", "450" ] },
-      { "math": [ "u_vitamin('mutagen')", "+=", "550" ] },
+      { "math": [ "u_vitamin('mutagen_feline')", "+=", "2500" ] },
+      { "math": [ "u_vitamin('mutagen')", "+=", "1000" ] },
       { "u_mutate": 0 },
-      { "math": [ "u_vitamin('mutagen_feline')", "-=", "350" ] },
-      { "math": [ "u_vitamin('mutagen')", "-=", "550" ] }
+      { "math": [ "u_vitamin('mutagen_feline')", "-=", "2500" ] },
+      { "math": [ "u_vitamin('mutagen')", "-=", "1000" ] }
     ]
   },
   {
@@ -67,11 +67,11 @@
     "deactivate_condition": { "not": { "u_has_trait": "perk_portal_storm_mutator_insect" } },
     "effect": [
       { "u_message": "Your whole body pulses in time with the raging storm.", "type": "info" },
-      { "math": [ "u_vitamin('mutagen_insect')", "+=", "450" ] },
-      { "math": [ "u_vitamin('mutagen')", "+=", "550" ] },
+      { "math": [ "u_vitamin('mutagen_insect')", "+=", "2500" ] },
+      { "math": [ "u_vitamin('mutagen')", "+=", "1000" ] },
       { "u_mutate": 0 },
-      { "math": [ "u_vitamin('mutagen_insect')", "-=", "350" ] },
-      { "math": [ "u_vitamin('mutagen')", "-=", "550" ] }
+      { "math": [ "u_vitamin('mutagen_insect')", "-=", "2500" ] },
+      { "math": [ "u_vitamin('mutagen')", "-=", "1000" ] }
     ]
   },
   {
@@ -92,11 +92,11 @@
     "deactivate_condition": { "not": { "u_has_trait": "perk_portal_storm_mutator_lupine" } },
     "effect": [
       { "u_message": "Your whole body pulses in time with the raging storm.", "type": "info" },
-      { "math": [ "u_vitamin('mutagen_lupine')", "+=", "450" ] },
-      { "math": [ "u_vitamin('mutagen')", "+=", "550" ] },
+      { "math": [ "u_vitamin('mutagen_lupine')", "+=", "2500" ] },
+      { "math": [ "u_vitamin('mutagen')", "+=", "1000" ] },
       { "u_mutate": 0 },
-      { "math": [ "u_vitamin('mutagen_lupine')", "-=", "350" ] },
-      { "math": [ "u_vitamin('mutagen')", "-=", "550" ] }
+      { "math": [ "u_vitamin('mutagen_lupine')", "-=", "2500" ] },
+      { "math": [ "u_vitamin('mutagen')", "-=", "1000" ] }
     ]
   },
   {
@@ -117,11 +117,11 @@
     "deactivate_condition": { "not": { "u_has_trait": "perk_portal_storm_mutator_plant" } },
     "effect": [
       { "u_message": "Your whole body pulses in time with the raging storm.", "type": "info" },
-      { "math": [ "u_vitamin('mutagen_plant')", "+=", "450" ] },
-      { "math": [ "u_vitamin('mutagen')", "+=", "550" ] },
+      { "math": [ "u_vitamin('mutagen_plant')", "+=", "2500" ] },
+      { "math": [ "u_vitamin('mutagen')", "+=", "1000" ] },
       { "u_mutate": 0 },
-      { "math": [ "u_vitamin('mutagen_plant')", "-=", "350" ] },
-      { "math": [ "u_vitamin('mutagen')", "-=", "550" ] }
+      { "math": [ "u_vitamin('mutagen_plant')", "-=", "2500" ] },
+      { "math": [ "u_vitamin('mutagen')", "-=", "1000" ] }
     ]
   },
   {
@@ -142,11 +142,11 @@
     "deactivate_condition": { "not": { "u_has_trait": "perk_portal_storm_mutator_spider" } },
     "effect": [
       { "u_message": "Your whole body pulses in time with the raging storm.", "type": "info" },
-      { "math": [ "u_vitamin('mutagen_spider')", "+=", "450" ] },
-      { "math": [ "u_vitamin('mutagen')", "+=", "550" ] },
+      { "math": [ "u_vitamin('mutagen_spider')", "+=", "2500" ] },
+      { "math": [ "u_vitamin('mutagen')", "+=", "1000" ] },
       { "u_mutate": 0 },
-      { "math": [ "u_vitamin('mutagen_spider')", "-=", "350" ] },
-      { "math": [ "u_vitamin('mutagen')", "-=", "550" ] }
+      { "math": [ "u_vitamin('mutagen_spider')", "-=", "2500" ] },
+      { "math": [ "u_vitamin('mutagen')", "-=", "1000" ] }
     ]
   }
 ]

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -982,7 +982,7 @@
           },
           { "set_string_var": "perk_portal_storm_mutator_bird", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Must not have another Stormwrought trait.",
+            "set_string_var": "Must not have another Stormwrought perk.",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
@@ -1002,7 +1002,7 @@
             }
           }
         ],
-        "topic": "TALK_PERK_MENU_PLAYSTYLE_STORMWROUGHT"
+        "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
       },
       {
         "condition": { "not": { "u_has_trait": "perk_portal_storm_mutator_feline" } },
@@ -1015,7 +1015,7 @@
           },
           { "set_string_var": "perk_portal_storm_mutator_feline", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Must not have another Stormwrought trait.",
+            "set_string_var": "Must not have another Stormwrought perk.",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
@@ -1035,11 +1035,11 @@
             }
           }
         ],
-        "topic": "TALK_PERK_MENU_PLAYSTYLE_STORMWROUGHT"
+        "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
       },
       {
         "condition": { "not": { "u_has_trait": "perk_portal_storm_mutator_insect" } },
-        "text": "Gain [<trait_name:perk_portal_storm_mutator_bird>]",
+        "text": "Gain [<trait_name:perk_portal_storm_mutator_insect>]",
         "effect": [
           { "set_string_var": "<trait_name:perk_portal_storm_mutator_insect>", "target_var": { "context_val": "trait_name" } },
           {
@@ -1048,7 +1048,7 @@
           },
           { "set_string_var": "perk_portal_storm_mutator_insect", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Must not have another Stormwrought trait.",
+            "set_string_var": "Must not have another Stormwrought perk.",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
@@ -1068,7 +1068,7 @@
             }
           }
         ],
-        "topic": "TALK_PERK_MENU_PLAYSTYLE_STORMWROUGHT"
+        "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
       },
       {
         "condition": { "not": { "u_has_trait": "perk_portal_storm_mutator_lupine" } },
@@ -1081,7 +1081,7 @@
           },
           { "set_string_var": "perk_portal_storm_mutator_lupine", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Must not have another Stormwrought trait.",
+            "set_string_var": "Must not have another Stormwrought perk.",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
@@ -1101,7 +1101,7 @@
             }
           }
         ],
-        "topic": "TALK_PERK_MENU_PLAYSTYLE_STORMWROUGHT"
+        "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
       },
       {
         "condition": { "not": { "u_has_trait": "perk_portal_storm_mutator_plant" } },
@@ -1114,7 +1114,7 @@
           },
           { "set_string_var": "perk_portal_storm_mutator_plant", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Must not have another Stormwrought trait.",
+            "set_string_var": "Must not have another Stormwrought perk.",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
@@ -1134,7 +1134,7 @@
             }
           }
         ],
-        "topic": "TALK_PERK_MENU_PLAYSTYLE_STORMWROUGHT"
+        "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
       },
       {
         "condition": { "not": { "u_has_trait": "perk_portal_storm_mutator_spider" } },
@@ -1147,7 +1147,7 @@
           },
           { "set_string_var": "perk_portal_storm_mutator_spider", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Must not have another Stormwrought trait.",
+            "set_string_var": "Must not have another Stormwrought perk.",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
@@ -1167,9 +1167,9 @@
             }
           }
         ],
-        "topic": "TALK_PERK_MENU_PLAYSTYLE_STORMWROUGHT"
+        "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
       },
-      { "text": "Playstyle Perks", "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE" },
+      { "text": "Playstyle Perks", "topic": "TALK_PERK_MENU_PLAYSTYLE" },
       { "text": "Lifestyle Perks", "topic": "TALK_PERK_MENU_MAIN" },
       { "text": "Settings", "topic": "TALK_PERK_MENU_CONFIG" },
       { "text": "Quit.", "topic": "TALK_DONE" }

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -960,6 +960,216 @@
         ],
         "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
       },
+      { "text": "Playstyle Perks: Stormwrought", "topic": "TALK_PERK_MENU_PLAYSTYLE_STORMWROUGHT" },
+      { "text": "Lifestyle Perks", "topic": "TALK_PERK_MENU_MAIN" },
+      { "text": "Settings", "topic": "TALK_PERK_MENU_CONFIG" },
+      { "text": "Quit.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_PERK_MENU_PLAYSTYLE_STORMWROUGHT",
+    "dynamic_line": "Stormwrought Playstyle Perks:\nLevel <u_val:current_level>.\n<u_val:num_perks> perk points to spend.\nCurrent EXP: <u_val:available_exp>.\nEXP to next level: <u_val:exp_to_perk>.",
+    "responses": [
+      {
+        "condition": { "not": { "u_has_trait": "perk_portal_storm_mutator_bird" } },
+        "text": "Gain [<trait_name:perk_portal_storm_mutator_bird>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_portal_storm_mutator_bird>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:perk_portal_storm_mutator_bird>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "perk_portal_storm_mutator_bird", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Must not have another Stormwrought trait.",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          {
+            "set_condition": "perk_condition",
+            "condition": {
+              "not": {
+                "u_has_any_trait": [
+                  "perk_portal_storm_mutator_bird",
+                  "perk_portal_storm_mutator_feline",
+                  "perk_portal_storm_mutator_insect",
+                  "perk_portal_storm_mutator_lupine",
+                  "perk_portal_storm_mutator_plant",
+                  "perk_portal_storm_mutator_spider"
+                ]
+              }
+            }
+          }
+        ],
+        "topic": "TALK_PERK_MENU_PLAYSTYLE_STORMWROUGHT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "perk_portal_storm_mutator_feline" } },
+        "text": "Gain [<trait_name:perk_portal_storm_mutator_feline>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_portal_storm_mutator_feline>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:perk_portal_storm_mutator_feline>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "perk_portal_storm_mutator_feline", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Must not have another Stormwrought trait.",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          {
+            "set_condition": "perk_condition",
+            "condition": {
+              "not": {
+                "u_has_any_trait": [
+                  "perk_portal_storm_mutator_bird",
+                  "perk_portal_storm_mutator_feline",
+                  "perk_portal_storm_mutator_insect",
+                  "perk_portal_storm_mutator_lupine",
+                  "perk_portal_storm_mutator_plant",
+                  "perk_portal_storm_mutator_spider"
+                ]
+              }
+            }
+          }
+        ],
+        "topic": "TALK_PERK_MENU_PLAYSTYLE_STORMWROUGHT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "perk_portal_storm_mutator_insect" } },
+        "text": "Gain [<trait_name:perk_portal_storm_mutator_bird>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_portal_storm_mutator_insect>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:perk_portal_storm_mutator_insect>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "perk_portal_storm_mutator_insect", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Must not have another Stormwrought trait.",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          {
+            "set_condition": "perk_condition",
+            "condition": {
+              "not": {
+                "u_has_any_trait": [
+                  "perk_portal_storm_mutator_bird",
+                  "perk_portal_storm_mutator_feline",
+                  "perk_portal_storm_mutator_insect",
+                  "perk_portal_storm_mutator_lupine",
+                  "perk_portal_storm_mutator_plant",
+                  "perk_portal_storm_mutator_spider"
+                ]
+              }
+            }
+          }
+        ],
+        "topic": "TALK_PERK_MENU_PLAYSTYLE_STORMWROUGHT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "perk_portal_storm_mutator_lupine" } },
+        "text": "Gain [<trait_name:perk_portal_storm_mutator_lupine>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_portal_storm_mutator_lupine>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:perk_portal_storm_mutator_lupine>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "perk_portal_storm_mutator_lupine", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Must not have another Stormwrought trait.",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          {
+            "set_condition": "perk_condition",
+            "condition": {
+              "not": {
+                "u_has_any_trait": [
+                  "perk_portal_storm_mutator_bird",
+                  "perk_portal_storm_mutator_feline",
+                  "perk_portal_storm_mutator_insect",
+                  "perk_portal_storm_mutator_lupine",
+                  "perk_portal_storm_mutator_plant",
+                  "perk_portal_storm_mutator_spider"
+                ]
+              }
+            }
+          }
+        ],
+        "topic": "TALK_PERK_MENU_PLAYSTYLE_STORMWROUGHT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "perk_portal_storm_mutator_plant" } },
+        "text": "Gain [<trait_name:perk_portal_storm_mutator_plant>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_portal_storm_mutator_plant>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:perk_portal_storm_mutator_plant>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "perk_portal_storm_mutator_plant", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Must not have another Stormwrought trait.",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          {
+            "set_condition": "perk_condition",
+            "condition": {
+              "not": {
+                "u_has_any_trait": [
+                  "perk_portal_storm_mutator_bird",
+                  "perk_portal_storm_mutator_feline",
+                  "perk_portal_storm_mutator_insect",
+                  "perk_portal_storm_mutator_lupine",
+                  "perk_portal_storm_mutator_plant",
+                  "perk_portal_storm_mutator_spider"
+                ]
+              }
+            }
+          }
+        ],
+        "topic": "TALK_PERK_MENU_PLAYSTYLE_STORMWROUGHT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "perk_portal_storm_mutator_spider" } },
+        "text": "Gain [<trait_name:perk_portal_storm_mutator_spider>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_portal_storm_mutator_spider>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:perk_portal_storm_mutator_spider>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "perk_portal_storm_mutator_spider", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Must not have another Stormwrought trait.",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          {
+            "set_condition": "perk_condition",
+            "condition": {
+              "not": {
+                "u_has_any_trait": [
+                  "perk_portal_storm_mutator_bird",
+                  "perk_portal_storm_mutator_feline",
+                  "perk_portal_storm_mutator_insect",
+                  "perk_portal_storm_mutator_lupine",
+                  "perk_portal_storm_mutator_plant",
+                  "perk_portal_storm_mutator_spider"
+                ]
+              }
+            }
+          }
+        ],
+        "topic": "TALK_PERK_MENU_PLAYSTYLE_STORMWROUGHT"
+      },
+      { "text": "Playstyle Perks", "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE" },
       { "text": "Lifestyle Perks", "topic": "TALK_PERK_MENU_MAIN" },
       { "text": "Settings", "topic": "TALK_PERK_MENU_CONFIG" },
       { "text": "Quit.", "topic": "TALK_DONE" }

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -630,5 +630,53 @@
         ]
       }
     ]
+  },
+  {
+    "type": "mutation",
+    "id": "perk_portal_storm_mutator_bird",
+    "name": { "str": "Stormwrought: Bird" },
+    "points": 0,
+    "description": "Exposure to portal storms and related phenomena causes your body change along predictable lines.  When out in a portal storm without any protection, you periodically have a chance to mutate.",
+    "category": [ "perk" ]
+  },
+  {
+    "type": "mutation",
+    "id": "perk_portal_storm_mutator_feline",
+    "name": { "str": "Stormwrought: Feline" },
+    "points": 0,
+    "description": "Exposure to portal storms and related phenomena causes your body change along predictable lines.  When out in a portal storm without any protection, you periodically have a chance to mutate.",
+    "category": [ "perk" ]
+  },
+  {
+    "type": "mutation",
+    "id": "perk_portal_storm_mutator_insect",
+    "name": { "str": "Stormwrought: Insect" },
+    "points": 0,
+    "description": "Exposure to portal storms and related phenomena causes your body change along predictable lines.  When out in a portal storm without any protection, you periodically have a chance to mutate.",
+    "category": [ "perk" ]
+  },
+  {
+    "type": "mutation",
+    "id": "perk_portal_storm_mutator_lupine",
+    "name": { "str": "Stormwrought: Lupine" },
+    "points": 0,
+    "description": "Exposure to portal storms and related phenomena causes your body change along predictable lines.  When out in a portal storm without any protection, you periodically have a chance to mutate.",
+    "category": [ "perk" ]
+  },
+  {
+    "type": "mutation",
+    "id": "perk_portal_storm_mutator_plant",
+    "name": { "str": "Stormwrought: Plant" },
+    "points": 0,
+    "description": "Exposure to portal storms and related phenomena causes your body change along predictable lines.  When out in a portal storm without any protection, you periodically have a chance to mutate.",
+    "category": [ "perk" ]
+  },
+  {
+    "type": "mutation",
+    "id": "perk_portal_storm_mutator_spider",
+    "name": { "str": "Stormwrought: Spider" },
+    "points": 0,
+    "description": "Exposure to portal storms and related phenomena causes your body change along predictable lines.  When out in a portal storm without any protection, you periodically have a chance to mutate.",
+    "category": [ "perk" ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Bombastic Perks] Add Stormwrought line of playstyle perks"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Always wanted to put something into the game that referenced [this](https://github.com/CleverRaven/Cataclysm-DDA/blob/32850991c495930ed18c3a10f05494697eea905b/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json#L1216) (aka the Catgirl gene), and finally figured out to a way to do it that's not silly.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add a set of playstyle perks, called Stormwrought [X], where [X] is one of Bird, Feline, Insect, Lupine, Plant, or Spider.  These trigger EoCs that, when you're out unprotected in a portal storm, run every 5-30 minutes and have a 1/3 chance when they trigger to mutate you in the appropriate category. ~~Post-instability rework, this just uses `u_mutate_category`, since there's no necessity to use vitamins to track instability anymore~~. Edit: `u_mutate_category` seems to automatically bring up the mutation selector which doesn't fit with portal storm randomness, so it's back to mutagen.  To work around the issues with `u_mutate_category`, the EoC adds primer and mutagen, forces a mutation with `u_mutate`, then removes primer and mutagen to return to baseline, causing one mutation per EoC trigger. 

You can only have one Stormwrought perk. 

There's no reason to limit it to those mutation lines, I just had to start somewhere. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Traits exist and are selectable, show up in their own menu (so they don't overwhelm the other Playstyle perks if more are added), and hanging out in a portal storm causes mutation. Mutagen properly removed after mutating. Wearing a 5-point anchor prevents mutation. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

It'd be nice if `u_mutate_category` had a kwarg that turned on or off the selector. I double-checked and `SHOW_MUTATION_SELECTOR` is set as false (the test world just had default mods + Bombastic Perks)
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
