### PR TITLE
Pigeon reproduction + Foundations for future bird audit

### DIFF
--- a/data/json/items/comestibles/egg.json
+++ b/data/json/items/comestibles/egg.json
@@ -47,6 +47,14 @@
   },
   {
     "type": "COMESTIBLE",
+    "id": "egg_pigeon",
+    "name": { "str": "pigeon egg" },
+    "copy-from": "egg_chicken",
+    "proportional": { "volume": 0.27, "weight": 0.27, "calories": 0.27 },
+    "rot_spawn": "GROUP_EGG_PIGEON"
+  },
+  {
+    "type": "COMESTIBLE",
     "id": "egg_crow",
     "name": { "str": "crow egg" },
     "copy-from": "egg_chicken",

--- a/data/json/monstergroups/eggs.json
+++ b/data/json/monstergroups/eggs.json
@@ -30,6 +30,11 @@
     "monsters": [ { "monster": "mon_grouse_chick" } ]
   },
   {
+    "name": "GROUP_EGG_PIGEON",
+    "type": "monstergroup",
+    "monsters": [ { "monster": "mon_pigeon_chick" } ]
+  },
+  {
     "name": "GROUP_EGG_CROW",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_crow_chick" } ]

--- a/data/json/monsters/bird.json
+++ b/data/json/monsters/bird.json
@@ -1,5 +1,50 @@
 [
   {
+    "abstract": "mon_bird_flying_base",
+    "type": "MONSTER",
+    "name": { "str": "flying bird abstract" },
+    "description": "This is an abstract monsters for other wild flying birds to copy from, so that we have some common foundation to work with.  If it appears in the game that's a bug.",
+    "bodytype": "bird",
+    "default_faction": "small_animal",
+    "categories": [ "WILDLIFE" ],
+    "species": [ "BIRD" ],
+    "volume": "600 ml",
+    "weight": "450 g",
+    "//": "0.75g/ml density for most wild flying birds",
+    "hp": 4,
+    "speed": 200,
+    "material": [ "flesh" ],
+    "symbol": "v",
+    "color": "dark_gray",
+    "aggression": -99,
+    "morale": 5,
+    "melee_dice": 1,
+    "melee_dice_sides": 1,
+    "melee_damage": [ { "damage_type": "cut", "amount": 0 } ],
+    "dodge": 4,
+    "families": [ "prof_intro_biology", "prof_physiology", "prof_wp_flying", "prof_wp_basic_bird" ],
+    "weakpoint_sets": [ "wps_bird_body" ],
+    "harvest": "bird_tiny",
+    "dissect": "dissect_bird_sample_single",
+    "baby_flags": [ "SPRING", "SUMMER" ],
+    "fear_triggers": [ "SOUND", "PLAYER_CLOSE", "FRIEND_ATTACKED", "FRIEND_DIED", "FIRE", "HURT" ],
+    "biosignature": { "biosig_item": "feces_bird", "biosig_timer": 4 },
+    "flags": [
+      "SEES",
+      "HEARS",
+      "ANIMAL",
+      "PATH_AVOID_DANGER_1",
+      "PATH_AVOID_FIRE",
+      "WARM",
+      "FLIES",
+      "SWARMS",
+      "CANPLAY",
+      "CAN_BE_CULLED",
+      "PET_WONT_FOLLOW",
+      "SMALL_HIDER"
+    ]
+  },
+  {
     "id": "mon_chicken",
     "type": "MONSTER",
     "name": { "str": "chicken" },
@@ -394,7 +439,7 @@
     "bodytype": "bird",
     "categories": [ "WILDLIFE" ],
     "species": [ "BIRD" ],
-    "volume": "750 ml",
+    "volume": "80 ml",
     "weight": "60 g",
     "hp": 1,
     "speed": 40,
@@ -407,13 +452,25 @@
     "melee_skill": 1,
     "melee_dice": 1,
     "melee_dice_sides": 1,
-    "melee_damage": [ { "damage_type": "cut", "amount": 1 } ],
+    "melee_damage": [ { "damage_type": "cut", "amount": 0 } ],
     "dodge": 1,
     "families": [ "prof_intro_biology", "prof_physiology", "prof_wp_basic_bird" ],
     "harvest": "bird_tiny",
     "upgrades": { "age_grow": 14, "into": "mon_chicken" },
     "//": "Grows up into a standard chicken as a fallback",
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "SWARMS", "CAN_BE_CULLED", "SMALL_HIDER" ]
+    "fear_triggers": [ "SOUND", "PLAYER_CLOSE", "FRIEND_ATTACKED", "FRIEND_DIED", "FIRE", "HURT" ],
+    "flags": [
+      "SEES",
+      "HEARS",
+      "ANIMAL",
+      "PATH_AVOID_DANGER_1",
+      "PATH_AVOID_FIRE",
+      "WARM",
+      "SWARMS",
+      "CAN_BE_CULLED",
+      "CANPLAY",
+      "SMALL_HIDER"
+    ]
   },
   {
     "id": "mon_chicken_chick",
@@ -426,8 +483,7 @@
       "food": [ "BIRDFOOD" ],
       "feed": "The %s seems to like you!  It runs around your legs and seems friendly.",
       "pet": "The %s runs around your leg."
-    },
-    "extend": { "flags": [ "CANPLAY" ] }
+    }
   },
   {
     "id": "mon_grouse_chick",
@@ -445,7 +501,6 @@
       "feed": "The %s seems to like you!  It runs around your legs and seems friendly.",
       "pet": "The %s runs around your leg."
     },
