### PR TITLE
Test to ensure unconditional and conditional nest placement works

### DIFF
--- a/data/mods/TEST_DATA/nest_conditional_placement_test.json
+++ b/data/mods/TEST_DATA/nest_conditional_placement_test.json
@@ -5,6 +5,7 @@
     "subtype": "mutable",
     "locations": [ "land" ],
     "check_for_locations_area": [ { "type": [ "land", "ncpt_predecessors" ], "from": [ -1, -1, 0 ], "to": [ 1, 1, 0 ] } ],
+    "rotate": false,
     "occurrences": [ 0, 0 ],
     "joins": [ "ncpt_joins" ],
     "overmaps": {

--- a/data/mods/TEST_DATA/nest_conditional_placement_test.json
+++ b/data/mods/TEST_DATA/nest_conditional_placement_test.json
@@ -1,0 +1,128 @@
+[
+  {
+    "type": "overmap_special",
+    "id": "nest_conditional_placement_test_mutable",
+    "subtype": "mutable",
+    "locations": [ "land" ],
+    "check_for_locations_area": [ { "type": [ "land", "ncpt_predecessors" ], "from": [ -1, -1, 0 ], "to": [ 1, 1, 0 ] } ],
+    "occurrences": [ 0, 0 ],
+    "joins": [ "ncpt_joins" ],
+    "overmaps": {
+      "test_map": {
+        "overmap": "nest_conditional_placement_test",
+        "north": "ncpt_joins",
+        "east": "ncpt_joins",
+        "locations": [ "ncpt_predecessors" ]
+      },
+      "neighbors_s": { "overmap": "ncpt_neighbors", "south": "ncpt_joins" },
+      "neighbors_w": { "overmap": "ncpt_neighbors", "west": "ncpt_joins" },
+      "flags": { "overmap": "ncpt_flags" }
+    },
+    "root": "test_map",
+    "phases": [
+      [
+        {
+          "name": "maps_for_conditions",
+          "chunk": [
+            { "overmap": "neighbors_s", "pos": [ 0, -1, 0 ] },
+            { "overmap": "neighbors_w", "pos": [ 1, 0, 0 ] },
+            { "overmap": "flags", "pos": [ 0, 1, 0 ] },
+            { "overmap": "flags", "pos": [ -1, 0, 0 ] }
+          ],
+          "max": 1
+        }
+      ]
+    ]
+  },
+  {
+    "type": "overmap_location",
+    "id": "ncpt_predecessors",
+    "terrains": [ "ncpt_predecessors" ]
+  },
+  {
+    "method": "json",
+    "om_terrain": "nest_conditional_placement_test",
+    "type": "mapgen",
+    "object": {
+      "fill_ter": "t_linoleum_gray",
+      "place_nested": [
+        { "chunks": [ "1x1_ncpt" ], "x": 0, "y": 0 },
+        { "else_chunks": [ "1x1_ncpt" ], "x": 0, "y": 1 },
+        {
+          "chunks": [ "1x1_ncpt" ],
+          "neighbors": { "north": [ "ncpt_neighbors" ], "east": [ "ncpt_neighbors" ] },
+          "x": 1,
+          "y": 0
+        },
+        {
+          "chunks": [ "1x1_ncpt" ],
+          "neighbors": { "south": [ "ncpt_neighbors" ], "west": [ "ncpt_neighbors" ] },
+          "x": 1,
+          "y": 1
+        },
+        { "chunks": [ "1x1_ncpt" ], "joins": { "north": [ "ncpt_joins" ], "east": [ "ncpt_joins" ] }, "x": 2, "y": 0 },
+        { "chunks": [ "1x1_ncpt" ], "joins": { "south": [ "ncpt_joins" ], "west": [ "ncpt_joins" ] }, "x": 2, "y": 1 },
+        { "chunks": [ "1x1_ncpt" ], "flags": { "south": [ "RISK_HIGH" ], "west": [ "RISK_HIGH" ] }, "x": 3, "y": 0 },
+        { "chunks": [ "1x1_ncpt" ], "flags": { "north": [ "RISK_HIGH" ], "east": [ "RISK_HIGH" ] }, "x": 3, "y": 1 },
+        {
+          "chunks": [ "1x1_ncpt" ],
+          "flags_any": { "north": [ "RISK_HIGH" ], "east": [ "RISK_HIGH" ], "south": [ "RISK_HIGH" ], "west": [ "RISK_HIGH" ] },
+          "x": 4,
+          "y": 0
+        },
+        {
+          "chunks": [ "1x1_ncpt" ],
+          "flags_any": { "north": [ "RISK_LOW" ], "east": [ "RISK_LOW" ], "south": [ "RISK_LOW" ], "west": [ "RISK_LOW" ] },
+          "x": 4,
+          "y": 1
+        },
+        { "chunks": [ "1x1_ncpt" ], "predecessors": [ "ncpt_predecessors" ], "x": 5, "y": 0 },
+        { "chunks": [ "1x1_ncpt" ], "predecessors": [ "field" ], "x": 5, "y": 1 },
+        { "chunks": [ "1x1_ncpt" ], "z_check": [ 0, 2, 4 ], "x": 6, "y": 0 },
+        { "chunks": [ "1x1_ncpt" ], "z_check": [ -1, 1, 3 ], "x": 6, "y": 1 }
+      ]
+    }
+  },
+  {
+    "method": "json",
+    "om_terrain": [ "ncpt_predecessors", "ncpt_flags", "ncpt_neighbors" ],
+    "type": "mapgen",
+    "object": { "fill_ter": "t_linoleum_gray" }
+  },
+  {
+    "method": "json",
+    "nested_mapgen_id": "1x1_ncpt",
+    "type": "mapgen",
+    "object": { "mapgensize": [ 1, 1 ], "rows": [ "." ], "terrain": { ".": "t_linoleum_white" } }
+  },
+  {
+    "type": "overmap_terrain",
+    "abstract": "ncpt_generic",
+    "name": "nest conditional placement test",
+    "sym": ".",
+    "color": "white",
+    "flags": [ "NO_ROTATE" ]
+  },
+  {
+    "type": "overmap_terrain",
+    "id": "nest_conditional_placement_test",
+    "copy-from": "ncpt_generic",
+    "extend": { "flags": [ "REQUIRES_PREDECESSOR" ] }
+  },
+  {
+    "type": "overmap_terrain",
+    "id": "ncpt_predecessors",
+    "copy-from": "ncpt_generic"
+  },
+  {
+    "type": "overmap_terrain",
+    "id": "ncpt_flags",
+    "copy-from": "ncpt_generic",
+    "extend": { "flags": [ "RISK_HIGH" ] }
+  },
+  {
+    "type": "overmap_terrain",
+    "id": "ncpt_neighbors",
+    "copy-from": "ncpt_generic"
+  }
+]

--- a/data/mods/TEST_DATA/nest_conditional_placement_test.json
+++ b/data/mods/TEST_DATA/nest_conditional_placement_test.json
@@ -138,7 +138,7 @@
     "name": "nest conditional placement test",
     "sym": ".",
     "color": "white",
-    "flags": [ "NO_ROTATE" ]
+    "flags": [ "NO_ROTATE", "SHOULD_NOT_SPAWN" ]
   },
   {
     "type": "overmap_terrain",

--- a/data/mods/TEST_DATA/nest_conditional_placement_test.json
+++ b/data/mods/TEST_DATA/nest_conditional_placement_test.json
@@ -79,8 +79,8 @@
         },
         { "chunks": [ "1x1_ncpt" ], "predecessors": [ "ncpt_predecessors" ], "x": 5, "y": 0 },
         { "chunks": [ "1x1_ncpt" ], "predecessors": [ "field" ], "x": 5, "y": 1 },
