### PR TITLE
You can shatter zombies' torso armour by hitting them real hard.

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -333,6 +333,17 @@
   },
   {
     "type": "effect_type",
+    "id": "shattered",
+    "name": [ "shattered" ],
+    "//": "Intended for monsters, has no effect except to create a new weak point.",
+    "desc": [ "Your armor has been shattered by a heavy attack." ],
+    "apply_message": "Your armor has been shattered.",
+    "max_duration": "PERMANENT",
+    "rating": "bad",
+    "show_in_info": true
+  },
+  {
+    "type": "effect_type",
     "id": "staggered",
     "name": [ "Staggered" ],
     "//": "Mainly for monsters",

--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -338,7 +338,6 @@
     "//": "Intended for monsters, has no effect except to create a new weak point.",
     "desc": [ "Your armor has been shattered by a heavy attack." ],
     "apply_message": "Your armor has been shattered.",
-    "max_duration": "PERMANENT",
     "rating": "bad",
     "show_in_info": true
   },

--- a/data/json/monster_weakpoints/humanoid_weakpoints.json
+++ b/data/json/monster_weakpoints/humanoid_weakpoints.json
@@ -309,7 +309,7 @@
             "permanent": true
           }
         ],
-        "coverage": 8
+        "coverage": 40
       },
       {
         "id": "armour_plate_melee",
@@ -340,7 +340,7 @@
             "permanent": true
           }
         ],
