### PR TITLE
Add foraging activity to outpost faction camp

### DIFF
--- a/data/json/recipes/basecamps/base/fbmc_outpost/recipe_modular_outpost_cross.json
+++ b/data/json/recipes/basecamps/base/fbmc_outpost/recipe_modular_outpost_cross.json
@@ -15,6 +15,7 @@
       { "id": "tool_storage" },
       { "id": "gathering" },
       { "id": "firewood" },
+      { "id": "foraging" },
       { "id": "sorting" },
       { "id": "logging" },
       { "id": "kitchen" },

--- a/data/json/recipes/basecamps/base/fbmc_outpost/recipe_modular_outpost_cross.json
+++ b/data/json/recipes/basecamps/base/fbmc_outpost/recipe_modular_outpost_cross.json
@@ -15,7 +15,7 @@
       { "id": "tool_storage" },
       { "id": "gathering" },
       { "id": "firewood" },
-      { "id": "foraging" },
+      { "id": "foraging" }
       { "id": "sorting" },
       { "id": "logging" },
       { "id": "kitchen" },

--- a/data/json/recipes/basecamps/base/fbmc_outpost/recipe_modular_outpost_cross.json
+++ b/data/json/recipes/basecamps/base/fbmc_outpost/recipe_modular_outpost_cross.json
@@ -15,7 +15,7 @@
       { "id": "tool_storage" },
       { "id": "gathering" },
       { "id": "firewood" },
-      { "id": "foraging" }
+      { "id": "foraging" },
       { "id": "sorting" },
       { "id": "logging" },
       { "id": "kitchen" },

--- a/data/json/recipes/basecamps/base/fbmc_outpost/recipe_modular_outpost_normal.json
+++ b/data/json/recipes/basecamps/base/fbmc_outpost/recipe_modular_outpost_normal.json
@@ -15,6 +15,7 @@
       { "id": "tool_storage" },
       { "id": "gathering" },
       { "id": "firewood" },
+      { "id": "foraging" },
       { "id": "sorting" },
       { "id": "logging" },
       { "id": "kitchen" },


### PR DESCRIPTION
#### Summary
Bugfixes "Add foraging activity to outpost faction camp"

#### Purpose of change

The Military Outpost faction camp was missing the `foraging` activity that is present in most other faction camp types, I believe this was an oversight rather than an intentional decision.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Adds the `foraging` activity. This will only affect newly built outpost faction camps, existing ones will remain without the activity. I could not see a way to migrate faction camp changes in existing saves.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Built an outpost camp with fix applied, sent an NPC off to forage.

#### Additional context
