### PR TITLE
add combat exoskeleton template to aftershock nanofab

### DIFF
--- a/data/mods/Aftershock/maps/furniture_and_terrain/terrain_manufactured.json
+++ b/data/mods/Aftershock/maps/furniture_and_terrain/terrain_manufactured.json
@@ -5,7 +5,12 @@
     "name": "nanofabricator control panel",
     "symbol": "&",
     "description": "A small computer panel attached to a nanofabricator.  It has a single slot for reading templates.",
-    "allowed_template_ids": [ "standard_template_construct", "standard_template_construct_combat_exoskeleton", "debug_template", "afs_10mm_smart_template" ],
+    "allowed_template_ids": [
+      "standard_template_construct",
+      "standard_template_construct_combat_exoskeleton",
+      "debug_template",
+      "afs_10mm_smart_template"
+    ],
     "color": "red",
     "looks_like": "f_console",
     "move_cost": 0,

--- a/data/mods/Aftershock/maps/furniture_and_terrain/terrain_manufactured.json
+++ b/data/mods/Aftershock/maps/furniture_and_terrain/terrain_manufactured.json
@@ -5,7 +5,7 @@
     "name": "nanofabricator control panel",
     "symbol": "&",
     "description": "A small computer panel attached to a nanofabricator.  It has a single slot for reading templates.",
-    "allowed_template_ids": [ "standard_template_construct", "debug_template", "afs_10mm_smart_template" ],
+    "allowed_template_ids": [ "standard_template_construct", "standard_template_construct_combat_exoskeleton", "debug_template", "afs_10mm_smart_template" ],
     "color": "red",
     "looks_like": "f_console",
     "move_cost": 0,


### PR DESCRIPTION
#### Summary
Bugfixes "Add Combat Exoskeleton template to Aftershock Nanofabricator"

#### Purpose of change

Allow the new combat exoskeleton nanofabricator templates to be used with nanofabricators when running the Aftershock mod.

#### Describe the solution

Aftershock overwrites the standard nanofabricator control panel to allow for the use of the mods Wraitheon production chips. The overwrite needs to be updated to allow for the use of the recently added combat exoskeleton templates added by #68758

#### Describe alternatives you've considered

Ideally there would be a way for Aftershock to extend the existing definition of the nanofabricator control panel terrain's allowed template ids rather than overwrite, but I'm not aware of an existing means for doing so.

#### Testing

Added the id for the combat exoskeleton template to the list of allowed nanofabricator templates in aftershock, loaded game, and was able to produce combat exoskeleton parts at a nanofabricator as expected.
