### PR TITLE
Aftershock: Crashed shuttles

### DIFF
--- a/data/mods/Aftershock/itemgroups/item_groups.json
+++ b/data/mods/Aftershock/itemgroups/item_groups.json
@@ -555,5 +555,36 @@
       { "item": "afs_cartridge", "count": [ 2, 6 ], "prob": 95, "charges": [ 50, 100 ] },
       { "group": "afs_exo_advanced_power", "prob": 25 }
     ]
+  },
+  {
+    "//": "Industrial amounts of mostly useless consumer goods",
+    "id": "afs_useless_cargo",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "afs_glass_device", "count": [ 100, 200 ] },
+      { "item": "afs_glass_AR_device", "count": [ 100, 200 ] },
+      { "item": "afs_company_jacket", "count": [ 100, 200 ] },
+      { "item": "technician_pants_gray", "count": [ 100, 200 ] },
+      { "item": "boots_winter", "count": [ 100, 200 ] },
+      { "item": "instant_coffee", "count": [ 100, 200 ], "container-item": "afs_foil_bag" },
+      { "item": "artificial_sweetener", "count": [ 100, 200 ], "container-item": "afs_foil_bag" },
+      { "item": "instant_coffee", "count": [ 100, 200 ], "container-item": "afs_foil_bag" },
+      { "item": "syringe", "count": [ 100, 200 ] },
+      { "item": "pliers", "count": [ 100, 200 ] },
+      { "item": "goggles_welding", "count": [ 100, 200 ] },
+      { "item": "jumper_cable", "count": [ 100, 200 ] },
+      { "item": "magnifying_glass", "count": [ 100, 200 ] },
+      { "item": "shovel", "count": [ 100, 200 ] },
+      { "item": "chunk_rubber", "count": [ 100, 200 ] },
+      { "item": "nail", "count": [ 100, 200 ] },
+      { "item": "bubblewrap", "count": [ 100, 200 ] },
+      { "item": "soap", "count": [ 100, 200 ] },
+      { "item": "cu_pipe", "count": [ 100, 200 ] },
+      { "item": "stapler", "count": [ 100, 200 ] },
+      { "item": "canister_empty", "count": [ 100, 200 ] },
+      { "item": "spring", "count": [ 100, 200 ] },
+      { "item": "material_soil", "count": [ 100, 200 ] }
+    ]
   }
 ]

--- a/data/mods/Aftershock/itemgroups/weapons/armories.json
+++ b/data/mods/Aftershock/itemgroups/weapons/armories.json
@@ -66,6 +66,12 @@
     ]
   },
   {
+    "id": "afs_wraitheon_smart_rifle_cache",
+    "type": "item_group",
+    "subtype": "collection",
+    "items": [ { "item": "afs_wa2519" }, { "item": "afs_25mm_smart", "count": [ 15, 25 ] } ]
+  },
+  {
     "id": "afs_augustmoon_guntrader_military_ammo",
     "type": "item_group",
     "subtype": "distribution",

--- a/data/mods/Aftershock/items/items.json
+++ b/data/mods/Aftershock/items/items.json
@@ -227,10 +227,23 @@
     "flags": [ "STURDY" ]
   },
   {
+    "type": "GENERIC",
+    "id": "afs_fusion_engine_core",
+    "name": { "str_sp": "fusion drive powerplant" },
+    "description": "A very heavy sphere of radiation shielding completely obscures the inner working of this hyperspace-age device.  Any experienced salvor knows that opening it would completely ruin it.",
+    "symbol": "o",
+    "color": "yellow",
+    "weight": "14 kg",
+    "volume": "1 L",
+    "price": "10 kUSD",
+    "material": [ "copper", "lead", "steel" ],
+    "category": "spare_parts"
+  },
+  {
     "id": "afs_glass_device",
-    "type": "ARMOR",
+    "type": "GENERIC",
     "name": { "str": "glass device" },
-    "description": "This transparent slate of computation glass was once an incredibly versatile hypercloud access point.  With all its functions dependent on a now broken FTL communications network, it's not really useful for anything.",
+    "description": "This transparent slate of computation glass was once an incredibly versatile hypercloud access point.  It continues to display \"No Connection\" in ancient english script.",
     "weight": "80 g",
     "volume": "80 ml",
     "price": "7 USD",
@@ -239,5 +252,21 @@
     "symbol": "[",
     "color": "light_gray",
     "flags": [ "STURDY" ]
+  },
+  {
+    "id": "afs_glass_AR_device",
+    "type": "ARMOR",
+    "name": { "str": "glass headset" },
+    "description": "This transparent lune of computation glass was once an incredibly versatile hypercloud access point.  It continues to display \"No Connection\" in ancient english script.  Although completely useless these sometimes gain popularity as a fashion accessory.",
+    "weight": "170 g",
+    "volume": "750 ml",
+    "price": "7 USD",
+    "price_postapoc": "5 USD",
+    "material": [ "glass" ],
+    "symbol": "[",
+    "color": "light_gray",
+    "armor": [ { "encumbrance": 5, "coverage": 100, "covers": [ "eyes" ] } ],
+    "material_thickness": 1,
+    "flags": [ "STURDY", "OUTER" ]
   }
 ]

