### PR TITLE
Reasonable incendiary ammo & dragon's breath

### DIFF
--- a/data/json/ammo_effects.json
+++ b/data/json/ammo_effects.json
@@ -86,7 +86,8 @@
   {
     "id": "INCENDIARY",
     "type": "ammo_effect",
-    "//": "Creature, that got hit with this projectile, would be ignited for a short duration, up to 4 seconds, (6 if creature is made out of flammable material or made out of veggy). Hardcoded"
+    "//": "Creature, that got hit with this projectile, would be ignited for a short duration, up to 4 seconds, (6 if creature is made out of flammable material or made out of veggy). Hardcoded in projectile::apply_effects_damage"
+    "//2": "10% chance to start fires on flammable (has flag FLAMMABLE_ASH) furniture/terrain **with defined shoot data**, hardcoded in map::shoot"
   },
   {
     "id": "IGNITE",

--- a/data/json/ammo_effects.json
+++ b/data/json/ammo_effects.json
@@ -92,7 +92,8 @@
   {
     "id": "IGNITE",
     "type": "ammo_effect",
-    "//": "Same as INCENDIARY, creature that got hit with this projectile, would be ignited for a short duration, up to 6 seconds, (10 if creature is made out of flammable material or made out of veggy). Hardcoded"
+    "//": "Same as INCENDIARY, creature that got hit with this projectile, would be ignited for a short duration, up to 6 seconds, (10 if creature is made out of flammable material or made out of veggy). Hardcoded",
+    "//2": "Guaranteed to start fires on flammable (has flag FLAMMABLE_ASH) furniture/terrain **with defined shoot data**, hardcoded in map::shoot"
   },
   {
     "id": "JET",
@@ -412,7 +413,7 @@
     "id": "PYROTECHNIC_DISPLAY",
     "type": "ammo_effect",
     "//": "Looks like huge fires, but doesn't actually burn stuff.",
-    "trail": { "field_type": "fd_fire_FAKE", "intensity_min": 2, "intensity_max": 3, "chance": 85 }
+    "trail": { "field_type": "fd_fire_FAKE", "intensity_min": 1, "intensity_max": 3, "chance": 85 }
   },
   {
     "id": "STREAM_GAS_FUNGICIDAL",

--- a/data/json/ammo_effects.json
+++ b/data/json/ammo_effects.json
@@ -86,7 +86,7 @@
   {
     "id": "INCENDIARY",
     "type": "ammo_effect",
-    "//": "Creature, that got hit with this projectile, would be ignited for a short duration, up to 4 seconds, (6 if creature is made out of flammable material or made out of veggy). Hardcoded in projectile::apply_effects_damage"
+    "//": "Creature, that got hit with this projectile, would be ignited for a short duration, up to 4 seconds, (6 if creature is made out of flammable material or made out of veggy). Hardcoded in projectile::apply_effects_damage",
     "//2": "10% chance to start fires on flammable (has flag FLAMMABLE_ASH) furniture/terrain **with defined shoot data**, hardcoded in map::shoot"
   },
   {
@@ -391,6 +391,12 @@
     "trail": { "field_type": "fd_smoke", "intensity_min": 1, "intensity_max": 2, "chance": 75 }
   },
   {
+    "id": "STREAM_TINY",
+    "type": "ammo_effect",
+    "//": "Sometimes leaves a trail of small fire fields. All of these STREAM_XXXXXX effects have hardcoded interactions in projectile_attack (ballistics.cpp)",
+    "trail": { "field_type": "fd_fire", "intensity_min": 1, "intensity_max": 1, "chance": 10 }
+  },
+  {
     "id": "STREAM",
     "type": "ammo_effect",
     "//": "Leaves a trail of fire fields",
@@ -401,6 +407,12 @@
     "type": "ammo_effect",
     "//": "Leaves a trail of intense fire fields",
     "trail": { "field_type": "fd_fire", "intensity_min": 2, "intensity_max": 2, "chance": 75 }
+  },
+  {
+    "id": "PYROTECHNIC_DISPLAY",
+    "type": "ammo_effect",
+    "//": "Looks like huge fires, but doesn't actually burn stuff.",
+    "trail": { "field_type": "fd_fire_FAKE", "intensity_min": 2, "intensity_max": 3, "chance": 85 }
   },
   {
     "id": "STREAM_GAS_FUNGICIDAL",

--- a/data/json/field_type.json
+++ b/data/json/field_type.json
@@ -334,6 +334,21 @@
     "display_field": true
   },
   {
+    "id": "fd_fire_FAKE",
+    "looks_like": "fd_fire",
+    "type": "field_type",
+    "intensity_levels": [
+      { "name": "glittering embers", "sym": "4", "color": "yellow", "light_emitted": 5, "translucency": 0.7 },
+      { "name": "spark shower", "color": "light_red", "light_emitted": 15, "translucency": 0.4 },
+      { "name": "wall of flames", "color": "red", "light_emitted": 40, "translucency": 0.1 }
+    ],
+    "priority": 4,
+    "half_life": "1 seconds",
+    "phase": "plasma",
+    "display_items": false,
+    "display_field": true
+  },
+  {
     "id": "fd_extinguisher",
     "type": "field_type",
     "intensity_levels": [

--- a/data/json/items/ammo/shot.json
+++ b/data/json/items/ammo/shot.json
@@ -178,7 +178,7 @@
     "price": "10 USD",
     "price_postapoc": "16 USD",
     "proportional": { "damage": { "damage_type": "bullet", "amount": 0.2 }, "recoil": 0.6, "loudness": 0.8, "range": 0.5 },
-    "extend": { "effects": [ "INCENDIARY", "STREAM", "NOGIB" ] }
+    "extend": { "effects": [ "INCENDIARY", "STREAM_TINY", "PYROTECHNIC_DISPLAY", "NOGIB" ] }
   },
   {
     "id": "shot_flechette",

--- a/data/json/items/fuel.json
+++ b/data/json/items/fuel.json
@@ -76,7 +76,7 @@
     "ammo_type": "diesel",
     "damage": { "damage_type": "heat", "amount": 5, "armor_penetration": 4 },
     "range": 4,
-    "effects": [ "FLAME", "STREAM", "INCENDIARY", "NEVER_MISFIRES" ]
+    "effects": [ "FLAME", "STREAM", "IGNITE", "NEVER_MISFIRES" ]
   },
   {
     "id": "jp8",
@@ -99,7 +99,7 @@
     "ammo_type": "jp8",
     "damage": { "damage_type": "heat", "amount": 5, "armor_penetration": 5 },
     "range": 4,
-    "effects": [ "FLAME", "STREAM", "INCENDIARY", "NEVER_MISFIRES" ]
+    "effects": [ "FLAME", "STREAM", "IGNITE", "NEVER_MISFIRES" ]
   },
   {
     "id": "avgas",
@@ -122,7 +122,7 @@
     "ammo_type": "avgas",
     "damage": { "damage_type": "heat", "amount": 5, "armor_penetration": 5 },
     "range": 4,
-    "effects": [ "FLAME", "STREAM", "INCENDIARY", "NEVER_MISFIRES" ]
+    "effects": [ "FLAME", "STREAM", "IGNITE", "NEVER_MISFIRES" ]
   },
   {
     "id": "biodiesel",
@@ -155,7 +155,7 @@
     "ammo_type": "gasoline",
     "damage": { "damage_type": "heat", "amount": 5, "armor_penetration": 5 },
     "range": 4,
-    "effects": [ "FLAME", "STREAM", "INCENDIARY", "NEVER_MISFIRES" ]
+    "effects": [ "FLAME", "STREAM", "IGNITE", "NEVER_MISFIRES" ]
   },
   {
     "id": "lamp_oil",
@@ -223,7 +223,7 @@
     "ammo_type": "flammable",
     "damage": { "damage_type": "heat", "amount": 15, "armor_penetration": 30 },
     "range": 6,
-    "effects": [ "FLAME", "STREAM_BIG", "INCENDIARY", "NEVER_MISFIRES" ]
+    "effects": [ "FLAME", "STREAM_BIG", "IGNITE", "NEVER_MISFIRES" ]
   },
   {
     "id": "gelled_gasoline",

--- a/data/json/items/gun/ups.json
+++ b/data/json/items/gun/ups.json
@@ -66,7 +66,7 @@
     "energy_drain": "20 kJ",
     "reload": 0,
     "modes": [ [ "DEFAULT", "3 rd.", 3 ], [ "BURST", "5 rd.", 5 ], [ "AUTO", "high auto", 15 ] ],
-    "ammo_effects": [ "LASER", "PLASMA_BUBBLE", "INCENDIARY" ],
+    "ammo_effects": [ "LASER", "PLASMA_BUBBLE", "IGNITE" ],
     "flags": [ "NO_UNLOAD", "NEVER_JAMS", "NO_UNWIELD", "NO_SALVAGE", "NO_REPAIR", "UNBREAKABLE_MELEE", "NON_FOULING", "USE_UPS" ],
     "overheat_threshold": 200,
     "cooling_value": 2,
@@ -97,7 +97,7 @@
     "loudness": 1,
     "energy_drain": "50 kJ",
     "reload": 0,
-    "ammo_effects": [ "LASER", "PLASMA_BUBBLE", "INCENDIARY" ],
+    "ammo_effects": [ "LASER", "PLASMA_BUBBLE", "IGNITE" ],
     "flags": [
       "NO_UNLOAD",
       "NEVER_JAMS",
@@ -154,7 +154,7 @@
       [ "stock accessory", 1 ],
       [ "underbarrel", 1 ]
     ],
-    "ammo_effects": [ "LASER", "INCENDIARY" ],
+    "ammo_effects": [ "LASER", "IGNITE" ],
     "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE", "USE_UPS", "OVERHEATS" ],
     "faults": [ "fault_overheat_melting", "fault_overheat_safety" ],
     "melee_damage": { "bash": 12 }

--- a/data/mods/Aftershock/ammo_effects.json
+++ b/data/mods/Aftershock/ammo_effects.json
@@ -40,5 +40,10 @@
     "id": "SEISMIC_MAPPING",
     "type": "ammo_effect",
     "aoe": { "field_type": "fd_clairvoyant", "intensity_min": 10, "intensity_max": 10 }
+  },
+  {
+    "id": "MULTI_EFFECTS",
+    "type": "ammo_effect",
+    "//": "Applies multi_projectile_effects to all ammo used by this weapon, even if the ammo doesn't normally have it. Hardcoded in projectile_attack (ranged.cpp)"
   }
 ]

--- a/data/mods/Aftershock/items/ammo/flashbulb.json
+++ b/data/mods/Aftershock/items/ammo/flashbulb.json
@@ -19,6 +19,6 @@
     "recoil": 45,
     "count": 4,
     "stack_size": 1,
-    "effects": [ "COOKOFF", "NEVER_MISFIRES", "LASER", "INCENDIARY", "DAZZLE_BEAM", "PUMP_LASER", "PLASMA_BUBBLE" ]
+    "effects": [ "COOKOFF", "NEVER_MISFIRES", "LASER", "IGNITE", "DAZZLE_BEAM", "PUMP_LASER", "PLASMA_BUBBLE" ]
   }
 ]