-        "coverage": 8
+        "coverage": 40
       },
       {
         "id": "armour_shattered",
@@ -348,7 +348,7 @@
         "armor_mult": { "all": 0.25 },
         "difficulty": { "broad": 3, "point": 2 },
         "coverage_mult": { "ranged": 0.8 },
-        "coverage": 8,
+        "coverage": 40,
         "required_effects": [ "shattered" ]
       },
       {

--- a/data/json/monster_weakpoints/humanoid_weakpoints.json
+++ b/data/json/monster_weakpoints/humanoid_weakpoints.json
@@ -281,6 +281,53 @@
         "coverage": 1
       },
       {
+        "id": "armour_plate_bullet",
+        "name": "directly on an armor plate",
+        "difficulty": 0,
+        "armor_mult": { "cut": 1.5, "stab": 1.5, "bash": 1.5 },
+        "coverage_mult": { "melee": 0 },
+        "//": "Note that most bullet hits on an armour plate probably shatter it, but not all of them shatter it enough to matter for future attacks.",
+        "effects": [
+          { "effect": "shattered", "chance": 25, "message": "The armor is shattered!", "damage_required": [ 1, 10 ] },
+          { "effect": "shattered", "chance": 50, "message": "The armor is shattered!", "damage_required": [ 11, 30 ] },
+          {
+            "effect": "shattered",
+            "chance": 75,
+            "message": "The armor is shattered!",
+            "damage_required": [ 31, 200 ]
+          }
+        ],
+        "coverage": 8
+      },
+      {
+        "id": "armour_plate_melee",
+        "name": "directly on an armor plate",
+        "difficulty": 0,
+        "armor_mult": { "cut": 1.3, "stab": 1.15, "bash": 1.15 },
+        "coverage_mult": { "ranged": 0 },
+        "//": "Note that most bullet hits on an armour plate probably shatter it, but not all of them shatter it enough to matter for future attacks.",
+        "effects": [
+          { "effect": "shattered", "chance": 15, "message": "The armor is shattered!", "damage_required": [ 5, 20 ] },
+          { "effect": "shattered", "chance": 40, "message": "The armor is shattered!", "damage_required": [ 21, 40 ] },
+          {
+            "effect": "shattered",
+            "chance": 60,
+            "message": "The armor is shattered!",
+            "damage_required": [ 41, 200 ]
+          }
+        ],
+        "coverage": 8
+      },
+      {
+        "id": "armour_shattered",
+        "name": "the shattered armor plating",
+        "armor_mult": { "all": 0.25 },
+        "difficulty": { "broad": 3, "point": 2 },
+        "coverage_mult": { "ranged": 0.8 },
+        "coverage": 8,
+        "required_effects": [ "shattered" ]
+      },
+      {
         "id": "side_armour",
         "name": "the weak armor on the side",
         "armor_mult": { "bullet": 0.3, "cut": 0.3, "stab": 0.15, "bash": 0.15 },

--- a/data/json/monster_weakpoints/humanoid_weakpoints.json
+++ b/data/json/monster_weakpoints/humanoid_weakpoints.json
@@ -282,8 +282,7 @@
       },
       {
         "id": "armour_plate_bullet",
-        "name": "directly on an armor plate",
-        "difficulty": 0,
+        "name": "the body armor",
         "armor_mult": { "cut": 1.5, "stab": 1.5, "bash": 1.5 },
         "coverage_mult": { "melee": 0 },
         "//": "Note that most bullet hits on an armour plate probably shatter it, but not all of them shatter it enough to matter for future attacks.",
@@ -314,8 +313,7 @@
       },
       {
         "id": "armour_plate_melee",
-        "name": "directly on an armor plate",
-        "difficulty": 0,
+        "name": "the body armor",
         "armor_mult": { "cut": 1.3, "stab": 1.15, "bash": 1.15 },
         "coverage_mult": { "ranged": 0 },
         "//": "Note that most bullet hits on an armour plate probably shatter it, but not all of them shatter it enough to matter for future attacks.",

--- a/data/json/monster_weakpoints/humanoid_weakpoints.json
+++ b/data/json/monster_weakpoints/humanoid_weakpoints.json
@@ -288,13 +288,26 @@
         "coverage_mult": { "melee": 0 },
         "//": "Note that most bullet hits on an armour plate probably shatter it, but not all of them shatter it enough to matter for future attacks.",
         "effects": [
-          { "effect": "shattered", "chance": 25, "message": "The armor is shattered!", "damage_required": [ 1, 10 ] },
-          { "effect": "shattered", "chance": 50, "message": "The armor is shattered!", "damage_required": [ 11, 30 ] },
+          {
+            "effect": "shattered",
+            "chance": 25,
+            "message": "The armor is shattered!",
+            "damage_required": [ 1, 10 ],
+            "permanent": true
+          },
+          {
+            "effect": "shattered",
+            "chance": 50,
+            "message": "The armor is shattered!",
+            "damage_required": [ 11, 30 ],
+            "permanent": true
+          },
           {
             "effect": "shattered",
             "chance": 75,
             "message": "The armor is shattered!",
-            "damage_required": [ 31, 200 ]
+            "damage_required": [ 31, 200 ],
+            "permanent": true
           }
         ],
         "coverage": 8
@@ -307,13 +320,26 @@
         "coverage_mult": { "ranged": 0 },
         "//": "Note that most bullet hits on an armour plate probably shatter it, but not all of them shatter it enough to matter for future attacks.",
         "effects": [
-          { "effect": "shattered", "chance": 15, "message": "The armor is shattered!", "damage_required": [ 5, 20 ] },
-          { "effect": "shattered", "chance": 40, "message": "The armor is shattered!", "damage_required": [ 21, 40 ] },
+          {
+            "effect": "shattered",
+            "chance": 15,
+            "message": "The armor is shattered!",
+            "damage_required": [ 5, 20 ],
+            "permanent": true
+          },
+          {
+            "effect": "shattered",
+            "chance": 40,
+            "message": "The armor is shattered!",
+            "damage_required": [ 21, 40 ],
+            "permanent": true
+          },
           {
             "effect": "shattered",
             "chance": 60,
             "message": "The armor is shattered!",
-            "damage_required": [ 41, 200 ]
+            "damage_required": [ 41, 200 ],
+            "permanent": true
           }
         ],
         "coverage": 8


### PR DESCRIPTION
#### Summary
Features "Shatter a zombie's torso armour with a good hard hit."

#### Purpose of change
Soldier zombies are wearing a version of ESAPI armour that is unreasonably better than player armour in several ways. One such way is that you can shoot them in the torso again and again and the armour never degrades.

#### Describe the solution
Adds a chance to hit a zombie right on the armour plate.

If you do so hard enough for any damage to get through the armour, there is a chance you've shattered enough plates to be able to get other shots through. The armour for that area is dramatically reduced.

Ranged vs melee attacks have a different set of options here, because to my limited understanding, it is somewhat more likely that a melee attack slips between plates rather than smashing a ton of them. Melee attacks can still shatter plates, they're just a bit less likely. However, all my understanding of body armour plates is from conversations I've mostly tried to tune out in discord, so some military gear nerd can offer other formulae here without any objection from me.

I don't see any easy way to distinguish an arrow from a bullet here. I'd prefer the arrow to use the melee attack model, but unless I go adjust the code to distinguish bullets even further, I think this will work okay simply by ramping up stab protection if an arrow hits straight on a plate - you have to hit that plate straight on with enough force to get through it, which is gonna be hard unless your arrows are something really impressive, and then shattering the plates seems fair.

#### Describe alternatives you've considered
Considered adding a further "very shattered" effect, if the zombie already has "shattered" and you hit it on the armour again; this second effect would make it much easier to shoot through the armour. If playtests suggest it's worth it, we can do that.

Also considered adding a version of this for helmets, but I just wasn't in the mood right now. Who knows, maybe later.

#### Testing
A big gun can shatter that armour.
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45136638/287c4ff7-6892-40d1-a38f-65b38df1262d)

A .22 calibre pistol normally can't hurt a soldier zombie, unless..
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45136638/af50659e-4e66-43c6-99ae-4c11ef6ee6c1)

#### Additional context
Fun stuff to add on a whim. This mechanic could, and probably should, be applied to other monsters. It adds a neat type of attrition we could use more of.

The effect is somewhat subtle as it stands. It could stand to be easier to pull off.