### PR TITLE
fix: AIM Now moving all items will not move favourite items, if other items are present.

### DIFF
--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -987,7 +987,7 @@ bool advanced_inventory::fill_lists_with_pane_items( Character &player_character
         item_list.push_back( entry.second );
     }
     for( const move_all_entry &entry : unsorted_fav_list ) {
-        item_list.push_back( entry.second );
+        fav_list.push_back( entry.second );
     }
     return true;
 }


### PR DESCRIPTION
#### Summary
Bugfixes "Now moving all items will not move favourite items, if other items are present."

#### Purpose of change

fix #73510

#### Describe the solution

There was a typo. The code ignored whether an item is favourited when all items couldn't fit into the destination.

I fixed that typo.

If the destination doesn't fit all moved items, then the current implementation behaves the same when:
1. You have items and favourite items.
2. You only have non-favourite items.

In either case, it only tries to move non-favourite items. Even if only favourite items fit.

#### Describe alternatives you've considered

Now when no ordinary items fit into the destination, but some favourite items do, nothing happens.
I concluded this is preferred behaviour over asking the player if they want to move favourite items, since no non-favourite items fit. This would lead to more frustration than benefit I believe. Also, this is less code. Also, the original author probably wanted the current implementation.

Possible frustration scenario:
1. The player doesn't read the second prompt.
2. "Yeah sure."
6. "Wait what? Why did it move my favourite item, when I still have a pillow to be moved?"

Another frustration / time-wasting scenario: The player reads the prompts and is annoyed that whenever the vehicle is full of loot, it asks them if they want to move their bandage.

#### Testing

Tried to move favourite `* 0.12L hunting knife` and `3.5L down-filled blanket` to destination with 1L space. It asked, "Not all fits, move anyway?"

#### Additional context
