### PR TITLE
know recipe? always ask group

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2769,12 +2769,10 @@ void activity_handlers::view_recipe_do_turn( player_activity *act, Character *yo
 
     recipe_id id( act->name );
     std::string itname;
-    const inventory &inven = you->crafting_inventory();
-    const std::vector<Character *> &helpers = you->get_crafting_helpers();
     if( act->index != 0 ) {
         // act->name is recipe_id
         itname = id->result_name();
-        if( !you->get_available_recipes( inven, &helpers ).contains( &id.obj() ) ) {
+        if( !you->get_group_available_recipes().contains( &id.obj() ) ) {
             add_msg( m_info, _( "You don't know how to craft the %s!" ), itname );
             return;
         }
@@ -2791,8 +2789,8 @@ void activity_handlers::view_recipe_do_turn( player_activity *act, Character *yo
     for( const auto& [_, r] : recipe_dict ) {
         if( !r.obsolete && ( item == r.result() || r.in_byproducts( item ) ) ) {
             is_byproduct = true;
-            // If if exists, do I know it?
-            if( you->get_available_recipes( inven, &helpers ).contains( &r ) ) {
+            // If a recipe exists, does my group know it?
+            if( you->get_group_available_recipes().contains( &r ) ) {
                 can_craft = true;
                 break;
             }

--- a/src/character.h
+++ b/src/character.h
@@ -3475,9 +3475,8 @@ class Character : public Creature, public visitable
         int last_batch;
 
         // Returns true if the character knows the recipe, is near a book or device
-        // providing the recipe or a nearby Character knows it.
-        bool has_recipe( const recipe *r, const inventory &crafting_inv,
-                         const std::vector<Character *> &helpers ) const;
+        // providing the recipe or a nearby allied Character knows it.
+        bool has_recipe( const recipe *r ) const;
         bool knows_recipe( const recipe *rec ) const;
         void learn_recipe( const recipe *rec );
         void forget_recipe( const recipe *rec );
@@ -3495,6 +3494,7 @@ class Character : public Creature, public visitable
         recipe_subset get_recipes_from_books( const inventory &crafting_inv ) const;
         /** Returns all recipes that are known from the books inside ereaders (either in inventory or nearby). */
         recipe_subset get_recipes_from_ebooks( const inventory &crafting_inv ) const;
+    protected:
         /**
           * Return all available recipes (from books and companions)
           * @param crafting_inv Current available items to craft
@@ -3502,6 +3502,11 @@ class Character : public Creature, public visitable
           */
         recipe_subset get_available_recipes( const inventory &crafting_inv,
                                              const std::vector<Character *> *helpers = nullptr ) const;
+    public:
+        /**
+          * Return all available recipes for any member of `this` crafter's group. Using `this` inventory.
+          */
+        recipe_subset get_group_available_recipes() const;
         /**
           * Returns the set of book types in crafting_inv that provide the
           * given recipe.

--- a/src/character_crafting.cpp
+++ b/src/character_crafting.cpp
@@ -18,10 +18,9 @@
 #include "type_id.h"
 #include "value_ptr.h"
 
-bool Character::has_recipe( const recipe *r, const inventory &crafting_inv,
-                            const std::vector<Character *> &helpers ) const
+bool Character::has_recipe( const recipe *r ) const
 {
-    return knows_recipe( r ) || get_available_recipes( crafting_inv, &helpers ).contains( r );
+    return knows_recipe( r ) || get_group_available_recipes().contains( r );
 }
 
 bool Character::knows_recipe( const recipe *rec ) const
@@ -179,6 +178,15 @@ recipe_subset Character::get_available_recipes( const inventory &crafting_inv,
 
     res.include( get_available_nested( res ) );
 
+    return res;
+}
+
+recipe_subset Character::get_group_available_recipes() const
+{
+    recipe_subset res;
+    for( const Character *guy : get_crafting_group() ) {
+        res.include( guy->get_available_recipes( crafting_inventory() ) );
+    }
     return res;
 }
 

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -578,7 +578,7 @@ bool Character::can_make( const recipe *r, int batch_size ) const
 {
     const inventory &crafting_inv = crafting_inventory();
 
-    if( !has_recipe( r, crafting_inv, get_crafting_group() ) ) {
+    if( !has_recipe( r ) ) {
         return false;
     }
 

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -412,7 +412,7 @@ void Character::long_craft( const std::optional<tripoint> &loc, const recipe_id 
 bool Character::making_would_work( const recipe_id &id_to_make, int batch_size ) const
 {
     const recipe &making = *id_to_make;
-    if( !( making && crafting_allowed( *this, making ) ) ) {
+    if( !making || !crafting_allowed( *this, making ) ) {
         return false;
     }
 

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1312,17 +1312,12 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
     int last_line = -1;
     bool just_toggled_unread = false;
 
-    const inventory &crafting_inv = crafter->crafting_inventory();
     const std::vector<Character *> crafting_group = crafter->get_crafting_group();
     int crafter_i = find( crafting_group.begin(), crafting_group.end(),
                           crafter ) - crafting_group.begin();
 
     // Get everyone's recipes
-    recipe_subset assemble_available_recipes;;
-    for( const Character *guy : crafting_group ) {
-        assemble_available_recipes.include( guy->get_available_recipes( crafting_inv ) );
-    }
-    const recipe_subset &available_recipes = assemble_available_recipes;
+    const recipe_subset &available_recipes = crafter->get_group_available_recipes();
     std::map<character_id, std::map<const recipe *, availability>> guy_availability_cache;
     // next line also inserts empty cache for crafter->getID()
     std::map<const recipe *, availability> *availability_cache =

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1843,13 +1843,11 @@ static hint_rating rate_action_disassemble( avatar &you, const item &it )
 
 static hint_rating rate_action_view_recipe( avatar &you, const item &it )
 {
-    const inventory &inven = you.crafting_inventory();
-    const std::vector<Character *> helpers = you.get_crafting_group();
     if( it.is_craft() ) {
         const recipe &craft_recipe = it.get_making();
         if( craft_recipe.is_null() || !craft_recipe.ident().is_valid() ) {
             return hint_rating::cant;
-        } else if( you.get_available_recipes( inven, &helpers ).contains( &craft_recipe ) ) {
+        } else if( you.get_group_available_recipes().contains( &craft_recipe ) ) {
             return hint_rating::good;
         }
     } else {
@@ -1860,8 +1858,8 @@ static hint_rating rate_action_view_recipe( avatar &you, const item &it )
         for( const auto& [_, r] : recipe_dict ) {
             if( !r.obsolete && ( item == r.result() || r.in_byproducts( item ) ) ) {
                 is_byproduct = true;
-                // If if exists, do I know it?
-                if( you.get_available_recipes( inven, &helpers ).contains( &r ) ) {
+                // If a recipe exists, does my group know it?
+                if( you.get_group_available_recipes().contains( &r ) ) {
                     can_craft = true;
                     break;
                 }

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -7288,8 +7288,7 @@ void iexamine::workbench_internal( Character &you, const tripoint &examp,
                     break;
                 }
                 const recipe &rec = selected_craft->get_making();
-                const inventory &inv = you.crafting_inventory();
-                if( !you.has_recipe( &rec, inv, you.get_crafting_group() ) ) {
+                if( !you.has_recipe( &rec ) ) {
                     you.add_msg_player_or_npc(
                         _( "You don't know the recipe for the %s and can't continue crafting." ),
                         _( "<npcname> doesn't know the recipe for the %s and can't continue crafting." ),

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6024,8 +6024,7 @@ void item::final_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
         // with the inventory display allowing you to select items, showing the things you could make with contained items could be confusing.
         const itype_id &tid = typeId();
         const inventory &crafting_inv = player_character.crafting_inventory();
-        const recipe_subset available_recipe_subset = player_character.get_available_recipes(
-                    crafting_inv );
+        const recipe_subset available_recipe_subset = player_character.get_group_available_recipes();
         const std::set<const recipe *> &item_recipes = available_recipe_subset.of_component( tid );
 
         insert_separation_line( info );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -8347,8 +8347,7 @@ std::optional<int> iuse::craft( Character *p, item *it, const tripoint & )
         return std::nullopt;
     }
     const recipe &rec = it->get_making();
-    const inventory &inv = p->crafting_inventory();
-    if( !p->has_recipe( &rec, inv, p->get_crafting_group() ) ) {
+    if( !p->has_recipe( &rec ) ) {
         p->add_msg_player_or_npc(
             _( "You don't know the recipe for the %s and can't continue crafting." ),
             _( "<npcname> doesn't know the recipe for the %s and can't continue crafting." ),

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -346,7 +346,7 @@ TEST_CASE( "crafting_with_a_companion", "[.]" )
 
         REQUIRE( std::find( helpers.begin(), helpers.end(), &who ) != helpers.end() );
         dummy.invalidate_crafting_inventory();
-        REQUIRE_FALSE( dummy.get_available_recipes( dummy.crafting_inventory(), &helpers ).contains( r ) );
+        REQUIRE_FALSE( dummy.get_group_available_recipes().contains( r ) );
         REQUIRE_FALSE( who.knows_recipe( r ) );
 
         WHEN( "you have the required skill" ) {
@@ -357,7 +357,7 @@ TEST_CASE( "crafting_with_a_companion", "[.]" )
 
                 THEN( "he helps you" ) {
                     dummy.invalidate_crafting_inventory();
-                    CHECK( dummy.get_available_recipes( dummy.crafting_inventory(), &helpers ).contains( r ) );
+                    CHECK( dummy.get_group_available_recipes().contains( r ) );
                 }
             }
             AND_WHEN( "he has the cookbook in his inventory" ) {
@@ -368,7 +368,7 @@ TEST_CASE( "crafting_with_a_companion", "[.]" )
 
                 THEN( "he shows it to you" ) {
                     dummy.invalidate_crafting_inventory();
-                    CHECK( dummy.get_available_recipes( dummy.crafting_inventory(), &helpers ).contains( r ) );
+                    CHECK( dummy.get_group_available_recipes().contains( r ) );
                 }
             }
         }
@@ -481,8 +481,7 @@ static void setup_test_craft( const recipe_id &rid )
 
     // This really shouldn't be needed, but for some reason the tests fail for mingw builds without it
     player_character.learn_recipe( &rec );
-    const inventory &inv = player_character.crafting_inventory();
-    REQUIRE( player_character.has_recipe( &rec, inv, player_character.get_crafting_helpers() ) );
+    REQUIRE( player_character.has_recipe( &rec ) );
     player_character.remove_weapon();
     REQUIRE( !player_character.is_armed() );
     player_character.make_craft( rid, 1 );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
fix #73096
~fix . #73123~ Decided against including this.

The colour is green now since somebody from your group can craft it.
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/ff586a4d-4ea0-47b9-ac6e-5c1b99b8017f)


Additionally:
- Examining an item now gives you what your group can craft from it.
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/d30c5404-19dd-4dd2-85ce-1826d14b3d7c)

You can test this in the #73096 save by smashing right (adjacent bench) and examining the `metal scrap` it drops.

#### Describe the solution

1. Make `Character::get_group_available_recipes` to replace all occurrences of `Characted::get_available_recipes`, since it was always called with `this` inventory and `this` helpers, except for the bugged cases. So this is a unification.
2. Make `Characted::get_available_recipes` protected
	- there are no calls outside Character to it, so we can
	- I cannot think of a case when you would want just your recipes and not recipes of your group (in the public interface), so making `protected` makes the programmers use the public `Character::get_group_available_recipes`


#### Describe alternatives you've considered

> Examining an item now gives you what your group can craft from it.

Change the caption from 'You could use it to craft:' to 'Your group could use it to craft:', should I?

#### Testing

Testing the fix of #73096:
 - I went by the steps, and the crafting window popped up with the pickaxe selected, as expected.


#### Additional context