### PR TITLE
Revert "Bow reload time fix (#73305)"

### DIFF
--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -48,14 +48,13 @@ class aim_activity_actor : public activity_actor
         std::vector<tripoint> fin_trajectory;
 
     public:
+        bool first_turn = true;
         std::string action;
         int aif_duration = 0; // Counts aim-and-fire duration
         bool aiming_at_critter = false; // Whether aiming at critter or a tile
         bool snap_to_target = false;
         /** Not to try to unload RELOAD_AND_SHOOT weapon if it is not loaded */
         bool loaded_RAS_weapon = false;
-        /* Item location for RAS weapon reload */
-        item_location reload_loc = item_location();
         bool shifting_view = false;
         tripoint initial_view_offset;
         /** Target UI requested to abort aiming */

--- a/src/character.h
+++ b/src/character.h
@@ -3129,7 +3129,7 @@ class Character : public Creature, public visitable
          *  @param gun item to fire (which does not necessary have to be in the players possession)
          *  @return number of shots actually fired
          */
-        int fire_gun( const tripoint &target, int shots, item &gun, item_location ammo = item_location() );
+        int fire_gun( const tripoint &target, int shots, item &gun );
         /** Execute a throw */
         dealt_projectile_attack throw_item( const tripoint &target, const item &to_throw,
                                             const std::optional<tripoint> &blind_throw_from_pos = std::nullopt );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -1730,7 +1730,7 @@ void npc::execute_action( npc_action action )
             if( is_hallucination() ) {
                 pretend_fire( this, mode.qty, *mode );
             } else {
-                fire_gun( tar, mode.qty, *mode, item_location() );
+                fire_gun( tar, mode.qty, *mode );
                 // "discard" the fake bio weapon after shooting it
                 if( is_using_bionic_weapon() ) {
                     discharge_cbm_weapon();

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -155,8 +155,7 @@ static const std::set<material_id> ferric = { material_iron, material_steel, mat
 static constexpr int AIF_DURATION_LIMIT = 10;
 
 static projectile make_gun_projectile( const item &gun );
-static int NPC_time_to_attack( const Character &p, const itype &firing );
-static int time_to_attack( const Character &p, const item &firing, const item_location &loc );
+static int time_to_attack( const Character &p, const itype &firing );
 /**
 * Handle spent ammo casings and linkages.
 * @param weap   Weapon.
@@ -368,9 +367,6 @@ class target_ui
         // how much they moved their aim point.
         // Relevant for TargetMode::Fire
         void apply_aim_turning_penalty() const;
-
-        // Update range & ammo from current gun mode
-        void update_ammo_range_from_gun_mode();
 
         // Switch firing mode.
         bool action_switch_mode();
@@ -865,10 +861,10 @@ int Character::fire_gun( const tripoint &target, int shots )
         debugmsg( "%s doesn't have a gun to fire", get_name() );
         return 0;
     }
-    return fire_gun( target, shots, *gun, item_location() );
+    return fire_gun( target, shots, *gun );
 }
 
-int Character::fire_gun( const tripoint &target, int shots, item &gun, item_location ammo )
+int Character::fire_gun( const tripoint &target, int shots, item &gun )
 {
     if( !gun.is_gun() ) {
         debugmsg( "%s tried to fire non-gun (%s).", get_name(), gun.tname() );
@@ -878,10 +874,6 @@ int Character::fire_gun( const tripoint &target, int shots, item &gun, item_loca
         add_msg_if_player( _( "A shotgun equipped with choke cannot fire slugs." ) );
         return 0;
     }
-    if( gun.ammo_required() > 0 && !gun.ammo_remaining() && !ammo ) {
-        debugmsg( "%s's gun %s is empty and has no ammo for reloading.", gun.tname() );
-        return 0;
-    }
     bool is_mech_weapon = false;
     if( is_mounted() &&
         mounted_creature->has_flag( mon_flag_RIDEABLE_MECH ) ) {
@@ -889,17 +881,15 @@ int Character::fire_gun( const tripoint &target, int shots, item &gun, item_loca
     }
 
     // cap our maximum burst size by ammo and energy
-    if( !gun.has_flag( flag_VEHICLE ) && !ammo ) {
+    if( !gun.has_flag( flag_VEHICLE ) ) {
         shots = std::min( shots, gun.shots_remaining( this ) );
     } else if( gun.ammo_required() ) {
         // This checks ammo only. Vehicle turret energy drain is handled elsewhere.
-        const int ammo_left = ammo ? ammo.get_item()->count() : gun.ammo_remaining();
-        shots = std::min( shots, ammo_left / gun.ammo_required() );
+        shots = std::min( shots, static_cast<int>( gun.ammo_remaining() / gun.ammo_required() ) );
     }
 
     if( shots <= 0 ) {
         debugmsg( "Attempted to fire zero or negative shots using %s", gun.tname() );
-        return 0;
     }
 
     map &here = get_map();
@@ -920,7 +910,6 @@ int Character::fire_gun( const tripoint &target, int shots, item &gun, item_loca
                               static_cast<float>( MAX_SKILL ) ) / static_cast<double>( MAX_SKILL * 2 );
 
     itype_id gun_id = gun.typeId();
-    int attack_moves = time_to_attack( *this, gun, ammo );
     skill_id gun_skill = gun.gun_skill();
     add_msg_debug( debugmode::DF_RANGED, "Gun skill (%s) %g", gun_skill.c_str(),
                    get_skill_level( gun_skill ) ) ;
@@ -929,9 +918,6 @@ int Character::fire_gun( const tripoint &target, int shots, item &gun, item_loca
     int hits = 0; // total shots on target
     int delay = 0; // delayed recoil that has yet to be applied
     while( curshot != shots ) {
-        if( !!ammo && !gun.ammo_remaining() ) {
-            gun.reload( get_avatar(), ammo, 1 );
-        }
         if( gun.faults.count( fault_gun_chamber_spent ) && curshot == 0 ) {
             mod_moves( -get_speed() * 0.5 );
             gun.faults.erase( fault_gun_chamber_spent );
@@ -1071,7 +1057,7 @@ int Character::fire_gun( const tripoint &target, int shots, item &gun, item_loca
         }
     }
     // Use different amounts of time depending on the type of gun and our skill
-    mod_moves( -attack_moves );
+    mod_moves( -time_to_attack( *this, *gun_id ) );
 
     const islot_gun &firing = *gun.type->gun;
     for( const std::pair<const bodypart_str_id, int> &hurt_part : firing.hurt_part_when_fired ) {
@@ -1707,7 +1693,7 @@ static std::vector<aim_type_prediction> calculate_ranged_chances(
     const target_ui &ui, const Character &you,
     target_ui::TargetMode mode, const input_context &ctxt, const item &weapon,
     const dispersion_sources &dispersion, const std::vector<confidence_rating> &confidence_ratings,
-    const Target_attributes &target, const tripoint &pos, const item_location &load_loc )
+    const Target_attributes &target, const tripoint &pos )
 {
     std::vector<aim_type> aim_types { get_default_aim_type() };
     std::vector<aim_type_prediction> aim_outputs;
@@ -1738,8 +1724,7 @@ static std::vector<aim_type_prediction> calculate_ranged_chances(
             prediction.moves = throw_moves;
         } else {
             prediction.moves = predict_recoil( you, weapon, target, ui.get_sight_dispersion(), aim_type,
-                                               you.recoil ).moves + time_to_attack( you, weapon,
-                                                       load_loc );
+                                               you.recoil ).moves + time_to_attack( you, *weapon.type );
         }
 
         // if the default method is "behind" the selected; e.g. you are in immediate
@@ -1954,8 +1939,7 @@ static bool pl_sees( const Creature &cr )
 }
 
 static int print_aim( const target_ui &ui, Character &you, const catacurses::window &w,
-                      int line_number, input_context &ctxt, const item &weapon, const tripoint &pos,
-                      item_location &load_loc )
+                      int line_number, input_context &ctxt, const item &weapon, const tripoint &pos )
 {
     // This is absolute accuracy for the player.
     // TODO: push the calculations duplicated from Creature::deal_projectile_attack() and
@@ -1975,7 +1959,7 @@ static int print_aim( const target_ui &ui, Character &you, const catacurses::win
 
     const std::vector<aim_type_prediction> aim_chances = calculate_ranged_chances( ui, you,
             target_ui::TargetMode::Fire, ctxt, weapon, dispersion, confidence_config,
-            Target_attributes( you.pos(), pos ), pos, load_loc );
+            Target_attributes( you.pos(), pos ), pos );
 
     return print_ranged_chance( w, line_number, aim_chances );
 }
@@ -2014,8 +1998,7 @@ static void draw_throw_aim( const target_ui &ui, const Character &you, const cat
                                   you.sees( target_pos ) );
 
     const std::vector<aim_type_prediction> aim_chances = calculate_ranged_chances( ui, you,
-            throwing_target_mode, ctxt, weapon, dispersion, confidence_config, attributes, target_pos,
-            item_location() );
+            throwing_target_mode, ctxt, weapon, dispersion, confidence_config, attributes, target_pos );
 
     text_y = print_ranged_chance( w, text_y, aim_chances );
 }
@@ -2121,33 +2104,13 @@ static projectile make_gun_projectile( const item &gun )
     return proj;
 }
 
-int NPC_time_to_attack( const Character &p, const itype &firing )
+int time_to_attack( const Character &p, const itype &firing )
 {
     const skill_id &skill_used = firing.gun->skill_used;
     const time_info_t &info = skill_used->time_to_attack();
     return std::max( info.min_time,
                      static_cast<int>( round( info.base_time - info.time_reduction_per_level * p.get_skill_level(
                                            skill_used ) ) ) );
-}
-
-int time_to_attack( const Character &p, const item &firing, const item_location &loc )
-{
-    const skill_id &skill_used = firing.type->gun->skill_used;
-    const time_info_t &info = skill_used->time_to_attack();
-    int RAS_time = 0;
-    if( !loc ) {
-        RAS_time = 0;
-    } else {
-        // At low stamina levels, firing starts getting slow.
-        const item_location gun = p.get_wielded_item();
-        int sta_percent = ( 100 * p.get_stamina() ) / p.get_stamina_max();
-        RAS_time += ( sta_percent < 25 ) ? ( ( 25 - sta_percent ) * 2 ) : 0;
-        item::reload_option opt = item::reload_option( &p, gun, loc );
-        RAS_time += opt.moves();
-    }
-    return std::max( info.min_time,
-                     static_cast<int>( round( info.base_time - info.time_reduction_per_level * p.get_skill_level(
-                                           skill_used ) ) ) + RAS_time );
 }
 
 static void cycle_action( item &weap, const itype_id &ammo, const tripoint &pos )
@@ -2419,7 +2382,7 @@ double Character::gun_value( const item &weap, int ammo ) const
         damage_factor += 0.5f * gun_damage.damage_units.front().res_pen;
     }
 
-    int move_cost = NPC_time_to_attack( *this, *weap.type );
+    int move_cost = time_to_attack( *this, *weap.type );
     if( gun.clip != 0 && gun.clip < 10 ) {
         // TODO: RELOAD_ONE should get a penalty here
         int reload_cost = gun.reload_time + encumb( bodypart_id( "hand_l" ) ) + encumb(
@@ -2503,7 +2466,6 @@ target_handler::trajectory target_ui::run()
         you->add_msg_if_player( m_bad, _( "You don't have enough %s to cast this spell" ),
                                 casting->energy_string() );
     } else if( mode == TargetMode::Fire ) {
-        update_ammo_range_from_gun_mode();
         sight_dispersion = you->most_accurate_aiming_method_limit( *relevant );
     }
 
@@ -2543,7 +2505,7 @@ target_handler::trajectory target_ui::run()
     bool attack_was_confirmed = false;
     bool reentered = false;
     bool resume_critter = false;
-    if( mode == TargetMode::Fire && !activity->action.empty() ) {
+    if( mode == TargetMode::Fire && !activity->first_turn ) {
         // We were in this UI during previous turn...
         reentered = true;
         std::string act_data = activity->action;
@@ -2597,7 +2559,7 @@ target_handler::trajectory target_ui::run()
             action.clear();
             attack_was_confirmed = false;
         }
-        if( !action.empty() && !prompt_friendlies_in_lof() ) {
+        if( !activity->first_turn && !action.empty() && !prompt_friendlies_in_lof() ) {
             // A friendly creature moved into line of fire during aim-and-shoot,
             // and player decided to stop aiming
             action.clear();
@@ -3339,34 +3301,6 @@ void target_ui::apply_aim_turning_penalty() const
     you->recoil = predicted_recoil;
 }
 
-void target_ui::update_ammo_range_from_gun_mode()
-{
-    if( mode == TargetMode::TurretManual ) {
-        itype_id ammo_current = turret->ammo_current();
-        if( ammo_current.is_null() ) {
-            ammo = nullptr;
-            range = 0;
-        } else {
-            ammo = item::find_type( ammo_current );
-            range = turret->range();
-        }
-    } else {
-        if( relevant->gun_current_mode().melee() ) {
-            range = relevant->current_reach_range( *you );
-        } else {
-            ammo = activity->reload_loc ? activity->reload_loc.get_item()->type :
-                   relevant->gun_current_mode().target->ammo_data();
-            if( activity->reload_loc ) {
-                item temp_weapon = *relevant;
-                temp_weapon.ammo_set( ammo->get_id() );
-                range = temp_weapon.gun_current_mode().target->gun_range( you );
-            } else {
-                range = relevant->gun_current_mode().target->gun_range( you );
-            }
-        }
-    }
-}
-
 bool target_ui::action_switch_mode()
 {
     uilist menu;
@@ -3455,15 +3389,8 @@ bool target_ui::action_switch_mode()
             refresh = true;
             range = relevant->current_reach_range( *you );
         } else {
-            ammo = activity->reload_loc ? activity->reload_loc.get_item()->type :
-                   relevant->gun_current_mode().target->ammo_data();
-            if( activity->reload_loc ) {
-                item temp_weapon = *relevant;
-                temp_weapon.ammo_set( ammo->get_id() );
-                range = temp_weapon.gun_current_mode().target->gun_range( you );
-            } else {
-                range = relevant->gun_current_mode().target->gun_range( you );
-            }
+            range = relevant->gun_current_mode().target->gun_range( you );
+            ammo = relevant->gun_current_mode().target->ammo_data();
         }
     }
 
@@ -3659,9 +3586,7 @@ void target_ui::draw_ui_window()
     } else if( status == Status::Good ) {
         // TODO: these are old, consider refactoring
         if( mode == TargetMode::Fire ) {
-            item_location load_loc = activity->reload_loc;
-            text_y = print_aim( *this, *you, w_target, text_y, ctxt, *relevant->gun_current_mode(), dst,
-                                load_loc );
+            text_y = print_aim( *this, *you, w_target, text_y, ctxt, *relevant->gun_current_mode(), dst );
         } else if( mode == TargetMode::Throw || mode == TargetMode::ThrowBlind ) {
             bool blind = mode == TargetMode::ThrowBlind;
             draw_throw_aim( *this, *you, w_target, text_y, ctxt, *relevant, dst, blind );

--- a/src/turret.cpp
+++ b/src/turret.cpp
@@ -317,7 +317,7 @@ int turret_data::fire( Character &c, const tripoint &target )
     gun_mode mode = base()->gun_current_mode();
 
     prepare_fire( c );
-    shots = c.fire_gun( target, mode.qty, *mode, item_location() );
+    shots = c.fire_gun( target, mode.qty, *mode );
     post_fire( c, shots );
     return shots;
 }

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -1174,7 +1174,7 @@ TEST_CASE( "EOC_combat_event_test", "[eoc]" )
         get_avatar().set_body();
         arm_shooter( get_avatar(), "shotgun_s" );
         get_avatar().recoil = 0;
-        get_avatar().fire_gun( target_pos, 1, *get_avatar().get_wielded_item(), item_location() );
+        get_avatar().fire_gun( target_pos, 1, *get_avatar().get_wielded_item() );
         if( !npc_dst_ranged.get_value( "npctalk_var_test_event_last_event" ).empty() ) {
             break;
         }
@@ -1194,7 +1194,7 @@ TEST_CASE( "EOC_combat_event_test", "[eoc]" )
         get_avatar().set_body();
         arm_shooter( get_avatar(), "shotgun_s" );
         get_avatar().recoil = 0;
-        get_avatar().fire_gun( mon_dst_ranged.pos(), 1, *get_avatar().get_wielded_item(), item_location() );
+        get_avatar().fire_gun( mon_dst_ranged.pos(), 1, *get_avatar().get_wielded_item() );
         if( !mon_dst_ranged.get_value( "npctalk_var_test_event_last_event" ).empty() ) {
             break;
         }

--- a/tests/ranged_balance_test.cpp
+++ b/tests/ranged_balance_test.cpp
@@ -459,7 +459,7 @@ static void shoot_monster( const std::string &gun_type, const std::vector<std::s
         shooter->recoil = 0;
         monster &mon = spawn_test_monster( monster_type, monster_pos, false );
         const int prev_HP = mon.get_hp();
-        shooter->fire_gun( monster_pos, 1, *shooter->get_wielded_item(), item_location() );
+        shooter->fire_gun( monster_pos, 1, *shooter->get_wielded_item() );
         damage.add( prev_HP - mon.get_hp() );
         if( damage.margin_of_error() < 0.05 && damage.n() > 100 ) {
             break;

--- a/tests/reload_time_test.cpp
+++ b/tests/reload_time_test.cpp
@@ -3,26 +3,18 @@
 #include "activity_actor_definitions.h"
 #include "avatar.h"
 #include "calendar.h"
-#include "creature_tracker.h"
-#include <game.h>
 #include "item.h"
 #include "map.h"
 #include "player_helpers.h"
 #include "point.h"
 
 #include <string>
-#include "map_helpers.h"
-
-static const mtype_id pseudo_debug_mon( "pseudo_debug_mon" );
 
 static void check_reload_time( const std::string &weapon, const std::string &ammo,
                                const std::string &container, int expected_moves )
 {
     const tripoint test_origin( 60, 60, 0 );
-    const tripoint spot( 61, 60, 0 );
-    clear_map();
     avatar &shooter = get_avatar();
-    g->place_critter_at( pseudo_debug_mon, spot );
     shooter.setpos( test_origin );
     shooter.set_wielded_item( item( weapon, calendar::turn_zero, 0 ) );
     if( container.empty() ) {
@@ -45,7 +37,7 @@ static void check_reload_time( const std::string &weapon, const std::string &amm
     CAPTURE( shooter.used_weapon()->get_reload_time() );
     aim_activity_actor act = aim_activity_actor::use_wielded();
     int moves_before = shooter.get_moves();
-    REQUIRE( shooter.fire_gun( spot, 1, *shooter.used_weapon(), shooter.ammo_location ) );
+    REQUIRE( act.load_RAS_weapon() );
     int moves_after = shooter.get_moves();
     int spent_moves = moves_before - moves_after;
     int expected_upper = expected_moves * 1.05;
@@ -60,47 +52,47 @@ TEST_CASE( "reload_from_inventory_times", "[reload],[inventory],[balance]" )
     clear_avatar();
     SECTION( "reloading a slingshot" ) {
         SECTION( "from a backpack" ) {
-            check_reload_time( "slingshot", "pebble", "backpack", 400 );
+            check_reload_time( "slingshot", "pebble", "backpack", 350 );
         }
         SECTION( "from an ammo pouch" ) {
-            check_reload_time( "slingshot", "pebble", "ammo_pouch", 137 );
+            check_reload_time( "slingshot", "pebble", "ammo_pouch", 87 );
         }
         SECTION( "from a tool belt" ) {
-            check_reload_time( "slingshot", "pebble", "tool_belt", 200 );
+            check_reload_time( "slingshot", "pebble", "tool_belt", 150 );
         }
         SECTION( "from a pocket" ) {
-            check_reload_time( "slingshot", "pebble", "pants", 200 );
+            check_reload_time( "slingshot", "pebble", "pants", 150 );
         }
         SECTION( "from the ground" ) {
-            check_reload_time( "slingshot", "pebble", "", 180 );
+            check_reload_time( "slingshot", "pebble", "", 130 );
         }
     }
     SECTION( "reloading a staff sling" ) {
         SECTION( "from a backpack" ) {
-            check_reload_time( "staff_sling", "rock", "backpack", 595 );
+            check_reload_time( "staff_sling", "rock", "backpack", 375 );
         }
         SECTION( "from a stone pouch" ) {
-            check_reload_time( "staff_sling", "rock", "stone_pouch", 315 );
+            check_reload_time( "staff_sling", "rock", "stone_pouch", 95 );
         }
         SECTION( "from a tool belt" ) {
-            check_reload_time( "staff_sling", "rock", "tool_belt", 380 );
+            check_reload_time( "staff_sling", "rock", "tool_belt", 160 );
         }
         SECTION( "from a pocket" ) {
-            check_reload_time( "staff_sling", "rock", "pants", 395 );
+            check_reload_time( "staff_sling", "rock", "pants", 175 );
         }
         SECTION( "from the ground" ) {
-            check_reload_time( "staff_sling", "rock", "", 370 );
+            check_reload_time( "staff_sling", "rock", "", 150 );
         }
     }
     SECTION( "reloading a bow" ) {
         SECTION( "from a duffel bag" ) {
-            check_reload_time( "longbow", "arrow_wood", "long_duffelbag", 410 );
+            check_reload_time( "longbow", "arrow_wood", "long_duffelbag", 360 );
         }
         SECTION( "from a quiver" ) {
-            check_reload_time( "longbow", "arrow_wood", "quiver", 130 );
+            check_reload_time( "longbow", "arrow_wood", "quiver", 80 );
         }
         SECTION( "from the ground" ) {
-            check_reload_time( "longbow", "arrow_wood", "", 190 );
+            check_reload_time( "longbow", "arrow_wood", "", 140 );
         }
     }
 }


### PR DESCRIPTION
This reverts commit da07b2aa8c97b9a2fd2737afcfdab9f6f549de49.

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

#73305 is a port of a bright nights pr which in turn was a port of #59977. There's no proper attribution in 73305 for the changes made by BN contributors, which is in violation of our license, but also I'm not sure what's going on here: as far as I can tell the changes made by the BN contributors were to suit the differences in their code base and aren't appropriate for a direct port to DDA. From a scan, it looks like the PR does new things, which then just confuses me because it's framed as a port of a BN change. Regardless, the attribution issue is an urgent one needing reversion and repair.

#### Describe the solution

Revert, try again if necessary.

#### Describe alternatives you've considered

None, attribution issues are a big deal.

#### Testing
n/a
