### PR TITLE
Not to use meat chunks in the smoking rack

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5965,8 +5965,10 @@ std::list<item> map::use_amount( const std::vector<tripoint> &reachable_pts, con
         }
     }
     for( const tripoint &p : reachable_pts ) {
-        std::list<item> tmp = use_amount_square( p, type, quantity, filter );
-        ret.splice( ret.end(), tmp );
+        if( accessible_items( p ) ) {
+            std::list<item> tmp = use_amount_square( p, type, quantity, filter );
+            ret.splice( ret.end(), tmp );
+        }
     }
     return ret;
 }


### PR DESCRIPTION
#### Summary
Bugfixes "Not to use meat chunks in the smoking rack"

#### Purpose of change

Fix https://github.com/CleverRaven/Cataclysm-DDA/issues/73173

When crafting command (either from character or from basecamp recipe) is to consume components on map, the function `map::use_charges` is called for components `count_by_charges`, and `map::use_amount` is called for components without charge.
If a furniture/terrain doesn't have the flag `LIQUIDCONT`, item in it that is `count_by_charges` will not be consumed.
There is no such process in `map::use_amount`, so meat chunk in somking rack is consumed in crafting command now.

#### Describe the solution

Add the check `accessible_items` to `map::use_amount`.

#### Describe alternatives you've considered

Only check if a furniture/terrain has the flag `SEALED`.

#### Testing

Build a camp and a smoking rack, get the rack loaded. Put a meat chunk on the right tile of the rack, and add the two tiles to `Basecamp: storage`.
Try to make cooked meat from crafting gui or basecamp recipe, see the meat chunk in the rack is still there.

#### Additional context

Thought that `LIQUIDCONT` is also the reason of items being counted in crafting gui, but it did not work the way I expected. 
Anyone familiar with it?
