### PR TITLE
AIM: when cannot wear, try to wield

### DIFF
--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -678,7 +678,7 @@ int advanced_inventory::print_header( advanced_inventory_pane &pane, aim_locatio
                               data_location == AIM_CONTAINER ? "><" :
                               squares[data_location].can_store_in_vehicle() ||
                               data_location == AIM_PARENT ? "<>" : "[]";
-        bool in_vehicle = pane.in_vehicle() && squares[data_location].id == area && sel == area &&
+        bool in_vehicle = pane.in_vehicle() && data_location == area && sel == area &&
                           area != AIM_ALL;
         bool all_brackets = area == AIM_ALL && ( data_location >= AIM_SOUTHWEST &&
                             data_location <= AIM_NORTHEAST );
@@ -1468,6 +1468,9 @@ void advanced_inventory::start_activity(
         if( destarea == AIM_WORN ) {
             const wear_activity_actor act( target_items, quantities );
             player_character.assign_activity( act );
+        } else if( destarea == AIM_WIELD ) {
+            player_character.assign_activity(
+                wield_activity_actor( target_items.front(), quantities.front() ) );
         } else if( destarea == AIM_INVENTORY ) {
             const std::optional<tripoint> starting_pos = from_vehicle
                     ? std::nullopt
@@ -1572,9 +1575,23 @@ bool advanced_inventory::action_move_item( advanced_inv_listitem *sitem,
     cata_assert( !sitem->items.empty() );
     avatar &player_character = get_avatar();
     if( destarea == AIM_WORN ) {
-        ret_val<void> can_wear = player_character.can_wear( *sitem->items.front().get_item() );
-        if( !can_wear.success() ) {
-            popup_getkey( can_wear.c_str(), PF_GET_KEY );
+        const item &itm = *sitem->items.front().get_item();
+        ret_val<void> can_wear = player_character.can_wear( itm );
+        ret_val<void> can_wield = player_character.can_wield( itm );
+        if( can_wear.success() ) {
+        } else if( can_wield.success() ) {
+            destarea = AIM_WIELD;
+            std::string err = can_wear.c_str();
+            err += "\n";
+            err += _( "Wield instead?" );
+            if( !query_yn( err ) ) {
+                return false;
+            }
+        } else {
+            std::string err = can_wear.c_str();
+            err += "\n";
+            err += can_wield.c_str();
+            popup_getkey( err.c_str(), PF_GET_KEY );
             return false;
         }
     }
@@ -1628,6 +1645,11 @@ bool advanced_inventory::action_move_item( advanced_inv_listitem *sitem,
         // exit so that the activity can be carried out
         exit = true;
 
+    } else if( srcarea == AIM_INVENTORY && destarea == AIM_WIELD ) {
+        do_return_entry();
+        const wield_activity_actor act( sitem->items.front(), amount_to_move );
+        player_character.assign_activity( act );
+        exit = true;
     } else if( srcarea == AIM_INVENTORY ||
                ( srcarea == AIM_WORN && sitem->items.front() != player_character.get_wielded_item() ) ) {
 
@@ -2138,7 +2160,7 @@ bool advanced_inventory::query_charges( aim_location destarea, const advanced_in
 
     // Check volume, this should work the same for inventory, map and vehicles, but not for worn
     const int room_for = it.charges_per_volume( free_volume );
-    if( amount > room_for && squares[destarea].id != AIM_WORN ) {
+    if( amount > room_for && destarea != AIM_WORN && destarea != AIM_WIELD ) {
         if( room_for <= 0 ) {
             if( destarea == AIM_INVENTORY ) {
                 popup_getkey( _( "You have no space for the %s." ), it.tname() );
@@ -2152,6 +2174,7 @@ bool advanced_inventory::query_charges( aim_location destarea, const advanced_in
     // Map and vehicles have a maximal item count, check that. Inventory does not have this.
     if( destarea != AIM_INVENTORY &&
         destarea != AIM_WORN &&
+        destarea != AIM_WIELD &&
         destarea != AIM_CONTAINER ) {
         const int cntmax = p.max_size - p.get_item_count();
         // For items counted by charges, adding it adds 0 items if something there stacks with it.
@@ -2171,7 +2194,7 @@ bool advanced_inventory::query_charges( aim_location destarea, const advanced_in
     }
     Character &player_character = get_player_character();
     // Inventory has a weight capacity, map and vehicle don't have that
-    if( destarea == AIM_INVENTORY  || destarea == AIM_WORN ) {
+    if( destarea == AIM_INVENTORY || destarea == AIM_WORN || destarea == AIM_WIELD ) {
         const units::mass unitweight = it.weight() / ( by_charges ? it.charges : 1 );
         const units::mass max_weight = player_character.weight_capacity() * 4 -
                                        player_character.weight_carried();

--- a/src/advanced_inv.h
+++ b/src/advanced_inv.h
@@ -160,7 +160,7 @@ class advanced_inventory
                                          std::vector<drop_or_stash_item_info> &fav_list, bool forbid_buckets );
 
         // Returns the x coordinate where the header started. The header is
-        // displayed right of it, everything left of it is till free.
+        // displayed right of it, everything left of it is still free.
         int print_header( advanced_inventory_pane &pane, aim_location sel );
         void init();
         /**

--- a/src/advanced_inv_area.h
+++ b/src/advanced_inv_area.h
@@ -27,6 +27,8 @@ enum aim_location : char {
     AIM_PARENT,
     AIM_WORN,
     NUM_AIM_LOCATIONS,
+    // cannot be selected, destination for when wearing item fails but item can be WIELDed
+    AIM_WIELD,
     // only useful for AIM_ALL
     AIM_AROUND_BEGIN = AIM_SOUTHWEST,
     AIM_AROUND_END = AIM_NORTHEAST


### PR DESCRIPTION
#### Summary
Interface "AIM: when cannot wear, try to wield"

#### Purpose of change
Resolve #73121

#### Describe the solution

 - Hack new destination into AIM: AIM_WIELD.
 - It can be accessed only as a destination when the destination is AIM_WEAR and the item cannot be worn but can be wielded.
 - Once one item is moved there, AIM_WIELD is not a selected destination anymore. (I believe).

#### Describe alternatives you've considered
Make it a proper selectable destination. More code, less hacky ( => less bugs?), more things in AIM.

#### Testing

~More testing should be done.~ Current testing is sufficient.

- I moved things to and from WORN.
- Before I finished, items sometimes disappeared, I only hope it is impossible now. **edit**: `source == dest` would probably need to be true for them to disappear (according to .h file)
- ~in `action_move_item` `squares[destarea]` is sometimes accessed. I think it should be undefined behaviour when `destarea = AIM_WIELD`, but didn't test it.~ Removed occurrences by refactoring
- ~bug: having no space to store and wearing a mattress asks to wield the mattress instead then fails with "Destination area is full.  Remove some items first." It probably considers the free volume of the inventory. It shouldn't, it should wield the mattress.~ Fixed.

#### Additional context

Demonstrating better flow of Wearing / Wielding:

https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/26a1eeed-5ae6-4c5d-a901-fba45b79e56d

