### PR TITLE
Shrink jmapgen int

### DIFF
--- a/data/json/mapgen/gas_stations/gas_station_bunker.json
+++ b/data/json/mapgen/gas_stations/gas_station_bunker.json
@@ -183,7 +183,7 @@
         { "group": "road", "chance": 60, "repeat": 10, "x": [ 1, 22 ], "y": [ 4, 22 ] }
       ],
       "toilets": { "T": {  } },
-      "gaspumps": { "!": { "amount": [ 2500, 12500 ], "fuel": "gasoline" }, "?": { "amount": [ 2500, 12500 ], "fuel": "diesel" } },
+      "gaspumps": { "!": { "amount": [ 25, 125 ], "fuel": "gasoline" }, "?": { "amount": [ 25, 125 ], "fuel": "diesel" } },
       "vehicles": { "v": { "vehicle": "parking_garage", "chance": 40, "rotation": 90 } },
       "place_nested": [ { "chunks": [ "s_gas_g1_bunker_below" ], "x": 15, "y": 42, "neighbors": { "below": "s_gas_b11" } } ]
     }

--- a/data/json/mapgen/helipad.json
+++ b/data/json/mapgen/helipad.json
@@ -58,7 +58,7 @@
       ],
       "palettes": [ "helipad_palette" ],
       "toilets": { "&": {  } },
-      "gaspumps": { "$": { "fuel": "jp8", "amount": [ 200000, 1000000 ] } },
+      "gaspumps": { "$": { "fuel": "jp8", "amount": [ 2000, 10000 ] } },
       "items": {
         "B": {
           "item": {

--- a/data/json/mapgen/lumbermill.json
+++ b/data/json/mapgen/lumbermill.json
@@ -56,7 +56,7 @@
         "vvvvvvvvvv____vvvvvvvvvvvvvvvvvvvv____vvvvvvvvvv"
       ],
       "palettes": [ "lumberyard" ],
-      "gaspumps": { "G": { "fuel": "gasoline", "amount": [ 50000, 268750 ] } },
+      "gaspumps": { "G": { "fuel": "gasoline", "amount": [ 500, 2687 ] } },
       "place_vehicles": [
         { "vehicle": "flatbed_truck", "x": [ 43, 45 ], "y": 33, "chance": 30, "rotation": 90 },
         { "vehicle": "pickup", "x": [ 35, 37 ], "y": [ 28, 31 ], "chance": 30, "rotation": 90 },

--- a/data/json/mapgen/map_extras/airdrop_mil.json
+++ b/data/json/mapgen/map_extras/airdrop_mil.json
@@ -51,8 +51,8 @@
       "place_furniture": [ { "furn": "f_432gal_drum_rubber", "x": 0, "y": 0 }, { "furn": "f_432gal_drum_rubber", "x": 1, "y": 1 } ],
       "place_item": [ { "item": "parachute_mil", "x": [ 0, 1 ], "y": 1 }, { "item": "parachute_mil", "x": 1, "y": [ 0, 1 ] } ],
       "place_liquids": [
-        { "liquid": "gasoline", "x": 0, "y": 0, "amount": [ 900000, 1000000 ] },
-        { "liquid": "gasoline", "x": 1, "y": 1, "amount": [ 900000, 1000000 ] }
+        { "liquid": "gasoline", "x": 0, "y": 0, "amount": [ 9000, 10000 ] },
+        { "liquid": "gasoline", "x": 1, "y": 1, "amount": [ 9000, 10000 ] }
       ]
     }
   },
@@ -64,8 +64,8 @@
       "mapgensize": [ 2, 2 ],
       "place_furniture": [ { "furn": "f_432gal_drum_rubber", "x": 0, "y": 0 }, { "furn": "f_432gal_drum_rubber", "x": 1, "y": 1 } ],
       "place_liquids": [
-        { "liquid": "diesel", "x": 0, "y": 0, "amount": [ 900000, 1000000 ] },
-        { "liquid": "diesel", "x": 1, "y": 1, "amount": [ 900000, 1000000 ] }
+        { "liquid": "diesel", "x": 0, "y": 0, "amount": [ 9000, 10000 ] },
+        { "liquid": "diesel", "x": 1, "y": 1, "amount": [ 9000, 10000 ] }
       ],
       "place_item": [ { "item": "parachute_mil", "x": [ 0, 1 ], "y": 1 }, { "item": "parachute_mil", "x": 1, "y": [ 0, 1 ] } ]
     }
