### PR TITLE
Fix GCC 9: initialize to `nullptr`

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8598,10 +8598,10 @@ game::vmenu_ret game::list_items( const std::vector<map_item_stack> &item_list )
                     col = iter->example->color_in_inventory();
                 }
                 bool print_new = highlight_unread_items;
-                const std::string *new_str;
+                const std::string *new_str = nullptr;
                 // 1 make space between item description and right padding (distance)
                 int new_width = 1;
-                const nc_color *new_col;
+                const nc_color *new_col = nullptr;
                 if( print_new ) {
                     switch( check_items_newness( iter->example ) ) {
                         case content_newness::NEW:


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

#73400 broke tests, I believe this is what ~Clang~ GCC, Curses, LTO 9 wants

#### Describe the solution

initialize to `nullptr`. So it is still undefined behaviour, but at least the value is initialized.

#### Describe alternatives you've considered

Ask if this is correct.

#### Testing

Let's see it compile

Broken tests in #73400 https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/8927978126/job/24523240306
Fixed tests here https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/8946092853/job/24576537951?pr=73473

#### Additional context

Mergers always surprise me with their sudden speed. I should have written "Do not merge yet!" before I went to sleep when I noticed it. Instead of relying on the merger to go through all the tests.