### PR TITLE
Fix Character::i_add_or_drop

### DIFF
--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -468,6 +468,7 @@ bool Character::i_add_or_drop( item &it, int qty, const item *avoid,
             i_add( it, true, avoid,
                    original_inventory_item, /*allow_drop=*/true, /*allow_wield=*/!has_wield_conflicts( it ) );
         } else {
+            retval = false;
             break;
         }
     }

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -454,25 +454,22 @@ bool Character::i_add_or_drop( item &it, int qty, const item *avoid,
     bool retval = true;
     bool drop = it.made_of( phase_id::LIQUID );
     bool add = it.is_gun() || !it.is_irremovable();
-    int added = 0;
     inv->assign_empty_invlet( it, *this );
     map &here = get_map();
     drop |= !can_pickWeight( it, !get_option<bool>( "DANGEROUS_PICKUPS" ) ) || !can_pickVolume( it );
     for( int i = 0; i < qty; ++i ) {
         if( drop ) {
-            // No need to loop now, we already knew that there isn't enough room for the item.
             retval &= !here.add_item_or_charges( pos(), it ).is_null();
-            added++;
-            break;
+            if( !retval ) {
+            // No need to loop now, we already knew that there isn't enough room for the item.
+                break;
+            }
         } else if( add ) {
             i_add( it, true, avoid,
                    original_inventory_item, /*allow_drop=*/true, /*allow_wield=*/!has_wield_conflicts( it ) );
-            added++;
+        } else {
+            break;
         }
-    }
-
-    for( int i = added; i < qty; ++i ) {
-        retval &= !here.add_item_or_charges( pos(), it ).is_null();
     }
 
     return retval;

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -461,7 +461,7 @@ bool Character::i_add_or_drop( item &it, int qty, const item *avoid,
         if( drop ) {
             retval &= !here.add_item_or_charges( pos(), it ).is_null();
             if( !retval ) {
-            // No need to loop now, we already knew that there isn't enough room for the item.
+                // No need to loop now, we already knew that there isn't enough room for the item.
                 break;
             }
         } else if( add ) {

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -456,8 +456,8 @@ bool Character::i_add_or_drop( item &it, int qty, const item *avoid,
     bool add = it.is_gun() || !it.is_irremovable();
     inv->assign_empty_invlet( it, *this );
     map &here = get_map();
-    drop |= !can_pickWeight( it, !get_option<bool>( "DANGEROUS_PICKUPS" ) ) || !can_pickVolume( it );
     for( int i = 0; i < qty; ++i ) {
+        drop |= !can_pickWeight( it, !get_option<bool>( "DANGEROUS_PICKUPS" ) ) || !can_pickVolume( it );
         if( drop ) {
             retval &= !here.add_item_or_charges( pos(), it ).is_null();
             if( !retval ) {


### PR DESCRIPTION
#### Summary
Bugfixes "Fix Character::i_add_or_drop"
#### Purpose of change
I think I made a mistake in https://github.com/CleverRaven/Cataclysm-DDA/pull/73523, so fix it.
#### Describe the solution
Restore the function to the way before it was modified.
If the item can neither be added to inventory or be dropped, break the loop immediately.
#### Describe alternatives you've considered
N/A
#### Testing
Compiled and tested locally, the anaerobic digester is less likely to cause lag now.
#### Additional context
N/A