### PR TITLE
Graphical construction preview

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -1091,52 +1091,22 @@ action_id handle_main_menu()
 
 std::optional<tripoint> choose_direction( const std::string &message, const bool allow_vertical )
 {
-    input_context ctxt( "DEFAULTMODE", keyboard_mode::keycode );
-    ctxt.set_iso( true );
-    ctxt.register_directions();
-    ctxt.register_action( "pause" );
-    ctxt.register_action( "QUIT" );
-    ctxt.register_action( "HELP_KEYBINDINGS" );
-    if( allow_vertical ) {
-        ctxt.register_action( "LEVEL_UP" );
-        ctxt.register_action( "LEVEL_DOWN" );
+    std::optional<tripoint_rel_ms> ret = choose_direction_rel_ms( message, allow_vertical );
+    if( ret.has_value() ) {
+        return ret->raw();
+    } else {
+        return std::nullopt;
     }
-
-    static_popup popup;
-    //~ %s: "Close where?" "Pry where?" etc.
-    popup.message( _( "%s (Direction button)" ), message ).on_top( true );
-
-    temp_hide_advanced_inv();
-    std::string action;
-    do {
-        ui_manager::redraw();
-        action = ctxt.handle_input();
-        if( std::optional<tripoint> vec = ctxt.get_direction( action ) ) {
-            FacingDirection &facing = get_player_character().facing;
-            // Make player's sprite face left/right if interacting with something to the left or right
-            if( vec->x > 0 ) {
-                facing = FacingDirection::RIGHT;
-            } else if( vec->x < 0 ) {
-                facing = FacingDirection::LEFT;
-            }
-            return vec;
-        } else if( action == "pause" ) {
-            return tripoint_zero;
-        } else if( action == "LEVEL_UP" ) {
-            return tripoint_above;
-        } else if( action == "LEVEL_DOWN" ) {
-            return tripoint_below;
-        }
-    } while( action != "QUIT" );
-
-    add_msg( _( "Never mind." ) );
-    return std::nullopt;
 }
 
 std::optional<tripoint_rel_ms> choose_direction_rel_ms( const std::string &message,
-        const bool allow_vertical )
+        const bool allow_vertical, const int timeout,
+        const std::function<void( const std::string &action )> &action_cb )
 {
     input_context ctxt( "DEFAULTMODE", keyboard_mode::keycode );
+    if( timeout >= 0 ) {
+        ctxt.set_timeout( timeout );
+    }
     ctxt.set_iso( true );
     ctxt.register_directions();
     ctxt.register_action( "pause" );
@@ -1172,6 +1142,9 @@ std::optional<tripoint_rel_ms> choose_direction_rel_ms( const std::string &messa
         } else if( action == "LEVEL_DOWN" ) {
             return tripoint_rel_ms( tripoint_below );
         }
+        if( action_cb ) {
+            action_cb( action );
+        }
     } while( action != "QUIT" );
 
     add_msg( _( "Never mind." ) );
