### PR TITLE
Container audit (mostly transparency)

### DIFF
--- a/data/json/items/containers/containers.json
+++ b/data/json/items/containers/containers.json
@@ -197,7 +197,15 @@
     "price": "0 cent",
     "price_postapoc": "0 cent",
     "to_hit": -1,
-    "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "6 L", "max_contains_weight": "10 kg", "moves": 400 } ],
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "transparent": true,
+        "max_contains_volume": "6 L",
+        "max_contains_weight": "10 kg",
+        "moves": 400
+      }
+    ],
     "material": [ "plastic" ],
     "symbol": ")",
     "color": "light_gray",
@@ -219,6 +227,7 @@
       {
         "pocket_type": "CONTAINER",
         "watertight": true,
+        "transparent": true,
         "max_contains_volume": "500 ml",
         "max_contains_weight": "1250 g",
         "moves": 400
@@ -338,6 +347,7 @@
       {
         "pocket_type": "CONTAINER",
         "watertight": true,
+        "transparent": true,
         "max_contains_volume": "250 ml",
         "max_contains_weight": "750 g",
         "spoil_multiplier": 0.8,
@@ -362,6 +372,7 @@
       {
         "pocket_type": "CONTAINER",
         "watertight": true,
+        "transparent": true,
         "max_contains_volume": "4500 ml",
         "max_contains_weight": "3000 g",
         "max_item_length": "29 cm",
@@ -475,6 +486,7 @@
       {
         "pocket_type": "CONTAINER",
         "watertight": true,
+        "transparent": true,
         "max_contains_volume": "500 ml",
         "max_contains_weight": "3 kg",
         "moves": 400
@@ -505,6 +517,7 @@
         "pocket_type": "CONTAINER",
         "watertight": true,
         "rigid": true,
+        "transparent": true,
         "max_contains_volume": "750 ml",
         "max_item_volume": "17 ml",
         "max_contains_weight": "3 kg",
@@ -532,6 +545,7 @@
         "airtight": true,
         "watertight": true,
         "rigid": true,
+        "transparent": true,
         "max_contains_volume": "500 ml",
         "max_item_volume": "17 ml",
         "max_contains_weight": "1250 g",
@@ -563,6 +577,7 @@
         "pocket_type": "CONTAINER",
         "watertight": true,
         "rigid": true,
+        "transparent": true,
         "max_contains_volume": "500 ml",
         "max_item_volume": "17 ml",
         "max_contains_weight": "1 kg",
@@ -595,6 +610,7 @@
         "pocket_type": "CONTAINER",
         "watertight": true,
         "rigid": true,
+        "transparent": true,
         "max_contains_volume": "250 ml",
         "max_item_volume": "17 ml",
         "max_contains_weight": "1 kg",
@@ -624,6 +640,7 @@
         "pocket_type": "CONTAINER",
         "watertight": true,
         "rigid": true,
+        "transparent": true,
         "max_contains_volume": "250 ml",
         "max_item_volume": "17 ml",
         "max_contains_weight": "1 kg",
@@ -675,6 +692,7 @@
         "airtight": true,
         "watertight": true,
         "rigid": true,
+        "transparent": true,
         "max_contains_volume": "500 ml",
         "max_item_volume": "64 ml",
         "max_contains_weight": "1250 g",
@@ -706,6 +724,7 @@
         "pocket_type": "CONTAINER",
         "watertight": true,
         "rigid": true,
+        "transparent": true,
         "max_contains_volume": "250 ml",
         "max_item_volume": "32 ml",
         "max_contains_weight": "1 kg",
@@ -737,6 +756,7 @@
         "airtight": true,
         "watertight": true,
         "rigid": true,
+        "transparent": true,
         "max_contains_volume": "500 ml",
         "max_item_volume": "64 ml",
         "max_contains_weight": "1250 g",
@@ -775,6 +795,7 @@
         "airtight": true,
         "watertight": true,
         "rigid": true,
+        "transparent": true,
         "max_contains_volume": "250 ml",
         "max_item_volume": "32 ml",
         "max_contains_weight": "1 kg",
@@ -804,6 +825,7 @@
         "pocket_type": "CONTAINER",
         "watertight": true,
         "rigid": true,
+        "transparent": true,
         "max_contains_volume": "2 L",
         "max_item_volume": "17 ml",
         "max_contains_weight": "3 kg",
@@ -1581,6 +1603,7 @@
       {
         "pocket_type": "CONTAINER",
         "watertight": true,
+        "transparent": true,
         "max_contains_volume": "3000 ml",
         "max_item_volume": "32 ml",
         "max_contains_weight": "20 kg"
@@ -2030,6 +2053,7 @@
         "pocket_type": "CONTAINER",
         "rigid": true,
         "watertight": true,
+        "transparent": true,
         "max_contains_volume": "250 ml",
         "max_contains_weight": "1250 g"
       }
@@ -2060,6 +2084,7 @@
         "pocket_type": "CONTAINER",
         "rigid": true,
         "watertight": true,
+        "transparent": true,
         "max_contains_volume": "10 ml",
         "max_contains_weight": "50 g"
       }
@@ -2151,6 +2176,7 @@
         "pocket_type": "CONTAINER",
         "rigid": true,
         "watertight": true,
+        "transparent": true,
         "max_contains_volume": "1 ml",
         "max_contains_weight": "5 g"
       }
@@ -2222,6 +2248,7 @@
         "pocket_type": "CONTAINER",
         "rigid": true,
         "watertight": true,
+        "transparent": true,
         "max_contains_volume": "3 L",
         "max_contains_weight": "6 kg",
         "sealed_data": { "spoil_multiplier": 0.0 }
@@ -2253,6 +2280,7 @@
         "pocket_type": "CONTAINER",
         "rigid": true,
         "watertight": true,
+        "transparent": true,
         "max_contains_volume": "500 ml",
         "max_contains_weight": "1 kg",
         "sealed_data": { "spoil_multiplier": 0.0 }
@@ -2285,6 +2313,7 @@
         "pocket_type": "CONTAINER",
         "rigid": true,
         "watertight": true,
+        "transparent": true,
         "max_contains_volume": "10 L",
         "max_item_volume": "32 ml",
         "max_contains_weight": "15 kg"
@@ -2373,6 +2402,7 @@
         "pocket_type": "CONTAINER",
         "rigid": true,
         "watertight": true,
+        "transparent": true,
         "max_contains_volume": "3750 ml",
         "max_item_volume": "32 ml",
         "max_contains_weight": "8 kg",
@@ -3244,6 +3274,7 @@
         "moves": 100,
         "watertight": true,
         "rigid": true,
+        "transparent": true,
         "item_restriction": [ "smart_phone", "smart_phone_flashlight", "smartphone_music" ]
       }
     ]
