### PR TITLE
[Bombastic Perks] More perks

### DIFF
--- a/data/mods/BombasticPerks/perkdata/early_to_rise.json
+++ b/data/mods/BombasticPerks/perkdata/early_to_rise.json
@@ -1,0 +1,25 @@
+[
+  {
+    "id": "morale_perk_early_to_rise",
+    "type": "morale_type",
+    "text": "Early Riser"
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_NETHER_ATTENTION_NIGHTMARES",
+    "eoc_type": "EVENT",
+    "required_event": "character_wakes_up",
+    "condition": {
+      "and": [
+        { "u_has_trait": "perk_early_to_rise" },
+        {
+          "or": [
+            { "math": [ "time_since('midnight', 'unit': 'hours') >= 4" ] },
+            { "math": [ "time_since('midnight', 'unit': 'hours') <= 7" ] }
+          ]
+        }
+      ]
+    },
+    "effect": [ { "u_add_morale": "morale_perk_early_to_rise", "bonus": 20, "duration": "6 hours", "decay_start": "3 hours" } ]
+  }
+]

--- a/data/mods/BombasticPerks/perkdata/early_to_rise.json
+++ b/data/mods/BombasticPerks/perkdata/early_to_rise.json
@@ -20,6 +20,14 @@
         }
       ]
     },
-    "effect": [ { "u_add_morale": "morale_perk_early_to_rise", "bonus": 20, "duration": "6 hours", "decay_start": "3 hours" } ]
+    "effect": [
+      {
+        "u_add_morale": "morale_perk_early_to_rise",
+        "bonus": 20,
+        "max_bonus": 20,
+        "duration": "6 hours",
+        "decay_start": "3 hours"
+      }
+    ]
   }
 ]

--- a/data/mods/BombasticPerks/perkdata/firstest_aid.json
+++ b/data/mods/BombasticPerks/perkdata/firstest_aid.json
@@ -5,9 +5,10 @@
     "eoc_type": "EVENT",
     "required_event": "character_takes_damage",
     "condition": { "u_has_trait": "perk_firstest_aid" },
-    "effect": [ 
-      { "u_lose_effect": "effect_perk_firstest_aid" }, 
-      { "u_add_effect": "effect_perk_firstest_aid", "duration": "2 minutes" } ]
+    "effect": [
+      { "u_lose_effect": "effect_perk_firstest_aid" },
+      { "u_add_effect": "effect_perk_firstest_aid", "duration": "2 minutes" }
+    ]
   },
   {
     "type": "effect_type",

--- a/data/mods/BombasticPerks/perkdata/firstest_aid.json
+++ b/data/mods/BombasticPerks/perkdata/firstest_aid.json
@@ -13,6 +13,7 @@
     "type": "effect_type",
     "id": "effect_perk_firstest_aid",
     "//": "Hidden effect used as a tracker",
+    "max_duration": "2 m",
     "name": [ "" ],
     "desc": [ "" ]
   }

