### PR TITLE
Re-writing ImTui (ImGui curses backend) 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,6 +33,25 @@
             ]
         },
         {
+            "name" : "Linux - X64 - Curses - Release",
+            "makeArgs": [
+                "-j4",
+                "CLANG=1",
+                "CCACHE=1",
+                "NATIVE=linux64", 
+                "RELEASE=1"
+            ]
+        },
+        {
+            "name" : "Linux - X64 - Curses - Debug",
+            "makeArgs": [
+                "-j4", 
+                "CLANG=1",
+                "CCACHE=1", 
+                "NATIVE=linux64"
+            ]
+        },
+        {
             "name" : "Windows - X64 - Tiles/Sound - Release",
             "makeArgs": [
                 "-j4",

--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -35,7 +35,6 @@ struct pairs {
 std::array<RGBTuple, color_loader<RGBTuple>::COLOR_NAMES_COUNT> rgbPalette;
 std::array<pairs, 100> colorpairs;   //storage for pair'ed colored
 
-ImTui::TScreen *imtui_screen = nullptr;
 std::vector<std::pair<int, ImTui::mouse_event>> imtui_events;
 
 cataimgui::client::client()
@@ -44,7 +43,7 @@ cataimgui::client::client()
     IMGUI_CHECKVERSION();
     ImGui::CreateContext();
 
-    imtui_screen = ImTui_ImplNcurses_Init();
+    ImTui_ImplNcurses_Init();
     ImTui_ImplText_Init();
 
     ImGui::GetIO().ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
@@ -73,7 +72,7 @@ void cataimgui::client::end_frame()
 {
     ImGui::Render();
 
-    ImTui_ImplText_RenderDrawData( ImGui::GetDrawData(), imtui_screen );
+    ImTui_ImplText_RenderDrawData( ImGui::GetDrawData() );
     ImTui_ImplNcurses_DrawScreen();
 }
 

--- a/src/third-party/imtui/imtui-impl-ncurses.cpp
+++ b/src/third-party/imtui/imtui-impl-ncurses.cpp
@@ -34,7 +34,19 @@
 #include <string>
 #include <thread>
 
-WINDOW* imtui_win = nullptr;
+// SDL_Renderer data
+struct ImTui_ImplNCurses_Data
+{
+    std::vector<WINDOW*> imtui_wins;
+    ImTui_ImplNCurses_Data() { memset((void*)this, 0, sizeof(*this)); }
+};
+
+// Backend data stored in io.BackendRendererUserData to allow support for multiple Dear ImGui contexts
+// It is STRONGLY preferred that you use docking branch with multi-viewports (== single Dear ImGui context + multiple windows) instead of multiple Dear ImGui contexts.
+static ImTui_ImplNCurses_Data* ImTui_ImplNCurses_GetBackendData()
+{
+    return ImGui::GetCurrentContext() ? (ImTui_ImplNCurses_Data*)ImGui::GetIO().BackendRendererUserData : nullptr;
+}
 
 namespace
 {
@@ -60,17 +72,6 @@ struct VSync {
         auto tNextCur_us = tNext_us + tStep_us;
 
         while( tNow_us < tNextCur_us - 100 ) {
-            if( tNow_us + 0.5 * tStepActive_us < tNextCur_us ) {
-                int ch = wgetch( imtui_win );
-
-                if( ch != ERR ) {
-                    ungetch( ch );
-                    tNextCur_us = tNow_us;
-
-                    return;
-                }
-            }
-
             std::this_thread::sleep_for( std::chrono::microseconds(
                                              std::min( ( uint64_t )( 0.9 * tStepActive_us ),
                                                      ( uint64_t )( 0.9 * ( tNextCur_us - tNow_us ) )
@@ -93,12 +94,14 @@ struct VSync {
 }
 
 static VSync g_vsync;
-static ImTui::TScreen *g_screen = nullptr;
 
-ImTui::TScreen *ImTui_ImplNcurses_Init( float fps_active, float fps_idle )
+void ImTui_ImplNcurses_Init( float fps_active, float fps_idle )
 {
-    if( g_screen == nullptr ) {
-        g_screen = new ImTui::TScreen();
+    if( ImGui::GetCurrentContext()->IO.BackendPlatformUserData == nullptr ) {
+        ImGui::GetCurrentContext()->IO.BackendPlatformUserData = new ImTui::ImplImtui_Data();
+    }
+    if(ImGui::GetIO().BackendRendererUserData == nullptr) {
+        ImGui::GetIO().BackendRendererUserData = new ImTui_ImplNCurses_Data();
     }
 
     if( fps_idle < 0.0 ) {
@@ -107,7 +110,7 @@ ImTui::TScreen *ImTui_ImplNcurses_Init( float fps_active, float fps_idle )
     fps_idle = std::min( fps_active, fps_idle );
     g_vsync = VSync( fps_active, fps_idle );
 
-    imtui_win = newwin(LINES, COLS, 0, 0);
+    //imtui_win = newwin(LINES, COLS, 0, 0);
     ImGui::GetIO().KeyMap[ImGuiKey_Tab]         = 9;
     ImGui::GetIO().KeyMap[ImGuiKey_LeftArrow]   = 260;
     ImGui::GetIO().KeyMap[ImGuiKey_RightArrow]  = 261;
@@ -139,8 +142,6 @@ ImTui::TScreen *ImTui_ImplNcurses_Init( float fps_active, float fps_idle )
 
     getmaxyx( stdscr, screenSizeY, screenSizeX );
     ImGui::GetIO().DisplaySize = ImVec2( screenSizeX, screenSizeY );
-
-    return g_screen;
 }
 
 void ImTui_ImplNcurses_Shutdown()
@@ -148,11 +149,11 @@ void ImTui_ImplNcurses_Shutdown()
     // ref #11 : https://github.com/ggerganov/imtui/issues/11
     printf( "\033[?1003l\n" ); // Disable mouse movement events, as l = low
 
-    if( g_screen ) {
-        delete g_screen;
+    ImTui_ImplNCurses_Data* data = ImTui_ImplNCurses_GetBackendData();
+    if( data ) {
+        delete data;
+        ImGui::GetIO().BackendRendererUserData = nullptr;
     }
-
-    g_screen = nullptr;
 }
 
 bool ImTui_ImplNcurses_NewFrame( std::vector<std::pair<int, ImTui::mouse_event>> key_events )
@@ -284,23 +285,6 @@ static int nActiveFrames = 10;
 static ImTui::TScreen screenPrev;
 static std::array<std::pair<bool, int>, 256 * 256> colPairs;
 
-bool is_in_bounds( int x, int y )
-{
-    ImGuiContext *ctxt = ImGui::GetCurrentContext();
-    // skip the first window, since ImGui seems to always have a "dummy" window that takes up most of the screen
-    for( int index = 1; index < ctxt->Windows.size(); index++ ) {
-        ImGuiWindow *win = ctxt->Windows[index];
-        if(win->Collapsed || !win->Active) {
-            continue;
-        }
-        if( x >= win->Pos.x && x < ( win->Pos.x + win->Size.x )  &&
-            y >= win->Pos.y && y < ( win->Pos.y + win->Size.y ) ) {
-            return true;
-        }
-    }
-    return false;
-}
-
 void ImTui_ImplNcurses_UploadColorPair( short p, short f, short b )
 {
     uint16_t imtui_p = b * 256 + f;
@@ -313,75 +297,84 @@ void ImTui_ImplNcurses_SetAllocedPairCount( short p )
     nColPairs = std::max(nColPairs, p) + 1;
 }
 
+void create_destroy_curses_windows(std::vector<WINDOW*> &windows)
+{
+    size_t cursesWinIdx = 0;
+    int imguiWinIdx = 0;
+    for(; imguiWinIdx < GImGui->Windows.Size; imguiWinIdx++) {
+        ImGuiWindow* imwin = GImGui->Windows[imguiWinIdx];
+        if(imwin->Collapsed || !imwin->Active) {
+            continue;
+        }
+        if(windows.size() <= cursesWinIdx) {
+            windows.push_back(newwin(short(imwin->Size.y), short(imwin->Size.x), short(imwin->Pos.y), short(imwin->Pos.x)));
+        } else {
+            WINDOW* win = windows[cursesWinIdx];
+            
+            if(win->_begx != short(imwin->Pos.x) || win->_begy != short(imwin->Pos.y) || win->_maxx != short(imwin->Size.x) || win->_maxy != imwin->Size.y) {
+                delwin(win);
+                windows[cursesWinIdx] = newwin(short(imwin->Size.y), short(imwin->Size.x), short(imwin->Pos.y), short(imwin->Pos.x));
+            }
+        }
+        cursesWinIdx++;
+    }
+    if(cursesWinIdx < int(windows.size())) {
+        size_t lastIndex = cursesWinIdx;
+        for(; cursesWinIdx < windows.size(); cursesWinIdx++) {
+            if(windows[cursesWinIdx] != nullptr) {
+                delwin(windows[cursesWinIdx]);
+            }
+        }
+        windows.erase(windows.begin() + lastIndex, windows.end());
+    }
+}
+
 void ImTui_ImplNcurses_DrawScreen( bool active )
 {
+    ImTui::ImplImtui_Data* bd = ImTui::ImTui_Impl_GetBackendData();
+    ImTui_ImplNCurses_Data* rd = ImTui_ImplNCurses_GetBackendData();
     if( active ) {
         nActiveFrames = 10;
     }
 
+    ImTui::TScreen& g_screen = bd->Screen;
+    create_destroy_curses_windows(rd->imtui_wins);
+    for(WINDOW *cursesWin : rd->imtui_wins) {
+        int nx = g_screen.nx;
+        int ny = g_screen.ny;
 
-    std::vector<ImRect> window_bounds;
-    for( ImGuiWindow *win : ImGui::GetCurrentContext()->Windows ) {
-        window_bounds.push_back( win->OuterRectClipped );
-    }
-    int nx = g_screen->nx;
-    int ny = g_screen->ny;
+        for( int y = cursesWin->_begy; y <= (cursesWin->_begy + cursesWin->_maxy); ++y ) {
+            constexpr int no_lastp = 0x7FFFFFFF;
+            int lastp = no_lastp;
+            wmove(cursesWin, y - cursesWin->_begy, 0);
+            for( int x = cursesWin->_begx; x <= (cursesWin->_begx +  cursesWin->_maxx); ++x ) {
+                const auto cell = g_screen.data[y * nx + x];
+                const uint16_t f = ( cell & 0x00FF0000 ) >> 16;
+                const uint16_t b = ( cell & 0xFF000000 ) >> 24;
+                const uint16_t p = b * 256 + f;
 
-    bool compare = true;
-
-    if( screenPrev.nx != nx || screenPrev.ny != ny ) {
-        screenPrev.resize( nx, ny );
-        compare = false;
-    }
-
-    int ic = 0;
-    wmove(imtui_win, 0, 0);
-    for( int y = 0; y < ny; ++y ) {
-        bool wmove_needed = true;
-        constexpr int no_lastp = 0x7FFFFFFF;
-        int lastp = no_lastp;
-        for( int x = 0; x < nx; ++x ) {
-            if( !is_in_bounds( x, y ) ) {
-                wmove_needed = true;
-                continue;
-            }
-            const auto cell = g_screen->data[y * nx + x];
-            const uint16_t f = ( cell & 0x00FF0000 ) >> 16;
-            const uint16_t b = ( cell & 0xFF000000 ) >> 24;
-            const uint16_t p = b * 256 + f;
-
-            if( wmove_needed ) {
-                wmove( imtui_win, y, x );
-            }
-            if( lastp != ( int ) p ) {
-                if( colPairs[p].first == false ) {
-                    init_pair( nColPairs, f, b );
-                    colPairs[p].first = true;
-                    colPairs[p].second = nColPairs;
-                    ++nColPairs;
+                if( lastp != ( int ) p ) {
+                    if( colPairs[p].first == false ) {
+                        init_pair( nColPairs, f, b );
+                        colPairs[p].first = true;
+                        colPairs[p].second = nColPairs;
+                        ++nColPairs;
+                    }
+                    wattron( cursesWin, COLOR_PAIR( colPairs[p].second ) );
+                    lastp = p;
                 }
-                wattron( imtui_win, COLOR_PAIR( colPairs[p].second ) );
-                lastp = p;
+
+                const uint16_t c = cell & 0x0000FFFF;
+                waddch( cursesWin, c );
             }
-
-            const uint16_t c = cell & 0x0000FFFF;
-            waddch( imtui_win, c );
+            if( lastp != no_lastp ) {
+                wattroff( cursesWin, COLOR_PAIR( colPairs[lastp].second ) );
+            }
         }
-        if( lastp != no_lastp ) {
-            wattroff( imtui_win, COLOR_PAIR( colPairs[lastp].second ) );
-        }
-
-        if( compare ) {
-            memcpy( screenPrev.data + y * nx, g_screen->data + y * nx, nx * sizeof( ImTui::TCell ) );
-        }
+        
+        wnoutrefresh(cursesWin);
     }
-    wrefresh(imtui_win);
-
-    if( !compare ) {
-        memcpy( screenPrev.data, g_screen->data, nx * ny * sizeof( ImTui::TCell ) );
-    }
-
-    //g_vsync.wait( nActiveFrames -- > 0 );
+    
 }
 
 bool ImTui_ImplNcurses_ProcessEvent()

--- a/src/third-party/imtui/imtui-impl-ncurses.h
+++ b/src/third-party/imtui/imtui-impl-ncurses.h
@@ -21,7 +21,7 @@ struct mouse_event {
 
 // fps_active - specify the redraw rate when the application is active
 // fps_idle - specify the redraw rate when the application is not active
-ImTui::TScreen *ImTui_ImplNcurses_Init( float fps_active = 60.0, float fps_idle = -1.0 );
+void ImTui_ImplNcurses_Init( float fps_active = 60.0, float fps_idle = -1.0 );
 
 void ImTui_ImplNcurses_Shutdown();
 

--- a/src/third-party/imtui/imtui-impl-text.cpp
+++ b/src/third-party/imtui/imtui-impl-text.cpp
@@ -65,10 +65,10 @@ void ScanLine(int x1, int y1, int x2, int y2, int ymax, std::vector<int> & xrang
 
 static std::vector<int> g_xrange;
 
-void drawTriangle(ImVec2 p0, ImVec2 p1, ImVec2 p2, unsigned char col, ImTui::TScreen * screen) {
-    int ymin = std::min(std::min(std::min((float) screen->size(), p0.y), p1.y), p2.y);
+void drawTriangle(ImVec2 p0, ImVec2 p1, ImVec2 p2, unsigned char col, ImTui::TScreen& screen) {
+    int ymin = std::min(std::min(std::min((float) screen.size(), p0.y), p1.y), p2.y);
     int ymax = std::max(std::max(std::max(0.0f, p0.y), p1.y), p2.y);
-
+    
     int ydelta = ymax - ymin + 1;
 
     if ((int) g_xrange.size() < 2*ydelta) {
@@ -90,8 +90,8 @@ void drawTriangle(ImVec2 p0, ImVec2 p1, ImVec2 p2, unsigned char col, ImTui::TSc
             int len = 1 + g_xrange[2*y+1] - g_xrange[2*y+0];
 
             while (len--) {
-                if (x >= 0 && x < screen->nx && y + ymin >= 0 && y + ymin < screen->ny) {
-                    auto & cell = screen->data[(y + ymin)*screen->nx + x];
+                if (x >= 0 && x < screen.nx && y + ymin >= 0 && y + ymin < screen.ny) {
+                    auto & cell = screen.data[(y + ymin)*screen.nx + x];
                     cell &= 0x00FF0000;
                     cell |= ' ';
                     cell |= ((ImTui::TCell)(col) << 24);
@@ -139,7 +139,7 @@ inline ImTui::TColor rgbToAnsi256(ImU32 col, bool doAlpha) {
     return res;
 }
 
-void ImTui_ImplText_RenderDrawData(ImDrawData * drawData, ImTui::TScreen * screen) {
+void ImTui_ImplText_RenderDrawData(ImDrawData * drawData) {
     // Avoid rendering when minimized, scale coordinates for retina displays (screen coordinates != framebuffer coordinates)
     int fb_width = (int)(drawData->DisplaySize.x * drawData->FramebufferScale.x);
     int fb_height = (int)(drawData->DisplaySize.y * drawData->FramebufferScale.y);
@@ -148,18 +148,23 @@ void ImTui_ImplText_RenderDrawData(ImDrawData * drawData, ImTui::TScreen * scree
         return;
     }
 
-    screen->resize(ImGui::GetIO().DisplaySize.x, ImGui::GetIO().DisplaySize.y);
-    screen->clear();
+    ImTui::ImplImtui_Data* bd = ImTui::ImTui_Impl_GetBackendData();
+    if(bd == nullptr) {
+        return;
+    }
+    int displayw = ImGui::GetIO().DisplaySize.x;
+    int displayh = ImGui::GetIO().DisplaySize.y;
 
-    // Will project scissor/clipping rectangles into framebuffer space
-    ImVec2 clip_off = drawData->DisplayPos;         // (0,0) unless using multi-viewports
-    ImVec2 clip_scale = drawData->FramebufferScale; // (1,1) unless using retina display which are often (2,2)
+    ImTui::TScreen &screen = bd->Screen;
+    screen.resize(displayw, displayh);
+    screen.clear();
+    for(int index = 0; index < drawData->CmdListsCount; index++) {
+        const ImDrawList* cmd_list = drawData->CmdLists[index];
 
-    // Render command lists
-    for (int n = 0; n < drawData->CmdListsCount; n++)
-    {
-        const ImDrawList* cmd_list = drawData->CmdLists[n];
-
+        // Will project scissor/clipping rectangles into framebuffer space
+        ImVec2 clip_off = drawData->DisplayPos;         // (0,0) unless using multi-viewports
+        ImVec2 clip_scale = drawData->FramebufferScale; // (1,1) unless using retina display which are often (2,2)
+        //int screen_offset = (screen.clipminy * displayw) + screen.clipminx;
         for (int cmd_i = 0; cmd_i < cmd_list->CmdBuffer.Size; cmd_i++)
         {
             const ImDrawCmd* pcmd = &cmd_list->CmdBuffer[cmd_i];
@@ -224,7 +229,7 @@ void ImTui_ImplText_RenderDrawData(ImDrawData * drawData, ImTui::TScreen * scree
                             int yy = (y) + 0;
                             if (xx < clip_rect.x || xx >= clip_rect.z || yy < clip_rect.y || yy >= clip_rect.w) {
                             } else {
-                                auto & cell = screen->data[yy*screen->nx + xx];
+                                auto & cell = screen.data[yy*screen.nx + xx];
                                 cell &= 0xFF000000;
                                 cell |= (col0 & 0xff000000) >> 24;
                                 cell |= ((ImTui::TCell)(rgbToAnsi256(col0, false)) << 16);
@@ -238,7 +243,6 @@ void ImTui_ImplText_RenderDrawData(ImDrawData * drawData, ImTui::TScreen * scree
             }
         }
     }
-
 }
 
 bool ImTui_ImplText_Init() {
@@ -307,6 +311,11 @@ bool ImTui_ImplText_Init() {
 }
 
 void ImTui_ImplText_Shutdown() {
+    ImTui::ImplImtui_Data* data = ImTui::ImTui_Impl_GetBackendData();
+    if( data ) {
+        delete data;
+        ImGui::GetIO().BackendPlatformUserData = nullptr;
+    }
 }
 
 void ImTui_ImplText_NewFrame() {

--- a/src/third-party/imtui/imtui-impl-text.h
+++ b/src/third-party/imtui/imtui-impl-text.h
@@ -13,4 +13,4 @@ struct TScreen;
 bool ImTui_ImplText_Init();
 void ImTui_ImplText_Shutdown();
 void ImTui_ImplText_NewFrame();
-void ImTui_ImplText_RenderDrawData(ImDrawData * drawData, ImTui::TScreen * screen);
+void ImTui_ImplText_RenderDrawData(ImDrawData * drawData);

--- a/src/third-party/imtui/imtui.h
+++ b/src/third-party/imtui/imtui.h
@@ -9,6 +9,8 @@
 
 #include <cstring>
 #include <cstdint>
+#include <vector>
+#include <string>
 
 namespace ImTui {
 
@@ -28,7 +30,6 @@ struct TScreen {
     int nmax = 0;
 
     TCell * data = nullptr;
-
     ~TScreen() {
         if (data) delete [] data;
     }
@@ -52,5 +53,15 @@ struct TScreen {
         data = new TCell[nmax];
     }
 };
+
+struct ImplImtui_Data
+{
+    TScreen Screen;
+};
+
+static ImplImtui_Data* ImTui_Impl_GetBackendData()
+{
+    return ImGui::GetCurrentContext() ? (ImplImtui_Data*)ImGui::GetIO().BackendPlatformUserData : nullptr;
+}
 
 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "refactored ImTuis drawing code to fix a black screen issue, and to improve performance"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes: #73031 
Fixes: #73392 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
ImTui was using a single ncurses window to draw all its data. this window encompasses the whole screen, which meant that no matter what, when that window was refreshed the first time, the screen would be blacked out.

The new and improved ImTui uses several windows based on the windows ImGui is attempting to draw. This means that ImTui can't overwrite cells on the terminal outside of where a window is meant to be drawn.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
load the game, verify you are not greeted with a black screen. 

~~also verify that any spaces where an ImTui window was drawn are overwritten, as expected, when it is closed.~~ this part got rolled into #73426
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
During my testing I was working a lot with WSL, and found this weird case where, if you build CDDA from a fresh copy with no localization, every time you start the game you get the same black screen bug and you have to press a key to show the language selection. I couldn't reproduce it in Linux so I wrote it off as unrelated.-
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
