### PR TITLE
[MoM] Add actual fear effect to Primal Terror telepathic power

### DIFF
--- a/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
+++ b/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
@@ -949,7 +949,7 @@ Powers causing telepathic damage have a 5% chance to down the target, a 33% chan
 *Duration*: Aftereffects last from 2 to 5 seconds, plus 0.75 to 1.75 seconds per power level<br />
 *Stamina Cost*: 6000, minus 100 per level to a minimum of 3500<br />
 *Channeling Time*: 125 moves, minus 5 moves per level to a minimum of 50<br />
-*Effects*: Assault the target's mind, unleashing their most elemental fears. Freezes the target in place for a number of moves depending on power level--the formula is from ((Power level / 4) * 6) / ((Power level / 4) + 3) to ((Power level / 4) * 10) / ((Power level / 4) + 3), and then multiply by 100 to get the moves subtracted from the target. Level 1 minimum is 46.5 moves lost, level 20 maximum is 625. For the aftereffect duration, the target suffers a -30 penalty to speed, a -2 penalty to dodge, a -2 penalty to hit, and a -8 penalty to bash damage.<br />
+*Effects*: Assault the target's mind, unleashing their most elemental fears. Freezes the target in place for a number of seconds depending on power level--the formula is from ((Power level / 4) * 6) / ((Power level / 4) + 3) to ((Power level / 4) * 10) / ((Power level / 4) + 3).  In addition, the target will suffer a lingering teror--for the aftereffect duration, the target suffers a -30 penalty to speed, a -2 penalty to dodge, a -2 penalty to hit, and a -8 penalty to bash damage. If an NPC, the target has their fear of the avatar increased by one-half the power level, and if a monster, the target has their morale reduced by 5 times the power level.<br />
 *Prerequisites*: Synaptic Blast 8, Mood Stabilization 8<br />
 
 ## Obscurity

