### PR TITLE
Remove city_center, simplify mx_fungal_zone

### DIFF
--- a/data/json/items/book/maps.json
+++ b/data/json/items/book/maps.json
@@ -53,7 +53,6 @@
       "radius": 135,
       "terrain": [
         { "om_terrain": "road", "om_terrain_match_type": "PREFIX" },
-        { "om_terrain": "city_center", "om_terrain_match_type": "TYPE" },
         "bridge",
         "fema_entrance",
         { "om_terrain": "bunker", "om_terrain_match_type": "TYPE" },
@@ -80,7 +79,6 @@
       "radius": 90,
       "terrain": [
         { "om_terrain": "road", "om_terrain_match_type": "PREFIX" },
-        { "om_terrain": "city_center", "om_terrain_match_type": "TYPE" },
         "bridge",
         "s_pharm",
         "s_gun",
@@ -104,7 +102,6 @@
       "radius": 90,
       "terrain": [
         { "om_terrain": "road", "om_terrain_match_type": "PREFIX" },
-        { "om_terrain": "city_center", "om_terrain_match_type": "TYPE" },
         { "om_terrain": "s_gas", "om_terrain_match_type": "TYPE" },
         { "om_terrain": "s_gas_rural", "om_terrain_match_type": "TYPE" },
         "roadstop",
@@ -199,7 +196,6 @@
       "radius": 90,
       "terrain": [
         { "om_terrain": "road", "om_terrain_match_type": "PREFIX" },
-        { "om_terrain": "city_center", "om_terrain_match_type": "TYPE" },
         "bridge",
         "hotel_tower",
         "s_restaurant",
@@ -224,7 +220,6 @@
       "radius": 90,
       "terrain": [
         { "om_terrain": "road", "om_terrain_match_type": "PREFIX" },
-        { "om_terrain": "city_center", "om_terrain_match_type": "TYPE" },
         "bridge",
         "s_restaurant_coffee",
         "s_restaurant",
@@ -248,7 +243,6 @@
       "radius": 90,
       "terrain": [
         { "om_terrain": "road", "om_terrain_match_type": "PREFIX" },
-        { "om_terrain": "city_center", "om_terrain_match_type": "TYPE" },
         "bridge",
         { "om_terrain": "field", "om_terrain_match_type": "PREFIX" },
         { "om_terrain": "swamp", "om_terrain_match_type": "TYPE" },
@@ -272,7 +266,6 @@
       "radius": 90,
       "terrain": [
         { "om_terrain": "road", "om_terrain_match_type": "PREFIX" },
-        { "om_terrain": "city_center", "om_terrain_match_type": "TYPE" },
         "bridge",
         "desolatebarn",
         "shoppingplaza",
@@ -301,7 +294,6 @@
       "terrain": [
         "bridge",
         { "om_terrain": "road", "om_terrain_match_type": "PREFIX" },
-        { "om_terrain": "city_center", "om_terrain_match_type": "TYPE" },
         "s_restaurant_coffee",
         "s_restaurant_fast",
         "s_restaurant",
@@ -322,14 +314,7 @@
     "use_action": {
       "type": "reveal_map",
       "radius": 90,
-      "terrain": [
-        "bridge",
-        { "om_terrain": "road", "om_terrain_match_type": "PREFIX" },
-        { "om_terrain": "city_center", "om_terrain_match_type": "TYPE" },
-        "s_grocery",
-        "trailer_commercial",
-        "bakery"
-      ],
+      "terrain": [ "bridge", { "om_terrain": "road", "om_terrain_match_type": "PREFIX" }, "s_grocery", "trailer_commercial", "bakery" ],
       "message": "You add roads, local grocery and convenience stores as well as bakeries to your map."
     }
   },
@@ -346,7 +331,6 @@
       "terrain": [
         "bridge",
         { "om_terrain": "road", "om_terrain_match_type": "PREFIX" },
-        { "om_terrain": "city_center", "om_terrain_match_type": "TYPE" },
         "bakery",
         "s_butcher",
         "craft_shop",
@@ -368,7 +352,6 @@
       "terrain": [
         "bridge",
         { "om_terrain": "road", "om_terrain_match_type": "PREFIX" },
-        { "om_terrain": "city_center", "om_terrain_match_type": "TYPE" },
         "s_bike_shop",
         "gym_fitness",
         "gym",
@@ -394,7 +377,6 @@
       "terrain": [
         "bridge",
         { "om_terrain": "road", "om_terrain_match_type": "PREFIX" },
-        { "om_terrain": "city_center", "om_terrain_match_type": "TYPE" },
         { "om_terrain": "park", "om_terrain_match_type": "PREFIX" },
         "veterinarian",
         "NatureTrail",
@@ -419,7 +401,6 @@
       "terrain": [
         "bridge",
         { "om_terrain": "road", "om_terrain_match_type": "PREFIX" },
-        { "om_terrain": "city_center", "om_terrain_match_type": "TYPE" },
         { "om_terrain": "bar", "om_terrain_match_type": "PREFIX" },
         "music_venue",
         "movietheater",
@@ -442,7 +423,6 @@
       "terrain": [
         "bridge",
         { "om_terrain": "road", "om_terrain_match_type": "PREFIX" },
-        { "om_terrain": "city_center", "om_terrain_match_type": "TYPE" },
         "s_gun",
         "s_hunting",
         "s_camping",
@@ -465,7 +445,6 @@
       "terrain": [
         "bridge",
         { "om_terrain": "road", "om_terrain_match_type": "PREFIX" },
-        { "om_terrain": "city_center", "om_terrain_match_type": "TYPE" },
         { "om_terrain": "museum", "om_terrain_match_type": "TYPE" },
         "s_antique",
         "s_library",
@@ -487,7 +466,6 @@
       "terrain": [
         "bridge",
         { "om_terrain": "road", "om_terrain_match_type": "PREFIX" },
-        { "om_terrain": "city_center", "om_terrain_match_type": "TYPE" },
         "mall_a_1",
         "mall_a_2",
         "mall_a_3",
@@ -524,7 +502,6 @@
       "terrain": [
         "bridge",
         { "om_terrain": "road", "om_terrain_match_type": "PREFIX" },
-        { "om_terrain": "city_center", "om_terrain_match_type": "TYPE" },
         "furniture",
         "home_improvement",
         "hdwr_large_1_2_0",
@@ -551,7 +528,6 @@
       "terrain": [
         "bridge",
         { "om_terrain": "road", "om_terrain_match_type": "PREFIX" },
-        { "om_terrain": "city_center", "om_terrain_match_type": "TYPE" },
         "s_electronicstore",
         "s_electronics",
         "s_hardware",

--- a/data/json/mapgen/road.json
+++ b/data/json/mapgen/road.json
@@ -1073,20 +1073,6 @@
   {
     "type": "mapgen",
     "method": "json",
-    "om_terrain": "city_center",
-    "//": "Need to fix magical teleportation with actual aligned manhole placement",
-    "object": {
-      "fill_ter": "t_region_grass",
-      "place_nested": [
-        { "chunks": [ "24x24_road_four_way_crossroad" ], "x": 0, "y": 0 },
-        { "chunks": [ "1x1_manhole" ], "x": [ 5, 18 ], "y": [ 5, 18 ] }
-      ],
-      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
-    }
-  },
-  {
-    "type": "mapgen",
-    "method": "json",
     "nested_mapgen_id": "24x24_road_four_way_rotary",
     "object": {
       "mapgensize": [ 24, 24 ],

--- a/data/json/obsoletion_and_migration_0.I/obsolete_overmap_terrain.json
+++ b/data/json/obsoletion_and_migration_0.I/obsolete_overmap_terrain.json
@@ -55,6 +55,11 @@
   },
   {
     "type": "oter_id_migration",
+    "//": "migrated in 0.I",
+    "oter_ids": { "city_center": "road_nesw_manhole" }
+  },
+  {
+    "type": "oter_id_migration",
     "//": "obsoleted in 0.G, but no migration in 0.G so to be removed after 0.I stable",
     "oter_ids": {
       "apartments_con_tower_001_east": "omt_obsolete",

--- a/data/json/overmap/map_extras.json
+++ b/data/json/overmap/map_extras.json
@@ -608,7 +608,11 @@
     "name": { "str": "Fungal infestation" },
     "description": "Fungal-infested location.",
     "generator": { "generator_method": "map_extra_function", "generator_id": "mx_fungal_zone" },
-    "min_max_zlevel": [ 0, 0 ]
+    "sym": "F",
+    "color": "yellow",
+    "autonote": true,
+    "min_max_zlevel": [ 0, 0 ],
+    "flags": [ "FUNGAL" ]
   },
   {
     "id": "mx_reed",

--- a/data/json/overmap/overmap_connections.json
+++ b/data/json/overmap/overmap_connections.json
@@ -8,7 +8,6 @@
       { "terrain": "road", "locations": [ "forest" ], "basic_cost": 20 },
       { "terrain": "road", "locations": [ "swamp" ], "basic_cost": 40 },
       { "terrain": "road_nesw_manhole", "locations": [  ] },
-      { "terrain": "city_center", "locations": [ "field", "road" ] },
       { "terrain": "bridge", "locations": [ "water" ], "basic_cost": 120 },
       { "terrain": "bridgehead_ground", "locations": [ "water" ], "basic_cost": 120, "flags": [ "ORTHOGONAL" ] }
     ]

--- a/data/json/overmap/overmap_terrain/overmap_terrain_recreational.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_recreational.json
@@ -1,40 +1,54 @@
 [
   {
     "type": "overmap_terrain",
-    "id": [ "park", "park_roof", "park_2", "park_3", "park_4", "park_5", "park_5_roof", "park_6", "park_7", "park_7_roof" ],
+    "abstract": "generic_park",
     "copy-from": "generic_city_building",
     "name": "park",
     "sym": "O",
-    "color": "green"
+    "color": "green",
+    "extras": "park"
+  },
+  {
+    "type": "overmap_terrain",
+    "id": [ "park", "park_roof", "park_2", "park_3", "park_4", "park_5", "park_5_roof", "park_6", "park_7", "park_7_roof" ],
+    "copy-from": "generic_park"
   },
   {
     "type": "overmap_terrain",
     "id": [ "playground", "playground_roof", "playground_1" ],
-    "copy-from": "park",
+    "copy-from": "generic_park",
     "name": "playground"
   },
   {
     "type": "overmap_terrain",
     "id": [ "dog_park" ],
-    "copy-from": "park",
+    "copy-from": "generic_park",
     "name": "dog park"
   },
   {
     "type": "overmap_terrain",
+    "abstract": "sports_court",
+    "copy-from": "generic_city_building",
+    "sym": "O",
+    "color": "dark_gray"
+  },
+  {
+    "type": "overmap_terrain",
     "id": [ "volleyball_court" ],
-    "copy-from": "park",
-    "name": "volleyball court"
+    "copy-from": "sports_court",
+    "name": "volleyball court",
+    "color": "yellow"
   },
   {
     "type": "overmap_terrain",
     "id": [ "tennis_court" ],
-    "copy-from": "park",
+    "copy-from": "sports_court",
     "name": "tennis court"
   },
   {
     "type": "overmap_terrain",
     "id": [ "baskeball_court" ],
-    "copy-from": "park",
+    "copy-from": "sports_court",
     "name": "basketball court"
   },
   {
@@ -90,7 +104,8 @@
     "copy-from": "generic_city_building",
     "name": "fishing pond",
     "sym": "S",
-    "color": "i_blue"
+    "color": "i_blue",
+    "extras": "park"
   },
   {
     "type": "overmap_terrain",
@@ -106,7 +121,8 @@
     "copy-from": "generic_city_building",
     "name": "small wooded trail",
     "sym": "S",
-    "color": "i_green"
+    "color": "i_green",
+    "extras": "park"
   },
   {
     "type": "overmap_terrain",
@@ -147,7 +163,8 @@
     "copy-from": "generic_city_building",
     "name": "nature trail",
     "sym": "S",
-    "color": "i_green"
+    "color": "i_green",
+    "extras": "park"
   },
   {
     "type": "overmap_terrain",
@@ -155,7 +172,8 @@
     "copy-from": "generic_city_building",
     "name": "public pond",
     "sym": "P",
-    "color": "i_green"
+    "color": "i_green",
+    "extras": "park"
   },
   {
     "type": "overmap_terrain",
@@ -165,7 +183,8 @@
     "color": "yellow",
     "see_cost": 5,
     "mondensity": 2,
-    "flags": [ "SIDEWALK", "SOURCE_FARMING" ]
+    "flags": [ "SIDEWALK", "SOURCE_FARMING" ],
+    "extras": "park"
   },
   {
     "type": "overmap_terrain",
@@ -174,7 +193,8 @@
     "name": "public garden",
     "looks_like": "publicgarden",
     "sym": "g",
-    "color": "light_green"
+    "color": "light_green",
+    "extras": "park"
   },
   {
     "type": "overmap_terrain",
@@ -1003,7 +1023,8 @@
     "copy-from": "generic_city_building",
     "name": "private park roof",
     "sym": "p",
-    "color": "light_green_red"
+    "color": "light_green_red",
+    "extras": "park"
   },
   {
     "type": "overmap_terrain",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_transportation.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_transportation.json
@@ -24,18 +24,6 @@
   },
   {
     "type": "overmap_terrain",
-    "id": "city_center",
-    "copy-from": "generic_transportation",
-    "name": "road",
-    "sym": "┼",
-    "color": "dark_gray",
-    "see_cost": 2,
-    "travel_cost_type": "road",
-    "extras": "city_center",
-    "flags": [ "NO_ROTATE" ]
-  },
-  {
-    "type": "overmap_terrain",
     "abstract": "generic_bridge",
     "copy-from": "generic_transportation",
     "name": "bridge",

--- a/data/json/regional_map_settings.json
+++ b/data/json/regional_map_settings.json
@@ -675,7 +675,7 @@
         }
       },
       "bridgehead_ground": { "chance": 5, "extras": { "mx_minefield": 100 } },
-      "city_center": { "chance": 20, "extras": { "mx_fungal_zone": 100 } },
+      "park": { "chance": 60, "extras": { "mx_fungal_zone": 100 } },
       "road_nesw_manhole": { "chance": 20, "extras": { "mx_city_trap": 1, "mx_laststand": 1 } },
       "build": {
         "chance": 90,

--- a/doc/REGION_SETTINGS.md
+++ b/doc/REGION_SETTINGS.md
@@ -395,14 +395,14 @@ The **overmap_connection_settings** section defines the `overmap_connection_id`s
 
 ### Fields
 
-|          Identifier          |                                                    Description                                                  |
-| ---------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| `intra_city_road_connection` | overmap_connection id used within cities. Should include locations for road, city_center and road_nesw_manhole. |
-| `inter_city_road_connection` | overmap_connection id used between cities. Should include locations for the intra city terrains.                |
-| `trail_connection`           | overmap_connection id used for forest trails.                                                                   |
-| `sewer_connection`           | overmap_connection id used for sewer connections.                                                               |
-| `subway_connection`          | overmap_connection id used for for both z-2 and z-4 subway connections.                                         |
-| `rail_connection`            | overmap_connection id used for rail connections. ( Unused in vanilla as of 0.H )                                |
+|          Identifier          |                                                    Description                                     |
+| ---------------------------- | -------------------------------------------------------------------------------------------------- |
+| `intra_city_road_connection` | overmap_connection id used within cities. Should include locations for road and road_nesw_manhole. |
+| `inter_city_road_connection` | overmap_connection id used between cities. Should include locations for the intra city terrains.   |
+| `trail_connection`           | overmap_connection id used for forest trails.                                                      |
+| `sewer_connection`           | overmap_connection id used for sewer connections.                                                  |
+| `subway_connection`          | overmap_connection id used for for both z-2 and z-4 subway connections.                            |
+| `rail_connection`            | overmap_connection id used for rail connections. ( Unused in vanilla as of 0.H )                   |
 
 ### Example
 

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -2163,9 +2163,9 @@ static bool mx_fungal_zone( map &m, const tripoint &abs_sub )
     const tripoint suitable_location = random_entry( suitable_locations, submap_center );
     m.add_spawn( mon_fungaloid_queen, 1, suitable_location );
     m.place_spawns( GROUP_FUNGI_FUNGALOID, 1,
-                             suitable_location.xy() + point_north_west,
-                             suitable_location.xy() + point_south_east,
-                             3, true );
+                    suitable_location.xy() + point_north_west,
+                    suitable_location.xy() + point_south_east,
+                    3, true );
     return true;
 }
 

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -2144,39 +2144,13 @@ static bool mx_city_trap( map &/*m*/, const tripoint &abs_sub )
     return true;
 }
 
-static bool mx_fungal_zone( map &/*m*/, const tripoint &abs_sub )
+static bool mx_fungal_zone( map &m, const tripoint &abs_sub )
 {
-    //First, find a city
-    // TODO: fix point types
-    const city_reference c = overmap_buffer.closest_city( tripoint_abs_sm( abs_sub ) );
-    const tripoint_abs_omt city_center_omt = project_to<coords::omt>( c.abs_sm_pos );
-
-    //Then find out which types of parks (defined in regional settings) exist in this city
-    std::vector<tripoint_abs_omt> valid_omt;
-    const auto &parks = g->get_cur_om().get_settings().city_spec.get_all_parks();
-    for( const auto &elem : parks ) {
-        for( const tripoint_abs_omt &p : points_in_radius( city_center_omt, c.city->size ) ) {
-            if( overmap_buffer.check_overmap_special_type( elem.obj, p ) ) {
-                valid_omt.push_back( p );
-            }
-        }
-    }
-
-    // If there's no parks in the city, bail out
-    if( valid_omt.empty() ) {
-        return false;
-    }
-
-    const tripoint_abs_omt &park_omt = random_entry( valid_omt, city_center_omt );
-
-    tinymap fungal_map;
-    fungal_map.load( park_omt, false );
-
-    // Then find suitable location for fungal spire to spawn (grass, dirt etc)
+    // Find suitable location for fungal spire to spawn (grass, dirt etc)
     const tripoint submap_center = { SEEX, SEEY, abs_sub.z };
     std::vector<tripoint> suitable_locations;
-    for( const tripoint &loc : fungal_map.points_in_radius( submap_center, 10 ) ) {
-        if( fungal_map.has_flag_ter( ter_furn_flag::TFLAG_DIGGABLE, loc ) ) {
+    for( const tripoint &loc : m.points_in_radius( submap_center, 10 ) ) {
+        if( m.has_flag_ter( ter_furn_flag::TFLAG_DIGGABLE, loc ) ) {
             suitable_locations.push_back( loc );
         }
     }
@@ -2187,8 +2161,8 @@ static bool mx_fungal_zone( map &/*m*/, const tripoint &abs_sub )
     }
 
     const tripoint suitable_location = random_entry( suitable_locations, submap_center );
-    fungal_map.add_spawn( mon_fungaloid_queen, 1, suitable_location );
-    fungal_map.place_spawns( GROUP_FUNGI_FUNGALOID, 1,
+    m.add_spawn( mon_fungaloid_queen, 1, suitable_location );
+    m.place_spawns( GROUP_FUNGI_FUNGALOID, 1,
                              suitable_location.xy() + point_north_west,
                              suitable_location.xy() + point_south_east,
                              3, true );

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -72,7 +72,6 @@ static const mongroup_id GROUP_ZOMBIE( "GROUP_ZOMBIE" );
 static const oter_str_id oter_central_lab( "central_lab" );
 static const oter_str_id oter_central_lab_core( "central_lab_core" );
 static const oter_str_id oter_central_lab_train_depot( "central_lab_train_depot" );
-static const oter_str_id oter_city_center( "city_center" );
 static const oter_str_id oter_empty_rock( "empty_rock" );
 static const oter_str_id oter_field( "field" );
 static const oter_str_id oter_forest( "forest" );
@@ -975,7 +974,7 @@ bool oter_t::type_is( const oter_type_t &type ) const
 bool oter_t::has_connection( om_direction::type dir ) const
 {
     // TODO: It's a DAMN UGLY hack. Remove it as soon as possible.
-    if( id == oter_road_nesw_manhole || id == oter_city_center ) {
+    if( id == oter_road_nesw_manhole ) {
         return true;
     }
     return om_lines::has_segment( line, dir );
@@ -5542,10 +5541,6 @@ void overmap::place_cities()
             do {
                 build_city_street( local_road, tmp.pos, tmp.size, cur_dir, tmp );
             } while( ( cur_dir = om_direction::turn_right( cur_dir ) ) != start_dir );
-
-            // Replace city's original intersection OMT with a dedicated 'city_center' OMT
-            // This allows setting map extras specifically to cities (or their centers)
-            ter_set( tripoint_om_omt( tmp.pos, 0 ), oter_city_center );
         }
     }
 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
#68752 added a new `city_center` OMT that's only used by `mx_fungal_zone`, and I don't really understand why it was needed in the first place as their reasoning was it "guaranteed spawn of map extras inside city borders" which it didn't need to do as that's where parks spawn to begin with.
Regardless it's unneeded and kinda hacky, I already don't like `road_nesw_manhole` being it's own OMT and will look at changing it too after #68496.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Removes all uses and references to `city_center`
Migrates `city_center` to the identical `road_nesw_manhole`
Simplifies `mx_fungal_zone` to just target the OMT the map extra targets rather than finding a random park in the city that made it at most 1 per city and target unsuitable `"parks"`
Adds an auto note to `mx_fungal_zone` now it targets the affected OMT
Adds the `FUNGAL` flag to `mx_fungal_zone` so it works with blacklisting
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Unhardcoding the extra, the same exact functionality isn't reproducible in JSON but with it being so small and now only targeting sensible parks it arguably wouldn't matter.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Checked `mx_fungal_zone` still spawns fine by changing chance to 1
Checked blacklisting `FUNGAL` disables `mx_fungal_zone`
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
