### PR TITLE
Adjust the overmap test to remove some failure modes and make it more robust

### DIFF
--- a/data/json/regional_map_settings.json
+++ b/data/json/regional_map_settings.json
@@ -1096,7 +1096,7 @@
         "police": 100,
         "police_1": 100,
         "police_2": 100,
-        "police_dept": 125,
+        "police_dept": 1250,
         "fire_station": 200,
         "fire_station_1": 200,
         "home_improvement": 200,

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -92,6 +92,7 @@ overmap &overmapbuffer::get( const point_abs_om &p )
 
     // That constructor loads an existing overmap or creates a new one.
     overmap &new_om = *( overmaps[ p ] = std::make_unique<overmap>( p ) );
+    overmap_count++;
     new_om.populate();
     // Note: fix_mongroups might load other overmaps, so overmaps.back() is not
     // necessarily the overmap at (x,y)
@@ -111,6 +112,7 @@ void overmapbuffer::create_custom_overmap( const point_abs_om &p, overmap_specia
         }
     }
     overmap &new_om = *( overmaps[ p ] = std::make_unique<overmap>( p ) );
+    overmap_count++;
     new_om.populate( specials );
 }
 
@@ -242,6 +244,8 @@ void overmapbuffer::clear()
     overmaps.clear();
     known_non_existing.clear();
     placed_unique_specials.clear();
+    unique_special_count.clear();
+    overmap_count = 0;
     last_requested_overmap = nullptr;
 }
 

--- a/src/overmapbuffer.h
+++ b/src/overmapbuffer.h
@@ -529,6 +529,14 @@ class overmapbuffer
         bool place_special( const overmap_special_id &special_id, const tripoint_abs_omt &center,
                             int radius );
 
+        int get_unique_special_count( const overmap_special_id &id ) {
+            return unique_special_count[id];
+        }
+
+        int get_overmap_count() const {
+            return overmap_count;
+        }
+
     private:
         /**
          * Common function used by the find_closest/all/random to determine if the location is
@@ -548,6 +556,11 @@ class overmapbuffer
         overmap mutable *last_requested_overmap;
         // Set of globally unique overmap specials that have already been placed
         std::unordered_set<overmap_special_id> placed_unique_specials;
+        // This tracks the unique specials we have placed. It is used to
+        // Adjust weights of special spawns to correct for things like failure to spawn.
+        std::unordered_map<overmap_special_id, int> unique_special_count;
+        // Global count of number of overmaps generated for this world.
+        int overmap_count = 0;
 
         /**
          * Get a list of notes in the (loaded) overmaps.
@@ -588,15 +601,25 @@ class overmapbuffer
          */
         void add_unique_special( const overmap_special_id &id );
         /**
+         * Logs the placement of the given unique overmap special.
+         */
+        void log_unique_special( const overmap_special_id &id ) {
+            unique_special_count[id]++;
+        }
+        /**
          * Returns true if the given globally unique overmap special has already been placed.
          */
         bool contains_unique_special( const overmap_special_id &id ) const;
         /**
-         * Writes the placed unique specials as a JSON value.
+         * Writes metadata about special placement as a JSON value.
          */
-        void serialize_placed_unique_specials( JsonOut &json ) const;
+        void serialize_overmap_global_state( JsonOut &json ) const;
         /**
-         * Reads placed unique specials from JSON and overwrites the global value.
+         * Reads metadata about special placement from JSON.
+         */
+        void deserialize_overmap_global_state( const JsonObject &json );
+        /**
+         * Reads deprecated placed unique specials data, replaced by overmap_global_state.
          */
         void deserialize_placed_unique_specials( const JsonValue &jsin );
     private:

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -1422,6 +1422,8 @@ void game::unserialize_master( const JsonValue &jv )
             weather_manager::unserialize_all( jsin );
         } else if( name == "timed_events" ) {
             timed_event_manager::unserialize_all( jsin );
+        } else if( name == "overmapbuffer" ) {
+            overmap_buffer.deserialize_overmap_global_state( jsin );
         } else if( name == "placed_unique_specials" ) {
             overmap_buffer.deserialize_placed_unique_specials( jsin );
         }
@@ -1548,8 +1550,8 @@ void game::serialize_master( std::ostream &fout )
 
         json.member( "active_missions" );
         mission::serialize_all( json );
