### PR TITLE
display fridge is a base item of a display fridge

### DIFF
--- a/data/json/furniture_and_terrain/appliances_refrigeration.json
+++ b/data/json/furniture_and_terrain/appliances_refrigeration.json
@@ -147,7 +147,7 @@
     "//2": "Rated 137 kwh on average, but since you use it, and it's upright, 1.5x as much",
     "epower": "-205 W",
     "size": "600 L",
-    "item": "heavy_duty_fridge",
+    "item": "display_fridge",
     "requirements": {
       "removal": { "time": "2 m" },
       "repair": {


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fix #73194
#### Describe the solution
Make display fridge a base item for display fridge appliance