### PR TITLE
Implemented scaffolding + doc

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -9129,26 +9129,7 @@
   },
   {
     "type": "construction",
-    "id": "constr_scaffolding_pipe_base",
-    "group": "build_scaffolding",
-    "category": "CONSTRUCT",
-    "required_skills": [ [ "fabrication", 3 ] ],
-    "time": "10 m",
-    "qualities": [ [ { "id": "WRENCH", "level": 1 } ] ],
-    "components": [
-      [ [ "pipe", 46 ] ],
-      [ [ "pipe_fittings", 55 ] ],
-      [ [ "2x4", 4 ], [ "wood_panel", 1 ] ],
-      [ [ "stick", 2 ] ],
-      [ [ "rope_natural", 2, "LIST" ] ]
-    ],
-    "pre_note": "Must be supported from directly below.",
-    "pre_special": [ "check_empty", "check_single_support" ],
-    "post_terrain": "t_scaffolding_pipe_base"
-  },
-  {
-    "type": "construction",
-    "id": "constr_scaffolding_pipe_down_above",
+    "id": "constr_scaffolding_pipe_up",
     "group": "build_scaffolding",
     "category": "CONSTRUCT",
     "required_skills": [ [ "fabrication", 3 ] ],
@@ -9161,10 +9142,9 @@
       [ [ "stick", 2 ] ],
       [ [ "rope_natural", 2, "LIST" ] ]
     ],
-    "pre_note": "Constructs down scaffolding directly above the target up tile.",
-    "pre_terrain": "t_scaffolding_pipe_base",
-    "pre_special": [ "check_up_OK", "check_nofloor_above" ],
-    "post_special": "add_matching_down_above",
+    "pre_note": "Constructs scaffolding on the tile and provides a platform on the Z level above.",
+    "pre_special": [ "check_empty", "check_single_support", "check_up_OK", "check_nofloor_above" ],
+    "post_special": "add_roof",
     "post_terrain": "t_scaffolding_pipe_up"
   },
   {
@@ -9182,7 +9162,7 @@
       [ [ "stick", 2 ] ],
       [ [ "rope_natural", 2, "LIST" ] ]
     ],
-    "pre_note": "Must have scaffolding below.",
+    "pre_note": "Builds another scaffolding level.",
     "pre_terrain": "t_scaffolding_pipe_down",
     "pre_special": [ "check_up_OK", "check_nofloor_above" ],
     "post_terrain": "t_scaffolding_pipe_updown",