@@ -79,8 +79,8 @@
       "place_furniture": [ { "furn": "f_432gal_drum_rubber", "x": 0, "y": 0 }, { "furn": "f_432gal_drum_rubber", "x": 1, "y": 1 } ],
       "place_item": [ { "item": "parachute_mil", "x": [ 0, 1 ], "y": 1 }, { "item": "parachute_mil", "x": 1, "y": [ 0, 1 ] } ],
       "place_liquids": [
-        { "liquid": "jp8", "x": 0, "y": 0, "amount": [ 900000, 1000000 ] },
-        { "liquid": "jp8", "x": 1, "y": 1, "amount": [ 900000, 1000000 ] }
+        { "liquid": "jp8", "x": 0, "y": 0, "amount": [ 9000, 10000 ] },
+        { "liquid": "jp8", "x": 1, "y": 1, "amount": [ 9000, 10000 ] }
       ]
     }
   },

--- a/data/json/mapgen/military/mil_base/mil_base_z0.json
+++ b/data/json/mapgen/military/mil_base/mil_base_z0.json
@@ -1144,7 +1144,7 @@
         "W": [ { "item": "mil_base_iv", "chance": 70 } ],
         "^": [ { "item": "mil_base_iv", "chance": 70 } ]
       },
-      "gaspumps": { "p": { "fuel": "jp8", "amount": [ 200000, 1000000 ] } },
+      "gaspumps": { "p": { "fuel": "jp8", "amount": [ 2000, 10000 ] } },
       "place_loot": [
         { "group": "mil_base_hmg", "x": 65, "y": 46, "chance": 10, "magazine": 100 },
         { "group": "SUS_janitors_closet", "x": 22, "y": 26, "chance": 90, "repeat": [ 1, 2 ] },

--- a/data/json/mapgen/mine/mine_entrance.json
+++ b/data/json/mapgen/mine/mine_entrance.json
@@ -156,7 +156,7 @@
         }
       },
       "place_monster": [ { "monster": "mon_feral_human_archaeologist", "chance": 13, "repeat": [ 1, 2 ], "x": [ 4, 7 ], "y": [ 5, 8 ] } ],
-      "gaspumps": { "@": { "fuel": "gasoline", "amount": [ 10000, 50000 ] }, "$": { "fuel": "diesel", "amount": [ 10000, 50000 ] } },
+      "gaspumps": { "@": { "fuel": "gasoline", "amount": [ 100, 500 ] }, "$": { "fuel": "diesel", "amount": [ 100, 500 ] } },
       "vehicles": { "Ø": { "vehicle": "tatra_truck", "chance": 50, "fuel": 40 } },
       "nested": { "`": { "chunks": [ [ "mechanical_fluid", 10 ], [ "gasoline_diesel_motor_oil", 80 ], [ "null", 80 ] ] } },
       "liquids": { "W": { "liquid": "water_clean", "amount": [ 0, 80 ] } }

--- a/data/json/mapgen/occupied_lumber_mill/occupied_lumber_mill.json
+++ b/data/json/mapgen/occupied_lumber_mill/occupied_lumber_mill.json
@@ -87,7 +87,7 @@
         { "type": "LOOT_CURRENCY", "faction": "wasteland_scavengers", "x": [ 26, 26 ], "y": [ 43, 43 ] },
         { "type": "LOOT_WOOD", "faction": "wasteland_scavengers", "x": [ 26, 26 ], "y": [ 44, 44 ] }
       ],
