### PR TITLE
Not to try to set charges for item without charge.

### DIFF
--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -449,11 +449,11 @@ void iuse_transform::info( const item &it, std::vector<iteminfo> &dump ) const
                                string_format( _( "%s (%d %s)" ), dummy.tname(), amount, ammo_type->nname( amount ) ) );
         } else if( !container.is_empty() ) {
             dump.emplace_back( "TOOL", _( "<bold>Turns into</bold>: " ),
-                                           amount > 1 ?
-                                           string_format( _( "%s (%d %s)" ),
-                                                          container->nname( 1 ), amount, target->nname( amount ) ) :
-                                           string_format( _( "%s (%s)" ),
-                                                          container->nname( 1 ), target->nname( amount ) ) );
+                               amount > 1 ?
+                               string_format( _( "%s (%d %s)" ),
+                                              container->nname( 1 ), amount, target->nname( amount ) ) :
+                               string_format( _( "%s (%s)" ),
+                                              container->nname( 1 ), target->nname( amount ) ) );
         } else {
             dump.emplace_back( "TOOL", _( "<bold>Turns into</bold>: " ),
                                string_format( _( "%s (%d)" ), target->nname( amount ), amount ) );

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -443,9 +443,9 @@ void iuse_transform::info( const item &it, std::vector<iteminfo> &dump ) const
     if( it.has_flag( flag_FIT ) ) {
         dummy.set_flag( flag_FIT );
     }
-    dump.emplace_back( "TOOL", _( "<bold>Turns into</bold>: "),
+    dump.emplace_back( "TOOL", _( "<bold>Turns into</bold>: " ),
                        string_format( _( "%d %s" ),
-                       amount, dummy.tname() ) );
+                                      amount, dummy.tname() ) );
 
     if( target_timer > 0_seconds ) {
         dump.emplace_back( "TOOL", _( "Countdown: " ), to_seconds<int>( target_timer ) );

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -433,7 +433,8 @@ void iuse_transform::finalize( const itype_id & )
 
 void iuse_transform::info( const item &it, std::vector<iteminfo> &dump ) const
 {
-    item dummy( target, calendar::turn, target->count_by_charges() ? std::max( ammo_qty, 1 ) : 1 );
+    int amount = std::max( ammo_qty, 1 );
+    item dummy( target, calendar::turn, 1 );
     dummy.set_itype_variant( variant_type );
     // If the variant is to be randomized, use default no-variant name
     if( variant_type == "<any>" ) {
@@ -442,8 +443,8 @@ void iuse_transform::info( const item &it, std::vector<iteminfo> &dump ) const
     if( it.has_flag( flag_FIT ) ) {
         dummy.set_flag( flag_FIT );
     }
-    dump.emplace_back( "TOOL", string_format( _( "<bold>Turns into</bold>: %s" ),
-                       dummy.tname() ) );
+    dump.emplace_back( "TOOL", string_format( _( "<bold>Turns into</bold>: %dge %s",  ),
+                       amount, dummy.tname() ) );
 
     if( target_timer > 0_seconds ) {
         dump.emplace_back( "TOOL", _( "Countdown: " ), to_seconds<int>( target_timer ) );

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -434,7 +434,7 @@ void iuse_transform::finalize( const itype_id & )
 void iuse_transform::info( const item &it, std::vector<iteminfo> &dump ) const
 {
     int amount = std::max( ammo_qty, 1 );
-    item dummy( target, calendar::turn, 1 );
+    item dummy( target, calendar::turn, target->count_by_charges() ? amount : 1 );
     dummy.set_itype_variant( variant_type );
     // If the variant is to be randomized, use default no-variant name
     if( variant_type == "<any>" ) {
@@ -443,9 +443,27 @@ void iuse_transform::info( const item &it, std::vector<iteminfo> &dump ) const
     if( it.has_flag( flag_FIT ) ) {
         dummy.set_flag( flag_FIT );
     }
-    dump.emplace_back( "TOOL", _( "<bold>Turns into</bold>: " ),
-                       string_format( _( "%d %s" ),
-                                      amount, dummy.tname() ) );
+    if( target->count_by_charges() || !ammo_type.is_empty() ) {
+        if( !ammo_type.is_empty() ) {
+            dump.emplace_back( "TOOL", _( "<bold>Turns into</bold>: " ),
+                               string_format( _( "%s (%d %s)" ), dummy.tname(), amount, ammo_type->nname( amount ) ) );
+        } else if( !container.is_empty() ) {
+            dump.emplace_back( "TOOL", _( "<bold>Turns into</bold>: " ),
+                                           amount > 1 ?
+                                           string_format( _( "%s (%d %s)" ),
+                                                          container->nname( 1 ), amount, target->nname( amount ) ) :
+                                           string_format( _( "%s (%s)" ),
+                                                          container->nname( 1 ), target->nname( amount ) ) );
+        } else {
+            dump.emplace_back( "TOOL", _( "<bold>Turns into</bold>: " ),
+                               string_format( _( "%s (%d)" ), target->nname( amount ), amount ) );
+        }
+    } else {
+        dump.emplace_back( "TOOL", _( "<bold>Turns into</bold>: " ),
+                           amount > 1 ?
+                           string_format( _( "%d %s" ), amount, target->nname( amount ) ) :
+                           string_format( _( "%s" ), target->nname( amount ) ) );
+    }
 
     if( target_timer > 0_seconds ) {
         dump.emplace_back( "TOOL", _( "Countdown: " ), to_seconds<int>( target_timer ) );

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -443,7 +443,8 @@ void iuse_transform::info( const item &it, std::vector<iteminfo> &dump ) const
     if( it.has_flag( flag_FIT ) ) {
         dummy.set_flag( flag_FIT );
     }
-    dump.emplace_back( "TOOL", string_format( _( "<bold>Turns into</bold>: %dge %s",  ),
+    dump.emplace_back( "TOOL", _( "<bold>Turns into</bold>: "),
+                       string_format( _( "%d %s" ),
                        amount, dummy.tname() ) );
 
     if( target_timer > 0_seconds ) {

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -433,7 +433,7 @@ void iuse_transform::finalize( const itype_id & )
 
 void iuse_transform::info( const item &it, std::vector<iteminfo> &dump ) const
 {
-    item dummy( target, calendar::turn, std::max( ammo_qty, 1 ) );
+    item dummy( target, calendar::turn, target->count_by_charges() ? std::max( ammo_qty, 1 ) : 1 );
     dummy.set_itype_variant( variant_type );
     // If the variant is to be randomized, use default no-variant name
     if( variant_type == "<any>" ) {


### PR DESCRIPTION
#### Summary
Bugfixes "Not to try to set charges for item without charge."
#### Purpose of change
Fix https://github.com/CleverRaven/Cataclysm-DDA/issues/72984.
If an item with `use_action` `transform`/`delayed_transform` and `target_charges` defined, in `iuse_transform::do_transform` the game will check if it is `count_by_charges`.
https://github.com/CleverRaven/Cataclysm-DDA/blob/34f99c8306ed1e7ba03f7d0be0dd0821c1701bf7/src/iuse_actor.cpp#L313-L328
But this process is absent in `iuse_transform::info`.
https://github.com/CleverRaven/Cataclysm-DDA/blob/34f99c8306ed1e7ba03f7d0be0dd0821c1701bf7/src/iuse_actor.cpp#L436
The incorrect number is detected in `item.cpp` and ignored.
https://github.com/CleverRaven/Cataclysm-DDA/blob/53a0a73092aff1de989b0951e9c1d5eba6d62359/src/item.cpp#L315-L320
#### Describe the solution
Check if the target is `count_by_charges` in `iuse_transform::info` to get rid of the debugmsg.
Let the game show the target item properly: with/without charges, with/without carrier, with/without container, singular or plural.
#### Describe alternatives you've considered
#### Testing
Compiled and tested locally.
#### Additional context