@@ -9190,36 +9170,17 @@
   },
   {
     "type": "construction",
-    "id": "remove_scaffolding_pipe_base",
+    "id": "remove_scaffolding_pipe_up",
     "group": "remove_scaffolding",
     "category": "CONSTRUCT",
     "required_skills": [ [ "fabrication", 3 ] ],
     "time": "30 m",
     "qualities": [ [ { "id": "WRENCH", "level": 1 } ] ],
-    "pre_note": "Removes scaffolding from the targeted tile.",
-    "pre_terrain": "t_scaffolding_pipe_base",
-    "post_terrain": "t_dirt",
-    "byproducts": [
-      { "item": "pipe", "count": 46 },
-      { "item": "pipe_fittings", "count": 55 },
-      { "item": "2x4", "count": 4 },
-      { "item": "stick", "count": 2 },
-      { "item": "rope_30", "count": 2 }
-    ]
-  },
-  {
-    "type": "construction",
-    "id": "remove_scaffolding_pipe_down_above",
-    "group": "remove_scaffolding",
-    "category": "CONSTRUCT",
-    "required_skills": [ [ "fabrication", 3 ] ],
-    "time": "30 m",
-    "qualities": [ [ { "id": "WRENCH", "level": 1 } ] ],
-    "pre_note": "Removes down scaffolding from directly above the construction tile.",
+    "pre_note": "Removes scaffolding.",
     "pre_terrain": "t_scaffolding_pipe_up",
     "pre_special": "check_matching_down_above",
     "post_special": "remove_above",
-    "post_terrain": "t_scaffolding_pipe_base",
+    "post_terrain": "t_dirt",
     "byproducts": [
       { "item": "pipe", "count": 46 },
       { "item": "pipe_fittings", "count": 55 },

--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -9134,8 +9134,14 @@
     "category": "CONSTRUCT",
     "required_skills": [ [ "fabrication", 3 ] ],
     "time": "10 m",
-    "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ], [ { "id": "WRENCH", "level": 1 } ] ],
-    "components": [ [ [ "pipe", 64 ] ], [ [ "pipe_fittings", 64 ] ], [ [ "2x4", 10 ] ], [ [ "nails", 20, "LIST" ] ] ],
+    "qualities": [ [ { "id": "WRENCH", "level": 1 } ] ],
+    "components": [
+      [ [ "pipe", 46 ] ],
+      [ [ "pipe_fittings", 55 ] ],
+      [ [ "2x4", 4 ], [ "wood_panel", 1 ] ],
+      [ [ "stick", 2 ] ],
+      [ [ "rope_natural", 2, "LIST" ] ]
+    ],
     "pre_note": "Must be supported from directly below.",
     "pre_special": [ "check_empty", "check_single_support" ],
     "post_terrain": "t_scaffolding_pipe_base"
@@ -9147,8 +9153,14 @@
     "category": "CONSTRUCT",
     "required_skills": [ [ "fabrication", 3 ] ],
     "time": "30 m",
-    "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ], [ { "id": "WRENCH", "level": 1 } ] ],
-    "components": [ [ [ "pipe", 64 ] ], [ [ "pipe_fittings", 64 ] ], [ [ "2x4", 10 ] ], [ [ "nails", 20, "LIST" ] ] ],
+    "qualities": [ [ { "id": "WRENCH", "level": 1 } ] ],
+    "components": [
+      [ [ "pipe", 46 ] ],
+      [ [ "pipe_fittings", 55 ] ],
+      [ [ "2x4", 4 ], [ "wood_panel", 1 ] ],
+      [ [ "stick", 2 ] ],
+      [ [ "rope_natural", 2, "LIST" ] ]
+    ],
     "pre_note": "Constructs down scaffolding directly above the target up tile.",
     "pre_terrain": "t_scaffolding_pipe_base",
     "pre_special": [ "check_up_OK", "check_nofloor_above" ],
@@ -9162,8 +9174,14 @@
     "category": "CONSTRUCT",
     "required_skills": [ [ "fabrication", 3 ] ],
     "time": "10 m",
-    "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ], [ { "id": "WRENCH", "level": 1 } ] ],
-    "components": [ [ [ "pipe", 64 ] ], [ [ "pipe_fittings", 64 ] ], [ [ "2x4", 10 ] ], [ [ "nails", 20, "LIST" ] ] ],
+    "qualities": [ [ { "id": "WRENCH", "level": 1 } ] ],
+    "components": [
+      [ [ "pipe", 46 ] ],
+      [ [ "pipe_fittings", 55 ] ],
+      [ [ "2x4", 4 ], [ "wood_panel", 1 ] ],
+      [ [ "stick", 2 ] ],
+      [ [ "rope_natural", 2, "LIST" ] ]
+    ],
     "pre_note": "Must have scaffolding below.",
     "pre_terrain": "t_scaffolding_pipe_down",
     "pre_special": [ "check_up_OK", "check_nofloor_above" ],
@@ -9177,15 +9195,16 @@
     "category": "CONSTRUCT",
     "required_skills": [ [ "fabrication", 3 ] ],
     "time": "30 m",
-    "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
+    "qualities": [ [ { "id": "WRENCH", "level": 1 } ] ],
     "pre_note": "Removes scaffolding from the targeted tile.",
     "pre_terrain": "t_scaffolding_pipe_base",
     "post_terrain": "t_dirt",
     "byproducts": [
-      { "item": "pipe", "count": 64 },
-      { "item": "pipe_fittings", "count": 64 },
-      { "item": "2x4", "count": 10 },
-      { "item": "nail", "count": 20 }
+      { "item": "pipe", "count": 46 },
+      { "item": "pipe_fittings", "count": 55 },
+      { "item": "2x4", "count": 4 },
+      { "item": "stick", "count": 2 },
+      { "item": "rope_30", "count": 2 }
     ]
   },
   {
@@ -9195,17 +9214,18 @@
     "category": "CONSTRUCT",
     "required_skills": [ [ "fabrication", 3 ] ],
     "time": "30 m",
-    "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
+    "qualities": [ [ { "id": "WRENCH", "level": 1 } ] ],
     "pre_note": "Removes down scaffolding from directly above the construction tile.",
     "pre_terrain": "t_scaffolding_pipe_up",
     "pre_special": "check_matching_down_above",
     "post_special": "remove_above",
     "post_terrain": "t_scaffolding_pipe_base",
     "byproducts": [
-      { "item": "pipe", "count": 64 },
-      { "item": "pipe_fittings", "count": 64 },
-      { "item": "2x4", "count": 10 },
-      { "item": "nail", "count": 20 }
+      { "item": "pipe", "count": 46 },
+      { "item": "pipe_fittings", "count": 55 },
+      { "item": "2x4", "count": 4 },
+      { "item": "stick", "count": 2 },
+      { "item": "rope_30", "count": 2 }
     ]
   },
   {
@@ -9215,17 +9235,18 @@
     "category": "CONSTRUCT",
     "required_skills": [ [ "fabrication", 3 ] ],
     "time": "30 m",
-    "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
+    "qualities": [ [ { "id": "WRENCH", "level": 1 } ] ],
     "pre_note": "Removes down scaffolding from directly above the construction tile.",
     "pre_terrain": "t_scaffolding_pipe_updown",
     "pre_special": "check_matching_down_above",
     "post_special": "remove_above",
     "post_terrain": "t_scaffolding_pipe_down",
     "byproducts": [
-      { "item": "pipe", "count": 64 },
-      { "item": "pipe_fittings", "count": 64 },
-      { "item": "2x4", "count": 10 },
-      { "item": "nail", "count": 20 }
+      { "item": "pipe", "count": 46 },
+      { "item": "pipe_fittings", "count": 55 },
+      { "item": "2x4", "count": 4 },
+      { "item": "stick", "count": 2 },
+      { "item": "rope_30", "count": 2 }
     ]
   }
 ]

--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -9126,5 +9126,106 @@
     "pre_special": "check_empty",
     "post_terrain": "f_piano",
     "activity_level": "LIGHT_EXERCISE"
