### PR TITLE
Wet Towels No Longer Prompt to be Turned Off

### DIFF
--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -2780,7 +2780,7 @@
     "to_hit": -1,
     "revert_to": "towel",
     "use_action": [ "TOWEL" ],
-    "flags": [ "WET" ],
+    "flags": [ "WET", "SLEEP_IGNORE" ],
     "material_thickness": 0.3,
     "armor": [ { "coverage": 50, "covers": [ "torso", "leg_l", "leg_r" ] } ]
   },


### PR DESCRIPTION
#### Summary
Bugfixes "Wet Towels No Longer Prompt to be Turned Off"

#### Purpose of change
Wet towels would prompt the player to be turned off prior to sleeping and that's just silly.
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/41651793/ca93aa17-9f35-4826-9b14-126b753f1dfb)

#### Describe the solution
Add SLEEP_IGNORE flag to wet towels, which is a flag that exists specifically to stop this popup on items where it doesn't make sense.

#### Describe alternatives you've considered
Getting ready for my doctor appointment instead of making PRs

#### Testing
Checked that wet towels still prompted when sleeping.  Added SLEEP_IGNORE and made sure it no longer prompted. Huzzah.

#### Additional context

closes #59809

