### PR TITLE
damaged appiance-items remain damaged when transformed to appliance and back

### DIFF
--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1179,8 +1179,8 @@ std::optional<int> deploy_appliance_actor::use( Character *p, item &it, const tr
         return std::nullopt;
     }
 
-    place_appliance( suitable.value(), vpart_appliance_from_item( appliance_base ) );
     it.spill_contents( suitable.value() );
+    place_appliance( suitable.value(), vpart_appliance_from_item( appliance_base ), it );
     p->mod_moves( -to_moves<int>( 2_seconds ) );
     return 1;
 }


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
There was an exploit, where you could took damaged appliance item (like fridge), activate it, and it will transform into pristine appliance (and you can take it down back). No more
#### Describe the solution
Apply suggestion, that Renech send me
#### Testing
Compiled it, ~~spend some time trying to damage fridge, failed because they are pure steel, someone please fix~~ spawned minifridge, damaged it, activated it - still smashed; take it down, still smashed; activated construction recipe - still smashed