-        { "chunks": [ "1x1_ncpt" ], "z_check": [ 0, 2, 4 ], "x": 6, "y": 0 },
-        { "chunks": [ "1x1_ncpt" ], "z_check": [ -1, 1, 3 ], "x": 6, "y": 1 },
+        { "chunks": [ "1x1_ncpt" ], "check_z": [ 0, 2, 4 ], "x": 6, "y": 0 },
+        { "chunks": [ "1x1_ncpt" ], "check_z": [ -1, 1, 3 ], "x": 6, "y": 1 },
         {
           "chunks": [ "1x1_ncpt" ],
           "neighbors": {

--- a/data/mods/TEST_DATA/nest_conditional_placement_test.json
+++ b/data/mods/TEST_DATA/nest_conditional_placement_test.json
@@ -80,7 +80,43 @@
         { "chunks": [ "1x1_ncpt" ], "predecessors": [ "ncpt_predecessors" ], "x": 5, "y": 0 },
         { "chunks": [ "1x1_ncpt" ], "predecessors": [ "field" ], "x": 5, "y": 1 },
         { "chunks": [ "1x1_ncpt" ], "z_check": [ 0, 2, 4 ], "x": 6, "y": 0 },
-        { "chunks": [ "1x1_ncpt" ], "z_check": [ -1, 1, 3 ], "x": 6, "y": 1 }
+        { "chunks": [ "1x1_ncpt" ], "z_check": [ -1, 1, 3 ], "x": 6, "y": 1 },
+        {
+          "chunks": [ "1x1_ncpt" ],
+          "neighbors": {
+            "north": [ { "om_terrain": "ncpt", "om_terrain_match_type": "PREFIX" } ],
+            "east": [ { "om_terrain": "ncpt", "om_terrain_match_type": "PREFIX" } ],
+            "south": [ { "om_terrain": "ncpt", "om_terrain_match_type": "PREFIX" } ],
+            "west": [ { "om_terrain": "ncpt", "om_terrain_match_type": "PREFIX" } ]
+          },
+          "x": 22,
+          "y": 0
+        },
+        {
+          "chunks": [ "1x1_ncpt" ],
+          "neighbors": {
+            "above": [ { "om_terrain": "ncpt", "om_terrain_match_type": "PREFIX" } ],
+            "below": [ { "om_terrain": "ncpt", "om_terrain_match_type": "PREFIX" } ]
+          },
+          "x": 22,
+          "y": 1
+        },
+        {
+          "chunks": [ "1x1_ncpt" ],
+          "neighbors": { "north": [ "ncpt_neighbors" ], "east": [ "ncpt_neighbors" ] },
+          "joins": { "north": [ "ncpt_joins" ], "east": [ "ncpt_joins" ] },
+          "flags": { "south": [ "RISK_HIGH" ], "west": [ "RISK_HIGH" ] },
+          "x": 23,
+          "y": 0
+        },
+        {
+          "chunks": [ "1x1_ncpt" ],
+          "neighbors": { "north": [ "ncpt_neighbors" ], "east": [ "ncpt_neighbors" ] },
+          "joins": { "north": [ "ncpt_joins" ], "east": [ "ncpt_joins" ] },
+          "flags": { "south": [ "RISK_LOW" ], "west": [ "RISK_LOW" ] },
+          "x": 23,
+          "y": 1
+        }
       ]
     }
   },

