### PR TITLE
Simplified dig/mine stairs code

### DIFF
--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1630,11 +1630,7 @@ void construct::done_digormine_stair( const tripoint_bub_ms &p, bool dig,
                                       Character &player_character )
 {
     map &here = get_map();
-    const tripoint_abs_ms abs_pos = here.getglobal( p );
-    const tripoint_abs_omt pos_omt = project_to<coords::omt>( abs_pos );
-    tinymap tmpmap;
-    tmpmap.load( pos_omt + tripoint_below, false );
-    const tripoint local_tmp = tmpmap.getlocal( abs_pos );
+    const tripoint_bub_ms p_below = p + tripoint_below;
 
     bool dig_muts = player_character.has_trait( trait_PAINRESIST_TROGLO ) ||
                     player_character.has_trait( trait_STOCKY_TROGLO );
@@ -1645,7 +1641,7 @@ void construct::done_digormine_stair( const tripoint_bub_ms &p, bool dig,
     player_character.mod_thirst( 5 + mine_penalty + no_mut_penalty );
     player_character.mod_sleepiness( 10 + mine_penalty + no_mut_penalty );
 
-    if( tmpmap.ter( local_tmp ) == ter_t_lava ) {
+    if( here.ter( p_below ) == ter_t_lava ) {
         if( !query_yn( _( "The rock feels much warmer than normal.  Proceed?" ) ) ) {
             here.ter_set( p, ter_t_pit ); // You dug down a bit before detecting the problem
             unroll_digging( dig ? 8 : 12 );
@@ -1658,7 +1654,7 @@ void construct::done_digormine_stair( const tripoint_bub_ms &p, bool dig,
         return;
     }
 
-    bool impassable = tmpmap.impassable( local_tmp );
+    bool impassable = here.impassable( p_below );
     if( !impassable ) {
         add_msg( _( "You dig into a preexisting space, and improvise a ladder." ) );
     } else if( dig ) {
@@ -1667,11 +1663,8 @@ void construct::done_digormine_stair( const tripoint_bub_ms &p, bool dig,
         add_msg( _( "You drill out a passage, heading deeper underground." ) );
     }
     here.ter_set( p, ter_t_stairs_down ); // There's the top half
-    // Again, need to use submap-local coordinates.
-    tmpmap.ter_set( local_tmp, impassable ? ter_t_stairs_up :
-                    ter_t_ladder_up ); // and there's the bottom half.
-    // And save to the center coordinate of the current active map.
-    tmpmap.save();
+    here.ter_set( p_below, impassable ? ter_t_stairs_up :
+                  ter_t_ladder_up ); // and there's the bottom half.
 }
 
 void construct::done_dig_grave( const tripoint_bub_ms &p, Character &who )
@@ -1724,22 +1717,18 @@ void construct::done_mine_downstair( const tripoint_bub_ms &p, Character &who )
 void construct::done_mine_upstair( const tripoint_bub_ms &p, Character &player_character )
 {
     map &here = get_map();
-    const tripoint_abs_ms abs_pos = here.getglobal( p );
-    const tripoint_abs_omt pos_omt = project_to<coords::omt>( abs_pos );
-    tinymap tmpmap;
-    tmpmap.load( pos_omt + tripoint_above, false );
-    const tripoint local_tmp = tmpmap.getlocal( abs_pos );
+    const tripoint_bub_ms p_above = p + tripoint_above;
 
-    if( tmpmap.ter( local_tmp ) == ter_t_lava ) {
-        here.ter_set( p.xy(), ter_t_rock_floor ); // You dug a bit before discovering the problem
+    if( here.ter( p_above ) == ter_t_lava ) {
+        here.ter_set( p, ter_t_rock_floor ); // You dug a bit before discovering the problem
         add_msg( m_warning, _( "The rock overhead feels hot.  You decide *not* to mine magma." ) );
         unroll_digging( 12 );
         return;
     }
 
-    if( tmpmap.has_flag_ter( ter_furn_flag::TFLAG_SHALLOW_WATER, local_tmp ) ||
-        tmpmap.has_flag_ter( ter_furn_flag::TFLAG_DEEP_WATER, local_tmp ) ) {
-        here.ter_set( p.xy(), ter_t_rock_floor ); // You dug a bit before discovering the problem
+    if( here.has_flag_ter( ter_furn_flag::TFLAG_SHALLOW_WATER, p_above.raw() ) ||
+        here.has_flag_ter( ter_furn_flag::TFLAG_DEEP_WATER, p_above.raw() ) ) {
+        here.ter_set( p, ter_t_rock_floor ); // You dug a bit before discovering the problem
         add_msg( m_warning, _( "The rock above is rather damp.  You decide *not* to mine water." ) );
         unroll_digging( 12 );
         return;
@@ -1754,10 +1743,8 @@ void construct::done_mine_upstair( const tripoint_bub_ms &p, Character &player_c
     player_character.mod_sleepiness( 25 + no_mut_penalty );
 
     add_msg( _( "You drill out a passage, heading for the surface." ) );
-    here.ter_set( p.xy(), ter_t_stairs_up ); // There's the bottom half
-    // We need to write to submap-local coordinates.
-    tmpmap.ter_set( local_tmp, ter_t_stairs_down ); // and there's the top half.
-    tmpmap.save();
+    here.ter_set( p, ter_t_stairs_up ); // There's the bottom half
+    here.ter_set( p_above, ter_t_stairs_down ); // and there's the top half.
 }
 
 void construct::done_wood_stairs( const tripoint_bub_ms &p, Character &/*who*/ )


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #73407, i.e. digging operations using unnecessary tinymaps.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Remove the usage of tinymap and the associated coordinate conversion and instead make use of the map already fetched.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Leave it, as the code works.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

- Teleported to previously unrevealed overmap tile (to trigger potential problems with unloaded submaps, if any).
- Debug spawn materials needed to dig a staircase down.
- Dug the staircase.
- Went down and dug another staircase down (after digging horizontally to allow for the start on the second staircase).
- Went down and mined an up staircase and went up.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I don't understand the purpose of the save of the tinymap at the end of the operations. It can be noted that the map isn't stored, and all changes are now done to the map, so if there was a reason for the save call it should be gone with the tinymap. However, I'd be grateful of someone could provide some insight into its purpose (or lack thereof).

Did some typifying while modifying the code as that was localized to the operations modified, so the scope creep should be acceptable.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
