### PR TITLE
Show NEW! in List Items menu

### DIFF
--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -118,6 +118,7 @@
 #include "try_parse_integer.h"
 #include "type_id.h"
 #include "ui.h"
+#include "uistate.h"
 #include "ui_manager.h"
 #include "units.h"
 #include "units_utility.h"
@@ -191,6 +192,7 @@ std::string enum_to_string<debug_menu::debug_menu_index>( debug_menu::debug_menu
         case debug_menu::debug_menu_index::LEARN_MA: return "LEARN_MA";
         case debug_menu::debug_menu_index::UNLOCK_RECIPES: return "UNLOCK_RECIPES";
         case debug_menu::debug_menu_index::FORGET_ALL_RECIPES: return "FORGET_ALL_RECIPES";
+        case debug_menu::debug_menu_index::FORGET_ALL_ITEMS: return "FORGET_ALL_ITEMS";
         case debug_menu::debug_menu_index::EDIT_PLAYER: return "EDIT_PLAYER";
         case debug_menu::debug_menu_index::CONTROL_NPC: return "CONTROL_NPC";
         case debug_menu::debug_menu_index::SPAWN_ARTIFACT: return "SPAWN_ARTIFACT";
@@ -454,6 +456,7 @@ static int player_uilist()
         { uilist_entry( debug_menu_index::LEARN_MA, true, 'l', _( "Learn all melee styles" ) ) },
         { uilist_entry( debug_menu_index::UNLOCK_RECIPES, true, 'r', _( "Unlock all recipes" ) ) },
         { uilist_entry( debug_menu_index::FORGET_ALL_RECIPES, true, 'f', _( "Forget all recipes" ) ) },
+        { uilist_entry( debug_menu_index::FORGET_ALL_ITEMS, true, 'F', _( "Forget all items" ) ) },
         { uilist_entry( debug_menu_index::EDIT_PLAYER, true, 'p', _( "Edit player/NPC" ) ) },
         { uilist_entry( debug_menu_index::DAMAGE_SELF, true, 'd', _( "Damage self" ) ) },
         { uilist_entry( debug_menu_index::BLEED_SELF, true, 'b', _( "Bleed self" ) ) },
@@ -3054,6 +3057,13 @@ void debug()
             add_msg( m_info, _( "Recipe debug: forget recipes." ) );
             player_character.forget_all_recipes();
             add_msg( m_bad, _( "You don't know how to craft anymore." ) );
+        }
+        break;
+
+        case debug_menu_index::FORGET_ALL_ITEMS: {
+            add_msg( m_info, _( "Recipe debug: forget items." ) );
+            uistate.read_items.clear();
+            add_msg( m_bad, _( "You don't know about any items anymore." ) );
         }
         break;
 

--- a/src/debug_menu.h
+++ b/src/debug_menu.h
@@ -33,6 +33,7 @@ enum class debug_menu_index : int {
     LEARN_MA,
     UNLOCK_RECIPES,
     FORGET_ALL_RECIPES,
+    FORGET_ALL_ITEMS,
     UNLOCK_ALL,
     EDIT_PLAYER,
     CONTROL_NPC,

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8518,8 +8518,7 @@ game::vmenu_ret game::list_items( const std::vector<map_item_stack> &item_list )
             werase( w_items );
             calcStartPos( iStartPos, iActive, iMaxRows, iItemNum );
             int iNum = 0;
-            bool high = false;
-            bool low = false;
+            // ITEM LIST
             int index = 0;
             int iCatSortOffset = 0;
 
@@ -8528,60 +8527,49 @@ game::vmenu_ret game::list_items( const std::vector<map_item_stack> &item_list )
                     iNum++;
                 }
             }
