### PR TITLE
1L Silver Ingot should have "material" property of silver instead of lead

### DIFF
--- a/data/json/items/resources/metal.json
+++ b/data/json/items/resources/metal.json
@@ -953,7 +953,7 @@
     "volume": "1 L",
     "price": "7 kUSD 867 USD 50 cent",
     "price_postapoc": "104 USD 90 cent",
-    "material": [ "lead" ],
+    "material": [ "silver" ],
     "symbol": "=",
     "color": "light_gray"
   },


### PR DESCRIPTION

#### Summary
Bugfixes "1L Silver Ingot should have "material" property of silver instead of lead"


#### Purpose of change

I was stockpiling silver in game and noticed that the tier 1 silver ingot had the wrong material property. While it's unlikely people would encounter this outside of maximum item spawn rate, it's still not right. (Unless it is, then a note should be added)

Reproduction steps:
1: spawn in or craft a 1L size silver ingot.


#### Describe the solution

data/json/items/resources/metal.json : change material property of 1l_silver from 
"material": [ "lead" ], to
"material": [ "silver" ],

Karol1223's metals audit ( https://github.com/CleverRaven/Cataclysm-DDA/pull/64568 ) fixed a lot of the metal prices, but some of the properties were still broken.

Drew4484's metal ingots pull ( https://github.com/CleverRaven/Cataclysm-DDA/pull/56598 ) fixed all of the metal ingot materials except this one for some reason.


#### Describe alternatives you've considered

If this is intended behavior, there should be a note to explain why it is different from every other metal ingot.


#### Testing

Spawning the item using the debug menu now shows "silver" as the material.


#### Additional context

![Blaming Cataclysm-DDA_data_json_items_resources_metal json at master · CleverRaven_Cataclysm-DDA - Personal - Microsoft​ Edge 4_25_2024 10_58_08 AM](https://github.com/CleverRaven/Cataclysm-DDA/assets/109484946/773b4fc9-9a59-45fb-ac6a-369c03d09542)