--- a/data/mods/Aftershock/maps/furniture_and_terrain/furniture_spaceship_machinery.json
+++ b/data/mods/Aftershock/maps/furniture_and_terrain/furniture_spaceship_machinery.json
@@ -1,0 +1,89 @@
+[
+  {
+    "type": "furniture",
+    "id": "f_afs_shuttle_fusion_engine",
+    "name": "Direct fusion drive",
+    "looks_like": "t_metal_ventilation_shutter",
+    "description": "A powerful fusion engine fuelled by helium.  A miracle of hyperspace age technology, painstakingly reproduced from original schematics without true understanding.  Its core components are notably expensive.",
+    "symbol": "=",
+    "bgcolor": "white",
+    "move_cost_mod": -1,
+    "coverage": 50,
+    "required_str": -1,
+    "flags": [ "NOITEM", "BLOCKSDOOR" ],
+    "keg_capacity": 20,
+    "bash": {
+      "str_min": 60,
+      "str_max": 120,
+      "sound": "metal screeching!",
+      "sound_fail": "clang!",
+      "items": [
+        { "item": "scrap", "count": [ 2, 7 ] },
+        { "item": "afs_material_2", "count": [ 2, 12 ] },
+        { "item": "afs_material_3", "count": [ 0, 3 ] },
+        { "item": "afs_circuitry_2", "count": [ 0, 2 ] },
+        { "item": "afs_energy_storage_3", "count": [ 1, 2 ] },
+        { "item": "afs_heat_2_salvage", "count": [ 2, 4 ] },
+        { "item": "frame", "count": 1 },
+        { "item": "afs_magnet_3", "count": [ 0, 2 ] },
+        { "item": "afs_heat_4", "count": [ 0, 1 ] },
+        { "item": "afs_fusion_engine_core", "count": [ 0, 1 ] }
+      ]
+    },
+    "deconstruct": {
+      "items": [
+        { "item": "scrap", "count": [ 2, 7 ] },
+        { "item": "afs_material_2", "count": [ 2, 12 ] },
+        { "item": "afs_material_3", "count": [ 0, 3 ] },
+        { "item": "afs_circuitry_2", "count": [ 0, 2 ] },
+        { "item": "afs_energy_storage_3", "count": [ 1, 2 ] },
+        { "item": "afs_heat_2_salvage", "count": [ 2, 4 ] },
+        { "item": "frame", "count": 1 },
+        { "item": "afs_magnet_3", "count": [ 0, 2 ] },
+        { "item": "afs_heat_4", "count": [ 0, 1 ] },
+        { "item": "afs_fusion_engine_core", "count": [ 0, 1 ] }
+      ]
+    }
+  },
+  {
+    "type": "furniture",
+    "id": "f_afs_shuttle_manuevering_thruster",
+    "name": "Multi-axis manuevering thruster",
+    "looks_like": "f_vent",
+    "description": "A set of highly maneuverable chemical thrusters used is small to medium spacecraft.",
+    "symbol": "0",
+    "bgcolor": "white",
+    "move_cost_mod": -1,
+    "coverage": 50,
+    "required_str": -1,
+    "flags": [ "NOITEM", "BLOCKSDOOR" ],
+    "bash": {
+      "str_min": 60,
+      "str_max": 120,
+      "sound": "metal screeching!",
+      "sound_fail": "clang!",
+      "items": [
+        { "item": "scrap", "count": [ 4, 9 ] },
+        { "item": "afs_material_2", "count": [ 2, 12 ] },
+        { "item": "afs_material_3", "count": [ 0, 3 ] },
+        { "item": "afs_circuitry_2", "count": [ 0, 2 ] },
+        { "item": "afs_heat_2_salvage", "count": [ 2, 4 ] },
+        { "item": "frame", "count": 1 },
+        { "item": "afs_magnet_2", "count": [ 0, 2 ] },
+        { "item": "ammonia_liquid", "prob": 100, "count": [ 4, 8 ] }
+      ]
+    },
+    "deconstruct": {
+      "items": [
+        { "item": "scrap", "count": [ 4, 9 ] },
+        { "item": "afs_material_2", "count": [ 2, 12 ] },
+        { "item": "afs_material_3", "count": [ 0, 3 ] },
+        { "item": "afs_circuitry_2", "count": [ 0, 2 ] },
+        { "item": "afs_heat_2_salvage", "count": [ 2, 4 ] },
+        { "item": "frame", "count": 1 },
+        { "item": "afs_magnet_2", "count": [ 0, 2 ] },
+        { "item": "ammonia_liquid", "prob": 100, "count": [ 4, 8 ] }
+      ]
+    }
+  }
+]

