### PR TITLE
Update Cureall Effect

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -3091,7 +3091,9 @@
       "infected",
       "asthma",
       "common_cold",
-      "flu"
+      "flu",
+      "pre_flu",
+      "pre_common_cold"
     ],
     "base_mods": { "pkill_min": [ 5 ] }
   },


### PR DESCRIPTION
#### Summary
Bugfixes "Cureall Effect (Panacea) now cures early stages of cold and flu"

#### Purpose of change

As pointed out in #72778 the panacea effect would cure the common cold and the flu, but not the early stages, referred to as pre_flu and pre_common_cold.  Since the full blown version and early stages versions are the same conditions with different severities, it makes sense that both versions of them would be cured by the magically all-powerful cureall effect.

#### Describe the solution

I added the pre_common_cold and pre_flu effects to the list of things cured by the cureall (Panacea) effect.

#### Describe alternatives you've considered

Leaving it, but why would I do that

#### Testing

Made sure I didn't mess up syntax.  Added the two additional conditions to the cureall list.  Debug gave myself pre_flu, debugged panacea, ate the panacea, observed I was cured of the pre_flu.

#### Additional context

closes #72778
