### PR TITLE
Don't require parts to be unbroken for fake part generation

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -6385,7 +6385,7 @@ void vehicle::refresh( const bool remove_fakes )
     }
 
     const auto need_fake_part = [&]( const point & real_mount, const std::string & flag ) {
-        int real = part_with_feature( real_mount, flag, true );
+        int real = part_with_feature( real_mount, flag, false );
         if( real >= 0 && real < part_count() ) {
             return real;
         }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fix https://github.com/CleverRaven/Cataclysm-DDA/issues/71451

#### Describe the solution

Fake parts require unbroken real parts for generating the fake part, when a part goes to XX the `relative_parts` cache is still populated with the mount point of the fake part, but the part is no longer there and causes a debugmsg in display code that uses the cache for lookup.

Could also repopulate the relative_parts when a part damage goes to XX, but imo fake parts should be generated regardless of broken status, and a hit to the same mount point should still apply damage and finish breaking off the XX part

#### Describe alternatives you've considered

#### Testing

Scenario in linked issue works for testing

#### Additional context