--- a/data/mods/BombasticPerks/perkdata/firstest_aid.json
+++ b/data/mods/BombasticPerks/perkdata/firstest_aid.json
@@ -1,0 +1,19 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PERK_FIRSTEST_AID",
+    "eoc_type": "EVENT",
+    "required_event": "character_takes_damage",
+    "condition": { "u_has_trait": "perk_firstest_aid" },
+    "effect": [ 
+      { "u_lose_effect": "effect_perk_firstest_aid" }, 
+      { "u_add_effect": "effect_perk_firstest_aid", "duration": "2 minutes" } ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_perk_firstest_aid",
+    "//": "Hidden effect used as a tracker",
+    "name": [ "" ],
+    "desc": [ "" ]
+  }
+]

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -810,6 +810,25 @@
         "topic": "TALK_PERK_MENU_SELECT"
       },
       {
+        "condition": { "not": { "u_has_trait": "perk_firstest_aid" } },
+        "text": "Gain [<trait_name:perk_firstest_aid>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_firstest_aid>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:perk_firstest_aid>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "perk_firstest_aid", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Requires health care 4",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "math": [ "u_skill('firstaid')", ">=", "4" ] } }
+        ],
+        "topic": "TALK_PERK_MENU_SELECT"
+      },
+      {
         "condition": { "not": { "u_has_trait": "perk_popeye" } },
         "text": "Gain [<trait_name:perk_popeye>]",
         "effect": [

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -693,6 +693,25 @@
         "topic": "TALK_PERK_MENU_SELECT"
       },
       {
+        "condition": { "not": { "u_has_trait": "perk_static_stockpile" } },
+        "text": "Gain [<trait_name:perk_static_stockpile>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_static_stockpile>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:perk_static_stockpile>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "perk_static_stockpile", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Must have the Tingly perk",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "u_has_trait": "perk_tingly" } }
+        ],
+        "topic": "TALK_PERK_MENU_SELECT"
+      },
+      {
         "condition": { "not": { "u_has_trait": "perk_jumpy" } },
         "text": "Gain [<trait_name:perk_jumpy>]",
         "effect": [

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -924,6 +924,25 @@
         "topic": "TALK_PERK_MENU_SELECT"
       },
       {
+        "condition": { "not": { "u_has_trait": "perk_early_to_rise" } },
+        "text": "Gain [<trait_name:perk_early_to_rise>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_early_to_rise>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:perk_early_to_rise>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "perk_early_to_rise", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
+        ],
+        "topic": "TALK_PERK_MENU_SELECT"
+      },
+      {
         "condition": { "not": { "u_has_trait": "perk_duck_and_weave" } },
         "text": "Gain [<trait_name:perk_duck_and_weave>]",
         "effect": [

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -593,6 +593,25 @@
         "topic": "TALK_PERK_MENU_SELECT"
       },
       {
+        "condition": { "not": { "u_has_trait": "perk_big_eater" } },
+        "text": "Gain [<trait_name:perk_big_eater>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_big_eater>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:perk_big_eater>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "perk_big_eater", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
+        ],
+        "topic": "TALK_PERK_MENU_SELECT"
+      },
+      {
         "condition": { "not": { "u_has_trait": "perk_tuck_and_roll" } },
         "text": "Gain [<trait_name:perk_tuck_and_roll>]",
         "effect": [

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -1198,6 +1198,25 @@
         "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
       },
       {
+        "condition": { "not": { "u_has_trait": "perk_nocturnal" } },
+        "text": "Gain [<trait_name:perk_nocturnal>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_nocturnal>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:perk_nocturnal>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "perk_nocturnal", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
+        ],
+        "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
+      },
+      {
         "condition": { "not": { "u_has_trait": "perk_skeleton" } },
         "text": "Gain [<trait_name:perk_skeleton>]",
         "effect": [

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -362,7 +362,7 @@
             }
           ]
         },
-        "values": [ { "value": "POWER_TRICKLE", "add": 250 }, { "value": "ITEM_DAMAGE_ELEC", "add": 3 } ]
+        "values": [ { "value": "POWER_TRICKLE", "add": 250000 }, { "value": "ITEM_DAMAGE_ELEC", "add": 3 } ]
       }
     ]
   },

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -224,7 +224,7 @@
     "id": "perk_vengeful",
     "name": { "str": "Vengeful" },
     "points": 0,
-    "description": "Oh, they're not getting away with THAT.\n\nYou do +15% damage for two turns after you're hit.",
+    "description": "Oh, they're not getting away with THAT.  You do +15% damage for two turns after you're hit.",
     "category": [ "perk" ],
     "enchantments": [ "perk_ench_vengeful" ]
   },
@@ -362,7 +362,7 @@
             }
           ]
         },
-        "values": [ { "value": "POWER_TRICKLE", "add": 500 }, { "value": "ITEM_DAMAGE_ELEC", "add": 3 } ]
+        "values": [ { "value": "POWER_TRICKLE", "add": 250 }, { "value": "ITEM_DAMAGE_ELEC", "add": 3 } ]
       }
     ]
   },
@@ -391,6 +391,14 @@
     "description": "You've always been able to fall asleep within a few minutes of closing your eyes, no matter what else is going on around you.  You have a much easier time falling asleep.",
     "category": [ "perk" ],
     "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "SLEEPY", "add": 15 } ] } ]
