### PR TITLE
Aftershock: Blood bionics

### DIFF
--- a/data/mods/Aftershock/effects.json
+++ b/data/mods/Aftershock/effects.json
@@ -183,7 +183,7 @@
     "id": "synth_blood_permanent",
     "name": [ "Synthblood" ],
     "desc": [
-      "Your breaths instinctively grows more shallow as the synthetic blood carries oxygen throughout your body, increasing your speed, stamina, and general endurance."
+      "Your breaths instinctively grow shallow as the synthetic blood carries oxygen throughout your body, increasing your speed, stamina, and general endurance."
     ],
     "removes_effects": [ "synth_blood_perf" ],
     "rating": "good",

--- a/data/mods/Aftershock/effects.json
+++ b/data/mods/Aftershock/effects.json
@@ -180,6 +180,19 @@
   },
   {
     "type": "effect_type",
+    "id": "synth_blood_permanent",
+    "name": [ "Synthblood" ],
+    "desc": [
+      "Your breaths instinctively grows more shallow as the synthetic blood carries oxygen throughout your body, increasing your speed, stamina, and general endurance."
+    ],
+    "removes_effects": [ "synth_blood_perf" ],
+    "rating": "good",
+    "base_mods": { "speed_mod": [ 15 ], "str_mod": [ 1 ], "dex_mod": [ 1 ] },
+    "blood_analysis_description": "Synthetic blood",
+    "show_in_info": true
+  },
+  {
+    "type": "effect_type",
     "id": "afs_isohypsa_overwatch",
     "name": [ "Isohypsa Overwatch" ],
     "desc": [

--- a/data/mods/Aftershock/itemgroups/bionics_groups.json
+++ b/data/mods/Aftershock/itemgroups/bionics_groups.json
@@ -89,11 +89,13 @@
         [ "afs_bio_melee_counteraction", 10 ],
         [ "afs_bio_melee_optimization_unit", 10 ],
         [ "afs_bio_monowhip", 10 ],
+        [ "afs_bio_blood_plus", 10 ],
         [ "bio_forcefield_bash_cut_medium", 16 ],
         [ "bio_forcefield_bash_cut_heavy", 3 ],
         [ "bio_forcefield_ballistic_weak", 10 ],
         [ "bio_forcefield_ballistic_medium", 10 ],
         [ "afs_bio_translocator", 5 ],
+        [ "afs_bio_blood_brain", 1 ],
         [ "bio_shock_absorber", 2 ],
         [ "afs_bio_skullgun", 2 ]
       ]
@@ -178,6 +180,7 @@
         [ "afs_bio_neurosoft_aeronautics", 10 ],
         [ "afs_bio_dopamine_stimulators", 10 ],
         [ "afs_bio_monowhip", 10 ],
+        [ "afs_bio_blood_plus", 10 ],
         [ "afs_bio_translocator", 5 ],
         [ "afs_bio_skullgun", 2 ]
       ]

--- a/data/mods/Aftershock/items/cbms.json
+++ b/data/mods/Aftershock/items/cbms.json
@@ -42,7 +42,7 @@
     "copy-from": "bionic_general",
     "type": "BIONIC_ITEM",
     "name": { "str": "Synthblood Biofactory CBM" },
-    "description": "A mercurial brand biofactory that replaces the user's blood with a synthetic substitute.  Primarily desinged to boost combat performance, its common among the corporation's own security forces.  The biofactory can't be removed once integrated witha a host.",
+    "description": "A mercurial brand biofactory that replaces the user's blood with a synthetic substitute.  Primarily desinged to boost combat performance, its common among the corporation's own security forces.  The biofactory can't be removed once integrated with a host.",
     "price_postapoc": "15 kUSD",
     "difficulty": 5
   },

--- a/data/mods/Aftershock/items/cbms.json
+++ b/data/mods/Aftershock/items/cbms.json
@@ -38,6 +38,24 @@
     "difficulty": 5
   },
   {
+    "id": "afs_bio_blood_plus",
+    "copy-from": "bionic_general",
+    "type": "BIONIC_ITEM",
+    "name": { "str": "Synthblood Biofactory CBM" },
+    "description": "A mercurial brand biofactory that replaces the user's blood with a synthetic substitute.  Primarily desinged to boost combat performance, its common among the corporation's own security forces.  The biofactory can't be removed once integrated witha a host.",
+    "price_postapoc": "15 kUSD",
+    "difficulty": 5
+  },
+  {
+    "id": "afs_bio_blood_brain",
+    "copy-from": "bionic_general",
+    "type": "BIONIC_ITEM",
+    "name": { "str": "Blood Neurology CBM" },
+    "description": "A radical nanite treatment that allows its host's circulatory system to function as a secondary nervous system, greatly increasing their mental acuity and allowing them to survive trauma that would otherwise be fatal.  A cybernetic enhancement of this category is a rare find and could be easily traded for significant favors and resources.",
+    "price_postapoc": "475 kUSD",
+    "difficulty": 5
+  },
+  {
     "id": "afs_bio_linguistic_coprocessor",
     "copy-from": "bionic_general",
     "type": "BIONIC_ITEM",

--- a/data/mods/Aftershock/items/cbms.json
+++ b/data/mods/Aftershock/items/cbms.json
@@ -42,7 +42,7 @@
     "copy-from": "bionic_general",
     "type": "BIONIC_ITEM",
     "name": { "str": "Synthblood Biofactory CBM" },
-    "description": "A mercurial brand biofactory that replaces the user's blood with a synthetic substitute.  Primarily desinged to boost combat performance, its common among the corporation's own security forces.  The biofactory can't be removed once integrated with a host.",
+    "description": "A Mercurial Genomics brand biofactory that replaces the user's blood with a synthetic substitute.  Primarily designed to boost combat performance, its common among the corporation's own security forces.  The biofactory can't be removed once integrated with a host.",
     "price_postapoc": "15 kUSD",
     "difficulty": 5
   },

