### PR TITLE
choose-crafter-kb

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -742,6 +742,13 @@
   },
   {
     "type": "keybinding",
+    "id": "CHOOSE_CRAFTER",
+    "category": "CRAFTING",
+    "name": "Choose crafter",
+    "bindings": [ { "input_method": "keyboard_any", "key": "c" } ]
+  },
+  {
+    "type": "keybinding",
     "id": "CYCLE_BATCH",
     "category": "CRAFTING",
     "name": "Batch crafting",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/a2415b63-6b2c-4e96-810a-cb060d86d52b)

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

1. Open the crafting menu `&`, see "Choose crafter" keybinding
2. Open the keybindings menu '?' in the crafting menu, 'f'ilter for 'choo'

#### Additional context

If there are more keybindings, only the first is shown:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/6594d6d1-b3b9-4158-bf08-4f430673ca2c)

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/5be9ca9b-9ff1-4168-b391-80e932e7e50f)

I guess that is alright.