### PR TITLE
Fix include error

### DIFF
--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -49,6 +49,7 @@
 #include "npc.h"
 #include "options.h"
 #include "output.h"
+#include "overmap.h"
 #include "player_activity.h"
 #include "point.h"
 #include "requirements.h"


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Due to https://github.com/CleverRaven/Cataclysm-DDA/pull/72927, overmap.h is required in construction.h

#### Describe the solution
Include relevant headers.

#### Testing
Compiles.