### PR TITLE
Broken Wheels Now Give Rubber

### DIFF
--- a/data/json/vehicleparts/wheel.json
+++ b/data/json/vehicleparts/wheel.json
@@ -221,7 +221,10 @@
     "breaks_into": [
       { "item": "steel_lump", "count": [ 1, 2 ] },
       { "item": "steel_chunk", "count": [ 1, 2 ] },
-      { "item": "scrap", "count": [ 1, 2 ] }
+      { "item": "scrap", "count": [ 1, 2 ] },
+      { "item": "rubber_tire_chunk", "count": [ 0, 1 ] },
+      { "item": "chunk_rubber", "count": [ 8, 19 ] },
+      { "item": "shredded_rubber", "charges": [ 8, 20 ] }
     ],
     "wheel_terrain_modifiers": { "FLAT": [ 0, 4 ], "ROAD": [ 0, 2 ] },
     "contact_area": 153,
@@ -287,7 +290,13 @@
     "description": "A small wheel.",
     "damage_modifier": 50,
     "folded_volume": "2250 ml",
-    "breaks_into": [ { "item": "steel_lump" }, { "item": "steel_chunk", "count": [ 1, 3 ] }, { "item": "scrap", "count": [ 1, 3 ] } ],
+    "breaks_into": [
+      { "item": "steel_lump" },
+      { "item": "steel_chunk", "count": [ 1, 3 ] },
+      { "item": "scrap", "count": [ 1, 3 ] },
+      { "item": "chunk_rubber", "count": [ 4, 15 ] },
+      { "item": "shredded_rubber", "charges": [ 4, 10 ] }
+    ],
     "rolling_resistance": 1.62,
     "wheel_offroad_rating": 0.7,
     "wheel_terrain_modifiers": { "FLAT": [ 0, 3 ], "ROAD": [ 0, 1 ] },
@@ -316,7 +325,10 @@
     "breaks_into": [
       { "item": "steel_lump", "prob": 50 },
       { "item": "steel_chunk", "count": [ 1, 2 ] },
-      { "item": "scrap", "count": [ 1, 2 ] }
+      { "item": "scrap", "count": [ 1, 2 ] },
+      { "item": "rubber_tire_chunk", "count": [ 0, 1 ] },
+      { "item": "chunk_rubber", "count": [ 4, 13 ] },
+      { "item": "shredded_rubber", "charges": [ 5, 12 ] }
     ],
     "rolling_resistance": 0.45,
     "wheel_terrain_modifiers": { "FLAT": [ 0, 4 ], "ROAD": [ 0, 2 ] },
@@ -471,7 +483,10 @@
       { "item": "steel_lump", "prob": 50 },
       { "item": "steel_chunk", "count": [ 1, 5 ] },
       { "item": "scrap", "count": [ 1, 5 ] },
-      { "item": "plastic_chunk", "count": [ 1, 5 ] }
+      { "item": "plastic_chunk", "count": [ 1, 5 ] },
+      { "item": "rubber_tire_chunk", "count": [ 0, 1 ] },
+      { "item": "chunk_rubber", "count": [ 3, 12 ] },
+      { "item": "shredded_rubber", "charges": [ 12, 30 ] }
     ],
     "rolling_resistance": 29.0,
     "wheel_offroad_rating": 0.7,
@@ -500,7 +515,10 @@
     "breaks_into": [
       { "item": "steel_lump", "count": [ 1, 3 ] },
       { "item": "steel_chunk", "count": [ 1, 3 ] },
-      { "item": "scrap", "count": [ 1, 3 ] }
+      { "item": "scrap", "count": [ 1, 3 ] },
+      { "item": "rubber_tire_chunk", "count": [ 0, 1 ] },
+      { "item": "chunk_rubber", "count": [ 8, 19 ] },
+      { "item": "shredded_rubber", "charges": [ 8, 20 ] }
     ],
     "rolling_resistance": 1.9,
     "wheel_terrain_modifiers": { "FLAT": [ 0, 4 ], "ROAD": [ 0, 2 ] },
@@ -524,6 +542,14 @@
     "name": { "str": "off-road motorbike wheel" },
     "item": "wheel_motorbike_or",
     "contact_area": 60,
+    "breaks_into": [
+      { "item": "steel_lump", "count": [ 1, 3 ] },
+      { "item": "steel_chunk", "count": [ 1, 3 ] },
+      { "item": "scrap", "count": [ 1, 3 ] },
+      { "item": "rubber_tire_chunk", "count": [ 0, 1 ] },
+      { "item": "chunk_rubber", "count": [ 9, 25 ] },
+      { "item": "shredded_rubber", "charges": [ 8, 20 ] }
+    ],
     "wheel_offroad_rating": 0.7,
     "wheel_terrain_modifiers": { "FLAT": [ 0, 3 ], "ROAD": [ 0, 1 ] },
     "damage_reduction": { "bash": 10, "cut": 8, "stab": 4 }
@@ -541,7 +567,14 @@
     "description": "A small wheel.",
     "damage_modifier": 50,
     "folded_volume": "2250 ml",