+  },
+  {
+    "type": "construction",
+    "id": "constr_scaffolding_pipe_base",
+    "group": "build_scaffolding",
+    "category": "CONSTRUCT",
+    "required_skills": [ [ "fabrication", 3 ] ],
+    "time": "10 m",
+    "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ], [ { "id": "WRENCH", "level": 1 } ] ],
+    "components": [ [ [ "pipe", 64 ] ], [ [ "pipe_fittings", 64 ] ], [ [ "2x4", 10 ] ], [ [ "nails", 20, "LIST" ] ] ],
+    "pre_note": "Must be supported from directly below.",
+    "pre_special": [ "check_empty", "check_single_support" ],
+    "post_terrain": "t_scaffolding_pipe_base"
+  },
+  {
+    "type": "construction",
+    "id": "constr_scaffolding_pipe_down_above",
+    "group": "build_scaffolding",
+    "category": "CONSTRUCT",
+    "required_skills": [ [ "fabrication", 3 ] ],
+    "time": "30 m",
+    "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ], [ { "id": "WRENCH", "level": 1 } ] ],
+    "components": [ [ [ "pipe", 64 ] ], [ [ "pipe_fittings", 64 ] ], [ [ "2x4", 10 ] ], [ [ "nails", 20, "LIST" ] ] ],
+    "pre_note": "Constructs down scaffolding directly above the target up tile.",
+    "pre_terrain": "t_scaffolding_pipe_base",
+    "pre_special": [ "check_up_OK", "check_nofloor_above" ],
+    "post_special": "add_matching_down_above",
+    "post_terrain": "t_scaffolding_pipe_up"
+  },
+  {
+    "type": "construction",
+    "id": "constr_scaffolding_pipe_down",
+    "group": "build_scaffolding",
+    "category": "CONSTRUCT",
+    "required_skills": [ [ "fabrication", 3 ] ],
+    "time": "10 m",
+    "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ], [ { "id": "WRENCH", "level": 1 } ] ],
+    "components": [ [ [ "pipe", 64 ] ], [ [ "pipe_fittings", 64 ] ], [ [ "2x4", 10 ] ], [ [ "nails", 20, "LIST" ] ] ],
+    "pre_note": "Must have scaffolding below.",
+    "pre_terrain": "t_scaffolding_pipe_down",
+    "pre_special": [ "check_up_OK", "check_nofloor_above" ],
+    "post_terrain": "t_scaffolding_pipe_updown",
+    "post_special": "add_matching_down_above"
+  },
+  {
+    "type": "construction",
+    "id": "remove_scaffolding_pipe_base",
+    "group": "remove_scaffolding",
+    "category": "CONSTRUCT",
+    "required_skills": [ [ "fabrication", 3 ] ],
+    "time": "30 m",
+    "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
+    "pre_note": "Removes scaffolding from the targeted tile.",
+    "pre_terrain": "t_scaffolding_pipe_base",
+    "post_terrain": "t_dirt",
+    "byproducts": [
+      { "item": "pipe", "count": 64 },
+      { "item": "pipe_fittings", "count": 64 },
+      { "item": "2x4", "count": 10 },
+      { "item": "nail", "count": 20 }
+    ]
+  },
+  {
+    "type": "construction",
+    "id": "remove_scaffolding_pipe_down_above",
+    "group": "remove_scaffolding",
+    "category": "CONSTRUCT",
+    "required_skills": [ [ "fabrication", 3 ] ],
+    "time": "30 m",
+    "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
+    "pre_note": "Removes down scaffolding from directly above the construction tile.",
+    "pre_terrain": "t_scaffolding_pipe_up",
+    "pre_special": "check_matching_down_above",
+    "post_special": "remove_above",
+    "post_terrain": "t_scaffolding_pipe_base",
+    "byproducts": [
+      { "item": "pipe", "count": 64 },
+      { "item": "pipe_fittings", "count": 64 },
+      { "item": "2x4", "count": 10 },
+      { "item": "nail", "count": 20 }
+    ]
+  },
+  {
+    "type": "construction",
+    "id": "remove_scaffolding_pipe_down_above_updown",
+    "group": "remove_scaffolding",
+    "category": "CONSTRUCT",
+    "required_skills": [ [ "fabrication", 3 ] ],
+    "time": "30 m",
+    "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
+    "pre_note": "Removes down scaffolding from directly above the construction tile.",
+    "pre_terrain": "t_scaffolding_pipe_updown",
+    "pre_special": "check_matching_down_above",
+    "post_special": "remove_above",
+    "post_terrain": "t_scaffolding_pipe_down",
+    "byproducts": [
+      { "item": "pipe", "count": 64 },
+      { "item": "pipe_fittings", "count": 64 },
+      { "item": "2x4", "count": 10 },
+      { "item": "nail", "count": 20 }
+    ]
   }
 ]

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -1978,5 +1978,15 @@
     "type": "construction_group",
     "id": "place_piano",
     "name": "Place Piano"
+  },
+  {
+    "type": "construction_group",
+    "id": "build_scaffolding",
+    "name": "Place Scaffolding"
+  },
+  {
+    "type": "construction_group",
+    "id": "remove_scaffolding",
+    "name": "Remove Scaffolding"
   }
 ]

