### PR TITLE
Can order followers to go to player's current destination

### DIFF
--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -371,16 +371,21 @@ void talk_function::goto_location( npc &p )
                                  iter->camp_name(), iter->camp_omt_pos().to_string() );
     }
     selection_menu.addentry( i++, true, MENU_AUTOASSIGN, _( "My current location" ) );
+    if( !player_character.omt_path.empty() ) {
+        selection_menu.addentry( i++, true, MENU_AUTOASSIGN, _( "My destination" ) );
+    }
     selection_menu.addentry( i, true, MENU_AUTOASSIGN, _( "Cancel" ) );
     selection_menu.selected = 0;
     selection_menu.query();
     int index = selection_menu.ret;
-    if( index < 0 || index > static_cast<int>( camps.size() + 1 ) ||
-        index == static_cast<int>( camps.size() + 1 ) ) {
+    if( index < 0 || index >= i ) {
         return;
     }
     if( index == static_cast<int>( camps.size() ) ) {
         destination = player_character.global_omt_location();
+    } else if( index == static_cast<int>( camps.size() ) + 1 ) {
+        // This looks nuts, but omt_path is emplaced in reverse order. So the front of the vector is our destination
+        destination = player_character.omt_path.front();
     } else {
         const basecamp *selected_camp = camps[index];
         destination = selected_camp->camp_omt_pos();


### PR DESCRIPTION
#### Summary
Features "The player's overmap destination is now a valid destination for telling NPCs to go-to"

#### Purpose of change
Currently we can only tell NPCs to come to us or go to a camp, but what if we wanted them to go somewhere else? Surely they can read a map?

#### Describe the solution
Teach them to read maps. Now if you already have a destination set, you can tell the NPC to go there .

#### Describe alternatives you've considered


#### Testing
https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/7aa6df90-da57-463d-9f57-80db86765b2a

#### Additional context