-        json.member( "placed_unique_specials" );
-        overmap_buffer.serialize_placed_unique_specials( json );
+        json.member( "overmapbuffer" );
+        overmap_buffer.serialize_overmap_global_state( json );
 
         json.member( "timed_events" );
         timed_event_manager::serialize_all( json );
@@ -1684,9 +1686,26 @@ void creature_tracker::serialize( JsonOut &jsout ) const
     jsout.end_array();
 }
 
-void overmapbuffer::serialize_placed_unique_specials( JsonOut &json ) const
+void overmapbuffer::serialize_overmap_global_state( JsonOut &json ) const
 {
+    json.start_object();
+    json.member( "placed_unique_specials" );
     json.write_as_array( placed_unique_specials );
+    json.member( "overmap_count", overmap_buffer.overmap_count );
+    json.member( "unique_special_count", unique_special_count );
+    json.end_object();
+}
+
+void overmapbuffer::deserialize_overmap_global_state( const JsonObject &json )
+{
+    placed_unique_specials.clear();
+    JsonArray ja = json.get_array( "placed_unique_specials" );
+    for( const JsonValue &special : ja ) {
+        placed_unique_specials.emplace( special.get_string() );
+    }
+    unique_special_count.clear();
+    json.read( "unique_special_count", unique_special_count );
+    json.read( "overmap_count", overmap_count );
 }
 
 void overmapbuffer::deserialize_placed_unique_specials( const JsonValue &jsin )

--- a/tests/overmap_test.cpp
+++ b/tests/overmap_test.cpp
@@ -9,6 +9,7 @@
 #include "common_types.h"
 #include "coordinates.h"
 #include "enums.h"
+#include "game.h"
 #include "game_constants.h"
 #include "global_vars.h"
 #include "item_factory.h"
@@ -58,6 +59,7 @@ TEST_CASE( "set_and_get_overmap_scents", "[overmap]" )
 
 TEST_CASE( "default_overmap_generation_always_succeeds", "[overmap][slow]" )
 {
+    overmap_buffer.clear();
     int overmaps_to_construct = 10;
     for( const point_abs_om &candidate_addr : closest_points_first( point_abs_om(), 10 ) ) {
         // Skip populated overmaps.
@@ -77,7 +79,6 @@ TEST_CASE( "default_overmap_generation_always_succeeds", "[overmap][slow]" )
             break;
         }
     }
-    overmap_buffer.clear();
 }
 
 TEST_CASE( "default_overmap_generation_has_non_mandatory_specials_at_origin", "[overmap][slow]" )
