### PR TITLE
Adding the Classless category to the spell selection window

### DIFF
--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2766,8 +2766,10 @@ int known_magic::select_spell( Character &guy )
 
     std::vector<std::pair<std::string, std::string>> categories;
     for( const spell *s : known_spells ) {
-        if( s->can_cast( guy ) && s->spell_class().is_valid() ) {
-            categories.emplace_back( s->spell_class().str(), s->spell_class().obj().name() );
+        if( s->can_cast( guy ) && ( s->spell_class().is_valid() || s->spell_class() == trait_NONE ) ) {
+            const std::string spell_class_name = s->spell_class() == trait_NONE ? _( "Classless" ) :
+                                                 s->spell_class().obj().name();
+            categories.emplace_back( s->spell_class().str(), spell_class_name );
             std::sort( categories.begin(), categories.end(), []( const std::pair<std::string, std::string> &a,
             const std::pair<std::string, std::string> &b ) {
                 return localized_compare( a.second, b.second );
@@ -2789,7 +2791,7 @@ int known_magic::select_spell( Character &guy )
         {
             return guy.magic->is_favorite( known_spells[entry.retval]->id() );
         }
-        return known_spells[entry.retval]->spell_class().is_valid() && known_spells[entry.retval]->spell_class().str() == key;
+        return ( known_spells[entry.retval]->spell_class().is_valid() || known_spells[entry.retval]->spell_class() == trait_NONE ) && known_spells[entry.retval]->spell_class().str() == key;
     } );
     if( !favorites.empty() ) {
         spell_menu.set_category( "favorites" );


### PR DESCRIPTION
#### Summary
Interface "Adding Classless as a supernatural category"

#### Purpose of change

It's annoying to parse classless supernatural abilities from classed stuff when you have lots of SP abilities, so i made this PR to change that

#### Describe the solution

Changed the check so that the classless are show as a category and made it that so the header show in the menu is Classless as well.

#### Describe alternatives you've considered

Not doing it

#### Testing

1. Created a new character
2. Debugged in some spells
3. Confirmed that they were in the new category
4. Confirmed that classed spells won't go to the category

#### Additional context

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/59299346/28c276f4-cc7f-49e1-8925-259b45b6eae3)