### PR TITLE
Added to greater dimensional bag to enchanted_misc item group

### DIFF
--- a/data/mods/Magiclysm/itemgroups/itemgroups.json
+++ b/data/mods/Magiclysm/itemgroups/itemgroups.json
@@ -643,7 +643,8 @@
       { "item": "cauldron_demon_chitin", "prob": 20 },
       { "item": "fridge_holding_1", "prob": 12 },
       { "item": "bag_holding_1", "prob": 8 },
-      { "item": "bag_holding_2", "prob": 1 },
+      { "item": "bag_holding_2", "prob": 2 },
+      { "item": "bag_holding_3", "prob": 1 },
       { "item": "cauldron_orichalcum", "prob": 100 },
       { "item": "bleed_staff_minor", "prob": 8, "charges": [ 1, 5 ] },
       { "item": "grim_reaper_scythe", "prob": 2, "charges": [ 1, 3 ] }


### PR DESCRIPTION
#### Summary

Mods "add greater dimensional bag  to be spawned"

#### Purpose of change

I saw #70000 and decided to do something about it
fix #70000 

#### Describe the solution

Added greater dimensional bag to enchanted_misc, also upped the probability of bag_holding_2 since bag_holding_3 is now obtainable, it should be rarer than bag_holding_2.

#### Describe alternatives you've considered

Not doing it.

#### Testing

1. Creating a new character
2. Go visiting various forge of wonder
3. Check if the item spawned

#### Additional context

N/A