-    "extend": { "flags": [ "CANPLAY" ] },
     "volume": "250 ml",
     "weight": "50 g",
     "upgrades": { "age_grow": 36, "into": "mon_crow" }
@@ -499,7 +554,6 @@
       "feed": "The %s seems to like you!  It runs around your legs and seems friendly.",
       "pet": "The %s runs around your leg."
     },
-    "extend": { "flags": [ "CANPLAY" ] },
     "upgrades": { "age_grow": 18, "into": "mon_turkey" }
   },
   {
@@ -511,7 +565,6 @@
       "feed": "The %s seems to like you!  It runs around your legs and seems friendly.",
       "pet": "The %s runs around your leg."
     },
-    "extend": { "flags": [ "CANPLAY" ] },
     "upgrades": { "age_grow": 14, "into": "mon_pheasant" }
   },
   {
@@ -525,8 +578,7 @@
       "feed": "The %s seems to like you!  It runs around your legs and seems friendly.",
       "pet": "The %s runs around your leg."
     },
-    "upgrades": { "age_grow": 12, "into": "mon_duck" },
-    "extend": { "flags": [ "CANPLAY" ] }
+    "upgrades": { "age_grow": 12, "into": "mon_duck" }
   },
   {
     "id": "mon_goose_canadian_chick",
@@ -610,49 +662,28 @@
   {
     "id": "mon_pigeon",
     "type": "MONSTER",
-    "name": { "str": "pigeon" },
+    "name": { "str": "feral pigeon" },
     "description": "A gentle, plump, small-billed bird with a skin saddle, or cere, between its bill and forehead.  On the ground, it struts about with a characteristic bobbing of the head.  It is a strong, swift flier thanks to its long wings and powerful flight muscles.",
-    "bodytype": "bird",
-    "default_faction": "small_animal",
-    "categories": [ "WILDLIFE" ],
-    "species": [ "BIRD" ],
-    "volume": "1 L",
-    "weight": "360 g",
-    "hp": 4,
-    "speed": 150,
-    "material": [ "flesh" ],
-    "symbol": "v",
-    "color": "dark_gray",
-    "aggression": -99,
-    "morale": 5,
-    "melee_dice": 1,
-    "melee_dice_sides": 1,
-    "melee_damage": [ { "damage_type": "cut", "amount": 0 } ],
-    "dodge": 4,
-    "families": [ "prof_intro_biology", "prof_physiology", "prof_wp_flying", "prof_wp_basic_bird" ],
-    "weakpoint_sets": [ "wps_bird_body" ],
-    "harvest": "bird_tiny",
-    "dissect": "dissect_bird_sample_single",
-    "fear_triggers": [ "SOUND", "PLAYER_CLOSE", "FRIEND_ATTACKED", "FRIEND_DIED", "FIRE", "HURT" ],
-    "biosignature": { "biosig_item": "feces_bird", "biosig_timer": 4 },
+    "copy-from": "mon_bird_flying_base",
+    "volume": "467 ml",
+    "weight": "350 g",
+    "reproduction": { "baby_egg": "egg_pigeon", "baby_count": 3, "baby_timer": 32 },
     "petfood": {
       "food": [ "BIRDFOOD" ],
       "feed": "The %s seems to like you!  It runs around your legs and seems friendly.",
       "pet": "The %s runs around your leg."
-    },
-    "flags": [
-      "SEES",
-      "HEARS",
-      "SMELLS",
-      "ANIMAL",
-      "PATH_AVOID_DANGER_1",
-      "WARM",
-      "FLIES",
-      "SWARMS",
-      "CANPLAY",
-      "CAN_BE_CULLED",
-      "SMALL_HIDER"
-    ]
+    }
+  },
+  {
+    "id": "mon_pigeon_chick",
+    "type": "MONSTER",
+    "copy-from": "mon_generic_chick",
+    "upgrades": { "age_grow": 16, "into": "mon_pigeon" },
+    "petfood": {
+      "food": [ "BIRDFOOD" ],
+      "feed": "The %s seems to like you!  It runs around your legs and seems friendly.",
+      "pet": "The %s runs around your leg."
+    }
   },
   {
     "id": "mon_goose",
@@ -775,7 +806,6 @@
     "id": "mon_hummingbird_chick",
     "type": "MONSTER",
     "copy-from": "mon_generic_chick",
-    "volume": "80 ml",
     "weight": "7 g",
     "upgrades": { "age_grow": 11, "into": "mon_hummingbird" }
   },