-      "gaspumps": { "G": { "fuel": "gasoline", "amount": [ 50000, 268750 ] } },
+      "gaspumps": { "G": { "fuel": "gasoline", "amount": [ 500, 2687 ] } },
       "place_vehicles": [
         { "vehicle": "flatbed_truck", "x": [ 43, 45 ], "y": 33, "chance": 30, "fuel": 25, "status": 0, "rotation": 90 },
         {

--- a/data/mods/No_Hope/Mapgen/garage_gas.json
+++ b/data/mods/No_Hope/Mapgen/garage_gas.json
@@ -70,7 +70,7 @@
         "z": "f_crate_c",
         "S": "f_sink"
       },
-      "gaspumps": { "&": { "amount": [ 0, 100 ] } },
+      "gaspumps": { "&": { "amount": [ 0, 1 ] } },
       "toilets": { "t": {  } },
       "place_vendingmachines": [
         { "item_group": "vending_food", "x": 31, "y": 6, "lootable": true },

--- a/data/mods/No_Hope/Mapgen/helipad.json
+++ b/data/mods/No_Hope/Mapgen/helipad.json
@@ -58,7 +58,7 @@
       ],
       "palettes": [ "helipad_palette" ],
       "toilets": { "&": {  } },
-      "gaspumps": { "$": { "fuel": "jp8", "amount": [ 0, 100 ] } },
+      "gaspumps": { "$": { "fuel": "jp8", "amount": [ 0, 1 ] } },
       "items": {
         "B": {
           "item": {

--- a/data/mods/No_Hope/Mapgen/lumbermill.json
+++ b/data/mods/No_Hope/Mapgen/lumbermill.json
@@ -57,7 +57,7 @@
         "vvvvvvvvvv____vvvvvvvvvvvvvvvvvvvv____vvvvvvvvvv"
       ],
       "palettes": [ "lumberyard" ],
-      "gaspumps": { "G": { "fuel": "gasoline", "amount": [ 0, 5000 ] } },
+      "gaspumps": { "G": { "fuel": "gasoline", "amount": [ 0, 50 ] } },
       "place_vehicles": [
         { "vehicle": "flatbed_truck", "x": [ 43, 45 ], "y": 33, "chance": 30, "rotation": 90 },
         { "vehicle": "pickup", "x": [ 35, 37 ], "y": [ 28, 31 ], "chance": 30, "rotation": 90 },

--- a/data/mods/No_Hope/Mapgen/mil_base_z0.json
+++ b/data/mods/No_Hope/Mapgen/mil_base_z0.json
@@ -1130,7 +1130,7 @@
         "W": [ { "item": "mil_base_iv", "chance": 70 } ],
         "^": [ { "item": "mil_base_iv", "chance": 70 } ]
       },
-      "gaspumps": { "p": { "fuel": "jp8", "amount": [ 800, 4000 ] } },
+      "gaspumps": { "p": { "fuel": "jp8", "amount": [ 8, 40 ] } },
       "place_loot": [
         { "group": "mil_base_hmg", "x": 65, "y": 46, "chance": 10, "magazine": 100 },
         { "group": "SUS_janitors_closet", "x": 22, "y": 26, "chance": 90, "repeat": [ 1, 2 ] },

--- a/data/mods/No_Hope/Mapgen/mine_entrance.json
+++ b/data/mods/No_Hope/Mapgen/mine_entrance.json
@@ -155,7 +155,7 @@
           "failures": [ { "action": "alarm" } ]
         }
       },
-      "gaspumps": { "@": { "fuel": "gasoline", "amount": [ 0, 5000 ] }, "$": { "fuel": "diesel", "amount": [ 0, 5000 ] } },
+      "gaspumps": { "@": { "fuel": "gasoline", "amount": [ 0, 50 ] }, "$": { "fuel": "diesel", "amount": [ 0, 50 ] } },
       "vehicles": { "Ø": { "vehicle": "tatra_truck", "chance": 50, "fuel": 0, "status": 1 } },
       "nested": { "`": { "chunks": [ [ "mechanical_fluid", 10 ], [ "gasoline_diesel_motor_oil", 80 ], [ "null", 80 ] ] } },
       "liquids": { "W": { "liquid": "water_clean", "amount": [ 0, 80 ] } }

--- a/data/mods/No_Hope/Mapgen/necropolis.json
+++ b/data/mods/No_Hope/Mapgen/necropolis.json
@@ -1215,7 +1215,7 @@
       ],
       "palettes": [ "necropolis_a" ],
       "terrain": { "Z": "t_floor", "l": "t_floor", "u": "t_floor", "z": "t_floor" },
-      "gaspumps": { "&": { "amount": [ 0, 100 ] } },
+      "gaspumps": { "&": { "amount": [ 0, 1 ] } },
       "place_monsters": [
         { "monster": "GROUP_NECROPOLIS", "x": [ 1, 22 ], "y": [ 1, 22 ], "density": 0.1 },
         { "monster": "GROUP_NECROPOLIS", "x": [ 25, 46 ], "y": [ 1, 22 ], "density": 0.1 },

--- a/data/mods/No_Hope/Mapgen/regional_airport.json
+++ b/data/mods/No_Hope/Mapgen/regional_airport.json
@@ -35,7 +35,7 @@
       "palettes": [ "airport_palette" ],
       "place_furniture": [ { "furn": "f_gas_tank", "x": 4, "y": 10 } ],
       "place_liquids": [ { "liquid": "avgas", "x": 4, "y": 10, "repeat": [ 0, 100 ] } ],
-      "gaspumps": { "J": { "fuel": "avgas", "amount": [ 0, 100 ] } },
+      "gaspumps": { "J": { "fuel": "avgas", "amount": [ 0, 1 ] } },
       "place_monster": [ { "group": "GROUP_SMALL_STATION", "x": [ 4, 19 ], "y": [ 4, 19 ], "chance": 75, "repeat": [ 1, 4 ] } ],
       "place_loot": [
         { "group": "supplies_electronics", "x": 6, "y": [ 4, 6 ], "chance": 5, "repeat": [ 1, 3 ] },

--- a/data/mods/No_Hope/Mapgen/s_airport_private.json
+++ b/data/mods/No_Hope/Mapgen/s_airport_private.json
@@ -90,7 +90,7 @@
         "t": "f_locker",
         "u": "f_indoor_plant"
       },
-      "gaspumps": { "1": { "amount": [ 0, 100 ] } },
+      "gaspumps": { "1": { "amount": [ 0, 1 ] } },
       "place_loot": [
         { "group": "road", "chance": 50, "repeat": 4, "x": [ 1, 22 ], "y": [ 1, 19 ] },
         { "group": "allclothes", "chance": 5, "repeat": [ 10 ], "x": 29, "y": [ 5, 6 ] },

--- a/data/mods/No_Hope/Mapgen/s_gas.json
+++ b/data/mods/No_Hope/Mapgen/s_gas.json
@@ -42,7 +42,7 @@
         "s": "t_little_column",
         "|": "t_chainfence_v"
       },
-      "gaspumps": { "G": { "fuel": "gasoline", "amount": [ 0, 5000 ] }, "D": { "fuel": "diesel", "amount": [ 0, 5000 ] } },
+      "gaspumps": { "G": { "fuel": "gasoline", "amount": [ 0, 50 ] }, "D": { "fuel": "diesel", "amount": [ 0, 50 ] } },
       "furniture": { "9": "f_aut_gas_console" },
       "signs": { "P": { "signage": "Danger!  Do not smoke!  Risk of explosion!" } },
       "vendingmachines": { "1": { "item_group": "vending_drink", "lootable": true }, "2": { "item_group": "vending_food", "lootable": true } },
@@ -212,7 +212,7 @@
         "R": "f_shower"
       },
       "toilets": { ";": {  } },
-      "gaspumps": { "G": { "fuel": "gasoline", "amount": [ 0, 5000 ] }, "D": { "fuel": "diesel", "amount": [ 0, 5000 ] } },
+      "gaspumps": { "G": { "fuel": "gasoline", "amount": [ 0, 50 ] }, "D": { "fuel": "diesel", "amount": [ 0, 50 ] } },
       "place_items": [
         { "item": "bed", "x": [ 2, 3 ], "y": [ 19, 20 ], "chance": 80 },
         { "item": "dresser", "x": 2, "y": 21, "chance": 5 },

--- a/doc/MAPGEN.md
+++ b/doc/MAPGEN.md
@@ -879,7 +879,7 @@ Places a gas pump with fuel in it.
 
 | Field  | Description
 | ---    | ---
-| amount | (optional, integer or min/max array) the amount of fuel to be placed in the pump. If not specified, the amount is randomized between 10'000 and 50'000.
+| amount | (optional, integer or min/max array) the amount of fuel to be placed in the pump (multiplied by 100). If not specified, the amount is randomized between 10'000 and 50'000.
 | fuel   | (optional, string: "gasoline", "diesel", "jp8", or "avgas") the type of fuel to be placed in the pump. If not specified, the fuel is gasoline (75% chance) or diesel (25% chance).
 
 

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -872,7 +872,11 @@ mapgen_function_json_nested::mapgen_function_json_nested(
 {
 }
 
-jmapgen_int::jmapgen_int( point p ) : val( p.x ), valmax( p.y ) {}
+jmapgen_int::jmapgen_int( point p ) : val( p.x ), valmax( p.y )
+{
+    cata_assert( p.x <= std::numeric_limits<int16_t>::max() );
+    cata_assert( p.y <= std::numeric_limits<int16_t>::max() );
+}
 
 jmapgen_int::jmapgen_int( const JsonObject &jo, const std::string_view tag )
 {
@@ -881,9 +885,17 @@ jmapgen_int::jmapgen_int( const JsonObject &jo, const std::string_view tag )
         if( sparray.empty() || sparray.size() > 2 ) {
             jo.throw_error_at( tag, "invalid data: must be an array of 1 or 2 values" );
         }
-        val = sparray.get_int( 0 );
+        int tmpval = sparray.get_int( 0 );
+        if( tmpval >= std::numeric_limits<int16_t>::max() ) {
+            jo.throw_error_at( tag, string_format( "Value %d too large", tmpval ) );
+        }
+        val = tmpval;
         if( sparray.size() == 2 ) {
-            valmax = sparray.get_int( 1 );
+            int tmpvalmax = sparray.get_int( 1 );
+            if( tmpvalmax >= std::numeric_limits<int16_t>::max() ) {
+                jo.throw_error_at( tag, string_format( "Value %d too large", tmpvalmax ) );
+            }
+            valmax = tmpvalmax;
         } else {
             valmax = val;
         }
@@ -903,13 +915,25 @@ jmapgen_int::jmapgen_int( const JsonObject &jo, const std::string_view tag, cons
             jo.throw_error_at( tag, "invalid data: must be an array of 1 or 2 values" );
         }
         if( !sparray.empty() ) {
-            val = sparray.get_int( 0 );
+            int tmpval = sparray.get_int( 0 );
+            if( tmpval >= std::numeric_limits<int16_t>::max() ) {
+                jo.throw_error_at( tag, string_format( "Value %d too large", tmpval ) );
+            }
+            val = tmpval;
         }
         if( sparray.size() >= 2 ) {
-            valmax = sparray.get_int( 1 );
+            int tmpvalmax = sparray.get_int( 1 );
+            if( tmpvalmax >= std::numeric_limits<int16_t>::max() ) {
+                jo.throw_error_at( tag, string_format( "Value %d too large", tmpvalmax ) );
+            }
+            valmax = tmpvalmax;
         }
     } else if( jo.has_member( tag ) ) {
-        val = valmax = jo.get_int( tag );
+        int tmpval = jo.get_int( tag );
+        if( tmpval >= std::numeric_limits<int16_t>::max() ) {
+            jo.throw_error_at( tag, string_format( "Value %d too large", tmpval ) );
+        }
+        val = valmax = tmpval;
     }
 }
 
@@ -2122,7 +2146,7 @@ class jmapgen_gaspump : public jmapgen_piece
         void apply( const mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y,
                     const std::string &/*context*/ ) const override {
             const point r( x.get(), y.get() );
-            int charges = amount.get();
+            int charges = amount.get() * 100;
             dat.m.furn_set( r, furn_str_id::NULL_ID() );
             if( charges == 0 ) {
                 charges = rng( 10000, 50000 );
@@ -2173,6 +2197,12 @@ class jmapgen_liquid_item : public jmapgen_piece
                         newliquid.charges = amount.get();
                     } else {
                         newliquid.charges = amount.val;
+                    }
+                    if( migrated == itype_gasoline ||
+                        migrated == itype_avgas ||
+                        migrated == itype_diesel ||
+                        migrated == itype_jp8 ) {
+                        newliquid.charges *= 100;
                     }
                 }
                 if( newliquid.charges > 0 ) {
@@ -4748,6 +4778,7 @@ std::unordered_set<point> nested_mapgen::all_placement_coords() const
 void jmapgen_objects::finalize()
 {
     std::stable_sort( objects.begin(), objects.end(), compare_phases );
+    objects.shrink_to_fit();
 }
 
 void jmapgen_objects::check( const std::string &context, const mapgen_parameters &parameters ) const

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -79,10 +79,15 @@ class mapgen_function_builtin : public virtual mapgen_function
  * Actually a pair of integers that can rng, for numbers that will never exceed INT_MAX
  */
 struct jmapgen_int {
-    int val;
-    int valmax;
-    explicit jmapgen_int( int v ) : val( v ), valmax( v ) {}
-    jmapgen_int( int v, int v2 ) : val( v ), valmax( v2 ) {}
+    int16_t val;
+    int16_t valmax;
+    explicit jmapgen_int( int v ) : val( v ), valmax( v ) {
+        cata_assert( v <= std::numeric_limits<int16_t>::max() );
+    }
+    jmapgen_int( int v, int v2 ) : val( v ), valmax( v2 ) {
+        cata_assert( v <= std::numeric_limits<int16_t>::max() );
+        cata_assert( v2 <= std::numeric_limits<int16_t>::max() );
+    }
     explicit jmapgen_int( point p );
     /**
      * Throws as usually if the json is invalid or missing.


### PR DESCRIPTION
#### Summary
Performance "Decrease memory overhead by about 200MB or about 15% by slimming down mapgen data structure."

#### Purpose of change
As I outlined in #50344 I noticed a jmapgen data structure was consuming a large proportion of our RAM.

#### Describe the solution
Cut the ints used by the jmapgen_int data structure to store coordinates and amounts to half size to reduce memory utilization.
Added some validation of inputs to make sure we don't run into errors around truncation or overflow.
Adjusted place item and gaspumps mapgen handlers to scale gasoline and friends up to avoid overflow.

#### Describe alternatives you've considered
It's possible to eke out a bit more benefit by having some special handling in jmapgen_place in order to be even more conservative about how much data we use per entry, I think I might be able to get it down from the 12 bytes per entry achieved by this PR to maybe 8 bytes per entry, for an additional savings of ~50MB or so.
I'm skeptical of chasing down though, it's more likely that going after one of these other bands of allocation will get faster and more robust results.

#### Testing
Ran tests, ran around in game a bit.
Ran `valgrind --tool massif ./cata_test` to validate heap shrinkage. I left it running overnight, you can get faster results by just running one or two tests instead of the whole suite since all we're doing is checking allocations that happen at startup. I still recommend running a few tests though because massif is snapshot based and it might not catch all the startup allocation if it exits before running any tests.

#### Additional context
Here's the "after" massif report. The yellow band is jmapgen_place overhead, which now peaks at 157.4MiB, which is where I expect it to be after this adjustment. This is a different tool than I used to visualize the heap in #50344 but everything lines up.
![Screenshot from 2024-04-24 09-36-03](https://github.com/CleverRaven/Cataclysm-DDA/assets/860276/81744b3a-531f-4a15-bfc0-a68b76f05595)
This was generate as above with `valgrind --tool massif tests/cata_test` then visualized with `massif-visualizer massif.out.<pid>`
It is intentional that #50344 will still be open after this lands, it's still the single largest source of persistent RAM utilization.