### PR TITLE
Made army and USMC bayonets look like National Guard bayonets

### DIFF
--- a/data/json/items/melee/swords_and_blades.json
+++ b/data/json/items/melee/swords_and_blades.json
@@ -312,6 +312,7 @@
     "material": [ "hc_steel", "plastic" ],
     "symbol": ";",
     "color": "dark_gray",
+    "looks_like": "knife_combat",
     "gunmod_data": {
       "location": "bayonet lug",
       "mod_targets": [ "pistol", "smg", "rifle", "shotgun", "launcher", "crossbow" ],
@@ -383,6 +384,7 @@
     "material": [ "steel", "plastic" ],
     "symbol": ";",
     "color": "dark_gray",
+    "looks_like": "knife_combat",
     "gunmod_data": {
       "location": "bayonet lug",
       "mod_targets": [ "pistol", "smg", "rifle", "shotgun", "launcher", "crossbow" ],


### PR DESCRIPTION
#### Summary
Features "make army and marine bayonets look like national guard bayonets"

#### Purpose of change

Added "looks_like": "knife_combat", to both army and marine bayonets. Previously they would appear as a semicolon even on tilesets that had sprites for the national guard bayonet.

#### Describe the solution

This change makes the army and marine bayonets share sprites with the national guard bayonets.

#### Describe alternatives you've considered

Creating unique sprites for the army and marine bayonets.

#### Testing

I don't think such a small change warranted any testing.