### PR TITLE
Make continuous integration artifacts always have full debuginfo

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -85,7 +85,6 @@ jobs:
             os: ubuntu-20.04
             tiles: 0
             sound: 0
-            release: 1
             cmake: 0
             localize: 1
             test-stage: 1
@@ -102,7 +101,6 @@ jobs:
 
           - compiler: clang++
             os: macos-12
-            release: 1
             cmake: 0
             native: osx
             pch: 0
@@ -116,7 +114,6 @@ jobs:
 
           - compiler: g++-9
             os: ubuntu-latest
-            release: 1
             cmake: 0
             tiles: 0
             sound: 0
@@ -135,7 +132,6 @@ jobs:
 
           - compiler: clang++-12
             os: ubuntu-22.04
-            release: 0
             cmake: 0
             tiles: 1
             sound: 0
@@ -155,7 +151,6 @@ jobs:
 
           - compiler: g++-11
             os: ubuntu-latest
-            release: 0
             cmake: 0
             tiles: 0
             sound: 0
@@ -172,7 +167,6 @@ jobs:
 
           - compiler: g++
             os: ubuntu-latest
-            release: 0
             cmake: 0
             native:
             pch: 1
@@ -192,7 +186,6 @@ jobs:
 
           - compiler: g++-9
             os: ubuntu-latest
-            release: 1
             cmake: 1
             tiles: 1
             sound: 1
@@ -235,7 +228,7 @@ jobs:
         GOLD: ${{ matrix.gold }}
         LTO: ${{ matrix.lto }}
         LIBBACKTRACE: ${{ matrix.libbacktrace }}
-        RELEASE: ${{ matrix.release }}
+        RELEASE: 1
         ARCHIVE_SUCCESS: ${{ matrix.archive-success }}
         CCACHE_LIMIT: ${{ matrix.ccache_limit }}
         CCACHE_FILECLONE: true

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -343,3 +343,4 @@ jobs:
         name: cata_test
         path: tests/cata_test*
         if-no-files-found: ignore
+        retention-days: 9

--- a/build-scripts/gha_compile_only.sh
+++ b/build-scripts/gha_compile_only.sh
@@ -64,7 +64,7 @@ then
         ..
     make -j$num_jobs
 else
-    make -j "$num_jobs" RELEASE=1 CCACHE=1 CROSS="$CROSS_COMPILATION" LINTJSON=0 FRAMEWORK=1 UNIVERSAL_BINARY=1
+    make -j "$num_jobs" CCACHE=1 CROSS="$CROSS_COMPILATION" LINTJSON=0 FRAMEWORK=1 UNIVERSAL_BINARY=1 DEBUG_SYMBOLS=1
 
     # For CI on macOS, patch the test binary so it can find SDL2 libraries.
     if [[ ! -z "$OS" && "$OS" = "macos-12" ]]


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

1. When a continuous integration run fails, it uploads an artifact. I have noticed that those artifacts only have partial debug info (-g1) - they contain enough debug info to generate a backtrace, but not enough to view the contents of the variables in gdb. Having full debug info would be very helpful when debugging test failures.
2. Some builds in matrix.yml had "release: 0", but this was misleading because build-scripts/gha_compile_only.sh was always overriding this with RELEASE=1

#### Describe the solution

1. Emit full -g debug symbols in every build - helps debugging failed tests
2. **Keep** RELEASE=1 in every build to make tests run faster (trade-off: source level debugging of optimized code does not always work), but make it more clear that we are doing this

#### Additional context

Note: this is me coming back to #70701 with a fresh perspective
