### PR TITLE
Added construction of roofs

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -9365,5 +9365,35 @@
     "pre_note": "Must be supported directly from below or on at least two sides.",
     "pre_special": [ "check_support", "check_unblocked" ],
     "post_terrain": "t_wood_roof"
+  },
+  {
+    "type": "construction",
+    "id": "constr_chimney",
+    "group": "build_chimney",
+    "category": "CONSTRUCT",
+    "required_skills": [ [ "fabrication", 3 ] ],
+    "time": "2 h",
+    "qualities": [ [ { "id": "SMOOTH", "level": 1 } ] ],
+    "components": [
+      [ [ "brick", 30 ] ],
+      [ [ "mortar_build", 1 ], [ "mortar_lime", 1 ] ],
+      [ [ "water", 1 ], [ "water_clean", 1 ] ],
+      [ [ "sheet_metal", 2 ] ]
+    ],
+    "pre_special": "check_empty",
+    "post_terrain": "f_chimney"
+  },
+  {
+    "type": "construction",
+    "id": "constr_vent_pipe",
+    "group": "build_vent_pipe",
+    "category": "CONSTRUCT",
+    "required_skills": [ [ "fabrication", 3 ] ],
+    "time": "30 m",
+    "tools": [ [ [ "oxy_torch", 4 ], [ "welder", 20 ], [ "welder_crude", 30 ], [ "toolset", 30 ] ] ],
+    "qualities": [ [ { "id": "SAW_M", "level": 1 } ], [ { "id": "GLARE", "level": 1 } ] ],
+    "components": [ [ [ "pipe", 3 ] ] ],
+    "pre_special": "check_empty",
+    "post_terrain": "f_vent_pipe"
   }
 ]