--- a/tests/nest_conditional_placement_test.cpp
+++ b/tests/nest_conditional_placement_test.cpp
@@ -73,4 +73,16 @@ TEST_CASE( "nest_conditional_placement", "[map][nest]" )
     CHECK( flags_success );
     CHECK( flags_any_success );
     CHECK( z_check_success );
+    //Only run more advanced checks if we passed all the basic ones so as to not muddy more basic issues
+    if( unconditional_success && neighbors_success && joins_success && flags_success &&
+        flags_any_success && predecessors_success && z_check_success ) {
+        //Check the neighbors condition works with om_terrain_match_type
+        const bool om_terrain_match_type_success = tm.ter( { 22, 0, 0 } ) == placed &&
+                tm.ter( { 22, 1, 0 } ) == unplaced;
+        //Check that all conditions are required when multiple are specified
+        const bool multiconditional_success = tm.ter( { 23, 0, 0 } ) == placed &&
+                                              tm.ter( { 23, 1, 0 } ) == unplaced;
+        CHECK( om_terrain_match_type_success );
+        CHECK( multiconditional_success );
+    }
 }

--- a/tests/nest_conditional_placement_test.cpp
+++ b/tests/nest_conditional_placement_test.cpp
@@ -1,3 +1,4 @@
+#include "cata_catch.h"
 #include "city.h"
 #include "coordinates.h"
 #include "game_constants.h"
@@ -6,13 +7,14 @@
 #include "overmapbuffer.h"
 #include "test_data.h"
 
-static const oter_str_id field( "field" );
-static const oter_str_id ncpt_predecessors( "ncpt_predecessors" );
+static const oter_str_id oter_field( "field" );
+static const oter_str_id oter_ncpt_predecessors( "ncpt_predecessors" );
 
