### PR TITLE
Monster enchantments set bonus speed, not base

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3197,8 +3197,8 @@ void monster::process_one_effect( effect &it, bool is_new )
         }
     }
     //Reset max speed
-    this->set_speed_base( calculate_by_enchantment( this->get_speed_base(), enchant_vals::mod::SPEED,
-                          true ) );
+    set_speed_bonus( calculate_by_enchantment( get_speed_base(), enchant_vals::mod::SPEED,
+                     true ) - get_speed_base() );
 }
 
 void monster::process_effects()


### PR DESCRIPTION
#### Summary
Bugfixes "Monster enchantments set bonus speed, not base (stops infinite feedback loop)"

#### Purpose of change
* Fixes #73516

#### Describe the solution
Don't do exponential growth :)

#### Describe alternatives you've considered
Unit tests? If I was adding enchantment functionality in the first place I'd definitely do it, but this is just a bugfix

#### Testing
Used my debug menu from #73563 to read the speed of the relentless hulk, saw it growing each and every turn commensurate with the speed buff it should have been getting once. After setting bonus speed, watched it some more. Speed was properly increased over the base speed, but without modifying base speed or exponentially growing until Sonic graced our zombie game.

#### Additional context
