### PR TITLE
Fix migration of predecessor overmap terrains

### DIFF
--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -3977,6 +3977,16 @@ void overmap::migrate_oter_ids( const std::unordered_map<tripoint_om_omt, std::s
     }
 }
 
+oter_id overmap::get_or_migrate_oter( const std::string &oterid )
+{
+    auto migration = oter_id_migrations.find( oterid );
+    if( migration != oter_id_migrations.end() ) {
+        return oter_id( migration->second );
+    } else {
+        return oter_id( oterid );
+    }
+}
+
 void overmap::place_special_forced( const overmap_special_id &special_id,
                                     const tripoint_om_omt &p,
                                     om_direction::type dir )

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -553,6 +553,7 @@ class overmap
         static void reset_oter_id_migrations();
         static bool is_oter_id_obsolete( const std::string &oterid );
         void migrate_oter_ids( const std::unordered_map<tripoint_om_omt, std::string> &points );
+        oter_id get_or_migrate_oter( const std::string &oterid );
 };
 
 bool is_river( const oter_id &ter );


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

- Fixes #72618 - the migration of the list of predecessors of an overmap terrain on the map was not implemented

#### Describe the solution

Implement the missing migration.

Instead of assuming the save JSON contains a valid oter_id in the "predecessors" field we read it as a string, look it up in oter_id_migrations and replace it if found.

#### Testing

Based on "steps to reproduce" from #72618

* Before:
  * migration _fails_ to affect predecessors:
    ![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/52621858/4cc08a49-1ecc-46b7-9c1c-645240df6e7c)
  * removing the definition of o_base causes errors:

       DEBUG    : invalid overmap terrain id "o_base_north"

       FUNCTION : int_id<T> generic_factory<T>::convert(const string_id<T>&, const int_id<T>&, bool) const [with T = oter_t]
       FILE     : src/generic_factory.h
       LINE     : 513
       VERSION  : cdda-experimental-2024-04-25-2051 7636bcc

* After:
  * migration correctly modifies predecessors:
    ![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/52621858/51b1b2a1-9272-42e7-94d8-7e19f8a42e1b)
 * No errors if I remove the definition of o_base