### PR TITLE
Separate keybinding to select default ammo

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -2572,6 +2572,13 @@
   },
   {
     "type": "keybinding",
+    "name": "Select default ammo for wielded weapon which do not use a magazine",
+    "category": "DEFAULTMODE",
+    "id": "select_default_ammo",
+    "bindings": [ { "input_method": "keyboard_any", "key": "F3" } ]
+  },
+  {
+    "type": "keybinding",
     "name": "Drop item",
     "category": "DEFAULTMODE",
     "id": "drop",

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -256,6 +256,8 @@ std::string action_ident( action_id act )
             return "cast_spell";
         case ACTION_SELECT_FIRE_MODE:
             return "select_fire_mode";
+        case ACTION_SELECT_DEFAULT_AMMO:
+            return "select_default_ammo";
         case ACTION_UNLOAD_CONTAINER:
             return "unload_container";
         case ACTION_DROP:
@@ -966,6 +968,7 @@ action_id handle_action_menu()
             REGISTER_ACTION( ACTION_RELOAD_WIELDED );
             REGISTER_ACTION( ACTION_CAST_SPELL );
             REGISTER_ACTION( ACTION_SELECT_FIRE_MODE );
+            REGISTER_ACTION( ACTION_SELECT_DEFAULT_AMMO );
             REGISTER_ACTION( ACTION_THROW );
             REGISTER_ACTION( ACTION_FIRE_BURST );
             REGISTER_ACTION( ACTION_PICK_STYLE );

--- a/src/action.h
+++ b/src/action.h
@@ -183,6 +183,8 @@ enum action_id : int {
     ACTION_FIRE_BURST,
     /** Change fire mode of the current weapon */
     ACTION_SELECT_FIRE_MODE,
+    /** Change default ammo for current weapon */
+    ACTION_SELECT_DEFAULT_AMMO,
     /** Cast a spell (only if any spells are known) */
     ACTION_CAST_SPELL,
     /** Open the insert-item menu */

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2526,6 +2526,7 @@ input_context get_default_mode_input_context()
     ctxt.register_action( "cast_spell" );
     ctxt.register_action( "fire_burst" );
     ctxt.register_action( "select_fire_mode" );
+    ctxt.register_action( "select_default_ammo" );
     ctxt.register_action( "drop" );
     ctxt.register_action( "unload_container" );
     ctxt.register_action( "drop_adj" );

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2491,12 +2491,19 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
         }
 
         case ACTION_SELECT_FIRE_MODE:
-            if( weapon ) {
-                if( weapon->is_gun() && !weapon->is_gunmod() &&
-                    weapon->gun_all_modes().size() > 1 ) {
+            if( weapon && weapon->is_gun() && !weapon->is_gunmod() ) {
+                if( weapon->gun_all_modes().size() > 1 ) {
                     weapon->gun_cycle_mode();
-                } else if( weapon->has_flag( flag_RELOAD_ONE ) ||
-                           weapon->has_flag( flag_RELOAD_AND_SHOOT ) ) {
+                } else {
+                    add_msg( m_info, _( "Your %s has only one firing mode." ), weapon->tname() );
+                }
+            }
+            break;
+
+        case ACTION_SELECT_DEFAULT_AMMO:
+            if( weapon && weapon->is_gun() && !weapon->is_gunmod() ) {
+                if( weapon->has_flag( flag_RELOAD_ONE ) ||
+                    weapon->has_flag( flag_RELOAD_AND_SHOOT ) ) {
                     item::reload_option opt = player_character.select_ammo( weapon, false );
                     if( !opt ) {
                         break;


### PR DESCRIPTION
#### Summary
Interface "Separate keybinding to select default ammo for RELOAD_AND_SHOOT/RELOAD_ONE weapon"

#### Purpose of change

When pressing `F` to change firing mode, if the gun has only 1 mode, and it's either RELOAD_AND_SHOOT (slings, bows) or RELOAD_ONE (shotguns, revolvers), the game will instead try to set default ammo for it. 
Same thing happens when pressing reload_item, reload_weapon, or reload_wielded_item, with RELOAD_AND_SHOOT weapon held.

If the shotgun has a second magazine (e.g. Kel-Tec KSG), it has a second firing mode, so the player loses the ability to select default ammo.
If the shotgun has only one magazine and one firing mode, select default ammo for it, then attach an underbarrel gunmod shotgun. Normally, when the main magazine is filled up, you can then reload the underbarrel shotgun, but in this situation you are fobidden to do that, only "Can't reload the %s." is displayed.
Since that default ammo selection fallback from `F` key is disabled at this point, you can no longer reload the underbarrel shotgun, unless the default ammo is used up or dropped, or the gun is dropped once, which manually clears the ammo preferences.

#### Describe the solution

Added a separate keybinding select_default_ammo (default hotkey `F3`) for changing default gun ammo, and removed default ammo selection fallback from `F`.

#### Describe alternatives you've considered

Favorite ammo function works for all guns.

#### Testing

Compiled and tested locally.

#### Additional context