--- a/data/mods/MindOverMatter/effects/effects_psionic.json
+++ b/data/mods/MindOverMatter/effects/effects_psionic.json
@@ -1693,6 +1693,13 @@
   },
   {
     "type": "effect_type",
+    "id": "effect_telepath_primal_terror_attitude_modified",
+    "//": "A tracker effect to prevent the target's morale or fear from being modified more than once in a period of time",
+    "name": [ "" ],
+    "desc": [ "" ]
+  },
+  {
+    "type": "effect_type",
     "id": "effect_telepath_network_effect",
     "name": [ "Telepathic Network" ],
     "desc": [ "You are in constant communication with your allies, looking out for each other in combat." ],

--- a/data/mods/MindOverMatter/obsolete/powers.json
+++ b/data/mods/MindOverMatter/obsolete/powers.json
@@ -1,0 +1,65 @@
+[
+  {
+    "id": "telepathic_fear_self_effect",
+    "type": "SPELL",
+    "name": "[Ψ]Primal Terror Effect on self",
+    "description": "Use a target's own inner fears against them, paralyzing them with overwhelming terror.  The effect will not last long, but is completely immobilizing while it does, and it leaves a lingering horror behind in the target.",
+    "message": "",
+    "teachable": false,
+    "valid_targets": [ "self" ],
+    "spell_class": "TELEPATH",
+    "skill": "metaphysics",
+    "flags": [ "PSIONIC", "CONCENTRATE", "SILENT", "NO_HANDS", "NO_LEGS", "RANDOM_DAMAGE", "NO_PROJECTILE", "IGNORE_WALLS" ],
+    "difficulty": 6,
+    "max_level": { "math": [ "int_to_level(1)" ] },
+    "effect": "mod_moves",
+    "shape": "blast",
+    "//": "Complicated formula here is to produce diminishing returns, since mod_moves for too long might as well just kill the target.  Level 1 minimum is 46.5 moves lost, level 20 maximum is 625, all before Intelligence scaling",
+    "min_damage": {
+      "math": [
+        "( ( ( (u_spell_level('telepathic_fear') * 0.25 ) * 6 ) /  ( (u_spell_level('telepathic_fear') * 0.25 ) + 3) ) * 100) * (scaling_factor(u_val('intelligence') ) ) * -1 * u_nether_attunement_power_scaling"
+      ]
+    },
+    "max_damage": {
+      "math": [
+        "( ( ( (u_spell_level('telepathic_fear') * 0.25 ) * 10 ) /  ( (u_spell_level('telepathic_fear') * 0.25 ) + 3) ) * 100) * (scaling_factor(u_val('intelligence') ) ) * -1 * u_nether_attunement_power_scaling"
+      ]
+    }
+  },
+  {
+    "id": "telepathic_fear_extra",
+    "type": "SPELL",
+    "name": "[Ψ]Primal Terror Effect",
+    "description": "Applies a longer debuff when using Primal Terror.  It's a bug if you have it directly.",
+    "message": "",
+    "teachable": false,
+    "flags": [ "PSIONIC", "SILENT", "RANDOM_DURATION", "NO_PROJECTILE", "IGNORE_WALLS" ],
+    "max_level": { "math": [ "int_to_level(1)" ] },
+    "valid_targets": [ "hostile", "ground" ],
+    "effect": "attack",
+    "effect_str": "effect_telepathic_primal_terror",
+    "shape": "blast",
+    "min_duration": {
+      "math": [
+        "( (u_spell_level('telepathic_fear') * 75) + 200) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
+      ]
+    },
+    "max_duration": {
+      "math": [
+        "( (u_spell_level('telepathic_fear') * 175) + 500) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
+      ]
+    },
+    "min_range": {
+      "math": [
+        "min( (( (u_spell_level('telepathic_fear') * 1.1) + 3) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling), 80)"
+      ]
+    },
+    "max_range": 80,
+    "min_aoe": {
+      "math": [
+        "min( (( (u_spell_level('telepathic_fear') * 0.15) + 0) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling), 4)"
+      ]
+    },
+    "ignored_monster_species": [ "PSI_NULL" ]
+  }
+]

--- a/data/mods/MindOverMatter/powers/telepathy.json
+++ b/data/mods/MindOverMatter/powers/telepathy.json
@@ -329,26 +329,15 @@
     "description": "Use a target's own inner fears against them, paralyzing them with overwhelming terror.  The effect will not last long, but is completely immobilizing while it does, and it leaves a lingering horror behind in the target.",
     "message": "You unleash your target's fears.",
     "teachable": false,
-    "valid_targets": [ "hostile", "ground" ],
+    "valid_targets": [ "hostile" ],
     "spell_class": "TELEPATH",
     "skill": "metaphysics",
     "flags": [ "PSIONIC", "CONCENTRATE", "SILENT", "NO_HANDS", "NO_LEGS", "RANDOM_DAMAGE", "NO_PROJECTILE", "IGNORE_WALLS" ],
     "difficulty": 6,
     "max_level": { "math": [ "int_to_level(1)" ] },
-    "effect": "mod_moves",
-    "extra_effects": [ { "id": "telepathic_fear_extra", "hit_self": false } ],
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_TELEPATH_PRIMAL_TERROR",
     "shape": "blast",
-    "//": "Complicated formula here is to produce diminishing returns, since mod_moves for too long might as well just kill the target.  Level 1 minimum is 46.5 moves lost, level 20 maximum is 625, all before Intelligence scaling",
-    "min_damage": {
-      "math": [
-        "( ( ( (u_spell_level('telepathic_fear') * 0.25 ) * 6 ) /  ( (u_spell_level('telepathic_fear') * 0.25 ) + 3) ) * 100) * (scaling_factor(u_val('intelligence') ) ) * -1 * u_nether_attunement_power_scaling"
-      ]
-    },
-    "max_damage": {
-      "math": [
-        "( ( ( (u_spell_level('telepathic_fear') * 0.25 ) * 10 ) /  ( (u_spell_level('telepathic_fear') * 0.25 ) + 3) ) * 100) * (scaling_factor(u_val('intelligence') ) ) * -1 * u_nether_attunement_power_scaling"
-      ]
-    },
     "min_range": {
       "math": [
         "min( (( (u_spell_level('telepathic_fear') * 1.1) + 3) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling), 80)"
@@ -368,42 +357,6 @@
     "final_casting_time": 50,
     "casting_time_increment": -5,
     "ignored_monster_species": [ "ZOMBIE", "ROBOT", "NETHER", "NETHER_EMANATION", "LEECH_PLANT", "WORM", "FUNGUS", "SLIME", "PSI_NULL" ]
-  },
-  {
-    "id": "telepathic_fear_extra",
-    "type": "SPELL",
-    "name": "[Ψ]Primal Terror Effect",
-    "description": "Applies a longer debuff when using Primal Terror.  It's a bug if you have it directly.",
-    "message": "",
-    "teachable": false,
-    "flags": [ "PSIONIC", "SILENT", "RANDOM_DURATION", "NO_PROJECTILE", "IGNORE_WALLS" ],
-    "max_level": { "math": [ "int_to_level(1)" ] },
-    "valid_targets": [ "hostile", "ground" ],
-    "effect": "attack",
-    "effect_str": "effect_telepathic_primal_terror",
-    "shape": "blast",
-    "min_duration": {
-      "math": [
-        "( (u_spell_level('telepathic_fear') * 75) + 200) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
-      ]
-    },
-    "max_duration": {
-      "math": [
-        "( (u_spell_level('telepathic_fear') * 175) + 500) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
-      ]
-    },
-    "min_range": {
-      "math": [
-        "min( (( (u_spell_level('telepathic_fear') * 1.1) + 3) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling), 80)"
-      ]
-    },
-    "max_range": 80,
-    "min_aoe": {
-      "math": [
-        "min( (( (u_spell_level('telepathic_fear') * 0.15) + 0) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling), 4)"
-      ]
-    },
-    "ignored_monster_species": [ "PSI_NULL" ]
   },
   {
     "id": "telepathic_invisibility",

--- a/data/mods/MindOverMatter/powers/telepathy_eoc.json
+++ b/data/mods/MindOverMatter/powers/telepathy_eoc.json
@@ -1,6 +1,69 @@
 [
   {
     "type": "effect_on_condition",
+    "id": "EOC_TELEPATH_PRIMAL_TERROR",
+    "condition": {
+      "and": [
+        { "not": { "u_has_flag": "TEEP_IMMUNE" } },
+        {
+          "not": {
+            "and": [
+              { "u_has_flag": "TEEPSHIELD" },
+              { "math": [ "n_spell_level('telepathic_shield')", ">=", "n_spell_level('telepathic_fear')" ] }
+            ]
+          }
+        },
+        { "not": { "and": [ { "u_has_flag": "TEEPSHIELD" }, { "u_has_worn_with_flag": "PORTAL_PROOF" } ] } }
+      ]
+    },
+    "effect": [
+      { "math": [ "u_telepathy_intelligence", "=", "( ( n_val('intelligence') + 10) / 20 )" ] },
+      { "math": [ "u_telepathy_power_level", "=", "n_spell_level('telepathic_fear')" ] },
+      { "math": [ "u_nether_attunement_telepathy_scaling", "=", "n_nether_attunement_power_scaling" ] },
+      {
+        "u_add_effect": "psi_stunned",
+        "duration": {
+          "math": [
+            "rng( ( ( ( ( ( (u_telepathy_power_level * 0.25 ) * 6 ) /  ( (u_telepathy_power_level * 0.25 ) + 3) ) ) * (u_telepathy_intelligence ) ) * u_nether_attunement_telepathy_scaling),( ( ( ( ( (u_telepathy_power_level * 0.25 ) * 10 ) /  ( (u_telepathy_power_level * 0.25 ) + 3) ) ) * (u_telepathy_intelligence ) ) * u_nether_attunement_telepathy_scaling) )"
+          ]
+        }
+      },
+      {
+        "u_add_effect": "effect_telepathic_primal_terror",
+        "duration": {
+          "math": [
+            "rng( ( ( (u_telepathy_power_level * 0.75) + 2) * u_telepathy_intelligence * u_nether_attunement_telepathy_scaling),( ( (u_telepathy_power_level * 1.75) + 5) * u_telepathy_intelligence * u_nether_attunement_telepathy_scaling) )"
+          ]
+        }
+      },
+      { "run_eocs": "EOC_TELEPATH_PRIMAL_TERROR_ATTITUDE" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_TELEPATH_PRIMAL_TERROR_ATTITUDE",
+    "condition": { "not": { "u_has_effect": "effect_telepath_primal_terror_attitude_modified" } },
+    "effect": [
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_TELEPATH_PRIMAL_TERROR_ATTITUDE_2",
+            "condition": "u_is_npc",
+            "effect": [
+              { "math": [ "u_val('npc_fear')", "+=", "u_telepathy_power_level / 2" ] },
+              { "u_add_effect": "effect_telepath_primal_terror_attitude_modified", "duration": "1 hours" }
+            ],
+            "false_effect": [
+              { "math": [ "u_val('morale')", "-=", "u_telepathy_power_level * 5" ] },
+              { "u_add_effect": "effect_telepath_primal_terror_attitude_modified", "duration": "1 hours" }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_TELEPATH_NETWORK_ALLY_CHECK",
     "condition": { "npc_allies": 1 },
     "//": "Ideally this would check for allies within a certain radius nearby, something like u_npcs_nearby, but that doesn't seem to be possible.",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Add actual fear effect to Primal Terror telepathic power"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I had to use some hacks to make Primal Terror seem like it made the target afraid of the psion, but it turns out EoCs can modify `npc_fear` and monster `morale` directly.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Change the power to be EoC-based. It runs on the target, checks that they're not immune or resistant to telepathy, and if they can be affected, it stuns them for a few seconds, and puts a debuff on them, the same as before. However, now it also affects their fear of the avatar by reducing morale or inceasing npc_fear, if you use it on an NPC and you're powerful enough, when it wears off the NPC will actually run away from you (and same for monsters). 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Tested on both monsters and NPCs.  No errors, both ran when the stun wear off (the cougar test meant it ran away and lurked, coming closer and then getting skittish. NPCs just ran).  Power still does not work on zombies, as intended. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
