### PR TITLE
Maps only highlight newly revealed OMTs

### DIFF
--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1226,6 +1226,9 @@ std::optional<int> reveal_map_actor::use( Character *p, item &it, const tripoint
     if( !message.empty() ) {
         p->add_msg_if_player( m_good, "%s", message );
     }
+    if( p->map_revealed_omts.empty() ) {
+        p->add_msg_if_player( _( "You didn't learn anything new from the %s." ), it.tname() );
+    }
     it.mark_as_used_by_player( *p );
     return 0;
 }

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1197,9 +1197,11 @@ void reveal_map_actor::reveal_targets( const tripoint_abs_omt &center,
     const auto places = overmap_buffer.find_all( center, target.first, radius, false,
                         target.second );
     for( const tripoint_abs_omt &place : places ) {
+        if( !overmap_buffer.seen( place ) ) {
+            // Should be replaced with the character using the item passed as an argument if NPCs ever learn to use maps
+            get_avatar().map_revealed_omts.emplace( place );
+        }
         overmap_buffer.reveal( place, reveal_distance );
-        // Should be replaced with the character using the item passed as an argument if NPCs ever learn to use maps
-        get_avatar().map_revealed_omts.emplace( place );
     }
 }
 


### PR DESCRIPTION
#### Summary
Interface "Overmap only highlights newly revealed OMTs for maps"

#### Purpose of change
A much better implementation

#### Describe the solution
Check if we've seen the OMT before adding it to the list to highlight. If we have already seen it, we don't highlight it

#### Describe alternatives you've considered


#### Testing
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/827fb063-736f-405f-ba4f-8b8362476ce1)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/ac47c4d1-07fd-4544-ac9f-aa847c5f70d9)


#### Additional context