@@ -1191,10 +1164,11 @@ std::optional<tripoint> choose_adjacent( const tripoint &pos, const std::string 
 }
 
 std::optional<tripoint_bub_ms> choose_adjacent( const tripoint_bub_ms &pos,
-        const std::string &message,
-        bool allow_vertical )
+        const std::string &message, bool allow_vertical, int timeout,
+        const std::function<void( const std::string &action )> &action_cb )
 {
-    const std::optional<tripoint_rel_ms> dir = choose_direction_rel_ms( message, allow_vertical );
+    const std::optional<tripoint_rel_ms> dir = choose_direction_rel_ms(
+                message, allow_vertical, timeout, action_cb );
     if( dir ) {
         return pos + *dir;
     } else {

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -1124,8 +1124,11 @@ std::optional<tripoint_rel_ms> choose_direction_rel_ms( const std::string &messa
     }
 
     static_popup popup;
-    //~ %s: "Close where?" "Pry where?" etc.
-    popup.message( _( "%s (Direction button)" ), message ).on_top( true );
+    popup.message( allow_mouse
+                   //~ %s: "Close where?" "Pry where?" etc.
+                   ? _( "%s (Direction button or mouse)" )
+                   //~ %s: "Close where?" "Pry where?" etc.
+                   : _( "%s (Direction button)" ), message ).on_top( true );
 
     temp_hide_advanced_inv();
     std::string action;

--- a/src/action.h
+++ b/src/action.h
@@ -11,6 +11,7 @@
 
 #include "coordinates.h"
 
+class input_context;
 struct input_event;
 struct point;
 struct tripoint;
@@ -463,6 +464,13 @@ bool can_action_change_worldstate( action_id act );
  *
  * @param[in] message Message used in assembling the prompt to the player
  * @param[in] allow_vertical Allows player to select tiles above/below them if true
+ * @param[in] timeout Makes a timeout event happen every this many milliseconds.
+ *            A negative value disables the timeout.
+ * @param[in] action_cb A callback that is called on every input event that does
+ *            not cause the function to exit. The callback should return a pair
+ *            of bool and optional tripoint. If the bool is true, this function
+ *            exits with the return value set to the tripoint, or std::nullopt
+ *            if the tripoint is not a valid adjacent location.
  */
 std::optional<tripoint> choose_adjacent( const std::string &message, bool allow_vertical = false );
 // TODO: Get rid of untyped overload.
@@ -470,7 +478,8 @@ std::optional<tripoint> choose_adjacent( const tripoint &pos, const std::string 
         bool allow_vertical = false );
 std::optional<tripoint_bub_ms> choose_adjacent( const tripoint_bub_ms &pos,
         const std::string &message, bool allow_vertical = false, int timeout = -1,
-        const std::function<void( const std::string &action )> &action_cb = nullptr );
+        const std::function<std::pair<bool, std::optional<tripoint_bub_ms>>(
+            const input_context &ctxt, const std::string &action )> &action_cb = nullptr );
 
 /**
  * Request player input of a direction, possibly including vertical component
@@ -482,13 +491,24 @@ std::optional<tripoint_bub_ms> choose_adjacent( const tripoint_bub_ms &pos,
  *
  * @param[in] message Message used in assembling the prompt to the player
  * @param[in] allow_vertical Allows direction vector to have vertical component if true
+ * @param[in] allow_mouse Allows mouse movement and clicks. This function does not handle
+ *            the mouse events, because it does not know where the center position is.
+ *            Use `choose_adjacent` instead to handle mouse automatically.
+ * @param[in] timeout Makes a timeout event happen every this many milliseconds.
+ *            A negative value disables the timeout.
+ * @param[in] action_cb A callback that is called on every input event that does
+ *            not cause the function to exit. The callback should return a pair
+ *            of bool and optional tripoint. If the bool is true, this function
+ *            exits with the return value set to the tripoint, or std::nullopt
+ *            if the tripoint is not a valid direction.
  */
 // TODO: Get rid of untyped version and typed name extension.
 std::optional<tripoint> choose_direction( const std::string &message,
         bool allow_vertical = false );
 std::optional<tripoint_rel_ms> choose_direction_rel_ms( const std::string &message,
-        bool allow_vertical = false, int timeout = -1,
-        const std::function<void( const std::string &action )> &action_cb = nullptr );
+        bool allow_vertical = false, bool allow_mouse = false, int timeout = -1,
+        const std::function<std::pair<bool, std::optional<tripoint_rel_ms>>(
+            const input_context &ctxt, const std::string &action )> &action_cb = nullptr );
 
 /**
  * Request player input of adjacent tile with highlighting, possibly on different z-level

--- a/src/action.h
+++ b/src/action.h
@@ -469,8 +469,8 @@ std::optional<tripoint> choose_adjacent( const std::string &message, bool allow_
 std::optional<tripoint> choose_adjacent( const tripoint &pos, const std::string &message,
         bool allow_vertical = false );
 std::optional<tripoint_bub_ms> choose_adjacent( const tripoint_bub_ms &pos,
-        const std::string &message,
-        bool allow_vertical = false );
+        const std::string &message, bool allow_vertical = false, int timeout = -1,
+        const std::function<void( const std::string &action )> &action_cb = nullptr );
 
 /**
  * Request player input of a direction, possibly including vertical component
@@ -487,7 +487,8 @@ std::optional<tripoint_bub_ms> choose_adjacent( const tripoint_bub_ms &pos,
 std::optional<tripoint> choose_direction( const std::string &message,
         bool allow_vertical = false );
 std::optional<tripoint_rel_ms> choose_direction_rel_ms( const std::string &message,
-        bool allow_vertical = false );
+        bool allow_vertical = false, int timeout = -1,
+        const std::function<void( const std::string &action )> &action_cb = nullptr );
 
 /**
  * Request player input of adjacent tile with highlighting, possibly on different z-level

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2369,6 +2369,11 @@ bool cata_tiles::find_overlay_looks_like( const bool male, const std::string &ov
     return exists;
 }
 
+void cata_tiles::set_disable_occlusion( const bool val )
+{
+    disable_occlusion = val;
+}
+
 bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEGORY category,
         const std::string &subcategory, const tripoint &pos,
         int subtile, int rota, lit_level ll, int retract,
@@ -2388,7 +2393,7 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEG
     const point screen_pos = player_to_screen( pos.xy() );
 
     if( retract < 0 && ( prevent_occlusion_transp || prevent_occlusion_retract ) ) {
-        if( prevent_occlusion == 0 ) {
+        if( prevent_occlusion == 0 || disable_occlusion ) {
             retract = 0;
         } else if( prevent_occlusion == 1 ) {
             retract = 100;

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2125,8 +2125,8 @@ point_bub_ms cata_tiles::screen_to_player(
                             divide_round_down( scr_pos.y * 4, tile_size.x ) + 1 );
         const std::optional<point_bub_ms> player_1 = tile_to_player(
                     colrow, center, base_tile, iso );
-        //NOLINTNEXTLINE(cata-use-named-point-constants): the name would be confusing here (screen 'NSWE' are not map NSWE)
         const std::optional<point_bub_ms> player_2 = tile_to_player(
+                    //NOLINTNEXTLINE(cata-use-named-point-constants): the name would be confusing here (screen 'NSWE' are not map NSWE)
                     colrow + point( 1, 0 ), center, base_tile, iso );
         // We do not know the precise shape of the base tile, assuming rhombuses.
         // TODO: maybe let tilesets provide the exact shape of the base tile.

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1916,9 +1916,10 @@ void cata_tiles::draw_minimap( const point &dest, const tripoint &center, int wi
     minimap->draw( SDL_Rect{ dest.x, dest.y, width, height }, center );
 }
 
-point cata_tiles::get_window_base_tile_counts( const point &size ) const
+point cata_tiles::get_window_base_tile_counts(
+    const point &size, const point &tile_size, const bool iso )
 {
-    if( is_isometric() ) {
+    if( iso ) {
         //  |---sx---|
         //  w        |
         //  ~
@@ -1951,16 +1952,22 @@ point cata_tiles::get_window_base_tile_counts( const point &size ) const
         // rows = 1 + divide_round_up(sy, h)
         // ||
         // \/
-        const int columns = divide_round_up( size.x * 2, tile_width ) + 1;
-        const int rows = divide_round_up( size.y * 4, tile_width ) + 1;
+        const int columns = divide_round_up( size.x * 2, tile_size.x ) + 1;
+        const int rows = divide_round_up( size.y * 4, tile_size.x ) + 1;
         return point( columns, rows );
     } else {
         // Only the area from (0, 0) to (tile_width, tile_height) is considered
         // when checking which tiles are on-screen.
-        const int columns = divide_round_up( size.x, tile_width );
-        const int rows = divide_round_up( size.y, tile_height );
+        const int columns = divide_round_up( size.x, tile_size.x );
+        const int rows = divide_round_up( size.y, tile_size.y );
         return point( columns, rows );
     }
+}
+
+point cata_tiles::get_window_base_tile_counts( const point &size ) const
+{
+    return get_window_base_tile_counts(
+               size, point( tile_width, tile_height ), is_isometric() );
 }
 
 half_open_rectangle<point> cata_tiles::get_window_any_tile_range(
@@ -2027,25 +2034,39 @@ half_open_rectangle<point> cata_tiles::get_window_full_base_tile_range( const po
     }
 }
 
-std::optional<point> cata_tiles::tile_to_player( const point &colrow ) const
+std::optional<point_bub_ms> cata_tiles::tile_to_player(
+    const point &colrow, const point_bub_ms &o, const point &base_tile_cnt,
+    const bool iso )
 {
-    if( is_isometric() ) {
+    if( iso ) {
         // (following comments in get_window_base_tile_counts)
         //
         // Based on the screen tile pattern, the player position can be calculated
         // from the column and row numbers as follows
-        if( modulo( colrow.y - screentile_height / 2, 2 )
-            != modulo( colrow.x - screentile_width / 2, 2 ) ) {
+        if( modulo( colrow.y - base_tile_cnt.y / 2, 2 )
+            != modulo( colrow.x - base_tile_cnt.x / 2, 2 ) ) {
             return std::nullopt;
         }
-        return o + point {
-            divide_round_down( colrow.x - colrow.y - screentile_width / 2
-                               + screentile_height / 2, 2 ),
-            divide_round_down( colrow.y + colrow.x - screentile_height / 2
-                               - screentile_width / 2, 2 ),
+        return o + point_rel_ms {
+            divide_round_down( colrow.x - colrow.y - base_tile_cnt.x / 2
+                               + base_tile_cnt.y / 2, 2 ),
+            divide_round_down( colrow.y + colrow.x - base_tile_cnt.y / 2
+                               - base_tile_cnt.x / 2, 2 ),
         };
     } else {
-        return colrow + o;
+        return point_rel_ms( colrow ) + o;
+    }
+}
+
+std::optional<point> cata_tiles::tile_to_player( const point &colrow ) const
+{
+    std::optional<point_bub_ms> ret = tile_to_player(
+                                          colrow, point_bub_ms( o ),
+                                          point( screentile_width, screentile_height ), is_isometric() );
+    if( ret.has_value() ) {
+        return ret.value().raw();
+    } else {
+        return std::nullopt;
     }
 }
 
@@ -2084,6 +2105,69 @@ point cata_tiles::player_to_screen( const point &pos ) const
         };
     } else {
         return op + point { colrow.x * tile_width, colrow.y * tile_height };
+    }
+}
+
+point_bub_ms cata_tiles::screen_to_player(
+    const point &scr_pos, const point &tile_size,
+    const point &win_size, const point_bub_ms &center,
+    const bool iso )
+{
+    // `scr_pos` is the offset from the window origin
+    const point base_tile = get_window_base_tile_counts( win_size, tile_size, iso );
+    if( iso ) {
+        // Unlike `player_to_screen`, not shifting vertically here because only
+        // the base tile is considered.
+        //
+        // col = round_down( x / ( tw / 2.0 ) ) + 1 =>
+        // row = round_down( y / ( tw / 4.0 ) ) + 1 =>
+        const point colrow( divide_round_down( scr_pos.x * 2, tile_size.x ) + 1,
+                            divide_round_down( scr_pos.y * 4, tile_size.x ) + 1 );
+        const std::optional<point_bub_ms> player_1 = tile_to_player(
+                    colrow, center, base_tile, iso );
+        //NOLINTNEXTLINE(cata-use-named-point-constants): the name would be confusing here (screen 'NSWE' are not map NSWE)
+        const std::optional<point_bub_ms> player_2 = tile_to_player(
+                    colrow + point( 1, 0 ), center, base_tile, iso );
+        // We do not know the precise shape of the base tile, assuming rhombuses.
+        // TODO: maybe let tilesets provide the exact shape of the base tile.
+        if( player_1.has_value() ) {
+            // cell at `colrow` => |/|
+            const point pos_in_cell = scr_pos - point(
+                                          // relative to top-right of the cell:
+                                          // dx = x - col * ( tw / 2.0 ) =>
+                                          divide_round_down( colrow.x * tile_size.x, 2 ),
+                                          // dy = y - ( row - 1 ) * ( tw / 4.0 ) =>
+                                          divide_round_down( ( colrow.y - 1 ) * tile_size.x, 4 ) );
+            if( pos_in_cell.y * 2 <= -pos_in_cell.x ) {
+                // top-left of the cell, which is one tile north of player_1
+                return player_1.value() + point_rel_ms( 0, -1 );
+            } else {
+                // lower-right of the cell, which is player_1
+                return player_1.value();
+            }
+        } else {
+            // cell at `colrow` => |\|
+            const point pos_in_cell = scr_pos - point(
+                                          // relative to top-left of the cell:
+                                          // dx = x - ( col - 1 ) * ( tw / 2.0 ) =>
+                                          divide_round_down( ( colrow.x - 1 ) * tile_size.x, 2 ),
+                                          // dy = y - ( row - 1 ) * ( tw / 4.0 ) =>
+                                          divide_round_down( ( colrow.y - 1 ) * tile_size.x, 4 ) );
+            if( pos_in_cell.y * 2 <= pos_in_cell.x ) {
+                // top-right of the cell, which is one tile north of player_2
+                return player_2.value() + point_rel_ms( 0, -1 );
+            } else {
+                // lower-left of the cell, which is one tile northwest of player_2
+                return player_2.value() + point_rel_ms( -1, -1 );
+            }
+        }
+    } else {
+        return tile_to_player( point( divide_round_down( scr_pos.x, tile_size.x ),
+                                      divide_round_down( scr_pos.y, tile_size.y ) ),
+                               // similar to the subtraction by `POSX`/`POSY` in cata_tiles::draw
+                               center - point_rel_ms( win_size.x / tile_size.x / 2,
+                                       win_size.y / tile_size.y / 2 ),
+                               base_tile, iso ).value();
     }
 }
 

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -664,6 +664,8 @@ class cata_tiles
 
         bool has_draw_override( const tripoint &p ) const;
 
+        void set_disable_occlusion( bool val );
+
         /**
          * Initialize the current tileset (load tile images, load mapping), using the current
          * tileset as it is set in the options.
@@ -753,6 +755,8 @@ class cata_tiles
         int fog_alpha = 0;
 
         bool in_animation = false;
+
+        bool disable_occlusion = false;
 
         bool do_draw_explosion = false;
         bool do_draw_custom_explosion = false;

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -440,6 +440,8 @@ class cata_tiles
          ** basic x range of [0, tile_width) and the basic y range of
          ** [0, tile_width / 2) (isometric) or [0, tile_height) (non-isometric) **/
         point get_window_base_tile_counts( const point &size ) const;
