### PR TITLE
`Can't see` doesn't close the crafting GUI

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1171,19 +1171,13 @@ static void nested_toggle( recipe_id rec, bool &recalc, bool &keepline )
 static bool selection_ok( const std::vector<const recipe *> &list, const int current_line,
                           const bool nested_acceptable )
 {
-    std::string error_message;
     if( list.empty() ) {
-        error_message = _( "Nothing selected!" );
+        popup( _( "Nothing selected!" ) );
     } else if( list[current_line]->is_nested() && !nested_acceptable ) {
-        error_message = _( "Select a recipe within this group" );
+        popup( _( "Select a recipe within this group" ) );
     } else {
         return true;
     }
-
-    query_popup()
-    .message( "%s", error_message )
-    .option( "QUIT" )
-    .query();
     return false;
 }
 
@@ -1819,15 +1813,13 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
             line = -1;
             user_moved_line = highlight_unread_recipes;
         } else if( action == "CONFIRM" ) {
-            if( available.empty() || ( ( !available[line].can_craft ||
-                                         !available[line].crafter_has_primary_skill )
-                                       && !current[line]->is_nested() ) ) {
-                query_popup()
-                .message( "%s", _( "Crafter can't craft that!" ) )
-                .option( "QUIT" )
-                .query();
+            if( available.empty() ) {
+                popup( _( "Nothing selected!" ) );
             } else if( current[line]->is_nested() ) {
                 nested_toggle( current[line]->ident(), recalc, keepline );
+            } else if( !available[line].can_craft ||
+                       !available[line].crafter_has_primary_skill ) {
+                popup( _( "Crafter can't craft that!" ) );
             } else if( !crafter->check_eligible_containers_for_crafting( *current[line],
                        batch ? line + 1 : 1 ) ) {
                 // popup is already inside check

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1823,6 +1823,8 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
             } else if( !crafter->check_eligible_containers_for_crafting( *current[line],
                        batch ? line + 1 : 1 ) ) {
                 // popup is already inside check
+            } else if( crafter->lighting_craft_speed_multiplier( *current[line] ) <= 0.0f ) {
+                popup( _( "Crafter can't see!" ) );
             } else {
                 chosen = current[line];
                 batch_size_out = batch ? line + 1 : 1;
@@ -2067,6 +2069,9 @@ int choose_crafter( const std::vector<Character *> &crafting_group, int crafter_
             if( !avail.has_proficiencies ) {  // this is required proficiency
                 reasons.emplace_back( _( "proficiency" ) );
             }
+            if( chara->lighting_craft_speed_multiplier( *rec ) <= 0.0f ) {
+                reasons.emplace_back( _( "light" ) );
+            }
             std::string dummy;
             if( chara->is_npc() && !rec->npc_can_craft( dummy ) ) {
                 reasons.emplace_back( _( "is NPC" ) );
@@ -2076,7 +2081,7 @@ int choose_crafter( const std::vector<Character *> &crafting_group, int crafter_
                 // *INDENT-OFF* readable ternary operator
                 rec->is_nested()
                     ? colorize( "-", c_yellow )
-                    : avail.can_craft && avail.crafter_has_primary_skill
+                    : reasons.empty()
                         ? colorize( _( "yes" ), c_green )
                         : colorize( _( "no" ), c_red ) );
                 // *INDENT-ON* readable ternary operator


### PR DESCRIPTION
#### Summary
Interface ""Can't see" message doesn't close the crafting GUI"

### Purpose of change
Before, you would select a recipe, press enter. Nothing happens, but after a second you notice in the log "Can't see to craft." By that time you already forgot what you were crafting.

### Describe the solution

#### Can't see
Pressing CONFIRM pops up a popup "Can't see". The player immediately notices that. They press anything to dismiss it. Remember what they wanted to craft by looking at it. Then they close the crafting GUI.

It might seem like the same state, but the player isn't confused as to why is nothing happening and they do remember what were they crafting.

New "can't see" popup:

https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/f4f167cf-88bf-47fd-b4c3-b02cd2b72a2e

#### query_popup -> popup
Also refactored from `query_popup` to `popup`. Shorter code and it looks different:
before:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/338a6c64-da21-4bf5-b04e-0fa96695775d)
after:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/8b449e16-7e2a-4586-89c0-1ccbb6ecbe29)

####  Choose crafter
Added "missing: `light`" as a reason in the "Choose the crafter" menu why they cannot craft.
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/63118975-cf79-467f-9ab4-2417abf943a6)

####  Nothing selected
When no crafting recipe is selected and CONFIRM is pressed, "Nothing selected!" pops up instead of "Crafter can't craft that!".

### Describe alternatives you've considered


### Testing
I went through these menus and tried to select different things.

### Additional context
