### PR TITLE
Adds lots of mission-specific and chat dialogue for Liam

### DIFF
--- a/data/json/npcs/your_followers/liam_chat.json
+++ b/data/json/npcs/your_followers/liam_chat.json
@@ -241,7 +241,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_Liam_Opinions_MISSION_REFUGEE_Boris_CLEANUP",
-    "dynamic_line": ""I guess I get why the one Boris guy can't do it but I don't quite see why we have to go around asking everyone for him.  He lives here!  Anyway, you know I'm okay with getting my hands dirty, if you want to go offer to help him out I'll get busy with a scrubby.  I've cleaned worse things out of the Foodplace washroom.  Hell, I've cleaned worse things out of the back of my van when I was running for Amazon.\"  He gets a thousand-yard-stare for a moment.  \"Let's not discuss this any more.",
+    "dynamic_line": "I guess I get why the one Boris guy can't do it but I don't quite see why we have to go around asking everyone for him.  He lives here!  Anyway, you know I'm okay with getting my hands dirty, if you want to go offer to help him out I'll get busy with a scrubby.  I've cleaned worse things out of the Foodplace washroom.  Hell, I've cleaned worse things out of the back of my van when I was running for Amazon.\"  He gets a thousand-yard-stare for a moment.  \"Let's not discuss this any more.",
     "responses": [
       {
         "//": "Liam can't really count as a volunteer for this job but we could consider having the job go faster if you can't find enough local helpers and Liam is with you.",

--- a/data/json/npcs/your_followers/liam_chat.json
+++ b/data/json/npcs/your_followers/liam_chat.json
@@ -134,6 +134,19 @@
     "id": "BGSS_Liam_Father",
     "dynamic_line": "*snorts.  \"I was pretty low-contact with him the last couple years.  He got me that job in construction and when I left it, he tried to hit me, found out I'm not so much of a pushover as when I was fifteen.  Asshole.  I was still texting my mom a bit, apparently when things went to shit, he tried to join the riots.  I hope he got gunned down.\"",
     "responses": [
+      {
+        "text": "I remember your mom as kind of a quiet lady, she seemed all right.  Should we be trying to find her?",
+        "topic": "BGSS_Liam_Mother"
+      },
+      { "text": "Can we talk about something else?", "topic": "TALK_Liam_SOCIAL" },
+      { "text": "Harsh, but I hear you.  <end_talking>", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "BGSS_Liam_Mother",
+    "dynamic_line": "Well, things with her weren't as bad as with my dad, but I don't know if I'd go trying to hunt for her in a zombified city or anything.  Like, sure she didn't beat me up, but she didn't ever lift a finger to help me either.  She was still with him right up until the end, even when it was obvious that she was choosing him over me.  I don't wanna judge her for the life she led, but - \" he trails off for a moment, then twitches his shoulders and resumes.  \"Well, it's like I said.  I hope she's okay but I'm not gonna go risk my neck trying to find her.  You and Chris were my real family, you got me through those years.",
+    "responses": [
       { "text": "Can we talk about something else?", "topic": "TALK_Liam_SOCIAL" },
       { "text": "Harsh, but I hear you.  <end_talking>", "topic": "TALK_DONE" }
     ]
@@ -222,12 +235,40 @@
   },
   {
     "type": "talk_topic",
+    "id": "TALK_Liam_Opinions_RUBIK_ANUS_FETICK",
+    "dynamic_line": "I just like, wanna back up a second.  We're trying to score drugs for a cyborg so it can do surgery on you?  That's really where life's taking us, now?",
+    "responses": [
+      { "text": "…Yes.", "topic": "TALK_Liam_Opinions_RUBIK_ANUS_FETICK-1" },
+      { "text": "Yes?", "topic": "TALK_Liam_Opinions_RUBIK_ANUS_FETICK-1" },
+      { "text": "Yes!", "topic": "TALK_Liam_Opinions_RUBIK_ANUS_FETICK-1" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_Liam_Opinions_RUBIK_ANUS_FETICK-1",
+    "dynamic_line": "*grins.  \"Okay, just wanted to clear that up.  I thought maybe I was having some kind of psychotic break, glad it's at least mutual.  Anyway, first place that comes to mind for that kinda stuff would be a hospital, but that's suicide.  Maybe a pharmacy?  Would they have the right stuff?  Seems like a stretch.  Maybe like, a vet clinic or a private surgery clinic might be safer?  I'll level with you, I never got into anything harder than Mary Jane, this is past my paygrade.\"",
+    "responses": [ { "text": "Thanks man.  I'd like your opinion on something else, actually.", "topic": "TALK_Liam_Opinions" } ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_Liam_Opinions_EXODII_MISSION_CONTACT_HUB",
+    "dynamic_line": "Something about this kinda rubs me the wrong way, my friend.  I don't know what it is.  That Rubik guy seems nice enough but I feel like we're not getting the whole story.  Just tread carefully okay?",
+    "responses": [ { "text": "Thanks man.  I'd like your opinion on something else, actually.", "topic": "TALK_Liam_Opinions" } ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_Liam_Opinions_EXODII_MISSION_WAREHOUSE",
+    "dynamic_line": "Seems to me we could be wandering the area forever just looking for this thing, to be honest.  I guess we could go up somewhere high like a radio tower, maybe with some binoculars, and see if we can spot it?  Our best bet might be to ask a few folks that have been around though, pool our resources.",
+    "responses": [ { "text": "Thanks man.  I'd like your opinion on something else, actually.", "topic": "TALK_Liam_Opinions" } ]
+  },
+  {
+    "type": "talk_topic",
     "id": [
       "TALK_Liam_Opinions_MISSION_FREE_MERCHANTS_EVAC_1",
       "TALK_Liam_Opinions_MISSION_FREE_MERCHANTS_EVAC_2",
       "TALK_Liam_Opinions_MISSION_FREE_MERCHANTS_EVAC_2-1",
       "TALK_Liam_Opinions_MISSION_FREE_MERCHANTS_EVAC_3",
-      "TALK_Liam_Opinions_RUBIK_ANUS_FETICK",
+      "TALK_Liam_Opinions_RUBIK_ANUS_FETICK-1",
       "TALK_Liam_Opinions_EXODII_MISSION_CONTACT_HUB",
       "TALK_Liam_Opinions_EXODII_MISSION_WAREHOUSE"
     ],

--- a/data/json/npcs/your_followers/liam_chat.json
+++ b/data/json/npcs/your_followers/liam_chat.json
@@ -172,6 +172,11 @@
         "condition": { "u_has_assigned_mission": "MISSION_FREE_MERCHANTS_EVAC_3" }
       },
       {
+        "text": "What do you think about helping these guys clean up all that dead zombie mess?",
+        "topic": "TALK_Liam_Opinions_MISSION_REFUGEE_Boris_CLEANUP",
+        "condition": { "u_has_assigned_mission": "MISSION_REFUGEE_Boris_CLEANUP" }
+      },
+      {
         "text": "Where do you think we can get some anesthetic for that robot guy?",
         "topic": "TALK_Liam_Opinions_RUBIK_ANUS_FETICK",
         "condition": { "u_has_assigned_mission": "RUBIK_ANUS_FETICK" }
@@ -235,6 +240,18 @@
   },
   {
     "type": "talk_topic",
+    "id": "TALK_Liam_Opinions_MISSION_REFUGEE_Boris_CLEANUP",
+    "dynamic_line": ""I guess I get why the one Boris guy can't do it but I don't quite see why we have to go around asking everyone for him.  He lives here!  Anyway, you know I'm okay with getting my hands dirty, if you want to go offer to help him out I'll get busy with a scrubby.  I've cleaned worse things out of the Foodplace washroom.  Hell, I've cleaned worse things out of the back of my van when I was running for Amazon.\"  He gets a thousand-yard-stare for a moment.  \"Let's not discuss this any more.",
+    "responses": [
+      {
+        "//": "Liam can't really count as a volunteer for this job but we could consider having the job go faster if you can't find enough local helpers and Liam is with you.",
+        "text": "Thanks Liam, I knew I could count on you.",
+        "topic": "TALK_Liam_Opinions"
+      }
+    ]
+  },
+  {
+    "type": "talk_topic",
     "id": "TALK_Liam_Opinions_RUBIK_ANUS_FETICK",
     "dynamic_line": "I just like, wanna back up a second.  We're trying to score drugs for a cyborg so it can do surgery on you?  That's really where life's taking us, now?",
     "responses": [
@@ -268,6 +285,7 @@
       "TALK_Liam_Opinions_MISSION_FREE_MERCHANTS_EVAC_2",
       "TALK_Liam_Opinions_MISSION_FREE_MERCHANTS_EVAC_2-1",
       "TALK_Liam_Opinions_MISSION_FREE_MERCHANTS_EVAC_3",
+      "TALK_Liam_Opinions_MISSION_REFUGEE_Boris_CLEANUP",
       "TALK_Liam_Opinions_RUBIK_ANUS_FETICK-1",
       "TALK_Liam_Opinions_EXODII_MISSION_CONTACT_HUB",
       "TALK_Liam_Opinions_EXODII_MISSION_WAREHOUSE"

--- a/data/json/npcs/your_followers/liam_chat.json
+++ b/data/json/npcs/your_followers/liam_chat.json
@@ -112,7 +112,7 @@
   {
     "type": "talk_topic",
     "id": "BGSS_Liam3",
-    "dynamic_line": "I wanna say it was a hell of a story, but really, I was on the way back to Boston from a delivery and a thing about the riots on the radio.  I was close to the cabin so I just thought, 'this is starting to sound really fuckin bad.'  I called in sick and took a few days out there.  By the time I had to think about going back to work, we were into that wild time when half the people were trying to keep things running and the other half were trying to burn everything down.  I shut the blinds and stayed in, until Chris showed up acting like a freak.",
+    "dynamic_line": "I wanna say it was a hell of a story, but really, I was on the way back to Boston from a delivery and a thing about the riots on the radio.  I was close to the cabin so I just thought, 'this is starting to sound really fuckin bad.'  I called in sick and took a few days to hunker down out of civilization.  By the time I had to think about going back to work, we were into that wild time when half the people were trying to keep things running and the other half were trying to burn everything down.  I shut the blinds and stayed in, until Chris showed up acting like a freak.",
     "responses": [
       { "text": "You picked up a lot of useful skills over the years, hey.", "topic": "BGSS_Liam_Expertise" },
       { "text": "Can we talk about something else?", "topic": "TALK_Liam_SOCIAL" },
@@ -122,7 +122,7 @@
   {
     "type": "talk_topic",
     "id": "BGSS_Liam_Expertise",
-    "dynamic_line": "It doesn't feel that way, but I guess so.  I don't know if I ever told you, but my dad was quite the weirdo prepper.  He built the cabin and when I was a kid we'd come out here and do drills for the end of the world.  It's part of why I was kinda wacked out on apocalypse stuff when you and I first met, back when we made the plan to come out here.  He taught me archery and some survival skills but I never really took to it, partly because my ol' man was a real piece of work.\"  He stares off for a minute.  \"To be honest, though, now that we're in the middle of a real-ass apocalypse, I can see a lot of what he taught me was just crap anyway.\"",
+    "dynamic_line": "It doesn't feel that way, but I guess so.  I don't know if I ever told you, but my dad was quite the weirdo prepper.  He built the cabin and when I was a kid we'd head out and do drills for the end of the world.  It's part of why I was kinda wacked out on apocalypse stuff when you and I first met, back when we made the plan for where to meet up and all.  He taught me archery and some survival skills but I never really took to it, partly because my ol' man was a real piece of work.\"  He stares off for a minute.  \"To be honest, though, now that we're in the middle of a real-ass apocalypse, I can see a lot of what he taught me was just crap anyway.\"",
     "responses": [
       { "text": "What happened to your father?  You never talked about him much.", "topic": "BGSS_Liam_Father" },
       { "text": "Can we talk about something else?", "topic": "TALK_Liam_SOCIAL" },

--- a/data/json/npcs/your_followers/liam_chat.json
+++ b/data/json/npcs/your_followers/liam_chat.json
@@ -407,13 +407,20 @@
     "type": "talk_topic",
     "id": "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_5",
     "dynamic_line": "I dunno,\" he points to your Marshal badge.  \"I guess if they give you a shiny bit of metal you're not really an assassin for hire anymore, you're the law.  Judge, jury, and executioner.\"  He scratches his neck and looks away for a moment.  \"You know how I feel about all these high risk missions, but we've gotten this far.  It's different now than when we started out.  I don't think you need my advice, you know I'll have your back whatever happens.",
-    "responses": [ { "text": "I might not need it, but I still like to hear it.  I'd like your opinion on something else, anyway.", "topic": "TALK_Liam_Opinions" } ]
+    "responses": [
+      {
+        "text": "I might not need it, but I still like to hear it.  I'd like your opinion on something else, anyway.",
+        "topic": "TALK_Liam_Opinions"
+      }
+    ]
   },
   {
     "type": "talk_topic",
     "id": "TALK_Liam_Opinions_MISSION_OLD_GUARD_REPEATER_BEGIN",
     "dynamic_line": "Honestly my friend, this is the kinda stuff I hoped we'd be doing when we offered to help these guys out.  Fresh air, great views, climbing on things we'd have gotten in trouble for in the old days, maybe pushing a zombie off the edge of a maintenance platform to see how big a splat it leaves at the bottom.  Sounds wicked.  Let's bring a couple cold ones up to the top and crack a brew while we survey the wasteland, hey?",
-    "responses": [ { "text": "Sounds like a great idea.  I'd like your opinion on something else, though.", "topic": "TALK_Liam_Opinions" } ]
+    "responses": [
+      { "text": "Sounds like a great idea.  I'd like your opinion on something else, though.", "topic": "TALK_Liam_Opinions" }
+    ]
   },
   {
     "type": "talk_topic",

--- a/data/json/npcs/your_followers/liam_chat.json
+++ b/data/json/npcs/your_followers/liam_chat.json
@@ -177,6 +177,36 @@
         "condition": { "u_has_assigned_mission": "MISSION_REFUGEE_Boris_CLEANUP" }
       },
       {
+        "text": "What're your thoughts on this mission to kill bandits for the old guard?",
+        "topic": "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_1",
+        "condition": { "u_has_assigned_mission": "MISSION_OLD_GUARD_REP_1" }
+      },
+      {
+        "text": "Deal with Informant?",
+        "topic": "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_2",
+        "condition": { "u_has_assigned_mission": "MISSION_OLD_GUARD_REP_2" }
+      },
+      {
+        "text": "Find exodii?",
+        "topic": "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_3",
+        "condition": { "u_has_assigned_mission": "MISSION_OLD_GUARD_REP_3" }
+      },
+      {
+        "text": "Secure trade route kill monster?",
+        "topic": "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_4",
+        "condition": { "u_has_assigned_mission": "MISSION_OLD_GUARD_REP_4" }
+      },
+      {
+        "text": "Assassinate raider leader?",
+        "topic": "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_5",
+        "condition": { "u_has_assigned_mission": "MISSION_OLD_GUARD_REP_5" }
+      },
+      {
+        "text": "install repeater in radio tower?",
+        "topic": "TALK_Liam_Opinions_MISSION_OLD_GUARD_REPEATER_BEGIN",
+        "condition": { "u_has_assigned_mission": "MISSION_OLD_GUARD_REPEATER_BEGIN" }
+      },
+      {
         "text": "Where do you think we can get some anesthetic for that robot guy?",
         "topic": "TALK_Liam_Opinions_RUBIK_ANUS_FETICK",
         "condition": { "u_has_assigned_mission": "RUBIK_ANUS_FETICK" }
@@ -242,10 +272,93 @@
     "type": "talk_topic",
     "id": "TALK_Liam_Opinions_MISSION_REFUGEE_Boris_CLEANUP",
     "dynamic_line": "I guess I get why the one Boris guy can't do it but I don't quite see why we have to go around asking everyone for him.  He lives here!  Anyway, you know I'm okay with getting my hands dirty, if you want to go offer to help him out I'll get busy with a scrubby.  I've cleaned worse things out of the Foodplace washroom.  Hell, I've cleaned worse things out of the back of my van when I was running for Amazon.\"  He gets a thousand-yard-stare for a moment.  \"Let's not discuss this any more.",
+    "speaker_effect": {
+      "effect": [
+        { "npc_add_var": "cleanup_asked", "type": "mission", "context": "Boris_mission_1", "value": "yes" },
+        { "math": [ "u_mission_cleanup_promises_Boris_mission_1", "+=", "1" ] }
+      ]
+    },
     "responses": [
       {
-        "//": "Liam can't really count as a volunteer for this job but we could consider having the job go faster if you can't find enough local helpers and Liam is with you.",
+        "//": "It's a bit weird that Liam doesn't leave your party, if you ask four other people and he goes to help, but no big deal I think.  Ideally this should be coded so that he only helps out if you also do, and he shortens the time, but I'm trying to make some quick improvements here, not write a bunch of EoC.",
         "text": "Thanks Liam, I knew I could count on you.",
+        "topic": "TALK_Liam_Opinions",
+        "effect": [
+          { "npc_add_var": "cleanup_asked", "type": "mission", "context": "Boris_mission_1", "value": "yes" },
+          { "math": [ "u_mission_cleanup_promises_Boris_mission_1", "+=", "1" ] }
+        ],
+        "condition": { "not": { "npc_has_var": "cleanup_asked", "type": "mission", "context": "Boris_mission_1", "value": "yes" } }
+      },
+      {
+        "text": "Thanks Liam, I knew I could count on you.",
+        "topic": "TALK_Liam_Opinions",
+        "condition": { "npc_has_var": "cleanup_asked", "type": "mission", "context": "Boris_mission_1", "value": "yes" }
+      }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_1",
+    "dynamic_line": "*blows out a long breath.  \"Well, my friend, I do think it's good to help clean out some of the mess that's going on.  I'll be with you for it.  I'm just not sure why you figure I'm the right guy for this job.  Shouldn't you have, like, a cop or a soldier or something?  I'm a delivery driver.\"",
+    "responses": [
+      {
+        "text": "Don't sell yourself short, Liam.  You've got my back.",
+        "topic": "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_1-Reassure"
+      },
+      {
+        "text": "I'll handle the tough parts, Liam.  You're there to cover my back, that's all.",
+        "topic": "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_1-Bravado"
+      },
+      {
+        "text": "In troubled times, we learn what sort of people we really are.",
+        "topic": "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_1-Fortunecookie"
+      },
+      {
+        "text": "Meh.  What's a few bandits?  We'll flatten 'em.",
+        "topic": "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_1-Psycho"
+      }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_1-Reassure",
+    "dynamic_line": "Thanks.  You're right.  Okay, I can do this.\"  He shakes his shoulders and limbers up, like a boxer preparing for a match.  \"Let's go.",
+    "responses": [
+      {
+        "text": "Hold up Balboa, I'd like your opinion on something else, actually.",
+        "topic": "TALK_Liam_Opinions"
+      }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_1-Bravado",
+    "dynamic_line": "Oh, oh yeah that makes sense.  Okay, well, that's something I can do.  I'll cover your back like it's never been covered before.  You and me like Calvin and Hobbes baby.",
+    "responses": [
+      {
+        "text": "Thanks, Hooch.  I'd like your opinion on something else, actually.",
+        "topic": "TALK_Liam_Opinions"
+      }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_1-Fortunecookie",
+    "dynamic_line": "*sniffs the air around your head.  \"You been getting in the ganja?  No judgment if so, but maybe you shouldn't be taking mercenary jobs while you're high, y'know?\"",
+    "responses": [
+      {
+        "text": "Shut up, you're not my dad!  Anyway, I'd like your opinion on something else, actually.",
+        "topic": "TALK_Liam_Opinions"
+      }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_1-Psycho",
+    "dynamic_line": "*gives you some serious sideye.  \"You okay?  This is serious shit, you're making me kinda worried getting so gung-ho about it.\"",
+    "responses": [
+      {
+        "text": "Don't worry, man.  Trust me, it'll be great.  Anyway, I'd like your opinion on something else.",
         "topic": "TALK_Liam_Opinions"
       }
     ]

--- a/data/json/npcs/your_followers/liam_chat.json
+++ b/data/json/npcs/your_followers/liam_chat.json
@@ -1,0 +1,83 @@
+[
+  {
+    "type": "talk_topic",
+    "id": [ "TALK_Liam_SOCIAL" ],
+    "dynamic_line": "Any time, what's on your mind?",
+    "responses": [
+      { "text": "Can I ask you a bit about yourself?", "topic": "BGSS_Liam1" },
+      { "text": "You picked up a lot of useful skills over the years, hey.", "topic": "BGSS_Liam_Expertise" },
+      {
+        "text": "I just wanted to chat, you know.  To relax.",
+        "topic": "TALK_FRIEND_Liam_CHAT",
+        "condition": { "not": { "npc_has_effect": "asked_to_socialize" } }
+      },
+      { "text": "I changed my mind, wanted to ask you something else.", "topic": "TALK_NONE" },
+      { "text": "Let's go.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_FRIEND_Liam_CHAT",
+    "dynamic_line": [ "Sure.  Can I tell you about this idea I had for a comic I'm never gonna make?",
+    "//": "TK: custom chat topics here that actually include small talk that expands Liam's character, while still giving the socialize bonus.",
+    "responses": [
+      {
+        "text": "<chitchat_player_responses>",
+        "topic": "TALK_DONE",
+        "switch": true,
+        "effect": [ "morale_chat_activity", { "npc_add_effect": "asked_to_socialize", "duration": 7000 } ]
+      }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "BGSS_Liam1",
+    "dynamic_line": "Well, sure.  I dunno what more there is to tell, we've known each other for ages.",
+    "responses": [
+      { "text": "We hadn't caught up in a while before <the_cataclysm>.  What've you been doing?", "topic": "BGSS_Liam2" },
+      { "text": "You picked up a lot of useful skills over the years, hey.", "topic": "BGSS_Liam_Expertise" },
+      { "text": "Can we talk about something else?", "topic": "TALK_Liam_SOCIAL" },
+      { "text": "<end_talking>", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "BGSS_Liam2",
+    "dynamic_line": "*shrugs.  \"Same as I was when we used to hang out more, mostly.  I quit my job at Foodplace a while back, got tired of the stupid outfits.  Worked doing labor in construction for a bit, but I didn't like my boss so I ditched it.  Got a job doing deliveries for Amazon, which was absolutely shitty, but I managed to jump from that to a bit of a better delivery job for a smaller company.  It was actually going pretty good before everything happened.\"",
+    "responses": [
+      { "text": "How did you make it through the cataclysm?", "topic": "BGSS_Liam3" },
+      { "text": "You picked up a lot of useful skills over the years, hey.", "topic": "BGSS_Liam_Expertise" },
+      { "text": "Can we talk about something else?", "topic": "TALK_Liam_SOCIAL" },
+      { "text": "<end_talking>", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "BGSS_Liam3",
+    "dynamic_line": "I wanna say it was a hell of a story, but really, I was on the way back to Boston from a delivery and a thing about the riots on the radio.  I was close to the cabin so I just thought, 'this is starting to sound really fuckin bad.'  I called in sick and took a few days out there.  By the time I had to think about going back to work, we were into that wild time when half the people were trying to keep things running and the other half were trying to burn everything down.  I shut the blinds and stayed in, until Chris showed up acting like a freak.",
+    "responses": [
+      { "text": "You picked up a lot of useful skills over the years, hey.", "topic": "BGSS_Liam_Expertise" },
+      { "text": "Can we talk about something else?", "topic": "TALK_Liam_SOCIAL" },
+      { "text": "<end_talking>", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "BGSS_Liam_Expertise",
+    "dynamic_line": "It doesn't feel that way, but I guess so.  I don't know if I ever told you, but my dad was quite the weirdo prepper.  He built the cabin and when I was a kid we'd come out here and do drills for the end of the world.  It's part of why I was kinda wacked out on apocalypse stuff when you and I first met, back when we made the plan to come out here.  He taught me archery and some survival skills but I never really took to it, partly because my ol' man was a real piece of work.\"  He stares off for a minute.  \"To be honest, though, now that we're in the middle of a real-ass apocalypse, I can see a lot of what he taught me was just crap anyway.\"",
+    "responses": [
+      { "text": "What happened to your father?  You never talked about him much.", "topic": "BGSS_Liam_Father" },
+      { "text": "Can we talk about something else?", "topic": "TALK_Liam_SOCIAL" },
+      { "text": "<end_talking>", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "BGSS_Liam_Father",
+    "dynamic_line": "*snorts.  \"I was pretty low-contact with him the last couple years.  He got me that job in construction and when I left it, he tried to hit me, found out I'm not so much of a pushover as when I was fifteen.  Asshole.  I was still texting my mom a bit, apparently when things went to shit, he tried to join the riots.  I hope he got gunned down.\"",
+    "responses": [
+      { "text": "Can we talk about something else?", "topic": "TALK_Liam_SOCIAL" },
+      { "text": "Harsh, but I hear you.  <end_talking>", "topic": "TALK_DONE" }
+    ]
+  }
+]

--- a/data/json/npcs/your_followers/liam_chat.json
+++ b/data/json/npcs/your_followers/liam_chat.json
@@ -27,32 +27,32 @@
     "responses": [
       {
         "text": "We're always gonna be friends, right?  Even with the apocalypse… changing us?",
-        "topic": "TALK_FRIEND_Liam_CHAT_Friends4ever"
+        "topic": "TALK_FRIEND_Liam_CHAT_Friends4ever",
         "effect": [ "morale_chat_activity", { "npc_add_effect": "asked_to_socialize", "duration": 7000 } ]
       },
       {
         "text": "What do you miss most about the internet?",
-        "topic": "TALK_FRIEND_Liam_CHAT_Internet"
+        "topic": "TALK_FRIEND_Liam_CHAT_Internet",
         "effect": [ "morale_chat_activity", { "npc_add_effect": "asked_to_socialize", "duration": 7000 } ]
       },
       {
         "text": "Now that we've got no responsibilities, is there anything you'd like to see or do?",
-        "topic": "TALK_FRIEND_Liam_CHAT_Goals"
+        "topic": "TALK_FRIEND_Liam_CHAT_Goals",
         "effect": [ "morale_chat_activity", { "npc_add_effect": "asked_to_socialize", "duration": 7000 } ]
       },
       {
         "text": "What do you think the rest of the world is like these days?",
-        "topic": "TALK_FRIEND_Liam_CHAT_World"
+        "topic": "TALK_FRIEND_Liam_CHAT_World",
         "effect": [ "morale_chat_activity", { "npc_add_effect": "asked_to_socialize", "duration": 7000 } ]
       },
       {
         "text": "Do you miss any food from the old days?",
-        "topic": "TALK_FRIEND_Liam_CHAT_Food"
+        "topic": "TALK_FRIEND_Liam_CHAT_Food",
         "effect": [ "morale_chat_activity", { "npc_add_effect": "asked_to_socialize", "duration": 7000 } ]
       },
       {
         "text": "<chitchat_player_responses>",
-        "topic": "TALK_DONE"
+        "topic": "TALK_DONE",
         "effect": [ "morale_chat_activity", { "npc_add_effect": "asked_to_socialize", "duration": 7000 } ]
       }
     ]
@@ -60,52 +60,32 @@
   {
     "type": "talk_topic",
     "id": "TALK_FRIEND_Liam_CHAT_Friends4ever",
-    "dynamic_line": "Aww, of course.  No matter what happens, you're always you and I'm always me, right?  We've been through worse than this./"  He pauses, his brow furrowed.  /"Well, okay, maybe we haven't.  But we've stuck through it all for so many years, what's a little apocalypse gonna change?  Or a little mutation, or grievous bodily harm, or zombies, or interdimensional monster attacks and serious life-altering PTSD, or whatever.  Who cares.  You're my family, more than my birth family ever was.",
-    "responses": [
-      {
-        "text": "(Continue chatting)", "topic": "TALK_DONE"
-      }
-    ]
+    "dynamic_line": "Aww, of course.  No matter what happens, you're always you and I'm always me, right?  We've been through worse than this.\"  He pauses, his brow furrowed.  \"Well, okay, maybe we haven't.  But we've stuck through it all for so many years, what's a little apocalypse gonna change?  Or a little mutation, or grievous bodily harm, or zombies, or interdimensional monster attacks and serious life-altering PTSD, or whatever.  Who cares.  You're my family, more than my birth family ever was.",
+    "responses": [ { "text": "(Continue chatting)", "topic": "TALK_DONE" } ]
   },
   {
     "type": "talk_topic",
     "id": "TALK_FRIEND_Liam_CHAT_Internet",
     "dynamic_line": "OK, I know you're leading me up to say something dirty, and yeah I miss that, but you know what?  Really the thing I miss most is social media.  No seriously!  Stop looking at me like that!  I liked being able to just talk to people no matter where they were, any time.  I had friends in Sweden, and Brazil, and the West Coast.  I'm never gonna know what happened to them, and that busts me up bad.  They mattered to me, you know?\"  His voice catches a bit, and he coughs.  \"You're here though, and that helps a lot.  Can't imagine trying to do this lone-wolf.  How about you, what were you thinking of when you asked?",
-    "responses": [
-      {
-        "text": "(Continue chatting)", "topic": "TALK_DONE"
-      }
-    ]
+    "responses": [ { "text": "(Continue chatting)", "topic": "TALK_DONE" } ]
   },
   {
     "type": "talk_topic",
     "id": "TALK_FRIEND_Liam_CHAT_Goals",
     "dynamic_line": "*laughs.  \"You know me, I was never high on the ambition front.  Honestly, if you weren't around I'd probably clean up my dad's old cabin, try to learn how to set up a power supply, and scavenge for parts until I'd built the best damn gaming rig the world will ever see.  Then I'd load up whatever games I could find.\"  He pauses.  \"Or maybe it'd be easier to set up a console, I dunno.  Most consoles aren't gonna like the no-internet thing right?  There's probably a way to crack 'em but without the internet where would we even check?\"  He rubs his chin.  \"Still.  I'd have maybe found a way.  How about you, what's the big overarching plan for all this?\"",
-    "responses": [
-      {
-        "text": "(Continue chatting)", "topic": "TALK_DONE"
-      }
-    ]
+    "responses": [ { "text": "(Continue chatting)", "topic": "TALK_DONE" } ]
   },
   {
     "type": "talk_topic",
     "id": "TALK_FRIEND_Liam_CHAT_World",
     "dynamic_line": "Oh dude, good question.  The news reports made it sound like this is everywhere, you know?  Still, somewhere out there's gotta be better than this, right?  Maybe like, up in the Yukon or Siberia or something it's all kinda normal?  I think most places are like this though, just one big fucked up mess.  Maybe they've got different monsters though, like, carnivorous rocks or some shit.  How 'bout you, what do you think is out there?",
-    "responses": [
-      {
-        "text": "(Continue chatting)", "topic": "TALK_DONE"
-      }
-    ]
+    "responses": [ { "text": "(Continue chatting)", "topic": "TALK_DONE" } ]
   },
   {
     "type": "talk_topic",
     "id": "TALK_FRIEND_Liam_CHAT_Food",
     "dynamic_line": "I never thought I'd hear myself say this, but I kinda miss the EdiBurger3 from FoodPlace.  I worked there so long, I hated everything, but as soon as you tell me I'm *never* gonna have a fresh, greasy EB3 again, suddenly it's all my stomach wants.  Don't try to track one down or anything though.  I'm pretty sure I miss the *idea* more than the actual *thing*.  And I don't think we could cook up a copy, it'd be pretty hard to get the right blend of animal product and sawdust for the MeatCylinder.\"  He stares whistfully into space for a moment.  \"How about you, what were you thinking of when you asked?",
-    "responses": [
-      {
-        "text": "(Continue chatting)", "topic": "TALK_DONE"
-      }
-    ]
+    "responses": [ { "text": "(Continue chatting)", "topic": "TALK_DONE" } ]
   },
   {
     "type": "talk_topic",

--- a/data/json/npcs/your_followers/liam_chat.json
+++ b/data/json/npcs/your_followers/liam_chat.json
@@ -84,7 +84,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_FRIEND_Liam_CHAT_Food",
-    "dynamic_line": "I never thought I'd hear myself say this, but I kinda miss the Ediburger3 from Foodplace.  I worked there so long, I hated everything, but as soon as you tell me I'm *never* gonna have a fresh, greasy EB3 again, suddenly it's all my stomach wants.  Don't try to track one down or anything though.  I'm pretty sure I miss the *idea* more than the actual *thing*.  And I don't think we could cook up a copy, it'd be pretty hard to get the right blend of animal product and sawdust for the Meatcylinder.\"  He stares whistfully into space for a moment.  \"How about you, what were you thinking of when you asked?",
+    "dynamic_line": "I never thought I'd hear myself say this, but I kinda miss the Ediburger3 from Foodplace.  I worked there so long, I hated everything, but as soon as you tell me I'm *never* gonna have a fresh, greasy EB3 again, suddenly it's all my stomach wants.  Don't try to track one down or anything though.  I'm pretty sure I miss the *idea* more than the actual *thing*.  And I don't think we could cook up a copy, it'd be pretty hard to get the right blend of animal product and sawdust for the Meatcylinder.\"  He stares wistfully into space for a moment.  \"How about you, what were you thinking of when you asked?",
     "responses": [ { "text": "(Continue chatting)", "topic": "TALK_DONE" } ]
   },
   {
@@ -360,7 +360,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_1-Psycho",
-    "dynamic_line": "*gives you some serious sideye.  \"You okay?  This is serious shit, you're making me kinda worried getting so gung-ho about it.\"",
+    "dynamic_line": "*gives you some serious side-eye.  \"You okay?  This is serious shit, you're making me kinda worried getting so gung-ho about it.\"",
     "responses": [
       {
         "text": "Don't worry, man.  Trust me, it'll be great.  Anyway, I'd like your opinion on something else.",
@@ -435,7 +435,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_Liam_Opinions_RUBIK_ANUS_FETICK-1",
-    "dynamic_line": "*grins.  \"Okay, just wanted to clear that up.  I thought maybe I was having some kind of psychotic break, glad it's at least mutual.  Anyway, first place that comes to mind for that kinda stuff would be a hospital, but that's suicide.  Maybe a pharmacy?  Would they have the right stuff?  Seems like a stretch.  Maybe like, a vet clinic or a private surgery clinic might be safer?  I'll level with you, I never got into anything harder than Mary Jane, this is past my paygrade.\"",
+    "dynamic_line": "*grins.  \"Okay, just wanted to clear that up.  I thought maybe I was having some kind of psychotic break, glad it's at least mutual.  Anyway, first place that comes to mind for that kinda stuff would be a hospital, but that's suicide.  Maybe a pharmacy?  Would they have the right stuff?  Seems like a stretch.  Maybe like, a vet clinic or a private surgery clinic might be safer?  I'll level with you, I never got into anything harder than Mary Jane, this is past my pay grade.\"",
     "responses": [ { "text": "Thanks man.  I'd like your opinion on something else, actually.", "topic": "TALK_Liam_Opinions" } ]
   },
   {

--- a/data/json/npcs/your_followers/liam_chat.json
+++ b/data/json/npcs/your_followers/liam_chat.json
@@ -25,46 +25,36 @@
       "You remember that girl from high school I had that huge crush on?  Emily?  I wonder if she's still alive.  I shoulda asked her out.",
       "Aw dude.  I was just remembering about this crowdfunded board game I backed right before things went to hell.  It'd be fulfilling right about now, I bet.",
       "Does it ever seem to you like the stars are in different places from where they used to be?  I can find all the old constellations, but they look different now.",
-      "Since everything went down, I keep having this recurring dream where I'm at Foodplace again, and Luke Skywalker is there, demanding an EB3 combo with extra Beverage, and he's being a real Karen about it.  Do you think it means something?",
+      "Since everything went down, I keep having this recurring dream where I'm at Foodplace again, and Luke Skywalker is there, demanding an EB2 combo with extra Beverage, and he's being a real Karen about it.  Do you think it means something?",
       "Maybe it's weird but this whole thing sorta feels like an extended camping trip.  With zombies.",
       "I slept weird last night.  Got this awful crick in my neck.",
       "Do you think the internet is still out there somewhere, floating around in some still-functional servers somehow?  It's weird to think about what happened to all that data.",
       "Remember that guy Daren in elementary who used to tell all those weird-ass creepy stories?  Chris hated him but I thought he was interesting.  I wonder if he's alive, he'd have loved this.",
       "You know what I could really use right now?  A hot bath.",
-      "Next time we hit a library, I'm gonna see if they've got a copy of Gideon the Ninth.  I read that book a while ago, but I was super high and I don't remember much of it."
+      "Next time we hit a library, I'm gonna see if they've got a copy of Gideon the Ninth.  I read that book a while ago, but I was super high and I don't remember much of it.",
+      "Do you remember what day of the week it is?",
+      "Next time I get a chance, I'm gonna make a nice big bowl of mac and cheese.",
+      "Y'know, these shoes are surprisingly comfy.  You wouldn't think it to look at 'em.",
+      "Do you think zombies know what's going on?  Like, are the original people still in there watching all this happen?  I sure hope not.",
+      "It's funny how fast all this weird shit starts to feel normal, don't you think?"
     ],
-    "//": "TK: custom chat topics here that actually include small talk that expands Liam's character, while still giving the socialize bonus.",
+    "speaker_effect": { "effect": [ "morale_chat_activity", { "npc_add_effect": "asked_to_socialize", "duration": 7000 } ] },
     "responses": [
       {
         "text": "We're always gonna be friends, right?  Even with the apocalypse… changing us?",
-        "topic": "TALK_FRIEND_Liam_CHAT_Friends4ever",
-        "effect": [ "morale_chat_activity", { "npc_add_effect": "asked_to_socialize", "duration": 7000 } ]
+        "topic": "TALK_FRIEND_Liam_CHAT_Friends4ever"
       },
-      {
-        "text": "What do you miss most about the internet?",
-        "topic": "TALK_FRIEND_Liam_CHAT_Internet",
-        "effect": [ "morale_chat_activity", { "npc_add_effect": "asked_to_socialize", "duration": 7000 } ]
-      },
+      { "text": "What do you miss most about the internet?", "topic": "TALK_FRIEND_Liam_CHAT_Internet" },
       {
         "text": "Now that we've got no responsibilities, is there anything you'd like to see or do?",
-        "topic": "TALK_FRIEND_Liam_CHAT_Goals",
-        "effect": [ "morale_chat_activity", { "npc_add_effect": "asked_to_socialize", "duration": 7000 } ]
+        "topic": "TALK_FRIEND_Liam_CHAT_Goals"
       },
       {
         "text": "What do you think the rest of the world is like these days?",
-        "topic": "TALK_FRIEND_Liam_CHAT_World",
-        "effect": [ "morale_chat_activity", { "npc_add_effect": "asked_to_socialize", "duration": 7000 } ]
+        "topic": "TALK_FRIEND_Liam_CHAT_World"
       },
-      {
-        "text": "Do you miss any food from the old days?",
-        "topic": "TALK_FRIEND_Liam_CHAT_Food",
-        "effect": [ "morale_chat_activity", { "npc_add_effect": "asked_to_socialize", "duration": 7000 } ]
-      },
-      {
-        "text": "<chitchat_player_responses>",
-        "topic": "TALK_DONE",
-        "effect": [ "morale_chat_activity", { "npc_add_effect": "asked_to_socialize", "duration": 7000 } ]
-      }
+      { "text": "Do you miss any food from the old days?", "topic": "TALK_FRIEND_Liam_CHAT_Food" },
+      { "text": "<chitchat_player_responses>", "topic": "TALK_DONE" }
     ]
   },
   {
@@ -94,7 +84,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_FRIEND_Liam_CHAT_Food",
-    "dynamic_line": "I never thought I'd hear myself say this, but I kinda miss the EdiBurger3 from FoodPlace.  I worked there so long, I hated everything, but as soon as you tell me I'm *never* gonna have a fresh, greasy EB3 again, suddenly it's all my stomach wants.  Don't try to track one down or anything though.  I'm pretty sure I miss the *idea* more than the actual *thing*.  And I don't think we could cook up a copy, it'd be pretty hard to get the right blend of animal product and sawdust for the MeatCylinder.\"  He stares whistfully into space for a moment.  \"How about you, what were you thinking of when you asked?",
+    "dynamic_line": "I never thought I'd hear myself say this, but I kinda miss the Ediburger3 from Foodplace.  I worked there so long, I hated everything, but as soon as you tell me I'm *never* gonna have a fresh, greasy EB3 again, suddenly it's all my stomach wants.  Don't try to track one down or anything though.  I'm pretty sure I miss the *idea* more than the actual *thing*.  And I don't think we could cook up a copy, it'd be pretty hard to get the right blend of animal product and sawdust for the Meatcylinder.\"  He stares whistfully into space for a moment.  \"How about you, what were you thinking of when you asked?",
     "responses": [ { "text": "(Continue chatting)", "topic": "TALK_DONE" } ]
   },
   {
@@ -217,12 +207,12 @@
         }
       },
       {
-        "text": "Secure trade route kill monster?",
+        "text": "Do you think it's really a monster hitting those trade caravans?  Any ideas how we should deal with it?",
         "topic": "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_4",
         "condition": { "u_has_assigned_mission": "MISSION_OLD_GUARD_REP_4" }
       },
       {
-        "text": "Assassinate raider leader?",
+        "text": "So, we're officially assassins for hire now.  How do you feel about that?",
         "topic": "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_5",
         "condition": { "u_has_assigned_mission": "MISSION_OLD_GUARD_REP_5" }
       },
@@ -392,6 +382,41 @@
   },
   {
     "type": "talk_topic",
+    "id": "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_3-NotMet",
+    "dynamic_line": "I dunno, but compared to the last two missions for that guy, I gotta admit I'm kinda stoked.  Robots?  This sounds *wicked*.  Do you think we're talking more Terminator, or Wall-E?  Doesn't matter.  Robots!",
+    "responses": [ { "text": "Thanks man.  I'd like your opinion on something else, actually.", "topic": "TALK_Liam_Opinions" } ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_3-HasMet",
+    "dynamic_line": "Uh, well, we *did* meet that weird cyborg guy in the castle full of giant robot dogs matching this exact description, right?  Tell me you remember that.  Damn, it's worse saying it out loud.  I still can't really believe all this stuff has really happened.",
+    "responses": [
+      {
+        "text": "Oh, right, I remember that.  I'd like your opinion on something else, though.",
+        "topic": "TALK_Liam_Opinions"
+      }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_4",
+    "dynamic_line": "You know me my friend,\" he shrugs and grins at you.  \"I'd have said it was some kinda cryptid or something *before* the world got flooded with monsters and mutants.  Nowadays, I think I'd be more surprised if it was bandits again.  As for how to deal with it, well, I guess we're getting pretty good at dealing with this kind of thing now.  Let's handle it how we usually do: with style.",
+    "responses": [ { "text": "Damn straight.  I'd like your opinion on something else, though.", "topic": "TALK_Liam_Opinions" } ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_5",
+    "dynamic_line": "I dunno,\" he points to your Marshal badge.  \"I guess if they give you a shiny bit of metal you're not really an assassin for hire anymore, you're the law.  Judge, jury, and executioner.\"  He scratches his neck and looks away for a moment.  \"You know how I feel about all these high risk missions, but we've gotten this far.  It's different now than when we started out.  I don't think you need my advice, you know I'll have your back whatever happens.",
+    "responses": [ { "text": "I might not need it, but I still like to hear it.  I'd like your opinion on something else, anyway.", "topic": "TALK_Liam_Opinions" } ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_Liam_Opinions_MISSION_OLD_GUARD_REPEATER_BEGIN",
+    "dynamic_line": "Honestly my friend, this is the kinda stuff I hoped we'd be doing when we offered to help these guys out.  Fresh air, great views, climbing on things we'd have gotten in trouble for in the old days, maybe pushing a zombie off the edge of a maintenance platform to see how big a splat it leaves at the bottom.  Sounds wicked.  Let's bring a couple cold ones up to the top and crack a brew while we survey the wasteland, hey?",
+    "responses": [ { "text": "Sounds like a great idea.  I'd like your opinion on something else, though.", "topic": "TALK_Liam_Opinions" } ]
+  },
+  {
+    "type": "talk_topic",
     "id": "TALK_Liam_Opinions_RUBIK_ANUS_FETICK",
     "dynamic_line": "I just like, wanna back up a second.  We're trying to score drugs for a cyborg so it can do surgery on you?  That's really where life's taking us, now?",
     "responses": [
@@ -430,6 +455,11 @@
       "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_1-Fortunecookie",
       "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_1-Psycho",
       "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_2",
+      "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_3-NotMet",
+      "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_3-HasMet",
+      "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_4",
+      "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_5",
+      "TALK_Liam_Opinions_MISSION_OLD_GUARD_REPEATER_BEGIN",
       "TALK_Liam_Opinions_MISSION_REFUGEE_Boris_CLEANUP",
       "TALK_Liam_Opinions_RUBIK_ANUS_FETICK-1",
       "TALK_Liam_Opinions_EXODII_MISSION_CONTACT_HUB",

--- a/data/json/npcs/your_followers/liam_chat.json
+++ b/data/json/npcs/your_followers/liam_chat.json
@@ -4,9 +4,9 @@
     "id": [ "TALK_Liam_SOCIAL" ],
     "dynamic_line": "Any time, what's on your mind?",
     "responses": [
+      { "text": "I'd like your opinion on a job we're doing.", "topic": "TALK_Liam_Opinions" },
       { "text": "Can I ask you a bit about yourself?", "topic": "BGSS_Liam1" },
       { "text": "You picked up a lot of useful skills over the years, hey.", "topic": "BGSS_Liam_Expertise" },
-      { "text": "I'd like your opinion on something.", "topic": "TALK_Liam_Opinions" },
       {
         "text": "I just wanted to chat, you know.  To relax.",
         "topic": "TALK_FRIEND_Liam_CHAT",

--- a/data/json/npcs/your_followers/liam_chat.json
+++ b/data/json/npcs/your_followers/liam_chat.json
@@ -26,10 +26,84 @@
     "//": "TK: custom chat topics here that actually include small talk that expands Liam's character, while still giving the socialize bonus.",
     "responses": [
       {
-        "text": "<chitchat_player_responses>",
-        "topic": "TALK_DONE",
-        "switch": true,
+        "text": "We're always gonna be friends, right?  Even with the apocalypse… changing us?",
+        "topic": "TALK_FRIEND_Liam_CHAT_Friends4ever"
         "effect": [ "morale_chat_activity", { "npc_add_effect": "asked_to_socialize", "duration": 7000 } ]
+      },
+      {
+        "text": "What do you miss most about the internet?",
+        "topic": "TALK_FRIEND_Liam_CHAT_Internet"
+        "effect": [ "morale_chat_activity", { "npc_add_effect": "asked_to_socialize", "duration": 7000 } ]
+      },
+      {
+        "text": "Now that we've got no responsibilities, is there anything you'd like to see or do?",
+        "topic": "TALK_FRIEND_Liam_CHAT_Goals"
+        "effect": [ "morale_chat_activity", { "npc_add_effect": "asked_to_socialize", "duration": 7000 } ]
+      },
+      {
+        "text": "What do you think the rest of the world is like these days?",
+        "topic": "TALK_FRIEND_Liam_CHAT_World"
+        "effect": [ "morale_chat_activity", { "npc_add_effect": "asked_to_socialize", "duration": 7000 } ]
+      },
+      {
+        "text": "Do you miss any food from the old days?",
+        "topic": "TALK_FRIEND_Liam_CHAT_Food"
+        "effect": [ "morale_chat_activity", { "npc_add_effect": "asked_to_socialize", "duration": 7000 } ]
+      },
+      {
+        "text": "<chitchat_player_responses>",
+        "topic": "TALK_DONE"
+        "effect": [ "morale_chat_activity", { "npc_add_effect": "asked_to_socialize", "duration": 7000 } ]
+      }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_FRIEND_Liam_CHAT_Friends4ever",
+    "dynamic_line": "Aww, of course.  No matter what happens, you're always you and I'm always me, right?  We've been through worse than this./"  He pauses, his brow furrowed.  /"Well, okay, maybe we haven't.  But we've stuck through it all for so many years, what's a little apocalypse gonna change?  Or a little mutation, or grievous bodily harm, or zombies, or interdimensional monster attacks and serious life-altering PTSD, or whatever.  Who cares.  You're my family, more than my birth family ever was.",
+    "responses": [
+      {
+        "text": "(Continue chatting)", "topic": "TALK_DONE"
+      }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_FRIEND_Liam_CHAT_Internet",
+    "dynamic_line": "OK, I know you're leading me up to say something dirty, and yeah I miss that, but you know what?  Really the thing I miss most is social media.  No seriously!  Stop looking at me like that!  I liked being able to just talk to people no matter where they were, any time.  I had friends in Sweden, and Brazil, and the West Coast.  I'm never gonna know what happened to them, and that busts me up bad.  They mattered to me, you know?\"  His voice catches a bit, and he coughs.  \"You're here though, and that helps a lot.  Can't imagine trying to do this lone-wolf.  How about you, what were you thinking of when you asked?",
+    "responses": [
+      {
+        "text": "(Continue chatting)", "topic": "TALK_DONE"
+      }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_FRIEND_Liam_CHAT_Goals",
+    "dynamic_line": "*laughs.  \"You know me, I was never high on the ambition front.  Honestly, if you weren't around I'd probably clean up my dad's old cabin, try to learn how to set up a power supply, and scavenge for parts until I'd built the best damn gaming rig the world will ever see.  Then I'd load up whatever games I could find.\"  He pauses.  \"Or maybe it'd be easier to set up a console, I dunno.  Most consoles aren't gonna like the no-internet thing right?  There's probably a way to crack 'em but without the internet where would we even check?\"  He rubs his chin.  \"Still.  I'd have maybe found a way.  How about you, what's the big overarching plan for all this?\"",
+    "responses": [
+      {
+        "text": "(Continue chatting)", "topic": "TALK_DONE"
+      }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_FRIEND_Liam_CHAT_World",
+    "dynamic_line": "Oh dude, good question.  The news reports made it sound like this is everywhere, you know?  Still, somewhere out there's gotta be better than this, right?  Maybe like, up in the Yukon or Siberia or something it's all kinda normal?  I think most places are like this though, just one big fucked up mess.  Maybe they've got different monsters though, like, carnivorous rocks or some shit.  How 'bout you, what do you think is out there?",
+    "responses": [
+      {
+        "text": "(Continue chatting)", "topic": "TALK_DONE"
+      }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_FRIEND_Liam_CHAT_Food",
+    "dynamic_line": "I never thought I'd hear myself say this, but I kinda miss the EdiBurger3 from FoodPlace.  I worked there so long, I hated everything, but as soon as you tell me I'm *never* gonna have a fresh, greasy EB3 again, suddenly it's all my stomach wants.  Don't try to track one down or anything though.  I'm pretty sure I miss the *idea* more than the actual *thing*.  And I don't think we could cook up a copy, it'd be pretty hard to get the right blend of animal product and sawdust for the MeatCylinder.\"  He stares whistfully into space for a moment.  \"How about you, what were you thinking of when you asked?",
+    "responses": [
+      {
+        "text": "(Continue chatting)", "topic": "TALK_DONE"
       }
     ]
   },

--- a/data/json/npcs/your_followers/liam_chat.json
+++ b/data/json/npcs/your_followers/liam_chat.json
@@ -112,7 +112,7 @@
   {
     "type": "talk_topic",
     "id": "BGSS_Liam3",
-    "dynamic_line": "I wanna say it was a hell of a story, but really, I was on the way back to Boston from a delivery and a thing about the riots on the radio.  I was close to the cabin so I just thought, 'this is starting to sound really fuckin bad.'  I called in sick and took a few days to hunker down out of civilization.  By the time I had to think about going back to work, we were into that wild time when half the people were trying to keep things running and the other half were trying to burn everything down.  I shut the blinds and stayed in, until Chris showed up acting like a freak.",
+    "dynamic_line": "I wanna say it was a hell of a story, but really, I was on the way back to Boston from a delivery and a thing about the riots came on the radio.  I was close to the cabin so I just thought, 'this is starting to sound really fuckin bad.'  I called in sick and took a few days to hunker down out of civilization.  By the time I had to think about going back to work, we were into that wild time when half the people were trying to keep things running and the other half were trying to burn everything down.  I shut the blinds and stayed in, until Chris showed up acting like a freak.",
     "responses": [
       { "text": "You picked up a lot of useful skills over the years, hey.", "topic": "BGSS_Liam_Expertise" },
       { "text": "Can we talk about something else?", "topic": "TALK_Liam_SOCIAL" },
@@ -217,7 +217,7 @@
         "condition": { "u_has_mission": "MISSION_OLD_GUARD_REP_5" }
       },
       {
-        "text": "install repeater in radio tower?",
+        "text": "Well, now we're radio technicians.  Sounds fun, don't you think?",
         "topic": "TALK_Liam_Opinions_MISSION_OLD_GUARD_REPEATER_BEGIN",
         "condition": { "u_has_mission": "MISSION_OLD_GUARD_REPEATER_BEGIN" }
       },

--- a/data/json/npcs/your_followers/liam_chat.json
+++ b/data/json/npcs/your_followers/liam_chat.json
@@ -94,6 +94,31 @@
         "topic": "TALK_Liam_Opinions_MISSION_FREE_MERCHANTS_EVAC_1",
         "condition": { "u_has_assigned_mission": "MISSION_FREE_MERCHANTS_EVAC_1" }
       },
+      {
+        "text": "What do you think about taking down this bandit camp?",
+        "topic": "TALK_Liam_Opinions_MISSION_FREE_MERCHANTS_EVAC_2",
+        "condition": { "u_has_assigned_mission": "MISSION_FREE_MERCHANTS_EVAC_2" }
+      },
+      {
+        "text": "Any thoughts about bringing this prospectus out to the ranch?",
+        "topic": "TALK_Liam_Opinions_MISSION_FREE_MERCHANTS_EVAC_3",
+        "condition": { "u_has_assigned_mission": "MISSION_FREE_MERCHANTS_EVAC_3" }
+      },
+      {
+        "text": "Where do you think we can get some anesthetic for that robot guy?",
+        "topic": "TALK_Liam_Opinions_RUBIK_ANUS_FETICK",
+        "condition": { "u_has_assigned_mission": "RUBIK_ANUS_FETICK" }
+      },
+      {
+        "text": "Any thoughts on this scouting mission, checking out this bunker thing?",
+        "topic": "TALK_Liam_Opinions_EXODII_MISSION_CONTACT_HUB",
+        "condition": { "u_has_assigned_mission": "EXODII_MISSION_CONTACT_HUB" }
+      },
+      {
+        "text": "How do you think we should start looking for this lost interdimensional building?",
+        "topic": "TALK_Liam_Opinions_EXODII_MISSION_WAREHOUSE",
+        "condition": { "u_has_assigned_mission": "EXODII_MISSION_WAREHOUSE" }
+      },
       { "text": "Can we chat about something else?", "topic": "TALK_Liam_SOCIAL" },
       { "text": "<end_talking>", "topic": "TALK_DONE" }
     ]

--- a/data/json/npcs/your_followers/liam_chat.json
+++ b/data/json/npcs/your_followers/liam_chat.json
@@ -182,14 +182,29 @@
         "condition": { "u_has_assigned_mission": "MISSION_OLD_GUARD_REP_1" }
       },
       {
-        "text": "Deal with Informant?",
+        "text": "How do you think we should track down this enemy informant?",
         "topic": "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_2",
         "condition": { "u_has_assigned_mission": "MISSION_OLD_GUARD_REP_2" }
       },
       {
-        "text": "Find exodii?",
-        "topic": "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_3",
-        "condition": { "u_has_assigned_mission": "MISSION_OLD_GUARD_REP_3" }
+        "text": "What do you think about these robots?  Crazy stuff, hey?",
+        "topic": "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_3-NotMet",
+        "condition": {
+          "and": [
+            { "u_has_assigned_mission": "MISSION_OLD_GUARD_REP_3" },
+            { "not": { "u_has_var": "u_met_Rubik", "type": "general", "context": "meeting", "value": "yes" } }
+          ]
+        }
+      },
+      {
+        "text": "What do you think about these robots?  Crazy stuff, hey?",
+        "topic": "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_3-HasMet",
+        "condition": {
+          "and": [
+            { "u_has_assigned_mission": "MISSION_OLD_GUARD_REP_3" },
+            { "u_has_var": "u_met_Rubik", "type": "general", "context": "meeting", "value": "yes" }
+          ]
+        }
       },
       {
         "text": "Secure trade route kill monster?",
@@ -323,23 +338,13 @@
     "type": "talk_topic",
     "id": "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_1-Reassure",
     "dynamic_line": "Thanks.  You're right.  Okay, I can do this.\"  He shakes his shoulders and limbers up, like a boxer preparing for a match.  \"Let's go.",
-    "responses": [
-      {
-        "text": "Hold up Balboa, I'd like your opinion on something else, actually.",
-        "topic": "TALK_Liam_Opinions"
-      }
-    ]
+    "responses": [ { "text": "Hold up Balboa, I'd like your opinion on something else, actually.", "topic": "TALK_Liam_Opinions" } ]
   },
   {
     "type": "talk_topic",
     "id": "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_1-Bravado",
     "dynamic_line": "Oh, oh yeah that makes sense.  Okay, well, that's something I can do.  I'll cover your back like it's never been covered before.  You and me like Calvin and Hobbes baby.",
-    "responses": [
-      {
-        "text": "Thanks, Hooch.  I'd like your opinion on something else, actually.",
-        "topic": "TALK_Liam_Opinions"
-      }
-    ]
+    "responses": [ { "text": "Thanks, Hooch.  I'd like your opinion on something else, actually.", "topic": "TALK_Liam_Opinions" } ]
   },
   {
     "type": "talk_topic",
@@ -359,6 +364,18 @@
     "responses": [
       {
         "text": "Don't worry, man.  Trust me, it'll be great.  Anyway, I'd like your opinion on something else.",
+        "topic": "TALK_Liam_Opinions"
+      }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_2",
+    "dynamic_line": "You know, this sounds like it's gonna be some big exciting mystery whodunnit, but I have this feeling if we just look around for someone who is acting obviously and extremely suspicious it'll all fall apart at once.",
+    "//": "I really need to touch up the informant quest :(",
+    "responses": [
+      {
+        "text": "That's optimistic, thanks man.  I'd like your opinion on something else, actually.",
         "topic": "TALK_Liam_Opinions"
       }
     ]
@@ -398,6 +415,11 @@
       "TALK_Liam_Opinions_MISSION_FREE_MERCHANTS_EVAC_2",
       "TALK_Liam_Opinions_MISSION_FREE_MERCHANTS_EVAC_2-1",
       "TALK_Liam_Opinions_MISSION_FREE_MERCHANTS_EVAC_3",
+      "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_1-Reassure",
+      "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_1-Bravado",
+      "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_1-Fortunecookie",
+      "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_1-Psycho",
+      "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_2",
       "TALK_Liam_Opinions_MISSION_REFUGEE_Boris_CLEANUP",
       "TALK_Liam_Opinions_RUBIK_ANUS_FETICK-1",
       "TALK_Liam_Opinions_EXODII_MISSION_CONTACT_HUB",

--- a/data/json/npcs/your_followers/liam_chat.json
+++ b/data/json/npcs/your_followers/liam_chat.json
@@ -159,39 +159,39 @@
       {
         "text": "Any ideas about this job to clear out the back bay for Smokes?",
         "topic": "TALK_Liam_Opinions_MISSION_FREE_MERCHANTS_EVAC_1",
-        "condition": { "u_has_assigned_mission": "MISSION_FREE_MERCHANTS_EVAC_1" }
+        "condition": { "u_has_mission": "MISSION_FREE_MERCHANTS_EVAC_1" }
       },
       {
         "text": "What do you think about taking down this bandit camp?",
         "topic": "TALK_Liam_Opinions_MISSION_FREE_MERCHANTS_EVAC_2",
-        "condition": { "u_has_assigned_mission": "MISSION_FREE_MERCHANTS_EVAC_2" }
+        "condition": { "u_has_mission": "MISSION_FREE_MERCHANTS_EVAC_2" }
       },
       {
         "text": "Any thoughts about bringing this prospectus out to the ranch?",
         "topic": "TALK_Liam_Opinions_MISSION_FREE_MERCHANTS_EVAC_3",
-        "condition": { "u_has_assigned_mission": "MISSION_FREE_MERCHANTS_EVAC_3" }
+        "condition": { "u_has_mission": "MISSION_FREE_MERCHANTS_EVAC_3" }
       },
       {
         "text": "What do you think about helping these guys clean up all that dead zombie mess?",
         "topic": "TALK_Liam_Opinions_MISSION_REFUGEE_Boris_CLEANUP",
-        "condition": { "u_has_assigned_mission": "MISSION_REFUGEE_Boris_CLEANUP" }
+        "condition": { "u_has_mission": "MISSION_REFUGEE_Boris_CLEANUP" }
       },
       {
         "text": "What're your thoughts on this mission to kill bandits for the old guard?",
         "topic": "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_1",
-        "condition": { "u_has_assigned_mission": "MISSION_OLD_GUARD_REP_1" }
+        "condition": { "u_has_mission": "MISSION_OLD_GUARD_REP_1" }
       },
       {
         "text": "How do you think we should track down this enemy informant?",
         "topic": "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_2",
-        "condition": { "u_has_assigned_mission": "MISSION_OLD_GUARD_REP_2" }
+        "condition": { "u_has_mission": "MISSION_OLD_GUARD_REP_2" }
       },
       {
         "text": "What do you think about these robots?  Crazy stuff, hey?",
         "topic": "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_3-NotMet",
         "condition": {
           "and": [
-            { "u_has_assigned_mission": "MISSION_OLD_GUARD_REP_3" },
+            { "u_has_mission": "MISSION_OLD_GUARD_REP_3" },
             { "not": { "u_has_var": "u_met_Rubik", "type": "general", "context": "meeting", "value": "yes" } }
           ]
         }
@@ -201,7 +201,7 @@
         "topic": "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_3-HasMet",
         "condition": {
           "and": [
-            { "u_has_assigned_mission": "MISSION_OLD_GUARD_REP_3" },
+            { "u_has_mission": "MISSION_OLD_GUARD_REP_3" },
             { "u_has_var": "u_met_Rubik", "type": "general", "context": "meeting", "value": "yes" }
           ]
         }
@@ -209,32 +209,32 @@
       {
         "text": "Do you think it's really a monster hitting those trade caravans?  Any ideas how we should deal with it?",
         "topic": "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_4",
-        "condition": { "u_has_assigned_mission": "MISSION_OLD_GUARD_REP_4" }
+        "condition": { "u_has_mission": "MISSION_OLD_GUARD_REP_4" }
       },
       {
         "text": "So, we're officially assassins for hire now.  How do you feel about that?",
         "topic": "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_5",
-        "condition": { "u_has_assigned_mission": "MISSION_OLD_GUARD_REP_5" }
+        "condition": { "u_has_mission": "MISSION_OLD_GUARD_REP_5" }
       },
       {
         "text": "install repeater in radio tower?",
         "topic": "TALK_Liam_Opinions_MISSION_OLD_GUARD_REPEATER_BEGIN",
-        "condition": { "u_has_assigned_mission": "MISSION_OLD_GUARD_REPEATER_BEGIN" }
+        "condition": { "u_has_mission": "MISSION_OLD_GUARD_REPEATER_BEGIN" }
       },
       {
         "text": "Where do you think we can get some anesthetic for that robot guy?",
         "topic": "TALK_Liam_Opinions_RUBIK_ANUS_FETICK",
-        "condition": { "u_has_assigned_mission": "RUBIK_ANUS_FETICK" }
+        "condition": { "u_has_mission": "RUBIK_ANUS_FETICK" }
       },
       {
         "text": "Any thoughts on this scouting mission, checking out this bunker thing?",
         "topic": "TALK_Liam_Opinions_EXODII_MISSION_CONTACT_HUB",
-        "condition": { "u_has_assigned_mission": "EXODII_MISSION_CONTACT_HUB" }
+        "condition": { "u_has_mission": "EXODII_MISSION_CONTACT_HUB" }
       },
       {
         "text": "How do you think we should start looking for this lost interdimensional building?",
         "topic": "TALK_Liam_Opinions_EXODII_MISSION_WAREHOUSE",
-        "condition": { "u_has_assigned_mission": "EXODII_MISSION_WAREHOUSE" }
+        "condition": { "u_has_mission": "EXODII_MISSION_WAREHOUSE" }
       },
       { "text": "Can we talk about something else?", "topic": "TALK_FRIEND_Liam" },
       { "text": "<end_talking>", "topic": "TALK_DONE" }

--- a/data/json/npcs/your_followers/liam_chat.json
+++ b/data/json/npcs/your_followers/liam_chat.json
@@ -6,6 +6,7 @@
     "responses": [
       { "text": "Can I ask you a bit about yourself?", "topic": "BGSS_Liam1" },
       { "text": "You picked up a lot of useful skills over the years, hey.", "topic": "BGSS_Liam_Expertise" },
+      { "text": "I'd like your opinion on something.", "topic": "TALK_Liam_Opinions" },
       {
         "text": "I just wanted to chat, you know.  To relax.",
         "topic": "TALK_FRIEND_Liam_CHAT",
@@ -18,7 +19,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_FRIEND_Liam_CHAT",
-    "dynamic_line": [ "Sure.  Can I tell you about this idea I had for a comic I'm never gonna make?",
+    "dynamic_line": [
+      "Sure.  Can I tell you about this idea I had for a comic I'm never gonna make?",
+      "Lately I've been thinking about my Steam library and all those games I was putting off for a bad time.  Now it's a bad time and I can't play 'em.  Tragedy of our era, right?"
+    ],
     "//": "TK: custom chat topics here that actually include small talk that expands Liam's character, while still giving the socialize bonus.",
     "responses": [
       {
@@ -78,6 +82,30 @@
     "responses": [
       { "text": "Can we talk about something else?", "topic": "TALK_Liam_SOCIAL" },
       { "text": "Harsh, but I hear you.  <end_talking>", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_Liam_Opinions",
+    "dynamic_line": "My opinion?  Sure, my friend, hit me up, what's eating you?",
+    "responses": [
+      {
+        "text": "Any ideas about this job to clear out the back bay for Smokes?",
+        "topic": "TALK_Liam_Opinions_MISSION_FREE_MERCHANTS_EVAC_1",
+        "condition": { "u_has_assigned_mission": "MISSION_FREE_MERCHANTS_EVAC_1" }
+      },
+      { "text": "Can we chat about something else?", "topic": "TALK_Liam_SOCIAL" },
+      { "text": "<end_talking>", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_Liam_Opinions_MISSION_FREE_MERCHANTS_EVAC_1",
+    "dynamic_line": "*rubs his chin thoughtfully.  \"Maybe we can set up a bottleneck in the hallway?  First we drag a few lockers or something to funnel them, then one of us hangs close to the barricade and the other stands back and fires arrows or something?\"  He shrugs.  \"I'm not great at tactics, and I'm a bit nervous about what's back there.\"",
+    "responses": [
+      { "text": "Thanks man.  I'd like your opinion on something else, actually.", "topic": "TALK_Liam_Opinions" },
+      { "text": "Can we chat about something else?", "topic": "TALK_Liam_SOCIAL" },
+      { "text": "<end_talking>", "topic": "TALK_DONE" }
     ]
   }
 ]

--- a/data/json/npcs/your_followers/liam_chat.json
+++ b/data/json/npcs/your_followers/liam_chat.json
@@ -119,7 +119,7 @@
         "topic": "TALK_Liam_Opinions_EXODII_MISSION_WAREHOUSE",
         "condition": { "u_has_assigned_mission": "EXODII_MISSION_WAREHOUSE" }
       },
-      { "text": "Can we chat about something else?", "topic": "TALK_Liam_SOCIAL" },
+      { "text": "Can we talk about something else?", "topic": "TALK_FRIEND_Liam" },
       { "text": "<end_talking>", "topic": "TALK_DONE" }
     ]
   },
@@ -127,8 +127,58 @@
     "type": "talk_topic",
     "id": "TALK_Liam_Opinions_MISSION_FREE_MERCHANTS_EVAC_1",
     "dynamic_line": "*rubs his chin thoughtfully.  \"Maybe we can set up a bottleneck in the hallway?  First we drag a few lockers or something to funnel them, then one of us hangs close to the barricade and the other stands back and fires arrows or something?\"  He shrugs.  \"I'm not great at tactics, and I'm a bit nervous about what's back there.\"",
+    "responses": [ { "text": "Thanks man.  I'd like your opinion on something else, actually.", "topic": "TALK_Liam_Opinions" } ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_Liam_Opinions_MISSION_FREE_MERCHANTS_EVAC_2",
+    "dynamic_line": "You sure we haven't bit off more than we can chew here?\"  He stares at you for a moment.  \"This isn't DOTA2, this is real life.  These guys are gonna have guns and shit.  I know we've been through a lot together but if they're ready for us they could take us out before we're even close enough to see them.  I mean, I'm with you if you think we can do it, but be careful, okay?",
     "responses": [
-      { "text": "Thanks man.  I'd like your opinion on something else, actually.", "topic": "TALK_Liam_Opinions" },
+      {
+        "text": "Thanks man, I'll keep that in mind.  We gotta do this though.  Any suggestions for how to do it safely?.",
+        "topic": "TALK_Liam_Opinions_MISSION_FREE_MERCHANTS_EVAC_2-1"
+      },
+      {
+        "text": "Thanks man, I'll keep that in mind.  We'll do this carefully.  I'd like your opinion on something else, actually.",
+        "topic": "TALK_Liam_Opinions"
+      }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_Liam_Opinions_MISSION_FREE_MERCHANTS_EVAC_2-1",
+    "dynamic_line": "If you're gonna insist on it then I say we drive up quick in the dark, take cover behind the car, and make a ton of noise.  Then we take cover and when they come to check things out, we pick them off.  Or maybe we come in silent, from a distance, and take out their sentries.  A bow is great for that, if we can make the shots.  This whole thing still seems ridiculous though.",
+    "responses": [
+      {
+        "text": "Thanks man, I'll keep that in mind.  We'll do this carefully.  I'd like your opinion on something else, actually.",
+        "topic": "TALK_Liam_Opinions"
+      }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_Liam_Opinions_MISSION_FREE_MERCHANTS_EVAC_3",
+    "dynamic_line": "I'm kinda looking forward to it.  It's good to see people already building up something to last, after everything that's gone down.  Wonder what we'll find out there.",
+    "responses": [
+      {
+        "text": "That's optimistic, thanks man.  I'd like your opinion on something else, actually.",
+        "topic": "TALK_Liam_Opinions"
+      }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": [
+      "TALK_Liam_Opinions_MISSION_FREE_MERCHANTS_EVAC_1",
+      "TALK_Liam_Opinions_MISSION_FREE_MERCHANTS_EVAC_2",
+      "TALK_Liam_Opinions_MISSION_FREE_MERCHANTS_EVAC_2-1",
+      "TALK_Liam_Opinions_MISSION_FREE_MERCHANTS_EVAC_3",
+      "TALK_Liam_Opinions_RUBIK_ANUS_FETICK",
+      "TALK_Liam_Opinions_EXODII_MISSION_CONTACT_HUB",
+      "TALK_Liam_Opinions_EXODII_MISSION_WAREHOUSE"
+    ],
+    "responses": [
+      { "text": "I want to talk about something a bit more fundamental now.", "topic": "TALK_FRIEND_Liam" },
       { "text": "Can we chat about something else?", "topic": "TALK_Liam_SOCIAL" },
       { "text": "<end_talking>", "topic": "TALK_DONE" }
     ]

--- a/data/json/npcs/your_followers/liam_chat.json
+++ b/data/json/npcs/your_followers/liam_chat.json
@@ -21,7 +21,17 @@
     "id": "TALK_FRIEND_Liam_CHAT",
     "dynamic_line": [
       "Sure.  Can I tell you about this idea I had for a comic I'm never gonna make?",
-      "Lately I've been thinking about my Steam library and all those games I was putting off for a bad time.  Now it's a bad time and I can't play 'em.  Tragedy of our era, right?"
+      "Lately I've been thinking about my Steam library and all those games I was putting off for a bad time.  Now it's a bad time and I can't play 'em.  Tragedy of our era, right?",
+      "You remember that girl from high school I had that huge crush on?  Emily?  I wonder if she's still alive.  I shoulda asked her out.",
+      "Aw dude.  I was just remembering about this crowdfunded board game I backed right before things went to hell.  It'd be fulfilling right about now, I bet.",
+      "Does it ever seem to you like the stars are in different places from where they used to be?  I can find all the old constellations, but they look different now.",
+      "Since everything went down, I keep having this recurring dream where I'm at Foodplace again, and Luke Skywalker is there, demanding an EB3 combo with extra Beverage, and he's being a real Karen about it.  Do you think it means something?",
+      "Maybe it's weird but this whole thing sorta feels like an extended camping trip.  With zombies.",
+      "I slept weird last night.  Got this awful crick in my neck.",
+      "Do you think the internet is still out there somewhere, floating around in some still-functional servers somehow?  It's weird to think about what happened to all that data.",
+      "Remember that guy Daren in elementary who used to tell all those weird-ass creepy stories?  Chris hated him but I thought he was interesting.  I wonder if he's alive, he'd have loved this.",
+      "You know what I could really use right now?  A hot bath.",
+      "Next time we hit a library, I'm gonna see if they've got a copy of Gideon the Ninth.  I read that book a while ago, but I was super high and I don't remember much of it."
     ],
     "//": "TK: custom chat topics here that actually include small talk that expands Liam's character, while still giving the socialize bonus.",
     "responses": [

--- a/data/json/npcs/your_followers/liam_main_dialogue.json
+++ b/data/json/npcs/your_followers/liam_main_dialogue.json
@@ -182,6 +182,9 @@
   {
     "id": "TALK_Liam_Callsigns",
     "type": "talk_topic",
-    "dynamic_line": "Roger that red burrito, that's a ten-forward on the callsigns.  Glad you like 'em."
+    "dynamic_line": "Roger that red burrito, that's a ten-forward on the callsigns.  Glad you like 'em.",
+    "responses": [
+      { "text": "You're weird, my friend.  Red burrito, out.", "topic": "TALK_DONE" }
+    ]
   }
 ]

--- a/data/json/npcs/your_followers/liam_main_dialogue.json
+++ b/data/json/npcs/your_followers/liam_main_dialogue.json
@@ -3,7 +3,7 @@
     "id": [ "TALK_FRIEND_Liam", "TALK_FRIEND_Liam_Abilities", "TALK_Liam_Callsigns" ],
     "type": "talk_topic",
     "dynamic_line": {
-      "is_by_radio": " *pshhhttt* This big turtle, I read you loud and clear, red burrito.",
+      "is_by_radio": " *pshhhttt* This is big turtle, I read you loud and clear, red burrito.",
       "no": { "has_reason": { "use_reason": true }, "no": "So, here we are.  What's up?" }
     },
     "responses": [
@@ -15,6 +15,7 @@
         "effect": "reveal_stats"
       },
       { "text": "There's something I want you to do.", "topic": "TALK_Liam_ORDERS" },
+      { "text": "I'd like your opinion on a job we're doing.", "topic": "TALK_Liam_Opinions" },
       {
         "text": "I just wanted to talk for a bit.",
         "condition": { "and": [ "at_safe_space", { "not": "is_by_radio" } ] },

--- a/data/json/npcs/your_followers/liam_main_dialogue.json
+++ b/data/json/npcs/your_followers/liam_main_dialogue.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": [ "TALK_FRIEND_Liam", "TALK_FRIEND_Liam_Abilities" ],
+    "id": [ "TALK_FRIEND_Liam", "TALK_FRIEND_Liam_Abilities", "TALK_Liam_Callsigns" ],
     "type": "talk_topic",
     "dynamic_line": {
       "is_by_radio": " *pshhhttt* This big turtle, I read you loud and clear, red burrito.",
@@ -178,5 +178,10 @@
       { "text": "Never mind then.", "topic": "TALK_NONE" },
       { "text": "Forget it, let's get going.", "topic": "TALK_DONE" }
     ]
-  }
+  },
+  {
+    "id": "TALK_Liam_Callsigns",
+    "type": "talk_topic",
+    "dynamic_line": "Roger that red burrito, that's a ten-forward on the callsigns.  Glad you like 'em."
+  },
 ]

--- a/data/json/npcs/your_followers/liam_main_dialogue.json
+++ b/data/json/npcs/your_followers/liam_main_dialogue.json
@@ -183,5 +183,5 @@
     "id": "TALK_Liam_Callsigns",
     "type": "talk_topic",
     "dynamic_line": "Roger that red burrito, that's a ten-forward on the callsigns.  Glad you like 'em."
-  },
+  }
 ]

--- a/data/json/npcs/your_followers/liam_main_dialogue.json
+++ b/data/json/npcs/your_followers/liam_main_dialogue.json
@@ -41,36 +41,6 @@
     "dynamic_line": "As you know, I am experienced in practically every low-wage job on the Eastern seaboard, and I'm probably a regional leading expert on video games.  My dad made me learn archery and I kinda kept it up.  What else is there?"
   },
   {
-    "id": [ "TALK_Liam_SOCIAL" ],
-    "type": "talk_topic",
-    "dynamic_line": "Any time, what's on your mind?",
-    "responses": [
-      { "text": "Can I ask you a bit about yourself?", "topic": "BGSS_Liam1" },
-      { "text": "You picked up a lot of useful skills over the years, hey.", "topic": "BGSS_Liam_Expertise" },
-      {
-        "text": "I just wanted to chat, you know.  To relax.",
-        "topic": "TALK_FRIEND_Liam_CHAT",
-        "condition": { "not": { "npc_has_effect": "asked_to_socialize" } }
-      },
-      { "text": "I changed my mind, wanted to ask you something else.", "topic": "TALK_NONE" },
-      { "text": "Let's go.", "topic": "TALK_DONE" }
-    ]
-  },
-  {
-    "type": "talk_topic",
-    "id": "TALK_FRIEND_Liam_CHAT",
-    "dynamic_line": "Sure.  Can I tell you about this idea I had for a comic I'm never gonna make?",
-    "//": "TK: custom chat topics here that actually include small talk that expands Liam's character, while still giving the socialize bonus.",
-    "responses": [
-      {
-        "text": "<chitchat_player_responses>",
-        "topic": "TALK_DONE",
-        "switch": true,
-        "effect": [ "morale_chat_activity", { "npc_add_effect": "asked_to_socialize", "duration": 7000 } ]
-      }
-    ]
-  },
-  {
     "id": [ "TALK_Liam_ORDERS" ],
     "type": "talk_topic",
     "dynamic_line": [
@@ -207,57 +177,6 @@
       },
       { "text": "Never mind then.", "topic": "TALK_NONE" },
       { "text": "Forget it, let's get going.", "topic": "TALK_DONE" }
-    ]
-  },
-  {
-    "type": "talk_topic",
-    "id": "BGSS_Liam1",
-    "dynamic_line": "Well, sure.  I dunno what more there is to tell, we've known each other for ages.",
-    "responses": [
-      { "text": "We hadn't caught up in a while before <the_cataclysm>.  What've you been doing?", "topic": "BGSS_Liam2" },
-      { "text": "You picked up a lot of useful skills over the years, hey.", "topic": "BGSS_Liam_Expertise" },
-      { "text": "Can we talk about something else?", "topic": "TALK_Liam_SOCIAL" },
-      { "text": "<end_talking>", "topic": "TALK_DONE" }
-    ]
-  },
-  {
-    "type": "talk_topic",
-    "id": "BGSS_Liam2",
-    "dynamic_line": "*shrugs.  \"Same as I was when we used to hang out more, mostly.  I quit my job at Foodplace a while back, got tired of the stupid outfits.  Worked doing labor in construction for a bit, but I didn't like my boss so I ditched it.  Got a job doing deliveries for Amazon, which was absolutely shitty, but I managed to jump from that to a bit of a better delivery job for a smaller company.  It was actually going pretty good before everything happened.\"",
-    "responses": [
-      { "text": "How did you make it through the cataclysm?", "topic": "BGSS_Liam3" },
-      { "text": "You picked up a lot of useful skills over the years, hey.", "topic": "BGSS_Liam_Expertise" },
-      { "text": "Can we talk about something else?", "topic": "TALK_Liam_SOCIAL" },
-      { "text": "<end_talking>", "topic": "TALK_DONE" }
-    ]
-  },
-  {
-    "type": "talk_topic",
-    "id": "BGSS_Liam3",
-    "dynamic_line": "I wanna say it was a hell of a story, but really, I was on the way back to Boston from a delivery and a thing about the riots on the radio.  I was close to the cabin so I just thought, 'this is starting to sound really fuckin bad.'  I called in sick and took a few days out there.  By the time I had to think about going back to work, we were into that wild time when half the people were trying to keep things running and the other half were trying to burn everything down.  I shut the blinds and stayed in, until Chris showed up acting like a freak.",
-    "responses": [
-      { "text": "You picked up a lot of useful skills over the years, hey.", "topic": "BGSS_Liam_Expertise" },
-      { "text": "Can we talk about something else?", "topic": "TALK_Liam_SOCIAL" },
-      { "text": "<end_talking>", "topic": "TALK_DONE" }
-    ]
-  },
-  {
-    "type": "talk_topic",
-    "id": "BGSS_Liam_Expertise",
-    "dynamic_line": "It doesn't feel that way, but I guess so.  I don't know if I ever told you, but my dad was quite the weirdo prepper.  He built the cabin and when I was a kid we'd come out here and do drills for the end of the world.  It's part of why I was kinda wacked out on apocalypse stuff when you and I first met, back when we made the plan to come out here.  He taught me archery and some survival skills but I never really took to it, partly because my ol' man was a real piece of work.\"  He stares off for a minute.  \"To be honest, though, now that we're in the middle of a real-ass apocalypse, I can see a lot of what he taught me was just crap anyway.\"",
-    "responses": [
-      { "text": "What happened to your father?  You never talked about him much.", "topic": "BGSS_Liam_Father" },
-      { "text": "Can we talk about something else?", "topic": "TALK_Liam_SOCIAL" },
-      { "text": "<end_talking>", "topic": "TALK_DONE" }
-    ]
-  },
-  {
-    "type": "talk_topic",
-    "id": "BGSS_Liam_Father",
-    "dynamic_line": "*snorts.  \"I was pretty low-contact with him the last couple years.  He got me that job in construction and when I left it, he tried to hit me, found out I'm not so much of a pushover as when I was fifteen.  Asshole.  I was still texting my mom a bit, apparently when things went to shit, he tried to join the riots.  I hope he got gunned down.\"",
-    "responses": [
-      { "text": "Can we talk about something else?", "topic": "TALK_Liam_SOCIAL" },
-      { "text": "Harsh, but I hear you.  <end_talking>", "topic": "TALK_DONE" }
     ]
   }
 ]

--- a/data/json/npcs/your_followers/liam_main_dialogue.json
+++ b/data/json/npcs/your_followers/liam_main_dialogue.json
@@ -184,8 +184,6 @@
     "id": "TALK_Liam_Callsigns",
     "type": "talk_topic",
     "dynamic_line": "Roger that red burrito, that's a ten-forward on the callsigns.  Glad you like 'em.",
-    "responses": [
-      { "text": "You're weird, my friend.  Red burrito, out.", "topic": "TALK_DONE" }
-    ]
+    "responses": [ { "text": "You're weird, my friend.  Red burrito, out.", "topic": "TALK_DONE" } ]
   }
 ]


### PR DESCRIPTION
#### Summary
Content "Adds a lot of mission-specific and chat/small-talk dialogue to Liam (Friends to the End scenario)"

#### Purpose of change

Liam is becoming a bit popular as a companion, which warms my heart. I recently played disco elysium and now I have severe dialogue envy. I'm never going to achieve that level but I thought I'd give some NPCs a bit more love.


#### Describe the solution

This will add some context specific dialogue to Liam (your companion in Friends to the End scenario). This dialogue is primarily mission-keyed, allowing you to ask them their thoughts on specific missions; they might offer tips or advice, or just character-building information. There are also a number of small talk questions suggested by Discord, added to his "chat" dialogue option. These represent the start of a longer conversation, and asking them gives you the "chatted with a friend" morale boost.

Originally I was going to do the same for Luo and the Merc, but I've already done a lot and I'm still on Liam, so I'll save them for followup.

UPDATE: Calling this done now. Liam can respond to most old guard quests, most refugee center quests, and most rubik quests to offer thoughts and advice. He can have some more interesting small talk in the Chat option and has a selection of amusing responses. 400 lines of new dialogue and json infrastructure. Not bad I say.

I also fixed up a few errors from earlier, including an easter egg I forgot to add and a few spots where his dialogue wouldn't make sense unless you were standing in his cabin when you talk to him about it.

Included in this PR:
- several video game references
- Foodplace humour
- A hard-to-find book recommendation
- Family drama!
- Reassuring, sappy friendship dialogue
- Someone who'll stick with you even if you're an edgy murderhobo
- Fair reactions to the bizarre nature of your new reality
- Some file reorganization here to keep individual dialogue files from getting unmanageably long

#### Describe alternatives you've considered

Leaving them boring

Adding dialogue keyed to a different context

Adding a bunch of variables so they can remember what you said and react to it later. That would be great but it's an almost unbelievable amount of work.

#### Testing
Written and proofread, should be pretty safe but I'll try to run some play tests tonight

#### Additional context
I'll probably more or less copy this template and just rewrite the dialogue for the other static NPCs so that's cool. Gonna have to decide if I want to expand Liam further first or not, since that would make it a little easier to copy it over.

Aside from adding other mission responses I might also consider talk responses about missions you've *finished*. The problem there is that, for assigned missions, the dialogue is self-clearing, but for finished missions it remains and the list gets quite long. For now I am avoiding it. This also adds a fun element in that the dialogue is one shot only, if you don't ask him while on the mission, you miss out: I hope this will encourage people to interact with their NPCs a bit more, which in turn will be a nice habit to be in if I continue to add more dialogue