### PR TITLE
More debug power

### DIFF
--- a/data/json/items/armor/storage.json
+++ b/data/json/items/armor/storage.json
@@ -2948,7 +2948,7 @@
     ],
     "warmth": 0,
     "material_thickness": 0,
-    "flags": [ "BELTED", "WATER_FRIENDLY", "TARDIS", "OVERSIZE" ],
+    "flags": [ "BELTED", "WATER_FRIENDLY", "TARDIS", "OVERSIZE", "WATCH", "THERMOMETER" ],
     "armor": [ { "encumbrance": [ 0, 0 ], "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_back" ] } ]
   },
   {

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -9123,6 +9123,17 @@
   },
   {
     "type": "mutation",
+    "id": "DEBUG_STAMINA",
+    "name": { "str": "Debug Stamina" },
+    "points": 99,
+    "valid": false,
+    "description": "Your energy to squash bugs is endless!",
+    "enchantments": [ { "values": [ { "value": "STAMINA_REGEN_MOD", "add": 9 } ] } ],
+    "debug": true,
+    "active": true
+  },
+  {
+    "type": "mutation",
     "id": "DEBUG_PREVENT_DEATH",
     "name": { "str": "Debug Prevent Death" },
     "points": 99,

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -150,10 +150,13 @@ static const trait_id trait_DEBUG_BIONICS( "DEBUG_BIONICS" );
 static const trait_id trait_DEBUG_CLAIRVOYANCE( "DEBUG_CLAIRVOYANCE" );
 static const trait_id trait_DEBUG_CLOAK( "DEBUG_CLOAK" );
 static const trait_id trait_DEBUG_HS( "DEBUG_HS" );
+static const trait_id trait_DEBUG_LIGHT( "DEBUG_LIGHT" );
 static const trait_id trait_DEBUG_LS( "DEBUG_LS" );
 static const trait_id trait_DEBUG_MANA( "DEBUG_MANA" );
+static const trait_id trait_DEBUG_MIND_CONTROL( "DEBUG_MIND_CONTROL" );
 static const trait_id trait_DEBUG_NODMG( "DEBUG_NODMG" );
 static const trait_id trait_DEBUG_NOTEMP( "DEBUG_NOTEMP" );
+static const trait_id trait_DEBUG_STAMINA( "DEBUG_STAMINA" );
 static const trait_id trait_DEBUG_SPEED( "DEBUG_SPEED" );
 static const trait_id trait_NONE( "NONE" );
 
@@ -2895,8 +2898,8 @@ void debug()
 
     // Used for quick setup, constructed outside the switches to reduce duplicate code
     std::vector<trait_id> setup_traits{trait_DEBUG_BIONICS, trait_DEBUG_CLAIRVOYANCE, trait_DEBUG_CLOAK,
-                                       trait_DEBUG_HS, trait_DEBUG_LS, trait_DEBUG_MANA, trait_DEBUG_NODMG,
-                                       trait_DEBUG_NOTEMP, trait_DEBUG_SPEED};
+                                       trait_DEBUG_HS, trait_DEBUG_LIGHT, trait_DEBUG_LS, trait_DEBUG_MANA, trait_DEBUG_MIND_CONTROL,
+                                       trait_DEBUG_NODMG, trait_DEBUG_NOTEMP, trait_DEBUG_STAMINA, trait_DEBUG_SPEED};
 
     avatar &player_character = get_avatar();
     map &here = get_map();


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Debug quick setup could cover even more common needs

#### Describe the solution
Implement them

Now adds the following mutations with quick setup and toggle:
Debug mind control (already exists, just forgot to add it before) lets you instantly recruit NPCs with a chat command

Debug light  (already exists, just forgot to add it before) prevents many common things from stopping when darkness hits (which check light level as opposed to whether you have clairvoyance. This is less invasive)

Debug stamina (new) gives you 10x as much stamina regen. Because DEBUG_SPEED let you walk 11x as fast, but didn't modify your stamina drain on walking... meaning that you'd eventually walk yourself out of stamina, prompting a query. Unfortunate!
-There is an existing mutation, DEBUG_CARDIO, which sounds like it should handle this but it uh, doesn't? In any case stamina and cardio are distinct concepts, so more debug power is more debug power.

Also added WATCH and THERMOMETER flags to the pocket universe, so the sidebar can provide that information instantly when quick setup is applied.

#### Describe alternatives you've considered


#### Testing
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/f1104af5-0512-4a86-994a-b5bfcbbb9c35)


#### Additional context
