### PR TITLE
[Xedra Evolved] Move Paraclesian eye traits to Personal layer

### DIFF
--- a/data/mods/Xedra_Evolved/items/armor/integrated.json
+++ b/data/mods/Xedra_Evolved/items/armor/integrated.json
@@ -126,7 +126,6 @@
   },
   {
     "id": "integrated_ierde_eyes",
-    "//": "These do not preclude wearing glasses, but you'll get double-up penalties.  If you really needed to you could likely still situate the lenses in front of them.  You should probably just augment your eyes though.",
     "type": "ARMOR",
     "category": "armor",
     "name": { "str_sp": "ierde eyes" },
@@ -142,7 +141,7 @@
     "warmth": 0,
     "material_thickness": 1.5,
     "environmental_protection": 10,
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "SOFT", "WATER_FRIENDLY", "SUN_GLASSES", "NO_REPAIR", "NO_SALVAGE" ],
+    "flags": [ "INTEGRATED", "UNBREAKABLE", "PERSONAL", "SOFT", "WATER_FRIENDLY", "SUN_GLASSES", "NO_REPAIR", "NO_SALVAGE" ],
     "armor": [
       {
         "material": [ { "type": "fae_flesh", "covered_by_mat": 100, "thickness": 0.5 } ],
@@ -241,7 +240,6 @@
   },
   {
     "id": "integrated_arvore_eyes",
-    "//": "These do not preclude wearing glasses, but you'll get double-up penalties.  If you really needed to you could likely still situate the lenses in front of them.  You should probably just augment your eyes though.",
     "type": "ARMOR",
     "category": "armor",
     "name": { "str_sp": "arvore eyes" },
@@ -257,7 +255,7 @@
     "warmth": 0,
     "material_thickness": 1.5,
     "environmental_protection": 10,
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "SKINTIGHT", "SOFT", "WATER_FRIENDLY", "SUN_GLASSES", "NO_REPAIR", "NO_SALVAGE" ],
+    "flags": [ "INTEGRATED", "UNBREAKABLE", "PERSONAL", "SOFT", "WATER_FRIENDLY", "SUN_GLASSES", "NO_REPAIR", "NO_SALVAGE" ],
     "armor": [
       {
         "material": [ { "type": "fae_flesh", "covered_by_mat": 100, "thickness": 0.5 } ],
@@ -377,7 +375,6 @@
   },
   {
     "id": "integrated_salamander_eyes",
-    "//": "These do not preclude wearing glasses, but you'll get double-up penalties.  If you really needed to you could likely still situate the lenses in front of them.  You should probably just augment your eyes though.",
     "type": "ARMOR",
     "category": "armor",
     "name": { "str_sp": "salamander eyes" },
@@ -394,7 +391,7 @@
     "material_thickness": 1.5,
     "environmental_protection": 10,
     "qualities": [ [ "GLARE", 1 ] ],
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "SKINTIGHT", "SOFT", "WATER_FRIENDLY", "SUN_GLASSES", "NO_REPAIR", "NO_SALVAGE" ],
+    "flags": [ "INTEGRATED", "UNBREAKABLE", "PERSONAL", "SOFT", "WATER_FRIENDLY", "SUN_GLASSES", "NO_REPAIR", "NO_SALVAGE" ],
     "armor": [
       {
         "material": [ { "type": "fae_flesh", "covered_by_mat": 100, "thickness": 0.5 } ],
@@ -472,7 +469,6 @@
   },
   {
     "id": "integrated_undine_eyes",
-    "//": "These do not preclude wearing glasses, but you'll get double-up penalties.  If you really needed to you could likely still situate the lenses in front of them.  You should probably just augment your eyes though.",
     "type": "ARMOR",
     "category": "armor",
     "name": { "str_sp": "undine eyes" },
@@ -491,7 +487,7 @@
     "flags": [
       "INTEGRATED",
       "UNBREAKABLE",
-      "SKINTIGHT",
+      "PERSONAL",
       "SOFT",
       "WATER_FRIENDLY",
       "SUN_GLASSES",
@@ -587,7 +583,6 @@
   },
   {
     "id": "integrated_sylph_eyes",
-    "//": "These do not preclude wearing glasses, but you'll get double-up penalties.  If you really needed to you could likely still situate the lenses in front of them.  You should probably just augment your eyes though.",
     "type": "ARMOR",
     "category": "armor",
     "name": { "str_sp": "sylph eyes" },
@@ -606,7 +601,7 @@
     "flags": [
       "INTEGRATED",
       "UNBREAKABLE",
-      "SKINTIGHT",
+      "PERSONAL",
       "SOFT",
       "WATER_FRIENDLY",
       "SUN_GLASSES",
@@ -704,7 +699,6 @@
   },
   {
     "id": "integrated_homullus_eyes",
-    "//": "These do not preclude wearing glasses, but you'll get double-up penalties.  If you really needed to you could likely still situate the lenses in front of them.  You should probably just augment your eyes though.",
     "type": "ARMOR",
     "category": "armor",
     "name": { "str_sp": "homullus eyes" },
@@ -720,7 +714,7 @@
     "warmth": 0,
     "material_thickness": 1.5,
     "environmental_protection": 10,
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "SOFT", "WATER_FRIENDLY", "SUN_GLASSES", "NO_REPAIR", "NO_SALVAGE" ],
+    "flags": [ "INTEGRATED", "UNBREAKABLE", "PERSONAL", "SOFT", "WATER_FRIENDLY", "SUN_GLASSES", "NO_REPAIR", "NO_SALVAGE" ],
     "armor": [
       {
         "material": [ { "type": "fae_flesh", "covered_by_mat": 100, "thickness": 0.5 } ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Xedra Evolved] Move Paraclesian eye traits to Personal layer"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Each eye trait has a comment mentioning that they cause double-up penalties when worn with glasses. Well, if they're on the `PERSONAL` layer, this doesn't happen. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Move the eye traits to the `PERSONAL` layer.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Loaded up a game as an Ierde, put on some sunglasses. No conflicts. 

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/120433252/49e2a376-7a9a-4879-b0aa-91437921ccac)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
