### PR TITLE
Aftershock: Magazine flag audit

### DIFF
--- a/data/mods/Aftershock/items/magazine/25mm.json
+++ b/data/mods/Aftershock/items/magazine/25mm.json
@@ -13,6 +13,7 @@
     "color": "dark_gray",
     "ammo_type": [ "afs_25mm" ],
     "reload_time": 60,
+    "flags": [ "MAG_BULKY" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "afs_25mm": 40 } } ]
   }
 ]

--- a/data/mods/Aftershock/items/magazine/alien.json
+++ b/data/mods/Aftershock/items/magazine/alien.json
@@ -14,7 +14,7 @@
     "ammo_type": [ "battery" ],
     "capacity": 4500,
     "looks_like": "battery",
-    "flags": [ "NO_SALVAGE", "NO_UNLOAD" ],
+    "flags": [ "NO_SALVAGE", "NO_UNLOAD", "MAG_BULKY" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 4500 } } ]
   }
 ]

--- a/data/mods/Aftershock/items/magazine/energy_cell.json
+++ b/data/mods/Aftershock/items/magazine/energy_cell.json
@@ -13,7 +13,7 @@
     "symbol": "#",
     "color": "light_gray",
     "ammo_type": [ "battery" ],
-    "flags": [ "NO_UNLOAD", "RECHARGE" ],
+    "flags": [ "NO_UNLOAD", "RECHARGE", "MAG_COMPACT" ],
     "capacity": 1500,
     "reload_time": 3,
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 1500 } } ]
@@ -42,7 +42,7 @@
     "price_postapoc": "50 USD",
     "capacity": 600,
     "reload_time": 5,
-    "flags": [ "NO_UNLOAD" ],
+    "flags": [ "NO_UNLOAD", "MAG_COMPACT" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 600 } } ]
   },
   {
@@ -57,7 +57,7 @@
     "capacity": 15000,
     "count": 15000,
     "reload_time": 5,
-    "flags": [ "NO_UNLOAD" ],
+    "flags": [ "NO_UNLOAD", "MAG_COMPACT" ],
     "default_ammo": "afs_battery_plus",
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 15000 } } ]
   }

--- a/data/mods/Aftershock/items/magazine/plasma.json
+++ b/data/mods/Aftershock/items/magazine/plasma.json
@@ -13,7 +13,7 @@
     "symbol": "o",
     "color": "light_blue",
     "ammo_type": [ "afs_shydrogen" ],
-    "flags": [ "NO_UNLOAD", "NO_RELOAD" ],
+    "flags": [ "NO_UNLOAD", "NO_RELOAD", "MAG_COMPACT" ],
     "capacity": 4,
     "reload_time": 10,
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "airtight": true, "ammo_restriction": { "afs_shydrogen": 4 } } ]
@@ -32,7 +32,7 @@
     "symbol": "o",
     "color": "light_blue",
     "ammo_type": [ "afs_shydrogen" ],
-    "flags": [ "NO_UNLOAD", "NO_RELOAD" ],
+    "flags": [ "NO_UNLOAD", "NO_RELOAD", "MAG_COMPACT" ],
     "capacity": 4,
     "reload_time": 10,
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "airtight": true, "ammo_restriction": { "afs_shydrogen": 20 } } ]
@@ -51,7 +51,7 @@
     "symbol": "o",
     "color": "light_red",
     "ammo_type": [ "afs_shydrogen" ],
-    "flags": [ "NO_UNLOAD", "NO_RELOAD" ],
+    "flags": [ "NO_UNLOAD", "NO_RELOAD", "MAG_COMPACT" ],
     "capacity": 40,
     "reload_time": 40,
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "airtight": true, "ammo_restriction": { "afs_shydrogen": 40 } } ]

--- a/data/mods/Aftershock/items/magazine/voltaic.json
+++ b/data/mods/Aftershock/items/magazine/voltaic.json
@@ -9,6 +9,7 @@
     "volume": "125 ml",
     "price": "3 kUSD",
     "price_postapoc": "3 kUSD",
+    "flags": [ "MAG_COMPACT" ],
     "capacity": 500,
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 1500 } } ]
   }


### PR DESCRIPTION
#### Summary
Mods "Aftershock: Audit magazine flags for better storage"

#### Purpose of change
Audit the flags of mod magazines before adding new military gear.

#### Describe the solution
Add flags based on volume and plausible shape.

#### Testing

Loaded game
