### PR TITLE
Fix obtain cost in reloading action, and a typo in item_handling_cost.

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7288,7 +7288,7 @@ int Character::item_handling_cost( const item &it, bool penalties, int base_cost
 {
     int mv = base_cost;
     if( penalties ) {
-        // 40 moves per liter, up to 200 at 5 liters
+        // 50 moves per liter, up to 200 at 4 liters
         mv += std::min( 200, it.volume( false, false, charges_in_it ) / 20_ml );
     }
 

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -717,7 +717,7 @@ class item_location::impl::item_in_container : public item_location::impl
                 return 0;
             }
 
-            int primary_cost = ch.item_handling_cost( *target(), true, container_mv );
+            int primary_cost = ch.item_handling_cost( *target(), true, container_mv, qty );
             primary_cost = ch.enchantment_cache->modify_value( enchant_vals::mod::OBTAIN_COST_MULTIPLIER,
                            primary_cost );
             int parent_obtain_cost = container.obtain_cost( ch, qty );


### PR DESCRIPTION
#### Summary
Bugfixes "Fix obtain cost in reloading action, and a typo in item_handling_cost"
#### Purpose of change
Fix https://github.com/CleverRaven/Cataclysm-DDA/issues/73354.
When calculating obtain cost from container, `qty` is lost, so `charges_in_it` remains -1, thus penalties is counted by the volume of the whole bulk instead of the actual amount you are going to handle.
#### Describe the solution
Add the missing `qty`.
The penalty is actually 50 moves per liter, up to 200 at 4 liters.
#### Describe alternatives you've considered
No to do this.
#### Testing
Compiled and tested locally.
#### Additional context