### PR TITLE
Clamp metabolism enchantment to prevent lag

### DIFF
--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -715,7 +715,9 @@ float Character::metabolic_rate_base() const
 {
     static const std::string hunger_rate_string( "PLAYER_HUNGER_RATE" );
     float hunger_rate = get_option< float >( hunger_rate_string );
-    return enchantment_cache->modify_value( enchant_vals::mod::METABOLISM, hunger_rate );
+    const float final_hunger_rate = enchantment_cache->modify_value( enchant_vals::mod::METABOLISM,
+                                    hunger_rate );
+    return std::clamp( final_hunger_rate, 0.0f, float_max );
 }
 
 // TODO: Make this less chaotic to let NPC retroactive catch up work here


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fix #72781
#### Describe the solution
Clamp result value to prevent negative numbers, that will loop for a looong time down the line, in weariness step
#### Testing
Compiled the game, applied effect that applies -10x metabolism
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/67688115/4e8905a4-5bb9-4f50-bd60-736e086baa56)
observed unedited version with the same effect:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/67688115/470c317b-e106-464c-84ae-d1ba29bafe30)
#### Additional context
Doesn't fix the weariness issues when you have low metabolism