### PR TITLE
Fix anaerobic digester

### DIFF
--- a/data/json/furniture_and_terrain/furniture-tools.json
+++ b/data/json/furniture_and_terrain/furniture-tools.json
@@ -1345,11 +1345,10 @@
     "crafting_pseudo_item": "fake_digester_tank",
     "deconstruct": {
       "items": [
-        { "item": "brick", "count": 60 },
+        { "item": "brick", "count": [ 200, 400 ] },
         { "item": "pipe", "count": [ 6, 8 ] },
         { "item": "pipe_fittings", "count": [ 6, 8 ] },
         { "item": "sheet_metal_small", "count": [ 10, 20 ] },
-        { "item": "metal_tank", "count": 1 },
         { "item": "hose", "count": 1 }
       ]
     },
@@ -1376,11 +1375,10 @@
     "crafting_pseudo_item": "fake_digester_tank",
     "deconstruct": {
       "items": [
-        { "item": "brick", "count": 60 },
+        { "item": "brick", "count": [ 200, 400 ] },
         { "item": "pipe", "count": [ 6, 8 ] },
         { "item": "pipe_fittings", "count": [ 6, 8 ] },
         { "item": "sheet_metal_small", "count": [ 10, 20 ] },
-        { "item": "metal_tank", "count": 1 },
         { "item": "hose", "count": 1 }
       ]
     },

--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -355,12 +355,12 @@
     "name": { "str_sp": "fermentable liquid mixture" },
     "volume": "500 ml",
     "weight": "500 g",
-    "description": "A mixture of various organic wastes and water.  Wait about two months for them to be fermented in a tank.",
+    "description": "A mixture of various organic wastes and water.  Wait about two months for them to be fermented in a tank.  Also, biogas production will start after one month.",
     "copy-from": "fertilizer_liquid",
     "price": "0 cent",
     "price_postapoc": "0 cent",
     "flags": [ "NUTRIENT_OVERRIDE", "TRADER_AVOID" ],
-    "compostable": { "time": "60 days", "results": [ "fermented_fertilizer_liquid", "biogas" ] },
+    "compostable": { "time": "60 days", "results": { "fermented_fertilizer_liquid": 1, "biogas": 250 } },
     "charges": 1
   },
   {

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -471,7 +471,7 @@ bool Character::i_add_or_drop( item &it, int qty, const item *avoid,
         }
     }
 
