### PR TITLE
[Mind Over Matter] Combination Psychic Powers

### DIFF
--- a/data/mods/MindOverMatter/powers/combination_powers/pyrokinesis.json
+++ b/data/mods/MindOverMatter/powers/combination_powers/pyrokinesis.json
@@ -85,5 +85,95 @@
     "max_aoe": 10,
     "max_range": 12,
     "ignored_monster_species": [ "PSI_NULL" ]
+  },
+  {
+    "id": "pyro_biokinetic_dragon_breath",
+    "type": "SPELL",
+    "//": "Requires Pyrokinesis and Biokinesis to learn.",
+    "name": "[Ψ]Dragon's Spittle",
+    "description": "Your body synthesizes a flammable, sticky goop, which is expelled from one of your orificies and ignited.  Causes a raging inferno which sticks around, slowing down enemies caught in the blast..",
+    "message": "You spew forth burning goop!",
+    "teachable": false,
+    "valid_targets": [ "hostile", "ground", "ally" ],
+    "spell_class": "PYROKINETIC",
+    "skill": "metaphysics",
+    "flags": [ "PSIONIC", "CONCENTRATE", "IGNITE_FLAMMABLE", "RANDOM_DAMAGE", "NO_HANDS", "NO_LEGS" ],
+    "difficulty": 6,
+    "max_level": { "math": [ "int_to_level(1)" ] },
+    "effect": "attack",
+    "extra_effects": [ { "id": "pyro_biokinetic_dragon_breath_goop_effect" }, { "id": "psionic_drained_difficulty_six", "hit_self": true } ],
+    "shape": "line",
+    "damage_type": "heat",
+    "min_damage": {
+      "math": [
+        "( (u_spell_level('pyro_biokinetic_dragon_breath') * 3) + 40) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
+      ]
+    },
+    "max_damage": {
+      "math": [
+        "( (u_spell_level('pyro_biokinetic_dragon_breath') * 3) + 55) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
+      ]
+    },
+    "min_range": {
+      "math": [
+        "( (u_spell_level('pyro_biokinetic_dragon_breath') * 0.5) + 5) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
+      ]
+    },
+    "max_range": {
+      "math": [
+        "( (u_spell_level('pyro_biokinetic_dragon_breath') * 0.5) + 5) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
+      ]
+    },
+    "field_id": "fd_fire",
+    "min_field_intensity": 1,
+    "max_field_intensity": 4,
+    "field_chance": 2,
+    "energy_source": "STAMINA",
+    "base_energy_cost": 3000,
+    "final_energy_cost": 1750,
+    "energy_increment": -156,
+    "base_casting_time": 100,
+    "final_casting_time": 35,
+    "casting_time_increment": -4,
+    "sound_type": "combat",
+    "sound_id": "fire_spell",
+    "sound_description": "a crackle!",
+    "ignored_monster_species": [ "PSI_NULL" ]
+  },
+  {
+    "id": "pyro_biokinetic_dragon_breath_goop_effect",
+    "type": "SPELL",
+    "name": "[Ψ]Dragon's Spittle Effect",
+    "description": "Projects a spray of flammable bile.",
+    "valid_targets": [ "ground" ],
+    "effect": "attack",
+    "shape": "cone",
+    "flags": [ "VERBAL", "PERMANENT" ],
+    "difficulty": 6,
+    "max_level": { "math": [ "int_to_level(1)" ] },
+    "min_range": {
+      "math": [
+        "( (u_spell_level('pyro_biokinetic_dragon_breath') * 0.5) + 5) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
+      ]
+    },
+    "max_range": {
+      "math": [
+        "( (u_spell_level('pyro_biokinetic_dragon_breath') * 0.5) + 5) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
+      ]
+    },
+    "min_aoe": {
+      "math": [
+        "min( (( (u_spell_level('pyro_biokinetic_dragon_breath') * 0.5) + 2) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling), 8)"
+      ]
+    },
+    "max_aoe": {
+      "math": [
+        "min( (( (u_spell_level('pyro_biokinetic_dragon_breath') * 0.5) + 8) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling), 8)"
+      ]
+    },
+    "field_id": "fd_web",
+    "field_chance": 1,
+    "min_field_intensity": 3,
+    "max_field_intensity": 3
   }
 ]