--- a/data/json/furniture_and_terrain/terrain-zlevel-transitions.json
+++ b/data/json/furniture_and_terrain/terrain-zlevel-transitions.json
@@ -224,26 +224,6 @@
   },
   {
     "type": "terrain",
-    "//": "Had to introduce base because GOES_UP results in teleport to 'matching' location if nothing above.",
-    "id": "t_scaffolding_pipe_base",
-    "name": "scaffolding up",
-    "description": "Scaffolding leading up.",
-    "symbol": "<",
-    "looks_like": "t_ladder_up",
-    "color": "dark_gray",
-    "move_cost": 2,
-    "flags": [ "TRANSPARENT", "PLACE_ITEM", "SUPPORTS_ROOF", "SINGLE_SUPPORT" ],
-    "bash": {
-      "str_min": 20,
-      "str_max": 150,
-      "sound": "metal screeching!",
-      "sound_fail": "clang!",
-      "ter_set": "t_dirt",
-      "items": [ { "item": "steel_chunk", "count": [ 1, 6 ] }, { "item": "scrap", "count": [ 3, 12 ] } ]
-    }
-  },
-  {
-    "type": "terrain",
     "id": "t_scaffolding_pipe_up",
     "name": "scaffolding up",
     "description": "Scaffolding leading up.",
@@ -251,6 +231,7 @@
     "looks_like": "t_ladder_up",
     "color": "dark_gray",
     "move_cost": 2,
+    "roof": "t_scaffolding_pipe_down",
     "flags": [ "TRANSPARENT", "GOES_UP", "PLACE_ITEM", "DIFFICULT_Z", "SUPPORTS_ROOF", "SINGLE_SUPPORT" ],
     "bash": {
       "str_min": 20,
@@ -258,7 +239,13 @@
       "sound": "metal screeching!",
       "sound_fail": "clang!",
       "ter_set": "t_dirt",
-      "items": [ { "item": "steel_chunk", "count": [ 1, 6 ] }, { "item": "scrap", "count": [ 3, 12 ] } ]
+      "items": [
+        { "item": "pipe", "count": [ 10, 46 ] },
+        { "item": "pipe_fittings", "count": [ 10, 55 ] },
+        { "item": "2x4", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 0, 2 ] },
+        { "item": "rope_30", "count": [ 0, 2 ] }
+      ]
     }
   },
   {
@@ -277,7 +264,13 @@
       "sound": "metal screeching!",
       "sound_fail": "clang!",
       "ter_set": "t_open_air_rooved",
-      "items": [ { "item": "steel_chunk", "count": [ 1, 6 ] }, { "item": "scrap", "count": [ 3, 12 ] } ]
+      "items": [
+        { "item": "pipe", "count": [ 10, 46 ] },
+        { "item": "pipe_fittings", "count": [ 10, 55 ] },
+        { "item": "2x4", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 0, 2 ] },
+        { "item": "rope_30", "count": [ 0, 2 ] }
+      ]
     }
   },
   {
@@ -295,7 +288,13 @@
       "sound": "metal screeching!",
       "sound_fail": "clang!",
       "ter_set": "t_ladder_down",
-      "items": [ { "item": "steel_chunk", "count": [ 1, 6 ] }, { "item": "scrap", "count": [ 3, 12 ] } ]
+      "items": [
+        { "item": "pipe", "count": [ 10, 46 ] },
+        { "item": "pipe_fittings", "count": [ 10, 55 ] },
+        { "item": "2x4", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 0, 2 ] },
+        { "item": "rope_30", "count": [ 0, 2 ] }
+      ]
     }
   },
   {

--- a/data/json/furniture_and_terrain/terrain-zlevel-transitions.json
+++ b/data/json/furniture_and_terrain/terrain-zlevel-transitions.json
@@ -224,6 +224,82 @@
   },
   {
     "type": "terrain",
+    "//": "Had to introduce base because GOES_UP results in teleport to 'matching' location if nothing above.",
+    "id": "t_scaffolding_pipe_base",
+    "name": "scaffolding up",
+    "description": "Scaffolding leading up.",
+    "symbol": "<",
+    "looks_like": "t_ladder_up",
+    "color": "dark_gray",
+    "move_cost": 2,
+    "flags": [ "TRANSPARENT", "PLACE_ITEM", "SUPPORTS_ROOF", "SINGLE_SUPPORT" ],
+    "bash": {
+      "str_min": 20,
+      "str_max": 150,
+      "sound": "metal screeching!",
+      "sound_fail": "clang!",
+      "ter_set": "t_dirt",
+      "items": [ { "item": "steel_chunk", "count": [ 1, 6 ] }, { "item": "scrap", "count": [ 3, 12 ] } ]
+    }
+  },
+  {
+    "type": "terrain",
+    "id": "t_scaffolding_pipe_up",
+    "name": "scaffolding up",
+    "description": "Scaffolding leading up.",
+    "symbol": "<",
+    "looks_like": "t_ladder_up",
+    "color": "dark_gray",
+    "move_cost": 2,
+    "flags": [ "TRANSPARENT", "GOES_UP", "PLACE_ITEM", "DIFFICULT_Z", "SUPPORTS_ROOF", "SINGLE_SUPPORT" ],
+    "bash": {
+      "str_min": 20,
+      "str_max": 150,
+      "sound": "metal screeching!",
+      "sound_fail": "clang!",
+      "ter_set": "t_dirt",
+      "items": [ { "item": "steel_chunk", "count": [ 1, 6 ] }, { "item": "scrap", "count": [ 3, 12 ] } ]
+    }
+  },
+  {
+    "type": "terrain",
+    "id": "t_scaffolding_pipe_down",
+    "name": "scaffolding down",
+    "description": "Scaffolding leading down.",
+    "symbol": ">",
+    "looks_like": "t_ladder_down",
+    "color": "dark_gray",
+    "move_cost": 2,
+    "flags": [ "TRANSPARENT", "GOES_DOWN", "PLACE_ITEM", "DIFFICULT_Z", "SINGLE_SUPPORT" ],
+    "bash": {
+      "str_min": 20,
+      "str_max": 150,
+      "sound": "metal screeching!",
+      "sound_fail": "clang!",
+      "ter_set": "t_open_air_rooved",
+      "items": [ { "item": "steel_chunk", "count": [ 1, 6 ] }, { "item": "scrap", "count": [ 3, 12 ] } ]
+    }
+  },
+  {
+    "type": "terrain",
+    "id": "t_scaffolding_pipe_updown",
+    "name": "scaffolding up/down",
+    "description": "Scaffolding leading up and down.",
+    "symbol": "H",
+    "color": "dark_gray",
+    "move_cost": 2,
+    "flags": [ "TRANSPARENT", "GOES_UP", "GOES_DOWN", "PLACE_ITEM", "DIFFICULT_Z", "SUPPORTS_ROOF", "SINGLE_SUPPORT" ],
+    "bash": {
+      "str_min": 20,
+      "str_max": 150,
+      "sound": "metal screeching!",
+      "sound_fail": "clang!",
+      "ter_set": "t_ladder_down",
+      "items": [ { "item": "steel_chunk", "count": [ 1, 6 ] }, { "item": "scrap", "count": [ 3, 12 ] } ]
+    }
+  },
+  {
+    "type": "terrain",
     "id": "t_ramp_down_high",
     "name": "road ramp down (high end)",
     "description": "The upper end of an asphalt ramp leading down.",

--- a/data/json/furniture_and_terrain/terrain-zlevel-transitions.json
+++ b/data/json/furniture_and_terrain/terrain-zlevel-transitions.json
@@ -258,20 +258,7 @@
     "color": "dark_gray",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "GOES_DOWN", "PLACE_ITEM", "DIFFICULT_Z", "SINGLE_SUPPORT" ],