--- a/data/mods/Aftershock/items/ammo/plasma.json
+++ b/data/mods/Aftershock/items/ammo/plasma.json
@@ -15,6 +15,6 @@
     "ammo_type": "afs_shydrogen",
     "range": 0,
     "count": 1,
-    "effects": [ "INCENDIARY" ]
+    "effects": [ "IGNITE" ]
   }
 ]

--- a/data/mods/Aftershock/items/gun/laser.json
+++ b/data/mods/Aftershock/items/gun/laser.json
@@ -72,7 +72,7 @@
       [ "stock mount", 1 ],
       [ "underbarrel mount", 1 ]
     ],
-    "ammo_effects": [ "LASER", "INCENDIARY" ],
+    "ammo_effects": [ "LASER", "IGNITE" ],
     "flags": [ "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE", "USE_UPS" ],
     "melee_damage": { "bash": 4 }
   },
@@ -168,7 +168,7 @@
     "overheat_threshold": 150,
     "modes": [ [ "DEFAULT", "pulse", 1 ], [ "BURST", "2s sequence", 2 ] ],
     "ammo_to_fire": 0,
-    "ammo_effects": [ "INCENDIARY", "DAZZLE_BEAM", "PLASMA_BUBBLE" ],
+    "ammo_effects": [ "IGNITE", "DAZZLE_BEAM", "PLASMA_BUBBLE" ],
     "delete": { "flags": [ "NO_UNLOAD", "NO_RELOAD" ] },
     "energy_drain": "30 kJ",
     "built_in_mods": [ "afs_holo_aim_assist" ],