-static const overmap_special_id test_mutable( "nest_conditional_placement_test_mutable" );
+static const overmap_special_id
+overmap_special_nest_conditional_placement_test_mutable( "nest_conditional_placement_test_mutable" );
 
-static const ter_str_id placed( "t_linoleum_white" );
-static const ter_str_id unplaced( "t_linoleum_gray" );
+static const ter_str_id ter_t_linoleum_gray( "t_linoleum_gray" ); //Signifies the nest wasn't placed
+static const ter_str_id ter_t_linoleum_white( "t_linoleum_white" ); //Signifies the nest was placed
 
 //Check unconditional nests place and that each nest condition works as intended
 TEST_CASE( "nest_conditional_placement", "[map][nest]" )
@@ -24,7 +26,7 @@ TEST_CASE( "nest_conditional_placement", "[map][nest]" )
     overmap_buffer.create_custom_overmap( overmap_point, empty_special_batch );
     overmap *om = overmap_buffer.get_existing( overmap_point );
 
-    const overmap_special &special = *test_mutable;
+    const overmap_special &special = *overmap_special_nest_conditional_placement_test_mutable;
     const tripoint_om_omt test_omt_pos( OMAPX / 2, OMAPY / 2, 0 );
     const tripoint_rel_omt tinymap_point_offset( OMAPX / 2, OMAPY / 2, 0 );
     const tripoint_abs_omt tinymap_point = om->global_base_point() + tinymap_point_offset;
@@ -35,11 +37,11 @@ TEST_CASE( "nest_conditional_placement", "[map][nest]" )
     for( int i = -1; i < 2; i++ ) {
         for( int j = -1; j < 2; j++ ) {
             tripoint_rel_omt offset( i, j, 0 );
-            om->ter_set( test_omt_pos + offset, field.id() );
+            om->ter_set( test_omt_pos + offset, oter_field.id() );
         }
     }
     //Add the predecessor omt