--- a/data/json/requirements/cooking_components.json
+++ b/data/json/requirements/cooking_components.json
@@ -100,6 +100,7 @@
         [ "egg_bluejay", 1 ],
         [ "egg_cardinal", 1 ],
         [ "egg_robin", 1 ],
+        [ "egg_pigeon", 1 ],
         [ "egg_sparrow", 2 ],
         [ "egg_duck", 1 ],
         [ "egg_goose_canadian", 1 ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Pigeons could not breed and that made me sad
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
**NEW Bird Abstract**
- For the most part identical to old pigeon definition, new stuff includes ``PATH_AVOID_FIRE`` and ``PET_WONT_FOLLOW`` flags, reproduction flags for spring and summer so they don't breed all year round, lowered proportional volume (and a fancy JSON note to boot!) and 25% higher speed. Also removed ``SMELLS``
- Currently only used by pigeons. I intend to make more extensive use of this when I get to auditing wildlife more thoroughly

**Chick Abstract**
- Volume lowered to 80ml because the old volume was ridiculous
- Added ``CANPLAY`` for the abstract - for chicks that aren't tameable this changes nothing, for chicks that were this saves on a few JSON lines
- Removed that one weird flat cut damage they'd do in fights (??)
- Added fear triggers

**Pigeon**
- Slighly lowered weight, significantly lowered volume
- Renamed to "feral pigeon" in case we wanna add some other pigeons/doves in the future. I know I do
- Added reproduction, chicks and eggs for it
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Density taken from https://svpow.com/2013/06/01/how-dense-are-birds-some-new-old-data-also-hummingbirds-and-ketchup/, since our birds are alive so I had to take air sacks into consideration
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
