### PR TITLE
[Bombastic Perks] Yet more perks

### DIFF
--- a/data/mods/BombasticPerks/perkdata/absit_invidia.json
+++ b/data/mods/BombasticPerks/perkdata/absit_invidia.json
@@ -1,0 +1,57 @@
+[
+  {
+    "id": "ANTI_EVIL_EYE_GEAR",
+    "type": "json_flag",
+    "info": "Wearing this will protect you from the Evil Eye."
+  },
+  {
+    "id": "holy_symbol",
+    "type": "ARMOR",
+    "copy-from": "holy_symbol",
+    "name": { "str": "holy symbol" },
+    "extend": { "flags": [ "ANTI_EVIL_EYE_GEAR" ] }
+  },
+  {
+    "id": "holy_symbol_wood",
+    "type": "ARMOR",
+    "copy-from": "holy_symbol_wood",
+    "name": { "str": "handmade holy symbol" },
+    "extend": { "flags": [ "ANTI_EVIL_EYE_GEAR" ] }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PERK_ABSIT_INVIDIA_HOLY_SYMBOL",
+    "eoc_type": "EVENT",
+    "required_event": "character_gains_effect",
+    "condition": {
+      "and": [
+        { "u_has_trait": "perk_absit_invidia" },
+        { "compare_string": [ "taint", { "context_val": "effect" } ] },
+        { "u_has_worn_with_flag": "ANTI_EVIL_EYE_GEAR" }
+      ]
+    },
+    "effect": [ { "u_lose_effect": "taint" } ]
+  },
+  {
+    "id": "salt",
+    "type": "COMESTIBLE",
+    "copy-from": "salt",
+    "name": { "str": "salt" },
+    "use_action": {
+      "type": "effect_on_conditions",
+      "description": "Throw some salt over your shoulder.",
+      "effect_on_conditions": [ "EOC_PERK_ABSIT_INVIDIA_SALT" ]
+    }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PERK_ABSIT_INVIDIA_SALT",
+    "effect": [
+      { "u_lose_effect": "taint" },
+      {
+        "u_message": "You toss the salt over your shoulder and mutter under your breath the words that you remember from your childhood.",
+        "type": "mixed"
+      }
+    ]
+  }
+]

--- a/data/mods/BombasticPerks/perkdata/bellringer.json
+++ b/data/mods/BombasticPerks/perkdata/bellringer.json
@@ -1,0 +1,32 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_perk_bellringer_application_monster",
+    "eoc_type": "EVENT",
+    "required_event": "character_melee_attacks_monster",
+    "condition": {
+      "and": [ { "u_has_trait": "perk_bellringer" }, { "or": [ { "npc_has_effect": "dazed" }, { "npc_has_effect": "stunned" } ] } ]
+    },
+    "effect": [ { "npc_add_effect": "effect_perk_bellringer", "duration": 1 } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_perk_bellringer_application_character",
+    "eoc_type": "EVENT",
+    "required_event": "character_melee_attacks_character",
+    "condition": {
+      "and": [ { "u_has_trait": "perk_bellringer" }, { "or": [ { "npc_has_effect": "dazed" }, { "npc_has_effect": "stunned" } ] } ]
+    },
+    "effect": [ { "npc_add_effect": "effect_perk_bellringer", "duration": 1 } ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_perk_bellringer",
+    "name": [ "Bell-ringing" ],
+    "desc": [ "This is really going to hurt.  Applied to targets of the Bellringer perk." ],
+    "apply_message": "",
+    "rating": "bad",
+    "max_duration": "1 s",
+    "enchantments": [ { "values": [ { "value": "ARMOR_BASH", "multiply": -0.33 } ] } ]
+  }
+]

--- a/data/mods/BombasticPerks/perkdata/duck_and_weave.json
+++ b/data/mods/BombasticPerks/perkdata/duck_and_weave.json
@@ -37,16 +37,13 @@
         }
       ]
     },
