### PR TITLE
[DinoMod] skeletal looks_like fix

### DIFF
--- a/data/mods/DinoMod/monsters/zed-dinosaur.json
+++ b/data/mods/DinoMod/monsters/zed-dinosaur.json
@@ -396,6 +396,7 @@
     "type": "MONSTER",
     "id": "mon_zyrannosaurus",
     "name": { "str": "Z-Rex", "str_pl": "Z-Rexes" },
+    "looks_like": "mon_tyrannosaurus",
     "species": [ "ZOMBIE" ],
     "default_faction": "zombie",
     "symbol": "Z",

--- a/data/mods/DinoMod/monsters/zinosaur_upgrade.json
+++ b/data/mods/DinoMod/monsters/zinosaur_upgrade.json
@@ -3042,7 +3042,7 @@
     "type": "MONSTER",
     "id": "mon_silophosaurus",
     "name": { "str_sp": "skeletal dilophosaurus" },
-    "looks_like": "mon_zyrannosaurus",
+    "looks_like": "mon_syrannosaurus",
     "description": "Monstrous columns of dense bone lifting sharp, pointed teeth dripping with black goo.  Two especially bony crests on the top of the head complete the effect.",
     "default_faction": "zombie",
     "symbol": "Z",


### PR DESCRIPTION

#### Summary
Mods "[DinoMod] skeletal looks_like fix"

#### Purpose of change

visual bugfix

#### Describe the solution

Two tiny tweaks to the looks_like chain so that skeletal evolutions have a looks_like trail to skeletal T-Rex and from there to the normal zombie T-Rex. Surfaced by the Falcarius work

#### Describe alternatives you've considered

Roll it into the Falcarius PR

#### Testing

Tiny JSON tweaks

#### Additional context

Part of a larger effort for all of the major tilesets to have some kind of art coverage for all DinoMod monsters, by hook or by crook