### PR TITLE
d for debug (keybinding)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -22,7 +22,7 @@ body:
     attributes:
       label: Attach save file
       description: |
-        `ESC`Main Menu -> `b`Debug Menu -> `i`Info -> `!`Generate minimized save archive
+        `ESC`Main Menu -> `d`Debug Menu -> `i`Info -> `!`Generate minimized save archive
       placeholder: |
         Write N/A if not applicable.
 
@@ -69,7 +69,7 @@ body:
     attributes:
       label: Versions and configuration
       description: |
-        `ESC`Main Menu -> `b`Debug Menu -> `i`Info -> `r`Generate game report
+        `ESC`Main Menu -> `d`Debug Menu -> `i`Info -> `r`Generate game report
       placeholder: |
         - OS: [e.g. iOS 8 or Windows 10 or Ubuntu 18.04]
         - Game Version: [e.g. d6ec466 (64-bit) ]

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -1052,9 +1052,13 @@ action_id handle_main_menu()
     const input_context ctxt = get_default_mode_input_context();
     std::vector<uilist_entry> entries;
 
-    const auto REGISTER_ACTION = [&]( action_id name ) {
-        entries.emplace_back( name, true, hotkey_for_action( name, /*maximum_modifier_count=*/1 ),
-                              ctxt.get_action_name( action_ident( name ) ) );
+    const auto REGISTER_ACTION = [&]( action_id name, std::optional<char> kb = std::nullopt ) {
+        std::optional<input_event> hotkey = hotkey_for_action( name, /*maximum_modifier_count=*/1 );
+        if( hotkey.has_value() || !kb.has_value() ) {
+            entries.emplace_back( name, true, hotkey, ctxt.get_action_name( action_ident( name ) ) );
+        } else {
+            entries.emplace_back( name, true, kb.value(), ctxt.get_action_name( action_ident( name ) ) );
+        }
     };
 
     REGISTER_ACTION( ACTION_HELP );
@@ -1074,7 +1078,7 @@ action_id handle_main_menu()
     REGISTER_ACTION( ACTION_ACTIONMENU );
     REGISTER_ACTION( ACTION_QUICKSAVE );
     REGISTER_ACTION( ACTION_SAVE );
-    REGISTER_ACTION( ACTION_DEBUG );
+    REGISTER_ACTION( ACTION_DEBUG, 'd' );
 
     uilist smenu;
     smenu.settext( _( "MAIN MENU" ) );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Inconsistency in GitHub hinting debug is `b` vs in-game menu where it is `c`. See solution.

#### Describe the solution

Make the debug menu keybinding consistently be `d`.
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/dc0d528d-441e-4cf7-a228-8e0e79f26e96)
Change the hint on GitHub to consistently suggest `d` for the debug menu ~(untested, the following is a mock-up)~ tested on my fork:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/c6fa3c7b-454e-43df-b79d-e0cc44139da2)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/c6ef3002-bcfa-4b0a-8896-868277f1b5bb)


#### Describe alternatives you've considered

Leaving it at `c`, reserving `c` for it and fixing the GitHub hint. Since I am already doing this, `d` is better for debug.

The code isn't pretty, but the ternary operator didn't compile:
```cpp
    const auto REGISTER_ACTION = [&]( action_id name, std::optional<char> kb = std::nullopt ) {
        entries.emplace_back( name, true, kb.has_value() ? kb.value() : hotkey_for_action( name, /*maximum_modifier_count=*/1 ),
                              ctxt.get_action_name( action_ident( name ) ) );
    };
```
```cpp
1>C:\GitHub\Cataclysm-DDA\src\action.cpp(1056,1): error C2679: binary '?': no operator found which takes a right-hand operand of type 'std::optional<input_event>' (or there is no acceptable conversion)
1>C:\GitHub\Cataclysm-DDA\src\action.cpp(1056,1): message : could be 'built-in C++ operator?(int, int)'
1>C:\GitHub\Cataclysm-DDA\src\action.cpp(1056,1): message : while trying to match the argument list '(_Ty, std::optional<input_event>)'
1>        with
1>        [
1>            _Ty=char
1>        ]
```

#### Testing

You can now `ESC` `d` `i` `!` as the GitHub suggests.

I thought it would break if a couple more options were added. But setting it to 5, I found out it is magical and works:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/1f30c8fb-3e82-419f-8084-7fc875a60b86)

#### Additional context