-            for( auto iter = filtered_items.begin(); iter != filtered_items.end(); ++index ) {
-                if( highPEnd > 0 && index < highPEnd + iCatSortOffset ) {
-                    high = true;
-                    low = false;
-                } else if( index >= lowPStart + iCatSortOffset ) {
-                    high = false;
-                    low = true;
-                } else {
-                    high = false;
-                    low = false;
-                }
-
-                if( iNum >= iStartPos && iNum < iStartPos + std::min( iMaxRows, iItemNum ) ) {
-                    int iThisPage = 0;
-                    if( !mSortCategory[iNum].empty() ) {
-                        iCatSortOffset++;
-                        mvwprintz( w_items, point( 1, iNum - iStartPos ), c_magenta, mSortCategory[iNum] );
-                    } else {
-                        if( iNum == iActive ) {
-                            iThisPage = page_num;
-                        }
-                        std::string sText;
-                        if( iter->vIG.size() > 1 ) {
-                            sText += string_format( "[%d/%d] (%d) ", iThisPage + 1, iter->vIG.size(), iter->totalcount );
-                        }
-                        sText += iter->example->tname();
-                        if( iter->vIG[iThisPage].count > 1 ) {
-                            sText += string_format( "[%d]", iter->vIG[iThisPage].count );
-                        }
-
-                        nc_color col = c_light_gray;
-                        if( iNum == iActive ) {
-                            col = hilite( c_white );
-                        } else if( high ) {
-                            col = c_yellow;
-                        } else if( low ) {
-                            col = c_red;
-                        } else {
-                            col = iter->example->color_in_inventory();
-                        }
-                        trim_and_print( w_items, point( 1, iNum - iStartPos ), width - 9, col, sText );
-                        const int numw = iItemNum > 9 ? 2 : 1;
-                        const point p( iter->vIG[iThisPage].pos.xy() );
-                        mvwprintz( w_items, point( width - 6 - numw, iNum - iStartPos ),
-                                   iNum == iActive ? c_light_green : c_light_gray,
-                                   "%*d %s", numw, rl_dist( point_zero, p ),
-                                   direction_name_short( direction_from( point_zero, p ) ) );
-                        ++iter;
-                    }
-                } else {
+            for( auto iter = filtered_items.begin(); iter != filtered_items.end(); ++index, iNum++ ) {
+                if( iNum < iStartPos || iNum >= iStartPos + std::min( iMaxRows, iItemNum ) ) {
                     ++iter;
+                    continue;
                 }
-                iNum++;
+                int iThisPage = 0;
+                if( !mSortCategory[iNum].empty() ) {
+                    iCatSortOffset++;
+                    mvwprintz( w_items, point( 1, iNum - iStartPos ), c_magenta, mSortCategory[iNum] );
+                    continue;
+                }
+                if( iNum == iActive ) {
+                    iThisPage = page_num;
+                }
+                std::string sText;
+                if( iter->vIG.size() > 1 ) {
+                    sText += string_format( "[%d/%d] (%d) ", iThisPage + 1, iter->vIG.size(), iter->totalcount );
+                }
+                sText += iter->example->tname();
+                if( iter->vIG[iThisPage].count > 1 ) {
+                    sText += string_format( "[%d]", iter->vIG[iThisPage].count );
+                }
+
+                nc_color col = c_light_gray;
+                if( iNum == iActive ) {
+                    col = hilite( c_white );
+                } else if( highPEnd > 0 && index < highPEnd + iCatSortOffset ) {  // priority high
+                    col = c_yellow;
+                } else if( index >= lowPStart + iCatSortOffset ) {  // priority low
+                    col = c_red;
+                } else {  // priority medium
+                    col = iter->example->color_in_inventory();
+                }
+                trim_and_print( w_items, point( 1, iNum - iStartPos ), width - 9, col, sText );
+                const int numw = iItemNum > 9 ? 2 : 1;
+                const point p( iter->vIG[iThisPage].pos.xy() );
+                mvwprintz( w_items, point( width - 6 - numw, iNum - iStartPos ),
+                           iNum == iActive ? c_light_green : c_light_gray,
+                           "%*d %s", numw, rl_dist( point_zero, p ),
+                           direction_name_short( direction_from( point_zero, p ) ) );
+                ++iter;
             }
+            // ITEM DESCRIPTION
             iNum = 0;
             for( int i = 0; i < iActive; i++ ) {
                 if( !mSortCategory[i].empty() ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8323,6 +8323,7 @@ void game::reset_item_list_state( const catacurses::window &window, int height, 
     tokens.emplace_back( _( "<C>ompare" ) );
     tokens.emplace_back( _( "<F>ilter" ) );
     tokens.emplace_back( _( "<+/->Priority" ) );
+    tokens.emplace_back( _( "<T>ravel to" ) );
 
     int gaps = tokens.size() + 1;
     letters = 0;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8584,9 +8584,13 @@ game::vmenu_ret game::list_items( const std::vector<map_item_stack> &item_list )
                     iNum++;
                 }
             }
-            mvwprintz( w_items_border, point( ( width - 9 ) / 2 + ( iItemNum > 9 ? 0 : 1 ), 0 ),
-                       c_light_green, " %*d", iItemNum > 9 ? 2 : 1, iItemNum > 0 ? iActive - iNum + 1 : 0 );
-            wprintz( w_items_border, c_white, " / %*d ", iItemNum > 9 ? 2 : 1, iItemNum - iCatSortNum );
+            const int current_i = iItemNum > 0 ? iActive - iNum + 1 : 0;
+            const int numd = current_i > 999 ? 4 :
+                             current_i > 99 ? 3 :
+                             current_i > 9 ? 2 : 1;
+            mvwprintz( w_items_border, point( width / 2 - numd - 2, 0 ), c_light_green, " %*d", numd,
+                       current_i );
+            wprintz( w_items_border, c_white, " / %*d ", numd, iItemNum - iCatSortNum );
             werase( w_item_info );
 
             if( iItemNum > 0 && activeItem ) {

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -366,6 +366,7 @@ void uistatedata::serialize( JsonOut &json ) const
     json.member( "overmap_show_forest_trails", overmap_show_forest_trails );
     json.member( "vmenu_show_items", vmenu_show_items );
     json.member( "list_item_sort", list_item_sort );
+    json.member( "read_items", read_items );
     json.member( "list_item_filter_active", list_item_filter_active );
     json.member( "list_item_downvote_active", list_item_downvote_active );
     json.member( "list_item_priority_active", list_item_priority_active );
@@ -476,6 +477,7 @@ void uistatedata::deserialize( const JsonObject &jo )
     }
 
     jo.read( "list_item_sort", list_item_sort );
+    jo.read( "read_items", read_items );
     jo.read( "list_item_filter_active", list_item_filter_active );
     jo.read( "list_item_downvote_active", list_item_downvote_active );
     jo.read( "list_item_priority_active", list_item_priority_active );

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -1713,6 +1713,32 @@ std::list<const item *> item_contents::all_items_top( const
     return all_items_internal;
 }
 
+content_newness item_contents::get_content_newness( const std::set<itype_id> &read_items ) const
+{
+    content_newness ret = content_newness::SEEN;
+    for( const item_pocket *pocket : get_all_standard_pockets() ) {
+        // taking transparent from item_contents::all_known_contents()
+        if( !pocket->transparent() ) {
+            ret = content_newness::MIGHT_BE_HIDDEN;
+            continue;
+        }
+        for( const item *itm : pocket->all_items_top() ) {
+            if( !read_items.count( itm->typeId() ) ) {
+                return content_newness::NEW;
+            }
+            switch( itm->get_contents().get_content_newness( read_items ) ) {
+                case content_newness::NEW:
+                    return content_newness::NEW;
+                case content_newness::MIGHT_BE_HIDDEN:
+                    ret = content_newness::MIGHT_BE_HIDDEN;
+                case content_newness::SEEN:
+                    break;
+            }
+        }
+    }
+    return ret;
+}
+
 std::list<const item *> item_contents::all_items_top( pocket_type pk_type ) const
 {
     return all_items_top( [pk_type]( const item_pocket & pocket ) {

--- a/src/item_contents.h
+++ b/src/item_contents.h
@@ -27,6 +27,13 @@ class iteminfo_query;
 struct iteminfo;
 struct tripoint;
 
+/// NEW!ness to player, if they seen such item already
+enum class content_newness {
+    NEW,  // at least one item is new
+    MIGHT_BE_HIDDEN,  // at least one item might be hidden and none are NEW
+    SEEN
+};
+
 class item_contents
 {
     public:
@@ -125,6 +132,9 @@ class item_contents
         // returns all the ablative armor in pockets
         std::list<item *> all_ablative_armor();
         std::list<const item *> all_ablative_armor() const;
+
+        /// don't check top level item, do check its pockets, do check all nested
+        content_newness get_content_newness( const std::set<itype_id> &read_items ) const;
 
         /** gets all gunmods in the item */
         std::vector<item *> gunmods();

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1948,6 +1948,12 @@ void options_manager::add_options_interface()
              true
            );
 
+        add( "HIGHLIGHT_UNREAD_ITEMS", page_id,
+             to_translation( "Highlight unread items" ),
+             to_translation( "If true, highlight unread items to allow tracking of newly discovered items." ),
+             true
+           );
+
         add( "SCREEN_READER_MODE", page_id, to_translation( "Screen reader mode" ),
              to_translation( "On supported UI screens, tweaks display of text to optimize for screen readers.  Targeted towards using the open-source screen reader 'orca' using curses for display." ),
              // See doc/USER_INTERFACE_AND_ACCESSIBILITY.md for testing and implementation notes

--- a/src/uistate.h
+++ b/src/uistate.h
@@ -160,6 +160,7 @@ class uistatedata
 
         // V Menu Stuff
         int list_item_sort = 0;
+        std::set<itype_id> read_items;
 
         // These three aren't serialized because deserialize can extraect them
         // from the history


### PR DESCRIPTION
#### Summary
Interface "Show NEW! in List Items menu"

#### Purpose of change
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/2c5f825f-c101-48b7-b444-199ee761e716)

Discussed something similar in
 - https://github.com/CleverRaven/Cataclysm-DDA/issues/72697#issuecomment-2027737339
   - > List the items you find in a room, highlight ones you haven't seen before

Relaxed `transparent` for pockets, so that open containers are considered transparent. One line change in commit 5bade42d76b411babc0eb853d4935d10c253cdeb. Originally introduced in #56623 and @I-am-Erk was maybe against this, so we will see...

#### Describe the solution
Heavily inspired by this, which has done it for crafting menu. ~referred to as _OTHER_.~
 - #49819

- ~_OTHER_ allows for reading / unreading recipes. This allows only reading (marking as not NEW!) by going to the item entry by `UP` or `DOWN` action.~
- ~_OTHER_ marks as read for more than just `UP` & `DOWN`, like mouse support. This doesn't.~

These actions will unNEW:
- `UP`, `DOWN`
- `COMPARE`, `EXAMINE`, `SCROLL_ITEM_INFO_UP`, `SCROLL_ITEM_INFO_DOWN`
- `TRAVEL_TO`
- `RIGHT`, `LEFT` (when there are 5 piles of a thing, the LEFT and RIGHT move to the next or previous pile)

These actions will NOT unNEW:
- `PAGE_DOWN`, `PAGE_UP`
- `FILTER`, `RESET_FILTER`, `PRIORITY_INCREASE`, `PRIORITY_DECREASE`, `SORT`
- `zoom_in`, `zoom_out`
- `NEXT_TAB`, `PREV_TAB`

Note: The List Items menu does not have mouse support.

`uistate` remembers a set of items (`item_id`s to be precise) in a new member variable `read_items`. It is persistent. I actually don't know if per character or totally.

- Enjoy the feature in the Item List menu brought up by `V`.
- if an item is not in `read_items`, `NEW!` is written, as seen in the picture
- If the item is a `transparent` container, then if the item or anything inside the item (recursively, for `transparent` containers) is not in `read_items`, `NEW!` is displayed.
  - If you saw a plastic bag but not meat jerky, then `plastic bag -> meat jerky` is `NEW!`.
- if it is not `NEW!` but some container in the nested path is not `transparent`, then it is marked as "hides contents"
  - ![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/16e0b52b-4f4f-478d-8bf5-b42de05439dc)
- if you `UP` or `DOWN` to an item, then it is added to `read_items`, so it is no longer `NEW!`
- If the item is a `transparent` container, then the item and everything inside the item (recursively, for `transparent` containers) is put into `read_items` and it is no longer `NEW!`
  - if you `DOWN` to a `zipper bag > plastic bag > meat jerky`, then none of these items are `NEW!` anymore.

#### Describe alternatives you've considered

- Don't change the `transparent` pocket function, but add `transparent` to individual plastic bags, zipper bags etc.
  - My solution is simpler, so if it is agreed upon, I would greatly prefer it. Otherwise, I already see the frustration with "This one pocket isn't working with NEW! properly" and at least 5 PRs fixing these individually and still missing some.
  - Unless there is a good reason to do this alternative, I would prefer less frustration and menial adding of `"transparent": true`  to some pockets.
- Don't hide forgetting items in the debug menu, allow the player to use it. Even add it to the List Items menu.
- Add "Mark all as read" to the List Items menu.
- Add "Show NEW! first" to the List Items menu.
- Reimplement List Items menu in ImGui. Maybe I should have, I spend too much time fixing these small things that will go away one day. - @mqrause is working on it in #55503

#### Testing

[TEST Item List-trimmed.tar.gz](https://github.com/CleverRaven/Cataclysm-DDA/files/15192193/TEST.Item.List-trimmed.tar.gz) (updated for `hides contents test`)

`NEW`:
In this save, I verified that:
1. (requires merging of #73458)
1. NEW disappears on `DOWN` and `UP`, but not on `PageUp` etc.
2. I can restart it in the debug menu > `p` Player > `F` Forget all items
3. going to `plastic bag > wild herbs` unNEWs both `plastic bag` and `wild herbs` items
   - ![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/df80ca0d-cf4f-485c-89bd-cc6131475dea)
4. going to `plastic bag`, but not `wild herbs` does NOT unNEW `plastic bag > wild herbs`
5. going to both `plastic bag` and `wild herbs` does unNEW `plastic bag > wild herbs`

`hides contents`:
1. Similar to the above case
2. Merge #73458, so that plastic bags etc. are transparent.
3. explore list from save and get this
   - ![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/ec0b69d7-69f3-470d-8409-54ca8b539a52)


Apart from that, I checked the other things shown in the screenshot atop.

#### Additional context

~Introduced a bug (probably):~
~From this code:~
~https://github.com/CleverRaven/Cataclysm-DDA/blob/db4aa91cc3ddef0dc75f5512e0a2b169ae0deb14/src/item_contents.h#L118-L122~

~I used `all_items_top` instead of `all_known_contents` because the former didn't work with a `plastic bag`, maybe it is not transparent yet. So the player probably reveals items inside sealed non-transparent containers they shouldn't see.~

~I would like to allow the player to browse these items later, so it should be addressed, it not only might leak the contents of a container (if you already have the item contained), but it could later show recipes etc. for the yet unseen item inside.~

Discovered a ~bug:
These keybindings don't reflect the bound keybinding, The green letter is hardcoded:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/8e134ef8-93ec-461a-86fe-d09b7a52b504)


We seem to be thinking similarly with @mqrause, which is cool, I like there is more of me since more things I care about will be implemented into CDDA :).