--- a/data/mods/Aftershock/items/gunmods/shotguns.json
+++ b/data/mods/Aftershock/items/gunmods/shotguns.json
@@ -40,7 +40,7 @@
     "mod_targets": [ "shotgun" ],
     "damage_modifier": { "damage_type": "electric", "amount": 3, "armor_penetration": 7 },
     "energy_drain_modifier": "20 kJ",
-    "ammo_effects": [ "SMALL_ELECTRIC_BURST" ],
+    "ammo_effects": [ "SMALL_ELECTRIC_BURST", "MULTI_EFFECTS" ],
     "dispersion_modifier": 15,
     "range_modifier": 5,
     "handling_modifier": -2,

--- a/data/mods/CrazyCataclysm/crazy_items.json
+++ b/data/mods/CrazyCataclysm/crazy_items.json
@@ -81,7 +81,7 @@
     "durability": 10,
     "loudness": 50,
     "reload": 0,
-    "ammo_effects": [ "PLASMA", "EXPLOSIVE_HUGE", "STREAM_BIG", "INCENDIARY", "WIDE" ],
+    "ammo_effects": [ "PLASMA", "EXPLOSIVE_HUGE", "STREAM_BIG", "IGNITE", "WIDE" ],
     "flags": [ "NEVER_JAMS", "NO_UNLOAD", "TRADER_AVOID", "BIONIC_WEAPON", "USES_BIONIC_POWER" ],
     "melee_damage": { "bash": 12 }
   },

