### PR TITLE
Debug menu monster editing

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -2047,6 +2047,15 @@ void Creature::set_summon_time( const time_duration &length )
     lifespan_end = calendar::turn + length;
 }
 
+time_point Creature::get_summon_time()
+{
+    if( !lifespan_end.has_value() ) {
+        return calendar::turn_zero;
+    }
+
+    return lifespan_end.value();
+}
+
 void Creature::decrement_summon_timer()
 {
     if( !lifespan_end ) {

--- a/src/creature.h
+++ b/src/creature.h
@@ -1183,6 +1183,7 @@ class Creature : public viewer
         void clear_killer();
         // summoned creatures via spells
         void set_summon_time( const time_duration &length );
+        time_point get_summon_time();
         // handles removing the creature if the timer runs out
         void decrement_summon_timer();
         void set_summoner( Creature *summoner );

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -480,7 +480,7 @@ static void monster_ammo_edit( monster &mon )
     uilist smenu;
     int pos = 0;
     char hotkey = 'a';
-    auto &ammo_map = mon.type->starting_ammo;
+    const auto &ammo_map = mon.type->starting_ammo;
     std::vector<itype_id> ammos;
     for( const std::pair<const itype_id, int> &pair : ammo_map ) {
         ammos.emplace_back( pair.first );
@@ -570,7 +570,7 @@ static void monster_edit_menu()
     if( critter ) {
         std::string size_string = "DEBUG";
         // This existing map isn't already extracted for translation...?
-        for( const std::pair<const std::string, creature_size> &size_pair : critter->size_map ) {
+        for( const std::pair<const std::string, creature_size> &size_pair : monster::size_map ) {
             if( size_pair.second == critter->get_size() ) {
                 size_string = size_pair.first;
                 break;

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -194,6 +194,7 @@ std::string enum_to_string<debug_menu::debug_menu_index>( debug_menu::debug_menu
         case debug_menu::debug_menu_index::FORGET_ALL_RECIPES: return "FORGET_ALL_RECIPES";
         case debug_menu::debug_menu_index::FORGET_ALL_ITEMS: return "FORGET_ALL_ITEMS";
         case debug_menu::debug_menu_index::EDIT_PLAYER: return "EDIT_PLAYER";
+        case debug_menu::debug_menu_index::EDIT_MONSTER: return "EDIT_MONSTER";
         case debug_menu::debug_menu_index::CONTROL_NPC: return "CONTROL_NPC";
         case debug_menu::debug_menu_index::SPAWN_ARTIFACT: return "SPAWN_ARTIFACT";
         case debug_menu::debug_menu_index::SPAWN_CLAIRVOYANCE: return "SPAWN_CLAIRVOYANCE";
@@ -474,6 +475,205 @@ static int player_uilist()
     return uilist( _( "Player…" ), uilist_initializer );
 }
 
+static void monster_ammo_edit( monster &mon )
+{
+    uilist smenu;
+    int pos = 0;
+    char hotkey = 'a';
+    auto &ammo_map = mon.type->starting_ammo;
+    std::vector<itype_id> ammos;
+    for( const std::pair<const itype_id, int> &pair : ammo_map ) {
+        ammos.emplace_back( pair.first );
+        const itype *display_type = item::find_type( pair.first );
+        smenu.addentry( pos, true, hotkey, "%s: %d", display_type->nname( 1 ), mon.ammo[pair.first] );
+        pos++;
+        hotkey++;
+    }
+    smenu.query();
+
+    if( smenu.ret > static_cast<int>( ammo_map.size() ) || smenu.ret < 0 ) {
+        return;
+    }
+    itype_id new_ammo;
+    new_ammo = ammos[smenu.ret];
+    if( new_ammo.is_valid() ) {
+        int value;
+        const itype *display_type = item::find_type( new_ammo );
+        if( query_int( value, _( "Set %s to how much ammo?  Currently: %d" ), display_type->nname( 1 ),
+                       mon.ammo[new_ammo] ) )  {
+            if( value < 0 ) {
+                value = 0;
+            }
+            mon.ammo[new_ammo] = value;
+        }
+    }
+}
+
+static int creature_uilist()
+{
+    std::vector<uilist_entry> uilist_initializer = {
+        { uilist_entry( debug_menu_index::EDIT_MONSTER, true, 'c', _( "Edit monster" ) ) },
+    };
+
+    return uilist( _( "Monster…" ), uilist_initializer );
+}
+
+static void monster_edit_menu()
+{
+    std::vector<tripoint> locations;
+    uilist monster_menu;
+    int charnum = 0;
+    for( const monster &mon : g->all_monsters() ) {
+        monster_menu.addentry( charnum++, true, MENU_AUTOASSIGN, mon.disp_name() );
+        locations.emplace_back( mon.pos() );
+    }
+
+    if( locations.empty() ) {
+        popup( _( "No monsters found inside the bubble, aborting." ) );
+        return;
+    }
+
+    pointmenu_cb callback( locations );
+    monster_menu.callback = &callback;
+    monster_menu.w_y_setup = 0;
+    monster_menu.query();
+    if( monster_menu.ret < 0 || static_cast<size_t>( monster_menu.ret ) >= locations.size() ) {
+        return;
+    }
+    const size_t index = monster_menu.ret;
+    monster *critter = get_creature_tracker().creature_at<monster>( locations[index], true );
+    uilist nmenu;
+
+    if( critter ) {
+        std::string size_string = "DEBUG";
+        // This existing map isn't already extracted for translation...?
+        for( const std::pair<const std::string, creature_size> &size_pair : critter->size_map ) {
+            if( size_pair.second == critter->get_size() ) {
+                size_string = size_pair.first;
+                break;
+            }
+        }
+        std::stringstream data;
+        data << string_format( _( "Monster %s of type %s" ), critter->disp_name(),
+                               critter->type->id.c_str() ) << std::endl;
+        if( Creature *summoner = critter->get_summoner() ) {
+            data << string_format( _( "Summoned by: %s" ), summoner->disp_name() ) << std::endl;
+        }
+        if( critter->get_summon_time() != calendar::turn_zero ) {
+            data << string_format( _( "Expires in: %s" ),
+                                   to_string( critter->get_summon_time() - calendar::turn ) ) << std::endl;
+        }
+        data << string_format( _( "Faction: %s" ), critter->get_monster_faction().id().str() ) << std::endl;
+        data << string_format( _( "HP(max): %d (%d)" ), critter->get_hp(),
+                               critter->get_hp_max() ) << std::endl;
+        data << string_format( _( "Volume: %sL (size %s)" ), units::to_liter( critter->get_volume() ),
+                               size_string ) << std::endl;
+        data << string_format( _( "Speed(base): %d (%d)" ), critter->get_speed(),
+                               critter->get_speed_base() ) << std::endl;
+        data << string_format( _( "Aggression(base): %d (%d)" ), critter->anger,
+                               critter->type->agro ) << std::endl;
+        data << string_format( _( "Morale(base): %d (%d)" ), critter->morale,
+                               critter->type->morale ) << std::endl;
+        if( !critter->ammo.empty() ) {
+            for( auto &ammos : critter->ammo ) {
+                data << string_format( _( "Ammo: %s rounds of %s" ), ammos.second,
+                                       ammos.first.c_str() ) << std::endl;
+            }
+        }
+        if( critter->wander_pos != critter->get_location() && critter->wander_pos != tripoint_abs_ms() ) {
+            data << string_format( _( "Wandering towards: %s" ), critter->wander_pos.to_string() ) << std::endl;
+            data << string_format( _( "From cur location: %s" ),
+                                   critter->get_location().to_string() ) << std::endl;
+            data << string_format( _( "Desire to wander: %d" ), critter->wandf ) << std::endl;
+        }
+        // TODO: Move these out into a sub-menu, this is too many lines!
+        if( !critter->inv.empty() ) {
+            for( item &drop : critter->inv ) {
+                data << string_format( _( "Cached item drop: %s" ), drop.tname() ) << std::endl;
+            }
+        }
+        if( !critter->dissectable_inv.empty() ) {
+            for( item &harvest : critter->dissectable_inv ) {
+                data << string_format( _( "Cached dissection result: %s" ), harvest.tname() ) << std::endl;
+            }
+        }
+
+        nmenu.text = data.str();
+    } else {
+        return; //No monster, no editing!
+    }
+
+    enum {
+        D_HP, D_MORALE, D_AGGRO, D_ADD_EFFECT, D_ADD_AMMO, D_TELE, D_WANDER_DES, D_WANDER
+    };
+    nmenu.addentry( D_HP, true, 'h', "%s", _( "Set hit points" ) );
+    nmenu.addentry( D_MORALE, true, 'o', "%s", _( "Set morale" ) );
+    nmenu.addentry( D_AGGRO, true, 'a', "%s", _( "Set aggression" ) );
+    nmenu.addentry( D_ADD_EFFECT, true, 'E', "%s", _( "Add an effect" ) );
+    nmenu.addentry( D_ADD_AMMO, true, 'A', "%s", _( "Modify ammo" ) );
+    nmenu.addentry( D_TELE, true, 'e', "%s", _( "Teleport" ) );
+    nmenu.addentry( D_WANDER_DES, true, 'W', "%s",
+                    _( "Set wander destination (also sets wander desire to 1000 turns)" ) );
+    nmenu.addentry( D_WANDER, true, 'w', "%s", _( "Set wander desire" ) );
+
+    nmenu.query();
+    switch( nmenu.ret ) {
+        case D_HP: {
+            int value = 0;
+            if( query_int( value,  _( "Set the hitpoints to?  Currently: %d" ), critter->get_hp() ) ) {
+                critter->set_hp( value );
+            }
+        }
+        break;
+        case D_MORALE: {
+            int value = 0;
+            if( query_int( value, _( "Set the morale to?  Currently: %d" ), critter->morale ) ) {
+                critter->morale = value;
+            }
+        }
+        break;
+        case D_AGGRO: {
+            int value = 0;
+            if( query_int( value, _( "Set aggression to?  Currently: %d" ), critter->anger ) ) {
+                critter->anger = value;
+            }
+        }
+        break;
+        case D_ADD_EFFECT: {
+            wisheffect( *critter->as_monster() );
+            break;
+        }
+        case D_ADD_AMMO: {
+            if( critter->ammo.empty() )  {
+                popup( _( "This monster doesn't have any defined ammo." ) );
+                break;
+            }
+            monster_ammo_edit( *critter );
+            break;
+        }
+        case D_TELE: {
+            if( const std::optional<tripoint> newpos = g->look_around() ) {
+                critter->setpos( *newpos );
+            }
+            break;
+        }
+        case D_WANDER_DES: {
+            if( const std::optional<tripoint> newpos = g->look_around() ) {
+                critter->wander_to( get_map().getglobal( *newpos ), 1000 );
+            }
+            break;
+        }
+        case D_WANDER: {
+            int value = 0;
+            if( query_int( value, _( "Set wander desire to?  Currently: %d" ), critter->wandf ) ) {
+                critter->wandf = value;
+            }
+            break;
+        }
+
+    }
+}
+
 static int info_uilist( bool display_all_entries = true )
 {
     // always displayed
@@ -636,7 +836,7 @@ static int faction_uilist()
 static std::optional<debug_menu_index> debug_menu_uilist( bool display_all_entries = true )
 {
     enum {
-        D_INFO, D_GAME, D_SPAWNING, D_PLAYER, D_FACTION, D_VEHICLE, D_TELEPORT, D_MAP, D_QUICK_SETUP
+        D_INFO, D_GAME, D_SPAWNING, D_PLAYER, D_MONSTER, D_FACTION, D_VEHICLE, D_TELEPORT, D_MAP, D_QUICK_SETUP
     };
 
     std::vector<uilist_entry> menu = {
@@ -648,6 +848,7 @@ static std::optional<debug_menu_index> debug_menu_uilist( bool display_all_entri
             { uilist_entry( D_GAME,        true, 'g', _( "Game…" ) ) },
             { uilist_entry( D_SPAWNING,    true, 's', _( "Spawning…" ) ) },
             { uilist_entry( D_PLAYER,      true, 'p', _( "Player…" ) ) },
+            { uilist_entry( D_MONSTER,     true, 'c', _( "Monster…" ) ) },
             { uilist_entry( D_FACTION,     true, 'f', _( "Faction…" ) ) },
             { uilist_entry( D_VEHICLE,     true, 'v', _( "Vehicle…" ) ) },
             { uilist_entry( D_TELEPORT,    true, 't', _( "Teleport…" ) ) },
@@ -680,6 +881,9 @@ static std::optional<debug_menu_index> debug_menu_uilist( bool display_all_entri
                 break;
             case D_PLAYER:
                 action = player_uilist();
+                break;
+            case D_MONSTER:
+                action = creature_uilist();
                 break;
             case D_FACTION:
                 action = faction_uilist();
@@ -3517,6 +3721,10 @@ void debug()
 
         case debug_menu_index::EDIT_PLAYER:
             character_edit_menu();
+            break;
+
+        case debug_menu_index::EDIT_MONSTER:
+            monster_edit_menu();
             break;
 
         case debug_menu_index::CONTROL_NPC:

--- a/src/debug_menu.h
+++ b/src/debug_menu.h
@@ -36,6 +36,7 @@ enum class debug_menu_index : int {
     FORGET_ALL_ITEMS,
     UNLOCK_ALL,
     EDIT_PLAYER,
+    EDIT_MONSTER,
     CONTROL_NPC,
     SPAWN_ARTIFACT,
     SPAWN_CLAIRVOYANCE,

--- a/src/debug_menu.h
+++ b/src/debug_menu.h
@@ -9,6 +9,7 @@
 #include <string_view>
 
 class Character;
+class Creature;
 struct tripoint;
 template <typename E> struct enum_traits;
 
@@ -110,9 +111,7 @@ enum class debug_menu_index : int {
     last
 };
 
-template<typename T>
-void wisheffect( T &p );
-
+void wisheffect( Creature &p );
 void wishitem( Character *you = nullptr );
 void wishitem( Character *you, const tripoint & );
 void wishmonster( const std::optional<tripoint> &p );

--- a/src/debug_menu.h
+++ b/src/debug_menu.h
@@ -109,7 +109,9 @@ enum class debug_menu_index : int {
     last
 };
 
-void wisheffect( Character &p );
+template<typename T>
+void wisheffect( T &p );
+
 void wishitem( Character *you = nullptr );
 void wishitem( Character *you, const tripoint & );
 void wishmonster( const std::optional<tripoint> &p );

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -466,7 +466,8 @@ void debug_menu::wishbionics( Character *you )
     }
 }
 
-void debug_menu::wisheffect( Character &p )
+template<typename T>
+void debug_menu::wisheffect( T &p )
 {
     static bodypart_str_id effectbp = bodypart_str_id::NULL_ID();
     std::vector<effect> effects;
@@ -637,6 +638,8 @@ void debug_menu::wisheffect( Character &p )
         }
     } while( efmenu.ret != UILIST_CANCEL );
 }
+template void debug_menu::wisheffect<Character>( Character &p );
+template void debug_menu::wisheffect<monster>( monster &p );
 
 class wish_monster_callback: public uilist_callback
 {

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -466,8 +466,7 @@ void debug_menu::wishbionics( Character *you )
     }
 }
 
-template<typename T>
-void debug_menu::wisheffect( T &p )
+void debug_menu::wisheffect( Creature &p )
 {
     static bodypart_str_id effectbp = bodypart_str_id::NULL_ID();
     std::vector<effect> effects;
@@ -638,8 +637,6 @@ void debug_menu::wisheffect( T &p )
         }
     } while( efmenu.ret != UILIST_CANCEL );
 }
-template void debug_menu::wisheffect<Character>( Character &p );
-template void debug_menu::wisheffect<monster>( monster &p );
 
 class wish_monster_callback: public uilist_callback
 {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
I wanted the infrastructure to help debug some stuff. It'll come in handy later, plus some of our JSON contributors have requested such a feature. Why not?

#### Describe the solution
Add a new debug menu, for editing monsters. Give it some toys and other useful information.

#### Describe alternatives you've considered
Much of this could probably be folded into character_edit_menu() to limit the amount of extra code, but that function is already over 400 lines. Add some ternaries to switch between dealing with `Character`s and `monster`s would balloon it even more. Better to keep these separate, and refactor common portions together later (like when switching to imgui)

#### Testing
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/fa42607d-da8b-4ec3-b445-939f59f4641f)


#### Additional context
Squash on merge please, I made a mess out of the commits.