-    "breaks_into": [ { "item": "steel_lump" }, { "item": "steel_chunk", "count": [ 1, 3 ] }, { "item": "scrap", "count": [ 1, 3 ] } ],
+    "breaks_into": [
+      { "item": "steel_lump" },
+      { "item": "steel_chunk", "count": [ 1, 3 ] },
+      { "item": "scrap", "count": [ 1, 3 ] },
+      { "item": "rubber_tire_chunk", "count": [ 0, 1 ] },
+      { "item": "chunk_rubber", "count": [ 2, 12 ] },
+      { "item": "shredded_rubber", "charges": [ 5, 15 ] }
+    ],
     "rolling_resistance": 1.5,
     "wheel_offroad_rating": 0.3,
     "wheel_terrain_modifiers": { "FLAT": [ 0, 5 ], "ROAD": [ 0, 2 ] },
@@ -598,7 +631,10 @@
     "breaks_into": [
       { "item": "steel_lump", "prob": 50 },
       { "item": "steel_chunk", "count": [ 1, 2 ] },
-      { "item": "scrap", "count": [ 1, 2 ] }
+      { "item": "scrap", "count": [ 1, 2 ] },
+      { "item": "rubber_tire_chunk", "count": [ 0, 1 ] },
+      { "item": "chunk_rubber", "count": [ 4, 13 ] },
+      { "item": "shredded_rubber", "charges": [ 5, 12 ] }
     ],
     "rolling_resistance": 0.45,
     "wheel_terrain_modifiers": { "FLAT": [ 0, 4 ], "ROAD": [ 0, 2 ] },
@@ -628,7 +664,10 @@
     "breaks_into": [
       { "item": "steel_lump", "prob": 50 },
       { "item": "steel_chunk", "count": [ 1, 2 ] },
-      { "item": "scrap", "count": [ 1, 2 ] }
+      { "item": "scrap", "count": [ 1, 2 ] },
+      { "item": "rubber_tire_chunk", "count": [ 0, 1 ] },
+      { "item": "chunk_rubber", "count": [ 6, 20 ] },
+      { "item": "shredded_rubber", "charges": [ 10, 24 ] }
     ],
     "rolling_resistance": 1.95,
     "wheel_offroad_rating": 0.3,
@@ -658,7 +697,10 @@
     "breaks_into": [
       { "item": "steel_lump", "count": [ 2, 3 ] },
       { "item": "steel_chunk", "count": [ 2, 3 ] },
-      { "item": "scrap", "count": [ 2, 3 ] }
+      { "item": "scrap", "count": [ 2, 3 ] },
+      { "item": "rubber_tire_chunk", "count": [ 1, 3 ] },
+      { "item": "chunk_rubber", "count": [ 8, 24 ] },
+      { "item": "shredded_rubber", "charges": [ 8, 20 ] }
     ],
     "rolling_resistance": 0.575,
     "wheel_terrain_modifiers": { "FLAT": [ 0, 4 ], "ROAD": [ 0, 2 ] },


### PR DESCRIPTION
#### Summary
Bugfixes "Adds Rubber to Materials Given by Broken Wheels"

#### Purpose of change
As pointed out in #57307 broken wheels only gave metal and no rubber when they were taken from vehicles, despite of course being (most of them) called 50% rubber.  I saw no reason why this would be intentional.

#### Describe the solution
I went through all the wheels I could find, checked which are rubber, and then assigned them rubber parts.  This comes in the form of Thick Rubber Chunks, Chunks of Rubber, and Shredded Rubber. Initially I planned to use their existing deconstruction recipes and give 10-30% of that material, but this didn't work due to several of them having silly deconstruction amounts.

#### Describe alternatives you've considered
I wondered if this was intentional, I believe that was suggested in the one issue, and if I'd found that reason I wouldn't have done this.

#### Testing
Normal Stuff, checked every single wheel's material and pulled the ones that are rubber, mathed out the values I thought were appropriate, tested all the json locally, ensured that each one I changed (and those that copy-from it), properly deconstructed when broken into the pieces I've assigned, and then sanity-checked them just to make sure some little 8" wheel wasn't giving more than a 17" wheel or anything.

#### Additional context
Okay, so initially the plan was to make breaks_into material 10-30% range based on their deconstructions.  However, some of them have silly deconstructs, for example, a set of wheelchair wheels deconstructs into 6x the Rubber Tire Strips that a standard 17" vehicle wheel does.  Which is nonsense.  So, unfortunately, I had to sort of wing it.

My intention was to keep the materials lower than what you'd expect, I'd rather give too little than too much, and since these previously all gave 0 rubber materials, it's still objectively an improvement.  And regardless, I tried to balance them against each other, so even if they're not perfect they're relative enough in my opinion.

And then Shredded Rubber should realistically be spawning in the hundreds or thousands for each wheel, but it has almost no value in the game, and having several thousand spawning from just a few wheels made me feel really, uh, nervous, so I just made it a handful.

Spreadsheet with random notes I made while working on this:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/41651793/f4400d71-adf3-4b1e-84b6-27c013b82a65)

GuardianDLL also asked me to make the shredded rubber use charges instead of count, so I did that for each of these.

closes #57307

Feel like I'm forgetting something but I'm sure I already over-explained enough.

Some of these also lack disassembly recipes, or their recipes do not make sense when compared to other wheels, fixing those will be a separate PR if I even decide to do that.  