--- a/data/mods/Aftershock/player/bionic_eocs.json
+++ b/data/mods/Aftershock/player/bionic_eocs.json
@@ -21,6 +21,13 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "afs_eoc_blood_brain_heal",
+    "eoc_type": "PREVENT_DEATH",
+    "condition": { "u_has_bionics": "afs_bio_blood_brain" },
+    "effect": [ { "math": [ "u_hp('head')", "=", "1" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "afs_eoc_chembaseline",
     "effect": [
       { "u_lose_effect": "decreased_performance" },

--- a/data/mods/Aftershock/player/bionics.json
+++ b/data/mods/Aftershock/player/bionics.json
@@ -110,7 +110,7 @@
           { "value": "PERCEPTION", "add": 4 },
           { "value": "DEXTERITY", "add": 4 },
           { "value": "PAIN", "multiply": -0.33 },
-          { "value": "PAIN_PENALTY_MOD_INT", "add": - 4 }
+          { "value": "PAIN_PENALTY_MOD_INT", "add": -4 }
         ]
       }
     ]

--- a/data/mods/Aftershock/player/bionics.json
+++ b/data/mods/Aftershock/player/bionics.json
@@ -84,6 +84,38 @@
     "time": "1 s"
   },
   {
+    "id": "afs_bio_blood_plus",
+    "type": "bionic",
+    "name": { "str": "Synthetic Marrow" },
+    "description": "The interior of your femurs have been scrapped clean, the marrow replaced with a Mercurial brand bio-factory that produces high efficiency blood analogues.  The blood substitutes are fine-tuned for combat, increasing stamina, disease resistance and clotting speed.",
+    "cant_remove_reason": "The biofactory has perfectly integrated with your body, removing it would be pointless and potentially fatal.",
+    "occupied_bodyparts": [ [ "leg_l", 2 ], [ "leg_r", 2 ] ],
+    "enchantments": [
+      {
+        "ench_effects": [ { "effect": "synth_blood_permanent", "intensity": 2 } ],
+        "values": [ { "value": "CARDIO_MULTIPLIER", "multiply": 1.2 } ]
+      }
+    ]
+  },
+  {
+    "id": "afs_bio_blood_brain",
+    "type": "bionic",
+    "name": { "str": "Blood Neurology" },
+    "description": "Your blood is laced with neuron-analogue nanites, allowing your entire circulatory system to function as a secondary brain.  This radical modification increases your intelligence, reflexes and perception by 4, increases your pain tolerance and allows you to survive brain damage that would otherwise prove fatal.",
+    "occupied_bodyparts": [ [ "leg_l", 2 ], [ "leg_r", 2 ] ],
+    "enchantments": [
+      {
+        "values": [
+          { "value": "INTELLIGENCE", "add": 4 },
+          { "value": "PERCEPTION", "add": 4 },
+          { "value": "DEXTERITY", "add": 4 },
+          { "value": "PAIN", "multiply": -0.33 },
+          { "value": "PAIN_PENALTY_MOD_INT", "add": 4 }
+        ]
+      }
+    ]
+  },
+  {
     "id": "afs_bio_melee_optimization_unit",
     "type": "bionic",
     "name": { "str": "Melee Optimization Unit" },

--- a/data/mods/Aftershock/player/bionics.json
+++ b/data/mods/Aftershock/player/bionics.json
@@ -110,7 +110,7 @@
           { "value": "PERCEPTION", "add": 4 },
           { "value": "DEXTERITY", "add": 4 },
           { "value": "PAIN", "multiply": -0.33 },
-          { "value": "PAIN_PENALTY_MOD_INT", "add": 4 }
+          { "value": "PAIN_PENALTY_MOD_INT", "add": - 4 }
         ]
       }
     ]


### PR DESCRIPTION
#### Summary
Mods "Aftershock: New combat bionics"

#### Purpose of change
More chrome.

#### Describe the solution
The new bionics are:

- Blood neurology: A powerful stat enhancer that also diminishes pain and its effects on intelligence. Prevents you from dying from head trauma although you still suffer when your main brain gets shaken.
- Synthetic Marrow: A cardio increase, grants you a slightly weakened  extra dex, strength and speed from the synthblood effect.

#### Testing
Used both bionics a bit.