### PR TITLE
[Magiclysm] fix summon_undead_swarm using summon_undead spell level as check

### DIFF
--- a/data/mods/Magiclysm/Spells/animist.json
+++ b/data/mods/Magiclysm/Spells/animist.json
@@ -240,7 +240,7 @@
     "type": "effect_on_condition",
     "id": "EOC_SUMMON_ZOMBIE_SWARM",
     "effect": {
-      "switch": { "math": [ "u_spell_level('summon_undead')" ] },
+      "switch": { "math": [ "u_spell_level('summon_undead_swarm')" ] },
       "cases": [
         { "case": 0, "effect": { "u_cast_spell": { "id": "summon_zombie_dog" } } },
         { "case": 5, "effect": { "u_cast_spell": { "id": "summon_dog_skeleton" } } },


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
fix #73443
#### Describe the solution
make EOC_SUMMON_ZOMBIE_SWARM check the correct spell