-    "bash": {
-      "str_min": 20,
-      "str_max": 150,
-      "sound": "metal screeching!",
-      "sound_fail": "clang!",
-      "ter_set": "t_open_air_rooved",
-      "items": [
-        { "item": "pipe", "count": [ 10, 46 ] },
-        { "item": "pipe_fittings", "count": [ 10, 55 ] },
-        { "item": "2x4", "count": [ 1, 4 ] },
-        { "item": "stick", "count": [ 0, 2 ] },
-        { "item": "rope_30", "count": [ 0, 2 ] }
-      ]
-    }
+    "bash": { "str_min": 20, "str_max": 150, "sound": "metal screeching!", "sound_fail": "clang!", "ter_set": "t_open_air" }
   },
   {
     "type": "terrain",
@@ -287,7 +274,7 @@
       "str_max": 150,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "ter_set": "t_ladder_down",
+      "ter_set": "t_scaffolding_pipe_down",
       "items": [
         { "item": "pipe", "count": [ 10, 46 ] },
         { "item": "pipe_fittings", "count": [ 10, 55 ] },

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -2499,8 +2499,9 @@ request](https://github.com/CleverRaven/Cataclysm-DDA/pull/36657) and the
 | `done_mark_practice_target`| Sets a target practice trap at the location
 | `done_ramp_low`        | Sets a t_ramp_down_low at the tile above the target
 | `done_ramp_high`       | Sets a t_ramp_down_high at the tile above the target
-| `add_matching_down_above`| The terrain on the Z level above is set to the corresponding terrain at this level, but with the "down" suffix instead
-| `remove_above`         | Remove the terrain at the Z level above and replace it with t_open_air.
+| `done_matching_down_above`| The terrain on the Z level above is set to the corresponding terrain at this level, but with the "down" suffix instead
+| `remove_above`         | Remove the terrain at the Z level above and replace it with t_open_air
+| `add_roof`             | Add the roof specified for the terrain at the site to the tile above
 
 
 ### Scent_types

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -2447,10 +2447,11 @@ request](https://github.com/CleverRaven/Cataclysm-DDA/pull/36657) and the
 "vehicle_start": true,                                              // Hardcoded check for construction recipe, that result into vehicle frame; Can be used only with `done_vehicle`
 "time": "30 m",                                                     // Time required to complete construction. Integers will be read as minutes or a time string can be used.
 "components": [ [ [ "spear_wood", 4 ], [ "pointy_stick", 4 ] ] ],   // Items used in construction
-"pre_special": "check_empty",                                       // Required something that isn't terrain
+"pre_special": [ "check_empty", "check_up_OK" ],                    // Required something that isn't terrain. The syntax also allows for a square bracket enclosed list of specials which all have to be fulfilled
 "pre_terrain": "t_pit",                                             // Alternative to pre_special; Required terrain to build on
 "pre_flags": [ "WALL", { "flag": "DIGGABLE", "force_terrain": true } ], // Flags beginning furniture/terrain must have. force_ter forces the flag to apply to the underlying terrain
 "post_terrain": "t_pit_spiked",                                     // Terrain type after construction is complete
+"post_special": "done_mine_upstairs",                               // Required to do something beyond setting the post terrain. The syntax also allows for a square bracket enclosed list of specials which all have to be fulfilled
 "pre_note": "Build a spikes on a diggable terrain",                 // Create an annotation to this recipe
 "dark_craftable": true,                                             // If true, you can construct it with lack of light
 "byproducts": [ { "item": "material_soil", "count": [ 2, 5 ] } } ], // Items, that would be left after construction
@@ -2463,19 +2464,44 @@ request](https://github.com/CleverRaven/Cataclysm-DDA/pull/36657) and the
 | `check_channel`        | Must be empty and have a current in at least one orthogonal tile
 | `check_empty`          | Tile is empty (no furniture, trap, item, or vehicle) and flat terrain
 | `check_empty_lite`     | Tile is empty (no furniture, trap, item, or vehicle)
-| `check_support`        | Must have at least two solid walls/obstructions nearby on orthogonals (non-diagonal directions only) to support the tile
-| `check_support_below`  | Must have at least two solid walls/obstructions at the Z level below on orthogonals (non-diagonal directions only) to support the tile and be empty lite but with a ledge trap acceptable, as well as open air
+| `check_support`        | Must have at least two solid walls/obstructions nearby on orthogonals (non-diagonal directions only) or solid support directly below to support the tile
+| `check_support_below`  | Must have at least two solid walls/obstructions at the Z level below on orthogonals (non-diagonal directions only) or solid support directly below to support the tile and be empty lite but with a ledge trap acceptable, as well as open air
+| `check_single_support` | Must have solid support directly below to support the tile
 | `check_stable`         | Tile on level below has a flag `SUPPORTS_ROOF`
 | `check_empty_stable`   | Tile is empty and stable
 | `check_nofloor_above`  | Tile on level above has a flag `NO_FLOOR`
 | `check_deconstruction` | The furniture (or tile, if no furniture) in the target tile must have a "deconstruct" entry
-| `check_empty_up_OK`    | Tile is empty and is below the maximum possible elevation (can build up here)
 | `check_up_OK`          | Tile is below the maximum possible elevation (can build up here)
 | `check_down_OK`        | Tile is above the lowest possible elevation (can dig down here)
 | `check_no_trap`        | There is no trap object in this tile
 | `check_ramp_low`       | Both this and the next level above can be built up one additional Z level
 | `check_ramp_high`      | There is a complete downramp on the next higher level, and both this and next level above can be built up one additional Z level
 | `check_no_wiring`      | The tile must either be free of a vehicle, or at least a vehicle that doesn't have the WIRING flag
+| `check_matching_down_above`| The tile directly above must have the same base identifier but with a suffix of 'down'
+
+| post_special            | Description
+|---                     |---
+| `done_trunk_plank`     | Generate logs and then planks here (under the assumption the tile was a trunk or stump)
+| `done_grave`           | Finish grave digging by performing burial activities
+| `done_vehicle`         | Create a new vehicle and name it
+| `done_appliance`       | Finish the placement of a partially placed appliance
+| `done_wiring`          | Place a wiring "appliance" at the location
+| `done_deconstruct`     | Finish deconstruction of furniture or, if not present, terrain
+| `done_dig_grave`       | Finish digging up a grave and find what's inside of it
+| `done_dig_grave_nospawn`| Finish digging up a grave and retrieve a coffin (which is not an option above)
+| `done_dig_stair`       | Finish diggins stairs downwards (with handling of what's beneath and how to get up)
+| `done_mine_downstair`  | Same as the previous one, but mining rather than digging
+| `done_mine_upstair`    | Finish mining stairs from below
+| `done_wood_stairs`     | Finish building stairs from below
+| `done_window_curtains` | Finish boarding up window and get materials from curtains
+| `done_extract_maybe_revert_to_dirt`| Finish sand/clay extraction, which may exhaust the resource
+| `done_mark_firewood`   | Sets a firewood source trap at the location
+| `done_mark_practice_target`| Sets a target practice trap at the location
+| `done_ramp_low`        | Sets a t_ramp_down_low at the tile above the target
+| `done_ramp_high`       | Sets a t_ramp_down_high at the tile above the target
+| `add_matching_down_above`| The terrain on the Z level above is set to the corresponding terrain at this level, but with the "down" suffix instead
+| `remove_above`         | Remove the terrain at the Z level above and replace it with t_open_air.
+
 
 ### Scent_types
 

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -157,9 +157,12 @@ static bool check_nothing( const tripoint_bub_ms & )
 static bool check_channel( const tripoint_bub_ms & ); // tile has adjacent flowing water
 static bool check_empty_lite( const tripoint_bub_ms & );
 static bool check_empty( const tripoint_bub_ms & ); // tile is empty
-static bool check_support( const tripoint_bub_ms & ); // at least two orthogonal supports
+static bool check_support( const tripoint_bub_ms
+                           & ); // at least two orthogonal supports or from below
 static bool check_support_below( const tripoint_bub_ms
-                                 & ); // at least two orthogonal supports at the level below
+                                 & ); // at least two orthogonal supports at the level below or from below
+static bool check_single_support( const tripoint_bub_ms
+                                  &p ); // Only support from directly below matters
 static bool check_stable( const tripoint_bub_ms & ); // tile below has a flag SUPPORTS_ROOF
 static bool check_nofloor_above( const tripoint_bub_ms & ); // tile above has a flag NO_FLOOR
 static bool check_deconstruct( const tripoint_bub_ms
@@ -171,6 +174,8 @@ static bool check_ramp_high( const tripoint_bub_ms
                              & ); // one of the adjacent tiles on the z-level above has a completed down ramp
 static bool check_no_wiring( const tripoint_bub_ms
                              & ); // tile doesn't contain appliances/vehicle parts with WIRING flag like ap_wall_wiring
+static bool check_matching_down_above( const tripoint_bub_ms
+                                       &p ); // tile above has the same base name but with the "down suffix
 
 // Special actions to be run post-terrain-mod
 static void done_nothing( const tripoint_bub_ms &, Character & ) {}
@@ -193,6 +198,8 @@ static void done_mark_firewood( const tripoint_bub_ms &, Character & );
 static void done_mark_practice_target( const tripoint_bub_ms &, Character & );
 static void done_ramp_low( const tripoint_bub_ms &, Character & );
 static void done_ramp_high( const tripoint_bub_ms &, Character & );
+static void done_matching_down_above( const tripoint_bub_ms &p, Character & );
+static void remove_above( const tripoint_bub_ms &p, Character & );
 
 static void do_turn_shovel( const tripoint_bub_ms &, Character & );
 static void do_turn_exhume( const tripoint_bub_ms &, Character & );
@@ -1251,9 +1258,16 @@ bool construct::check_support( const tripoint_bub_ms &p )
     }
     int num_supports = 0;
     for( const point &offset : four_adjacent_offsets ) {
-        if( here.has_flag( ter_furn_flag::TFLAG_SUPPORTS_ROOF, p + offset ) ) {
+        if( here.has_flag( ter_furn_flag::TFLAG_SUPPORTS_ROOF, p + offset ) &&
+            !here.has_flag( ter_furn_flag::TFLAG_SINGLE_SUPPORT, p + offset ) ) {
             num_supports++;
         }
+    }
+    // We want to find "walls" below (including windows and doors), but not open rooms and the like.
+    if( here.has_flag( ter_furn_flag::TFLAG_SUPPORTS_ROOF, p + tripoint_below ) &&
+        ( here.has_flag( ter_furn_flag::TFLAG_WALL, p + tripoint_below ) ||
+          here.has_flag( ter_furn_flag::TFLAG_CONNECT_WITH_WALL, p + tripoint_below ) ) ) {
+        num_supports += 2;
     }
     return num_supports >= 2;
 }
@@ -1283,11 +1297,27 @@ bool construct::check_support_below( const tripoint_bub_ms &p )
     // need two or more orthogonally adjacent supports at the Z level below
     int num_supports = 0;
     for( const point &offset : four_adjacent_offsets ) {
-        if( here.has_flag( ter_furn_flag::TFLAG_SUPPORTS_ROOF, p + offset + tripoint_below ) ) {
+        if( here.has_flag( ter_furn_flag::TFLAG_SUPPORTS_ROOF, p + offset + tripoint_below ) &&
+            !here.has_flag( ter_furn_flag::TFLAG_SINGLE_SUPPORT, p + offset + tripoint_below ) ) {
             num_supports++;
         }
     }
+    // We want to find "walls" below (including windows and doors), but not open rooms and the like.
+    if( here.has_flag( ter_furn_flag::TFLAG_SUPPORTS_ROOF, p + tripoint_below ) &&
+        ( here.has_flag( ter_furn_flag::TFLAG_WALL, p + tripoint_below ) ||
+          here.has_flag( ter_furn_flag::TFLAG_CONNECT_WITH_WALL, p + tripoint_below ) ) ) {
+        num_supports += 2;
+    }
     return num_supports >= 2;
+}
+
+bool construct::check_single_support( const tripoint_bub_ms &p )
+{
+    map &here = get_map();
+    if( here.impassable( p ) ) {
+        return false;
+    }
+    return here.has_flag( ter_furn_flag::TFLAG_SUPPORTS_ROOF, p + tripoint_below );
 }
 
 bool construct::check_stable( const tripoint_bub_ms &p )
@@ -1351,6 +1381,16 @@ bool construct::check_no_wiring( const tripoint_bub_ms &p )
 
     const vehicle &veh_target = vp->vehicle();
     return !veh_target.has_tag( flag_WIRING );
+}
+
+bool construct::check_matching_down_above( const tripoint_bub_ms &p )
+{
+    map &here = get_map();
+    const std::string ter_here = here.ter( p ).id().str();
+    const std::string ter_above = here.ter( p + tripoint_above ).id().str();
+    const size_t separation = ter_here.find_last_of( '_' );
+    return separation > 0 &&
+           ter_here.substr( 0, separation + 1 ) + "down" == ter_above;
 }
 
 void construct::done_trunk_plank( const tripoint_bub_ms &/*p*/, Character &/*who*/ )
