### PR TITLE
Fixes Dirt Mound Inconsistencies

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -6239,6 +6239,20 @@
   },
   {
     "type": "construction",
+    "id": "constr_extract_dirt_mound",
+    "group": "extract_dirt",
+    "//": "Step 1 : extract dirt",
+    "category": "OTHER",
+    "required_skills": [ [ "survival", 0 ] ],
+    "time": "30 m",
+    "qualities": [ [ { "id": "DIG", "level": 1 } ] ],
+    "byproducts": [ { "item": "material_soil", "count": [ 100, 200 ] } ],
+    "pre_terrain": "t_dirtmoundfloor",
+    "post_terrain": "t_dirt",
+    "activity_level": "EXTRA_EXERCISE"
+  },
+  {
+    "type": "construction",
     "id": "constr_kiln_empty",
     "group": "build_charcoal_kiln",
     "category": "FURN",

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -1006,6 +1006,11 @@
   },
   {
     "type": "construction_group",
+    "id": "extract_dirt",
+    "name": "Extract Dirt"
+  },
+  {
+    "type": "construction_group",
     "id": "extrude_resin_floor_and_roof",
     "name": "Extrude Resin Floor and Roof"
   },

--- a/data/json/furniture_and_terrain/terrain-floors-outdoors.json
+++ b/data/json/furniture_and_terrain/terrain-floors-outdoors.json
@@ -134,7 +134,7 @@
     "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100 },
     "examine_action": "dirtmound"
   },
-  {
+   {
     "type": "terrain",
     "id": "t_dirtmoundfloor",
     "name": "mound of upturned dirt",
@@ -146,16 +146,15 @@
     "connects_to": "DIRT",
     "move_cost": 3,
     "coverage": 40,
-    "flags": [ "TRANSPARENT", "DIGGABLE", "MOUNTABLE", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS" ],
+    "flags": [ "DIGGABLE", "SUPPORTS_ROOF", "HIDE_PLACE" ],
     "bash": {
       "sound": "thump",
       "ter_set": "t_null",
       "str_min": 50,
       "str_max": 100,
       "str_min_supported": 100,
-      "items": [ { "item": "splinter", "count": [ 2, 8 ] }, { "item": "nail", "charges": [ 5, 10 ] } ]
-    },
-    "examine_action": "dirtmound"
+      "items": [ { "item": "material_soil", "count": [ 100, 200 ] } ]
+    }
   },
   {
     "type": "terrain",

--- a/data/json/furniture_and_terrain/terrain-floors-outdoors.json
+++ b/data/json/furniture_and_terrain/terrain-floors-outdoors.json
@@ -134,7 +134,7 @@
     "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100 },
     "examine_action": "dirtmound"
   },
-   {
+  {
     "type": "terrain",
     "id": "t_dirtmoundfloor",
     "name": "mound of upturned dirt",

--- a/data/json/furniture_and_terrain/terrain-floors-outdoors.json
+++ b/data/json/furniture_and_terrain/terrain-floors-outdoors.json
@@ -146,7 +146,7 @@
     "connects_to": "DIRT",
     "move_cost": 3,
     "coverage": 40,
-    "flags": [ "DIGGABLE", "SUPPORTS_ROOF", "HIDE_PLACE" ],
+    "flags": [ "TRANSPARENT" ],
     "bash": {
       "sound": "thump",
       "ter_set": "t_null",


### PR DESCRIPTION
#### Summary
Features "Provides new utility to mounds of upturned dirt, as well as fixing inconsistencies with its counterpart."

#### Purpose of change
Fixes #73621 

#### Describe the solution

This change removes some nonsensical flags from the Mound of Upturned Dirt, and adds the HIDE_PLACE flag to match its description, where it states that it looks as though one could crawl inside of it.

This also adds an option to remove the mound of dirt, as previously, the only method was through smashing. This provides a simple construction akin to the extraction of sand and clay, except it will always convert to a dirt tile, rather then at a chance.

Keeping the support_roofs flag should allow the change to not negatively impact any current building that might rely on the mound for support

#### Describe alternatives you've considered

Main things that come to mind are adjusting the drop amounts of soil, and swapping to the maybe_revert_to_dirt special to better match the other extraction constructions.

#### Testing

Spawned in an upturned dirt mound, hid in it, and dug it up with the new construction.

#### Additional context

N/A