### PR TITLE
fix arithmetical error crash

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -988,10 +988,10 @@ std::pair<std::string, nc_color> display::carry_weight_text_color( const avatar 
 {
     int carry_wt;
 
-    if (u.weight_capacity() > 0) { 
-        carry_wt = (100 * u.weight_carried()) / u.weight_capacity();
+    if( u.weight_capacity() > 0 ) {
+        carry_wt = ( 100 * u.weight_carried() ) / u.weight_capacity();
     } else {
-        carry_wt = 100; 
+        carry_wt = 100;
     }
 
     std::string weight_text = string_format( "%d%%", carry_wt );

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -988,7 +988,7 @@ std::pair<std::string, nc_color> display::carry_weight_text_color( const avatar 
 {
     int carry_wt;
 
-    if( u.weight_capacity() > 0 ) {
+    if( u.weight_capacity() > 0_gram ) {
         carry_wt = ( 100 * u.weight_carried() ) / u.weight_capacity();
     } else {
         carry_wt = 100;

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -986,7 +986,14 @@ std::pair<std::string, nc_color> display::move_count_and_mode_text_color( const 
 // Weight carried, relative to capacity, in %, like "90%".
 std::pair<std::string, nc_color> display::carry_weight_text_color( const avatar &u )
 {
-    int carry_wt = ( 100 * u.weight_carried() ) / u.weight_capacity();
+    int carry_wt;
+
+    if (u.weight_capacity() > 0) { 
+        carry_wt = (100 * u.weight_carried()) / u.weight_capacity();
+    } else {
+        carry_wt = 100; 
+    }
+
     std::string weight_text = string_format( "%d%%", carry_wt );
 
     nc_color weight_color = c_green;


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
fix #73355
#### Describe the solution
Put failsafe against dividing by zero
#### Describe alternatives you've considered
Use some another value but 100
Make custom return if u.weight_capacity() < 0