### PR TITLE
make integrated_photo_eyes SEMITANGIBLE

### DIFF
--- a/data/mods/MindOverMatter/items/psions_summon_items.json
+++ b/data/mods/MindOverMatter/items/psions_summon_items.json
@@ -311,7 +311,18 @@
     "symbol": "[",
     "color": "yellow",
     "qualities": [ [ "GLARE", 1 ] ],
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "SKINTIGHT", "SOFT", "WATER_FRIENDLY", "SUN_GLASSES", "NO_REPAIR", "NO_SALVAGE", "AURA" ],
+    "flags": [
+      "INTEGRATED",
+      "UNBREAKABLE",
+      "SKINTIGHT",
+      "SOFT",
+      "WATER_FRIENDLY",
+      "SUN_GLASSES",
+      "NO_REPAIR",
+      "NO_SALVAGE",
+      "AURA",
+      "SEMITANGIBLE"
+    ],
     "armor": [
       {
         "material": [ { "type": "light", "covered_by_mat": 100, "thickness": 0.1 } ],


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
I forgot to add SEMITANGIBLE to integrated_photo_eyes #72935
#### Describe the solution
Add flag
#### Additional context
https://github.com/CleverRaven/Cataclysm-DDA/pull/72935#issuecomment-2052162593
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/67688115/48436950-6ccf-4c20-a4b4-3c839d704f2b)
