### PR TITLE
killed monster can run EoC directly

### DIFF
--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -82,6 +82,7 @@ For example, `{ "npc_has_effect": "Shadow_Reveal" }`, used by shadow lieutenant,
 | mutation: "deactivated_eocs"                     | character (Character)       | NONE                        |
 | mutation: "processed_eocs"                       | character (Character)       | NONE                        |
 | recipe: "result_eocs"                            | crafter (Character)         | NONE                        |
+| monster death: "death_function"                  | killed monster (monster)    | you (avatar)                |
 
 Using `use_action: "type": "effect_on_conditions"` automatically passes the context variable `id`, that stores the id of an item that was activated
 Using `bionics: "activated_eocs"` automatically passes the context variable `act_cost` that stores the value of `act_cost` field

--- a/doc/MONSTERS.md
+++ b/doc/MONSTERS.md
@@ -450,7 +450,8 @@ How the monster behaves on death.
 {
     "corpse_type": "NORMAL", // can be: BROKEN, NO_CORPSE, NORMAL (default)
     "message": "The %s dies!", // substitute %s for the monster's name.
-    "effect": { "id": "death_boomer", "hit_self": true }  // the actual effect that gets called when the monster dies.  follows the syntax of fake_spell.
+    "effect": { "id": "death_boomer", "hit_self": true }  // the spell that gets called when the monster dies.  follows the syntax of fake_spell.
+    "eoc": "debug_eoc_message",  // eoc that would be run when monster dies. Alpha talker is monster, beta talker is player (always).
 }
 ```
 

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -21,6 +21,7 @@
 #include "cursesdef.h"
 #include "debug.h"
 #include "effect.h"
+#include "effect_on_condition.h"
 #include "effect_source.h"
 #include "event.h"
 #include "event_bus.h"
@@ -2838,6 +2839,16 @@ void monster::die( Creature *nkiller )
             death_spell.cast_all_effects( *this, killer->pos() );
         } else if( type->mdeath_effect.sp.self ) {
             death_spell.cast_all_effects( *this, pos() );
+        }
+    }
+
+    if( type->mdeath_effect.eoc.has_value() ) {
+        //Not a hallucination, go process the death effects.
+        if( type->mdeath_effect.eoc.value().is_valid() ) {
+            dialogue d( get_talker_for( *this ), nullptr );
+            type->mdeath_effect.eoc.value()->activate( d );
+        } else {
+            debugmsg( "eoc id %s is not valid", type->mdeath_effect.eoc.value().str() );
         }
     }
 

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -1815,6 +1815,7 @@ void monster_death_effect::load( const JsonObject &jo )
     optional( jo, was_loaded, "effect", sp );
     has_effect = sp.is_valid();
     optional( jo, was_loaded, "corpse_type", corpse_type, mdeath_type::NORMAL );
+    optional( jo, was_loaded, "eoc", eoc );
 }
 
 void monster_death_effect::deserialize( const JsonObject &data )

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -254,6 +254,7 @@ struct monster_death_effect {
     bool was_loaded = false;
     bool has_effect = false;
     fake_spell sp;
+    std::optional<effect_on_condition_id> eoc;
     translation death_message;
     mdeath_type corpse_type = mdeath_type::NORMAL;
 


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Json power
#### Describe the solution
death_function has field `eoc`, that can run EoC directly 
#### Describe alternatives you've considered
Not using it, instead always having a spell that runs said EoC
#### Testing

```c++
    "death_function": {
      "eoc": "debug_eoc_messag",
      "message": "The %s explodes!",
      "corpse_type": "NO_CORPSE"
    },
...
  {
    "type": "effect_on_condition",
    "id": "debug_eoc_message",
    "effect": [ { "message": "Congrats, the code works as expected." } ]
  },
```
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/67688115/1e299783-e9ee-4a44-96c0-51610780f44e)
#### Additional context
This code is so far from being good as it is physically possible:
field accept only string, i failed to find how to make it loop on vector
while alpha talker is correctly assigned to monster, for whatever reason beta is always avatar, not killer
validation doesn't work, if you run eoc with ~~wrong id, it just silently fails~~
i have no idea how to resolve any of it, ~~but i find only the last one being critical enough to put it in draft~~ since the last one was resolved, i think it can be merged as it is 