-    om->ter_set( test_omt_pos, ncpt_predecessors.id() );
+    om->ter_set( test_omt_pos, oter_ncpt_predecessors.id() );
     //Place the mutable over the predecessor omt
     if( om->can_place_special( special, test_omt_pos, dir, false ) ) {
         std::vector<tripoint_om_omt> placed_points =
@@ -52,21 +54,21 @@ TEST_CASE( "nest_conditional_placement", "[map][nest]" )
     tinymap tm;
     tm.load( tinymap_point, false );
 
-    //The y0 row is always supposed to place while the y1 row should always fail
-    const bool unconditional_success = tm.ter( { 0, 0, 0 } ) == placed &&
-                                       tm.ter( { 0, 1, 0 } ) == unplaced;
-    const bool neighbors_success = tm.ter( { 1, 0, 0 } ) == placed &&
-                                   tm.ter( { 1, 1, 0 } ) == unplaced;
-    const bool joins_success = tm.ter( { 2, 0, 0 } ) == placed &&
-                               tm.ter( { 2, 1, 0 } ) == unplaced;
-    const bool flags_success = tm.ter( { 3, 0, 0 } ) == placed &&
-                               tm.ter( { 3, 1, 0 } ) == unplaced;
-    const bool flags_any_success = tm.ter( { 4, 0, 0 } ) == placed &&
-                                   tm.ter( { 4, 1, 0 } ) == unplaced;
-    const bool predecessors_success = tm.ter( { 5, 0, 0 } ) == placed &&
-                                      tm.ter( { 5, 1, 0 } ) == unplaced;
-    const bool z_check_success = tm.ter( { 6, 0, 0 } ) == placed &&
-                                 tm.ter( { 6, 1, 0 } ) == unplaced;
+    //The y0 row has conditions that should result in t_linoleum_white being placed while the y1 row has conditions that should always fail to place t_linoleum_white
+    const bool unconditional_success = tm.ter( { 0, 0, 0 } ) == ter_t_linoleum_white &&
+                                       tm.ter( { 0, 1, 0 } ) == ter_t_linoleum_gray;
+    const bool neighbors_success = tm.ter( { 1, 0, 0 } ) == ter_t_linoleum_white &&
+                                   tm.ter( { 1, 1, 0 } ) == ter_t_linoleum_gray;
+    const bool joins_success = tm.ter( { 2, 0, 0 } ) == ter_t_linoleum_white &&
+                               tm.ter( { 2, 1, 0 } ) == ter_t_linoleum_gray;
+    const bool flags_success = tm.ter( { 3, 0, 0 } ) == ter_t_linoleum_white &&
+                               tm.ter( { 3, 1, 0 } ) == ter_t_linoleum_gray;
+    const bool flags_any_success = tm.ter( { 4, 0, 0 } ) == ter_t_linoleum_white &&
+                                   tm.ter( { 4, 1, 0 } ) == ter_t_linoleum_gray;
+    const bool predecessors_success = tm.ter( { 5, 0, 0 } ) == ter_t_linoleum_white &&
+                                      tm.ter( { 5, 1, 0 } ) == ter_t_linoleum_gray;
+    const bool z_check_success = tm.ter( { 6, 0, 0 } ) == ter_t_linoleum_white &&
+                                 tm.ter( { 6, 1, 0 } ) == ter_t_linoleum_gray;
     CHECK( unconditional_success );
     CHECK( neighbors_success );
     CHECK( joins_success );
@@ -77,11 +79,11 @@ TEST_CASE( "nest_conditional_placement", "[map][nest]" )
     if( unconditional_success && neighbors_success && joins_success && flags_success &&
         flags_any_success && predecessors_success && z_check_success ) {
         //Check the neighbors condition works with om_terrain_match_type
-        const bool om_terrain_match_type_success = tm.ter( { 22, 0, 0 } ) == placed &&
-                tm.ter( { 22, 1, 0 } ) == unplaced;
+        const bool om_terrain_match_type_success = tm.ter( { 22, 0, 0 } ) == ter_t_linoleum_white &&
+                tm.ter( { 22, 1, 0 } ) == ter_t_linoleum_gray;
         //Check that all conditions are required when multiple are specified
-        const bool multiconditional_success = tm.ter( { 23, 0, 0 } ) == placed &&
-                                              tm.ter( { 23, 1, 0 } ) == unplaced;
+        const bool multiconditional_success = tm.ter( { 23, 0, 0 } ) == ter_t_linoleum_white &&
+                                              tm.ter( { 23, 1, 0 } ) == ter_t_linoleum_gray;
         CHECK( om_terrain_match_type_success );
         CHECK( multiconditional_success );
     }

--- a/tests/nest_conditional_placement_test.cpp
+++ b/tests/nest_conditional_placement_test.cpp
@@ -15,7 +15,7 @@ static const ter_str_id placed( "t_linoleum_white" );
 static const ter_str_id unplaced( "t_linoleum_gray" );
 
 //Check unconditional nests place and that each nest condition works as intended
-TEST_CASE( "nest_conditional_placement", "[overmap]" )
+TEST_CASE( "nest_conditional_placement", "[map][nest]" )
 {
     //Create a fresh overmap with no specials to guarentee no preexisting joins. Placed at an arbitary point so it doesn't overwrite other tests overmaps
     const point_abs_om overmap_point( 122, 122 );

--- a/tests/nest_conditional_placement_test.cpp
+++ b/tests/nest_conditional_placement_test.cpp
@@ -1,0 +1,76 @@
+#include "city.h"
+#include "coordinates.h"
+#include "game_constants.h"
+#include "map.h"
+#include "overmap.h"
+#include "overmapbuffer.h"
+#include "test_data.h"
+
+static const oter_str_id field( "field" );
+static const oter_str_id ncpt_predecessors( "ncpt_predecessors" );
+
+static const overmap_special_id test_mutable( "nest_conditional_placement_test_mutable" );
+
+static const ter_str_id placed( "t_linoleum_white" );
+static const ter_str_id unplaced( "t_linoleum_gray" );
+
+//Check unconditional nests place and that each nest condition works as intended
+TEST_CASE( "nest_conditional_placement", "[overmap]" )
+{
+    //Create a fresh overmap with no specials to guarentee no preexisting joins. Placed at an arbitary point so it doesn't overwrite other tests overmaps
+    const point_abs_om overmap_point( 122, 122 );
+    const std::vector<const overmap_special *> empty_specials;
+    overmap_special_batch empty_special_batch( overmap_point, empty_specials );
+    overmap_buffer.create_custom_overmap( overmap_point, empty_special_batch );
+    overmap *om = overmap_buffer.get_existing( overmap_point );
+
+    const overmap_special &special = *test_mutable;
+    const tripoint_om_omt test_omt_pos( OMAPX / 2, OMAPY / 2, 0 );
+    const tripoint_rel_omt tinymap_point_offset( OMAPX / 2, OMAPY / 2, 0 );
+    const tripoint_abs_omt tinymap_point = om->global_base_point() + tinymap_point_offset;
+    const om_direction::type dir = om_direction::type::north;
+    const city cit;
+
+    //Add land to guarentee mutable placement
+    for( int i = -1; i < 2; i++ ) {
+        for( int j = -1; j < 2; j++ ) {
+            tripoint_rel_omt offset( i, j, 0 );
+            om->ter_set( test_omt_pos + offset, field.id() );
+        }
+    }
+    //Add the predecessor omt
+    om->ter_set( test_omt_pos, ncpt_predecessors.id() );
+    //Place the mutable over the predecessor omt
+    if( om->can_place_special( special, test_omt_pos, dir, false ) ) {
+        std::vector<tripoint_om_omt> placed_points =
+            om->place_special( special, test_omt_pos, dir, cit, false, false );
+        //Require that the mutable placed and placed more than just the root
+        const bool mutable_placed_successfully = placed_points.size() > 1;
+        REQUIRE( mutable_placed_successfully );
+    }
+
+    tinymap tm;
+    tm.load( tinymap_point, false );
+
+    //The y0 row is always supposed to place while the y1 row should always fail
+    const bool unconditional_success = tm.ter( { 0, 0, 0 } ) == placed &&
+                                       tm.ter( { 0, 1, 0 } ) == unplaced;
+    const bool neighbors_success = tm.ter( { 1, 0, 0 } ) == placed &&
+                                   tm.ter( { 1, 1, 0 } ) == unplaced;
+    const bool joins_success = tm.ter( { 2, 0, 0 } ) == placed &&
+                               tm.ter( { 2, 1, 0 } ) == unplaced;
+    const bool flags_success = tm.ter( { 3, 0, 0 } ) == placed &&
+                               tm.ter( { 3, 1, 0 } ) == unplaced;
+    const bool flags_any_success = tm.ter( { 4, 0, 0 } ) == placed &&
+                                   tm.ter( { 4, 1, 0 } ) == unplaced;
+    const bool predecessors_success = tm.ter( { 5, 0, 0 } ) == placed &&
+                                      tm.ter( { 5, 1, 0 } ) == unplaced;
+    const bool z_check_success = tm.ter( { 6, 0, 0 } ) == placed &&
+                                 tm.ter( { 6, 1, 0 } ) == unplaced;
+    CHECK( unconditional_success );
+    CHECK( neighbors_success );
+    CHECK( joins_success );
+    CHECK( flags_success );
+    CHECK( flags_any_success );
+    CHECK( z_check_success );
+}

--- a/tests/nest_conditional_placement_test.cpp
+++ b/tests/nest_conditional_placement_test.cpp
@@ -55,20 +55,21 @@ TEST_CASE( "nest_conditional_placement", "[map][nest]" )
     tm.load( tinymap_point, false );
 
     //The y0 row has conditions that should result in t_linoleum_white being placed while the y1 row has conditions that should always fail to place t_linoleum_white
-    const bool unconditional_success = tm.ter( { 0, 0, 0 } ) == ter_t_linoleum_white &&
-                                       tm.ter( { 0, 1, 0 } ) == ter_t_linoleum_gray;
-    const bool neighbors_success = tm.ter( { 1, 0, 0 } ) == ter_t_linoleum_white &&
-                                   tm.ter( { 1, 1, 0 } ) == ter_t_linoleum_gray;
-    const bool joins_success = tm.ter( { 2, 0, 0 } ) == ter_t_linoleum_white &&
-                               tm.ter( { 2, 1, 0 } ) == ter_t_linoleum_gray;
-    const bool flags_success = tm.ter( { 3, 0, 0 } ) == ter_t_linoleum_white &&
-                               tm.ter( { 3, 1, 0 } ) == ter_t_linoleum_gray;
-    const bool flags_any_success = tm.ter( { 4, 0, 0 } ) == ter_t_linoleum_white &&
-                                   tm.ter( { 4, 1, 0 } ) == ter_t_linoleum_gray;
-    const bool predecessors_success = tm.ter( { 5, 0, 0 } ) == ter_t_linoleum_white &&
-                                      tm.ter( { 5, 1, 0 } ) == ter_t_linoleum_gray;
-    const bool z_check_success = tm.ter( { 6, 0, 0 } ) == ter_t_linoleum_white &&
-                                 tm.ter( { 6, 1, 0 } ) == ter_t_linoleum_gray;
+    //Can remove tripoint_omt_ms disambiguation once tinymap::ter raw tripoint overload is removed
+    const bool unconditional_success = tm.ter( tripoint_omt_ms{ 0, 0, 0 } ) == ter_t_linoleum_white &&
+                                       tm.ter( tripoint_omt_ms{ 0, 1, 0 } ) == ter_t_linoleum_gray;
+    const bool neighbors_success = tm.ter( tripoint_omt_ms{ 1, 0, 0 } ) == ter_t_linoleum_white &&
+                                   tm.ter( tripoint_omt_ms{ 1, 1, 0 } ) == ter_t_linoleum_gray;
+    const bool joins_success = tm.ter( tripoint_omt_ms{ 2, 0, 0 } ) == ter_t_linoleum_white &&
+                               tm.ter( tripoint_omt_ms{ 2, 1, 0 } ) == ter_t_linoleum_gray;
+    const bool flags_success = tm.ter( tripoint_omt_ms{ 3, 0, 0 } ) == ter_t_linoleum_white &&
+                               tm.ter( tripoint_omt_ms{ 3, 1, 0 } ) == ter_t_linoleum_gray;
+    const bool flags_any_success = tm.ter( tripoint_omt_ms{ 4, 0, 0 } ) == ter_t_linoleum_white &&
+                                   tm.ter( tripoint_omt_ms{ 4, 1, 0 } ) == ter_t_linoleum_gray;
+    const bool predecessors_success = tm.ter( tripoint_omt_ms{ 5, 0, 0 } ) == ter_t_linoleum_white &&
+                                      tm.ter( tripoint_omt_ms{ 5, 1, 0 } ) == ter_t_linoleum_gray;
+    const bool z_check_success = tm.ter( tripoint_omt_ms{ 6, 0, 0 } ) == ter_t_linoleum_white &&
+                                 tm.ter( tripoint_omt_ms{ 6, 1, 0 } ) == ter_t_linoleum_gray;
     CHECK( unconditional_success );
     CHECK( neighbors_success );
     CHECK( joins_success );
@@ -79,11 +80,13 @@ TEST_CASE( "nest_conditional_placement", "[map][nest]" )
     if( unconditional_success && neighbors_success && joins_success && flags_success &&
         flags_any_success && predecessors_success && z_check_success ) {
         //Check the neighbors condition works with om_terrain_match_type
-        const bool om_terrain_match_type_success = tm.ter( { 22, 0, 0 } ) == ter_t_linoleum_white &&
-                tm.ter( { 22, 1, 0 } ) == ter_t_linoleum_gray;
+        const bool om_terrain_match_type_success = tm.ter( tripoint_omt_ms{ 22, 0, 0 } ) ==
+                ter_t_linoleum_white &&
+                tm.ter( tripoint_omt_ms{ 22, 1, 0 } ) == ter_t_linoleum_gray;
         //Check that all conditions are required when multiple are specified
-        const bool multiconditional_success = tm.ter( { 23, 0, 0 } ) == ter_t_linoleum_white &&
-                                              tm.ter( { 23, 1, 0 } ) == ter_t_linoleum_gray;
+        const bool multiconditional_success = tm.ter( tripoint_omt_ms{ 23, 0, 0 } ) == ter_t_linoleum_white
+                                              &&
+                                              tm.ter( tripoint_omt_ms{ 23, 1, 0 } ) == ter_t_linoleum_gray;
         CHECK( om_terrain_match_type_success );
         CHECK( multiconditional_success );
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Prevent a repeat of #67197
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
The test checks each conditional placement method with both a condition that should resolve true and another that should resolve false, as well as an unconditional nest with an else_chunks for it's false test
Checks that om_terrain_match_type works in neighbors
Checks that if multiple conditions are used all must be true
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Adding this sooner
Giving each nest an else_chunk with a false terrain so you have true/false/unplaced as opposed to placed/unplaced
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Ran 550 times locally with no fails
(Running it 500 times on my not particularly powerful PC only took 27.88s, I love how fast code can be)
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
