### PR TITLE
clang-tidy

### DIFF
--- a/src/npc.h
+++ b/src/npc.h
@@ -1147,7 +1147,7 @@ class npc : public Character
         // Returns true if did something and we should end turn
         bool scan_new_items();
         // Returns score for how well this weapon might kill things
-        double evaluate_weapon( item &it, bool can_use_gun, bool use_silent ) const;
+        double evaluate_weapon( item &maybe_weapon, bool can_use_gun, bool use_silent ) const;
         // Returns best weapon. Can return null (fists)
         item *evaluate_best_weapon() const;
         // Returns true if did wield it

--- a/src/npc.h
+++ b/src/npc.h
@@ -1147,7 +1147,7 @@ class npc : public Character
         // Returns true if did something and we should end turn
         bool scan_new_items();
         // Returns score for how well this weapon might kill things
-        double evaluate_weapon( item &maybe_weapon, bool can_use_gun, bool use_silent ) const;
+        double evaluate_weapon( item &it, bool can_use_gun, bool use_silent ) const;
         // Returns best weapon. Can return null (fists)
         item *evaluate_best_weapon() const;
         // Returns true if did wield it

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -4042,21 +4042,21 @@ bool npc::do_player_activity()
     return moves != old_moves;
 }
 
-double npc::evaluate_weapon( item &it, bool can_use_gun, bool use_silent ) const
+double npc::evaluate_weapon( item &maybe_weapon, bool can_use_gun, bool use_silent ) const
 {
-    bool allowed = can_use_gun && it.is_gun() && ( !use_silent || it.is_silent() );
+    bool allowed = can_use_gun && maybe_weapon.is_gun() && ( !use_silent || maybe_weapon.is_silent() );
     // According to unmodified evaluation score, NPCs almost always prioritize wielding guns if they have one.
     // This is relatively reasonable, as players can issue commands to NPCs when we do not want them to use ranged weapons.
     // Conversely, we cannot directly issue commands when we want NPCs to prioritize ranged weapons.
     // Note that the scoring method here is different from the 'weapon_value' used elsewhere.
-    double val_gun = allowed ? gun_value( it, it.shots_remaining( this ) ) : 0;
+    double val_gun = allowed ? gun_value( maybe_weapon, maybe_weapon.shots_remaining( this ) ) : 0;
     add_msg_debug( debugmode::DF_NPC_ITEMAI,
                    "%s %s valued at <color_light_cyan>%1.2f as a ranged weapon to wield</color>.",
-                   disp_name( true ), it.type->get_id().str(), val_gun );
-    double val_melee = melee_value( it );
+                   disp_name( true ), maybe_weapon.type->get_id().str(), val_gun );
+    double val_melee = melee_value( maybe_weapon );
     add_msg_debug( debugmode::DF_NPC_ITEMAI,
                    "%s %s valued at <color_light_cyan>%1.2f as a melee weapon to wield</color>.", disp_name( true ),
-                   it.type->get_id().str(), val_melee );
+                   maybe_weapon.type->get_id().str(), val_melee );
     double val = std::max( val_gun, val_melee );
     return val;
 }


### PR DESCRIPTION
#### Summary
Bugfixes "clang-tidy readability-inconsistent-declaration-parameter-name"
#### Purpose of change
A readability-inconsistent-declaration-parameter-name error popped out in my PR at where I didn't modified.
Seems that https://github.com/CleverRaven/Cataclysm-DDA/pull/73498 accidentally used different parameter name while defining evaluate_weapon.
https://github.com/CleverRaven/Cataclysm-DDA/blob/6e767b2dee40c6173c345d78edf75f96a0c11132/src/npc.h#L1150
https://github.com/CleverRaven/Cataclysm-DDA/blob/6e767b2dee40c6173c345d78edf75f96a0c11132/src/npcmove.cpp#L4045
#### Describe the solution
Use the same parameter name
#### Describe alternatives you've considered
N/A
#### Testing
No extra test needed I think.
#### Additional context
N/A