### PR TITLE
Recalculate weight when inventory changes due to pet carrier use

### DIFF
--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -8005,6 +8005,7 @@ std::optional<int> iuse::capture_monster_act( Character *p, item *it, const trip
         const std::string contained_name = it->get_var( "contained_name", "" );
 
         if( it->release_monster( pos ) ) {
+            p->invalidate_weight_carried_cache();
             // It's been activated somewhere where there isn't a player or monster, good.
             return 0;
         }
@@ -8022,6 +8023,7 @@ std::optional<int> iuse::capture_monster_act( Character *p, item *it, const trip
             }
             if( it->release_monster( *pos_ ) ) {
                 p->add_msg_if_player( _( "You release the %s." ), contained_name );
+                p->invalidate_weight_carried_cache();
                 return 0;
             }
             p->add_msg_if_player( m_info, _( "You can't place the %s there!" ), contained_name );
@@ -8069,6 +8071,7 @@ std::optional<int> iuse::capture_monster_act( Character *p, item *it, const trip
             if( f.friendly != 0 || one_in( chance ) ) {
                 p->add_msg_if_player( _( "You capture the %1$s in your %2$s." ),
                                       f.type->nname(), it->tname() );
+                p->invalidate_weight_carried_cache();
                 return it->contain_monster( target );
             } else {
                 p->add_msg_if_player( m_bad, _( "The %1$s avoids your attempts to put it in the %2$s." ),


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Fixes #73450 

This problem wasn't apparent before because vanilla's pet carrier is limited to animals of SMALL size or less. Sky island's version lets you capture HUGE.

#### Describe the solution
Invalidate the using character's cached weight whenever an animal is captured or released

#### Describe alternatives you've considered
item::set_var() would also be a good place to call this, but it doesn't have knowledge of what character it is or isn't attached to

#### Testing
Captured a horse, got knocked to the ground immediately. Released the horse, was able to get up without any other inventory changes.

#### Additional context
