### PR TITLE
Use ncurses accessor macros

### DIFF
--- a/src/third-party/imtui/imtui-impl-ncurses.cpp
+++ b/src/third-party/imtui/imtui-impl-ncurses.cpp
@@ -311,7 +311,7 @@ void create_destroy_curses_windows(std::vector<WINDOW*> &windows)
         } else {
             WINDOW* win = windows[cursesWinIdx];
             
-            if(win->_begx != short(imwin->Pos.x) || win->_begy != short(imwin->Pos.y) || win->_maxx != short(imwin->Size.x) || win->_maxy != imwin->Size.y) {
+            if(getbegx( win ) != short(imwin->Pos.x) || getbegy( win ) != short(imwin->Pos.y) || getmaxx(win) != short(imwin->Size.x) || getmaxy(win) != imwin->Size.y) {
                 delwin(win);
                 windows[cursesWinIdx] = newwin(short(imwin->Size.y), short(imwin->Size.x), short(imwin->Pos.y), short(imwin->Pos.x));
             }
@@ -343,11 +343,11 @@ void ImTui_ImplNcurses_DrawScreen( bool active )
         int nx = g_screen.nx;
         int ny = g_screen.ny;
 
-        for( int y = cursesWin->_begy; y <= (cursesWin->_begy + cursesWin->_maxy); ++y ) {
+        for( int y = getbegy(cursesWin); y <= (getbegy(cursesWin) + getmaxy(cursesWin)); ++y ) {
             constexpr int no_lastp = 0x7FFFFFFF;
             int lastp = no_lastp;
-            wmove(cursesWin, y - cursesWin->_begy, 0);
-            for( int x = cursesWin->_begx; x <= (cursesWin->_begx +  cursesWin->_maxx); ++x ) {
+            wmove(cursesWin, y - getbegy(cursesWin), 0);
+            for( int x = getbegx(cursesWin); x <= (getbegx(cursesWin) +  getmaxx(cursesWin)); ++x ) {
                 const auto cell = g_screen.data[y * nx + x];
                 const uint16_t f = ( cell & 0x00FF0000 ) >> 16;
                 const uint16_t b = ( cell & 0xFF000000 ) >> 24;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
It was pointed out that the experimental builds on cataclysm.org weren't updating, that means one of the release builds is broken.
Fixes #73562 
Turns out it's macOS curses build https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/9003013225/job/24732683327#step:27:370
It's broken because macOS defaults to treating the WINDOW struct as opaque, i.e. you're not allowed to directly access data members and must use the accessor macros.

#### Describe the solution
Use the accessor macros.

#### Describe alternatives you've considered
You CAN make WINDOW un-opaque, but this is best practice for portability.

#### Testing
Builds and works locally, I'll need to see if it succeeds the macOS build in CI since I don't have a macOS build env.