### PR TITLE
Fix stamina regains when dodging

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1941,7 +1941,7 @@ void Character::on_try_dodge()
 
     const int base_burn_rate = get_option<int>( STATIC( "PLAYER_BASE_STAMINA_BURN_RATE" ) );
     const float dodge_skill_modifier = ( 20.0f - get_skill_level( skill_dodge ) ) / 20.0f;
-    burn_energy_legs( std::floor( static_cast<float>( base_burn_rate ) * 6.0f *
+    burn_energy_legs( - std::floor( static_cast<float>( base_burn_rate ) * 6.0f *
                                   dodge_skill_modifier ) );
     set_activity_level( EXTRA_EXERCISE );
 }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1942,7 +1942,7 @@ void Character::on_try_dodge()
     const int base_burn_rate = get_option<int>( STATIC( "PLAYER_BASE_STAMINA_BURN_RATE" ) );
     const float dodge_skill_modifier = ( 20.0f - get_skill_level( skill_dodge ) ) / 20.0f;
     burn_energy_legs( - std::floor( static_cast<float>( base_burn_rate ) * 6.0f *
-                                  dodge_skill_modifier ) );
+                                    dodge_skill_modifier ) );
     set_activity_level( EXTRA_EXERCISE );
 }
 


### PR DESCRIPTION
#### Summary
Bugfixes "Fix stamina regains when dodging"
#### Purpose of change
Fix https://github.com/CleverRaven/Cataclysm-DDA/issues/73349
#### Describe the solution
Add minus sign to burn_energy_legs in on_try_dodge.
#### Describe alternatives you've considered
N/A
#### Testing
Spawned a zombie, now stamina will gradually decrease while dodging attack form it.
#### Additional context
N/A