@@ -1776,6 +1816,23 @@ void construct::done_ramp_high( const tripoint_bub_ms &p, Character &/*who*/ )
     get_map().ter_set( top, ter_t_ramp_down_high );
 }
 
+void construct::done_matching_down_above( const tripoint_bub_ms &p, Character &/*who*/ )
+{
+    map &here = get_map();
+    const std::string ter_here = here.ter( p ).id().str();
+    const std::string ter_above = here.ter( p + tripoint_above ).id().str();
+    const size_t separation = ter_here.find_last_of( '_' );
+    if( separation > 0 ) {
+        here.ter_set( p + tripoint_above, ter_id( ter_here.substr( 0, separation + 1 ) + "down" ) );
+    }
+}
+
+void construct::remove_above( const tripoint_bub_ms &p, Character &/*who*/ )
+{
+    map &here = get_map();
+    here.ter_set( p + tripoint_above, ter_t_open_air );
+}
+
 void construct::do_turn_shovel( const tripoint_bub_ms &p, Character &who )
 {
     // TODO: fix point types
@@ -1949,6 +2006,7 @@ void load_construction( const JsonObject &jo )
             { "check_empty_lite", construct::check_empty_lite },
             { "check_support", construct::check_support },
             { "check_support_below", construct::check_support_below },
+            { "check_single_support", construct::check_single_support },
             { "check_stable", construct::check_stable },
             { "check_nofloor_above", construct::check_nofloor_above },
             { "check_deconstruct", construct::check_deconstruct },
@@ -1956,7 +2014,8 @@ void load_construction( const JsonObject &jo )
             { "check_down_OK", construct::check_down_OK },
             { "check_no_trap", construct::check_no_trap },
             { "check_ramp_high", construct::check_ramp_high },
-            { "check_no_wiring", construct::check_no_wiring }
+            { "check_no_wiring", construct::check_no_wiring },
+            { "check_matching_down_above", construct::check_matching_down_above }
         }
     };
     static const std::map<std::string, void( * )( const tripoint_bub_ms &, Character & )>