@@ -3271,6 +3302,7 @@
         "moves": 100,
         "watertight": true,
         "rigid": true,
+        "transparent": true,
         "item_restriction": [ "camera" ]
       }
     ]
@@ -3673,6 +3705,7 @@
       {
         "pocket_type": "CONTAINER",
         "watertight": true,
+        "transparent": true,
         "max_contains_volume": "3750 ml",
         "max_contains_weight": "7 kg",
         "max_item_length": "26 cm"
@@ -3839,6 +3872,7 @@
         "max_contains_weight": "3 kg",
         "max_item_length": "20 cm",
         "rigid": true,
+        "transparent": true,
         "moves": 100
       }
     ],
@@ -4164,6 +4198,7 @@
         "max_contains_volume": "2000 ml",
         "max_contains_weight": "1500 g",
         "airtight": true,
+        "transparent": true,
         "moves": 50,
         "sealed_data": { "spoil_multiplier": 0.0 },
         "watertight": true
@@ -4674,6 +4709,7 @@
       {
         "pocket_type": "CONTAINER",
         "watertight": true,
+        "transparent": true,
         "max_contains_volume": "299 ml",
         "max_contains_weight": "2500 g"
       }
@@ -4702,6 +4738,7 @@
       {
         "pocket_type": "CONTAINER",
         "watertight": true,
+        "transparent": true,
         "max_contains_volume": "82 ml",
         "max_contains_weight": "500 g"
       }
