### PR TITLE
No magic dissectables

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3078,12 +3078,15 @@ void monster::drop_items_on_death( item *corpse )
     }
 }
 
-void monster::spawn_dissectables_on_death( item *corpse )
+void monster::spawn_dissectables_on_death( item *corpse ) const
 {
     if( is_hallucination() ) {
         return;
     }
     if( type->dissect.is_empty() ) {
+        return;
+    }
+    if( !corpse ) {
         return;
     }
 
@@ -3101,8 +3104,6 @@ void monster::spawn_dissectables_on_death( item *corpse )
             }
             if( corpse ) {
                 corpse->put_in( dissectable, pocket_type::CORPSE );
-            } else {
-                get_map().add_item_or_charges( pos(), dissectable );
             }
         }
     }

--- a/src/monster.h
+++ b/src/monster.h
@@ -458,7 +458,7 @@ class monster : public Creature
 
         void die( Creature *killer ) override; //this is the die from Creature, it calls kill_mo
         void drop_items_on_death( item *corpse );
-        void spawn_dissectables_on_death( item *corpse ); //spawn dissectable CBMs into CORPSE pocket
+        void spawn_dissectables_on_death( item *corpse ) const; //spawn dissectable CBMs into CORPSE pocket
         //spawn monster's inventory without killing it
         void generate_inventory( bool disableDrops = true );
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
~~Fixes some bug(s) (to be linked later™)~~ Apparently this was never reported? But @Karol1223  encountered it when adding dissections to graboids, and they thought it had the same cause as another bug. It does not, so I guess this one doesn't close anything at all.

#### Describe the solution
Don't magic dissectables out of thin air in any circumstance. If we want NO_CORPSE monsters to drop stuff on death we can just give them death_drops in json.

#### Describe alternatives you've considered


#### Testing
Gave graboid(NO_CORPSE death type) some sample dissection results. Killed graboid, watched it "split in two" and samples fall out of the sky.

Applied patch, killed graboid again. No magic samples.

#### Additional context
I tracked when this code was originally added in a #57322 commit and as far as I can tell this was always erroneous?