### PR TITLE
Re-add generic cards, make the MoM Magician start with only generic cards

### DIFF
--- a/data/json/items/fluff.json
+++ b/data/json/items/fluff.json
@@ -40,7 +40,7 @@
       {
         "id": "deck_of_cards_worn",
         "name": { "str": "worn deck of cards", "str_pl": "worn decks of cards" },
-        "description": "A deck of 52 playing cards. Judging by the bent, frayed edges and faded prints, it saw its share of games.",
+        "description": "A deck of 52 playing cards.  Judging by the bent, frayed edges and faded prints, it saw its share of games.",
         "weight": 6
       },
       {

--- a/data/json/items/fluff.json
+++ b/data/json/items/fluff.json
@@ -32,19 +32,34 @@
     "use_action": [ "PLAY_GAME" ],
     "variants": [
       {
+        "id": "generic_deck_of_cards",
+        "name": { "str": "deck of cards", "str_pl": "decks of cards" },
+        "description": "A fairly new, glossy deck of 52 playing cards.",
+        "weight": 30
+      },
+      {
+        "id": "deck_of_cards_worn",
+        "name": { "str": "worn deck of cards", "str_pl": "worn decks of cards" },
+        "description": "A deck of 52 playing cards. Judging by the bent, frayed edges and faded prints, it saw its share of games.",
+        "weight": 6
+      },
+      {
         "id": "uno",
         "name": { "str": "deck of Uno cards", "str_pl": "decks of Uno cards" },
-        "description": "A set of Uno cards meant to play a game of Uno with your companions.  Just don't yell Uno too loud to avoid attracting the undead."
+        "description": "A set of Uno cards meant to play a game of Uno with your companions.  Just don't yell Uno too loud to avoid attracting the undead.",
+        "weight": 4
       },
       {
         "id": "onirim",
         "name": { "str": "deck of Shadowcaser cards", "str_pl": "decks of Shadowcaser cards" },
-        "description": "A set of cards used in the solo or two-player cooperative card game called Shadowcaser.  The deck consists of 76 unique cards.  Shadowcaser is a immersive card game set in a dream world where players find themselves trapped in a mysterious labyrinthine dream.  The objective of the game is for players to escape this dream world by unlocking eight doors before they run out of time or succumb to the nightmares haunting them."
+        "description": "A set of cards used in the solo or two-player cooperative card game called Shadowcaser.  The deck consists of 76 unique cards.  Shadowcaser is a immersive card game set in a dream world where players find themselves trapped in a mysterious labyrinthine dream.  The objective of the game is for players to escape this dream world by unlocking eight doors before they run out of time or succumb to the nightmares haunting them.",
+        "weight": 1
       },
       {
         "id": "cards_magic",
         "name": { "str": "deck of Sorcery cards", "str_pl": "decks of Sorcery cards" },
-        "description": "A set of cards meant to play the game \"Sorcery.\"  Each card has a fun picture of a different monster."
+        "description": "A set of cards meant to play the game \"Sorcery.\"  Each card has a fun picture of a different monster.",
+        "weight": 2
       },
       {
         "id": "deck_of_cards_makeshift",

--- a/data/mods/MindOverMatter/professions.json
+++ b/data/mods/MindOverMatter/professions.json
@@ -195,7 +195,7 @@
           { "item": "sneakers" },
           { "item": "matrix_crystal_drained" },
           { "item": "tshirt", "variant": "generic_tshirt" },
-          { "item": "deck_of_cards" },
+          { "item": "deck_of_cards", "variant": "generic_deck_of_cards" },
           { "item": "tophat" },
           { "item": "teddy_bear", "variant": "toy_plush_rabbit" }
         ]


### PR DESCRIPTION
#### Summary
Bugfixes "Re-add generic cards, make the MoM Magician start with only generic cards"

#### Purpose of change
#73457 turned all the various card games into variants, but in the process removed the generic deck of cards.

#### Describe the solution
Added a generic variant. I also made the Magician from Mind over Matter start with only it, doesn't make much sense for a stage magician to do tricks with a MtG deck hahaha. I also added a "worn deck of cards" because those tend to get janked up over time.

#### Describe alternatives you've considered
Leaving as is, adding more variants.

#### Testing
None needed.

#### Additional context
N/A
