### PR TITLE
Changed map::shift to call add_roofs and compressed the code

### DIFF
--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -115,6 +115,7 @@ static const ter_str_id ter_t_dirt( "t_dirt" );
 static const ter_str_id ter_t_hole( "t_hole" );
 static const ter_str_id ter_t_ladder_up( "t_ladder_up" );
 static const ter_str_id ter_t_lava( "t_lava" );
+static const ter_str_id ter_t_open_air( "t_open_air" );
 static const ter_str_id ter_t_pit( "t_pit" );
 static const ter_str_id ter_t_ramp_down_high( "t_ramp_down_high" );
 static const ter_str_id ter_t_ramp_down_low( "t_ramp_down_low" );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -8058,7 +8058,7 @@ void map::shift( const point &sp )
                 loadn( point( gridx, gridy ), true );
 
                 for( int gridz = zmin; gridz <= zmax; gridz++ ) {
-                    loaded_grids.emplace_back( tripoint( gridx, gridy, gridz ) );
+                    loaded_grids.emplace_back( gridx, gridy, gridz );
                 }
             }
         }
@@ -8694,7 +8694,7 @@ void map::add_roofs( const tripoint &grid )
     for( int x = 0; x < SEEX; x++ ) {
         for( int y = 0; y < SEEY; y++ ) {
             const ter_id ter_here = sub_here->get_ter( { x, y } );
-            if( !ter_here->has_flag( "EMPTY_SPACE" ) ) {
+            if( ter_here.id() != ter_t_open_air ) {
                 continue;
             }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fix #73474, i.e. failure to generate treetops "randomly".
Fix recent bug introduced into add_roofs: when looking for terrain to add roofs to, the ground beneath the deep water got it placed over the deep water. Reverted the logic back to what it was before Empty Space was introduced.
Put it into this PR because this is what makes it apparent (of add_roofs aren't called, bugs in it won't be noticed).

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Change map::shift to call the loadn operation that calls add_roofs and processes all Z levels in a single call. This required a change to how the Z level loop is organized. Also changed nested 'if' logic with essentially repeated code in each to figure out which direction in which to iterate up front and get rid of the duplicated code.

Rejected calls from maps that don't support Z levels, as such calls would make little sense (and there aren't any currently), as well as offsets out of bounds (rather than just issue a debug message) to ensure nothing blows up further down due to an unsupported offset.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Also typifying the code.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Loading a save and walk in all 8 directions and look at tree tops when trees were encountered. No treetops found to be absent. Also stepped a few levels down stairs and a level up to a roof.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I wouldn't mind if a reviewer double checked the logic for iterations and determination that submaps have to be loaded.

It can also be noted that the changed code processes submaps in a different order from before when it comes to Z levels and stores newly loaded submap coordinates in a different order. However, I don't think the Z level processing order matters, and I don't think the order in which loaded grid coordinates are processed by 'actualize' matters.

Also, I failed to see any reason the Z level cache handling would have to be done in conjunction with the actual shifting (the cache variable isn't used further), and so concluded it can all be done before the shifting, rather than integrated in the same loop.

This ought to fix all game play cases of magic treetop/roof placement associated with the loading of generated maps. Dynamic changes to maps aren't addressed until affected maps are loaded (or associated code explicitly places what should be placed, rather than relying on loading being triggered).
The game play condition is made because I don't really understand how the editmap stuff works. It may or may not require something to trigger a loading of the third dimension.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