@@ -87,6 +88,7 @@ TEST_CASE( "default_overmap_generation_has_non_mandatory_specials_at_origin", "[
     overmap_special mandatory;
     overmap_special optional;
 
+    overmap_buffer.clear();
     // Get some specific overmap specials so we can assert their presence later.
     // This should probably be replaced with some custom specials created in
     // memory rather than tying this test to these, but it works for now...
@@ -129,7 +131,6 @@ TEST_CASE( "default_overmap_generation_has_non_mandatory_specials_at_origin", "[
 
     INFO( "Failed to place optional special on origin " );
     CHECK( found_optional == true );
-    overmap_buffer.clear();
 }
 
 TEST_CASE( "is_ot_match", "[overmap][terrain]" )
@@ -388,21 +389,38 @@ TEST_CASE( "overmap_terrain_coverage", "[overmap][slow]" )
     std::unordered_map<itype_id, float> item_counts;
     finalize_item_counts( item_counts );
     map &main_map = get_map();
-    point_abs_omt map_origin = project_to<coords::omt>( main_map.get_abs_sub().xy() );
-    for( int i = 0; i < 10; ++i ) {
-        for( const point_abs_omt &p : closest_points_first( map_origin, 5, 3 * ( OMAPX - 1 ) ) ) {
-            // We need to avoid OMTs that overlap with the 'main' map, so we start at a
-            // non-zero minimum radius and ensure that the 'main' map is inside that
-            // minimum radius.
-            if( main_map.inbounds( tripoint_abs_ms( project_to<coords::ms>( p ), 0 ) ) ) {
+    point_abs_om overmap_origin = project_to<coords::om>( main_map.get_abs_sub().xy() );
+    g->place_player_overmap( { project_to<coords::omt>( overmap_origin + ( 6 * point_north_west ) ), 0 } );
+    // Don't inherit overmap state from initialization or previous tests.
+    overmap_buffer.clear();
+    for( int i = 0; i < 7; ++i ) {
+        // First we just touch all the overmaps in an area to cause them to generate.
+        for( const point_abs_om &om_cur : closest_points_first( overmap_origin, 0, 3 ) ) {
+            point_abs_omt omt_start = project_to<coords::omt>( om_cur );
+            overmap_buffer.ter( { omt_start, 0 } );
+        }
+        // Then we scan the generated overmaps.
+        for( const point_abs_om &om_cur : closest_points_first( overmap_origin, 0, 5 ) ) {
+            point_abs_omt omt_start = project_to<coords::omt>( om_cur );
+            // In the two rows of overmaps outside the central area, special placement logic.
+            // Can trigger additional overmap placement, this checcks to see if an overmap
+            // Has already been placed, and skips it if it hasn't.
+            // This insures we can scan all the overmaps we generate.
+            if( overmap_buffer.ter_existing( { omt_start, 0 } ) == oter_id() ) {
                 continue;
             }
-            for( int z = -OVERMAP_DEPTH; z <= OVERMAP_HEIGHT; ++z ) {
-                tripoint_abs_omt tp( p, z );
-                oter_type_id id = overmap_buffer.ter( tp )->get_type_id();
-                auto iter_bool = stats.emplace( id, tp );
-                iter_bool.first->second.last_observed = tp;
-                ++iter_bool.first->second.count;
+            point_abs_omt omt_end = omt_start + ( point_south_east * OMAPX );
+            for( point_abs_omt p = omt_start; p.y() < omt_end.y(); p.y()++ ) {
+                for( p.x() = omt_start.x(); p.x() < omt_end.x(); p.x()++ ) {
+                    REQUIRE( !main_map.inbounds( tripoint_abs_ms( project_to<coords::ms>( p ), 0 ) ) );
+                    for( int z = -OVERMAP_DEPTH; z <= OVERMAP_HEIGHT; ++z ) {
+                        tripoint_abs_omt tp( p, z );
+                        oter_type_id id = overmap_buffer.ter( tp )->get_type_id();
+                        auto iter_bool = stats.emplace( id, tp );
+                        iter_bool.first->second.last_observed = tp;
+                        ++iter_bool.first->second.count;
+                    }
+                }
             }
         }
         // The second phase of this test is to perform the tile-level mapgen
@@ -447,7 +465,6 @@ TEST_CASE( "overmap_terrain_coverage", "[overmap][slow]" )
             CAPTURE( msg );
             CAPTURE( msg.empty() );
         }
-
         overmap_buffer.reset();
     }
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Overmap test has been extra flaky recently, so I dove in to try and address this.
I also tackled a systemic issue in unique special placement.
The status quo is that when deciding what specials to attempt to place on an overmap, the code invokes one_in( x, y ) for each unique, using that to prune the list of specials to attempt to place. The problem here is that the test (and for that matter the player) does not visit a really huge number of different overmaps, the test visits about 300, a typical player will reach far fewer than that. Meanwhile some unique specials have a spawn rate around 5 / 100 or even 2 / 100, meaning it doesn't take much of an outlier at all to not generate *at least one of the specials* in 300 overmaps.

#### Describe the solution
I realized that if a global unique spawns on a chunk of an overmap we don't scan, we will never find it, so I did two things:
Moved the player outside the region we're scanning.
Adjusted how we iterate over overmaps to insure that we are scanning in an overmap-aligned way so we visit every tile of every overmap we generate, and generate overmaps in a pattern that insures we catch all of them.
Also added some more overmapbuffer resets to insure we're starting with a clean slate.
Also noticed I messed up the spawn rate for the police dept so fixed that.
Finally, I tackled unique overmap special placement, which seems to be a big part of the problem.
What I did was attempt to adjust the chances of selecting a special in a way that reinforces the intent of the current setting. Basically I'm tracking the rate of occurrence of the unique specials, and if they are occurring more often than specified, it dials down the chances of selecting that special again, and if the rate of occurrence is lower than configured it increases the rate of occurrence.  The result is the rate of occurence for specials should follow their configured values more closely rather than less, specials that are placed easily would "back off" and make room for specials that have more trouble finding a placement.

#### Describe alternatives you've considered
~~We're still subject to failures due to how overmap specials are placed, but since that requires digging into overmap generation instead of the test I'm pushing that off to a different PR.~~
Scope Creep Shmope Creep

#### Testing
while tests/cata_test "overmap_terrain_coverage"; do :; done
I'm up to 30 runs in a row with no failures, ~~though it looks like a persistent unrelated failure during initialization has made it in.~~ This was just a local build desync.