-    for( int i = added; i < qty; ++i) {
+    for( int i = added; i < qty; ++i ) {
         retval &= !here.add_item_or_charges( pos(), it ).is_null();
     }
 

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -454,16 +454,25 @@ bool Character::i_add_or_drop( item &it, int qty, const item *avoid,
     bool retval = true;
     bool drop = it.made_of( phase_id::LIQUID );
     bool add = it.is_gun() || !it.is_irremovable();
+    int added = 0;
     inv->assign_empty_invlet( it, *this );
     map &here = get_map();
+    drop |= !can_pickWeight( it, !get_option<bool>( "DANGEROUS_PICKUPS" ) ) || !can_pickVolume( it );
     for( int i = 0; i < qty; ++i ) {
-        drop |= !can_pickWeight( it, !get_option<bool>( "DANGEROUS_PICKUPS" ) ) || !can_pickVolume( it );
         if( drop ) {
+            // No need to loop now, we already knew that there isn't enough room for the item.
             retval &= !here.add_item_or_charges( pos(), it ).is_null();
+            added++;
+            break;
         } else if( add ) {
             i_add( it, true, avoid,
                    original_inventory_item, /*allow_drop=*/true, /*allow_wield=*/!has_wield_conflicts( it ) );
+            added++;
         }
+    }
+
+    for( int i = added; i < qty; ++i) {
+        retval &= !here.add_item_or_charges( pos(), it ).is_null();
     }
 
     return retval;

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -3943,12 +3943,13 @@ void iexamine::compost_full( Character &you, const tripoint &examp )
                     } else {
                         for( const std::pair<const itype_id, int> &result : results ) {
                             item biogas( result.first, gas_birthday );
-                            // 40L biogas for 1 KG of biomass over the whole anaerobic digestion process.
-                            // 1 unit of biomass(0.5 KG) for 80 units(0.25 mL for each unit) of biogas.
+                            // 40 L biogas for 1 KG of biomass over the whole anaerobic digestion process.
+                            // 1 unit of biomass(0.5 KG) for 80 units(0.25 L for each unit) of biogas.
                             int gas_amount = result.second * count * max_gas_gatherable * 80 / 30;
                             if( result.first->phase == phase_id::GAS ) {
-                                you.i_add_or_drop( biogas, gas_amount );
-                                add_msg( _( "Gathered %s units of biogas" ), gas_amount );
+                                biogas.charges = gas_amount;
+                                you.i_add_or_drop( biogas );
+                                add_msg( _( "Gathered %s units of biogas." ), gas_amount );
                             }
                         }
                     }
@@ -3977,11 +3978,12 @@ void iexamine::compost_full( Character &you, const tripoint &examp )
                     add_msg( _( "The %s is now ready for use." ), result.first->nname( amount ) );
                 } else if( result.first->phase == phase_id::GAS ) {
                     if( !max_gas_gatherable ) {
-                        add_msg( _( "You released gas in the tank." ) );
+                        add_msg( _( "You released some biogas from the tank." ) );
                     } else {
                         int gas_amount = result.second * count * max_gas_gatherable * 80 / 30;
-                        you.i_add_or_drop( compost, gas_amount );
-                        add_msg( _( "Gathered %s units of biogas" ), gas_amount );
+                        compost.charges = gas_amount;
+                        you.i_add_or_drop( compost );
+                        add_msg( _( "Gathered %s units of biogas." ), gas_amount );
                     }
                 } else {
                     you.i_add_or_drop( compost, amount );

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -3945,11 +3945,15 @@ void iexamine::compost_full( Character &you, const tripoint &examp )
                             item biogas( result.first, gas_birthday );
                             // 40 L biogas for 1 KG of biomass over the whole anaerobic digestion process.
                             // 1 unit of biomass(0.5 KG) for 80 units(0.25 L for each unit) of biogas.
-                            int gas_amount = result.second * count * max_gas_gatherable * 80 / 30;
+                            int gas_amount = count * max_gas_gatherable * 80 / 30;
                             if( result.first->phase == phase_id::GAS ) {
-                                biogas.charges = gas_amount;
-                                you.i_add_or_drop( biogas );
-                                add_msg( _( "Gathered %s units of biogas." ), gas_amount );
+                                if( !you.can_pickVolume_partial( biogas ) ) {
+                                    add_msg( _( "You released some biogas from the tank." ) );
+                                } else {
+                                    biogas.charges = result.second;
+                                    you.i_add_or_drop( biogas, gas_amount );
+                                    add_msg( _( "Gathered %s units of biogas." ), gas_amount );
+                                }
                             }
                         }
                     }
@@ -3977,12 +3981,12 @@ void iexamine::compost_full( Character &you, const tripoint &examp )
                     here.add_item( examp, compost );
                     add_msg( _( "The %s is now ready for use." ), result.first->nname( amount ) );
                 } else if( result.first->phase == phase_id::GAS ) {
-                    if( !max_gas_gatherable ) {
+                    int gas_amount = count * max_gas_gatherable * 80 / 30;
+                    if( !gas_amount || !you.can_pickVolume_partial( compost ) ) {
                         add_msg( _( "You released some biogas from the tank." ) );
                     } else {
-                        int gas_amount = result.second * count * max_gas_gatherable * 80 / 30;
-                        compost.charges = gas_amount;
-                        you.i_add_or_drop( compost );
+                        compost.charges = result.second;
+                        you.i_add_or_drop( compost, gas_amount );
                         add_msg( _( "Gathered %s units of biogas." ), gas_amount );
                     }
                 } else {


### PR DESCRIPTION
#### Summary
Bugfixes "Fix anaerobic digester"
#### Purpose of change
Fix https://github.com/CleverRaven/Cataclysm-DDA/issues/73509.
#### Describe the solution
Fixed the `compost_full` function, now the loop in `Character::i_add_or_drop` will not be called again and again.
Also fixed some typo or minor mistakes in comment and description, and deconstruct result of the digester (forgot to change it to the correct result when adding the contents).
#### Describe alternatives you've considered
N/A
#### Testing
Follow the steps to reproduce the bug, game will not freeze or lag now.
#### Additional context
N/A