### PR TITLE
Modify comment in weather.h

### DIFF
--- a/src/weather.h
+++ b/src/weather.h
@@ -23,7 +23,7 @@ class translation;
  * @name BODYTEMP
  * Body temperature.
  * Most values can be changed with no impact on calculations.
- * Maximum heat cannot pass 57 C, otherwise the player will vomit to death.
+ * Maximum heat cannot pass 57 C (the player will die of heatstroke)
  */
 ///@{
 //!< More aggressive cold effects.


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/73102
Heatstroke no longer (for a long time) causes vomitting to death.

#### Describe the solution
Change comment.