--- a/data/mods/Generic_Guns/ammo/shot.json
+++ b/data/mods/Generic_Guns/ammo/shot.json
@@ -58,7 +58,7 @@
       "dispersion": 1.2,
       "range": 0.5
     },
-    "extend": { "effects": [ "INCENDIARY", "STREAM", "NOGIB" ] }
+    "extend": { "effects": [ "INCENDIARY", "PYROTECHNIC_DISPLAY", "STREAM_TINY", "NOGIB" ] }
   },
   {
     "id": "shot_explosive",

--- a/data/mods/Magiclysm/items/fuel.json
+++ b/data/mods/Magiclysm/items/fuel.json
@@ -16,7 +16,7 @@
     "ammo_type": "dragon_blood",
     "damage": { "damage_type": "stab", "amount": 5, "armor_penetration": 5 },
     "range": 4,
-    "effects": [ "FLAME", "STREAM", "INCENDIARY", "NEVER_MISFIRES" ]
+    "effects": [ "FLAME", "STREAM", "IGNITE", "NEVER_MISFIRES" ]
   },
   {
     "id": "blood_tainted",

--- a/data/mods/MindOverMatter/items/teleporter_start_items.json
+++ b/data/mods/MindOverMatter/items/teleporter_start_items.json
@@ -20,7 +20,7 @@
     "loudness": 20,
     "reload": 200,
     "range": 45,
-    "ammo_effects": [ "PLASMA", "PLASMA_BUBBLE", "INCENDIARY" ],
+    "ammo_effects": [ "PLASMA", "PLASMA_BUBBLE", "IGNITE" ],
     "ammo": [ "mom_fusion_ammo" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "magazine_well": "25 ml", "item_restriction": [ "mom_fusion_mag" ] } ],
     "flags": [ "NEVER_JAMS", "NON_FOULING", "NEEDS_NO_LUBE" ]

--- a/data/mods/MindOverMatter/items/weapons.json
+++ b/data/mods/MindOverMatter/items/weapons.json
@@ -91,7 +91,7 @@
       [ "underbarrel", 1 ]
     ],
     "ammo": [ "mom_pulse_rifle_ammo" ],
-    "ammo_effects": [ "LASER", "INCENDIARY" ],
+    "ammo_effects": [ "LASER", "IGNITE" ],
     "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE", "NO_REPAIR", "OVERHEATS" ],
     "faults": [ "fault_overheat_explosion", "fault_overheat_melting" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "mom_pulse_rifle_ammo": 1 } } ],

--- a/data/mods/Xedra_Evolved/items/ammo.json
+++ b/data/mods/Xedra_Evolved/items/ammo.json
@@ -98,7 +98,7 @@
     "range": 12,
     "count": 1,
     "recoil": 900,
-    "effects": [ "INCENDIARY" ],
+    "effects": [ "IGNITE" ],
     "flags": [ "ZERO_WEIGHT" ]
   },
   {

--- a/data/mods/Xedra_Evolved/items/inventor/gun.json
+++ b/data/mods/Xedra_Evolved/items/inventor/gun.json
@@ -99,7 +99,7 @@
       [ "stock accessory", 1 ],
       [ "underbarrel", 1 ]
     ],
