### PR TITLE
Update to furniture water purifier looks like line.

### DIFF
--- a/data/json/furniture_and_terrain/appliances.json
+++ b/data/json/furniture_and_terrain/appliances.json
@@ -51,7 +51,7 @@
     "flags": [ "OBSTACLE", "APPLIANCE" ],
     "pseudo_tools": [ { "id": "water_purifier", "hotkey": "p" } ],
     "item": "stationary_water_purifier",
-    "looks_like": "f_water_purifier",
+    "looks_like": "f_water_heater",
     "breaks_into": [
       { "item": "scrap", "count": [ 2, 7 ] },
       { "item": "steel_chunk", "count": [ 0, 3 ] },


### PR DESCRIPTION

#### Summary
Json edit: Changed ap_water_purifier looks like line from f_water_purifer to f_water_heater. 

#### Purpose of change
It seemed odd that water purifiers when hooked up in the base did not just use the tile sprite for water purifiers when first found in the game world and just used the big white W. 

#### Describe the solution

after looking at the json I noted that the water purifiers you find that have not been turned into a appliance used the f_water_heater sprite not f_water_purifier sprite so I changed it.

#### Describe alternatives you've considered

Thought about making new sprite but I'm not that skilled and feel like the sprite for the furniture works nicely

#### Testing

Changed looks like line and the sprite showed up in my base instead of the white W

#### Additional context

N/A