@@ -1979,7 +2038,10 @@ void load_construction( const JsonObject &jo )
             { "done_mark_firewood", construct::done_mark_firewood },
             { "done_mark_practice_target", construct::done_mark_practice_target },
             { "done_ramp_low", construct::done_ramp_low },
-            { "done_ramp_high", construct::done_ramp_high }
+            { "done_ramp_high", construct::done_ramp_high },
+            { "add_matching_down_above", construct::done_matching_down_above },
+            { "remove_above", construct::remove_above }
+
         }
     };
     static const std::map<std::string, void( * )( const tripoint_bub_ms &, Character & )>

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -198,7 +198,7 @@ static void done_mark_firewood( const tripoint_bub_ms &, Character & );
 static void done_mark_practice_target( const tripoint_bub_ms &, Character & );
 static void done_ramp_low( const tripoint_bub_ms &, Character & );
 static void done_ramp_high( const tripoint_bub_ms &, Character & );
-static void done_matching_down_above( const tripoint_bub_ms &p, Character & );
+static void add_matching_down_above( const tripoint_bub_ms &p, Character & );
 static void remove_above( const tripoint_bub_ms &p, Character & );
 
 static void do_turn_shovel( const tripoint_bub_ms &, Character & );
@@ -1816,7 +1816,7 @@ void construct::done_ramp_high( const tripoint_bub_ms &p, Character &/*who*/ )
     get_map().ter_set( top, ter_t_ramp_down_high );
 }
 
-void construct::done_matching_down_above( const tripoint_bub_ms &p, Character &/*who*/ )
+void construct::add_matching_down_above( const tripoint_bub_ms &p, Character &/*who*/ )
 {
     map &here = get_map();
     const std::string ter_here = here.ter( p ).id().str();
@@ -2039,7 +2039,7 @@ void load_construction( const JsonObject &jo )
             { "done_mark_practice_target", construct::done_mark_practice_target },
             { "done_ramp_low", construct::done_ramp_low },
             { "done_ramp_high", construct::done_ramp_high },
-            { "add_matching_down_above", construct::done_matching_down_above },
+            { "add_matching_down_above", construct::add_matching_down_above },
             { "remove_above", construct::remove_above }
 
         }

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -200,6 +200,7 @@ static void done_ramp_low( const tripoint_bub_ms &, Character & );
 static void done_ramp_high( const tripoint_bub_ms &, Character & );
 static void add_matching_down_above( const tripoint_bub_ms &p, Character & );
 static void remove_above( const tripoint_bub_ms &p, Character & );
