### PR TITLE
Atomic Smartphone Flashlight Fix

### DIFF
--- a/data/mods/Aftershock/items/tools.json
+++ b/data/mods/Aftershock/items/tools.json
@@ -184,7 +184,6 @@
         "type": "transform"
       }
     ],
-    "tick_action": [ "MP3_ON" ],
     "extend": { "flags": [ "TRADER_AVOID", "LIGHT_25" ] }
   },
   {


### PR DESCRIPTION
#### Summary
Bugfixes "Allows the Atomic Smartphone flashlight to be used without also activating its music"

#### Purpose of change

Fixes #73470 

#### Describe the solution

The tick action under Atomic Smartphone Flashlight would activate the mp3 player whenever the flashlight was in use. By removing this line of code, it no longer plays music whilst illuminating your surroundings

#### Describe alternatives you've considered

Making a separate USE action to enable both the flashlight and the music at the same time would solve this, as well as add some extra functionality to normal smartphones, however, that is well outside of my realm of knowledge.

#### Testing

Upon receiving both an Atomic Smartphone, and Wraitheon Executive Smartphone, usage of the flashlight no longer activates the MP3 player.

#### Additional context

N/A
