### PR TITLE
Adding the spell name to the casting wait thingy

### DIFF
--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -50,6 +50,7 @@ static const activity_id ACT_NULL( "ACT_NULL" );
 static const activity_id ACT_PICKAXE( "ACT_PICKAXE" );
 static const activity_id ACT_PICKUP_MENU( "ACT_PICKUP_MENU" );
 static const activity_id ACT_READ( "ACT_READ" );
+static const activity_id ACT_SPELLCASTING( "ACT_SPELLCASTING" );
 static const activity_id ACT_TRAVELLING( "ACT_TRAVELLING" );
 static const activity_id ACT_VEHICLE( "ACT_VEHICLE" );
 static const activity_id ACT_VIEW_RECIPE( "ACT_VIEW_RECIPE" );
@@ -196,6 +197,11 @@ std::optional<std::string> player_activity::get_progress_message( const avatar &
 
                 extra_info = string_format( "%d%%", percentage );
             }
+        }
+
+        if( type == ACT_SPELLCASTING ) {
+            const std::string spell_name = u.magic->get_spell( spell_id( name ) ).name();
+            extra_info = string_format( "%s …", spell_name );
         }
     }
 


### PR DESCRIPTION
#### Summary

Interface "Adding spell name to the casting... widget"

#### Purpose of change

I saw the issue #72644 and resolved to work on it
fixes #72644

#### Describe the solution

It adds the name of the spell that is being casted to the extra_info in get_progress_message

#### Describe alternatives you've considered

Not doing it

#### Testing

1. Spawned a new character with spells
2. Spawned a monster
3. Tried to cast a spell with the monster close and the ignore distraction off

#### Additional context

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/59299346/8f4f781b-d359-48e6-a48d-778496e35898)