-    "ammo_effects": [ "LASER", "INCENDIARY" ],
+    "ammo_effects": [ "LASER", "IGNITE" ],
     "faults": [ "fault_overheat_explosion", "fault_overheat_venting", "fault_overheat_melting", "fault_overheat_safety" ],
     "flags": [
       "NEVER_JAMS",
@@ -162,7 +162,7 @@
       [ "stock accessory", 1 ],
       [ "underbarrel", 1 ]
     ],
-    "ammo_effects": [ "LASER", "INCENDIARY" ],
+    "ammo_effects": [ "LASER", "IGNITE" ],
     "faults": [ "fault_overheat_explosion", "fault_overheat_venting", "fault_overheat_melting", "fault_overheat_safety" ],
     "flags": [
       "NEVER_JAMS",
@@ -222,7 +222,7 @@
       [ "stock accessory", 1 ],
       [ "underbarrel", 1 ]
     ],
-    "ammo_effects": [ "LASER", "PLASMA_BUBBLE", "INCENDIARY" ],
+    "ammo_effects": [ "LASER", "PLASMA_BUBBLE", "IGNITE" ],
     "faults": [ "fault_overheat_explosion", "fault_overheat_venting", "fault_overheat_melting", "fault_overheat_safety" ],
     "flags": [
       "NEVER_JAMS",

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -3467,6 +3467,7 @@ See [GAME_BALANCE.md](GAME_BALANCE.md)'s `MELEE_WEAPONS` section for the criteri
 "dispersion" : 0,     // Inaccuracy of ammo, measured in 100ths of Minutes Of Angle (MOA)
 "shot_counter": 5,    // Increases amount of shots produced by gun by this amount. `"shot_counter": 5` means each shot will be counted as 6 shots (1 you actually perform + 5); designed for using in suppressor mod breakage and for stuff like replaceable barrels, but not used anywhere at this moment
 "projectile_count": 5,// amount of pellets, that the ammo will shot, like in shotgun-like weapon; if used, shot_damage should be specified
+"multi_projectile_effects": true,// (Optional) Boolean, default false. If the projectile_count is greater than 1, determines if the extra projectiles will also trigger any ammo effects. (For more on ammo effects see below)
 "shot_damage": { "damage_type": "bullet", "amount": 15 } // Optional field specifying the damage caused by a single projectile fired from this round. If present projectile_count must also be specified; syntax is equal to damage
 "critical_multiplier": 4, // All ranged damage dealt would be multiplied by this, if it was a critical hit
 "shot_spread": 100,   // Optional field specifying the additional dispersion of single projectiles. Only meaningful if shot_count is present.

--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -240,6 +240,7 @@ dealt_projectile_attack projectile_attack( const projectile &proj_arg, const tri
     const auto &proj_effects = proj.proj_effects;
 
     const bool stream = proj_effects.count( "STREAM" ) > 0 ||
+                        proj_effects.count( "STREAM_TINY" ) > 0 ||
                         proj_effects.count( "STREAM_BIG" ) > 0 ||
                         proj_effects.count( "JET" ) > 0;
     const char bullet = stream ? '#' : '*';

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -879,34 +879,38 @@ void projectile::apply_effects_damage( Creature &target, Creature *source,
 
     Character &player_character = get_player_character();
     if( proj_effects.count( "INCENDIARY" ) ) {
-        if( target.made_of( material_veggy ) || target.made_of_any( Creature::cmat_flammable ) ) {
-            target.add_effect( effect_source( source ), effect_onfire, rng( 2_turns, 6_turns ),
-                               dealt_dam.bp_hit );
-        } else if( target.made_of_any( Creature::cmat_flesh ) && one_in( 4 ) ) {
-            target.add_effect( effect_source( source ), effect_onfire, rng( 1_turns, 4_turns ),
-                               dealt_dam.bp_hit );
-        }
-        if( player_character.has_trait( trait_PYROMANIA ) &&
-            !player_character.has_morale( MORALE_PYROMANIA_STARTFIRE ) &&
-            player_character.sees( target ) ) {
-            player_character.add_msg_if_player( m_good,
-                                                _( "You feel a surge of euphoria as flame engulfs %s!" ), target.get_name() );
-            player_character.add_morale( MORALE_PYROMANIA_STARTFIRE, 15, 15, 8_hours, 6_hours );
-            player_character.rem_morale( MORALE_PYROMANIA_NOFIRE );
+        if( x_in_y( 1, 100 ) ) { // 1% chance
+            if( target.made_of( material_veggy ) || target.made_of_any( Creature::cmat_flammable ) ) {
+                target.add_effect( effect_source( source ), effect_onfire, rng( 2_turns, 6_turns ),
+                                   dealt_dam.bp_hit );
+            } else if( target.made_of_any( Creature::cmat_flesh ) && one_in( 4 ) ) {
+                target.add_effect( effect_source( source ), effect_onfire, rng( 1_turns, 4_turns ),
+                                   dealt_dam.bp_hit );
+            }
+            if( player_character.has_trait( trait_PYROMANIA ) &&
+                !player_character.has_morale( MORALE_PYROMANIA_STARTFIRE ) &&
+                player_character.sees( target ) ) {
+                player_character.add_msg_if_player( m_good,
+                                                    _( "You feel a surge of euphoria as flame engulfs %s!" ), target.get_name() );
+                player_character.add_morale( MORALE_PYROMANIA_STARTFIRE, 15, 15, 8_hours, 6_hours );
+                player_character.rem_morale( MORALE_PYROMANIA_NOFIRE );
+            }
         }
     } else if( proj_effects.count( "IGNITE" ) ) {
-        if( target.made_of( material_veggy ) || target.made_of_any( Creature::cmat_flammable ) ) {
-            target.add_effect( effect_source( source ), effect_onfire, 6_turns, dealt_dam.bp_hit );
-        } else if( target.made_of_any( Creature::cmat_flesh ) ) {
-            target.add_effect( effect_source( source ), effect_onfire, 10_turns, dealt_dam.bp_hit );
-        }
-        if( player_character.has_trait( trait_PYROMANIA ) &&
-            !player_character.has_morale( MORALE_PYROMANIA_STARTFIRE ) &&
-            player_character.sees( target ) ) {
-            player_character.add_msg_if_player( m_good,
-                                                _( "You feel a surge of euphoria as flame engulfs %s!" ), target.get_name() );
-            player_character.add_morale( MORALE_PYROMANIA_STARTFIRE, 15, 15, 8_hours, 6_hours );
-            player_character.rem_morale( MORALE_PYROMANIA_NOFIRE );
+        if( x_in_y( 1, 2 ) ) { // 50% chance
+            if( target.made_of( material_veggy ) || target.made_of_any( Creature::cmat_flammable ) ) {
+                target.add_effect( effect_source( source ), effect_onfire, 10_turns, dealt_dam.bp_hit );
+            } else if( target.made_of_any( Creature::cmat_flesh ) ) {
+                target.add_effect( effect_source( source ), effect_onfire, 6_turns, dealt_dam.bp_hit );
+            }
+            if( player_character.has_trait( trait_PYROMANIA ) &&
+                !player_character.has_morale( MORALE_PYROMANIA_STARTFIRE ) &&
+                player_character.sees( target ) ) {
+                player_character.add_msg_if_player( m_good,
+                                                    _( "You feel a surge of euphoria as flame engulfs %s!" ), target.get_name() );
+                player_character.add_morale( MORALE_PYROMANIA_STARTFIRE, 15, 15, 8_hours, 6_hours );
+                player_character.rem_morale( MORALE_PYROMANIA_NOFIRE );
+            }
         }
     }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3089,7 +3089,7 @@ void item::ammo_info( std::vector<iteminfo> &info, const iteminfo_query *parts, 
     }
     if( ammo.ammo_effects.count( "INCENDIARY" ) &&
         parts->test( iteminfo_parts::AMMO_FX_INCENDIARY ) ) {
-        fx.emplace_back( _( "This ammo <neutral>starts fires</neutral>." ) );
+        fx.emplace_back( _( "This ammo <neutral>may start fires</neutral>." ) );
     }
     if( !fx.empty() ) {
         insert_separation_line( info );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3087,7 +3087,7 @@ void item::ammo_info( std::vector<iteminfo> &info, const iteminfo_query *parts, 
             }
         }
     }
-    if( ammo.ammo_effects.count( "INCENDIARY" ) &&
+    if( ( ammo.ammo_effects.count( "INCENDIARY" ) || ammo.ammo_effects.count( "IGNITE" ) ) &&
         parts->test( iteminfo_parts::AMMO_FX_INCENDIARY ) ) {
         fx.emplace_back( _( "This ammo <neutral>may start fires</neutral>." ) );
     }

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2679,6 +2679,7 @@ void islot_ammo::load( const JsonObject &jo )
     assign( jo, "drop_chance", drop_chance, strict, 0.0f, 1.0f );
     optional( jo, was_loaded, "drop_active", drop_active, true );
     optional( jo, was_loaded, "projectile_count", count, 1 );
+    optional( jo, was_loaded, "multi_projectile_effects", multi_projectile_effects, false );
     optional( jo, was_loaded, "shot_spread", shot_spread, 0 );
     assign( jo, "shot_damage", shot_damage, strict );
     // Damage instance assign reader handles pierce and prop_damage

--- a/src/itype.h
+++ b/src/itype.h
@@ -993,6 +993,10 @@ struct islot_ammo : common_ranged_data {
      */
     int count = 1;
     /**
+     * Whether this multi-projectile shot has its effects applied to all projectiles
+     */
+    bool multi_projectile_effects = false;
+    /**
      * Spread/dispersion between projectiles fired from the same round.
      */
     int shot_spread = 0;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4493,6 +4493,7 @@ void map::shoot( const tripoint &p, projectile &proj, const bool hit_items )
 
     const auto &ammo_effects = proj.proj_effects;
     const bool incendiary = ammo_effects.count( "INCENDIARY" );
+    const bool ignite = ammo_effects.count( "IGNITE" );
     const bool laser = ammo_effects.count( "LASER" );
 
     if( const optional_vpart_position vp = veh_at( p ) ) {
@@ -4527,8 +4528,11 @@ void map::shoot( const tripoint &p, projectile &proj, const bool hit_items )
                 add_msg( _( "The shot is stopped by the %s!" ), data.name() );
             }
             // only very flammable furn/ter can be set alight with incendiary rounds
-            if( incendiary && data.has_flag( ter_furn_flag::TFLAG_FLAMMABLE_ASH ) ) {
-                if( x_in_y( 1, 10 ) ) { // 10% chance
+            if( data.has_flag( ter_furn_flag::TFLAG_FLAMMABLE_ASH ) ) {
+                if( incendiary && x_in_y( 1, 10 ) ) { // 10% chance
+                    add_field( p, fd_fire, 1 );
+                }
+                if( ignite ) {
                     add_field( p, fd_fire, 1 );
                 }
             }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4499,6 +4499,7 @@ void map::shoot( const tripoint &p, projectile &proj, const bool hit_items )
         dam = vp->vehicle().damage( *this, vp->part_index(), dam, main_damage_type, hit_items );
     }
 
+    // This lambda is only called if the furniture/terrain has shoot data!
     const auto shoot_furn_ter = [&]( const map_data_common_t &data ) {
         const map_shoot_info &shoot = *data.shoot;
         bool destroyed = false;
@@ -4527,7 +4528,9 @@ void map::shoot( const tripoint &p, projectile &proj, const bool hit_items )
             }
             // only very flammable furn/ter can be set alight with incendiary rounds
             if( incendiary && data.has_flag( ter_furn_flag::TFLAG_FLAMMABLE_ASH ) ) {
-                add_field( p, fd_fire, 1 );
+                if( x_in_y( 1, 10 ) ) { // 10% chance
+                    add_field( p, fd_fire, 1 );
+                }
             }
             // bash_ter_furn already triggers the alarm
             // TODO: fix alarm event weirdness (not just here, also in bash, hack, etc)
@@ -4545,9 +4548,9 @@ void map::shoot( const tripoint &p, projectile &proj, const bool hit_items )
     bool hit_something = false;
 
     // shoot through furniture or terrain and see if we hit something
-    if( furniture->shoot ) {
+    if( furniture->shoot ) { // Shoot data is optional, most furniture will never trigger this
         hit_something |= shoot_furn_ter( furniture.obj() );
-    } else if( terrain->shoot ) {
+    } else if( terrain->shoot ) { // Shoot data is optional, most terrain will never trigger this
         hit_something |= shoot_furn_ter( terrain.obj() );
         // fall back to just bashing when shoot data is not defined
     } else if( impassable( p ) && !is_transparent( p ) ) {

--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -48,6 +48,7 @@ projectile &projectile::operator=( const projectile &other )
     speed = other.speed;
     range = other.range;
     count = other.count;
+    multi_projectile_effects = other.multi_projectile_effects;
     shot_spread = other.shot_spread;
     shot_impact = other.shot_impact;
     proj_effects = other.proj_effects;

--- a/src/projectile.h
+++ b/src/projectile.h
@@ -22,6 +22,8 @@ struct projectile {
         int range = 0;
         // Number of projectiles fired at a time, one except in cases like shotgun rounds.
         int count = 1;
+        // Whether ammo effects apply to all projectiles
+        bool multi_projectile_effects = false;
         // The potential dispersion between different projectiles fired from one round.
         int shot_spread = 0;
         // Damage dealt by a single shot.

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -955,6 +955,9 @@ int Character::fire_gun( const tripoint &target, int shots, item &gun )
         bool multishot = proj.count > 1;
         std::map< Creature *, std::pair < int, int >> targets_hit;
         for( int projectile_number = 0; projectile_number < proj.count; ++projectile_number ) {
+            if( !first && !proj.multi_projectile_effects ) {
+                proj.proj_effects.erase( proj.proj_effects.begin(), proj.proj_effects.end() );
+            }
             dealt_projectile_attack shot = projectile_attack( proj, pos(), aim,
                                            dispersion, this, in_veh, wp_attack, first );
             first = false;
@@ -2080,6 +2083,7 @@ static projectile make_gun_projectile( const item &gun )
         const auto &ammo = gun.ammo_data()->ammo;
         proj.critical_multiplier = ammo->critical_multiplier;
         proj.count = ammo->count;
+        proj.multi_projectile_effects = ammo->multi_projectile_effects;
         proj.shot_spread = ammo->shot_spread * gun.gun_shot_spread_multiplier();
         if( !ammo->drop.is_null() && x_in_y( ammo->drop_chance, 1.0 ) ) {
             item drop( ammo->drop );

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -2084,6 +2084,9 @@ static projectile make_gun_projectile( const item &gun )
         proj.critical_multiplier = ammo->critical_multiplier;
         proj.count = ammo->count;
         proj.multi_projectile_effects = ammo->multi_projectile_effects;
+        if( fx.count( "MULTI_EFFECTS" ) ) {
+            proj.multi_projectile_effects = true;
+        }
         proj.shot_spread = ammo->shot_spread * gun.gun_shot_spread_multiplier();
         if( !ammo->drop.is_null() && x_in_y( ammo->drop_chance, 1.0 ) ) {
             item drop( ammo->drop );


### PR DESCRIPTION
#### Summary
Balance "Dragon's breath and incendiary ammo don't outclass literal flamethrowers"

#### Purpose of change
* Closes #65836

This is what firing four dragon's breath rounds looks like:
https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/7ede400b-4992-49f0-a6c0-12b8d15c8062

This is patently absurd.


#### Describe the solution
ea6164841a16a9ca1d5f0135aec01c5004a0e87d INCENDIARY-effect rounds (dragon's breath, tracer ammo) is not guaranteed to cause fires. Against creatures the chance is reduced to 1%, against flammable terrain 10%*. IGNITE-effect reduced to 50% chance against creatures, 100% against terrain (previously IGNITE did not interaction with terrain). Also swapped IGNITE's duration for flesh vs flammable materials, since it improperly assigned flesh a higher time to burn.

*Caveat: This doesn't even trigger against most terrain. Pre-existing behavior, not in scope, definitely not changing that fact here. Added some comments to very loudly inform future contributors looking at the code.

d9910b1c5169aab8280d97be420828f9475cd041 Basically a bugfix. Since shotguns fire extra projectiles their ammo effects were getting applied to every projectile... Added an optional boolean (default false) to toggle this behavior back on if desired, but otherwise erase ammo effects for projectiles past the first. (I can imagine that e.g. aftershock may want multi-shot projectiles that each cause an explosion at the target, or whatever.)

f7ca9446773c0bb06370c5608fb9ff0abb6ce7eb Nerf the hell out of fire chance for dragon's breath projectiles. Give them a new effect `PYROTECHNIC_DISPLAY` which looks about as impressive as their pre-PR firing. But that does not do anything besides look impressive. Dragon's breath still retains a small fire chance along their line of fire, and as INCENDIARY ammo they can set their target alight, given they fulfill the previously mentioned conditions.

#### Describe alternatives you've considered
I wanted to get it to draw explosion fx along the line of fire but fake fire fields that dissipate after a few seconds is fine too, I guess.

#### Testing
After tweaking dragon's breath fire chance way down:

https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/74ca97c0-7be3-4259-9cbc-f7dfeca64a28



After adding the fake fire effects:

https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/00a6b1ea-e90b-4fa0-9837-b8c03d547714



#### Additional context
