### PR TITLE
Make CZ 75 16 Round Mag Actually Hold 16 Rounds and Fix ID

### DIFF
--- a/data/json/itemgroups/Weapons_Mods_Ammo/magazines.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/magazines.json
@@ -180,7 +180,7 @@
       [ "hptjcpmag", 2 ],
       [ "hptjhpmag", 2 ],
       [ "witness_mag_10", 2 ],
-      [ "cz75mag_12rd", 9 ],
+      [ "cz75mag_16rd", 9 ],
       [ "cz75mag_20rd", 5 ],
       [ "cz75mag_26rd", 2 ],
       [ "ccpmag", 4 ],

--- a/data/json/itemgroups/Weapons_Mods_Ammo/nested_guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/nested_guns.json
@@ -559,8 +559,8 @@
     "ammo": 100,
     "entries": [
       { "item": "cz75", "charges": [ 0, 26 ] },
-      { "item": "cz75mag_12rd" },
-      { "item": "cz75mag_12rd", "prob": 50 },
+      { "item": "cz75mag_16rd" },
+      { "item": "cz75mag_16rd", "prob": 50 },
       { "group": "on_hand_9mm" }
     ]
   },

--- a/data/json/items/gun/9mm.json
+++ b/data/json/items/gun/9mm.json
@@ -1220,7 +1220,7 @@
       {
         "magazine_well": "230 ml",
         "pocket_type": "MAGAZINE_WELL",
-        "item_restriction": [ "cz75mag_12rd", "cz75mag_20rd", "cz75mag_26rd" ]
+        "item_restriction": [ "cz75mag_16rd", "cz75mag_20rd", "cz75mag_26rd" ]
       }
     ],
     "melee_damage": { "bash": 8 }

