### PR TITLE
Refactor draw colored text

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -36,6 +36,22 @@ struct pairs {
 std::array<RGBTuple, color_loader<RGBTuple>::COLOR_NAMES_COUNT> rgbPalette;
 std::array<pairs, 100> colorpairs;   //storage for pair'ed colored
 
+ImVec4 cataimgui::imvec4_from_color( nc_color &color )
+{
+    int pair_id = color.get_index();
+    pairs &pair = colorpairs[pair_id];
+
+    int palette_index = pair.FG != 0 ? pair.FG : pair.BG;
+    if( color.is_bold() ) {
+        palette_index += color_loader<RGBTuple>::COLOR_NAMES_COUNT / 2;
+    }
+    RGBTuple &rgbCol = rgbPalette[palette_index];
+    return { static_cast<float>( rgbCol.Red / 255. ),
+             static_cast<float>( rgbCol.Green / 255. ),
+             static_cast<float>( rgbCol.Blue / 255. ),
+             static_cast<float>( 255. ) };
+}
+
 std::vector<std::pair<int, ImTui::mouse_event>> imtui_events;
 
 static int GetFallbackStrWidth( const char *s_begin, const char *s_end,
@@ -188,6 +204,15 @@ RGBTuple color_loader<RGBTuple>::from_rgb( const int r, const int g, const int b
 #include "wcwidth.h"
 #include <imgui/imgui_impl_sdl2.h>
 #include <imgui/imgui_impl_sdlrenderer2.h>
+
+ImVec4 cataimgui::imvec4_from_color( nc_color &color )
+{
+    SDL_Color c = curses_color_to_SDL( color );
+    return { static_cast<float>( c.r / 255. ),
+             static_cast<float>( c.g / 255. ),
+             static_cast<float>( c.b / 255. ),
+             static_cast<float>( c.a / 255. ) };
+}
 
 cataimgui::client::client( const SDL_Renderer_Ptr &sdl_renderer, const SDL_Window_Ptr &sdl_window,
                            const GeometryRenderer_Ptr &sdl_geometry ) :
@@ -417,24 +442,7 @@ void cataimgui::window::draw_colored_text( std::string const &text, nc_color &co
             if( i++ != 0 ) {
                 ImGui::SameLine( 0, 0 );
             }
-#if !(defined(TILES) || defined(WIN32))
-            int pair_id = color.get_index();
-            pairs &pair = colorpairs[pair_id];
-
-            int palette_index = pair.FG != 0 ? pair.FG : pair.BG;
-            if( color.is_bold() ) {
-                palette_index += color_loader<RGBTuple>::COLOR_NAMES_COUNT / 2;
-            }
-            RGBTuple &rgbCol = rgbPalette[palette_index];
-            ImGui::TextColored( { static_cast<float>( rgbCol.Red / 255. ), static_cast<float>( rgbCol.Green / 255. ),
-                                  static_cast<float>( rgbCol.Blue / 255. ), static_cast<float>( 255. ) },
-                                "%s", seg.c_str() );
-#else
-            SDL_Color c = curses_color_to_SDL( color );
-            ImGui::TextColored( { static_cast<float>( c.r / 255. ), static_cast<float>( c.g / 255. ),
-                                  static_cast<float>( c.b / 255. ), static_cast<float>( c.a / 255. ) },
-                                "%s", seg.c_str() );
-#endif
+            ImGui::TextColored( color, "%s", seg.c_str() );
             GImGui->LastItemData.ID = itemId;
             if( is_focused && !*is_focused ) {
                 *is_focused = ImGui::IsItemFocused();

--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -393,7 +393,7 @@ void cataimgui::imvec2_to_point( ImVec2 *src, point *dest )
     }
 }
 
-static void PushOrPopColor( const std::string_view seg )
+static void PushOrPopColor( const std::string_view seg, int minimumColorStackSize )
 {
     color_tag_parse_result tag = get_color_from_tag( seg, report_color_error::yes );
     switch( tag.type ) {
@@ -401,7 +401,9 @@ static void PushOrPopColor( const std::string_view seg )
             ImGui::PushStyleColor( ImGuiCol_Text, tag.color );
             break;
         case color_tag_parse_result::close_color_tag:
-            ImGui::PopStyleColor();
+            if( GImGui->ColorStack.Size > minimumColorStackSize ) {
+                ImGui::PopStyleColor();
+            }
             break;
         case color_tag_parse_result::non_color_tag:
             // Do nothing
@@ -455,7 +457,7 @@ void cataimgui::window::draw_colored_text( std::string const &text,
             }
 
             if( seg[0] == '<' ) {
-                PushOrPopColor( seg );
+                PushOrPopColor( seg, startColorStackCount );
                 seg = rm_prefix( seg );
             }
 

--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -430,6 +430,7 @@ void cataimgui::window::draw_colored_text( std::string const &text,
         float wrap_width, bool *is_selected, bool *is_focused, bool *is_hovered )
 {
     ImGui::PushID( text.c_str() );
+    int startColorStackCount = GImGui->ColorStack.Size;
     ImGuiID itemId = GImGui->CurrentWindow->IDStack.back();
     size_t chars_per_line = size_t( wrap_width );
     if( chars_per_line == 0 ) {
@@ -472,7 +473,10 @@ void cataimgui::window::draw_colored_text( std::string const &text,
 
         }
     }
-
+    for( int curColorStackCount = GImGui->ColorStack.Size; curColorStackCount > startColorStackCount;
+         curColorStackCount-- ) {
+        ImGui::PopStyleColor();
+    }
     ImGui::PopID();
 }
 

--- a/src/cata_imgui.h
+++ b/src/cata_imgui.h
@@ -97,6 +97,9 @@ class window
         void draw_colored_text( std::string const &text, nc_color &color,
                                 float wrap_width = 0.0F, bool *is_selected = nullptr,
                                 bool *is_focused = nullptr, bool *is_hovered = nullptr );
+        void draw_colored_text( std::string const &text,
+                                float wrap_width = 0.0F, bool *is_selected = nullptr,
+                                bool *is_focused = nullptr, bool *is_hovered = nullptr );
         bool action_button( const std::string &action, const std::string &text );
         bool has_button_action();
         std::string get_button_action();

--- a/src/cata_imgui.h
+++ b/src/cata_imgui.h
@@ -15,6 +15,7 @@ struct input_event;
 
 struct point;
 struct ImVec2;
+struct ImVec4;
 class Font;
 class input_context;
 
@@ -77,6 +78,8 @@ class client
 
 void point_to_imvec2( point *src, ImVec2 *dest );
 void imvec2_to_point( ImVec2 *src, point *dest );
+
+ImVec4 imvec4_from_color( nc_color &color );
 
 class window
 {

--- a/src/color.cpp
+++ b/src/color.cpp
@@ -16,6 +16,7 @@
 #include "filesystem.h"
 #include "flexbuffer_json-inl.h"
 #include "flexbuffer_json.h"
+#include "imgui/imgui.h"
 #include "input_context.h"
 #include "json.h"
 #include "output.h"
@@ -26,9 +27,12 @@
 #include "translations.h"
 #include "ui.h"
 #include "ui_manager.h"
-#if !(defined(TILES) || defined(WIN32))
 #include "cata_imgui.h"
-#endif
+
+nc_color::operator ImVec4()
+{
+    return cataimgui::imvec4_from_color( *this );
+}
 
 void nc_color::serialize( JsonOut &jsout ) const
 {

--- a/src/color.h
+++ b/src/color.h
@@ -359,7 +359,7 @@ class nc_color
     public:
         nc_color() : attribute_value( 0 ), index( 0 ) { }
 
-        operator ImVec4();
+        operator ImVec4(); // NOLINT(google-explicit-constructor): the conversion is not expensive
 
         // Most of the functions here are implemented in ncurses_def.cpp
         // (for ncurses builds) *and* in cursesport.cpp (for other builds).

--- a/src/color.h
+++ b/src/color.h
@@ -344,6 +344,8 @@ enum hl_enum {
     NUM_HL
 };
 
+struct ImVec4;
+
 class nc_color
 {
     private:
@@ -356,6 +358,8 @@ class nc_color
 
     public:
         nc_color() : attribute_value( 0 ), index( 0 ) { }
+
+        operator ImVec4();
 
         // Most of the functions here are implemented in ncurses_def.cpp
         // (for ncurses builds) *and* in cursesport.cpp (for other builds).

--- a/src/popup.cpp
+++ b/src/popup.cpp
@@ -58,8 +58,7 @@ void query_popup_impl::draw_controls()
     mouse_selected_option = -1;
 
     for( const std::string &line : parent->folded_msg ) {
-        nc_color col = parent->default_text_color;
-        draw_colored_text( line, col );
+        draw_colored_text( line, parent->default_text_color );
     }
 
     if( !parent->buttons.empty() ) {


### PR DESCRIPTION
#### Summary
Infrastructure "refactor cataimgui::draw_colored_text"

#### Purpose of change

Simplifies the function so that it doesn't keep track of a redundant color stack, and so that the base color argument is optional. This simplifies 99% of the callers.

#### Describe the solution

I also added a conversion function to the nc_color class so that instances can be used anywhere ImGui expects an ImVec4.

#### Testing

The easiest way to test is to look at the new item info window written by mqrause in #73456; it has lots of wrapped text with embedded colors.

#### Additional context

See also https://github.com/ocornut/imgui/issues/2313#issuecomment-458084296, which has a nicer implementation of the same idea. Amongst several other improvements, it works with proportionally–spaced fonts, while our current solution only works with monospaced fonts.

