### PR TITLE
Edit shattering weakpoint

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -334,7 +334,7 @@
   {
     "type": "effect_type",
     "id": "shattered",
-    "name": [ "shattered" ],
+    "name": [ "Shattered Armor" ],
     "//": "Intended for monsters, has no effect except to create a new weak point.",
     "desc": [ "Your armor has been shattered by a heavy attack." ],
     "apply_message": "Your armor has been shattered.",

--- a/data/json/monster_weakpoints/humanoid_weakpoints.json
+++ b/data/json/monster_weakpoints/humanoid_weakpoints.json
@@ -290,21 +290,21 @@
           {
             "effect": "shattered",
             "chance": 25,
-            "message": "The armor is shattered!",
+            "message": "The %s's armor is shattered!",
             "damage_required": [ 1, 10 ],
             "permanent": true
           },
           {
             "effect": "shattered",
             "chance": 50,
-            "message": "The armor is shattered!",
+            "message": "The %s's armor is shattered!",
             "damage_required": [ 11, 30 ],
             "permanent": true
           },
           {
             "effect": "shattered",
             "chance": 75,
-            "message": "The armor is shattered!",
+            "message": "The %s's armor is shattered!",
             "damage_required": [ 31, 200 ],
             "permanent": true
           }


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
I intended to fix 73351 actually, but apparently there is no way to stop weakpoint from working, if it already has an effect. Rest of issues i've met still stands
Related to #73351 
#### Describe the solution
rename `shattered` -> `Shattered Armor`, to be consistent and easier to understand 
replace message `The armor is shattered!` -> `The %s's armor is shattered!`
#### Describe alternatives you've considered
Slap conditions for weakpoints (i don't know how)