-    "effect": [
-      { "math": [ "u_duck_and_weave_counter", "=", "0" ] },
-      { "u_lose_effect": "effect_perk_duck_and_weave", "duration": 1 }
-    ]
+    "effect": [ { "math": [ "u_duck_and_weave_counter", "=", "0" ] }, { "u_lose_effect": "effect_perk_duck_and_weave" } ]
   },
   {
     "type": "effect_type",
     "id": "effect_perk_duck_and_weave",
     "name": [ "Running without Rhythm" ],
-    "desc": [ "You definitely won't attract the worm.  +25% dodge chance, +1 dodge attempt." ],
+    "desc": [ "You definitely won't attract the worm.  +5 effective dodge, +1 dodge attempt." ],
     "rating": "good",
     "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "BONUS_DODGE", "add": 1 }, { "value": "DODGE_CHANCE", "add": 5 } ] } ]
   }

--- a/data/mods/BombasticPerks/perkdata/duck_and_weave.json
+++ b/data/mods/BombasticPerks/perkdata/duck_and_weave.json
@@ -7,7 +7,40 @@
     "condition": {
       "and": [ { "u_has_trait": "perk_duck_and_weave" }, { "compare_string": [ "run", { "context_val": "movement_mode" } ] } ]
     },
-    "effect": [ { "u_add_effect": "effect_perk_duck_and_weave", "duration": 1 } ]
+    "effect": [
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_perk_duck_and_weave_2",
+            "condition": { "math": [ "u_duck_and_weave_counter", ">=", "4" ] },
+            "effect": [ { "u_add_effect": "effect_perk_duck_and_weave", "duration": 1 } ],
+            "false_effect": [ { "math": [ "u_duck_and_weave_counter", "+=", "1" ] } ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_perk_duck_and_weave_reset",
+    "eoc_type": "EVENT",
+    "required_event": "avatar_moves",
+    "condition": {
+      "and": [
+        { "u_has_trait": "perk_duck_and_weave" },
+        {
+          "or": [
+            { "compare_string": [ "walk", { "context_val": "movement_mode" } ] },
+            { "compare_string": [ "crouch", { "context_val": "movement_mode" } ] },
+            { "compare_string": [ "prone", { "context_val": "movement_mode" } ] }
+          ]
+        }
+      ]
+    },
+    "effect": [
+      { "math": [ "u_duck_and_weave_counter", "=", "0" ] },
+      { "u_lose_effect": "effect_perk_duck_and_weave", "duration": 1 }
+    ]
   },
   {
     "type": "effect_type",

--- a/data/mods/BombasticPerks/perkdata/duck_and_weave.json
+++ b/data/mods/BombasticPerks/perkdata/duck_and_weave.json
@@ -1,0 +1,20 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_perk_duck_and_weave",
+    "eoc_type": "EVENT",
+    "required_event": "avatar_moves",
+    "condition": {
+      "and": [ { "u_has_trait": "perk_duck_and_weave" }, { "compare_string": [ "run", { "context_val": "movement_mode" } ] } ]
+    },
+    "effect": [ { "u_add_effect": "effect_perk_duck_and_weave", "duration": 1 } ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_perk_duck_and_weave",
+    "name": [ "Running without Rhythm" ],
+    "desc": [ "You definitely won't attract the worm.  +25% dodge chance, +1 dodge attempt." ],
+    "rating": "good",
+    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "BONUS_DODGE", "add": 1 }, { "value": "DODGE_CHANCE", "add": 5 } ] } ]
+  }
+]

--- a/data/mods/BombasticPerks/perkdata/duck_and_weave.json
+++ b/data/mods/BombasticPerks/perkdata/duck_and_weave.json
@@ -12,7 +12,7 @@
         "run_eocs": [
           {
             "id": "EOC_perk_duck_and_weave_2",
-            "condition": { "math": [ "u_duck_and_weave_counter", ">=", "4" ] },
+            "condition": { "math": [ "u_duck_and_weave_counter", ">=", "3" ] },
             "effect": [ { "u_add_effect": "effect_perk_duck_and_weave", "duration": 1 } ],
             "false_effect": [ { "math": [ "u_duck_and_weave_counter", "+=", "1" ] } ]
           }

--- a/data/mods/BombasticPerks/perkdata/popeye.json
+++ b/data/mods/BombasticPerks/perkdata/popeye.json
@@ -37,6 +37,6 @@
     "apply_message": "You feel strong!",
     "remove_message": "Your strength deflates.",
     "rating": "good",
-    "base_mods": { "str_mod": [ 2 ] }
+    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "STRENGTH", "add": 2 } ] } ]
   }
 ]