--- a/data/json/items/magazine/10mm.json
+++ b/data/json/items/magazine/10mm.json
@@ -162,7 +162,7 @@
   },
   {
     "id": "witness_mag_10",
-    "looks_like": "cz75mag_12rd",
+    "looks_like": "cz75mag_16rd",
     "type": "MAGAZINE",
     "name": { "str": "EAA Witness 15-round magazine" },
     "description": "A 15-round steel box magazine for 10mm Auto EAA Witness pistols.",

--- a/data/json/items/magazine/9mm.json
+++ b/data/json/items/magazine/9mm.json
@@ -1392,7 +1392,7 @@
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "9mm": 15 } } ]
   },
   {
-    "id": "cz75mag_12rd",
+    "id": "cz75mag_16rd",
     "looks_like": "glock17_17",
     "type": "MAGAZINE",
     "name": { "str": "CZ 75 16-round magazine" },
@@ -1407,7 +1407,7 @@
     "color": "light_gray",
     "ammo_type": [ "9mm" ],
     "flags": [ "MAG_COMPACT" ],
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "9mm": 12 } } ]
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "9mm": 16 } } ]
   },
   {
     "id": "cz75mag_20rd",

--- a/data/json/obsoletion_and_migration_0.I/migration_items.json
+++ b/data/json/obsoletion_and_migration_0.I/migration_items.json
@@ -1313,6 +1313,11 @@
     "replace": "stanag30"
   },
   {
+    "id": "cz75mag_12rd",
+    "type": "MIGRATION",
+    "replace": "cz75mag_16rd"
+  },
+  {
     "id": "mossberg_500",
     "type": "MIGRATION",
     "from_variant": "mossberg_500_security",

--- a/data/mods/Generic_Guns/magazines/gg_magazines_migration.json
+++ b/data/mods/Generic_Guns/magazines/gg_magazines_migration.json
@@ -61,7 +61,7 @@
       "hptc9mag_8rd",
       "hptc9mag_10rd",
       "hptc9mag_15rd",
-      "cz75mag_12rd",
+      "cz75mag_16rd",
       "cz75mag_20rd",
       "p08mag_8rd",
       "clip9mm_10rd",

--- a/gfx/GiantDays/tile_config.json
+++ b/gfx/GiantDays/tile_config.json
@@ -7351,7 +7351,7 @@
             "p320mag_17rd_9x19mm",
             "p38mag",
             "j22mag",
-            "cz75mag_12rd",
+            "cz75mag_16rd",
             "cz75mag_20rd",
             "cz75mag_26rd",
             "wp22mag",

--- a/gfx/NeoDaysTileset/tile_config.json
+++ b/gfx/NeoDaysTileset/tile_config.json
@@ -2464,7 +2464,7 @@
             "p320mag_17rd_9x19mm",
             "p38mag",
             "j22mag",
-            "cz75mag_12rd",
+            "cz75mag_16rd",
             "cz75mag_20rd",
             "cz75mag_26rd",
             "wp22mag",

--- a/gfx/RetroDaysTileset/tile_config.json
+++ b/gfx/RetroDaysTileset/tile_config.json
@@ -2186,7 +2186,7 @@
             "p320mag_17rd_9x19mm",
             "p38mag",
             "j22mag",
-            "cz75mag_12rd",
+            "cz75mag_16rd",
             "cz75mag_20rd",
             "cz75mag_26rd",
             "wp22mag",

--- a/tests/ammo_set_test.cpp
+++ b/tests/ammo_set_test.cpp
@@ -295,7 +295,7 @@ TEST_CASE( "ammo_set_items_with_MAGAZINE_WELL_pockets_without_magazine",
 {
     GIVEN( "CZ 75 B 9mm gun w/o magazine" ) {
         item cz75( "cz75" );
-        itype_id cz75mag_12rd_id( "cz75mag_12rd" );
+        itype_id cz75mag_16rd_id( "cz75mag_16rd" );
         itype_id cz75mag_20rd_id( "cz75mag_20rd" );
         itype_id cz75mag_26rd_id( "cz75mag_26rd" );
         itype_id ammo9mm_id( "9mm" );
@@ -303,22 +303,22 @@ TEST_CASE( "ammo_set_items_with_MAGAZINE_WELL_pockets_without_magazine",
         REQUIRE_FALSE( cz75.is_magazine() );
         REQUIRE( cz75.magazine_current() == nullptr );
         REQUIRE( cz75.magazine_compatible().size() == 3 );
-        REQUIRE( cz75.magazine_compatible().count( cz75mag_12rd_id ) == 1 );
+        REQUIRE( cz75.magazine_compatible().count( cz75mag_16rd_id ) == 1 );
         REQUIRE( cz75.magazine_compatible().count( cz75mag_20rd_id ) == 1 );
         REQUIRE( cz75.magazine_compatible().count( cz75mag_26rd_id ) == 1 );
-        REQUIRE( cz75.magazine_default().str() == cz75mag_12rd_id.str() );
+        REQUIRE( cz75.magazine_default().str() == cz75mag_16rd_id.str() );
         const ammotype &amtype = ammo9mm_id->ammo->type;
         REQUIRE( cz75.ammo_capacity( amtype ) == 0 );
         REQUIRE( !cz75.ammo_default().is_null() );
         REQUIRE( cz75.magazine_default()->magazine->default_ammo.str() == ammo9mm_id.str() );
         WHEN( "set 9mm ammo in the gun w/o magazine w/o quantity" ) {
             cz75.ammo_set( ammo9mm_id );
-            THEN( "gun with new cz75mag_12rd magazine has 12 rounds of 9mm" ) {
-                CHECK( cz75.ammo_remaining() == 12 );
+            THEN( "gun with cz75mag_16rd magazine has 16 rounds of 9mm" ) {
+                CHECK( cz75.ammo_remaining() == 16 );
                 CHECK( cz75.ammo_current().str() == ammo9mm_id.str() );
                 REQUIRE( cz75.magazine_current() != nullptr );
-                CHECK( cz75.magazine_current()->typeId().str() == cz75mag_12rd_id.str() );
-                CHECK( cz75.magazine_current()->ammo_remaining() == 12 );
+                CHECK( cz75.magazine_current()->typeId().str() == cz75mag_16rd_id.str() );
+                CHECK( cz75.magazine_current()->ammo_remaining() == 16 );
                 CHECK( cz75.magazine_current()->ammo_current().str() == ammo9mm_id.str() );
             }
         }


### PR DESCRIPTION
#### Summary
Bugfixes "Make CZ 75 16 Round Mag Actually Hold 16 Rounds and Fix ID"

#### Purpose of change
The CZ 75 16 Round Magazine could only hold 12 rounds, despite a recent rework basing its volume/size on a 16 round mag.  Also apparently 12 round mags never existed, heres a link to that: https://github.com/CleverRaven/Cataclysm-DDA/pull/71540#issuecomment-1932795164
Also in that PR they updated the size and whatnot, but its id still read as 12 rounds.

#### Describe the solution
Well here was my checklist throughout.
Changing the Magazine Capacity -  data/json/items/magazine/9mm.json 1410
Change the id (it has 12rd in the id but should be 16rd): - data/json/items/magazine/9mm.json 1395 X
Change every reference to old id
- json/itemgroups/weapons_mods_ammo/magazines.json 183 X
- json/itemgroups/weapons_mods_ammo/nested_guns.json 562 and 563 X
- json/items/gun/9mm.json 1223 X
- json/items/magazine/10mm.json 165 X
- data/mods/generic_guns/magazins/gg_magazines_migration.json 64 X
- gfx/giantdays/tile_config.json 7354 X 
- gfx/neodaystileset/tile_config.json 2467 X
- gfx/retrodaystileset/tile_config.json 2189 X
-tests/ammo_set_test.cpp 298 306 309 316 320 X
AND CHANGE ABOVE TEST TO REFLECT AMMO CAPACITY CHANGE X

Add migration of old id to new id
data/json/obsoletion_and_migration_0.I/migration_items.json add near other mags X

#### Describe alternatives you've considered
Just changing the capacity but leaving the id stuff alone.

#### Testing
I booted it up and got no errors about missing ids, hopefully this was all done correctly, I tried to be thorough.  Couldn't test the change to the test itself, so... we'll see if this PR fails a bunch of tests or how that goes... 

#### Additional context
***Please god someone check my changes to the test, it's c++ and I'm scared I made a mistake since I struggle to read c++.  Seriously, please check this x_x***