### PR TITLE
Fixing popup buttons not wrapping to a new line

### DIFF
--- a/src/popup.cpp
+++ b/src/popup.cpp
@@ -22,6 +22,12 @@ class query_popup_impl : public cataimgui::window
         nc_color default_text_color;
         query_popup *parent;
         short last_keyboard_selected_option;
+
+        std::vector<std::vector<std::string>> fold_query(
+                                               const std::string &category,
+                                               keyboard_mode pref_kbd_mode,
+                                               const std::vector<query_popup::query_option> &options,
+                                               int max_width, int horz_padding );
     public:
         short keyboard_selected_option;
 
@@ -59,6 +65,9 @@ void query_popup_impl::draw_controls()
     if( !parent->buttons.empty() ) {
         int current_line = 0;
         for( size_t ind = 0; ind < parent->buttons.size(); ++ind ) {
+            if( ind != 0 && current_line == parent->buttons[ind].pos.y ) {
+                ImGui::SameLine();
+            }
             ImGui::SetCursorPosX( float( parent->buttons[ind].pos.x ) );
             ImGui::Button( remove_color_tags( parent->buttons[ind].text ).c_str() );
             if( ImGui::IsItemHovered() ) {
@@ -67,9 +76,6 @@ void query_popup_impl::draw_controls()
             if( keyboard_selected_option != last_keyboard_selected_option &&
                 keyboard_selected_option == short( ind ) && ImGui::IsWindowFocused() ) {
                 ImGui::SetKeyboardFocusHere( -1 );
-            }
-            if( current_line == parent->buttons[ind].pos.y ) {
-                ImGui::SameLine();
             }
             current_line = parent->buttons[ind].pos.y;
         }
@@ -81,15 +87,15 @@ void query_popup_impl::on_resized()
     size_t frame_padding = size_t( ImGui::GetStyle().FramePadding.x * 2 );
     size_t item_padding = size_t( ImGui::GetStyle().ItemSpacing.x );
     // constexpr size_t vert_padding = 1;
-    size_t max_line_width = str_width_to_pixels( FULL_SCREEN_WIDTH - 1 * 2 );
+    size_t max_line_width = str_width_to_pixels( FULL_SCREEN_WIDTH );
 
     // Fold message text
     parent->folded_msg = foldstring( parent->text, max_line_width );
 
     // Fold query buttons
-    const auto &folded_query = query_popup::fold_query( parent->category, parent->pref_kbd_mode,
-                               parent->options, max_line_width,
-                               frame_padding + item_padding );
+    const auto &folded_query = fold_query( parent->category, parent->pref_kbd_mode,
+                                           parent->options, max_line_width,
+                                           frame_padding + item_padding );
 
     // Calculate size of message part
     msg_width = 0;
@@ -123,10 +129,11 @@ void query_popup_impl::on_resized()
                 for( const auto &opt : line ) {
                     button_width += get_text_width( remove_color_tags( opt ) );
                 }
+                button_width += btn_padding( line.size() );
                 // Right align.
                 // TODO: multi-line buttons
-                size_t button_x = std::max( size_t( 0 ),
-                                            size_t( msg_width - button_width - btn_padding( line.size() ) ) );
+                size_t button_x = button_width > msg_width ? size_t( 0 ) :
+                                  size_t( msg_width - button_width );
                 for( const auto &opt : line ) {
                     parent->buttons.emplace_back( opt, point( button_x, line_idx ) );
                     button_x += get_text_width( remove_color_tags( opt ) ) + frame_padding + item_padding;
@@ -219,10 +226,10 @@ query_popup &query_popup::preferred_keyboard_mode( const keyboard_mode mode )
     return *this;
 }
 
-std::vector<std::vector<std::string>> query_popup::fold_query(
+std::vector<std::vector<std::string>> query_popup_impl::fold_query(
                                        const std::string &category,
                                        const keyboard_mode pref_kbd_mode,
-                                       const std::vector<query_option> &options,
+                                       const std::vector<query_popup::query_option> &options,
                                        const int max_width, const int horz_padding )
 {
     input_context ctxt( category, pref_kbd_mode );
@@ -235,7 +242,7 @@ std::vector<std::vector<std::string>> query_popup::fold_query(
     for( const query_popup::query_option &opt : options ) {
         const std::string &name = ctxt.get_action_name( opt.action );
         const std::string &desc = ctxt.get_desc( opt.action, name, opt.filter );
-        const int this_query_width = utf8_width( desc, true ) + horz_padding;
+        const int this_query_width = get_text_width( remove_color_tags( desc ) ) + horz_padding;
         ++query_cnt;
         query_width += this_query_width;
         if( query_width > max_width + horz_padding ) {

--- a/src/popup.cpp
+++ b/src/popup.cpp
@@ -132,7 +132,7 @@ void query_popup_impl::on_resized()
                 button_width += btn_padding( line.size() );
                 // Right align.
                 // TODO: multi-line buttons
-                size_t button_x = button_width > msg_width ? size_t( 0 ) :
+                size_t button_x = button_width > int( msg_width ) ? size_t( 0 ) :
                                   size_t( msg_width - button_width );
                 for( const auto &opt : line ) {
                     parent->buttons.emplace_back( opt, point( button_x, line_idx ) );

--- a/src/popup.h
+++ b/src/popup.h
@@ -231,11 +231,6 @@ class query_popup
         mutable std::vector<std::string> folded_msg;
         mutable std::vector<button> buttons;
 
-        static std::vector<std::vector<std::string>> fold_query(
-                    const std::string &category,
-                    keyboard_mode pref_kbd_mode,
-                    const std::vector<query_option> &options,
-                    int max_width, int horz_padding );
         void invalidate_ui() const;
 
         template <typename ...Args>


### PR DESCRIPTION

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fixes issue where ImGui popup doesnt wrap buttons to a new line when the overall length is too long"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes: [#72986](https://github.com/CleverRaven/Cataclysm-DDA/issues/72986)
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
The function query_popup::fold_query wasn't working properly which caused the buttons to not wrap to a new line.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Try to craft an item in a dangerous area with the game's language set to Russian, see that the popup shows with the proper size.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Before: 
![popup_width_before](https://github.com/CleverRaven/Cataclysm-DDA/assets/24497894/fb7b2080-4d72-45b9-a7a0-dbae2ac90075)
After: 
![popup_width_after](https://github.com/CleverRaven/Cataclysm-DDA/assets/24497894/7843b6d5-22a8-4ea8-9be4-a04e4a9d9b2d)


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
