### PR TITLE
Add translation context to short art snippets

### DIFF
--- a/data/json/snippets/art/general_art.json
+++ b/data/json/snippets/art/general_art.json
@@ -3,10 +3,10 @@
     "type": "snippet",
     "category": "<random_flat_direction>",
     "text": [
-      { "id": "random_flat_direction_0001", "text": "left" },
-      { "id": "random_flat_direction_0002", "text": "right" },
-      { "id": "random_flat_direction_0003", "text": "top" },
-      { "id": "random_flat_direction_0004", "text": "bottom" }
+      { "id": "random_flat_direction_0001", "text": { "ctxt": "random_flat_direction", "str": "left" } },
+      { "id": "random_flat_direction_0002", "text": { "ctxt": "random_flat_direction", "str": "right" } },
+      { "id": "random_flat_direction_0003", "text": { "ctxt": "random_flat_direction", "str": "top" } },
+      { "id": "random_flat_direction_0004", "text": { "ctxt": "random_flat_direction", "str": "bottom" } }
     ]
   },
   {
@@ -30,15 +30,15 @@
     "type": "snippet",
     "category": "<painting_style>",
     "text": [
-      { "id": "painting_style_0001", "text": "baroque" },
-      { "id": "painting_style_0002", "text": "impressionist" },
-      { "id": "painting_style_0003", "text": "realist" },
-      { "id": "painting_style_0004", "text": "abstract" },
-      { "id": "painting_style_0005", "text": "photorealist" },
-      { "id": "painting_style_0006", "text": "expressionist" },
-      { "id": "painting_style_0007", "text": "surrealist" },
-      { "id": "painting_style_0008", "text": "pop art" },
-      { "id": "painting_style_0009", "text": "minimalist" }
+      { "id": "painting_style_0001", "text": { "ctxt": "painting_style", "str": "baroque" } },
+      { "id": "painting_style_0002", "text": { "ctxt": "painting_style", "str": "impressionist" } },
+      { "id": "painting_style_0003", "text": { "ctxt": "painting_style", "str": "realist" } },
+      { "id": "painting_style_0004", "text": { "ctxt": "painting_style", "str": "abstract" } },
+      { "id": "painting_style_0005", "text": { "ctxt": "painting_style", "str": "photorealist" } },
+      { "id": "painting_style_0006", "text": { "ctxt": "painting_style", "str": "expressionist" } },
+      { "id": "painting_style_0007", "text": { "ctxt": "painting_style", "str": "surrealist" } },
+      { "id": "painting_style_0008", "text": { "ctxt": "painting_style", "str": "pop art" } },
+      { "id": "painting_style_0009", "text": { "ctxt": "painting_style", "str": "minimalist" } }
     ]
   },
   {
@@ -62,16 +62,16 @@
     "category": "<random_color>",
     "//": "There can potentially be hundreds of these if so desired, with how many different colors there are.  A list can be found here: https://en.wikipedia.org/wiki/List_of_colors:_A%E2%80%93F",
     "text": [
-      { "id": "random_color_0001", "text": "red" },
-      { "id": "random_color_0002", "text": "white" },
-      { "id": "random_color_0003", "text": "blue" },
-      { "id": "random_color_0004", "text": "green" },
-      { "id": "random_color_0005", "text": "orange" },
-      { "id": "random_color_0006", "text": "brown" },
-      { "id": "random_color_0007", "text": "pink" },
-      { "id": "random_color_0008", "text": "purple" },
-      { "id": "random_color_0009", "text": "gray" },
-      { "id": "random_color_0010", "text": "black" }
+      { "id": "random_color_0001", "text": { "ctxt": "random_color", "str": "red" } },
+      { "id": "random_color_0002", "text": { "ctxt": "random_color", "str": "white" } },
+      { "id": "random_color_0003", "text": { "ctxt": "random_color", "str": "blue" } },
+      { "id": "random_color_0004", "text": { "ctxt": "random_color", "str": "green" } },
+      { "id": "random_color_0005", "text": { "ctxt": "random_color", "str": "orange" } },
+      { "id": "random_color_0006", "text": { "ctxt": "random_color", "str": "brown" } },
+      { "id": "random_color_0007", "text": { "ctxt": "random_color", "str": "pink" } },
+      { "id": "random_color_0008", "text": { "ctxt": "random_color", "str": "purple" } },
+      { "id": "random_color_0009", "text": { "ctxt": "random_color", "str": "gray" } },
+      { "id": "random_color_0010", "text": { "ctxt": "random_color", "str": "black" } }
     ]
   },
   {
@@ -86,25 +86,25 @@
     "type": "snippet",
     "category": "<random_shape_2d>",
     "text": [
-      { "id": "random_shape_2d_0001", "text": "square" },
-      { "id": "random_shape_2d_0002", "text": "circle" },
-      { "id": "random_shape_2d_0003", "text": "triangle" },
-      { "id": "random_shape_2d_0004", "text": "star" },
-      { "id": "random_shape_2d_0005", "text": "trapezoid" },
-      { "id": "random_shape_2d_0006", "text": "rectangle" },
-      { "id": "random_shape_2d_0007", "text": "hexagon" },
-      { "id": "random_shape_2d_0008", "text": "parallelogram" },
-      { "id": "random_shape_2d_0009", "text": "square" }
+      { "id": "random_shape_2d_0001", "text": { "ctxt": "random_shape_2d", "str": "square" } },
+      { "id": "random_shape_2d_0002", "text": { "ctxt": "random_shape_2d", "str": "circle" } },
+      { "id": "random_shape_2d_0003", "text": { "ctxt": "random_shape_2d", "str": "triangle" } },
+      { "id": "random_shape_2d_0004", "text": { "ctxt": "random_shape_2d", "str": "star" } },
+      { "id": "random_shape_2d_0005", "text": { "ctxt": "random_shape_2d", "str": "trapezoid" } },
+      { "id": "random_shape_2d_0006", "text": { "ctxt": "random_shape_2d", "str": "rectangle" } },
+      { "id": "random_shape_2d_0007", "text": { "ctxt": "random_shape_2d", "str": "hexagon" } },
+      { "id": "random_shape_2d_0008", "text": { "ctxt": "random_shape_2d", "str": "parallelogram" } },
+      { "id": "random_shape_2d_0009", "text": { "ctxt": "random_shape_2d", "str": "square" } }
     ]
   },
   {
     "type": "snippet",
     "category": "<random_shape_3d>",
     "text": [
-      { "id": "random_shape_3d_0001", "text": "cone" },
-      { "id": "random_shape_3d_0002", "text": "sphere" },
-      { "id": "random_shape_3d_0003", "text": "cube" },
-      { "id": "random_shape_3d_0004", "text": "tube" }
+      { "id": "random_shape_3d_0001", "text": { "ctxt": "random_shape_3d", "str": "cone" } },
+      { "id": "random_shape_3d_0002", "text": { "ctxt": "random_shape_3d", "str": "sphere" } },
+      { "id": "random_shape_3d_0003", "text": { "ctxt": "random_shape_3d", "str": "cube" } },
+      { "id": "random_shape_3d_0004", "text": { "ctxt": "random_shape_3d", "str": "tube" } }
     ]
   }
 ]


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Add translation context to short art snippets, so an orange circle can be correctly translated as a round shape with a color between red and yellow, rather than a citrus slice.

#### Describe the solution
Add context.

#### Describe alternatives you've considered
THIS IS THE ONLY WAY

#### Testing
Just text changes, should be fine if the CI passes.

#### Additional context