+static void add_roof(const tripoint_bub_ms& p, Character&);
 
 static void do_turn_shovel( const tripoint_bub_ms &, Character & );
 static void do_turn_exhume( const tripoint_bub_ms &, Character & );
@@ -1833,6 +1834,16 @@ void construct::remove_above( const tripoint_bub_ms &p, Character &/*who*/ )
     here.ter_set( p + tripoint_above, ter_t_open_air );
 }
 
+void construct::add_roof(const tripoint_bub_ms& p, Character&/*who*/)
+{
+    map& here = get_map();
+    ter_id roof = here.ter(p).obj().roof;
+    if (!roof) {
+        debugmsg("add_roof post_ter called on terrain lacking roof definition, %s.", here.ter(p).id().c_str());
+    }
+    here.ter_set(p + tripoint_above, roof);
+}
+
 void construct::do_turn_shovel( const tripoint_bub_ms &p, Character &who )
 {
     // TODO: fix point types
@@ -2040,7 +2051,8 @@ void load_construction( const JsonObject &jo )
             { "done_ramp_low", construct::done_ramp_low },
             { "done_ramp_high", construct::done_ramp_high },
             { "add_matching_down_above", construct::add_matching_down_above },
-            { "remove_above", construct::remove_above }
+            { "remove_above", construct::remove_above },
+            { "add_roof", construct::add_roof }
 
         }
     };

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -200,7 +200,7 @@ static void done_ramp_low( const tripoint_bub_ms &, Character & );
 static void done_ramp_high( const tripoint_bub_ms &, Character & );
 static void add_matching_down_above( const tripoint_bub_ms &p, Character & );
 static void remove_above( const tripoint_bub_ms &p, Character & );
-static void add_roof(const tripoint_bub_ms& p, Character&);
+static void add_roof( const tripoint_bub_ms &p, Character & );
 
 static void do_turn_shovel( const tripoint_bub_ms &, Character & );
 static void do_turn_exhume( const tripoint_bub_ms &, Character & );
@@ -1834,14 +1834,15 @@ void construct::remove_above( const tripoint_bub_ms &p, Character &/*who*/ )
     here.ter_set( p + tripoint_above, ter_t_open_air );
 }
 
-void construct::add_roof(const tripoint_bub_ms& p, Character&/*who*/)
+void construct::add_roof( const tripoint_bub_ms &p, Character &/*who*/ )
 {
-    map& here = get_map();
-    ter_id roof = here.ter(p).obj().roof;
-    if (!roof) {
-        debugmsg("add_roof post_ter called on terrain lacking roof definition, %s.", here.ter(p).id().c_str());
+    map &here = get_map();
+    ter_id roof = here.ter( p ).obj().roof;
+    if( !roof ) {
+        debugmsg( "add_roof post_ter called on terrain lacking roof definition, %s.",
+                  here.ter( p ).id().c_str() );
     }
-    here.ter_set(p + tripoint_above, roof);
+    here.ter_set( p + tripoint_above, roof );
 }
 
 void construct::do_turn_shovel( const tripoint_bub_ms &p, Character &who )


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
#73207, i.e. introduce scaffolding as a means to reach heights for construction (and exploration)

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Introduction of a new set of terrain tiles for the various roles of scaffolding.
- Introduction of construction/removal construction "recipes" for scaffolding.
- Introduction of a few new pre and post operations to support the required logic. This means transforming the scaffolding tiles to match their role (base without anything on top of it, up only (at the ground, when there's another level above), up/down when there's scaffolding both above and below, allowing traffic in both directions, and down, which is at the top, allowing only downward traffic.
- Documentation of the new JSON operations. This also resulted in some documentation of stuff that hadn't been (and if you need an excuse for the scope creep, it's actually stuff I used, at least the fields, if not every value).
- The SINGLE_SUPPORT flag was extended somewhat, so it is used to block scaffolding to be legal support for construction for anything to the sides. Real world scaffolding typically takes support from the walls, not vice versa. However, there's currently nothing stopping players to build stand alone scaffolding towers as lookout platforms, even though they probably shouldn't support themselves fully when reaching higher Z levels.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Adding construction and removal of higher level scaffolding from the side, not just below to the side. However, that would get messy, as you'd have to compare the string version of the tile you're going to change to with tiles below. The current, restricted, logic allow only for a stack of scaffolding to be build from the same type (there is only one included, but room for expansion), while construction to the side would allow for mixing in ways that would be hard to handle.
- Skip the "base" version of scaffolding. However, it was introduced to ensure characters weren't teleported when going up from an "up" tile when there's no scaffolding above (teleported to the top of the ladder at the evac shelter roof).
- Introduction of scaffolding from different sets of materials. That was considered to be better done in a separate PR (and probably by someone good at dealing with materials).
- The introduction of a scaffolding kit which would be assembled as an item and then be used for construction (and returned on removal). That makes logical sense, but it would become quite heavy and bulky. In the real world parts can be moved separately, but a kit is a unit. As it currently stand nails are returned on deconstruction, which doesn't make sense as such, but does if it's considered to be kit parts.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Constructed and removed scaffolding for a number of Z levels (requires two towers, as construction is from the side and below). Tried various combinations, but failed to remove something that shouldn't be possible to remove: everything in a tower had to be removed in the reverse order to which they were installed.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

The PR would definitely benefit from having time and materials audited. I've made some back of an envelope guesses.

This suffers from the common problem of "terrain" being unable to "remember" what actual terrain it was placed on, so it's not possible to restore the original terrain. Thus, "t_dirt" was selected.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
