### PR TITLE
fix bandaging and disinfection showing wrong quality

### DIFF
--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -3518,7 +3518,7 @@ int heal_actor::finish_using( Character &healer, Character &patient, item &it,
         int bandages_intensity = get_bandaged_level( healer );
         patient.add_effect( effect_bandaged, 1_turns, healed );
         effect &e = patient.get_effect( effect_bandaged, healed );
-        e.set_duration( e.get_int_dur_factor() * bandages_intensity );
+        e.set_duration( e.get_int_dur_factor() * ( bandages_intensity + 0.5f ) );
         patient.set_part_damage_bandaged( healed,
                                           patient.get_part_hp_max( healed ) - patient.get_part_hp_cur( healed ) );
         practice_amount += 2 * bandages_intensity;
@@ -3527,7 +3527,7 @@ int heal_actor::finish_using( Character &healer, Character &patient, item &it,
         int disinfectant_intensity = get_disinfected_level( healer );
         patient.add_effect( effect_disinfected, 1_turns, healed );
         effect &e = patient.get_effect( effect_disinfected, healed );
-        e.set_duration( e.get_int_dur_factor() * disinfectant_intensity );
+        e.set_duration( e.get_int_dur_factor() * ( disinfectant_intensity + 0.5f ) );
         patient.set_part_damage_disinfected( healed,
                                              patient.get_part_hp_max( healed ) - patient.get_part_hp_cur( healed ) );
         practice_amount += 2 * disinfectant_intensity;


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
When you apply bandage, the game simply apply effect. The length of the effect is `int_dur_factor of effect * bandages quality`. Which means when you apply bandages with quality level 3, the length of the effect is `4 * 3 =` 12 h. Which means in the very next second int_dur_factor would make the strength of effect one level lower and, therefore, the actual quality of the bandage 
Fix #64339
Fix #73336
#### Describe the solution
Slap additional 0.5 to bandage quality when effect legnth is calculated, so quality, shown by UI, would exist at least two hours before fading away
#### Describe alternatives you've considered
Slap 0.95, so shown bandage quality would last almost the entire duration of the effect