--- a/data/mods/BombasticPerks/perkdata/sight_beyond_sight.json
+++ b/data/mods/BombasticPerks/perkdata/sight_beyond_sight.json
@@ -1,0 +1,26 @@
+[
+  {
+    "type": "mutation",
+    "id": "perk_sight_beyond_sight_active",
+    "name": { "str": "Sight Beyond Sight Active" },
+    "points": 0,
+    "player_display": false,
+    "description": "Your Sight Beyond Sight is active.  You should never see this.",
+    "enchantments": [
+      {
+        "values": [ { "value": "SIGHT_RANGE_NETHER", "add": { "math": [ "( u_val('perception') + u_val('intelligence'))" ] } } ]
+      }
+    ],
+    "flags": [ "BLIND" ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_perk_sight_beyond_sight_ON",
+    "condition": { "not": { "u_has_trait": "perk_sight_beyond_sight_active" } },
+    "effect": [
+      { "u_add_trait": "perk_sight_beyond_sight_active" },
+      { "u_message": "You close your eyes and feel the air.", "type": "good" }
+    ],
+    "false_effect": [ { "u_lose_trait": "perk_sight_beyond_sight_active" }, { "u_message": "You open your eyes.", "type": "neutral" } ]
+  }
+]

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -280,7 +280,7 @@
           },
           { "set_string_var": "perk_bellringer", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Requires unarmred 4 or bashing weapons 4",
+            "set_string_var": "Requires unarmed 4 or bashing weapons 4",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -643,30 +643,7 @@
           },
           {
             "set_condition": "perk_condition",
-            "condition": {
-              "or": [
-                { "math": [ "u_val('dexterity_base')", ">=", "10" ] },
-                {
-                  "and": [
-                    { "math": [ "u_val('dexterity')", ">=", "10" ] },
-                    {
-                      "u_has_any_trait": [
-                        "perk_DEX_UP",
-                        "perk_DEX_UP_2",
-                        "DEX_UP",
-                        "DEX_UP_2",
-                        "DEX_UP_3",
-                        "DEX_UP_4",
-                        "DEX_ALPHA",
-                        "BENDY1",
-                        "BENDY2",
-                        "BENDY3"
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "condition": { "math": [ "u_val('dexterity_base') + u_val('dexterity_bonus')", ">=", "10" ] }
           }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
@@ -745,29 +722,7 @@
           },
           {
             "set_condition": "perk_condition",
-            "condition": {
-              "or": [
-                { "math": [ "u_val('perception_base')", ">=", "10" ] },
-                {
-                  "and": [
-                    { "math": [ "u_val('perception')", ">=", "10" ] },
-                    {
-                      "u_has_any_trait": [
-                        "perk_PER_UP",
-                        "perk_PER_UP_2",
-                        "PER_UP",
-                        "PER_UP_2",
-                        "PER_UP_3",
-                        "PER_UP_4",
-                        "PER_ALPHA",
-                        "BIRD_EYE",
-                        "PER_SLIME_OK"
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "condition": { "math": [ "u_val('perception_base') + u_val('perception_bonus')", ">=", "10" ] }
           }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
@@ -846,30 +801,7 @@
           },
           {
             "set_condition": "perk_condition",
-            "condition": {
-              "or": [
-                { "math": [ "u_val('dexterity_base')", ">=", "12" ] },
-                {
-                  "and": [
-                    { "math": [ "u_val('dexterity')", ">=", "12" ] },
-                    {
-                      "u_has_any_trait": [
-                        "perk_DEX_UP",
-                        "perk_DEX_UP_2",
-                        "DEX_UP",
-                        "DEX_UP_2",
-                        "DEX_UP_3",
-                        "DEX_UP_4",
-                        "DEX_ALPHA",
-                        "BENDY1",
-                        "BENDY2",
-                        "BENDY3"
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
+            "condition": { "math": [ "u_val('dexterity_base') + u_val('dexterity_bonus')", ">=", "12" ] }
           }
         ],
         "topic": "TALK_PERK_MENU_SELECT"

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -248,6 +248,28 @@
         "topic": "TALK_PERK_MENU_SELECT"
       },
       {
+        "condition": { "not": { "u_has_trait": "perk_bellringer" } },
+        "text": "Gain [<trait_name:perk_bellringer>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_bellringer>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:perk_bellringer>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "perk_bellringer", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Requires unarmred 4 or bashing weapons 4",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          {
+            "set_condition": "perk_condition",
+            "condition": { "or": [ { "math": [ "u_skill('bashing')", ">=", "4" ] }, { "math": [ "u_skill('unarmed')", ">=", "4" ] } ] }
+          }
+        ],
+        "topic": "TALK_PERK_MENU_SELECT"
+      },
+      {
         "condition": { "not": { "u_has_trait": "perk_safety_net" } },
         "text": "Gain [<trait_name:perk_safety_net>]",
         "effect": [

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -769,6 +769,25 @@
         "topic": "TALK_PERK_MENU_SELECT"
       },
       {
+        "condition": { "not": { "u_has_trait": "perk_absit_invidia" } },
+        "text": "Gain [<trait_name:perk_absit_invidia>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_absit_invidia>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:perk_absit_invidia>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "perk_absit_invidia", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Requires the Spiritual trait",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "u_has_trait": "SPIRITUAL" } }
+        ],
+        "topic": "TALK_PERK_MENU_SELECT"
+      },
+      {
         "condition": { "not": { "u_has_trait": "perk_popeye" } },
         "text": "Gain [<trait_name:perk_popeye>]",
         "effect": [

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -641,7 +641,33 @@
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "math": [ "u_val('dexterity_base')", ">=", "10" ] } }
+          {
+            "set_condition": "perk_condition",
+            "condition": {
+              "or": [
+                { "math": [ "u_val('dexterity_base')", ">=", "10" ] },
+                {
+                  "and": [
+                    { "math": [ "u_val('dexterity')", ">=", "10" ] },
+                    {
+                      "u_has_any_trait": [
+                        "perk_DEX_UP",
+                        "perk_DEX_UP_2",
+                        "DEX_UP",
+                        "DEX_UP_2",
+                        "DEX_UP_3",
+                        "DEX_UP_4",
+                        "DEX_ALPHA",
+                        "BENDY1",
+                        "BENDY2",
+                        "BENDY3"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },
@@ -717,7 +743,32 @@
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "math": [ "u_val('perception_base')", ">=", "10" ] } }
+          {
+            "set_condition": "perk_condition",
+            "condition": {
+              "or": [
+                { "math": [ "u_val('perception_base')", ">=", "10" ] },
+                {
+                  "and": [
+                    { "math": [ "u_val('perception')", ">=", "10" ] },
+                    {
+                      "u_has_any_trait": [
+                        "perk_PER_UP",
+                        "perk_PER_UP_2",
+                        "PER_UP",
+                        "PER_UP_2",
+                        "PER_UP_3",
+                        "PER_UP_4",
+                        "PER_ALPHA",
+                        "BIRD_EYE",
+                        "PER_SLIME_OK"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },
@@ -775,6 +826,51 @@
             "i18n": true
           },
           { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
+        ],
+        "topic": "TALK_PERK_MENU_SELECT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "perk_duck_and_weave" } },
+        "text": "Gain [<trait_name:perk_duck_and_weave>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_duck_and_weave>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:perk_duck_and_weave>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "perk_duck_and_weave", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Requires dexterity 12",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          {
+            "set_condition": "perk_condition",
+            "condition": {
+              "or": [
+                { "math": [ "u_val('dexterity_base')", ">=", "12" ] },
+                {
+                  "and": [
+                    { "math": [ "u_val('dexterity')", ">=", "12" ] },
+                    {
+                      "u_has_any_trait": [
+                        "perk_DEX_UP",
+                        "perk_DEX_UP_2",
+                        "DEX_UP",
+                        "DEX_UP_2",
+                        "DEX_UP_3",
+                        "DEX_UP_4",
+                        "DEX_ALPHA",
+                        "BENDY1",
+                        "BENDY2",
+                        "BENDY3"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -153,6 +153,28 @@
         "topic": "TALK_PERK_MENU_SELECT"
       },
       {
+        "condition": { "not": { "u_has_trait": "perk_sight_beyond_sight" } },
+        "text": "Gain [<trait_name:perk_sight_beyond_sight>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_sight_beyond_sight>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:perk_sight_beyond_sight>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "perk_sight_beyond_sight", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Requires perception 13",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          {
+            "set_condition": "perk_condition",
+            "condition": { "math": [ "u_val('perception_base') + u_val('perception_bonus')", ">=", "13" ] }
+          }
+        ],
+        "topic": "TALK_PERK_MENU_SELECT"
+      },
+      {
         "condition": { "not": { "u_has_trait": "perk_holdout_pocket" } },
         "text": "Gain [<trait_name:perk_holdout_pocket>]",
         "effect": [

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -530,6 +530,25 @@
         "topic": "TALK_PERK_MENU_SELECT"
       },
       {
+        "condition": { "not": { "u_has_trait": "perk_ghost_stealth" } },
+        "text": "Gain [<trait_name:perk_ghost_stealth>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_ghost_stealth>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:perk_ghost_stealth>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "perk_ghost_stealth", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
+        ],
+        "topic": "TALK_PERK_MENU_SELECT"
+      },
+      {
         "condition": { "not": { "u_has_trait": "perk_tuck_and_roll" } },
         "text": "Gain [<trait_name:perk_tuck_and_roll>]",
         "effect": [

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -325,7 +325,7 @@
     "id": "perk_duck_and_weave",
     "name": { "str": "Duck and Weave" },
     "points": 0,
-    "description": "Run without rhythm.  While running, you gain 5 effective dodge and +1 bonus dodge attempt.",
+    "description": "Run without rhythm.  After a short wind-up period, you gain 5 effective dodge and +1 bonus dodge attempt as long as you keep running.",
     "category": [ "perk" ]
   },
   {
@@ -342,7 +342,7 @@
     "id": "perk_non_combatant",
     "name": { "str": "Non-Combatant" },
     "points": 0,
-    "description": "Hey, that's against the Geneva Convention!  When not wielding a weapon, or object that could be used as an improvised weapon, you take -15% reduced damage.",
+    "description": "Hey, that's against the Geneva Convention!  When not wielding a weapon, or object that could be used as an improvised weapon, you take -25% reduced damage.",
     "category": [ "perk" ],
     "//": "u_has_weapon checks if you're wielding ANYTHNG, not a weapon specifically, hence the long condition below.",
     "enchantments": [

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -156,6 +156,14 @@
   },
   {
     "type": "mutation",
+    "id": "perk_bellringer",
+    "name": { "//~": " 'To have your bell rung' means to be hit on the head.", "str": "Bellringer" },
+    "points": 0,
+    "description": "You're very good at the follow-through when your enemies are reeling.  When in melee combat with an enemy that is dazed or stunned, you do +33% extra bash damage.",
+    "category": [ "perk" ]
+  },
+  {
+    "type": "mutation",
     "id": "perk_thick_skull",
     "name": { "str": "Thick Skull" },
     "points": 0,

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -248,7 +248,7 @@
     "category": [ "perk" ],
     "enchantments": [
       {
-        "condition": { "math": [ "u_characters_nearby('radius': 20, 'attitude': 'ally')", "==", "0" ] },
+        "condition": { "math": [ "u_characters_nearby('radius': 20, 'attitude': 'allies')", "==", "0" ] },
         "values": [ { "value": "STEALTH_MODIFIER", "add": 15 } ]
       }
     ]

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -316,9 +316,17 @@
     "id": "perk_sleepy",
     "name": { "str": "Easy Sleeper" },
     "points": 0,
-    "description": "You've always been able to fall asleep within a few minutes of closing your eyes, no matter what else is going on around you.  You have a much easier time falling asleep.'",
+    "description": "You've always been able to fall asleep within a few minutes of closing your eyes, no matter what else is going on around you.  You have a much easier time falling asleep.",
     "category": [ "perk" ],
     "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "SLEEPY", "add": 15 } ] } ]
+  },
+  {
+    "type": "mutation",
+    "id": "perk_duck_and_weave",
+    "name": { "str": "Duck and Weave" },
+    "points": 0,
+    "description": "Run without rhythm.  While running, you gain 5 effective dodge and +1 bonus dodge attempt.",
+    "category": [ "perk" ]
   },
   {
     "type": "mutation",

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -95,6 +95,18 @@
   },
   {
     "type": "mutation",
+    "id": "perk_sight_beyond_sight",
+    "name": { "str": "Sight Beyond Sight" },
+    "points": 0,
+    "description": "You have an instinctive sense for the uncanny and unearthy. Activate this perk to close your eyes and become aware of nearby Nether creatures.",
+    "category": [ "perk" ],
+    "activated_is_setup": true,
+    "active": true,
+    "activated_eocs": [ "EOC_perk_sight_beyond_sight_ON" ],
+    "deactivated_eocs": [ "EOC_perk_sight_beyond_sight_ON" ]
+  },
+  {
+    "type": "mutation",
     "id": "perk_holdout_pocket",
     "name": { "str": "Holdout Pocket" },
     "points": 0,

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -221,6 +221,20 @@
   },
   {
     "type": "mutation",
+    "id": "perk_ghost_stealth",
+    "name": { "str": "Ghost" },
+    "points": 0,
+    "description": "You've gotten pretty good at sneaking up on people.  When you have no allies within 20 squares, enemies' vision detection range is reduced by 15%.",
+    "category": [ "perk" ],
+    "enchantments": [
+      {
+        "condition": { "math": [ "u_characters_nearby('radius': 20, 'attitude': 'ally')", "==", "0" ] },
+        "values": [ { "value": "STEALTH_MODIFIER", "add": 15 } ]
+      }
+    ]
+  },
+  {
+    "type": "mutation",
     "id": "perk_tuck_and_roll",
     "name": { "str": "Tuck and Roll" },
     "points": 0,

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -486,6 +486,14 @@
   },
   {
     "type": "mutation",
+    "id": "perk_absit_invidia",
+    "name": { "str": "Absit Invidia" },
+    "points": 0,
+    "description": "Your Nana told you about the evil eye and how to protect yourself when you were a small child.  You don't remember her telling you the evil eye was giant, disembodied, and on fire, but some of the things she taught you work all the same.  You are immune to the Tainted Mind effect as long as you're wearing a holy symbol necklace, and can use some salt to remove it if you do acquire it.",
+    "category": [ "perk" ]
+  },
+  {
+    "type": "mutation",
     "id": "perk_metamagic_quicken",
     "name": { "str": "Metamagic: Quicken Spell" },
     "points": 0,

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -98,7 +98,7 @@
     "id": "perk_sight_beyond_sight",
     "name": { "str": "Sight Beyond Sight" },
     "points": 0,
-    "description": "You have an instinctive sense for the uncanny and unearthy. Activate this perk to close your eyes and become aware of nearby Nether creatures.",
+    "description": "You have an instinctive sense for the uncanny and unearthy.  Activate this perk to close your eyes and become aware of nearby Nether creatures.",
     "category": [ "perk" ],
     "activated_is_setup": true,
     "active": true,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Bombastic Perks] Yet more perks"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Had yet more ideas for perks. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Adding more perks:

- Duck and Weave: Run without rhythm and you won't attract their bites.  You gain +5 effective dodge and +1 dodge attempt while running (done as an effect that lasts 1 turn and is applied each time you run).
- Absit Invidia: Your Nana told you about the evil eye and how to protect yourself when you were a small child.  You don't remember her telling you the evil eye was giant, disembodied, and on fire, but some of the things she taught you work all the same. You are immune to the Tainted Mind effect as long as you're wearing a holy symbol necklace, and can use some salt to remove it if you do acquire it (_Requires the Spiritual trait_)
- Ghost: When traveling alone, you're much less conspicuous.  Enemies' vision range with respect towards you are reduced by 15%, but only when you have no allies within 20 meters.
- Bellringer: You're good at the follow-through when your enemies are reeling.  You do 33% extra bash damage to enemies that are dazed or stunned (_Requires Unarmed or Bash 4_)
- Sight Beyond Sight: You have an instinctive sense for the uncanny and unearthy.  Activate this perk to close your eyes and become aware of nearby Nether creatures (_Requires Perception 13_)

Also did some infrastructure updates. Fixed the description of Non-Combatant, changed Of Sailors and Spinach to use an enchantment instead of the deprecated `base_mods`, and made Long Shot and Quick Recovery check for attribute of 10+ rather than base attribute of 10+ (since mutations now use enchantments and no longer count as modifying the base). If there's ever some way of distinguishing between effect-based attribute increases and mutation-based attribute increases, that should be implemented.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Perks work (though Bell-ringer is a little finicky). Changes to salt do not make it unusable in cooking recipes.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