@@ -4797,6 +4834,7 @@
         "pocket_type": "CONTAINER",
         "watertight": true,
         "rigid": true,
+        "transparent": true,
         "max_contains_volume": "3785 ml",
         "max_contains_weight": "10 kg"
       }
@@ -4923,6 +4961,7 @@
       {
         "pocket_type": "CONTAINER",
         "rigid": true,
+        "transparent": true,
         "max_contains_volume": "20 ml",
         "max_contains_weight": "40 g",
         "moves": 150
@@ -4930,6 +4969,7 @@
       {
         "pocket_type": "CONTAINER",
         "rigid": true,
+        "transparent": true,
         "max_contains_volume": "20 ml",
         "max_contains_weight": "40 g",
         "moves": 150
@@ -4937,6 +4977,7 @@
       {
         "pocket_type": "CONTAINER",
         "rigid": true,
+        "transparent": true,
         "max_contains_volume": "20 ml",
         "max_contains_weight": "40 g",
         "moves": 150
@@ -4944,6 +4985,7 @@
       {
         "pocket_type": "CONTAINER",
         "rigid": true,
+        "transparent": true,
         "max_contains_volume": "20 ml",
         "max_contains_weight": "40 g",
         "moves": 150
@@ -4951,6 +4993,7 @@
       {
         "pocket_type": "CONTAINER",
         "rigid": true,
+        "transparent": true,
         "max_contains_volume": "20 ml",
         "max_contains_weight": "40 g",
         "moves": 150
@@ -4958,6 +5001,7 @@
       {
         "pocket_type": "CONTAINER",
         "rigid": true,
+        "transparent": true,
         "max_contains_volume": "20 ml",
         "max_contains_weight": "40 g",
         "moves": 150
@@ -4965,6 +5009,7 @@
       {
         "pocket_type": "CONTAINER",
         "rigid": true,
+        "transparent": true,
         "max_contains_volume": "20 ml",
         "max_contains_weight": "40 g",
         "moves": 150

--- a/data/json/items/containers/containers.json
+++ b/data/json/items/containers/containers.json
@@ -1580,7 +1580,6 @@
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
-        "rigid": true,
         "watertight": true,
         "max_contains_volume": "3000 ml",
         "max_item_volume": "32 ml",
@@ -4896,6 +4895,7 @@
         "pocket_type": "CONTAINER",
         "watertight": true,
         "rigid": true,
+        "open_container": true,
         "max_contains_volume": "341 ml",
         "max_item_volume": "250 ml",
         "max_contains_weight": "1150 g",

--- a/data/json/items/containers/containers.json
+++ b/data/json/items/containers/containers.json
@@ -296,15 +296,7 @@
     "price": "0 cent",
     "price_postapoc": "0 cent",
     "to_hit": -1,
-    "pocket_data": [
-      {
-        "pocket_type": "CONTAINER",
-        "watertight": false,
-        "max_contains_volume": "2500 ml",
-        "max_contains_weight": "2 kg",
-        "moves": 200
-      }
-    ],
+    "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "2 kg", "moves": 200 } ],
     "material": [ "paper" ],
     "symbol": ")",
     "color": "white",
@@ -323,15 +315,7 @@
     "price": "0 cent",
     "price_postapoc": "0 cent",
     "to_hit": -2,
-    "pocket_data": [
-      {
-        "pocket_type": "CONTAINER",
-        "watertight": false,
-        "max_contains_volume": "10000 ml",
-        "max_contains_weight": "15 kg",
-        "moves": 200
-      }
-    ],
+    "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "10000 ml", "max_contains_weight": "15 kg", "moves": 200 } ],
     "material": [ "paper" ],
     "symbol": ")",
     "color": "white",
@@ -1729,7 +1713,6 @@
       {
         "pocket_type": "CONTAINER",
         "rigid": true,
-        "watertight": false,
         "max_contains_volume": "600 ml",
         "max_contains_weight": "1 kg",
         "max_item_length": "45 mm"
@@ -3887,7 +3870,6 @@
         "max_contains_weight": "4000 g",
         "max_item_length": "20 cm",
         "moves": 100,
-        "rigid": false,
         "volume_encumber_modifier": 0.3
       }
     ],
@@ -4692,9 +4674,7 @@
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
-        "rigid": false,
         "watertight": true,
-        "open_container": false,
         "max_contains_volume": "299 ml",
         "max_contains_weight": "2500 g"
       }
@@ -4722,9 +4702,7 @@
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
-        "rigid": false,
         "watertight": true,
-        "open_container": false,
         "max_contains_volume": "82 ml",
         "max_contains_weight": "500 g"
       }
@@ -4842,16 +4820,7 @@
     "material": [ "plastic" ],
     "symbol": "l",
     "color": "green",
-    "pocket_data": [
-      {
-        "pocket_type": "CONTAINER",
-        "rigid": true,
-        "watertight": false,
-        "open_container": false,
-        "max_contains_volume": "1100 ml",
-        "max_contains_weight": "2 kg"
-      }
-    ],
+    "pocket_data": [ { "pocket_type": "CONTAINER", "rigid": true, "max_contains_volume": "1100 ml", "max_contains_weight": "2 kg" } ],
     "qualities": [ [ "CONTAIN", 1 ] ],
     "flags": [ "COLLAPSE_CONTENTS" ]
   },
@@ -4872,9 +4841,6 @@
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
-        "rigid": false,
-        "watertight": false,
-        "open_container": false,
         "max_contains_volume": "1000 ml",
         "max_contains_weight": "2 kg",
         "max_item_length": "20 cm"


### PR DESCRIPTION
#### Summary
Balance "Make most plastic and glass containers transparent"

#### Purpose of change

Working on #73400 revealed that containers are not transparent (apart from two exceptions). The most notable non-transparent containers are a `plastic bag` and a `plastic bottle`.

Some containers didn't make sense.
 - `tankard_wooden` wasn't an open container, so you could transport coffee in it in your bag
   - ![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/800b8133-2541-47ee-b3c2-8afc646bb23d)
 - `camelbak`, which is a hydration pack was rigid
   - ![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/45bbfd1e-8b99-4ca5-97da-50fe1f8167b9)

#### Describe the solution

I went through all containers in items/containers/containers.json and added `"transparent": true` where it made sense. If it had a URL in "//", I looked at that, if not, I often googled it. If at least half of the pictures were transparent, I made it transparent - my rationale is a benefit of the doubt, the non-transparent container will be more annoying to work with in the future, I think.

- Made `tankard_wooden` `"open_container": true`.
- Removed `"rigid": true` from `camelbak`.

#### Describe alternatives you've considered

#### Testing

~TODO:~ Rebased #73400 onto this and enjoyed that I can see inside the containers (meaning they don't indicate `hides content`, which means they are transparent.)

1. Merge with / rebase onto #73400.
2. Spawn all items inside containers.
3. `V`iew Item List.
4. Sort it by category.
5. Scroll to the food category.
6. Go over all items, so they are not `NEW!`.
7. Observe if "hides contents" make sense.
   - It does.
     - Things like `paper wrapper` and `tin can (sealed)` still hide contents
     - While `plastic bottle`, `glass bottle`, and `plastic bag` don't hide contents.
   - ![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/ca1e7fae-5d33-480b-9dba-11ba9a4a8bd5)


#### Additional context

 - `bag_plastic_small` is watertight, so you can put water in it, put it on the ground or in a bag and it won't spill
   - ![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/c7f8a1bd-4dea-487b-b07b-dd72b5bd3ec0)

I didn't believe the bag would hold liquid, so I took one IRL, filled it with water and it didn't leak! Marvellous!