--- a/data/mods/MindOverMatter/powers/combination_powers/pyrokinesis.json
+++ b/data/mods/MindOverMatter/powers/combination_powers/pyrokinesis.json
@@ -1,0 +1,89 @@
+[
+  {
+    "id": "pyro_photokinetic_combo_flash",
+    "type": "SPELL",
+    "//": "Requires Pyrokinesis and Photokinesis to learn.",
+    "name": "[Ψ]Sunspot",
+    "description": "By strongly exciting the air at a particular point and enchancing the resulting photons, you produce an extreme burst of light, capable of blinding anyone who sees it, including your friends.  The sheer energy of this reaction also creates a searing heatwave.",
+    "message": "The air erupts into an eye-searing flash!",
+    "teachable": false,
+    "valid_targets": [ "hostile", "ally", "ground" ],
+    "spell_class": "PYROKINETIC",
+    "skill": "metaphysics",
+    "flags": [ "PSIONIC", "CONCENTRATE", "NO_HANDS", "NO_PROJECTILE", "NO_LEGS", "RANDOM_DURATION" ],
+    "difficulty": 4,
+    "max_level": { "math": [ "int_to_level(1)" ] },
+    "effect": "attack",
+    "effect_str": "effect_pyrokinetic_flash",
+    "extra_effects": [ { "id": "pyro_photokinetic_combo_fireball" }, { "id": "psionic_drained_difficulty_four", "hit_self": true } ],
+    "shape": "blast",
+    "affected_body_parts": [ "eyes" ],
+    "min_range": {
+      "math": [
+        "min( (( (u_spell_level('pyro_photokinetic_combo_flash') * 4) + 6) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling), 50)"
+      ]
+    },
+    "max_range": 80,
+    "min_aoe": {
+      "math": [
+        "min( (( (u_spell_level('pyro_photokinetic_combo_flash') * 1.2) + 6) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling), 8)"
+      ]
+    },
+    "max_aoe": 30,
+    "min_duration": {
+      "math": [
+        "( (u_spell_level('pyro_photokinetic_combo_flash') * 1000) + 5000) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
+      ]
+    },
+    "max_duration": {
+      "math": [
+        "( (u_spell_level('pyro_photokinetic_combo_flash') * 1100) + 7000) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
+      ]
+    },
+    "energy_source": "STAMINA",
+    "base_energy_cost": 2500,
+    "final_energy_cost": 1200,
+    "energy_increment": -109,
+    "base_casting_time": 200,
+    "final_casting_time": 100,
+    "casting_time_increment": -8,
+    "ignored_monster_species": [ "PSI_NULL" ]
+  },
+  {
+    "id": "pyro_photokinetic_combo_fireball",
+    "type": "SPELL",
+    "name": "[Ψ]Sunspot Fireball",
+    "description": "Cause a burst of flames for Sunspot.  It is a bug if you have this.",
+    "valid_targets": [ "hostile", "ground", "ally" ],
+    "flags": [ "PSIONIC", "CONCENTRATE", "LOUD", "NO_PROJECTILE", "IGNITE_FLAMMABLE", "RANDOM_DAMAGE", "NO_HANDS", "NO_LEGS" ],
+    "max_level": { "math": [ "int_to_level(1)" ] },
+    "spell_class": "PYROKINETIC",
+    "effect": "attack",
+    "shape": "blast",
+    "damage_type": "heat",
+    "difficulty": 0,
+    "min_damage": {
+      "math": [
+        "( (u_spell_level('pyro_photokinetic_combo_fireball') * 1.5) + 6) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
+      ]
+    },
+    "max_damage": {
+      "math": [
+        "( (u_spell_level('pyro_photokinetic_combo_fireball') * 3) + 12) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
+      ]
+    },
+    "min_range": {
+      "math": [
+        "clamp( ( (u_spell_level('pyro_photokinetic_combo_fireball') + 1) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling), 1, 5)"
+      ]
+    },
+    "min_aoe": {
+      "math": [
+        "min( (( (u_spell_level('pyro_photokinetic_combo_flash') * 0.25) + 3) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling), 8)"
+      ]
+    },
+    "max_aoe": 10,
+    "max_range": 12,
+    "ignored_monster_species": [ "PSI_NULL" ]
+  }
+]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Mind Over Matter] Add class-intermixing powers."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Add some combination powers to Mind Over Matter, requiring attunement to two or more psychic classes to learn and use. Outlined in #71278.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add some combination powers for players to learn/use:
Pyrokinesis:

- [Ψ]Sunspot: Pyrokinesis/Photokinesis, using the powers of controlling fire and light, the psion can create a big, bright flash which can induce blindness, along with creating a fireball to sear enemies. Like a big version of Brilliant Flash/Fountain of Flames.
-  [Ψ]Dragon's Spittle: Pyrokinesis/Biokinesis, allows the caster to spew a bunch of flammable webs from their mouth, setting them on fire in so doing. This works somewhat like Napalm, allowing the flames to stick around, even on non-flammable tiles. Requires a web-spinning mutation to learn and use.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not doing this.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
TBD
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I plan to add a lot more of these later, but I'm a bit tied up with some other projects.

I also don't know where to have the player get these right now, since these aren't meant to be learned by natural inquisition. Maybe by doing a deep search in nether-attuned places, getting these out of books in psychic labs, or maybe studying the brains of dead/feral psions? Perhaps NPCs could also teach these?
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
