### PR TITLE
Add a final cleanup phase to Craters

### DIFF
--- a/data/json/overmap/overmap_mutable/crater.json
+++ b/data/json/overmap/overmap_mutable/crater.json
@@ -30,6 +30,13 @@
         "east": { "id": "crater_to_crater", "type": "available" },
         "south": { "id": "crater_to_crater", "type": "available" },
         "west": { "id": "crater_to_crater", "type": "available" }
+      },
+      "ground_cleanup": {
+        "overmap": "core_small",
+        "north": { "id": "root", "type": "available" },
+        "east": { "id": "root", "type": "available" },
+        "south": { "id": "root", "type": "available" },
+        "west": { "id": "root", "type": "available" }
       }
     },
     "root": "core_root",
@@ -160,7 +167,8 @@
           "max": { "binomial": [ 1, 0.66 ] }
         }
       ],
-      [ { "overmap": "cleanup", "weight": 1 } ]
+      [ { "overmap": "cleanup", "weight": 1 } ],
+      [ { "overmap": "ground_cleanup", "weight": 1 } ]
     ]
   }
 ]

--- a/data/json/overmap/overmap_mutable/crater.json
+++ b/data/json/overmap/overmap_mutable/crater.json
@@ -32,7 +32,7 @@
         "west": { "id": "crater_to_crater", "type": "available" }
       },
       "ground_cleanup": {
-        "overmap": "core_small",
+        "overmap": "crater_core_small",
         "north": { "id": "root", "type": "available" },
         "east": { "id": "root", "type": "available" },
         "south": { "id": "root", "type": "available" },


### PR DESCRIPTION
#### Summary
Bugfixes "Maybe prevent rare crater generation error"

#### Purpose of change
My assessment is that this should fix the rare crater generation error that sometimes haunts tests.

Fixes: #73435

#### Describe the solution
As I understand it, crater generation might rarely fail in its last phases because the final phases all place multiple  tile chunks, in rare cases  combinations of neighboring over-map specials might produce scenarios where none of those chunks can fit, causing the error.

I added a final phase that fills those orphan chunks with a single tile of "core_small". Which should take care of any gaps to small for the rest of the chunks to fit,

Actual changes in how the craters generate should be basically negligible.

#### Testing
Error didn't seem to occur anymore even while placing  60+ craters per overmap, I do not have access to the kind of more robust testing to verify this at the moment.
