### PR TITLE
DO NOT MERGE: artifact size benchmark

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -85,7 +85,6 @@ jobs:
             os: ubuntu-20.04
             tiles: 0
             sound: 0
-            release: 1
             cmake: 0
             localize: 1
             test-stage: 1
@@ -102,7 +101,6 @@ jobs:
 
           - compiler: clang++
             os: macos-12
-            release: 1
             cmake: 0
             native: osx
             pch: 0
@@ -116,7 +114,6 @@ jobs:
 
           - compiler: g++-9
             os: ubuntu-latest
-            release: 1
             cmake: 0
             tiles: 0
             sound: 0
@@ -135,7 +132,6 @@ jobs:
 
           - compiler: clang++-12
             os: ubuntu-22.04
-            release: 0
             cmake: 0
             tiles: 1
             sound: 0
@@ -155,7 +151,6 @@ jobs:
 
           - compiler: g++-11
             os: ubuntu-latest
-            release: 0
             cmake: 0
             tiles: 0
             sound: 0
@@ -172,7 +167,6 @@ jobs:
 
           - compiler: g++
             os: ubuntu-latest
-            release: 0
             cmake: 0
             native:
             pch: 1
@@ -192,7 +186,6 @@ jobs:
 
           - compiler: g++-9
             os: ubuntu-latest
-            release: 1
             cmake: 1
             tiles: 1
             sound: 1
@@ -235,7 +228,7 @@ jobs:
         GOLD: ${{ matrix.gold }}
         LTO: ${{ matrix.lto }}
         LIBBACKTRACE: ${{ matrix.libbacktrace }}
-        RELEASE: ${{ matrix.release }}
+        RELEASE: 1
         ARCHIVE_SUCCESS: ${{ matrix.archive-success }}
         CCACHE_LIMIT: ${{ matrix.ccache_limit }}
         CCACHE_FILECLONE: true

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -77,7 +77,7 @@ jobs:
   varied_builds:
     needs: [ skip-duplicates-code, skip-duplicates-data, matrix-variables ]
     strategy:
-      fail-fast: ${{ fromJSON(needs.matrix-variables.outputs.fail_fast) }}
+      fail-fast: false
       max-parallel: ${{ fromJSON(needs.matrix-variables.outputs.max_parallel) }}
       matrix:
         include:
@@ -234,7 +234,7 @@ jobs:
         CCACHE_FILECLONE: true
         CCACHE_HARDLINK: true
         CCACHE_NOCOMPRESS: true
-        SKIP: ${{ ( github.event.pull_request.draft == true && matrix.title != 'Basic Build and Test (Clang 10, Ubuntu, Curses)' ) || ( matrix.dont_skip_data_only_changes == 0 && needs.skip-duplicates.outputs.should_skip_code == 'true' ) || ( matrix.dont_skip_data_only_changes != 0 && needs.skip-duplicates-mods.outputs.should_skip_data == 'true' ) }}
+        SKIP: ${{ ( false == true && matrix.title != 'Basic Build and Test (Clang 10, Ubuntu, Curses)' ) || ( matrix.dont_skip_data_only_changes == 0 && needs.skip-duplicates.outputs.should_skip_code == 'true' ) || ( matrix.dont_skip_data_only_changes != 0 && needs.skip-duplicates-mods.outputs.should_skip_data == 'true' ) }}
         SKIP_TESTS: ${{ needs.matrix-variables.outputs.skip_tests }}
     steps:
     - name: checkout repository
@@ -317,7 +317,7 @@ jobs:
     # TODO: post ccache here, however actions/cache@v2 does not support manual upload step
     - name: run tests
       if: ${{ env.SKIP == 'false' && env.SKIP_TESTS == 'false' }}
-      run: bash ./build-scripts/gha_test_only.sh
+      run: true
     - run: |
         echo ${{ github.event.number }} > pull_request_id
         echo "true" > ${{ env.ARCHIVE_SUCCESS }}
@@ -338,8 +338,8 @@ jobs:
         path: ${{ env.ARCHIVE_SUCCESS }}
     - name: upload artifacts if failed
       uses: actions/upload-artifact@v4
-      if: failure()
+      if: ${{ always() }}
       with:
-        name: cata_test
+        name: ${{ matrix.title }}
         path: tests/cata_test*
         if-no-files-found: ignore

--- a/build-scripts/gha_compile_only.sh
+++ b/build-scripts/gha_compile_only.sh
@@ -64,7 +64,7 @@ then
         ..
     make -j$num_jobs
 else
-    make -j "$num_jobs" RELEASE=1 CCACHE=1 CROSS="$CROSS_COMPILATION" LINTJSON=0 FRAMEWORK=1 UNIVERSAL_BINARY=1
+    make -j "$num_jobs" CCACHE=1 CROSS="$CROSS_COMPILATION" LINTJSON=0 FRAMEWORK=1 UNIVERSAL_BINARY=1 DEBUG_SYMBOLS=1
 
     # For CI on macOS, patch the test binary so it can find SDL2 libraries.
     if [[ ! -z "$OS" && "$OS" = "macos-12" ]]


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

This is a benchmark to determine the size of artifacts produced by continuous integration when enabling full debug info.

Note: for the purposes of this benchmark I have disabled a test that fails too often to (hopefully) get continuous integration to run every build.