+        static point get_window_base_tile_counts(
+            const point &size, const point &tile_size, bool iso );
         /** Coordinate range of tiles at the given relative z-level that fit
          ** into the given dimensions, fully or partially shown, according to
          ** the maximum tile extent. May be negative, and 0 corresponds to the
@@ -699,8 +701,15 @@ class cata_tiles
         }
         void do_tile_loading_report();
         std::optional<point> tile_to_player( const point &colrow ) const;
+        static std::optional<point_bub_ms> tile_to_player(
+            const point &colrow, const point_bub_ms &o,
+            const point &base_tile_cnt, bool iso );
         point player_to_tile( const point &pos ) const;
         point player_to_screen( const point &pos ) const;
+        static point_bub_ms screen_to_player(
+            const point &scr_pos, const point &tile_size,
+            const point &win_size, const point_bub_ms &center,
+            const bool iso );
         static std::vector<options_manager::id_and_option> build_renderer_list();
         static std::vector<options_manager::id_and_option> build_display_list();
     private:

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -709,7 +709,7 @@ class cata_tiles
         static point_bub_ms screen_to_player(
             const point &scr_pos, const point &tile_size,
             const point &win_size, const point_bub_ms &center,
-            const bool iso );
+            bool iso );
         static std::vector<options_manager::id_and_option> build_renderer_list();
         static std::vector<options_manager::id_and_option> build_display_list();
     private:

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -753,19 +753,19 @@ construction_id construction_menu( const bool blueprint )
 
         w_con = catacurses::newwin( w_height, w_width, point( w_x0, w_y0 ) );
 
+        // center player tile in the visible part of main UI
 #if defined( TILES )
-        // center player tile in the visible part of main UI
-        const int y_shift = ( ter_dims.window_size_pixel.y - norm_dims.scaled_font_size.y * w_y0
-                              // shift up to reveal the full height of the topmost tile
-                              - ( tile_extra_height + tile_height - 1 ) / tile_height * tile_height
-                              + tile_height * 2 - 1 ) / ( tile_height * 2 );
-        if( g->is_tileset_isometric() ) {
-            player_character.view_offset = tripoint( -y_shift, y_shift, 0 );
-        } else {
-            player_character.view_offset = tripoint( 0, y_shift, 0 );
-        }
+        const point visible_center(
+            ter_dims.window_size_pixel.x / 2,
+            ( norm_dims.scaled_font_size.y * w_y0
+              // shift up to reveal the full height of the topmost tile
+              + ( tile_extra_height + tile_height - 1 ) / tile_height * tile_height ) / 2 );
+        const point_bub_ms target = cata_tiles::screen_to_player(
+                                        visible_center,
+                                        ter_dims.scaled_font_size, ter_dims.window_size_pixel,
+                                        player_character.pos_bub().xy(), g->is_tileset_isometric() );
+        player_character.view_offset = tripoint( ( player_character.pos_bub().xy() - target ).raw(), 0 );
 #else
-        // center player tile in the visible part of main UI
         player_character.view_offset = tripoint( 0, ( w_height + 1 ) / 2, 0 );
 #endif
         g->invalidate_main_ui_adaptor();

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -704,8 +704,10 @@ construction_id construction_menu( const bool blueprint )
         const window_dimensions norm_dims = get_window_dimensions( catacurses::stdscr );
         const int tile_height = g->is_tileset_isometric()
                                 ? ter_dims.scaled_font_size.x / 2 : ter_dims.scaled_font_size.y;
-        const int tile_extra_height = tilecontext->get_max_tile_extent().p_max.y * get_scaling_factor()
-                                      - tile_height;
+        const int tile_extra_height = use_tiles
+                                      ? tilecontext->get_max_tile_extent().p_max.y * get_scaling_factor()
+                                      - tile_height
+                                      : 0;
         // desired number of reserved lines from the construction menu.
         const int reserve_height = ( ( reserve_tile_height
                                        // reserve the minimum number of full tiles that makes the

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -406,7 +406,9 @@ static shared_ptr_fast<game::draw_callback_t> construction_preview_callback(
                         here.drawsq( g->w_terrain, loc,
                                      drawsq_params().highlight( true )
                                      .show_items( true )
-                                     .furniture_override( blink ? furn_str_id( post_id ) : furn_str_id::NULL_ID() ) );
+                                     .furniture_override( blink && preview
+                                                          ? furn_str_id( post_id )
+                                                          : furn_str_id::NULL_ID() ) );
                     }
                 } else {
                     if( is_draw_tiles_mode() ) {
@@ -418,7 +420,9 @@ static shared_ptr_fast<game::draw_callback_t> construction_preview_callback(
                         here.drawsq( g->w_terrain, loc,
                                      drawsq_params().highlight( true )
                                      .show_items( true )
-                                     .terrain_override( blink ? ter_str_id( post_id ) : ter_str_id::NULL_ID() ) );
+                                     .terrain_override( blink && preview
+                                                        ? ter_str_id( post_id )
+                                                        : ter_str_id::NULL_ID() ) );
                     }
                 }
             } else {

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1180,8 +1180,9 @@ void place_construction( std::vector<construction_group_str_id> const &groups )
                 valid, mouse_pos, blink );
     g->add_draw_callback( draw_preview );
 
+    const tripoint_bub_ms &loc = player_character.pos_bub();
     const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent(
-                player_character.pos_bub(), _( "Construct where?" ),
+                loc, _( "Construct where?" ),
                 /*allow_vertical=*/false, /*timeout=*/get_option<int>( "BLINK_SPEED" ),
     [&]( const input_context & ctxt, const std::string & action ) {
         if( action == "TIMEOUT" ) {
@@ -1192,7 +1193,9 @@ void place_construction( std::vector<construction_group_str_id> const &groups )
         if( action == "MOUSE_MOVE" ) {
             const std::optional<tripoint> mouse_pos_raw = ctxt.get_coordinates(
                         g->w_terrain, g->ter_view_p.xy(), true );
-            if( mouse_pos_raw.has_value() ) {
+            if( mouse_pos_raw.has_value() && mouse_pos_raw->z == loc.z()
+                && mouse_pos_raw->x >= loc.x() - 1 && mouse_pos_raw->x <= loc.x() + 1
+                && mouse_pos_raw->y >= loc.y() - 1 && mouse_pos_raw->y <= loc.y() + 1 ) {
                 mouse_pos = tripoint_bub_ms( *mouse_pos_raw );
             } else {
                 mouse_pos = std::nullopt;

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -13,6 +13,7 @@
 #include "avatar.h"
 #include "build_reqs.h"
 #include "calendar.h"
+#include "cata_scope_helpers.h"
 #include "cata_utility.h"
 #include "character.h"
 #include "colony.h"
@@ -22,6 +23,7 @@
 #include "coordinates.h"
 #include "creature.h"
 #include "cursesdef.h"
+#include "cursesport.h"
 #include "debug.h"
 #include "enums.h"
 #include "event.h"
@@ -50,10 +52,12 @@
 #include "options.h"
 #include "output.h"
 #include "overmap.h"
+#include "panels.h"
 #include "player_activity.h"
 #include "point.h"
 #include "requirements.h"
 #include "rng.h"
+#include "sdltiles.h"
 #include "skill.h"
 #include "sounds.h"
 #include "string_formatter.h"
@@ -374,6 +378,62 @@ static std::string furniture_qualities_string( const furn_id &fid )
     return ret;
 }
 
+static std::pair<std::map<tripoint_bub_ms, const construction *>, std::vector<construction *>>
+        valid_constructions_near_player( const std::vector<construction_group_str_id> &groups,
+                const inventory &total_inv, avatar &player_character );
+
+static shared_ptr_fast<game::draw_callback_t> construction_preview_callback(
+    const std::map<tripoint_bub_ms, const construction *> &valid,
+    const std::optional<tripoint_bub_ms> &mouse_pos, const bool &blink )
+{
+    return make_shared_fast<game::draw_callback_t>( [&]() {
+        map &here = get_map();
+        // Draw construction result preview on valid squares
+        // TODO: fix point types
+        for( const auto &elem : valid ) {
+            const tripoint_bub_ms &loc = elem.first;
+            const construction &con = *elem.second;
+            const std::string &post_id = con.post_terrain;
+            const bool preview = !mouse_pos.has_value() || mouse_pos.value() == loc;
+            if( !post_id.empty() ) {
+                if( con.post_is_furniture ) {
+                    if( is_draw_tiles_mode() ) {
+                        if( blink && preview ) {
+                            g->draw_furniture_override( loc.raw(), furn_str_id( post_id ) );
+                        }
+                        g->draw_highlight( loc.raw() );
+                    } else {
+                        here.drawsq( g->w_terrain, loc,
+                                     drawsq_params().highlight( true )
+                                     .show_items( true )
+                                     .furniture_override( blink ? furn_str_id( post_id ) : furn_str_id::NULL_ID() ) );
+                    }
+                } else {
+                    if( is_draw_tiles_mode() ) {
+                        if( blink && preview ) {
+                            g->draw_terrain_override( loc.raw(), ter_str_id( post_id ) );
+                        }
+                        g->draw_highlight( loc.raw() );
+                    } else {
+                        here.drawsq( g->w_terrain, loc,
+                                     drawsq_params().highlight( true )
+                                     .show_items( true )
+                                     .terrain_override( blink ? ter_str_id( post_id ) : ter_str_id::NULL_ID() ) );
+                    }
+                }
+            } else {
+                if( is_draw_tiles_mode() ) {
+                    g->draw_highlight( loc.raw() );
+                } else {
+                    here.drawsq( g->w_terrain, loc,
+                                 drawsq_params().highlight( true )
+                                 .show_items( true ) );
+                }
+            }
+        }
+    } );
+}
+
 construction_id construction_menu( const bool blueprint )
 {
     if( !finalized ) {
@@ -438,6 +498,7 @@ construction_id construction_menu( const bool blueprint )
     ctxt.register_action( "HELP_KEYBINDINGS" );
     ctxt.register_action( "FILTER" );
     ctxt.register_action( "RESET_FILTER" );
+    ctxt.set_timeout( get_option<int>( "BLINK_SPEED" ) );
 
     const std::vector<construction_category> &construct_cat = construction_categories::get_all();
     const int tabcount = static_cast<int>( construction_category::count() );
@@ -446,6 +507,12 @@ construction_id construction_menu( const bool blueprint )
 
     const nc_color color_stage = c_white;
     ui_adaptor ui;
+
+    std::unique_ptr<on_out_of_scope> invalidate_main_ui = std::make_unique<on_out_of_scope>( []() {
+        g->invalidate_main_ui_adaptor();
+    } );
+    std::unique_ptr<restore_on_out_of_scope<tripoint>> restore_view
+            = std::make_unique<restore_on_out_of_scope<tripoint>>( player_character.view_offset );
 
     const auto recalc_buffer = [&]() {
         //leave room for top and bottom UI text
@@ -618,18 +685,76 @@ construction_id construction_menu( const bool blueprint )
     };
 
     ui.on_screen_resize( [&]( ui_adaptor & ui ) {
-        w_height = TERMY;
+        const int left_panel_width = panel_manager::get_manager().get_width_left();
+        const int right_panel_width = panel_manager::get_manager().get_width_right();
+
+        // 3 tiles of valid construction locations around the player character,
+        // plus 2 tiles of padding.
+        const int reserve_tile_height = 5;
+#if defined( TILES )
+        const window_dimensions ter_dims = get_window_dimensions( g->w_terrain );
+        const window_dimensions norm_dims = get_window_dimensions( catacurses::stdscr );
+        const int tile_height = g->is_tileset_isometric()
+                                ? ter_dims.scaled_font_size.x / 2 : ter_dims.scaled_font_size.y;
+        const int tile_extra_height = tilecontext->get_max_tile_extent().p_max.y * get_scaling_factor()
+                                      - tile_height;
+        // desired number of reserved lines from the construction menu.
+        const int reserve_height = ( ( reserve_tile_height
+                                       // reserve the minimum number of full tiles that makes the
+                                       // extra tile height visible.
+                                       + ( tile_extra_height + tile_height - 1 ) / tile_height )
+                                     // reserve the minimum number of construction menu lines that
+                                     // makes the reserved tiles visible.
+                                     * tile_height + norm_dims.scaled_font_size.y - 1 )
+                                   / norm_dims.scaled_font_size.y;
+#else
+        // desired number of reserved lines from the construction menu.
+        const int reserve_height = reserve_tile_height;
+#endif
+
+        w_height = TERMY - reserve_height;
+        // reduce height to match content
         if( static_cast<int>( available.size() ) + 2 < w_height ) {
             w_height = available.size() + 2;
         }
+        // but no lower than FULL_SCREEN_HEIGHT
         if( w_height < FULL_SCREEN_HEIGHT ) {
             w_height = FULL_SCREEN_HEIGHT;
         }
+        // if there is no enough space for main UI, hide it
+        if( w_height + reserve_height > TERMY ) {
+            w_height = std::max( TERMY, FULL_SCREEN_HEIGHT );
+        }
+        // number of normal lines for main UI (may be larger than reserve_height)
+        const int w_y0 = TERMY - w_height;
 
-        w_width = std::max( FULL_SCREEN_WIDTH, TERMX * 2 / 3 );
-        const int w_y0 = ( TERMY > w_height ) ? ( TERMY - w_height ) / 2 : 0;
-        const int w_x0 = ( TERMX > w_width ) ? ( TERMX - w_width ) / 2 : 0;
+        // keep side panel visible
+        w_width = TERMX - left_panel_width - right_panel_width;
+        int w_x0 = left_panel_width;
+        // unless width is too small
+        if( w_width < FULL_SCREEN_WIDTH ) {
+            w_width = std::max( TERMX, FULL_SCREEN_WIDTH );
+            w_x0 = 0;
+        }
+
         w_con = catacurses::newwin( w_height, w_width, point( w_x0, w_y0 ) );
+
+#if defined( TILES )
+        // center player tile in the visible part of main UI
+        const int y_shift = ( ter_dims.window_size_pixel.y - norm_dims.scaled_font_size.y * w_y0
+                              // shift up to reveal the full height of the topmost tile
+                              - ( tile_extra_height + tile_height - 1 ) / tile_height * tile_height
+                              + tile_height * 2 - 1 ) / ( tile_height * 2 );
+        if( g->is_tileset_isometric() ) {
+            player_character.view_offset = tripoint( -y_shift, y_shift, 0 );
+        } else {
+            player_character.view_offset = tripoint( 0, y_shift, 0 );
+        }
+#else
+        // center player tile in the visible part of main UI
+        player_character.view_offset = tripoint( 0, ( w_height + 1 ) / 2, 0 );
+#endif
+        g->invalidate_main_ui_adaptor();
 
         w_list_width = static_cast<int>( .375 * w_width );
         w_list_height = w_height - 4;
@@ -724,6 +849,14 @@ construction_id construction_menu( const bool blueprint )
         wnoutrefresh( w_list );
     } );
 
+    construction_group_str_id con_preview_group = construction_group_str_id::NULL_ID();
+    std::map<tripoint_bub_ms, const construction *> con_preview;
+    const std::optional<tripoint_bub_ms> mouse_pos; // dummy
+    bool blink = true;
+    shared_ptr_fast<game::draw_callback_t> draw_preview = construction_preview_callback(
+                con_preview, mouse_pos, blink );
+    g->add_draw_callback( draw_preview );
+
     do {
         if( update_cat ) {
             update_cat = false;
@@ -794,11 +927,29 @@ construction_id construction_menu( const bool blueprint )
             recalc_buffer();
         } // Finished updating
 
+        if( select < 0 || static_cast<size_t>( select ) >= constructs.size()
+            || con_preview_group != constructs[select] ) {
+            con_preview_group = ( select >= 0 || static_cast<size_t>( select ) < constructs.size() )
+                                ? constructs[select] : construction_group_str_id::NULL_ID();
+            if( con_preview_group.is_null() ) {
+                con_preview.clear();
+            } else {
+                con_preview = valid_constructions_near_player(
+                { con_preview_group }, total_inv, player_character ).first;
+            }
+        }
+
+        g->invalidate_main_ui_adaptor();
         ui_manager::redraw();
 
         const std::string action = ctxt.handle_input();
         const int recmax = static_cast<int>( constructs.size() );
         const int scroll_rate = recmax > 20 ? 10 : 3;
+        if( action == "TIMEOUT" ) {
+            blink = !blink;
+        } else {
+            blink = true;
+        }
         if( action == "FILTER" ) {
             string_input_popup popup;
             popup
@@ -849,6 +1000,9 @@ construction_id construction_menu( const bool blueprint )
                     if( !player_can_see_to_build( player_character, constructs[select] ) ) {
                         add_msg( m_info, _( "It is too dark to construct right now." ) );
                     } else {
+                        draw_preview.reset();
+                        restore_view.reset();
+                        invalidate_main_ui.reset();
                         ui.reset();
                         place_construction( { constructs[select] } );
                         uistate.last_construction = constructs[select];
@@ -985,17 +1139,16 @@ bool can_construct( const construction &con )
     return false;
 }
 
-void place_construction( std::vector<construction_group_str_id> const &groups )
+std::pair<std::map<tripoint_bub_ms, const construction *>, std::vector<construction *>>
+        valid_constructions_near_player( const std::vector<construction_group_str_id> &groups,
+                const inventory &total_inv, avatar &player_character )
 {
-    avatar &player_character = get_avatar();
-    const inventory &total_inv = player_character.crafting_inventory();
-
-    std::map<tripoint_bub_ms, const construction *> valid;
-    std::vector<construction *> cons;
+    std::pair<std::map<tripoint_bub_ms, const construction *>, std::vector<construction *>> ret;
+    std::map<tripoint_bub_ms, const construction *> &valid = ret.first;
+    std::vector<construction *> &cons = ret.second;
     map &here = get_map();
     for( construction_group_str_id const &group : groups ) {
         std::vector<construction *> const temp = constructions_by_group( group );
-        // TODO: fix point types
         for( const tripoint_bub_ms &p : here.points_in_radius( player_character.pos_bub(), 1 ) ) {
             for( const auto *con : temp ) {
                 if( p != player_character.pos_bub() && can_construct( *con, p ) &&
@@ -1006,57 +1159,25 @@ void place_construction( std::vector<construction_group_str_id> const &groups )
         }
         std::move( temp.begin(), temp.end(), std::back_inserter( cons ) );
     }
+    return ret;
+}
+
+void place_construction( std::vector<construction_group_str_id> const &groups )
+{
+    avatar &player_character = get_avatar();
+    const inventory &total_inv = player_character.crafting_inventory();
+
+    std::pair<std::map<tripoint_bub_ms, const construction *>, std::vector<construction *>>
+            valid_pair = valid_constructions_near_player( groups, total_inv, player_character );
+    std::map<tripoint_bub_ms, const construction *> &valid = valid_pair.first;
+    std::vector<construction *> &cons = valid_pair.second;
+    map &here = get_map();
 
     bool blink = true;
     std::optional<tripoint_bub_ms> mouse_pos;
 
-    shared_ptr_fast<game::draw_callback_t> draw_preview =
-    make_shared_fast<game::draw_callback_t>( [&]() {
-        map &here = get_map();
-        // Draw construction result preview on valid squares
-        // TODO: fix point types
-        for( const auto &elem : valid ) {
-            const tripoint_bub_ms &loc = elem.first;
-            const construction &con = *elem.second;
-            const std::string &post_id = con.post_terrain;
-            const bool preview = !mouse_pos.has_value() || mouse_pos.value() == loc;
-            if( !post_id.empty() ) {
-                if( con.post_is_furniture ) {
-                    if( is_draw_tiles_mode() ) {
-                        if( blink && preview ) {
-                            g->draw_furniture_override( loc.raw(), furn_str_id( post_id ) );
-                        }
-                        g->draw_highlight( loc.raw() );
-                    } else {
-                        here.drawsq( g->w_terrain, loc,
-                                     drawsq_params().highlight( true )
-                                     .show_items( true )
-                                     .furniture_override( blink ? furn_str_id( post_id ) : furn_str_id::NULL_ID() ) );
-                    }
-                } else {
-                    if( is_draw_tiles_mode() ) {
-                        if( blink && preview ) {
-                            g->draw_terrain_override( loc.raw(), ter_str_id( post_id ) );
-                        }
-                        g->draw_highlight( loc.raw() );
-                    } else {
-                        here.drawsq( g->w_terrain, loc,
-                                     drawsq_params().highlight( true )
-                                     .show_items( true )
-                                     .terrain_override( blink ? ter_str_id( post_id ) : ter_str_id::NULL_ID() ) );
-                    }
-                }
-            } else {
-                if( is_draw_tiles_mode() ) {
-                    g->draw_highlight( loc.raw() );
-                } else {
-                    here.drawsq( g->w_terrain, loc,
-                                 drawsq_params().highlight( true )
-                                 .show_items( true ) );
-                }
-            }
-        }
-    } );
+    shared_ptr_fast<game::draw_callback_t> draw_preview = construction_preview_callback(
+                valid, mouse_pos, blink );
     g->add_draw_callback( draw_preview );
 
     const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent(

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -7065,8 +7065,10 @@ bool map::draw_maptile( const catacurses::window &w, const tripoint &p,
 {
     drawsq_params param = params;
     nc_color tercol;
-    const ter_t &curr_ter = curr_maptile.get_ter_t();
-    const furn_t &curr_furn = curr_maptile.get_furn_t();
+    const ter_t &curr_ter = params.terrain_override().is_null()
+                            ? curr_maptile.get_ter_t() : params.terrain_override().obj();
+    const furn_t &curr_furn = params.furniture_override().is_null()
+                              ? curr_maptile.get_furn_t() : params.furniture_override().obj();
     const trap &curr_trap = curr_maptile.get_trap().obj();
     const field &curr_field = curr_maptile.get_field();
     int sym;
@@ -10557,4 +10559,14 @@ tripoint drawsq_params::center() const
     } else {
         return view_center;
     }
+}
+
+const ter_str_id &drawsq_params::terrain_override() const
+{
+    return ter_override;
+}
+
+const furn_str_id &drawsq_params::furniture_override() const
+{
+    return furn_override;
 }

--- a/src/map.h
+++ b/src/map.h
@@ -168,6 +168,8 @@ struct bash_params {
 struct drawsq_params {
     private:
         tripoint view_center = tripoint_min;
+        ter_str_id ter_override = ter_str_id::NULL_ID();
+        furn_str_id furn_override = furn_str_id::NULL_ID();
         bool do_highlight = false;
         bool do_show_items = true;
         bool do_low_light = false;
@@ -176,7 +178,7 @@ struct drawsq_params {
         bool do_output = true;
 
     public:
-        constexpr drawsq_params() = default;
+        drawsq_params() = default;
 
         /**
          * Highlight the tile. On TILES, draws an overlay; on CURSES, inverts color.
@@ -277,6 +279,23 @@ struct drawsq_params {
             return *this;
         }
         tripoint center() const;
+        //@}
+
+        /**
+         * Set terrain or furniture override.
+         * Default: no override.
+         */
+        //@{
+        drawsq_params &terrain_override( const ter_str_id &id ) {
+            ter_override = id;
+            return *this;
+        }
+        drawsq_params &furniture_override( const furn_str_id &id ) {
+            furn_override = id;
+            return *this;
+        }
+        const ter_str_id &terrain_override() const;
+        const furn_str_id &furniture_override() const;
         //@}
 };
 

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -3901,9 +3901,20 @@ static window_dimensions get_window_dimensions( const catacurses::window &win,
     // the window position is *always* in standard font dimensions!
     dim.window_pos_pixel = point( dim.window_pos_cell.x * fontwidth,
                                   dim.window_pos_cell.y * fontheight );
-    // But the size of the window is in the font dimensions of the window.
-    dim.window_size_pixel.x = dim.window_size_cell.x * dim.scaled_font_size.x;
-    dim.window_size_pixel.y = dim.window_size_cell.y * dim.scaled_font_size.y;
+    // But the size of the window might not be.
+    if( use_tiles && g && win == g->w_terrain ) {
+        // The terrain GUI has special size during rendering.
+        dim.window_size_pixel.x = TERRAIN_WINDOW_TERM_WIDTH * fontwidth;
+        dim.window_size_pixel.y = TERRAIN_WINDOW_TERM_HEIGHT * fontheight;
+    } else if( use_tiles && use_tiles_overmap && g && win == g->w_overmap ) {
+        // The overmap GUI has special size during rendering.
+        dim.window_size_pixel.x = OVERMAP_WINDOW_TERM_WIDTH * fontwidth;
+        dim.window_size_pixel.y = OVERMAP_WINDOW_TERM_HEIGHT * fontheight;
+    } else {
+        // Otherwise, the window size corresponds to the window font size.
+        dim.window_size_pixel.x = dim.window_size_cell.x * dim.scaled_font_size.x;
+        dim.window_size_pixel.y = dim.window_size_cell.y * dim.scaled_font_size.y;
+    }
 
     return dim;
 }


### PR DESCRIPTION
#### Summary
Features "Graphical construction preview"

#### Purpose of change
Show preview of selected construction in the construction menu and when placing construction. It's fancy, so why not?

Construction menu:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/11890223/b72980db-2836-4aa0-a4b2-07cc99ee7e79)

Construction placement (without mouse selection)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/11890223/6b2f9b28-8c5a-467c-a45d-ef1e977f8bd2)

Construction placement (mouse over tile)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/11890223/d089d6aa-476c-40ff-887c-8f79e9ba234d)

#### Describe the solution

Reuse the tile override code previously used for map editor preview, and add basic tile override code for curses, which currently does not handle tile connection with other override tiles. This PR is getting large so the tile connection should probably be implemented in a separate PR.

The construction menu is now placed at the bottom left/right of the screen to make the main UI and side bar visible when possible. The main UI now displays the construction preview at the center of the visible area. When placing a construciton, the main UI also displays the construction preview, and mousing over a tile will show the tile's preview only, and clicking on a tile will select the tile.

While I'm at it I also improved mouse terrain selection in isometric mode. Now it assumes a rhombus tile shape when mapping screen position to player position, which works better with existing tilesets. An off-by-one error when selecting tiles is also fixed.

#### Describe alternatives you've considered

Currently, the tiles code draws the preview tiles connected to each other whereas the curses code only does it connected to actual tiles. I think both are fine but they should be made consistent. However, it will require either implementing the tile override connection logic for curses which may involve a heavy overhaul of the drawing logic, or adding a flag to the tiles drawing code to ignore connection to other overrides. These changes should probably be implemented in separate PRs.

Currently, only the post terrain and post furniture of a construction is previewed. Construction byproducts are based on item groups and I'm not sure how to make a sensible preview of a potentially randomized result. I haven't looked into how the post flags, do-turn specials, and post specials affect a construction, but I imagine their implementation may not be that straightfoward, and therefore should probably be left off for a later PR.

#### Testing
Tested in the tiles (including isometric mode) and curses build. The preview is correctly displayed with the construction menu open and during construction placcement. The construction menu is correctly resized with the game window, and the main UI and the side bar are shown unless there is no space for them. Selecting a construction in the construction menu works as expected, and construction placement with keyboard or mouse works as expected.

#### Additional context
