### PR TITLE
fix `game.h` typo

### DIFF
--- a/src/game.h
+++ b/src/game.h
@@ -236,7 +236,7 @@ class game
         };
         /* Add callback that would be called in `game::draw`. This can be used to
          * implement map overlays in game menus. If parameters of the callback changes
-         * during its lifetime, `invaliate_main_ui_adaptor` has to be called for
+         * during its lifetime, `invalidate_main_ui_adaptor` has to be called for
          * the changes to take effect immediately on the next call to `ui_manager::redraw`.
          * Otherwise the callback may not take effect until the main ui is invalidated
          * due to resizing or other menus closing. The callback is disabled once all


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Typos need fixing.

Couldn't ctrl+f that bad boy. Luckily it was just a typo.

#### Describe the solution

fix typo

#### Describe alternatives you've considered

Wait until I find more typos as I browse the code. The branch was already dusty from being over a week old.

#### Testing

GitHub will test it.

#### Additional context
