### PR TITLE
Fix typos and plurals

### DIFF
--- a/data/mods/BombasticPerks/perkdata/absit_invidia.json
+++ b/data/mods/BombasticPerks/perkdata/absit_invidia.json
@@ -36,7 +36,7 @@
     "id": "salt",
     "type": "COMESTIBLE",
     "copy-from": "salt",
-    "name": { "str": "salt" },
+    "name": { "str_sp": "salt" },
     "use_action": {
       "type": "effect_on_conditions",
       "description": "Throw some salt over your shoulder.",

--- a/data/mods/MindOverMatter/snippets/snippets_observed.json
+++ b/data/mods/MindOverMatter/snippets/snippets_observed.json
@@ -4,7 +4,7 @@
     "category": "observed_effect_hearing_sounds",
     "text": [
       "You hear a whisper behind you, too low to make out any words.",
-      "You hear a single loud foostep behind you.",
+      "You hear a single loud footstep behind you.",
       "You hear a low growl that fades away into silence.",
       "You hear a drawn-out, rasping breath that ends in a cough.",
       "You hear a few moments of toneless droning before it abruptly ends.",

--- a/data/mods/Xedra_Evolved/items/notes_and_news.json
+++ b/data/mods/Xedra_Evolved/items/notes_and_news.json
@@ -2,7 +2,7 @@
   {
     "type": "GENERIC",
     "id": "report_march_lord",
-    "name": { "str": "Report CO001141" },
+    "name": { "str": "Report CO001141", "str_pl": "copies of Report CO001141" },
     "description": "A page from a report.",
     "copy-from": "survnote",
     "snippet_category": "changeling_march_lord_report"

--- a/data/mods/classic_zombies/items/guns.json
+++ b/data/mods/classic_zombies/items/guns.json
@@ -87,6 +87,6 @@
     "id": "m60",
     "name": { "str": "C6" },
     "copy-from": "m60",
-    "description": "The Colt Canada M6 is a general-purpose machine gun developed to replace the .30-caliber C5 GPMG.  Heavy and difficult to handle fired from the shoulder, as most people aren't action-movie heroes."
+    "description": "The Colt Canada C6 is a general-purpose machine gun developed to replace the .30-caliber C5 GPMG.  Heavy and difficult to handle fired from the shoulder, as most people aren't action-movie heroes."
   }
 ]


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
The description for the `C6` machine gun incorrectly refers to `M6`.

`footstep` is misspelled as `foostep`.

`Report CO001141` is incorrectly pluralized by appending an `s`.

`salt` in BombasticPerks is incorrectly pluralized as `salts`.

#### Describe the solution
Fix 'em.

#### Describe alternatives you've considered

#### Testing
Just simple text edits.

#### Additional context
