### PR TITLE
Tweak spawns of hidden lab under retirement home

### DIFF
--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -7096,9 +7096,9 @@
       { "point": [ 3, 3, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 3, 3, 0 ], "terrain": "road", "connection": "local_road", "from": [ 3, 2, 0 ] } ],
-    "city_distance": [ 0, 10 ],
+    "city_distance": [ 0, 20 ],
     "occurrences": [ 5, 100 ],
-    "flags": [ "UNIQUE", "RISK_HIGH", "GENERIC_LOOT", "MAN_MADE" ]
+    "flags": [ "GLOBAL_UNIQUE", "RISK_HIGH", "GENERIC_LOOT", "MAN_MADE" ]
   },
   {
     "type": "overmap_special",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
I've been seeing failures to spawn and I suspect the (arbitrary) distance from spawn parameters are the problem.

#### Describe the solution
Allow it to spawn further from cities.
While I was at it added global uniqueness, there's no reason to have multiple of these. 

#### Describe alternatives you've considered
Increased spawn chance might do it too, but it's already pretty high.

#### Testing
Just need multiple clean runs on the overnap_test

#### Additional context
Most recently seen here https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/8710039326/job/23891043450?pr=73037