### PR TITLE
Make some facial hair styles prevent gas masks activation

### DIFF
--- a/data/json/mutations/mutation_appearance.json
+++ b/data/json/mutations/mutation_appearance.json
@@ -137,7 +137,8 @@
     "starting_trait": true,
     "player_display": true,
     "vanity": true,
-    "types": [ "facial_hair" ]
+    "types": [ "facial_hair" ],
+    "flags": [ "NO_GASMASK" ]
   },
   {
     "id": "FACIAL_HAIR_SHORTBOXED",
@@ -149,7 +150,8 @@
     "starting_trait": true,
     "player_display": true,
     "vanity": true,
-    "types": [ "facial_hair" ]
+    "types": [ "facial_hair" ],
+    "flags": [ "NO_GASMASK" ]
   },
   {
     "id": "FACIAL_HAIR_CHEVRON",
@@ -173,7 +175,8 @@
     "starting_trait": true,
     "player_display": true,
     "vanity": true,
-    "types": [ "facial_hair" ]
+    "types": [ "facial_hair" ],
+    "flags": [ "NO_GASMASK" ]
   },
   {
     "id": "FACIAL_HAIR_HORSESHOE",
@@ -209,7 +212,8 @@
     "starting_trait": true,
     "player_display": true,
     "vanity": true,
-    "types": [ "facial_hair" ]
+    "types": [ "facial_hair" ],
+    "flags": [ "NO_GASMASK" ]
   },
   {
     "id": "FACIAL_HAIR_GUNSLINGER",
@@ -221,7 +225,8 @@
     "starting_trait": true,
     "player_display": true,
     "vanity": true,
-    "types": [ "facial_hair" ]
+    "types": [ "facial_hair" ],
+    "flags": [ "NO_GASMASK" ]
   },
   {
     "id": "FACIAL_HAIR_CHIN_STRIP",
@@ -245,7 +250,8 @@
     "starting_trait": true,
     "player_display": true,
     "vanity": true,
-    "types": [ "facial_hair" ]
+    "types": [ "facial_hair" ],
+    "flags": [ "NO_GASMASK" ]
   },
   {
     "id": "FACIAL_HAIR_CHIN_STRAP",
@@ -257,7 +263,8 @@
     "starting_trait": true,
     "player_display": true,
     "vanity": true,
-    "types": [ "facial_hair" ]
+    "types": [ "facial_hair" ],
+    "flags": [ "NO_GASMASK" ]
   },
   {
     "id": "FACIAL_HAIR_BEARD",
@@ -269,7 +276,8 @@
     "starting_trait": true,
     "player_display": true,
     "vanity": true,
-    "types": [ "facial_hair" ]
+    "types": [ "facial_hair" ],
+    "flags": [ "NO_GASMASK" ]
   },
   {
     "id": "FACIAL_HAIR_HANDLEBAR",
@@ -293,7 +301,8 @@
     "starting_trait": true,
     "player_display": true,
     "vanity": true,
-    "types": [ "facial_hair" ]
+    "types": [ "facial_hair" ],
+    "flags": [ "NO_GASMASK" ]
   },
   {
     "id": "FACIAL_HAIR_PENCIL",
@@ -317,7 +326,8 @@
     "starting_trait": true,
     "player_display": true,
     "vanity": true,
-    "types": [ "facial_hair" ]
+    "types": [ "facial_hair" ],
+    "flags": [ "NO_GASMASK" ]
   },
   {
     "id": "FACIAL_HAIR_SIDEBURNS",
@@ -329,7 +339,8 @@
     "starting_trait": true,
     "player_display": true,
     "vanity": true,
-    "types": [ "facial_hair" ]
+    "types": [ "facial_hair" ],
+    "flags": [ "NO_GASMASK" ]
   },
   {
     "id": "FACIAL_HAIR_SOUL_PATCH",
@@ -401,7 +412,8 @@
     "starting_trait": true,
     "player_display": true,
     "vanity": true,
-    "types": [ "facial_hair" ]
+    "types": [ "facial_hair" ],
+    "flags": [ "NO_GASMASK" ]
   },
   {
     "id": "FACIAL_HAIR_BEARD_VERY_LONG",
@@ -413,6 +425,7 @@
     "starting_trait": true,
     "player_display": true,
     "vanity": true,
-    "types": [ "facial_hair" ]
+    "types": [ "facial_hair" ],
+    "flags": [ "NO_GASMASK" ]
   }
 ]

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -299,6 +299,7 @@ static const itype_id itype_weather_reader( "weather_reader" );
 
 static const json_character_flag json_flag_ENHANCED_VISION( "ENHANCED_VISION" );
 static const json_character_flag json_flag_HYPEROPIC( "HYPEROPIC" );
+static const json_character_flag json_flag_NO_GASMASK( "NO_GASMASK" );
 static const json_character_flag json_flag_PAIN_IMMUNE( "PAIN_IMMUNE" );
 
 static const mongroup_id GROUP_FISH( "GROUP_FISH" );
@@ -3958,7 +3959,10 @@ std::optional<int> iuse::solarpack_off( Character *p, item *it, const tripoint &
 
 std::optional<int> iuse::gasmask_activate( Character *p, item *it, const tripoint & )
 {
-    if( it->ammo_remaining() == 0 ) {
+    if( p->has_trait_flag( json_flag_NO_GASMASK ) ) {
+        p->add_msg_if_player( _( "Your facial hair prevents you from sealing the %s to your face." ),
+                              it->tname() );
+    } else if( it->ammo_remaining() == 0 ) {
         p->add_msg_if_player( _( "Your %s doesn't have a filter." ), it->tname() );
     } else {
         p->add_msg_if_player( _( "You prepare your %s." ), it->tname() );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Some facial hair styles now prevent you from using gasmasks"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Santa can't wear a gas mask.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Big beard = no gas mask, mustache ok though.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Invert the if statement and check for a `GASMASK_COMPATIBLE` flag, I dunno, maybe it's more intuitive?

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tried activating a dust mask with a beard, couldn't.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Let's have a debate about what facial hair should be gas mask compatible.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
