### PR TITLE
delete (empty) src/mission_end.cpp

### DIFF
--- a/src/mission_end.cpp
+++ b/src/mission_end.cpp
@@ -1,1 +1,0 @@
-#include "mission.h" // IWYU pragma: associated


### PR DESCRIPTION

#### Summary
None

#### Purpose of change

- #62589

^Made this file empty, but didn't delete it. I don't know why. There is no reason to have an empty `.cpp` file.

#### Describe the solution

`rm`

#### Describe alternatives you've considered


#### Testing

I searched for occurrences of misson_end if it were required for some black magic. GitHub tests will show it still compiles.

#### Additional context

I was looking through my old PRs. I removed some includes in that file in #71141. Like the author of #62589, I didn't delete the empty `.cpp` file either.