+  },
+  {
+    "type": "mutation",
+    "id": "perk_early_to_rise",
+    "name": { "str": "Early to Rise" },
+    "points": 0,
+    "description": "That health, wealth, and wisdom is coming any day now. When you wake up between 4 and 7 a.m., you gain a mood boost for that morning.",
+    "category": [ "perk" ]
   },
   {
     "type": "mutation",

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -755,7 +755,7 @@
     "id": "perk_nocturnal",
     "name": { "str": "perk_nocturnal" },
     "points": 0,
-    "description": "Darkness is your ally. Others have merely adopted the dark, but you were born in it, molded by it. You gain +2 Perception and +1 Intelligence at night, and have a much easier time sleeping during the day. However, you also suffer -2 Perception when outdoors during the day and have a harder time sleeping at night.",
+    "description": "Darkness is your ally.  Others have merely adopted the dark, but you were born in it, molded by it.  You gain +2 Perception and +1 Intelligence at night, and have a much easier time sleeping during the day.  However, you also suffer -2 Perception when outdoors during the day and have a harder time sleeping at night.",
     "category": [ "perk" ],
     "enchantments": [
       {

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -343,6 +343,31 @@
   },
   {
     "type": "mutation",
+    "id": "perk_static_stockpile",
+    "name": { "str": "Static Stockpile" },
+    "points": 0,
+    "description": "You can't touch a door without zapping yourself. Whenever there is a shocker or a robot within 15 squares, or you are outside during a storm, you gain 500J of bionic power per second and your melee attacks will do a small amount of extra electrical damage.",
+    "category": [ "perk" ],
+    "enchantments": [
+      {
+        "condition": {
+          "or": [
+            { "and": [ "u_is_outside", { "or": [ { "is_weather": "lightning" }, { "is_weather": "thunder" } ] } ] },
+            {
+              "math": [
+                "u_monsters_nearby('mon_zombie_brute_shocker', 'mon_zombie_electric', 'mon_skeleton_electric', 'mon_frog_shocker', 'mon_zombie_static', 'mon_amalgamation_zapper', 'mon_zombie_nullfield', 'mon_exodii_worker', 'mon_exodii_quad', 'mon_zomborg', 'mon_zomborg_devourer', 'mon_robofac_skittergun', 'mon_EMP_hack', 'mon_c4_hack', 'mon_flashbang_hack', 'mon_gasbomb_hack', 'mon_grenade_hack', 'mon_manhack', 'exodii_sniper_drone', 'mon_tazer_hack', 'mon_lab_security_drone_GM', 'mon_lab_security_drone_YM', 'mon_lab_security_drone_BM', 'mon_lab_security_drone_BM2', 'mon_lab_security_drone_GR', 'mon_lab_security_drone_BS', 'mon_secubot', 'mon_talon_m202a1', 'mon_secubot_america', 'mon_skitterbot', 'mon_science_bot', 'mon_robofac_prototype', 'mon_dispatch', 'mon_dispatch_military', 'radius': 15)",
+                ">",
+                "0"
+              ]
+            }
+          ]
+        },
+        "values": [ { "value": "POWER_TRICKLE", "add": 500 }, { "value": "ITEM_DAMAGE_ELEC", "add": 3 } ]
+      }
+    ]
+  },
+  {
+    "type": "mutation",
     "id": "perk_jumpy",
     "name": { "str": "Jumpy" },
     "points": 0,

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -255,6 +255,19 @@
   },
   {
     "type": "mutation",
+    "id": "perk_big_eater",
+    "name": { "str": "Big Eater" },
+    "points": 0,
+    "description": "You can really put it away.  You eat food 10% faster and can eat 33% more food at a time.",
+    "category": [ "perk" ],
+    "enchantments": [
+      {
+        "values": [ { "value": "CONSUME_TIME_MOD", "multiply": -0.1 }, { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": 0.33 } ]
+      }
+    ]
+  },
+  {
+    "type": "mutation",
     "id": "perk_tuck_and_roll",
     "name": { "str": "Tuck and Roll" },
     "points": 0,

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -346,7 +346,7 @@
     "id": "perk_static_stockpile",
     "name": { "str": "Static Stockpile" },
     "points": 0,
-    "description": "You can't touch a door without zapping yourself. Whenever there is a shocker or a robot within 15 squares, or you are outside during a storm, you gain 500J of bionic power per second and your melee attacks will do a small amount of extra electrical damage.",
+    "description": "You can't touch a door without zapping yourself.  Whenever there is a shocker or a robot within 15 squares, or you are outside during a storm, you gain 500J of bionic power per second and your melee attacks will do a small amount of extra electrical damage.",
     "category": [ "perk" ],
     "enchantments": [
       {
@@ -397,7 +397,7 @@
     "id": "perk_early_to_rise",
     "name": { "str": "Early to Rise" },
     "points": 0,
-    "description": "That health, wealth, and wisdom is coming any day now. When you wake up between 4 and 7 a.m., you gain a mood boost for that morning.",
+    "description": "That health, wealth, and wisdom is coming any day now.  When you wake up between 4 and 7 a.m., you gain a mood boost for that morning.",
     "category": [ "perk" ]
   },
   {

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -752,6 +752,22 @@
   },
   {
     "type": "mutation",
+    "id": "perk_nocturnal",
+    "name": { "str": "perk_nocturnal" },
+    "points": 0,
+    "description": "Darkness is your ally. Others have merely adopted the dark, but you were born in it, molded by it. You gain +2 Perception and +1 Intelligence at night, and have a much easier time sleeping during the day. However, you also suffer -2 Perception when outdoors during the day and have a harder time sleeping at night.",
+    "category": [ "perk" ],
+    "enchantments": [
+      {
+        "condition": { "not": "is_day" },
+        "values": [ { "value": "PERCEPTION", "add": 2 }, { "value": "INTELLIGENCE", "add": 1 }, { "value": "SLEEPY", "add": -30 } ]
+      },
+      { "condition": "is_day", "values": [ { "value": "SLEEPY", "add": 50 } ] },
+      { "condition": { "and": [ "is_day", "u_is_outside" ] }, "values": [ { "value": "PERCEPTION", "add": -2 } ] }
+    ]
+  },
+  {
+    "type": "mutation",
     "id": "perk_ascetic_empowerment",
     "name": { "str": "Ascetic Empowerment" },
     "points": 0,

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -753,7 +753,7 @@
   {
     "type": "mutation",
     "id": "perk_nocturnal",
-    "name": { "str": "perk_nocturnal" },
+    "name": { "str": "Nocturnal" },
     "points": 0,
     "description": "Darkness is your ally.  Others have merely adopted the dark, but you were born in it, molded by it.  You gain +2 Perception and +1 Intelligence at night, and have a much easier time sleeping during the day.  However, you also suffer -2 Perception when outdoors during the day and have a harder time sleeping at night.",
     "category": [ "perk" ],

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -498,6 +498,20 @@
   },
   {
     "type": "mutation",
+    "id": "perk_firstest_aid",
+    "name": { "str": "Firstest Aid" },
+    "points": 0,
+    "description": "It's called \"First Aid\", right, so obviously it's better the faster you apply it.  Your bandages are 50% better at stopping bleeding, but only if you apply them within 2 minutes of taking damage.",
+    "category": [ "perk" ],
+    "enchantments": [
+      {
+        "condition": { "u_has_effect": "effect_perk_firstest_aid" },
+        "values": [ { "value": "BLEED_STOP_BONUS", "multiply": 0.5 } ]
+      }
+    ]
+  },
+  {
+    "type": "mutation",
     "id": "perk_absit_invidia",
     "name": { "str": "Absit Invidia" },
     "points": 0,

--- a/doc/MAGIC.md
+++ b/doc/MAGIC.md
@@ -873,7 +873,7 @@ Character status value  | Description
 `PAIN_PENALTY_MOD_SPEED`| Amount of speed you lose from pain. Default value is `pain^0.7`. Can't be bigger than 50 speed.
 `PAIN_REMOVE`           | When pain naturally decreases every five minutes the chance of pain removal will be modified by this much.  You will still always have at least a chance to reduce pain.
 `PERCEPTION`            | Affects the perception stat.
-`POWER_TRICKLE`         | Generates this amount of joules each second. Default value is zero, so better to use `add`
+`POWER_TRICKLE`         | Generates this amount of millijoules each second. Default value is zero, so better to use `add`
 `RANGE`                 | Modifies your characters range with firearms
 `RANGED_DAMAGE`         | Adds damage to ranged attacks.
 `READING_EXP`           | Changes the minimum you learn from each reading increment.


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Bombastic Perks] More perks"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I'm back with more perks.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the following perks:

- Firstest Aid: It's called "First Aid" so surely faster is better, right? Your bandages are 50% better at stopping bleeding if you apply them within 2 minutes of taking damage (_requires health care 4_)
- Big Eater: You can really put it away. You eat food 10% faster and can eat 33% more food at a time.
- Static Stockpile: You can't touch a door without zapping yourself.  Whenever there is a shocker or a robot within 15 squares, or you are outside during a storm, you gain 250J of bionic power per second and do a small amount of extra electrical damage. (Requires the Tingly perk)
- Early to Rise: That health, wealth, and wisdom is coming any day now. When you wake up between 4 and 7 a.m., you gain a mood boost for that morning.

And one Playstyle perk:

- Nocturnal: Darkness is your ally.  Others have merely adopted the dark, but you were born in it, molded by it.  You gain +2 Perception and +1 Intelligence at night, and have a much easier time sleeping during the day.  However, you also suffer -2 Perception when outdoors during the day and have a harder time sleeping at night. This explicitly does _not_ increase your night vision.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Perks are selectable and provide appropriate effects.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