--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -1433,7 +1433,7 @@
   {
     "type": "construction",
     "id": "constr_scrap_floor",
-    "group": "build_scrap_floor_with_roof",
+    "group": "build_scrap_floor_with_roof"
     "category": "CONSTRUCT",
     "required_skills": [ [ "fabrication", 5 ] ],
     "time": "90 m",

--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -1433,7 +1433,7 @@
   {
     "type": "construction",
     "id": "constr_scrap_floor",
-    "group": "build_metal_roof",
+    "group": "build_scrap_floor_with_roof",
     "category": "CONSTRUCT",
     "required_skills": [ [ "fabrication", 5 ] ],
     "time": "90 m",
@@ -1447,7 +1447,7 @@
   {
     "type": "construction",
     "id": "constr_ov_smreb_cage_thconc_floor",
-    "group": "build_concrete_roof",
+    "group": "build_concrete_floor_with_roof",
     "//": "Step 1: rebar cage & supports",
     "category": "CONSTRUCT",
     "required_skills": [ [ "fabrication", 5 ] ],
@@ -1460,7 +1460,7 @@
   {
     "type": "construction",
     "id": "constr_thconc_floor",
-    "group": "build_concrete_roof",
+    "group": "build_concrete_floor_with_roof",
     "//": "Step 2: roof & floor",
     "category": "CONSTRUCT",
     "required_skills": [ [ "fabrication", 5 ] ],
@@ -1474,7 +1474,7 @@
   {
     "type": "construction",
     "id": "constr_ov_reb_cage_strconc_floor",
-    "group": "build_reinforced_concrete_roof",
+    "group": "build_reinforced_concrete_floor_with_roof",
     "//": "Step 1: rebar cage & supports",
     "category": "CONSTRUCT",
     "required_skills": [ [ "fabrication", 6 ] ],
@@ -1488,7 +1488,7 @@
   {
     "type": "construction",
     "id": "constr_strconc_floor_halfway",
-    "group": "build_reinforced_concrete_roof",
+    "group": "build_reinforced_concrete_floor_with_roof",
     "//": "Step 2: start roof & floor",
     "category": "CONSTRUCT",
     "required_skills": [ [ "fabrication", 6 ] ],
@@ -1502,7 +1502,7 @@
   {
     "type": "construction",
     "id": "constr_strconc_floor",
-    "group": "build_reinforced_concrete_roof",
+    "group": "build_reinforced_concrete_floor_with_roof",
     "//": "Step 3: finish roof & floor",
     "category": "CONSTRUCT",
     "required_skills": [ [ "fabrication", 6 ] ],
@@ -1596,7 +1596,7 @@
   {
     "type": "construction",
     "id": "constr_floor",
-    "group": "build_roof",
+    "group": "build_floor_with_treated_roof",
     "category": "CONSTRUCT",
     "required_skills": [ [ "fabrication", 3 ] ],
     "time": "120 m",
@@ -1609,7 +1609,7 @@
   {
     "type": "construction",
     "id": "constr_dirtfloor_thatchroof",
-    "group": "build_thatched_roof",
+    "group": "build_dirt_floor_with_thatched_roof",
     "category": "CONSTRUCT",
     "required_skills": [ [ "fabrication", 3 ], [ "survival", 7 ] ],
     "time": "360 m",
@@ -1626,7 +1626,7 @@
   {
     "type": "construction",
     "id": "constr_floor_primitive",
-    "group": "build_log_sod_roof",
+    "group": "build_primitive_floor_with_log_sod_roof",
     "category": "CONSTRUCT",
     "required_skills": [ [ "fabrication", 4 ] ],
     "time": "120 m",
@@ -1644,7 +1644,7 @@
   {
     "type": "construction",
     "id": "constr_dirtfloor",
-    "group": "build_roof_over_dirt_floor",
+    "group": "build_dirt_floor_with_shingle_roof",
     "category": "CONSTRUCT",
     "required_skills": [ [ "fabrication", 3 ] ],
     "time": "60 m",
@@ -9209,5 +9209,161 @@
       { "item": "stick", "count": 2 },
       { "item": "rope_30", "count": 2 }
     ]
+  },
+  {
+    "type": "construction",
+    "id": "constr_brick_roof",
+    "group": "build_brick_roof",
+    "category": "CONSTRUCT",
+    "required_skills": [ [ "fabrication", 3 ] ],
+    "time": "120 m",
+    "qualities": [ [ { "id": "SMOOTH", "level": 1 } ] ],
+    "components": [ [ [ "brick", 15 ] ], [ [ "mortar_build", 1 ], [ "mortar_lime", 1 ] ], [ [ "water", 1 ], [ "water_clean", 1 ] ] ],
+    "pre_note": "Must be supported directly from below or on at least two sides.",
+    "pre_special": [ "check_support", "check_unblocked" ],
+    "post_terrain": "t_brick_roof"
+  },
+  {
+    "type": "construction",
+    "id": "constr_concrete_roof",
+    "group": "build_concrete_roof",
+    "category": "CONSTRUCT",
+    "required_skills": [ [ "fabrication", 5 ] ],
+    "time": "60 m",
+    "tools": [ [ [ "concrete_mix_tool", 25 ] ] ],
+    "qualities": [ [ { "id": "SMOOTH", "level": 2 } ] ],
+    "components": [ [ [ "concrete", 2 ] ], [ [ "water", 2 ], [ "water_clean", 2 ] ] ],
+    "pre_note": "Must be supported directly from below or on at least two sides.",
+    "pre_special": [ "check_support", "check_unblocked" ],
+    "post_terrain": "t_concrete_roof"
+  },
+  {
+    "type": "construction",
+    "id": "constr_flat_roof",
+    "group": "build_flat_roof",
+    "category": "CONSTRUCT",
+    "required_skills": [ [ "fabrication", 3 ] ],
+    "time": "60 m",
+    "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
+    "components": [ [ [ "wood_sheet", 1 ], [ "wood_panel", 2 ] ], [ [ "2x4", 6 ] ], [ [ "nails", 40, "LIST" ] ] ],
+    "pre_note": "Must be supported directly from below or on at least two sides.",
+    "pre_special": [ "check_support", "check_unblocked" ],
+    "post_terrain": "t_flat_roof"
+  },
+  {
+    "type": "construction",
+    "id": "constr_log_sod_roof",
+    "group": "build_log_sod_roof",
+    "category": "CONSTRUCT",
+    "required_skills": [ [ "fabrication", 4 ] ],
+    "time": "120 m",
+    "qualities": [ [ { "id": "HAMMER", "level": 2 } ] ],
+    "components": [
+      [ [ "log", 2 ] ],
+      [ [ "stick", 4 ], [ "2x4", 8 ], [ "stick_long", 2 ] ],
+      [ [ "material_soil", 40 ] ],
+      [ [ "birchbark", 12 ], [ "pine_bough", 12 ] ]
+    ],
+    "pre_note": "Must be supported directly from below or on at least two sides.",
+    "pre_special": [ "check_support", "check_unblocked" ],
+    "post_terrain": "t_log_sod_roof"
+  },
+  {
+    "type": "construction",
+    "id": "constr_metal_roof",
+    "group": "build_metal_roof",
+    "category": "CONSTRUCT",
+    "required_skills": [ [ "fabrication", 4 ], [ "mechanics", 4 ] ],
+    "time": "60 m",
+    "tools": [ [ [ "oxy_torch", 5 ], [ "welder", 25 ], [ "welder_crude", 40 ], [ "toolset", 40 ] ] ],
+    "qualities": [ [ { "id": "SAW_M", "level": 2 } ], [ { "id": "GLARE", "level": 1 } ] ],
+    "components": [ [ [ "steel_lump", 4 ], [ "steel_chunk", 12 ], [ "scrap", 36 ] ], [ [ "sheet_metal", 10 ] ] ],
+    "pre_note": "Must be supported directly from below or on at least two sides.",
+    "pre_special": [ "check_support", "check_unblocked" ],
+    "post_terrain": "t_metal_roof"
+  },
+  {
+    "type": "construction",
+    "id": "constr_metal_flat_roof",
+    "group": "build_metal_flat_roof",
+    "category": "CONSTRUCT",
+    "required_skills": [ [ "fabrication", 5 ] ],
+    "time": "45 m",
+    "qualities": [ { "id": "GLARE", "level": 1 } ],
+    "tools": [ [ [ "oxy_torch", 5 ], [ "welder", 25 ], [ "welder_crude", 40 ], [ "toolset", 40 ] ] ],
+    "components": [ [ [ "steel_plate", 2 ] ] ],
+    "pre_note": "Must be supported directly from below or on at least two sides.",
+    "pre_special": [ "check_support", "check_unblocked" ],
+    "post_terrain": "t_metal_flat_roof"
+  },
+  {
+    "type": "construction",
+    "id": "constr_resin_roof",
+    "group": "extrude_resin_roof",
+    "category": "CONSTRUCT",
+    "skill": "fabrication",
+    "difficulty": 1,
+    "time": "60 m",
+    "//": "Fairly time consuming as you have to extrude the resin slowly and wait for it to dry, then layer it on itself",
+    "components": [ [ [ "alien_pod_resin", 1 ] ] ],
+    "pre_note": "Must be supported directly from below or on at least two sides.",
+    "pre_special": [ "check_support", "check_unblocked" ],
+    "post_terrain": "t_resin_roof"
+  },
+  {
+    "type": "construction",
+    "id": "constr_shingle_flat_roof",
+    "group": "build_shingle_flat_roof",
+    "category": "CONSTRUCT",
+    "required_skills": [ [ "fabrication", 3 ] ],
+    "time": "60 m",
+    "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
+    "components": [ [ [ "wood_panel", 1 ] ], [ [ "2x4", 8 ] ], [ [ "nails", 20, "LIST" ] ] ],
+    "pre_note": "Must be supported directly from below or on at least two sides.",
+    "pre_special": [ "check_support", "check_unblocked" ],
+    "post_terrain": "t_shingle_flat_roof"
+  },
+  {
+    "type": "construction",
+    "id": "constr_thatched_roof",
+    "group": "build_thatched_roof",
+    "category": "CONSTRUCT",
+    "required_skills": [ [ "fabrication", 3 ], [ "survival", 7 ] ],
+    "time": "300 m",
+    "qualities": [ { "id": "CUT", "level": 2 } ],
+    "components": [
+      [ [ "2x4", 5 ], [ "stick", 10 ], [ "stick_long", 5 ] ],
+      [ [ "straw_pile", 60 ], [ "withered", 60 ] ],
+      [ [ "cordage", 8, "LIST" ] ]
+    ],
+    "pre_note": "Must be supported directly from below or on at least two sides.",
+    "pre_special": [ "check_support", "check_unblocked" ],
+    "post_terrain": "t_thatch_roof"
+  },
+  {
+    "type": "construction",
+    "id": "constr_treated_wood_roof",
+    "group": "build_treated_wood_roof",
+    "category": "CONSTRUCT",
+    "required_skills": [ [ "fabrication", 3 ] ],
+    "time": "60 m",
+    "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
+    "components": [ [ [ "wood_sheet", 1 ], [ "wood_panel", 2 ] ], [ [ "2x4", 6 ] ], [ [ "nails", 40, "LIST" ] ] ],
+    "pre_note": "Must be supported directly from below or on at least two sides.",
+    "pre_special": [ "check_support", "check_unblocked" ],
+    "post_terrain": "t_wood_treated_roof"
+  },
+  {
+    "type": "construction",
+    "id": "constr_wood_roof",
+    "group": "build_wood_roof",
+    "category": "CONSTRUCT",
+    "required_skills": [ [ "fabrication", 3 ] ],
+    "time": "60 m",
+    "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
+    "components": [ [ [ "wood_sheet", 1 ], [ "wood_panel", 2 ] ], [ [ "2x4", 6 ] ], [ [ "nails", 40, "LIST" ] ] ],
+    "pre_note": "Must be supported directly from below or on at least two sides.",
+    "pre_special": [ "check_support", "check_unblocked" ],
+    "post_terrain": "t_wood_roof"
   }
 ]

--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -1433,7 +1433,7 @@
   {
     "type": "construction",
     "id": "constr_scrap_floor",
-    "group": "build_scrap_floor_with_roof"
+    "group": "build_scrap_floor_with_roof",
     "category": "CONSTRUCT",
     "required_skills": [ [ "fabrication", 5 ] ],
     "time": "90 m",

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -166,8 +166,8 @@
   },
   {
     "type": "construction_group",
-    "id": "build_concrete_roof",
-    "name": "Build Concrete Roof"
+    "id": "build_concrete_floor_with_roof",
+    "name": "Build Concrete Floor with Roof"
   },
   {
     "type": "construction_group",
@@ -371,8 +371,8 @@
   },
   {
     "type": "construction_group",
-    "id": "build_log_sod_roof",
-    "name": "Build Log & Sod Roof"
+    "id": "build_primitive_floor_with_log_sod_roof",
+    "name": "Build Primitive Floor with Log & Sod Roof"
   },
   {
     "type": "construction_group",
@@ -456,8 +456,8 @@
   },
   {
     "type": "construction_group",
-    "id": "build_metal_roof",
-    "name": "Build Metal Roof"
+    "id": "build_scrap_floor_with_roof",
+    "name": "Build Scrap Floor with Roof"
   },
   {
     "type": "construction_group",
@@ -546,8 +546,8 @@
   },
   {
     "type": "construction_group",
-    "id": "build_reinforced_concrete_roof",
-    "name": "Build Reinforced Concrete Roof"
+    "id": "build_reinforced_concrete_floor_with_roof",
+    "name": "Build Reinforced Concrete Floor with Roof"
   },
   {
     "type": "construction_group",
@@ -651,13 +651,13 @@
   },
   {
     "type": "construction_group",
-    "id": "build_roof",
-    "name": "Build Roof"
+    "id": "build_floor_with_treated_roof",
+    "name": "Build Floor with Treated Roof"
   },
   {
     "type": "construction_group",
-    "id": "build_roof_over_dirt_floor",
-    "name": "Build Roof Over Dirt Floor"
+    "id": "build_dirt_floor_with_shingle_roof",
+    "name": "Build Dirt Floor with Flat Shingle Roof"
   },
   {
     "type": "construction_group",
@@ -821,8 +821,8 @@
   },
   {
     "type": "construction_group",
-    "id": "build_thatched_roof",
-    "name": "Build Thatched Roof"
+    "id": "build_dirt_floor_with_thatched_roof",
+    "name": "Build Dirt Floor with Thatched Roof"
   },
   {
     "type": "construction_group",
@@ -1988,5 +1988,60 @@
     "type": "construction_group",
     "id": "remove_scaffolding",
     "name": "Remove Scaffolding"
+  },
+  {
+    "type": "construction_group",
+    "id": "build_brick_roof",
+    "name": "Build Brick Roof"
+  },
+  {
+    "type": "construction_group",
+    "id": "build_concrete_roof",
+    "name": "Build Concrete Roof"
+  },
+  {
+    "type": "construction_group",
+    "id": "build_flat_roof",
+    "name": "Build Flat Roof"
+  },
+  {
+    "type": "construction_group",
+    "id": "build_log_sod_roof",
+    "name": "Build Log and Sod Roof"
+  },
+  {
+    "type": "construction_group",
+    "id": "build_metal_roof",
+    "name": "Build Metal Roof"
+  },
+  {
+    "type": "construction_group",
+    "id": "build_metal_flat_roof",
+    "name": "Build Flat Metal Roof"
+  },
+  {
+    "type": "construction_group",
+    "id": "extrude_resin_roof",
+    "name": "Extrude Resin Roof"
+  },
+  {
+    "type": "construction_group",
+    "id": "build_shingle_flat_roof",
+    "name": "Build Shingle Flat Roof"
+  },
+  {
+    "type": "construction_group",
+    "id": "build_thatched_roof",
+    "name": "Build Thatched Roof"
+  },
+  {
+    "type": "construction_group",
+    "id": "build_treated_wood_roof",
+    "name": "Build Treated Wood Roof"
+  },
+  {
+    "type": "construction_group",
+    "id": "build_wood_roof",
+    "name": "Build Wood Roof"
   }
 ]

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -2043,5 +2043,15 @@
     "type": "construction_group",
     "id": "build_wood_roof",
     "name": "Build Wood Roof"
+  },
+  {
+    "type": "construction_group",
+    "id": "build_chimney",
+    "name": "Build Chimney"
+  },
+  {
+    "type": "construction_group",
+    "id": "build_vent_pipe",
+    "name": "Build Vent Pipe"
   }
 ]

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -2462,8 +2462,9 @@ request](https://github.com/CleverRaven/Cataclysm-DDA/pull/36657) and the
 | pre_special            | Description
 |---                     |---
 | `check_channel`        | Must be empty and have a current in at least one orthogonal tile
-| `check_empty`          | Tile is empty (no furniture, trap, item, or vehicle) and flat terrain
 | `check_empty_lite`     | Tile is empty (no furniture, trap, item, or vehicle)
+| `check_empty`          | Tile is empty (no furniture, trap, item, or vehicle) and flat terrain
+| `check_unblocked`      | Tile is empty (no furniture, trap, item, or vehicle), and either flat terrain or empty space
 | `check_support`        | Must have at least two solid walls/obstructions nearby on orthogonals (non-diagonal directions only) or solid support directly below to support the tile
 | `check_support_below`  | Must have at least two solid walls/obstructions at the Z level below on orthogonals (non-diagonal directions only) or solid support directly below to support the tile and be empty lite but with a ledge trap acceptable, as well as open air
 | `check_single_support` | Must have solid support directly below to support the tile

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -157,6 +157,7 @@ static bool check_nothing( const tripoint_bub_ms & )
 static bool check_channel( const tripoint_bub_ms & ); // tile has adjacent flowing water
 static bool check_empty_lite( const tripoint_bub_ms & );
 static bool check_empty( const tripoint_bub_ms & ); // tile is empty
+static bool check_unblocked( const tripoint_bub_ms & ); // tile is empty or empty space
 static bool check_support( const tripoint_bub_ms
                            & ); // at least two orthogonal supports or from below
 static bool check_support_below( const tripoint_bub_ms
@@ -1245,9 +1246,21 @@ bool construct::check_empty( const tripoint_bub_ms &p )
     map &here = get_map();
     // @TODO should check for *visible* traps only. But calling code must
     // first know how to handle constructing on top of an invisible trap!
-    return ( here.has_flag( ter_furn_flag::TFLAG_FLAT, p ) && !here.has_furn( p ) &&
-             g->is_empty( p ) && here.tr_at( p ).is_null() &&
-             here.i_at( p ).empty() && !here.veh_at( p ) );
+    return here.has_flag( ter_furn_flag::TFLAG_FLAT, p ) && !here.has_furn( p ) &&
+           g->is_empty( p ) && here.tr_at( p ).is_null() &&
+           here.i_at( p ).empty() && !here.veh_at( p );
+}
+
+bool construct::check_unblocked( const tripoint_bub_ms &p )
+{
+    map &here = get_map();
+    // @TODO should check for *visible* traps only. But calling code must
+    // first know how to handle constructing on top of an invisible trap!
+    // Should also check for empty space rather than open air, when such a check exists.
+    return !here.has_furn( p ) &&
+           ( g->is_empty( p ) || here.ter( p ) == ter_t_open_air ) && ( here.tr_at( p ).is_null() ||
+                   here.tr_at( p ) == tr_ledge ) &&
+           here.i_at( p ).empty() && !here.veh_at( p );
 }
 
 bool construct::check_support( const tripoint_bub_ms &p )
@@ -2014,8 +2027,9 @@ void load_construction( const JsonObject &jo )
     static const std::map<std::string, bool( * )( const tripoint_bub_ms & )> pre_special_map = {{
             { "", construct::check_nothing },
             { "check_channel", construct::check_channel },
-            { "check_empty", construct::check_empty },
             { "check_empty_lite", construct::check_empty_lite },
+            { "check_empty", construct::check_empty },
+            { "check_unblocked", construct::check_unblocked },
             { "check_support", construct::check_support },
             { "check_support_below", construct::check_support_below },
             { "check_single_support", construct::check_single_support },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Add construction definitions for roofs. This allows for construction of roofs over things that currently don't get magic roofs (such as pony and glass walls) and allows for camp construction recipes to determine a construction cost for constructions specifying roofs (the end up as 0 otherwise), once 3D support gets merged.
Edit: Needed to roll the testing dice and decided to trigger that by adding construction of chimney and vent vane.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Go through all construction "recipes" that produce things which generate magic roofs and find all kinds of roofs used.
- Rename construction groups and descriptions using the term "roof" to clarify they actually produce a room tile with a roof above.
- Conjure up construction "recipes" for all roofs used, except for t_rock_roof, which shouldn't be generated by construction #73316.
- Created a new pre_condition to check for suitable locations for construction (gutters and on top of a wall are legal locations, but not a roof).
Edit:
- Add construction of chimney and vent vane.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

- Load a suitable save.
- Teleport up to the edge of the roof of the evac shelter camp.
- Debug create a log wall directly adjacent and below.
- Debug create construction materials for the roof to be tested.
- Construct said roof and look at it to verify the game says it's what you intended to construct.
- Kill the game.
- Repeat the above for each roof construction created.
Edit:
- Teleport onto the roof of an evac shelter.
- Construct Chimney and Vent Vane.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

The starting point is in a sorry state. Many construction "recipes" use very little resources, and in many cases do not seem to deduct anything for their magic roofs (while some definitely do). I haven't tried to delve into correcting this because I don't feel qualified at the least, don't like trying to deal with construction materials more than absolutely necessary, and it would constitute discouraged scope creep.
The comparison point is a room with the roof if available. Otherwise whatever conjures the roof is used.
Anyway, here's a summary of what was done:
- t_rock_roof: Created over various walls made out stone, but it's a natural stone material, not a constructed one. Bug report.
- t_wood_treated_roof: Taken materials for floor with roof. It's probably too little anyway.
- t_metal_roof: Used about half of the materials a door with a magic roof uses.
- t_shingle_flat_roof: Taken materials for floor with roof. It's probably too little anyway.
- t_resin_roof: Half the time due to only being roof rather than floor + roof.
- t_concrete_roof: Half time & materials.
- t_metal_flat_roof Half materials.
- t_flat_roof: Never constructed from any materials (all goes to doors). Copied the treated roof as a guessed analogue.
- t_wood_roof: Similar, but all materials appear to be used for the wall.
- t_thatch_roof: Assumed all materials are for the roof, as well as the bulk of the time.
- t_log_sod_roof: Assumed all materials and time are for the roof.
- t_brick roof: Copied the cost of the wall it's conjured up on top of. Should presumably use roof tiles and a wooden framework.

I have assumed the construction "recipe" names aren't stored in in-process constructions. If they are, there's a need for some kind of migration handling.

Edit: Since I needed to roll the testing dice again I decided to add chimney and vent vane furniture now rather than in a later PR. The intended purpose is to add these onto the roof of base camp constructions that place smoke generating equipment (fire place, stove, forge, ...).
Also note that since these aren't actually useful in the game itself, the construction pre_special is set to allow placement on roofs, rather than restrict placement in locations they'd make little sense. I don't actually expect them to be constructed by players directly, but only as part of camp constructions, but construction entries provide time, materials, etc. requirements for these to draw on.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
