### PR TITLE
Not to try to unload when bow not loaded.

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -432,6 +432,7 @@ void aim_activity_actor::serialize( JsonOut &jsout ) const
     jsout.member( "aif_duration", aif_duration );
     jsout.member( "aiming_at_critter", aiming_at_critter );
     jsout.member( "snap_to_target", snap_to_target );
+    jsout.member( "loaded_RAS_weapon", loaded_RAS_weapon );
     jsout.member( "shifting_view", shifting_view );
     jsout.member( "initial_view_offset", initial_view_offset );
     jsout.member( "aborted", aborted );
@@ -454,6 +455,7 @@ std::unique_ptr<activity_actor> aim_activity_actor::deserialize( JsonValue &jsin
     data.read( "aif_duration", actor.aif_duration );
     data.read( "aiming_at_critter", actor.aiming_at_critter );
     data.read( "snap_to_target", actor.snap_to_target );
+    data.read( "loaded_RAS_weapon", actor.loaded_RAS_weapon );
     data.read( "shifting_view", actor.shifting_view );
     data.read( "initial_view_offset", actor.initial_view_offset );
     data.read( "aborted", actor.aborted );
@@ -531,6 +533,7 @@ bool aim_activity_actor::load_RAS_weapon()
     reload_time += ( sta_percent < 25 ) ? ( ( 25 - sta_percent ) * 2 ) : 0;
 
     you.mod_moves( -reload_time );
+    loaded_RAS_weapon = true;
     return true;
 }
 
@@ -539,7 +542,7 @@ void aim_activity_actor::unload_RAS_weapon()
     // Unload reload-and-shoot weapons to avoid leaving bows pre-loaded with arrows
     avatar &you = get_avatar();
     item_location weapon = get_weapon();
-    if( !weapon ) {
+    if( !weapon || !loaded_RAS_weapon ) {
         return;
     }
 
@@ -556,6 +559,7 @@ void aim_activity_actor::unload_RAS_weapon()
             you.set_moves( moves_before_unload );
         }
     }
+    loaded_RAS_weapon = false;
 }
 
 void autodrive_activity_actor::update_player_vehicle( Character &who )

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -53,6 +53,8 @@ class aim_activity_actor : public activity_actor
         int aif_duration = 0; // Counts aim-and-fire duration
         bool aiming_at_critter = false; // Whether aiming at critter or a tile
         bool snap_to_target = false;
+        /** Not to try to unload RELOAD_AND_SHOOT weapon if it is not loaded */
+        bool loaded_RAS_weapon = false;
         bool shifting_view = false;
         tripoint initial_view_offset;
         /** Target UI requested to abort aiming */


### PR DESCRIPTION
#### Summary
Bugfixes "Do not try to unload your bow when it is not loaded."
#### Purpose of change

If you try to fire your bow, have sufficient arrow, but is not able to do so due to lack of str etc, you will still try to unload it and get a failure massage "Your %s isn't loaded.".
Now you will not try to unload your bow when it is not loaded.

#### Describe the solution

Check if the RAS weapon is successfully loaded.

#### Describe alternatives you've considered

Not to do this.

#### Testing

Try reloading a longbow with a 8 strength character. 

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
