### PR TITLE
Add new hairstyles from Mawranth's Hair Salon

### DIFF
--- a/data/json/effects_on_condition/item_eocs.json
+++ b/data/json/effects_on_condition/item_eocs.json
@@ -163,7 +163,10 @@
       { "u_lose_trait": "hair_curls" },
       { "u_lose_trait": "hair_bun" },
       { "u_lose_trait": "hair_punk_long" },
-      { "u_lose_trait": "hair_braid" }
+      { "u_lose_trait": "hair_braid" },
+      { "u_lose_trait": "hair_detective" },
+      { "u_lose_trait": "hair_super_princess" },
+      { "u_lose_trait": "hair_twintails" }
     ]
   },
   {

--- a/data/json/effects_on_condition/item_eocs.json
+++ b/data/json/effects_on_condition/item_eocs.json
@@ -156,7 +156,14 @@
       { "u_lose_trait": "hair_messy" },
       { "u_lose_trait": "hair_very_long" },
       { "u_lose_trait": "hair_extremely_long" },
-      { "u_lose_trait": "hair_body_length" }
+      { "u_lose_trait": "hair_body_length" },
+      { "u_lose_trait": "hair_modern" },
+      { "u_lose_trait": "hair_puff" },
+      { "u_lose_trait": "hair_beaded" },
+      { "u_lose_trait": "hair_curls" },
+      { "u_lose_trait": "hair_bun" },
+      { "u_lose_trait": "hair_punk_long" },
+      { "u_lose_trait": "hair_braid" }
     ]
   },
   {

--- a/data/json/effects_on_condition/npc_eocs/appearance_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/appearance_eocs.json
@@ -25,18 +25,36 @@
           ],
           "else": {
             "if": {
-              "or": [ { "u_has_trait": "hair_short" }, { "u_has_trait": "hair_short_no_fringe" }, { "u_has_trait": "hair_short_over_eye" } ]
+              "or": [
+                { "u_has_trait": "hair_modern" },
+                { "u_has_trait": "hair_short" },
+                { "u_has_trait": "hair_short_no_fringe" },
+                { "u_has_trait": "hair_short_over_eye" }
+              ]
             },
             "then": [
+              { "u_lose_trait": "hair_modern" },
               { "u_lose_trait": "hair_short" },
               { "u_lose_trait": "hair_short_no_fringe" },
               { "u_lose_trait": "hair_short_over_eye" },
               { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_medium" } }
             ],
             "else": {
-              "if": { "or": [ { "u_has_trait": "hair_medium" } ] },
+              "if": {
+                "or": [
+                  { "u_has_trait": "hair_medium" },
+                  { "u_has_trait": "hair_curls" },
+                  { "u_has_trait": "hair_puff" },
+                  { "u_has_trait": "hair_beaded" },
+                  { "u_has_trait": "hair_bun" }
+                ]
+              },
               "then": [
                 { "u_lose_trait": "hair_medium" },
+                { "u_lose_trait": "hair_curls" },
+                { "u_lose_trait": "hair_puff" },
+                { "u_lose_trait": "hair_beaded" },
+                { "u_lose_trait": "hair_bun" },
                 { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_long" } }
               ],
               "else": {
@@ -48,6 +66,7 @@
                 "else": {
                   "if": {
                     "or": [
+                      { "u_has_trait": "hair_punk_long" },
                       { "u_has_trait": "hair_long" },
                       { "u_has_trait": "hair_long_mohawk" },
                       { "u_has_trait": "hair_mullet" },
@@ -55,6 +74,7 @@
                     ]
                   },
                   "then": [
+                    { "u_lose_trait": "hair_punk_long" },
                     { "u_lose_trait": "hair_long" },
                     { "u_lose_trait": "hair_mullet" },
                     { "u_lose_trait": "hair_long_over_eye" },
@@ -68,9 +88,10 @@
                       { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_very_long" } }
                     ],
                     "else": {
-                      "if": { "or": [ { "u_has_trait": "hair_very_long" } ] },
+                      "if": { "or": [ { "u_has_trait": "hair_very_long" }, { "u_has_trait": "hair_braid" } ] },
                       "then": [
                         { "u_lose_trait": "hair_very_long" },
+                        { "u_lose_trait": "hair_braid" },
                         {
                           "run_eoc_with": "reset_natural_hair_color",
                           "variables": { "trait_id": "hair_extremely_long" }

--- a/data/json/effects_on_condition/npc_eocs/appearance_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/appearance_eocs.json
@@ -26,35 +26,35 @@
           "else": {
             "if": {
               "or": [
-                { "u_has_trait": "hair_modern" },
                 { "u_has_trait": "hair_short" },
                 { "u_has_trait": "hair_short_no_fringe" },
-                { "u_has_trait": "hair_short_over_eye" }
+                { "u_has_trait": "hair_short_over_eye" },
+                { "u_has_trait": "hair_modern" },
+                { "u_has_trait": "hair_detective" }
               ]
             },
             "then": [
-              { "u_lose_trait": "hair_modern" },
               { "u_lose_trait": "hair_short" },
               { "u_lose_trait": "hair_short_no_fringe" },
               { "u_lose_trait": "hair_short_over_eye" },
+              { "u_lose_trait": "hair_modern" },
+              { "u_lose_trait": "hair_detective" },
               { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_medium" } }
             ],
             "else": {
               "if": {
                 "or": [
                   { "u_has_trait": "hair_medium" },
-                  { "u_has_trait": "hair_curls" },
                   { "u_has_trait": "hair_puff" },
                   { "u_has_trait": "hair_beaded" },
-                  { "u_has_trait": "hair_bun" }
+                  { "u_has_trait": "hair_curls" }
                 ]
               },
               "then": [
                 { "u_lose_trait": "hair_medium" },
-                { "u_lose_trait": "hair_curls" },
                 { "u_lose_trait": "hair_puff" },
                 { "u_lose_trait": "hair_beaded" },
-                { "u_lose_trait": "hair_bun" },
+                { "u_lose_trait": "hair_curls" },
                 { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_long" } }
               ],
               "else": {
@@ -66,31 +66,35 @@
                 "else": {
                   "if": {
                     "or": [
-                      { "u_has_trait": "hair_punk_long" },
-                      { "u_has_trait": "hair_long" },
+                      { "u_has_trait": "hair_super_princess" },
                       { "u_has_trait": "hair_long_mohawk" },
+                      { "u_has_trait": "hair_long" },
+                      { "u_has_trait": "hair_long_over_eye" },
                       { "u_has_trait": "hair_mullet" },
-                      { "u_has_trait": "hair_long_over_eye" }
+                      { "u_has_trait": "hair_bun" }
                     ]
                   },
                   "then": [
-                    { "u_lose_trait": "hair_punk_long" },
-                    { "u_lose_trait": "hair_long" },
-                    { "u_lose_trait": "hair_mullet" },
-                    { "u_lose_trait": "hair_long_over_eye" },
+                    { "u_lose_trait": "hair_super_princess" },
                     { "u_lose_trait": "hair_long_mohawk" },
+                    { "u_lose_trait": "hair_long" },
+                    { "u_lose_trait": "hair_long_over_eye" },
+                    { "u_lose_trait": "hair_mullet" },
+                    { "u_lose_trait": "hair_bun" },
                     { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_messy" } }
                   ],
                   "else": {
-                    "if": { "or": [ { "u_has_trait": "hair_messy" } ] },
+                    "if": { "or": [ { "u_has_trait": "hair_messy" }, { "u_has_trait": "hair_punk_long" } ] },
                     "then": [
                       { "u_lose_trait": "hair_messy" },
+                      { "u_lose_trait": "hair_punk_long" },
                       { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_very_long" } }
                     ],
                     "else": {
-                      "if": { "or": [ { "u_has_trait": "hair_very_long" }, { "u_has_trait": "hair_braid" } ] },
+                      "if": { "or": [ { "u_has_trait": "hair_very_long" }, { "u_has_trait": "hair_twintails" }, { "u_has_trait": "hair_braid" } ] },
                       "then": [
                         { "u_lose_trait": "hair_very_long" },
+                        { "u_lose_trait": "hair_twintails" },
                         { "u_lose_trait": "hair_braid" },
                         {
                           "run_eoc_with": "reset_natural_hair_color",

--- a/data/json/mutations/appearance_hair_styles.json
+++ b/data/json/mutations/appearance_hair_styles.json
@@ -1643,6 +1643,231 @@
   },
   {
     "type": "mutation",
+    "id": "hair_twintails",
+    "name": { "str": "Hair: twin tails" },
+    "points": 0,
+    "description": "Two very long braids.",
+    "starting_trait": true,
+    "valid": false,
+    "purifiable": false,
+    "player_display": true,
+    "vanity": true,
+    "variants": [
+      {
+        "id": "black",
+        "name": { "str": "Hair: black, twin tails" },
+        "description": "Two very long black braids.",
+        "weight": 1
+      },
+      {
+        "id": "blond",
+        "name": { "str": "Hair: blond, twin tails" },
+        "description": "Two very long blond braids.",
+        "weight": 1
+      },
+      {
+        "id": "blue",
+        "name": { "str": "Hair: blue, twin tails" },
+        "description": "Two very long blue braids.",
+        "weight": 1
+      },
+      {
+        "id": "brown",
+        "name": { "str": "Hair: brown, twin tails" },
+        "description": "Two very long brown braids.",
+        "weight": 1
+      },
+      {
+        "id": "gray",
+        "name": { "str": "Hair: gray, twin tails" },
+        "description": "Two very long gray braids.",
+        "weight": 1
+      },
+      {
+        "id": "green",
+        "name": { "str": "Hair: green, twin tails" },
+        "description": "Two very long green braids.",
+        "weight": 1
+      },
+      {
+        "id": "pink",
+        "name": { "str": "Hair: pink, twin tails" },
+        "description": "Two very long pink braids.",
+        "weight": 1
+      },
+      {
+        "id": "purple",
+        "name": { "str": "Hair: purple, twin tails" },
+        "description": "Two very long purple braids.",
+        "weight": 1
+      },
+      {
+        "id": "red",
+        "name": { "str": "Hair: red, twin tails" },
+        "description": "Two very long red braids.",
+        "weight": 1
+      },
+      {
+        "id": "white",
+        "name": { "str": "Hair: white, twin tails" },
+        "description": "Two very long white braids.",
+        "weight": 1
+      }
+    ],
+    "types": [ "hair_style" ]
+  },
+  {
+    "type": "mutation",
+    "id": "hair_super_princess",
+    "name": { "str": "Hair: super princess" },
+    "points": 0,
+    "description": "Hair for the better princess.",
+    "starting_trait": true,
+    "valid": false,
+    "purifiable": false,
+    "player_display": true,
+    "vanity": true,
+    "variants": [
+      {
+        "id": "black",
+        "name": { "str": "Hair: black, super princess" },
+        "description": "Black hair for the better princess.",
+        "weight": 1
+      },
+      {
+        "id": "blond",
+        "name": { "str": "Hair: blond, super princess" },
+        "description": "Blond hair for the better princess.",
+        "weight": 1
+      },
+      {
+        "id": "blue",
+        "name": { "str": "Hair: blue, super princess" },
+        "description": "Blue hair for the better princess.",
+        "weight": 1
+      },
+      {
+        "id": "brown",
+        "name": { "str": "Hair: brown, super princess" },
+        "description": "Brown hair for the better princess.",
+        "weight": 1
+      },
+      {
+        "id": "gray",
+        "name": { "str": "Hair: gray, super princess" },
+        "description": "Gray hair for the better princess.",
+        "weight": 1
+      },
+      {
+        "id": "green",
+        "name": { "str": "Hair: green, super princess" },
+        "description": "Green hair for the better princess.",
+        "weight": 1
+      },
+      {
+        "id": "pink",
+        "name": { "str": "Hair: pink, super princess" },
+        "description": "Pink hair for the better princess.",
+        "weight": 1
+      },
+      {
+        "id": "purple",
+        "name": { "str": "Hair: purple, super princess" },
+        "description": "Purple hair for the better princess.",
+        "weight": 1
+      },
+      {
+        "id": "red",
+        "name": { "str": "Hair: red, super princess" },
+        "description": "Red hair for the better princess.",
+        "weight": 1
+      },
+      {
+        "id": "white",
+        "name": { "str": "Hair: white, super princess" },
+        "description": "White hair for the better princess.",
+        "weight": 1
+      }
+    ],
+    "types": [ "hair_style" ]
+  },
+  {
+    "type": "mutation",
+    "id": "hair_detective",
+    "name": { "str": "Hair: detective" },
+    "points": 0,
+    "description": "Hair for lawyers and crime solvers.",
+    "starting_trait": true,
+    "valid": false,
+    "purifiable": false,
+    "player_display": true,
+    "vanity": true,
+    "variants": [
+      {
+        "id": "black",
+        "name": { "str": "Hair: black, detective" },
+        "description": "Black hair for lawyers and crime solvers.",
+        "weight": 1
+      },
+      {
+        "id": "blond",
+        "name": { "str": "Hair: blond, detective" },
+        "description": "Blond hair for lawyers and crime solvers.",
+        "weight": 1
+      },
+      {
+        "id": "blue",
+        "name": { "str": "Hair: blue, detective" },
+        "description": "Blue hair for lawyers and crime solvers.",
+        "weight": 1
+      },
+      {
+        "id": "brown",
+        "name": { "str": "Hair: brown, detective" },
+        "description": "Brown hair for lawyers and crime solvers.",
+        "weight": 1
+      },
+      {
+        "id": "gray",
+        "name": { "str": "Hair: gray, detective" },
+        "description": "Gray hair for lawyers and crime solvers.",
+        "weight": 1
+      },
+      {
+        "id": "green",
+        "name": { "str": "Hair: green, detective" },
+        "description": "Green hair for lawyers and crime solvers.",
+        "weight": 1
+      },
+      {
+        "id": "pink",
+        "name": { "str": "Hair: pink, detective" },
+        "description": "Pink hair for lawyers and crime solvers.",
+        "weight": 1
+      },
+      {
+        "id": "purple",
+        "name": { "str": "Hair: purple, detective" },
+        "description": "Purple hair for lawyers and crime solvers.",
+        "weight": 1
+      },
+      {
+        "id": "red",
+        "name": { "str": "Hair: red, detective" },
+        "description": "Red hair for lawyers and crime solvers.",
+        "weight": 1
+      },
+      {
+        "id": "white",
+        "name": { "str": "Hair: white, detective" },
+        "description": "White hair for lawyers and crime solvers.",
+        "weight": 1
+      }
+    ],
+    "types": [ "hair_style" ]
+  },
+  {
+    "type": "mutation",
     "id": "natural_hair_color_black",
     "name": { "str": "Natural hair color: black" },
     "points": 0,

--- a/data/json/mutations/appearance_hair_styles.json
+++ b/data/json/mutations/appearance_hair_styles.json
@@ -1118,6 +1118,531 @@
   },
   {
     "type": "mutation",
+    "id": "hair_punk_long",
+    "name": { "str": "Hair: long punk" },
+    "points": 0,
+    "description": "You are rockin' with these long locks.",
+    "starting_trait": true,
+    "valid": false,
+    "purifiable": false,
+    "player_display": true,
+    "vanity": true,
+    "variants": [
+      {
+        "id": "black",
+        "name": { "str": "Hair: black, long punk" },
+        "description": "You are rockin' with these long black locks.",
+        "weight": 1
+      },
+      {
+        "id": "blond",
+        "name": { "str": "Hair: black, long punk" },
+        "description": "You are rockin' with these long blond locks.",
+        "weight": 1
+      },
+      {
+        "id": "blue",
+        "name": { "str": "Hair: black, long punk" },
+        "description": "You are rockin' with these long blue locks.",
+        "weight": 1
+      },
+      {
+        "id": "brown",
+        "name": { "str": "Hair: black, long punk" },
+        "description": "You are rockin' with these long brown locks.",
+        "weight": 1
+      },
+      {
+        "id": "gray",
+        "name": { "str": "Hair: black, long punk" },
+        "description": "You are rockin' with these long gray locks.",
+        "weight": 1
+      },
+      {
+        "id": "green",
+        "name": { "str": "Hair: black, long punk" },
+        "description": "You are rockin' with these long green locks.",
+        "weight": 1
+      },
+      {
+        "id": "pink",
+        "name": { "str": "Hair: black, long punk" },
+        "description": "You are rockin' with these long pink locks.",
+        "weight": 1
+      },
+      {
+        "id": "purple",
+        "name": { "str": "Hair: black, long punk" },
+        "description": "You are rockin' with these long purple locks.",
+        "weight": 1
+      },
+      {
+        "id": "red",
+        "name": { "str": "Hair: black, long punk" },
+        "description": "You are rockin' with these long red locks.",
+        "weight": 1
+      },
+      {
+        "id": "white",
+        "name": { "str": "Hair: black, long punk" },
+        "description": "You are rockin' with these long white locks.",
+        "weight": 1
+      }
+    ],
+    "types": [ "hair_style" ]
+  },
+  {
+    "type": "mutation",
+    "id": "hair_curls",
+    "name": { "str": "Hair: curls" },
+    "points": 0,
+    "description": "Your face is framed by cute curls.",
+    "starting_trait": true,
+    "valid": false,
+    "purifiable": false,
+    "player_display": true,
+    "vanity": true,
+    "variants": [
+      {
+        "id": "black",
+        "name": { "str": "Hair: black, curls" },
+        "description": "Your face is framed by cute curls.",
+        "weight": 1
+      },
+      {
+        "id": "blond",
+        "name": { "str": "Hair: blond, curls" },
+        "description": "Your face is framed by cute blond curls.",
+        "weight": 1
+      },
+      {
+        "id": "blue",
+        "name": { "str": "Hair: blue, curls" },
+        "description": "Your face is framed by cute blue curls.",
+        "weight": 1
+      },
+      {
+        "id": "brown",
+        "name": { "str": "Hair: brown, curls" },
+        "description": "Your face is framed by cute brown curls.",
+        "weight": 1
+      },
+      {
+        "id": "gray",
+        "name": { "str": "Hair: gray, curls" },
+        "description": "Your face is framed by cute gray curls.",
+        "weight": 1
+      },
+      {
+        "id": "green",
+        "name": { "str": "Hair: green, curls" },
+        "description": "Your face is framed by cute green curls.",
+        "weight": 1
+      },
+      {
+        "id": "pink",
+        "name": { "str": "Hair: pink, curls" },
+        "description": "Your face is framed by cute pink curls.",
+        "weight": 1
+      },
+      {
+        "id": "purple",
+        "name": { "str": "Hair: black, curls" },
+        "description": "Your face is framed by cute purple curls.",
+        "weight": 1
+      },
+      {
+        "id": "red",
+        "name": { "str": "Hair: red, curls" },
+        "description": "Your face is framed by cute red curls.",
+        "weight": 1
+      },
+      {
+        "id": "white",
+        "name": { "str": "Hair: white, curls" },
+        "description": "Your face is framed by cute white curls.",
+        "weight": 1
+      }
+    ],
+    "types": [ "hair_style" ]
+  },
+  {
+    "type": "mutation",
+    "id": "hair_modern",
+    "name": { "str": "Hair: modern" },
+    "points": 0,
+    "description": "Your modern and plain cut common among college students.",
+    "starting_trait": true,
+    "valid": false,
+    "purifiable": false,
+    "player_display": true,
+    "vanity": true,
+    "variants": [
+      {
+        "id": "black",
+        "name": { "str": "Hair: black, modern" },
+        "description": "Your modern and plain cut common among college students, black.",
+        "weight": 1
+      },
+      {
+        "id": "blond",
+        "name": { "str": "Hair: blond, modern" },
+        "description": "Your modern and plain cut common among college students, blond.",
+        "weight": 1
+      },
+      {
+        "id": "blue",
+        "name": { "str": "Hair: blue, modern" },
+        "description": "Your modern and plain cut common among college students, blue.",
+        "weight": 1
+      },
+      {
+        "id": "brown",
+        "name": { "str": "Hair: brown, modern" },
+        "description": "Your modern and plain cut common among college students, brown.",
+        "weight": 1
+      },
+      {
+        "id": "gray",
+        "name": { "str": "Hair: gray, modern" },
+        "description": "Your modern and plain cut common among college students, gray.",
+        "weight": 1
+      },
+      {
+        "id": "green",
+        "name": { "str": "Hair: green, modern" },
+        "description": "Your modern and plain cut common among college students, green.",
+        "weight": 1
+      },
+      {
+        "id": "pink",
+        "name": { "str": "Hair: pink, modern" },
+        "description": "Your modern and plain cut common among college students, pink.",
+        "weight": 1
+      },
+      {
+        "id": "purple",
+        "name": { "str": "Hair: purple, modern" },
+        "description": "Your modern and plain cut common among college students, purple.",
+        "weight": 1
+      },
+      {
+        "id": "red",
+        "name": { "str": "Hair: red, modern" },
+        "description": "Your modern and plain cut common among college students, red.",
+        "weight": 1
+      },
+      {
+        "id": "white",
+        "name": { "str": "Hair: white, modern" },
+        "description": "Your modern and plain cut common among college students, white.",
+        "weight": 1
+      }
+    ],
+    "types": [ "hair_style" ]
+  },
+  {
+    "type": "mutation",
+    "id": "hair_bun",
+    "name": { "str": "Hair: bun" },
+    "points": 0,
+    "description": "Your long hair is bound into a bun.",
+    "starting_trait": true,
+    "valid": false,
+    "purifiable": false,
+    "player_display": true,
+    "vanity": true,
+    "variants": [
+      {
+        "id": "black",
+        "name": { "str": "Hair: black, bun" },
+        "description": "Your long black hair is bound into a bun.",
+        "weight": 1
+      },
+      {
+        "id": "blond",
+        "name": { "str": "Hair: blond, bun" },
+        "description": "Your long blond hair is bound into a bun.",
+        "weight": 1
+      },
+      {
+        "id": "blue",
+        "name": { "str": "Hair: blue, bun" },
+        "description": "Your long blue hair is bound into a bun.",
+        "weight": 1
+      },
+      {
+        "id": "brown",
+        "name": { "str": "Hair: brown, bun" },
+        "description": "Your long brown hair is bound into a bun.",
+        "weight": 1
+      },
+      {
+        "id": "gray",
+        "name": { "str": "Hair: gray, bun" },
+        "description": "Your long gray hair is bound into a bun.",
+        "weight": 1
+      },
+      {
+        "id": "green",
+        "name": { "str": "Hair: green, bun" },
+        "description": "Your long green hair is bound into a bun.",
+        "weight": 1
+      },
+      {
+        "id": "pink",
+        "name": { "str": "Hair: pink, bun" },
+        "description": "Your long pink hair is bound into a bun.",
+        "weight": 1
+      },
+      {
+        "id": "purple",
+        "name": { "str": "Hair: purple, bun" },
+        "description": "Your long purple hair is bound into a bun.",
+        "weight": 1
+      },
+      {
+        "id": "red",
+        "name": { "str": "Hair: red, bun" },
+        "description": "Your long red hair is bound into a bun.",
+        "weight": 1
+      },
+      {
+        "id": "white",
+        "name": { "str": "Hair: white, bun" },
+        "description": "Your long white hair is bound into a bun.",
+        "weight": 1
+      }
+    ],
+    "types": [ "hair_style" ]
+  },
+  {
+    "type": "mutation",
+    "id": "hair_braid",
+    "name": { "str": "Hair: princess braid" },
+    "points": 0,
+    "description": "Your long hair is bound in a braid.",
+    "starting_trait": true,
+    "valid": false,
+    "purifiable": false,
+    "player_display": true,
+    "vanity": true,
+    "variants": [
+      {
+        "id": "black",
+        "name": { "str": "Hair: black, princess braid" },
+        "description": "Your long black hair is bound in a braid.",
+        "weight": 1
+      },
+      {
+        "id": "blond",
+        "name": { "str": "Hair: blond, princess braid" },
+        "description": "Your long blond hair is bound in a braid.",
+        "weight": 1
+      },
+      {
+        "id": "blue",
+        "name": { "str": "Hair: blue, princess braid" },
+        "description": "Your long blue hair is bound in a braid.",
+        "weight": 1
+      },
+      {
+        "id": "brown",
+        "name": { "str": "Hair: brown, princess braid" },
+        "description": "Your long brown hair is bound in a braid.",
+        "weight": 1
+      },
+      {
+        "id": "gray",
+        "name": { "str": "Hair: gray, princess braid" },
+        "description": "Your long gray hair is bound in a braid.",
+        "weight": 1
+      },
+      {
+        "id": "green",
+        "name": { "str": "Hair: green, princess braid" },
+        "description": "Your long green hair is bound in a braid.",
+        "weight": 1
+      },
+      {
+        "id": "pink",
+        "name": { "str": "Hair: pink, princess braid" },
+        "description": "Your long pink hair is bound in a braid.",
+        "weight": 1
+      },
+      {
+        "id": "purple",
+        "name": { "str": "Hair: purple, princess braid" },
+        "description": "Your long purple hair is bound in a braid.",
+        "weight": 1
+      },
+      {
+        "id": "red",
+        "name": { "str": "Hair: red, princess braid" },
+        "description": "Your long red hair is bound in a braid.",
+        "weight": 1
+      },
+      {
+        "id": "white",
+        "name": { "str": "Hair: white, princess braid" },
+        "description": "Your long white hair is bound in a braid.",
+        "weight": 1
+      }
+    ],
+    "types": [ "hair_style" ]
+  },
+  {
+    "type": "mutation",
+    "id": "hair_puff",
+    "name": { "str": "Hair: puffs" },
+    "points": 0,
+    "description": "Hair tied into two puffs.",
+    "starting_trait": true,
+    "valid": false,
+    "purifiable": false,
+    "player_display": true,
+    "vanity": true,
+    "variants": [
+      {
+        "id": "black",
+        "name": { "str": "Hair: black, puffs" },
+        "description": "Black hair tied into two puffs.",
+        "weight": 1
+      },
+      {
+        "id": "blond",
+        "name": { "str": "Hair: blond, puffs" },
+        "description": "Blond hair tied into two puffs.",
+        "weight": 1
+      },
+      {
+        "id": "blue",
+        "name": { "str": "Hair: blue, puffs" },
+        "description": "Blue hair tied into two puffs.",
+        "weight": 1
+      },
+      {
+        "id": "brown",
+        "name": { "str": "Hair: brown, puffs" },
+        "description": "Brown hair tied into two puffs.",
+        "weight": 1
+      },
+      {
+        "id": "gray",
+        "name": { "str": "Hair: gray, puffs" },
+        "description": "Gray hair tied into two puffs.",
+        "weight": 1
+      },
+      {
+        "id": "green",
+        "name": { "str": "Hair: green, puffs" },
+        "description": "Green hair tied into two puffs.",
+        "weight": 1
+      },
+      {
+        "id": "pink",
+        "name": { "str": "Hair: pink, puffs" },
+        "description": "Pink hair tied into two puffs.",
+        "weight": 1
+      },
+      {
+        "id": "purple",
+        "name": { "str": "Hair: purple, puffs" },
+        "description": "Purple hair tied into two puffs.",
+        "weight": 1
+      },
+      {
+        "id": "red",
+        "name": { "str": "Hair: red, puffs" },
+        "description": "Red hair tied into two puffs.",
+        "weight": 1
+      },
+      {
+        "id": "white",
+        "name": { "str": "Hair: white, puffs" },
+        "description": "White hair tied into two puffs.",
+        "weight": 1
+      }
+    ],
+    "types": [ "hair_style" ]
+  },
+  {
+    "type": "mutation",
+    "id": "hair_beaded",
+    "name": { "str": "Hair: beaded hair" },
+    "points": 0,
+    "description": "Hair threaded with beads.",
+    "starting_trait": true,
+    "valid": false,
+    "purifiable": false,
+    "player_display": true,
+    "vanity": true,
+    "variants": [
+      {
+        "id": "black",
+        "name": { "str": "Hair: black, beaded hair" },
+        "description": "Black hair threaded with beads.",
+        "weight": 1
+      },
+      {
+        "id": "blond",
+        "name": { "str": "Hair: blond, beaded hair" },
+        "description": "Blond hair threaded with beads.",
+        "weight": 1
+      },
+      {
+        "id": "blue",
+        "name": { "str": "Hair: blue, beaded hair" },
+        "description": "Blue hair threaded with beads.",
+        "weight": 1
+      },
+      {
+        "id": "brown",
+        "name": { "str": "Hair: brown, beaded hair" },
+        "description": "Brown hair threaded with beads.",
+        "weight": 1
+      },
+      {
+        "id": "gray",
+        "name": { "str": "Hair: gray, beaded hair" },
+        "description": "Gray hair threaded with beads.",
+        "weight": 1
+      },
+      {
+        "id": "green",
+        "name": { "str": "Hair: green, beaded hair" },
+        "description": "Green hair threaded with beads.",
+        "weight": 1
+      },
+      {
+        "id": "pink",
+        "name": { "str": "Hair: pink, beaded hair" },
+        "description": "Pink hair threaded with beads.",
+        "weight": 1
+      },
+      {
+        "id": "purple",
+        "name": { "str": "Hair: purple, beaded hair" },
+        "description": "Purple hair threaded with beads.",
+        "weight": 1
+      },
+      {
+        "id": "red",
+        "name": { "str": "Hair: red, beaded hair" },
+        "description": "Red hair threaded with beads.",
+        "weight": 1
+      },
+      {
+        "id": "white",
+        "name": { "str": "Hair: white, beaded hair" },
+        "description": "White hair threaded with beads.",
+        "weight": 1
+      }
+    ],
+    "types": [ "hair_style" ]
+  },
+  {
+    "type": "mutation",
     "id": "natural_hair_color_black",
     "name": { "str": "Natural hair color: black" },
     "points": 0,

--- a/data/json/mutations/appearance_hair_styles.json
+++ b/data/json/mutations/appearance_hair_styles.json
@@ -1580,61 +1580,61 @@
     "variants": [
       {
         "id": "black",
-        "name": { "str": "Hair: black, beaded hair" },
+        "name": { "str": "Hair: black, beaded" },
         "description": "Black hair threaded with beads.",
         "weight": 1
       },
       {
         "id": "blond",
-        "name": { "str": "Hair: blond, beaded hair" },
+        "name": { "str": "Hair: blond, beaded" },
         "description": "Blond hair threaded with beads.",
         "weight": 1
       },
       {
         "id": "blue",
-        "name": { "str": "Hair: blue, beaded hair" },
+        "name": { "str": "Hair: blue, beaded" },
         "description": "Blue hair threaded with beads.",
         "weight": 1
       },
       {
         "id": "brown",
-        "name": { "str": "Hair: brown, beaded hair" },
+        "name": { "str": "Hair: brown, beaded" },
         "description": "Brown hair threaded with beads.",
         "weight": 1
       },
       {
         "id": "gray",
-        "name": { "str": "Hair: gray, beaded hair" },
+        "name": { "str": "Hair: gray, beaded" },
         "description": "Gray hair threaded with beads.",
         "weight": 1
       },
       {
         "id": "green",
-        "name": { "str": "Hair: green, beaded hair" },
+        "name": { "str": "Hair: green, beaded" },
         "description": "Green hair threaded with beads.",
         "weight": 1
       },
       {
         "id": "pink",
-        "name": { "str": "Hair: pink, beaded hair" },
+        "name": { "str": "Hair: pink, beaded" },
         "description": "Pink hair threaded with beads.",
         "weight": 1
       },
       {
         "id": "purple",
-        "name": { "str": "Hair: purple, beaded hair" },
+        "name": { "str": "Hair: purple, beaded" },
         "description": "Purple hair threaded with beads.",
         "weight": 1
       },
       {
         "id": "red",
-        "name": { "str": "Hair: red, beaded hair" },
+        "name": { "str": "Hair: red, beaded" },
         "description": "Red hair threaded with beads.",
         "weight": 1
       },
       {
         "id": "white",
-        "name": { "str": "Hair: white, beaded hair" },
+        "name": { "str": "Hair: white, beaded" },
         "description": "White hair threaded with beads.",
         "weight": 1
       }

--- a/data/json/mutations/mutation_ordering.json
+++ b/data/json/mutations/mutation_ordering.json
@@ -119,15 +119,22 @@
       {
         "id": [
           "hair_bald",
+          "hair_beaded",
+          "hair_braid",
+          "hair_bun",
           "hair_buzzcut",
           "hair_crewcut",
+          "hair_curls",
           "hair_fro",
           "hair_long_over_eye",
           "hair_long",
           "hair_medium",
           "hair_messy",
+          "hair_modern",
           "hair_mohawk",
           "hair_ponytail",
+          "hair_puff",
+          "hair_punk_long",
           "hair_short_no_fringe",
           "hair_short_over_eye",
           "hair_short"

--- a/data/json/mutations/mutation_ordering.json
+++ b/data/json/mutations/mutation_ordering.json
@@ -125,6 +125,7 @@
           "hair_buzzcut",
           "hair_crewcut",
           "hair_curls",
+          "hair_detective",
           "hair_fro",
           "hair_long_over_eye",
           "hair_long",
@@ -137,7 +138,9 @@
           "hair_punk_long",
           "hair_short_no_fringe",
           "hair_short_over_eye",
-          "hair_short"
+          "hair_short",
+          "hair_super_princess",
+          "hair_twintails"
         ],
         "order": 1600
       },

--- a/data/json/npcs/EOC_talkers/haircutting.json
+++ b/data/json/npcs/EOC_talkers/haircutting.json
@@ -25,23 +25,26 @@
                 { "u_has_trait": "hair_short" },
                 { "u_has_trait": "hair_short_no_fringe" },
                 { "u_has_trait": "hair_short_over_eye" },
-                { "u_has_trait": "hair_medium" },
-                { "u_has_trait": "hair_mohawk" },
-                { "u_has_trait": "hair_long" },
-                { "u_has_trait": "hair_long_mohawk" },
-                { "u_has_trait": "hair_mullet" },
-                { "u_has_trait": "hair_long_over_eye" },
-                { "u_has_trait": "hair_messy" },
-                { "u_has_trait": "hair_very_long" },
-                { "u_has_trait": "hair_extremely_long" },
-                { "u_has_trait": "hair_body_length" },
-                { "u_has_trait": "hair_punk_long" },
-                { "u_has_trait": "hair_curls" },
                 { "u_has_trait": "hair_modern" },
-                { "u_has_trait": "hair_bun" },
-                { "u_has_trait": "hair_braid" },
+                { "u_has_trait": "hair_detective" },
+                { "u_has_trait": "hair_medium" },
                 { "u_has_trait": "hair_puff" },
-                { "u_has_trait": "hair_beaded" }
+                { "u_has_trait": "hair_mohawk" },
+                { "u_has_trait": "hair_beaded" },
+                { "u_has_trait": "hair_curls" },
+                { "u_has_trait": "hair_super_princess" },
+                { "u_has_trait": "hair_long_mohawk" },
+                { "u_has_trait": "hair_long" },
+                { "u_has_trait": "hair_long_over_eye" },
+                { "u_has_trait": "hair_mullet" },
+                { "u_has_trait": "hair_bun" },
+                { "u_has_trait": "hair_messy" },
+                { "u_has_trait": "hair_punk_long" },
+                { "u_has_trait": "hair_very_long" },
+                { "u_has_trait": "hair_twintails" },
+                { "u_has_trait": "hair_braid" },
+                { "u_has_trait": "hair_extremely_long" },
+                { "u_has_trait": "hair_body_length" }
               ]
             }
           ]
@@ -69,23 +72,26 @@
                 { "u_has_trait": "hair_short" },
                 { "u_has_trait": "hair_short_no_fringe" },
                 { "u_has_trait": "hair_short_over_eye" },
-                { "u_has_trait": "hair_medium" },
-                { "u_has_trait": "hair_mohawk" },
-                { "u_has_trait": "hair_long" },
-                { "u_has_trait": "hair_long_mohawk" },
-                { "u_has_trait": "hair_mullet" },
-                { "u_has_trait": "hair_long_over_eye" },
-                { "u_has_trait": "hair_messy" },
-                { "u_has_trait": "hair_very_long" },
-                { "u_has_trait": "hair_extremely_long" },
-                { "u_has_trait": "hair_body_length" },
-                { "u_has_trait": "hair_punk_long" },
-                { "u_has_trait": "hair_curls" },
                 { "u_has_trait": "hair_modern" },
-                { "u_has_trait": "hair_bun" },
-                { "u_has_trait": "hair_braid" },
+                { "u_has_trait": "hair_detective" },
+                { "u_has_trait": "hair_medium" },
                 { "u_has_trait": "hair_puff" },
-                { "u_has_trait": "hair_beaded" }
+                { "u_has_trait": "hair_mohawk" },
+                { "u_has_trait": "hair_beaded" },
+                { "u_has_trait": "hair_curls" },
+                { "u_has_trait": "hair_super_princess" },
+                { "u_has_trait": "hair_long_mohawk" },
+                { "u_has_trait": "hair_long" },
+                { "u_has_trait": "hair_long_over_eye" },
+                { "u_has_trait": "hair_mullet" },
+                { "u_has_trait": "hair_bun" },
+                { "u_has_trait": "hair_messy" },
+                { "u_has_trait": "hair_punk_long" },
+                { "u_has_trait": "hair_very_long" },
+                { "u_has_trait": "hair_twintails" },
+                { "u_has_trait": "hair_braid" },
+                { "u_has_trait": "hair_extremely_long" },
+                { "u_has_trait": "hair_body_length" }
               ]
             }
           ]
@@ -110,14 +116,26 @@
             { "u_has_trait": "natural_hair_growth" },
             {
               "or": [
+                { "u_has_trait": "hair_short_no_fringe" },
+                { "u_has_trait": "hair_short_over_eye" },
+                { "u_has_trait": "hair_modern" },
+                { "u_has_trait": "hair_detective" },
                 { "u_has_trait": "hair_medium" },
+                { "u_has_trait": "hair_puff" },
                 { "u_has_trait": "hair_mohawk" },
-                { "u_has_trait": "hair_long" },
+                { "u_has_trait": "hair_beaded" },
+                { "u_has_trait": "hair_curls" },
+                { "u_has_trait": "hair_super_princess" },
                 { "u_has_trait": "hair_long_mohawk" },
-                { "u_has_trait": "hair_mullet" },
+                { "u_has_trait": "hair_long" },
                 { "u_has_trait": "hair_long_over_eye" },
+                { "u_has_trait": "hair_mullet" },
+                { "u_has_trait": "hair_bun" },
                 { "u_has_trait": "hair_messy" },
+                { "u_has_trait": "hair_punk_long" },
                 { "u_has_trait": "hair_very_long" },
+                { "u_has_trait": "hair_twintails" },
+                { "u_has_trait": "hair_braid" },
                 { "u_has_trait": "hair_extremely_long" },
                 { "u_has_trait": "hair_body_length" }
               ]
@@ -144,25 +162,27 @@
             { "u_has_trait": "natural_hair_growth" },
             {
               "or": [
-                { "u_has_trait": "hair_short" },
                 { "u_has_trait": "hair_short_over_eye" },
-                { "u_has_trait": "hair_medium" },
-                { "u_has_trait": "hair_mohawk" },
-                { "u_has_trait": "hair_long" },
-                { "u_has_trait": "hair_long_mohawk" },
-                { "u_has_trait": "hair_mullet" },
-                { "u_has_trait": "hair_long_over_eye" },
-                { "u_has_trait": "hair_messy" },
-                { "u_has_trait": "hair_very_long" },
-                { "u_has_trait": "hair_extremely_long" },
-                { "u_has_trait": "hair_body_length" },
-                { "u_has_trait": "hair_punk_long" },
-                { "u_has_trait": "hair_curls" },
                 { "u_has_trait": "hair_modern" },
-                { "u_has_trait": "hair_bun" },
-                { "u_has_trait": "hair_braid" },
+                { "u_has_trait": "hair_detective" },
+                { "u_has_trait": "hair_medium" },
                 { "u_has_trait": "hair_puff" },
-                { "u_has_trait": "hair_beaded" }
+                { "u_has_trait": "hair_mohawk" },
+                { "u_has_trait": "hair_beaded" },
+                { "u_has_trait": "hair_curls" },
+                { "u_has_trait": "hair_super_princess" },
+                { "u_has_trait": "hair_long_mohawk" },
+                { "u_has_trait": "hair_long" },
+                { "u_has_trait": "hair_long_over_eye" },
+                { "u_has_trait": "hair_mullet" },
+                { "u_has_trait": "hair_bun" },
+                { "u_has_trait": "hair_messy" },
+                { "u_has_trait": "hair_punk_long" },
+                { "u_has_trait": "hair_very_long" },
+                { "u_has_trait": "hair_twintails" },
+                { "u_has_trait": "hair_braid" },
+                { "u_has_trait": "hair_extremely_long" },
+                { "u_has_trait": "hair_body_length" }
               ]
             }
           ]
@@ -187,14 +207,24 @@
             { "u_has_trait": "natural_hair_growth" },
             {
               "or": [
+                { "u_has_trait": "hair_modern" },
+                { "u_has_trait": "hair_detective" },
                 { "u_has_trait": "hair_medium" },
+                { "u_has_trait": "hair_puff" },
                 { "u_has_trait": "hair_mohawk" },
-                { "u_has_trait": "hair_long" },
+                { "u_has_trait": "hair_beaded" },
+                { "u_has_trait": "hair_curls" },
+                { "u_has_trait": "hair_super_princess" },
                 { "u_has_trait": "hair_long_mohawk" },
-                { "u_has_trait": "hair_mullet" },
+                { "u_has_trait": "hair_long" },
                 { "u_has_trait": "hair_long_over_eye" },
+                { "u_has_trait": "hair_mullet" },
+                { "u_has_trait": "hair_bun" },
                 { "u_has_trait": "hair_messy" },
+                { "u_has_trait": "hair_punk_long" },
                 { "u_has_trait": "hair_very_long" },
+                { "u_has_trait": "hair_twintails" },
+                { "u_has_trait": "hair_braid" },
                 { "u_has_trait": "hair_extremely_long" },
                 { "u_has_trait": "hair_body_length" }
               ]
@@ -215,19 +245,112 @@
         "topic": "TALK_DONE"
       },
       {
+        "text": "Get a modern cut.",
+        "condition": {
+          "and": [
+            { "u_has_trait": "natural_hair_growth" },
+            {
+              "or": [
+                { "u_has_trait": "hair_detective" },
+                { "u_has_trait": "hair_medium" },
+                { "u_has_trait": "hair_puff" },
+                { "u_has_trait": "hair_mohawk" },
+                { "u_has_trait": "hair_beaded" },
+                { "u_has_trait": "hair_curls" },
+                { "u_has_trait": "hair_super_princess" },
+                { "u_has_trait": "hair_long_mohawk" },
+                { "u_has_trait": "hair_long" },
+                { "u_has_trait": "hair_long_over_eye" },
+                { "u_has_trait": "hair_mullet" },
+                { "u_has_trait": "hair_bun" },
+                { "u_has_trait": "hair_messy" },
+                { "u_has_trait": "hair_punk_long" },
+                { "u_has_trait": "hair_very_long" },
+                { "u_has_trait": "hair_twintails" },
+                { "u_has_trait": "hair_braid" },
+                { "u_has_trait": "hair_extremely_long" },
+                { "u_has_trait": "hair_body_length" }
+              ]
+            }
+          ]
+        },
+        "effect": [
+          { "run_eocs": "reset_all_hair_types" },
+          {
+            "u_add_morale": "morale_haircut",
+            "bonus": 3,
+            "max_bonus": 5,
+            "duration": "30 minutes",
+            "decay_start": "30 minutes"
+          },
+          { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_modern" } }
+        ],
+        "topic": "TALK_DONE"
+      },
+      {
+        "text": "Get a detective cut.",
+        "condition": {
+          "and": [
+            { "u_has_trait": "natural_hair_growth" },
+            {
+              "or": [
+                { "u_has_trait": "hair_medium" },
+                { "u_has_trait": "hair_puff" },
+                { "u_has_trait": "hair_mohawk" },
+                { "u_has_trait": "hair_beaded" },
+                { "u_has_trait": "hair_curls" },
+                { "u_has_trait": "hair_super_princess" },
+                { "u_has_trait": "hair_long_mohawk" },
+                { "u_has_trait": "hair_long" },
+                { "u_has_trait": "hair_long_over_eye" },
+                { "u_has_trait": "hair_mullet" },
+                { "u_has_trait": "hair_bun" },
+                { "u_has_trait": "hair_messy" },
+                { "u_has_trait": "hair_punk_long" },
+                { "u_has_trait": "hair_very_long" },
+                { "u_has_trait": "hair_twintails" },
+                { "u_has_trait": "hair_braid" },
+                { "u_has_trait": "hair_extremely_long" },
+                { "u_has_trait": "hair_body_length" }
+              ]
+            }
+          ]
+        },
+        "effect": [
+          { "run_eocs": "reset_all_hair_types" },
+          {
+            "u_add_morale": "morale_haircut",
+            "bonus": 3,
+            "max_bonus": 5,
+            "duration": "30 minutes",
+            "decay_start": "30 minutes"
+          },
+          { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_detective" } }
+        ],
+        "topic": "TALK_DONE"
+      },
+      {
         "text": "Get a medium-length cut.",
         "condition": {
           "and": [
             { "u_has_trait": "natural_hair_growth" },
             {
               "or": [
+                { "u_has_trait": "hair_puff" },
                 { "u_has_trait": "hair_mohawk" },
-                { "u_has_trait": "hair_long" },
+                { "u_has_trait": "hair_beaded" },
+                { "u_has_trait": "hair_curls" },
+                { "u_has_trait": "hair_super_princess" },
                 { "u_has_trait": "hair_long_mohawk" },
-                { "u_has_trait": "hair_mullet" },
+                { "u_has_trait": "hair_long" },
                 { "u_has_trait": "hair_long_over_eye" },
+                { "u_has_trait": "hair_mullet" },
+                { "u_has_trait": "hair_bun" },
                 { "u_has_trait": "hair_messy" },
+                { "u_has_trait": "hair_punk_long" },
                 { "u_has_trait": "hair_very_long" },
+                { "u_has_trait": "hair_twintails" },
+                { "u_has_trait": "hair_braid" },
                 { "u_has_trait": "hair_extremely_long" },
                 { "u_has_trait": "hair_body_length" }
               ]
@@ -248,18 +371,65 @@
         "topic": "TALK_DONE"
       },
       {
+        "text": "Get a puff cut.",
+        "condition": {
+          "and": [
+            { "u_has_trait": "natural_hair_growth" },
+            {
+              "or": [
+                { "u_has_trait": "hair_mohawk" },
+                { "u_has_trait": "hair_beaded" },
+                { "u_has_trait": "hair_curls" },
+                { "u_has_trait": "hair_super_princess" },
+                { "u_has_trait": "hair_long_mohawk" },
+                { "u_has_trait": "hair_long" },
+                { "u_has_trait": "hair_long_over_eye" },
+                { "u_has_trait": "hair_mullet" },
+                { "u_has_trait": "hair_bun" },
+                { "u_has_trait": "hair_messy" },
+                { "u_has_trait": "hair_punk_long" },
+                { "u_has_trait": "hair_very_long" },
+                { "u_has_trait": "hair_twintails" },
+                { "u_has_trait": "hair_braid" },
+                { "u_has_trait": "hair_extremely_long" },
+                { "u_has_trait": "hair_body_length" }
+              ]
+            }
+          ]
+        },
+        "effect": [
+          { "run_eocs": "reset_all_hair_types" },
+          {
+            "u_add_morale": "morale_haircut",
+            "bonus": 3,
+            "max_bonus": 5,
+            "duration": "30 minutes",
+            "decay_start": "30 minutes"
+          },
+          { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_puff" } }
+        ],
+        "topic": "TALK_DONE"
+      },
+      {
         "text": "Get a mohawk.",
         "condition": {
           "and": [
             { "u_has_trait": "natural_hair_growth" },
             {
               "or": [
-                { "u_has_trait": "hair_long" },
+                { "u_has_trait": "hair_beaded" },
+                { "u_has_trait": "hair_curls" },
+                { "u_has_trait": "hair_super_princess" },
                 { "u_has_trait": "hair_long_mohawk" },
-                { "u_has_trait": "hair_mullet" },
+                { "u_has_trait": "hair_long" },
                 { "u_has_trait": "hair_long_over_eye" },
+                { "u_has_trait": "hair_mullet" },
+                { "u_has_trait": "hair_bun" },
                 { "u_has_trait": "hair_messy" },
+                { "u_has_trait": "hair_punk_long" },
                 { "u_has_trait": "hair_very_long" },
+                { "u_has_trait": "hair_twintails" },
+                { "u_has_trait": "hair_braid" },
                 { "u_has_trait": "hair_extremely_long" },
                 { "u_has_trait": "hair_body_length" }
               ]
@@ -280,14 +450,166 @@
         "topic": "TALK_DONE"
       },
       {
+        "text": "Get a beaded cut.",
+        "condition": {
+          "and": [
+            { "u_has_trait": "natural_hair_growth" },
+            {
+              "or": [
+                { "u_has_trait": "hair_curls" },
+                { "u_has_trait": "hair_super_princess" },
+                { "u_has_trait": "hair_long_mohawk" },
+                { "u_has_trait": "hair_long" },
+                { "u_has_trait": "hair_long_over_eye" },
+                { "u_has_trait": "hair_mullet" },
+                { "u_has_trait": "hair_bun" },
+                { "u_has_trait": "hair_messy" },
+                { "u_has_trait": "hair_punk_long" },
+                { "u_has_trait": "hair_very_long" },
+                { "u_has_trait": "hair_twintails" },
+                { "u_has_trait": "hair_braid" },
+                { "u_has_trait": "hair_extremely_long" },
+                { "u_has_trait": "hair_body_length" }
+              ]
+            }
+          ]
+        },
+        "effect": [
+          { "run_eocs": "reset_all_hair_types" },
+          {
+            "u_add_morale": "morale_haircut",
+            "bonus": 3,
+            "max_bonus": 5,
+            "duration": "30 minutes",
+            "decay_start": "30 minutes"
+          },
+          { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_beaded" } }
+        ],
+        "topic": "TALK_DONE"
+      },
+      {
+        "text": "Get a curly cut.",
+        "condition": {
+          "and": [
+            { "u_has_trait": "natural_hair_growth" },
+            {
+              "or": [
+                { "u_has_trait": "hair_super_princess" },
+                { "u_has_trait": "hair_long_mohawk" },
+                { "u_has_trait": "hair_long" },
+                { "u_has_trait": "hair_long_over_eye" },
+                { "u_has_trait": "hair_mullet" },
+                { "u_has_trait": "hair_bun" },
+                { "u_has_trait": "hair_messy" },
+                { "u_has_trait": "hair_punk_long" },
+                { "u_has_trait": "hair_very_long" },
+                { "u_has_trait": "hair_twintails" },
+                { "u_has_trait": "hair_braid" },
+                { "u_has_trait": "hair_extremely_long" },
+                { "u_has_trait": "hair_body_length" }
+              ]
+            }
+          ]
+        },
+        "effect": [
+          { "run_eocs": "reset_all_hair_types" },
+          {
+            "u_add_morale": "morale_haircut",
+            "bonus": 3,
+            "max_bonus": 5,
+            "duration": "30 minutes",
+            "decay_start": "30 minutes"
+          },
+          { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_curls" } }
+        ],
+        "topic": "TALK_DONE"
+      },
+      {
+        "text": "Get a super princess cut.",
+        "condition": {
+          "and": [
+            { "u_has_trait": "natural_hair_growth" },
+            {
+              "or": [
+                { "u_has_trait": "hair_long_mohawk" },
+                { "u_has_trait": "hair_long" },
+                { "u_has_trait": "hair_long_over_eye" },
+                { "u_has_trait": "hair_mullet" },
+                { "u_has_trait": "hair_bun" },
+                { "u_has_trait": "hair_messy" },
+                { "u_has_trait": "hair_punk_long" },
+                { "u_has_trait": "hair_very_long" },
+                { "u_has_trait": "hair_twintails" },
+                { "u_has_trait": "hair_braid" },
+                { "u_has_trait": "hair_extremely_long" },
+                { "u_has_trait": "hair_body_length" }
+              ]
+            }
+          ]
+        },
+        "effect": [
+          { "run_eocs": "reset_all_hair_types" },
+          {
+            "u_add_morale": "morale_haircut",
+            "bonus": 3,
+            "max_bonus": 5,
+            "duration": "30 minutes",
+            "decay_start": "30 minutes"
+          },
+          { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_super_princess" } }
+        ],
+        "topic": "TALK_DONE"
+      },
+      {
+        "text": "Get a long mohawk.",
+        "condition": {
+          "and": [
+            { "u_has_trait": "natural_hair_growth" },
+            {
+              "or": [
+                { "u_has_trait": "hair_long" },
+                { "u_has_trait": "hair_long_over_eye" },
+                { "u_has_trait": "hair_mullet" },
+                { "u_has_trait": "hair_bun" },
+                { "u_has_trait": "hair_messy" },
+                { "u_has_trait": "hair_punk_long" },
+                { "u_has_trait": "hair_very_long" },
+                { "u_has_trait": "hair_twintails" },
+                { "u_has_trait": "hair_braid" },
+                { "u_has_trait": "hair_extremely_long" },
+                { "u_has_trait": "hair_body_length" }
+              ]
+            }
+          ]
+        },
+        "effect": [
+          { "run_eocs": "reset_all_hair_types" },
+          {
+            "u_add_morale": "morale_haircut",
+            "bonus": 3,
+            "max_bonus": 5,
+            "duration": "30 minutes",
+            "decay_start": "30 minutes"
+          },
+          { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_long_mohawk" } }
+        ],
+        "topic": "TALK_DONE"
+      },
+      {
         "text": "Get a long cut.",
         "condition": {
           "and": [
             { "u_has_trait": "natural_hair_growth" },
             {
               "or": [
+                { "u_has_trait": "hair_long_over_eye" },
+                { "u_has_trait": "hair_mullet" },
+                { "u_has_trait": "hair_bun" },
                 { "u_has_trait": "hair_messy" },
+                { "u_has_trait": "hair_punk_long" },
                 { "u_has_trait": "hair_very_long" },
+                { "u_has_trait": "hair_twintails" },
+                { "u_has_trait": "hair_braid" },
                 { "u_has_trait": "hair_extremely_long" },
                 { "u_has_trait": "hair_body_length" }
               ]
@@ -314,8 +636,13 @@
             { "u_has_trait": "natural_hair_growth" },
             {
               "or": [
+                { "u_has_trait": "hair_mullet" },
+                { "u_has_trait": "hair_bun" },
                 { "u_has_trait": "hair_messy" },
+                { "u_has_trait": "hair_punk_long" },
                 { "u_has_trait": "hair_very_long" },
+                { "u_has_trait": "hair_twintails" },
+                { "u_has_trait": "hair_braid" },
                 { "u_has_trait": "hair_extremely_long" },
                 { "u_has_trait": "hair_body_length" }
               ]
@@ -336,42 +663,18 @@
         "topic": "TALK_DONE"
       },
       {
-        "text": "Get a long mohawk.",
-        "condition": {
-          "and": [
-            { "u_has_trait": "natural_hair_growth" },
-            {
-              "or": [
-                { "u_has_trait": "hair_messy" },
-                { "u_has_trait": "hair_very_long" },
-                { "u_has_trait": "hair_extremely_long" },
-                { "u_has_trait": "hair_body_length" }
-              ]
-            }
-          ]
-        },
-        "effect": [
-          { "run_eocs": "reset_all_hair_types" },
-          {
-            "u_add_morale": "morale_haircut",
-            "bonus": 3,
-            "max_bonus": 5,
-            "duration": "30 minutes",
-            "decay_start": "30 minutes"
-          },
-          { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_long_mohawk" } }
-        ],
-        "topic": "TALK_DONE"
-      },
-      {
         "text": "Get a mullet.",
         "condition": {
           "and": [
             { "u_has_trait": "natural_hair_growth" },
             {
               "or": [
+                { "u_has_trait": "hair_bun" },
                 { "u_has_trait": "hair_messy" },
+                { "u_has_trait": "hair_punk_long" },
                 { "u_has_trait": "hair_very_long" },
+                { "u_has_trait": "hair_twintails" },
+                { "u_has_trait": "hair_braid" },
                 { "u_has_trait": "hair_extremely_long" },
                 { "u_has_trait": "hair_body_length" }
               ]
@@ -392,11 +695,108 @@
         "topic": "TALK_DONE"
       },
       {
+        "text": "Get a bun.",
+        "condition": {
+          "and": [
+            { "u_has_trait": "natural_hair_growth" },
+            {
+              "or": [
+                { "u_has_trait": "hair_messy" },
+                { "u_has_trait": "hair_punk_long" },
+                { "u_has_trait": "hair_very_long" },
+                { "u_has_trait": "hair_twintails" },
+                { "u_has_trait": "hair_braid" },
+                { "u_has_trait": "hair_extremely_long" },
+                { "u_has_trait": "hair_body_length" }
+              ]
+            }
+          ]
+        },
+        "effect": [
+          { "run_eocs": "reset_all_hair_types" },
+          {
+            "u_add_morale": "morale_haircut",
+            "bonus": 3,
+            "max_bonus": 5,
+            "duration": "30 minutes",
+            "decay_start": "30 minutes"
+          },
+          { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_bun" } }
+        ],
+        "topic": "TALK_DONE"
+      },
+      {
+        "text": "Get a messy cut.",
+        "condition": {
+          "and": [
+            { "u_has_trait": "natural_hair_growth" },
+            {
+              "or": [
+                { "u_has_trait": "hair_punk_long" },
+                { "u_has_trait": "hair_very_long" },
+                { "u_has_trait": "hair_twintails" },
+                { "u_has_trait": "hair_braid" },
+                { "u_has_trait": "hair_extremely_long" },
+                { "u_has_trait": "hair_body_length" }
+              ]
+            }
+          ]
+        },
+        "effect": [
+          { "run_eocs": "reset_all_hair_types" },
+          {
+            "u_add_morale": "morale_haircut",
+            "bonus": 3,
+            "max_bonus": 5,
+            "duration": "30 minutes",
+            "decay_start": "30 minutes"
+          },
+          { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_messy" } }
+        ],
+        "topic": "TALK_DONE"
+      },
+      {
+        "text": "Get a long punk cut.",
+        "condition": {
+          "and": [
+            { "u_has_trait": "natural_hair_growth" },
+            {
+              "or": [
+                { "u_has_trait": "hair_very_long" },
+                { "u_has_trait": "hair_twintails" },
+                { "u_has_trait": "hair_braid" },
+                { "u_has_trait": "hair_extremely_long" },
+                { "u_has_trait": "hair_body_length" }
+              ]
+            }
+          ]
+        },
+        "effect": [
+          { "run_eocs": "reset_all_hair_types" },
+          {
+            "u_add_morale": "morale_haircut",
+            "bonus": 3,
+            "max_bonus": 5,
+            "duration": "30 minutes",
+            "decay_start": "30 minutes"
+          },
+          { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_punk_long" } }
+        ],
+        "topic": "TALK_DONE"
+      },
+      {
         "text": "Get a very long cut.",
         "condition": {
           "and": [
             { "u_has_trait": "natural_hair_growth" },
-            { "or": [ { "u_has_trait": "hair_extremely_long" }, { "u_has_trait": "hair_body_length" } ] }
+            {
+              "or": [
+                { "u_has_trait": "hair_twintails" },
+                { "u_has_trait": "hair_braid" },
+                { "u_has_trait": "hair_extremely_long" },
+                { "u_has_trait": "hair_body_length" }
+              ]
+            }
           ]
         },
         "effect": [
@@ -413,8 +813,52 @@
         "topic": "TALK_DONE"
       },
       {
+        "text": "Get twin tails.",
+        "condition": {
+          "and": [
+            { "u_has_trait": "natural_hair_growth" },
+            {
+              "or": [ { "u_has_trait": "hair_braid" }, { "u_has_trait": "hair_extremely_long" }, { "u_has_trait": "hair_body_length" } ]
+            }
+          ]
+        },
+        "effect": [
+          { "run_eocs": "reset_all_hair_types" },
+          {
+            "u_add_morale": "morale_haircut",
+            "bonus": 3,
+            "max_bonus": 5,
+            "duration": "30 minutes",
+            "decay_start": "30 minutes"
+          },
+          { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_twintails" } }
+        ],
+        "topic": "TALK_DONE"
+      },
+      {
+        "text": "Get a braid.",
+        "condition": {
+          "and": [
+            { "u_has_trait": "natural_hair_growth" },
+            { "or": [ { "u_has_trait": "hair_extremely_long" }, { "u_has_trait": "hair_body_length" } ] }
+          ]
+        },
+        "effect": [
+          { "run_eocs": "reset_all_hair_types" },
+          {
+            "u_add_morale": "morale_haircut",
+            "bonus": 3,
+            "max_bonus": 5,
+            "duration": "30 minutes",
+            "decay_start": "30 minutes"
+          },
+          { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_braid" } }
+        ],
+        "topic": "TALK_DONE"
+      },
+      {
         "text": "Get an extremely long cut.",
-        "condition": { "and": [ { "u_has_trait": "natural_hair_growth" }, { "u_has_trait": "hair_body_length" } ] },
+        "condition": { "and": [ { "u_has_trait": "natural_hair_growth" }, { "or": [ { "u_has_trait": "hair_body_length" } ] } ] },
         "effect": [
           { "run_eocs": "reset_all_hair_types" },
           {
@@ -509,6 +953,38 @@
         "topic": "TALK_DONE"
       },
       {
+        "text": "Get a modern cut.",
+        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
+        "effect": [
+          { "run_eocs": "reset_all_hair_types" },
+          {
+            "u_add_morale": "morale_haircut",
+            "bonus": 3,
+            "max_bonus": 5,
+            "duration": "30 minutes",
+            "decay_start": "30 minutes"
+          },
+          { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_modern" } }
+        ],
+        "topic": "TALK_DONE"
+      },
+      {
+        "text": "Get a detective cut.",
+        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
+        "effect": [
+          { "run_eocs": "reset_all_hair_types" },
+          {
+            "u_add_morale": "morale_haircut",
+            "bonus": 3,
+            "max_bonus": 5,
+            "duration": "30 minutes",
+            "decay_start": "30 minutes"
+          },
+          { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_detective" } }
+        ],
+        "topic": "TALK_DONE"
+      },
+      {
         "text": "Get a medium-length cut.",
         "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
         "effect": [
@@ -525,6 +1001,22 @@
         "topic": "TALK_DONE"
       },
       {
+        "text": "Get a puff cut.",
+        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
+        "effect": [
+          { "run_eocs": "reset_all_hair_types" },
+          {
+            "u_add_morale": "morale_haircut",
+            "bonus": 3,
+            "max_bonus": 5,
+            "duration": "30 minutes",
+            "decay_start": "30 minutes"
+          },
+          { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_puff" } }
+        ],
+        "topic": "TALK_DONE"
+      },
+      {
         "text": "Get a mohawk.",
         "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
         "effect": [
@@ -537,6 +1029,70 @@
             "decay_start": "30 minutes"
           },
           { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_mohawk" } }
+        ],
+        "topic": "TALK_DONE"
+      },
+      {
+        "text": "Get a beaded cut.",
+        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
+        "effect": [
+          { "run_eocs": "reset_all_hair_types" },
+          {
+            "u_add_morale": "morale_haircut",
+            "bonus": 3,
+            "max_bonus": 5,
+            "duration": "30 minutes",
+            "decay_start": "30 minutes"
+          },
+          { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_beaded" } }
+        ],
+        "topic": "TALK_DONE"
+      },
+      {
+        "text": "Get a curly cut.",
+        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
+        "effect": [
+          { "run_eocs": "reset_all_hair_types" },
+          {
+            "u_add_morale": "morale_haircut",
+            "bonus": 3,
+            "max_bonus": 5,
+            "duration": "30 minutes",
+            "decay_start": "30 minutes"
+          },
+          { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_curls" } }
+        ],
+        "topic": "TALK_DONE"
+      },
+      {
+        "text": "Get a super princess cut.",
+        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
+        "effect": [
+          { "run_eocs": "reset_all_hair_types" },
+          {
+            "u_add_morale": "morale_haircut",
+            "bonus": 3,
+            "max_bonus": 5,
+            "duration": "30 minutes",
+            "decay_start": "30 minutes"
+          },
+          { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_super_princess" } }
+        ],
+        "topic": "TALK_DONE"
+      },
+      {
+        "text": "Get a long mohawk.",
+        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
+        "effect": [
+          { "run_eocs": "reset_all_hair_types" },
+          {
+            "u_add_morale": "morale_haircut",
+            "bonus": 3,
+            "max_bonus": 5,
+            "duration": "30 minutes",
+            "decay_start": "30 minutes"
+          },
+          { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_long_mohawk" } }
         ],
         "topic": "TALK_DONE"
       },
@@ -573,7 +1129,7 @@
         "topic": "TALK_DONE"
       },
       {
-        "text": "Get a long mohawk.",
+        "text": "Get a mullet.",
         "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
         "effect": [
           { "run_eocs": "reset_all_hair_types" },
@@ -584,7 +1140,7 @@
             "duration": "30 minutes",
             "decay_start": "30 minutes"
           },
-          { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_long_mohawk" } }
+          { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_mullet" } }
         ],
         "topic": "TALK_DONE"
       },
@@ -605,70 +1161,6 @@
         "topic": "TALK_DONE"
       },
       {
-        "text": "Get a modern cut.",
-        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
-        "effect": [
-          { "run_eocs": "reset_all_hair_types" },
-          {
-            "u_add_morale": "morale_haircut",
-            "bonus": 3,
-            "max_bonus": 5,
-            "duration": "30 minutes",
-            "decay_start": "30 minutes"
-          },
-          { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_modern" } }
-        ],
-        "topic": "TALK_DONE"
-      },
-      {
-        "text": "Get a puff cut.",
-        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
-        "effect": [
-          { "run_eocs": "reset_all_hair_types" },
-          {
-            "u_add_morale": "morale_haircut",
-            "bonus": 3,
-            "max_bonus": 5,
-            "duration": "30 minutes",
-            "decay_start": "30 minutes"
-          },
-          { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_puff" } }
-        ],
-        "topic": "TALK_DONE"
-      },
-      {
-        "text": "Get a beaded cut.",
-        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
-        "effect": [
-          { "run_eocs": "reset_all_hair_types" },
-          {
-            "u_add_morale": "morale_haircut",
-            "bonus": 3,
-            "max_bonus": 5,
-            "duration": "30 minutes",
-            "decay_start": "30 minutes"
-          },
-          { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_beaded" } }
-        ],
-        "topic": "TALK_DONE"
-      },
-      {
-        "text": "Get a curled cut.",
-        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
-        "effect": [
-          { "run_eocs": "reset_all_hair_types" },
-          {
-            "u_add_morale": "morale_haircut",
-            "bonus": 3,
-            "max_bonus": 5,
-            "duration": "30 minutes",
-            "decay_start": "30 minutes"
-          },
-          { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_curls" } }
-        ],
-        "topic": "TALK_DONE"
-      },
-      {
         "text": "Get a bun cut.",
         "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
         "effect": [
@@ -685,6 +1177,22 @@
         "topic": "TALK_DONE"
       },
       {
+        "text": "Get a messy cut.",
+        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
+        "effect": [
+          { "run_eocs": "reset_all_hair_types" },
+          {
+            "u_add_morale": "morale_haircut",
+            "bonus": 3,
+            "max_bonus": 5,
+            "duration": "30 minutes",
+            "decay_start": "30 minutes"
+          },
+          { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_messy" } }
+        ],
+        "topic": "TALK_DONE"
+      },
+      {
         "text": "Get a long punk cut.",
         "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
         "effect": [
@@ -697,22 +1205,6 @@
             "decay_start": "30 minutes"
           },
           { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_punk_long" } }
-        ],
-        "topic": "TALK_DONE"
-      },
-      {
-        "text": "Get a braided cut.",
-        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
-        "effect": [
-          { "run_eocs": "reset_all_hair_types" },
-          {
-            "u_add_morale": "morale_haircut",
-            "bonus": 3,
-            "max_bonus": 5,
-            "duration": "30 minutes",
-            "decay_start": "30 minutes"
-          },
-          { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_braid" } }
         ],
         "topic": "TALK_DONE"
       },
@@ -749,7 +1241,39 @@
         "topic": "TALK_DONE"
       },
       {
-        "text": "Get an body-length cut.",
+        "text": "Get twin tails.",
+        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
+        "effect": [
+          { "run_eocs": "reset_all_hair_types" },
+          {
+            "u_add_morale": "morale_haircut",
+            "bonus": 3,
+            "max_bonus": 5,
+            "duration": "30 minutes",
+            "decay_start": "30 minutes"
+          },
+          { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_twintails" } }
+        ],
+        "topic": "TALK_DONE"
+      },
+      {
+        "text": "Get a braided cut.",
+        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
+        "effect": [
+          { "run_eocs": "reset_all_hair_types" },
+          {
+            "u_add_morale": "morale_haircut",
+            "bonus": 3,
+            "max_bonus": 5,
+            "duration": "30 minutes",
+            "decay_start": "30 minutes"
+          },
+          { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_braid" } }
+        ],
+        "topic": "TALK_DONE"
+      },
+      {
+        "text": "Get a body-length cut.",
         "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
         "effect": [
           { "run_eocs": "reset_all_hair_types" },

--- a/data/json/npcs/EOC_talkers/haircutting.json
+++ b/data/json/npcs/EOC_talkers/haircutting.json
@@ -34,7 +34,14 @@
                 { "u_has_trait": "hair_messy" },
                 { "u_has_trait": "hair_very_long" },
                 { "u_has_trait": "hair_extremely_long" },
-                { "u_has_trait": "hair_body_length" }
+                { "u_has_trait": "hair_body_length" },
+                { "u_has_trait": "hair_punk_long" },
+                { "u_has_trait": "hair_curls" },
+                { "u_has_trait": "hair_modern" },
+                { "u_has_trait": "hair_bun" },
+                { "u_has_trait": "hair_braid" },
+                { "u_has_trait": "hair_puff" },
+                { "u_has_trait": "hair_beaded" }
               ]
             }
           ]
@@ -71,7 +78,14 @@
                 { "u_has_trait": "hair_messy" },
                 { "u_has_trait": "hair_very_long" },
                 { "u_has_trait": "hair_extremely_long" },
-                { "u_has_trait": "hair_body_length" }
+                { "u_has_trait": "hair_body_length" },
+                { "u_has_trait": "hair_punk_long" },
+                { "u_has_trait": "hair_curls" },
+                { "u_has_trait": "hair_modern" },
+                { "u_has_trait": "hair_bun" },
+                { "u_has_trait": "hair_braid" },
+                { "u_has_trait": "hair_puff" },
+                { "u_has_trait": "hair_beaded" }
               ]
             }
           ]
@@ -141,7 +155,14 @@
                 { "u_has_trait": "hair_messy" },
                 { "u_has_trait": "hair_very_long" },
                 { "u_has_trait": "hair_extremely_long" },
-                { "u_has_trait": "hair_body_length" }
+                { "u_has_trait": "hair_body_length" },
+                { "u_has_trait": "hair_punk_long" },
+                { "u_has_trait": "hair_curls" },
+                { "u_has_trait": "hair_modern" },
+                { "u_has_trait": "hair_bun" },
+                { "u_has_trait": "hair_braid" },
+                { "u_has_trait": "hair_puff" },
+                { "u_has_trait": "hair_beaded" }
               ]
             }
           ]
@@ -580,6 +601,118 @@
             "decay_start": "30 minutes"
           },
           { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_mullet" } }
+        ],
+        "topic": "TALK_DONE"
+      },
+      {
+        "text": "Get a modern cut.",
+        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
+        "effect": [
+          { "run_eocs": "reset_all_hair_types" },
+          {
+            "u_add_morale": "morale_haircut",
+            "bonus": 3,
+            "max_bonus": 5,
+            "duration": "30 minutes",
+            "decay_start": "30 minutes"
+          },
+          { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_modern" } }
+        ],
+        "topic": "TALK_DONE"
+      },
+      {
+        "text": "Get a puff cut.",
+        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
+        "effect": [
+          { "run_eocs": "reset_all_hair_types" },
+          {
+            "u_add_morale": "morale_haircut",
+            "bonus": 3,
+            "max_bonus": 5,
+            "duration": "30 minutes",
+            "decay_start": "30 minutes"
+          },
+          { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_puff" } }
+        ],
+        "topic": "TALK_DONE"
+      },
+      {
+        "text": "Get a beaded cut.",
+        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
+        "effect": [
+          { "run_eocs": "reset_all_hair_types" },
+          {
+            "u_add_morale": "morale_haircut",
+            "bonus": 3,
+            "max_bonus": 5,
+            "duration": "30 minutes",
+            "decay_start": "30 minutes"
+          },
+          { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_beaded" } }
+        ],
+        "topic": "TALK_DONE"
+      },
+      {
+        "text": "Get a curled cut.",
+        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
+        "effect": [
+          { "run_eocs": "reset_all_hair_types" },
+          {
+            "u_add_morale": "morale_haircut",
+            "bonus": 3,
+            "max_bonus": 5,
+            "duration": "30 minutes",
+            "decay_start": "30 minutes"
+          },
+          { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_curls" } }
+        ],
+        "topic": "TALK_DONE"
+      },
+      {
+        "text": "Get a bun cut.",
+        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
+        "effect": [
+          { "run_eocs": "reset_all_hair_types" },
+          {
+            "u_add_morale": "morale_haircut",
+            "bonus": 3,
+            "max_bonus": 5,
+            "duration": "30 minutes",
+            "decay_start": "30 minutes"
+          },
+          { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_bun" } }
+        ],
+        "topic": "TALK_DONE"
+      },
+      {
+        "text": "Get a long punk cut.",
+        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
+        "effect": [
+          { "run_eocs": "reset_all_hair_types" },
+          {
+            "u_add_morale": "morale_haircut",
+            "bonus": 3,
+            "max_bonus": 5,
+            "duration": "30 minutes",
+            "decay_start": "30 minutes"
+          },
+          { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_punk_long" } }
+        ],
+        "topic": "TALK_DONE"
+      },
+      {
+        "text": "Get a braided cut.",
+        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
+        "effect": [
+          { "run_eocs": "reset_all_hair_types" },
+          {
+            "u_add_morale": "morale_haircut",
+            "bonus": 3,
+            "max_bonus": 5,
+            "duration": "30 minutes",
+            "decay_start": "30 minutes"
+          },
+          { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_braid" } }
         ],
         "topic": "TALK_DONE"
       },

--- a/data/json/npcs/appearance_trait_groups.json
+++ b/data/json/npcs/appearance_trait_groups.json
@@ -225,7 +225,10 @@
       { "trait": "hair_bun", "variant": "black", "prob": 15 },
       { "trait": "hair_braid", "variant": "black", "prob": 15 },
       { "trait": "hair_puff", "variant": "black", "prob": 15 },
-      { "trait": "hair_beaded", "variant": "black", "prob": 15 }
+      { "trait": "hair_beaded", "variant": "black", "prob": 15 },
+      { "trait": "hair_detective", "variant": "black", "prob": 5 },
+      { "trait": "hair_super_princess", "variant": "black", "prob": 5 },
+      { "trait": "hair_twintails", "variant": "black", "prob": 5 }
     ]
   },
   {
@@ -251,7 +254,10 @@
       { "trait": "hair_bun", "variant": "brown", "prob": 15 },
       { "trait": "hair_braid", "variant": "brown", "prob": 15 },
       { "trait": "hair_puff", "variant": "brown", "prob": 15 },
-      { "trait": "hair_beaded", "variant": "brown", "prob": 10 }
+      { "trait": "hair_beaded", "variant": "brown", "prob": 10 },
+      { "trait": "hair_detective", "variant": "brown", "prob": 5 },
+      { "trait": "hair_super_princess", "variant": "brown", "prob": 5 },
+      { "trait": "hair_twintails", "variant": "brown", "prob": 5 }
     ]
   },
   {
@@ -277,7 +283,10 @@
       { "trait": "hair_bun", "variant": "blond", "prob": 20 },
       { "trait": "hair_braid", "variant": "blond", "prob": 15 },
       { "trait": "hair_puff", "variant": "blond", "prob": 5 },
-      { "trait": "hair_beaded", "variant": "blond", "prob": 1 }
+      { "trait": "hair_beaded", "variant": "blond", "prob": 1 },
+      { "trait": "hair_detective", "variant": "blond", "prob": 5 },
+      { "trait": "hair_super_princess", "variant": "blond", "prob": 5 },
+      { "trait": "hair_twintails", "variant": "blond", "prob": 5 }
     ]
   },
   {
@@ -297,13 +306,16 @@
       { "trait": "hair_messy", "variant": "red", "prob": 13 },
       { "trait": "hair_short_over_eye", "variant": "red", "prob": 10 },
       { "trait": "hair_short_no_fringe", "variant": "red", "prob": 15 },
-      { "trait": "hair_punk_long", "variant": "blond", "prob": 1 },
-      { "trait": "hair_curls", "variant": "blond", "prob": 20 },
-      { "trait": "hair_modern", "variant": "blond", "prob": 5 },
-      { "trait": "hair_bun", "variant": "blond", "prob": 20 },
-      { "trait": "hair_braid", "variant": "blond", "prob": 15 },
-      { "trait": "hair_puff", "variant": "blond", "prob": 5 },
-      { "trait": "hair_beaded", "variant": "blond", "prob": 1 }
+      { "trait": "hair_punk_long", "variant": "red", "prob": 1 },
+      { "trait": "hair_curls", "variant": "red", "prob": 20 },
+      { "trait": "hair_modern", "variant": "red", "prob": 5 },
+      { "trait": "hair_bun", "variant": "red", "prob": 20 },
+      { "trait": "hair_braid", "variant": "red", "prob": 15 },
+      { "trait": "hair_puff", "variant": "red", "prob": 5 },
+      { "trait": "hair_beaded", "variant": "red", "prob": 1 },
+      { "trait": "hair_detective", "variant": "red", "prob": 10 },
+      { "trait": "hair_super_princess", "variant": "red", "prob": 10 },
+      { "trait": "hair_twintails", "variant": "red", "prob": 10 }
     ]
   },
   {
@@ -345,7 +357,10 @@
       { "trait": "hair_bun", "variant": "white", "prob": 1 },
       { "trait": "hair_braid", "variant": "white", "prob": 10 },
       { "trait": "hair_puff", "variant": "white", "prob": 1 },
-      { "trait": "hair_beaded", "variant": "white", "prob": 5 }
+      { "trait": "hair_beaded", "variant": "white", "prob": 5 },
+      { "trait": "hair_detective", "variant": "white", "prob": 10 },
+      { "trait": "hair_super_princess", "variant": "white", "prob": 10 },
+      { "trait": "hair_twintails", "variant": "white", "prob": 10 }
     ]
   },
   {
@@ -371,7 +386,10 @@
       { "trait": "hair_bun", "variant": "green", "prob": 1 },
       { "trait": "hair_braid", "variant": "green", "prob": 10 },
       { "trait": "hair_puff", "variant": "green", "prob": 1 },
-      { "trait": "hair_beaded", "variant": "green", "prob": 5 }
+      { "trait": "hair_beaded", "variant": "green", "prob": 5 },
+      { "trait": "hair_detective", "variant": "green", "prob": 15 },
+      { "trait": "hair_super_princess", "variant": "green", "prob": 15 },
+      { "trait": "hair_twintails", "variant": "green", "prob": 15 }
     ]
   },
   {
@@ -397,7 +415,10 @@
       { "trait": "hair_bun", "variant": "blue", "prob": 1 },
       { "trait": "hair_braid", "variant": "blue", "prob": 10 },
       { "trait": "hair_puff", "variant": "blue", "prob": 1 },
-      { "trait": "hair_beaded", "variant": "blue", "prob": 5 }
+      { "trait": "hair_beaded", "variant": "blue", "prob": 5 },
+      { "trait": "hair_detective", "variant": "blue", "prob": 15 },
+      { "trait": "hair_super_princess", "variant": "blue", "prob": 15 },
+      { "trait": "hair_twintails", "variant": "blue", "prob": 15 }
     ]
   },
   {
@@ -423,7 +444,10 @@
       { "trait": "hair_bun", "variant": "purple", "prob": 1 },
       { "trait": "hair_braid", "variant": "purple", "prob": 10 },
       { "trait": "hair_puff", "variant": "purple", "prob": 1 },
-      { "trait": "hair_beaded", "variant": "purple", "prob": 5 }
+      { "trait": "hair_beaded", "variant": "purple", "prob": 5 },
+      { "trait": "hair_detective", "variant": "purple", "prob": 15 },
+      { "trait": "hair_super_princess", "variant": "purple", "prob": 15 },
+      { "trait": "hair_twintails", "variant": "purple", "prob": 15 }
     ]
   },
   {
@@ -449,7 +473,10 @@
       { "trait": "hair_bun", "variant": "pink", "prob": 1 },
       { "trait": "hair_braid", "variant": "pink", "prob": 10 },
       { "trait": "hair_puff", "variant": "pink", "prob": 1 },
-      { "trait": "hair_beaded", "variant": "pink", "prob": 5 }
+      { "trait": "hair_beaded", "variant": "pink", "prob": 5 },
+      { "trait": "hair_detective", "variant": "pink", "prob": 15 },
+      { "trait": "hair_super_princess", "variant": "pink", "prob": 15 },
+      { "trait": "hair_twintails", "variant": "pink", "prob": 15 }
     ]
   }
 ]

--- a/data/json/npcs/appearance_trait_groups.json
+++ b/data/json/npcs/appearance_trait_groups.json
@@ -218,7 +218,14 @@
       { "trait": "hair_long_over_eye", "variant": "black", "prob": 10 },
       { "trait": "hair_messy", "variant": "black", "prob": 13 },
       { "trait": "hair_short_over_eye", "variant": "black", "prob": 10 },
-      { "trait": "hair_short_no_fringe", "variant": "black", "prob": 15 }
+      { "trait": "hair_short_no_fringe", "variant": "black", "prob": 15 },
+      { "trait": "hair_punk_long", "variant": "black", "prob": 5 },
+      { "trait": "hair_curls", "variant": "black", "prob": 15 },
+      { "trait": "hair_modern", "variant": "black", "prob": 5 },
+      { "trait": "hair_bun", "variant": "black", "prob": 15 },
+      { "trait": "hair_braid", "variant": "black", "prob": 15 },
+      { "trait": "hair_puff", "variant": "black", "prob": 15 },
+      { "trait": "hair_beaded", "variant": "black", "prob": 15 }
     ]
   },
   {
@@ -237,7 +244,14 @@
       { "trait": "hair_long_over_eye", "variant": "brown", "prob": 10 },
       { "trait": "hair_messy", "variant": "brown", "prob": 13 },
       { "trait": "hair_short_over_eye", "variant": "brown", "prob": 10 },
-      { "trait": "hair_short_no_fringe", "variant": "brown", "prob": 15 }
+      { "trait": "hair_short_no_fringe", "variant": "brown", "prob": 15 },
+      { "trait": "hair_punk_long", "variant": "brown", "prob": 10 },
+      { "trait": "hair_curls", "variant": "brown", "prob": 15 },
+      { "trait": "hair_modern", "variant": "brown", "prob": 10 },
+      { "trait": "hair_bun", "variant": "brown", "prob": 15 },
+      { "trait": "hair_braid", "variant": "brown", "prob": 15 },
+      { "trait": "hair_puff", "variant": "brown", "prob": 15 },
+      { "trait": "hair_beaded", "variant": "brown", "prob": 10 }
     ]
   },
   {
@@ -256,7 +270,14 @@
       { "trait": "hair_long_over_eye", "variant": "blond", "prob": 10 },
       { "trait": "hair_messy", "variant": "blond", "prob": 13 },
       { "trait": "hair_short_over_eye", "variant": "blond", "prob": 10 },
-      { "trait": "hair_short_no_fringe", "variant": "blond", "prob": 15 }
+      { "trait": "hair_short_no_fringe", "variant": "blond", "prob": 15 },
+      { "trait": "hair_punk_long", "variant": "blond", "prob": 1 },
+      { "trait": "hair_curls", "variant": "blond", "prob": 20 },
+      { "trait": "hair_modern", "variant": "blond", "prob": 5 },
+      { "trait": "hair_bun", "variant": "blond", "prob": 20 },
+      { "trait": "hair_braid", "variant": "blond", "prob": 15 },
+      { "trait": "hair_puff", "variant": "blond", "prob": 5 },
+      { "trait": "hair_beaded", "variant": "blond", "prob": 1 }
     ]
   },
   {
@@ -275,7 +296,14 @@
       { "trait": "hair_long_over_eye", "variant": "red", "prob": 10 },
       { "trait": "hair_messy", "variant": "red", "prob": 13 },
       { "trait": "hair_short_over_eye", "variant": "red", "prob": 10 },
-      { "trait": "hair_short_no_fringe", "variant": "red", "prob": 15 }
+      { "trait": "hair_short_no_fringe", "variant": "red", "prob": 15 },
+      { "trait": "hair_punk_long", "variant": "blond", "prob": 1 },
+      { "trait": "hair_curls", "variant": "blond", "prob": 20 },
+      { "trait": "hair_modern", "variant": "blond", "prob": 5 },
+      { "trait": "hair_bun", "variant": "blond", "prob": 20 },
+      { "trait": "hair_braid", "variant": "blond", "prob": 15 },
+      { "trait": "hair_puff", "variant": "blond", "prob": 5 },
+      { "trait": "hair_beaded", "variant": "blond", "prob": 1 }
     ]
   },
   {
@@ -288,7 +316,10 @@
       { "trait": "hair_fro", "variant": "gray", "prob": 1 },
       { "trait": "hair_short", "variant": "gray", "prob": 35 },
       { "trait": "hair_medium", "variant": "gray", "prob": 25 },
-      { "trait": "hair_long", "variant": "gray", "prob": 13 }
+      { "trait": "hair_long", "variant": "gray", "prob": 13 },
+      { "trait": "hair_curls", "variant": "gray", "prob": 20 },
+      { "trait": "hair_braid", "variant": "gray", "prob": 5 },
+      { "trait": "hair_beaded", "variant": "gray", "prob": 10 }
     ]
   },
   {
@@ -307,7 +338,14 @@
       { "trait": "hair_long_over_eye", "variant": "white", "prob": 10 },
       { "trait": "hair_messy", "variant": "white", "prob": 13 },
       { "trait": "hair_short_over_eye", "variant": "white", "prob": 10 },
-      { "trait": "hair_short_no_fringe", "variant": "white", "prob": 15 }
+      { "trait": "hair_short_no_fringe", "variant": "white", "prob": 15 },
+      { "trait": "hair_punk_long", "variant": "white", "prob": 25 },
+      { "trait": "hair_curls", "variant": "white", "prob": 10 },
+      { "trait": "hair_modern", "variant": "white", "prob": 25 },
+      { "trait": "hair_bun", "variant": "white", "prob": 1 },
+      { "trait": "hair_braid", "variant": "white", "prob": 10 },
+      { "trait": "hair_puff", "variant": "white", "prob": 1 },
+      { "trait": "hair_beaded", "variant": "white", "prob": 5 }
     ]
   },
   {
@@ -326,7 +364,14 @@
       { "trait": "hair_fro", "variant": "green", "prob": 1 },
       { "trait": "hair_medium", "variant": "green", "prob": 25 },
       { "trait": "hair_long", "variant": "green", "prob": 13 },
-      { "trait": "hair_short", "variant": "green", "prob": 35 }
+      { "trait": "hair_short", "variant": "green", "prob": 35 },
+      { "trait": "hair_punk_long", "variant": "green", "prob": 25 },
+      { "trait": "hair_curls", "variant": "green", "prob": 10 },
+      { "trait": "hair_modern", "variant": "green", "prob": 25 },
+      { "trait": "hair_bun", "variant": "green", "prob": 1 },
+      { "trait": "hair_braid", "variant": "green", "prob": 10 },
+      { "trait": "hair_puff", "variant": "green", "prob": 1 },
+      { "trait": "hair_beaded", "variant": "green", "prob": 5 }
     ]
   },
   {
@@ -345,7 +390,14 @@
       { "trait": "hair_fro", "variant": "blue", "prob": 1 },
       { "trait": "hair_medium", "variant": "blue", "prob": 25 },
       { "trait": "hair_long", "variant": "blue", "prob": 13 },
-      { "trait": "hair_short", "variant": "blue", "prob": 35 }
+      { "trait": "hair_short", "variant": "blue", "prob": 35 },
+      { "trait": "hair_punk_long", "variant": "blue", "prob": 25 },
+      { "trait": "hair_curls", "variant": "blue", "prob": 10 },
+      { "trait": "hair_modern", "variant": "blue", "prob": 25 },
+      { "trait": "hair_bun", "variant": "blue", "prob": 1 },
+      { "trait": "hair_braid", "variant": "blue", "prob": 10 },
+      { "trait": "hair_puff", "variant": "blue", "prob": 1 },
+      { "trait": "hair_beaded", "variant": "blue", "prob": 5 }
     ]
   },
   {
@@ -364,7 +416,14 @@
       { "trait": "hair_fro", "variant": "purple", "prob": 1 },
       { "trait": "hair_medium", "variant": "purple", "prob": 25 },
       { "trait": "hair_long", "variant": "purple", "prob": 13 },
-      { "trait": "hair_short", "variant": "purple", "prob": 35 }
+      { "trait": "hair_short", "variant": "purple", "prob": 35 },
+      { "trait": "hair_punk_long", "variant": "purple", "prob": 25 },
+      { "trait": "hair_curls", "variant": "purple", "prob": 10 },
+      { "trait": "hair_modern", "variant": "purple", "prob": 25 },
+      { "trait": "hair_bun", "variant": "purple", "prob": 1 },
+      { "trait": "hair_braid", "variant": "purple", "prob": 10 },
+      { "trait": "hair_puff", "variant": "purple", "prob": 1 },
+      { "trait": "hair_beaded", "variant": "purple", "prob": 5 }
     ]
   },
   {
@@ -383,7 +442,14 @@
       { "trait": "hair_fro", "variant": "pink", "prob": 1 },
       { "trait": "hair_medium", "variant": "pink", "prob": 25 },
       { "trait": "hair_long", "variant": "pink", "prob": 13 },
-      { "trait": "hair_short", "variant": "pink", "prob": 35 }
+      { "trait": "hair_short", "variant": "pink", "prob": 35 },
+      { "trait": "hair_punk_long", "variant": "pink", "prob": 25 },
+      { "trait": "hair_curls", "variant": "pink", "prob": 10 },
+      { "trait": "hair_modern", "variant": "pink", "prob": 25 },
+      { "trait": "hair_bun", "variant": "pink", "prob": 1 },
+      { "trait": "hair_braid", "variant": "pink", "prob": 10 },
+      { "trait": "hair_puff", "variant": "pink", "prob": 1 },
+      { "trait": "hair_beaded", "variant": "pink", "prob": 5 }
     ]
   }
 ]

--- a/data/json/npcs/appearance_trait_groups.json
+++ b/data/json/npcs/appearance_trait_groups.json
@@ -226,9 +226,9 @@
       { "trait": "hair_braid", "variant": "black", "prob": 15 },
       { "trait": "hair_puff", "variant": "black", "prob": 15 },
       { "trait": "hair_beaded", "variant": "black", "prob": 15 },
-      { "trait": "hair_detective", "variant": "black", "prob": 5 },
-      { "trait": "hair_super_princess", "variant": "black", "prob": 5 },
-      { "trait": "hair_twintails", "variant": "black", "prob": 5 }
+      { "trait": "hair_detective", "variant": "black", "prob": 1 },
+      { "trait": "hair_super_princess", "variant": "black", "prob": 1 },
+      { "trait": "hair_twintails", "variant": "black", "prob": 1 }
     ]
   },
   {
@@ -255,9 +255,9 @@
       { "trait": "hair_braid", "variant": "brown", "prob": 15 },
       { "trait": "hair_puff", "variant": "brown", "prob": 15 },
       { "trait": "hair_beaded", "variant": "brown", "prob": 10 },
-      { "trait": "hair_detective", "variant": "brown", "prob": 5 },
-      { "trait": "hair_super_princess", "variant": "brown", "prob": 5 },
-      { "trait": "hair_twintails", "variant": "brown", "prob": 5 }
+      { "trait": "hair_detective", "variant": "brown", "prob": 1 },
+      { "trait": "hair_super_princess", "variant": "brown", "prob": 1 },
+      { "trait": "hair_twintails", "variant": "brown", "prob": 1 }
     ]
   },
   {
@@ -284,9 +284,9 @@
       { "trait": "hair_braid", "variant": "blond", "prob": 15 },
       { "trait": "hair_puff", "variant": "blond", "prob": 5 },
       { "trait": "hair_beaded", "variant": "blond", "prob": 1 },
-      { "trait": "hair_detective", "variant": "blond", "prob": 5 },
-      { "trait": "hair_super_princess", "variant": "blond", "prob": 5 },
-      { "trait": "hair_twintails", "variant": "blond", "prob": 5 }
+      { "trait": "hair_detective", "variant": "blond", "prob": 1 },
+      { "trait": "hair_super_princess", "variant": "blond", "prob": 1 },
+      { "trait": "hair_twintails", "variant": "blond", "prob": 1 }
     ]
   },
   {
@@ -313,9 +313,9 @@
       { "trait": "hair_braid", "variant": "red", "prob": 15 },
       { "trait": "hair_puff", "variant": "red", "prob": 5 },
       { "trait": "hair_beaded", "variant": "red", "prob": 1 },
-      { "trait": "hair_detective", "variant": "red", "prob": 10 },
-      { "trait": "hair_super_princess", "variant": "red", "prob": 10 },
-      { "trait": "hair_twintails", "variant": "red", "prob": 10 }
+      { "trait": "hair_detective", "variant": "red", "prob": 1 },
+      { "trait": "hair_super_princess", "variant": "red", "prob": 1 },
+      { "trait": "hair_twintails", "variant": "red", "prob": 1 }
     ]
   },
   {
@@ -358,9 +358,9 @@
       { "trait": "hair_braid", "variant": "white", "prob": 10 },
       { "trait": "hair_puff", "variant": "white", "prob": 1 },
       { "trait": "hair_beaded", "variant": "white", "prob": 5 },
-      { "trait": "hair_detective", "variant": "white", "prob": 10 },
-      { "trait": "hair_super_princess", "variant": "white", "prob": 10 },
-      { "trait": "hair_twintails", "variant": "white", "prob": 10 }
+      { "trait": "hair_detective", "variant": "white", "prob": 1 },
+      { "trait": "hair_super_princess", "variant": "white", "prob": 1 },
+      { "trait": "hair_twintails", "variant": "white", "prob": 1 }
     ]
   },
   {
@@ -387,9 +387,9 @@
       { "trait": "hair_braid", "variant": "green", "prob": 10 },
       { "trait": "hair_puff", "variant": "green", "prob": 1 },
       { "trait": "hair_beaded", "variant": "green", "prob": 5 },
-      { "trait": "hair_detective", "variant": "green", "prob": 15 },
-      { "trait": "hair_super_princess", "variant": "green", "prob": 15 },
-      { "trait": "hair_twintails", "variant": "green", "prob": 15 }
+      { "trait": "hair_detective", "variant": "green", "prob": 1 },
+      { "trait": "hair_super_princess", "variant": "green", "prob": 1 },
+      { "trait": "hair_twintails", "variant": "green", "prob": 1 }
     ]
   },
   {
@@ -416,9 +416,9 @@
       { "trait": "hair_braid", "variant": "blue", "prob": 10 },
       { "trait": "hair_puff", "variant": "blue", "prob": 1 },
       { "trait": "hair_beaded", "variant": "blue", "prob": 5 },
-      { "trait": "hair_detective", "variant": "blue", "prob": 15 },
-      { "trait": "hair_super_princess", "variant": "blue", "prob": 15 },
-      { "trait": "hair_twintails", "variant": "blue", "prob": 15 }
+      { "trait": "hair_detective", "variant": "blue", "prob": 1 },
+      { "trait": "hair_super_princess", "variant": "blue", "prob": 1 },
+      { "trait": "hair_twintails", "variant": "blue", "prob": 1 }
     ]
   },
   {
@@ -445,9 +445,9 @@
       { "trait": "hair_braid", "variant": "purple", "prob": 10 },
       { "trait": "hair_puff", "variant": "purple", "prob": 1 },
       { "trait": "hair_beaded", "variant": "purple", "prob": 5 },
-      { "trait": "hair_detective", "variant": "purple", "prob": 15 },
-      { "trait": "hair_super_princess", "variant": "purple", "prob": 15 },
-      { "trait": "hair_twintails", "variant": "purple", "prob": 15 }
+      { "trait": "hair_detective", "variant": "purple", "prob": 1 },
+      { "trait": "hair_super_princess", "variant": "purple", "prob": 1 },
+      { "trait": "hair_twintails", "variant": "purple", "prob": 1 }
     ]
   },
   {
@@ -474,9 +474,9 @@
       { "trait": "hair_braid", "variant": "pink", "prob": 10 },
       { "trait": "hair_puff", "variant": "pink", "prob": 1 },
       { "trait": "hair_beaded", "variant": "pink", "prob": 5 },
-      { "trait": "hair_detective", "variant": "pink", "prob": 15 },
-      { "trait": "hair_super_princess", "variant": "pink", "prob": 15 },
-      { "trait": "hair_twintails", "variant": "pink", "prob": 15 }
+      { "trait": "hair_detective", "variant": "pink", "prob": 1 },
+      { "trait": "hair_super_princess", "variant": "pink", "prob": 1 },
+      { "trait": "hair_twintails", "variant": "pink", "prob": 1 }
     ]
   }
 ]

--- a/tools/spell_checker/dictionary.txt
+++ b/tools/spell_checker/dictionary.txt
@@ -5086,6 +5086,7 @@ Rochester
 Rockbolt
 rockclimbing
 Rockford
+rockin'
 Rockland
 Rockport
 rockwheel


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Add new hairstyles from Mawranth's Hair Salon"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
@Mawranth posted a few gorgeous sprites in the form of a [mod](https://github.com/Mawranth/Mawranth-Salon.git). Those absolutely deserve to be in the base game but they need the data to host them first, this PR aims to add it.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Checked Mawranth's implementation fixed it a little, formatted it correctly, added bells and whistles such as integration into the new hair growth system and npc distribution.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I am a bit torn on the pop references hairstyles (super princess, detective and twintails), for the time being they're being added as "normal" hairstyles but maybe they should be restricted to haircutting only, maybe they shouldn't spawn on npcs. I'll add them in a single commit so we can revert it just in case. Feel free to help me decide on the way they should be implemented, I need higher-up input here.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Spawned in game, mutated the different hair styles, seems to work fine.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
**ALL CREDITS SHOULD GO TO @Mawranth.** They wrote the descriptions, the names, had the original idea and everything, I am merely making the implementation easier on them.

The PR for the sprites can be found [there](https://github.com/I-am-Erk/CDDA-Tilesets/pull/2360).

I aim to do in this PR the same thing done in #61940 basically.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
