### PR TITLE
Add `weight_on_wheels` method

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -3407,8 +3407,7 @@ units::mass vehicle::weight_on_wheels() const
     units::mass animal_mass = 0_gram;
     for( const int e : engines ) {
         const vehicle_part &vp = parts[e];
-        if( vp.info().fuel_type == fuel_type_animal )
-        {
+        if( vp.info().fuel_type == fuel_type_animal ) {
             monster *mon = get_monster( e );
             if( mon != nullptr && mon->has_effect( effect_harnessed ) ) {
                 animal_mass += mon->get_weight();

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -3410,8 +3410,7 @@ units::mass vehicle::weight_on_wheels() const
         if( vp.info().fuel_type == fuel_type_animal )
         {
             monster *mon = get_monster( e );
-            if( mon != nullptr && mon->has_effect( effect_harnessed ))
-            {
+            if( mon != nullptr && mon->has_effect( effect_harnessed ) ) {
                 animal_mass += mon->get_weight();
             }
         }

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -3401,6 +3401,24 @@ units::mass vehicle::total_mass() const
     return mass_cache;
 }
 
+units::mass vehicle::weight_on_wheels() const
+{
+    const units::mass vehicle_mass = total_mass();
+    units::mass animal_mass = 0_gram;
+    for( const int e : engines ) {
+        const vehicle_part &vp = parts[e];
+        if( vp.info().fuel_type == fuel_type_animal )
+        {
+            monster *mon = get_monster( e );
+            if( mon != nullptr && mon->has_effect( effect_harnessed ))
+            {
+                animal_mass += mon->get_weight();
+            }
+        }
+    }
+    return vehicle_mass - animal_mass;
+}
+
 const point &vehicle::rotated_center_of_mass() const
 {
     // TODO: Bring back caching of this point
@@ -4493,7 +4511,7 @@ float vehicle::k_traction( float wheel_traction_area ) const
     if( fraction_without_traction == 0 ) {
         return 1.0f;
     }
-    const float mass_penalty = fraction_without_traction * to_kilogram( total_mass() );
+    const float mass_penalty = fraction_without_traction * to_kilogram( weight_on_wheels() );
     float traction = std::min( 1.0f, wheel_traction_area / mass_penalty );
     add_msg_debug( debugmode::DF_VEHICLE, "%s has traction %.2f", name, traction );
 

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1518,6 +1518,9 @@ class vehicle
 
         // get the total mass of vehicle, including cargo and passengers
         units::mass total_mass() const;
+        // Get the total mass of the vehicle minus the weight of any creatures that are
+        // powering it; ie, the mass of the vehicle that the wheels are supporting
+        units::mass weight_on_wheels() const;
 
         // Gets the center of mass calculated for precalc[0] coordinates
         const point &rotated_center_of_mass() const;


### PR DESCRIPTION
#### Summary
Bugfixes "Muscle-powered vehicles counting animal weight for traction purposes"

#### Purpose of change
Fixes #73341 

#### Describe the solution
When calculating traction and rolling resistance, the vehicle code used the entire weight of the vehicle to determine the loading that each wheel had. This did not account for the fact that beasts of burden are supporting their own weight and not contributing to the loading on the wheels of the vehicle they are pulling. This caused the issue seen in the original report - the 250kg wagon's wheels were bearing the weight of 2200 kg of horse, causing extremely low offroad traction and acceleration.

This changes adds a new function `weight_on_wheels` which returns the mass of the vehicle minus the weight of any harnessed creatures. This function is used in the two places where the mass of the vehicle is used to calculate loading effects on the wheels - traction and rolling resistance.

#### Describe alternatives you've considered
Making this a cached value that is calculated whenever `mass_cache` is. I didn't notice any performance issues but I'll admit that I wasn't looking for them.

#### Testing
Spawned two wagons and upgraded one of them to a four-horse configuration. Examined the rolling resistance and offroad rating of each with and without harnessed animals and observed no meaningful difference. Did some racing both on and off road and with a load:

| horse count | surface | load | time to 16 mph |
| -- | -- | -- | -- |
| 2 | road | 0 | 10s |
| 2 | road | 450 kg | 14s |
| 2 | dirt | 0 | 10s |
| 2 | dirt | 450 kg | n/a* |
| 4 | road | 0 | 13s |
| 4 | road | 450 kg | 19s |
| 4 | dirt | 0 | 13s |
| 4 | dirt | 450 kg | 31s |
* the vehicle topped out at 13 mph around 28 seconds

Without a load, both vehicles have an offroad rating of 100%, so they perform the same on dirt and pavement. With the load, this drops to 20%, and the power from the additional horses makes the difference

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
