### PR TITLE
[MoM] Fix Force Shove, Force Shove downs targets

### DIFF
--- a/data/mods/MindOverMatter/powers/telekinesis_eoc.json
+++ b/data/mods/MindOverMatter/powers/telekinesis_eoc.json
@@ -56,14 +56,15 @@
       { "math": [ "u_telekinesis_shove_spell_level", "=", "clamp(((u_weight_ratio - 1) * 2), 0, 30)" ] },
       { "u_location_variable": { "context_val": "loc" } },
       {
-        "if": { "math": [ "u_telekinesis_pull_spell_level", "<", "1" ] },
+        "if": { "math": [ "u_telekinesis_shove_spell_level", "<", "1" ] },
         "then": { "run_eocs": "EOC_TELEKINETIC_PUSH_DOWN_CHECKER" },
         "else": [
           {
             "npc_cast_spell": { "id": "telekinetic_force_shove_away", "min_level": { "math": [ "u_telekinesis_shove_spell_level" ] } },
             "loc": { "context_val": "loc" }
           },
-          { "npc_message": "You hurl your target away.", "type": "good" }
+          { "npc_message": "You hurl your target away.", "type": "good" },
+          { "run_eocs": "EOC_TELEKINETIC_PUSH_DOWN_CHECKER" }
         ]
       }
     ]
@@ -102,7 +103,8 @@
             "npc_cast_spell": { "id": "telekinetic_force_shove_toward", "min_level": { "math": [ "u_telekinesis_shove_spell_level" ] } },
             "loc": { "context_val": "loc" }
           },
-          { "npc_message": "You pull your target towards you.", "type": "good" }
+          { "npc_message": "You pull your target towards you.", "type": "good" },
+          { "run_eocs": "EOC_TELEKINETIC_PUSH_DOWN_CHECKER" }
         ]
       }
     ]
@@ -161,7 +163,8 @@
             "npc_cast_spell": { "id": "telekinetic_force_shove_away", "min_level": { "math": [ "u_telekinesis_shove_spell_level" ] } },
             "loc": { "context_val": "loc" }
           },
-          { "npc_message": "You hurl your target away.", "type": "good" }
+          { "npc_message": "You hurl your target away.", "type": "good" },
+          { "run_eocs": "EOC_TELEKINETIC_PUSH_DOWN_CHECKER" }
         ]
       }
     ]
@@ -190,7 +193,8 @@
             "npc_cast_spell": { "id": "telekinetic_force_shove_toward", "min_level": { "math": [ "u_telekinesis_shove_spell_level" ] } },
             "loc": { "context_val": "loc" }
           },
-          { "npc_message": "You pull your target towards you.", "type": "good" }
+          { "npc_message": "You pull your target towards you.", "type": "good" },
+          { "run_eocs": "EOC_TELEKINETIC_PUSH_DOWN_CHECKER" }
         ]
       }
     ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Fix Force Shove, Force Shove downs targets"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Someone said Force Shove was broken in shoving away, I checked and they were right, it was a one-line fix so I added one other thing I was planning to do that was very small. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Force Shove away was checking the variable for pulling toward, resulting in the weight limit ratio always being below 1 (aka no shoving), so I fixed that.

I also added a check for being downed after being shoved, because previously it was binary (you were either downed or shoved), but if you were hurled five meters by an invisible burst of telekinetic force, you'd probably fall over. Also, that's what happens when monsters telekinetically throw you.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Force Shove now works, downing occurs. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