--- a/data/mods/Aftershock/maps/furniture_and_terrain/terrain_spaceship.json
+++ b/data/mods/Aftershock/maps/furniture_and_terrain/terrain_spaceship.json
@@ -292,7 +292,7 @@
     "bgcolor": "brown",
     "move_cost": 0,
     "coverage": 60,
-    "flags": [ "TRANSPARENT", "MOUNTABLE", "SHORT", "SMALL_HIDE" ]
+    "flags": [ "TRANSPARENT", "MOUNTABLE", "SHORT", "SMALL_HIDE", "PLACE_ITEM", "CONTAINER" ]
   },
   {
     "type": "terrain",

--- a/data/mods/Aftershock/maps/mapgen/crashsites.json
+++ b/data/mods/Aftershock/maps/mapgen/crashsites.json
@@ -1,0 +1,126 @@
+[
+  {
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": [ "afs_crashed_cargo_shuttle" ],
+    "object": {
+      "predecessor_mapgen": "field",
+      "rows": [
+        "                        ",
+        "               -        ",
+        "             ,,0-       ",
+        "        #####,,,        ",
+        "       #----##    T,,   ",
+        "      0-----0--   ,,    ",
+        "      ###,--##     ,    ",
+        "     , ##,--, -   T     ",
+        "    TT,##,--,, #   #    ",
+        "     T,##,--,### TT#    ",
+        "      #---RR--#  ###    ",
+        "      #-,-II-,,   ##,   ",
+        "       ,,#II,  ,   #,   ",
+        "       ,,######,    ,   ",
+        "       ,,#,####      , ,",
+        "         ,###,,,        ",
+        "      TT   ##,,, ,      ",
+        "            ##,, ,      ",
+        "             ##,,,      ",
+        "             ##,,,      ",
+        "                ,,,     ",
+        "         T,     .,,     ",
+        "         ,,             ",
+        "          ,            ,"
+      ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "terrain": {
+        "-": "t_afs_space_ship_hull_wall",
+        "T": "t_intermodal_crate",
+        "q": "t_afs_escapepod_g",
+        "!": "t_metal_floor",
+        ",": "t_dirt",
+        "#": "t_dirtmound"
+      },
+      "furniture": {
+        "R": "f_reactor_meltdown",
+        "#": [ [ "f_wreckage", 1 ], [ "f_null", 15 ] ],
+        "I": "f_afs_shuttle_fusion_engine",
+        "0": "f_afs_shuttle_manuevering_thruster"
+      },
+      "items": {
+        "T": { "item": "afs_useless_cargo", "chance": 100 },
+        ",": { "item": "afs_shuttle_debris", "chance": 30 },
+        "#": { "item": "afs_shuttle_debris", "chance": 6 }
+      }
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": [ "afs_crashed_cargo_shuttle_wraitheon" ],
+    "object": {
+      "predecessor_mapgen": "field",
+      "rows": [
+        "                        ",
+        "               -        ",
+        "  x  x       ,,0-    x  ",
+        "        #####,,,        ",
+        "   x   #----####  ,,,  x",
+        "      0----,0--#  ,,    ",
+        "      ###,--## ##  ,    ",
+        "     , ##,-,, - ##,     ",
+        "     T,##,-,,  #####    ",
+        "      ,##,--,#######   x",
+        "    A #---RR--#  ###    ",
+        "      #-,-II-,,   ##,   ",
+        "       ,,#II,, , x #,   ",
+        "       ,,####,#,    ,   ",
+        "       ,,#,##,#x  W  , ,",
+        "         ,###,,,      x ",
+        "           ##,,, ,      ",
+        "          x ##,, ,A     ",
+        "             ##,,,      ",
+        "   x         ##,,,      ",
+        "                , ,     ",
+        "                .,,     ",
+        "                        ",
+        "                    x  ,"
+      ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "terrain": {
+        "-": "t_afs_space_ship_hull_wall",
+        "T": "t_intermodal_crate",
+        "!": "t_metal_floor",
+        ",": "t_dirt",
+        "#": "t_dirtmound"
+      },
+      "furniture": {
+        "R": "f_reactor_meltdown",
+        "#": [ [ "f_wreckage", 1 ], [ "f_null", 15 ] ],
+        "I": "f_afs_shuttle_fusion_engine",
+        "0": "f_afs_shuttle_manuevering_thruster"
+      },
+      "items": {
+        "T": { "item": "afs_wraitheon_smart_rifle_cache", "chance": 100 },
+        ",": { "item": "afs_shuttle_debris", "chance": 30 },
+        "#": { "item": "afs_shuttle_debris", "chance": 6 }
+      },
+      "monster": {
+        "W": { "monster": "mon_wraitheon_isohypsa" },
+        "A": { "monster": "mon_wraitheon_irradiant" },
+        "x": { "monster": "mon_wraitheon_kaburaya" }
+      }
+    }
+  },
+  {
+    "id": "afs_shuttle_debris",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "scrap", "prob": 30 },
+      { "item": "steel_chunk", "prob": 20 },
+      { "item": "afs_material_1", "prob": 10 },
+      { "item": "sheet_metal_small", "prob": 10 },
+      { "item": "sheet_metal", "prob": 5 }
+    ]
+  }
+]

--- a/data/mods/Aftershock/maps/overmap_specials.json
+++ b/data/mods/Aftershock/maps/overmap_specials.json
@@ -50,6 +50,26 @@
     "flags": [ "EXOPLANET" ]
   },
   {
+    "type": "overmap_special",
+    "id": "afs_crashed_cargo_shuttle",
+    "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "afs_crashed_cargo_shuttle_north" } ],
+    "locations": [ "land" ],
+    "city_distance": [ 5, -1 ],
+    "city_sizes": [ 0, -1 ],
+    "occurrences": [ 0, 1 ],
+    "flags": [ "EXOPLANET" ]
+  },
+  {
+    "type": "overmap_special",
+    "id": "afs_crashed_cargo_shuttle_wraitheon",
+    "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "afs_crashed_cargo_shuttle_wraitheon_north" } ],
+    "locations": [ "land" ],
+    "city_distance": [ 5, -1 ],
+    "city_sizes": [ 0, -1 ],
+    "occurrences": [ 0, 1 ],
+    "flags": [ "EXOPLANET", "GLOBALLY_UNIQUE" ]
+  },
+  {
     "id": "municipal_reactor",
     "type": "overmap_special",
     "connections": [ { "point": [ -1, 1, 0 ], "terrain": "road" } ],

--- a/data/mods/Aftershock/maps/overmap_terrain.json
+++ b/data/mods/Aftershock/maps/overmap_terrain.json
@@ -99,6 +99,24 @@
     "flags": [ "NO_ROTATE", "RISK_HIGH" ]
   },
   {
+    "id": "afs_crashed_cargo_shuttle",
+    "type": "overmap_terrain",
+    "name": "crashed cargo droneship",
+    "sym": "s",
+    "color": "i_red",
+    "see_cost": 2,
+    "flags": [ "RISK_HIGH" ]
+  },
+  {
+    "id": "afs_crashed_cargo_shuttle_wraitheon",
+    "type": "overmap_terrain",
+    "name": "crashed military droneship",
+    "sym": "s",
+    "color": "light_green",
+    "see_cost": 2,
+    "flags": [ "RISK_HIGH", "SOURCE_GUN", "SOURCE_AMMO" ]
+  },
+  {
     "type": "overmap_terrain",
     "id": [ "afs_formless_ruins_dynamic" ],
     "name": "formless ruins",


### PR DESCRIPTION

#### Summary
Mods "Aftershock: Add two crashed shuttle maps"

#### Purpose of change
More places to loot and a spawn for the Wraitheon smart rifle.

#### Describe the solution
Very small and simple maps, both have melted reactors that spew radiation and a very similar layout.

- The normal shuttle main valuables are the components you can get from the engines, most things it can spawn arent very valuable otherwise.
- The Wraitheon shulttle is surrounded by a lot of bots, has the same components, and spawns a single cargo crate with a Wraitheon Armories 2519 smart rifle and a large amount ammo. Its globally unique.

#### Testing
Spawned both maps

