### PR TITLE
Fix typo that made abandoned cabins and nursing home labs much more common

### DIFF
--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -295,7 +295,7 @@
     "locations": [ "forest" ],
     "city_distance": [ 12, -1 ],
     "occurrences": [ 30, 100 ],
-    "flags": [ "CLASSIC", "FARM", "GLOBAL_UNIQUE", "MAN_MADE" ]
+    "flags": [ "CLASSIC", "FARM", "GLOBALLY_UNIQUE", "MAN_MADE" ]
   },
   {
     "type": "overmap_special",
@@ -7098,7 +7098,7 @@
     "connections": [ { "point": [ 3, 3, 0 ], "terrain": "road", "connection": "local_road", "from": [ 3, 2, 0 ] } ],
     "city_distance": [ 0, 20 ],
     "occurrences": [ 5, 100 ],
-    "flags": [ "GLOBAL_UNIQUE", "RISK_HIGH", "GENERIC_LOOT", "MAN_MADE" ]
+    "flags": [ "GLOBALLY_UNIQUE", "RISK_HIGH", "GENERIC_LOOT", "MAN_MADE" ]
   },
   {
     "type": "overmap_special",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Several users reported seeing abandoned cabins in a large number of locations after #73037 landed.

#### Describe the solution
Poked at the change and realized I'd misconjugated the "GLOBALLY_UNIQUE" flag to "GLOBAL_UNIQUE", which removed the locations' uniqueness instead of increasing it.

#### Describe alternatives you've considered
Ehhhhh?
