### PR TITLE
Audit Vehicle Parts Breaks_into (Part One?)

### DIFF
--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -151,7 +151,12 @@
       "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "10 m", "using": "vehicle_weld_removal" },
       "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "5 m", "using": [ [ "repair_welding_standard", 1 ] ] }
     },
-    "breaks_into": "ig_vp_frame",
+    "breaks_into": [
+      { "item": "steel_lump", "count": [ 3, 5 ] },
+      { "item": "steel_chunk", "count": [ 3, 5 ] },
+      { "item": "scrap", "charges": [ 4, 8 ] },
+      { "item": "splinter", "count": [ 5, 9 ] }
+    ],
     "flags": [
       "ENGINE",
       "BOARDABLE",
@@ -229,7 +234,14 @@
       }
     },
     "flags": [ "BED", "BOARDABLE", "CARGO", "MOUNTABLE", "NONBELTABLE" ],
-    "breaks_into": "ig_vp_seat",
+    "breaks_into": [
+      { "count": [ 0, 2 ], "item": "sheet_cotton" },
+      { "count": [ 0, 5 ], "item": "cotton_patchwork" },
+      { "count": [ 9, 50 ], "item": "scrap_cotton" },
+      { "count": [ 0, 1 ], "item": "spring" },
+      { "count": [ 0, 2 ], "item": "wire" },
+      { "charges": [ 3, 8 ], "item": "scrap" }
+    ],
     "damage_reduction": { "all": 3, "bash": 5 },
     "variants": [ { "symbols": "#", "symbols_broken": "*" } ]
   },
@@ -252,11 +264,7 @@
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "5 m", "using": [ [ "repair_welding_standard", 1 ] ] }
     },
     "flags": [ "MOUNTABLE" ],
-    "breaks_into": [
-      { "item": "steel_lump", "count": [ 4, 6 ] },
-      { "item": "steel_chunk", "count": [ 4, 6 ] },
-      { "item": "scrap", "count": [ 4, 6 ] }
-    ],
+    "breaks_into": [ { "item": "steel_chunk", "count": [ 0, 1 ] }, { "item": "scrap", "charges": [ 3, 7 ] } ],
     "damage_reduction": { "all": 5 },
     "variants": [ { "symbols": "^", "symbols_broken": "#" } ]
   },
@@ -293,7 +301,11 @@
     "description": "A pair of handles.  You can mount other items on top of it.",
     "item": "frame_wood_light",
     "location": "structure",
-    "breaks_into": [ { "item": "splinter", "count": [ 3, 5 ] }, { "item": "string_36", "count": [ 10, 15 ] } ],
+    "breaks_into": [
+      { "item": "splinter", "count": [ 5, 8 ] },
+      { "item": "string_36", "count": [ 1, 3 ] },
+      { "item": "string_6", "count": [ 1, 4 ] }
+    ],
     "requirements": {
       "install": { "skills": [ [ "fabrication", 0 ] ], "time": "10 m", "using": [ [ "rope_natural_short", 1 ] ] },
       "repair": { "skills": [ [ "fabrication", 1 ] ], "time": "5 m", "using": [ [ "adhesive", 1 ] ] }
@@ -327,7 +339,12 @@
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "6 m", "using": [ [ "repair_welding_standard", 5 ] ] }
     },
     "flags": [ "AISLE", "BOARDABLE", "CARGO" ],
-    "breaks_into": "ig_vp_sheet_metal",
+    "breaks_into": [
+      { "item": "sheet_metal_small", "count": [ 0, 1 ] },
+      { "item": "steel_lump", "count": [ 1, 2 ] },
+      { "item": "steel_chunk", "count": [ 1, 3 ] },
+      { "item": "scrap", "charges": [ 4, 8 ] }
+    ],
     "damage_reduction": { "all": 28 },
     "variants": [
       { "id": "horizontal", "label": "Horizontal", "symbols": "┃┃━┃┃┃━┃", "symbols_broken": "#" },
@@ -360,6 +377,7 @@
     "description": "A collapsible aisle.",
     "folded_volume": "12500 ml",
     "item": "foldwoodframe",
+    "breaks_into": [ { "item": "splinter", "count": [ 7, 11 ] }, { "item": "nail", "charges": [ 5, 10 ] } ],
     "flags": [ "AISLE", "BOARDABLE", "CARGO" ]
   },
   {
@@ -389,7 +407,12 @@
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "10 m", "using": [ [ "repair_welding_standard", 6 ] ] }
     },
     "flags": [ "AISLE", "BOARDABLE", "CARGO", "CARGO_PASSABLE", "LOCKABLE_CARGO", "COVERED" ],
-    "breaks_into": "ig_vp_sheet_metal",
+    "breaks_into": [
+      { "item": "sheet_metal_small", "count": [ 1, 3 ] },
+      { "item": "steel_lump", "count": [ 2, 4 ] },
+      { "item": "steel_chunk", "count": [ 2, 8 ] },
+      { "item": "scrap", "charges": [ 11, 17 ] }
+    ],
     "damage_reduction": { "all": 28 },
     "variants": [ { "symbols": "=", "symbols_broken": "#" } ]
   },
@@ -496,9 +519,13 @@
       "removal": { "skills": [ [ "mechanics", 3 ] ], "qualities": [ { "id": "SCREW", "level": 1 } ] }
     },
     "breaks_into": [
-      { "item": "steel_lump", "prob": 50 },
-      { "item": "steel_chunk", "count": [ 1, 2 ] },
-      { "item": "scrap", "count": [ 0, 3 ] }
+      { "item": "RAM", "prob": 10 },
+      { "item": "steel_lump", "count": [ 0, 2 ] },
+      { "item": "steel_chunk", "count": [ 2, 4 ] },
+      { "item": "scrap", "charges": [ 5, 12 ] },
+      { "item": "e_scrap", "count": [ 2, 5 ] },
+      { "item": "plastic_chunk", "count": [ 3, 6 ] },
+      { "item": "cable", "charges": [ 9, 17 ] }
     ],
     "damage_reduction": { "all": 8 },
     "variants": [ { "symbols": "A", "symbols_broken": "#" } ]
@@ -683,7 +710,10 @@
       { "item": "steel_lump", "count": [ 8, 13 ] },
       { "item": "steel_chunk", "count": [ 8, 13 ] },
       { "item": "scrap", "count": [ 8, 13 ] },
-      { "item": "hose", "prob": 50 }
+      { "item": "hose", "prob": 50 },
+      { "item": "scrap_copper", "prob": 15 },
+      { "item": "cable", "charges": [ 1, 3 ] },
+      { "item": "copper", "charges": [ 7, 30 ] }
     ],
     "damage_reduction": { "all": 32 },
     "variants": [ { "symbols": "H", "symbols_broken": "#" } ]
@@ -718,7 +748,10 @@
       { "item": "steel_lump", "count": [ 8, 13 ] },
       { "item": "steel_chunk", "count": [ 8, 13 ] },
       { "item": "scrap", "count": [ 8, 13 ] },
-      { "item": "hose", "prob": 50 }
+      { "item": "hose", "prob": 50 },
+      { "item": "scrap_copper", "prob": 15 },
+      { "item": "cable", "charges": [ 1, 3 ] },
+      { "item": "copper", "charges": [ 7, 30 ] }
     ],
     "variants": [ { "symbols": "d", "symbols_broken": "#" } ]
   },
@@ -745,10 +778,13 @@
     },
     "flags": [ "CARGO", "OBSTACLE", "AUTOCLAVE", "COVERED", "ENABLED_DRAINS_EPOWER" ],
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 6, 10 ] },
-      { "item": "steel_chunk", "count": [ 6, 10 ] },
-      { "item": "scrap", "count": [ 6, 10 ] },
-      { "item": "hose", "prob": 50 }
+      { "item": "steel_lump", "count": [ 8, 13 ] },
+      { "item": "steel_chunk", "count": [ 8, 13 ] },
+      { "item": "scrap", "count": [ 8, 13 ] },
+      { "item": "hose", "prob": 50 },
+      { "item": "scrap_copper", "prob": 15 },
+      { "item": "cable", "charges": [ 1, 3 ] },
+      { "item": "copper", "charges": [ 7, 30 ] }
     ],
     "variants": [ { "symbols": "A", "symbols_broken": "#" } ]
   },
@@ -832,7 +868,11 @@
     "item": "frame_wood_light",
     "location": "center",
     "flags": [ "CARGO", "BOARDABLE", "COVERED", "HUGE_OK", "CARGO_PASSABLE" ],
-    "breaks_into": [ { "item": "splinter", "count": [ 3, 5 ] }, { "item": "string_36", "count": [ 10, 15 ] } ],
+    "breaks_into": [
+      { "item": "splinter", "count": [ 5, 8 ] },
+      { "item": "string_36", "count": [ 1, 3 ] },
+      { "item": "string_6", "count": [ 1, 4 ] }
+    ],
     "requirements": {
       "install": { "time": "10 m", "using": [ [ "rope_natural_short", 1 ] ] },
       "repair": { "time": "5 m", "using": [ [ "adhesive", 1 ] ] }
@@ -883,7 +923,7 @@
       "repair": { "skills": [ [ "fabrication", 2 ] ], "time": "30 m", "using": [ [ "adhesive", 2 ] ] }
     },
     "flags": [ "CARGO", "BOARDABLE", "COVERED", "LOCKABLE_CARGO", "CARGO_PASSABLE" ],
-    "breaks_into": [ { "item": "splinter", "count": [ 3, 5 ] }, { "item": "nail", "charges": [ 10, 15 ] } ],
+    "breaks_into": [ { "item": "splinter", "count": [ 4, 7 ] }, { "item": "nail", "charges": [ 10, 15 ] } ],
     "damage_reduction": { "all": 4 },
     "variants": [ { "symbols": "o", "symbols_broken": "#" } ]
   },
@@ -905,11 +945,7 @@
       "repair": { "skills": [ [ "fabrication", 2 ] ], "time": "15 m", "using": [ [ "adhesive", 2 ] ] }
     },
     "flags": [ "CARGO", "OBSTACLE", "FLAT_SURF", "WORKBENCH" ],
-    "breaks_into": [
-      { "item": "2x4", "count": [ 1, 6 ] },
-      { "item": "splinter", "count": [ 4, 6 ] },
-      { "item": "nail", "charges": [ 4, 7 ] }
-    ],
+    "breaks_into": [ { "item": "2x4", "prob": 5 }, { "item": "splinter", "count": [ 4, 8 ] }, { "item": "nail", "charges": [ 4, 7 ] } ],
     "workbench": { "multiplier": 1.1, "mass": 150000, "volume": "20 L" },
     "damage_reduction": { "all": 24 },
     "variants": [ { "symbols": "#", "symbols_broken": "#" } ]
@@ -932,11 +968,7 @@
       "repair": { "skills": [ [ "fabrication", 2 ] ], "time": "15 m", "using": [ [ "adhesive", 2 ] ] }
     },
     "flags": [ "CARGO", "OBSTACLE", "FLAT_SURF", "WORKBENCH" ],
-    "breaks_into": [
-      { "item": "2x4", "count": [ 1, 6 ] },
-      { "item": "splinter", "count": [ 4, 6 ] },
-      { "item": "nail", "charges": [ 4, 7 ] }
-    ],
+    "breaks_into": [ { "item": "2x4", "prob": 5 }, { "item": "splinter", "count": [ 4, 8 ] }, { "item": "nail", "charges": [ 4, 7 ] } ],
     "workbench": { "multiplier": 1.1, "mass": 150000, "volume": "20 L" },
     "damage_reduction": { "all": 16 },
     "variants": [ { "symbols": "#", "symbols_broken": "#" } ]
@@ -960,11 +992,7 @@
       "repair": { "skills": [ [ "fabrication", 2 ] ], "time": "15 m", "using": [ [ "adhesive", 2 ] ] }
     },
     "flags": [ "CARGO", "OBSTACLE", "FLAT_SURF" ],
-    "breaks_into": [
-      { "item": "2x4", "count": [ 1, 6 ] },
-      { "item": "splinter", "count": [ 4, 6 ] },
-      { "item": "nail", "charges": [ 4, 7 ] }
-    ],
+    "breaks_into": [ { "item": "splinter", "count": [ 4, 7 ] }, { "item": "nail", "charges": [ 10, 15 ] } ],
     "damage_reduction": { "all": 16 },
     "variants": [ { "symbols": "#", "symbols_broken": "#" } ]
   },

--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -709,7 +709,7 @@
     "breaks_into": [
       { "item": "steel_lump", "count": [ 8, 13 ] },
       { "item": "steel_chunk", "count": [ 8, 13 ] },
-      { "item": "scrap", "count": [ 8, 13 ] },
+      { "item": "scrap", "charges": [ 8, 13 ] },
       { "item": "hose", "prob": 50 },
       { "item": "scrap_copper", "prob": 15 },
       { "item": "cable", "charges": [ 1, 3 ] },
@@ -747,7 +747,7 @@
     "breaks_into": [
       { "item": "steel_lump", "count": [ 8, 13 ] },
       { "item": "steel_chunk", "count": [ 8, 13 ] },
-      { "item": "scrap", "count": [ 8, 13 ] },
+      { "item": "scrap", "charges": [ 8, 13 ] },
       { "item": "hose", "prob": 50 },
       { "item": "scrap_copper", "prob": 15 },
       { "item": "cable", "charges": [ 1, 3 ] },
@@ -780,7 +780,7 @@
     "breaks_into": [
       { "item": "steel_lump", "count": [ 8, 13 ] },
       { "item": "steel_chunk", "count": [ 8, 13 ] },
-      { "item": "scrap", "count": [ 8, 13 ] },
+      { "item": "scrap", "charges": [ 8, 13 ] },
       { "item": "hose", "prob": 50 },
       { "item": "scrap_copper", "prob": 15 },
       { "item": "cable", "charges": [ 1, 3 ] },


### PR DESCRIPTION
#### Summary
Balance "Assess and Change Vehicle Part breaks_into Entries"

#### Purpose of change
Many breaks_into materials (what a vehicle part gives when fully destroyed and removed) were incorrect, lacking materials, giving more materials than deconstructing them, giving higher materials instead of lower tier components (pipes instead of metal pieces), some used count instead of charges for copper wire/scrap metal, leading to much much higher numbers than hat should have appeared, etc. etc.

#### Describe the solution
Audit these vehicle parts, giving a sanity check. Here's what I wrote to explain it in my notes: 
<details>

<summary>My Rambling Thoughts/Why I Did Things</summary>

For vehicle parts breaking into other parts, I did have to sort of pick these just based on common sense.  I didn’t see anything about % of base material that should still be there after being destroyed, many of them gave more materials than the items they’re made from, and a lot were using identical catchall groups.  I only fixed those that were clearly incorrect, some were close enough and I also left the catchall itemgroups because they are probably connected to some things still/valuable. I also believe that many things used count instead of charges for scrap metal, which caused them to spawn in increments of 10. 

Many vehicle parts are made from 1 sheet metal, which has its own vp_sheet_metal itemgroup specifically for it.  This is also true for frames/heavy duty frames. I have left this the same for larger/beefier things made of sheet metal or whatever, but I did change some of them, like I felt the aisle should produce less metal and changed it.  However, after this I largely left them alone because I realized someone probably mathed out that group initially and set it how they thought was appropriate.  I may change this group directly, it gives too much material for 1 sheet metal, based on deconstruction materials.

I didn’t touch any solar panels or anything to do with radiation/reactors because I don’t know shit about them and for some reason I found it intimidating.

So, apologies if these are not perfect, but I believe all the changes I’ve made are improvements overall, and it is generally a small part of the game that no one’s particularly passionate about changing/working on, so yeah, I’m doing it, idk.
</details>

#### Describe alternatives you've considered
Not auditing because there are no clear cut rules on how to balance breaks_into, there's nothing in the docs or explained anywhere as to how to balance it that I was able to find.  Trying to audit them all at once, but ultimately decided better to do a little piece here and get feedback first if I did something wrong.

#### Testing
Basically just checked a bunch of parts to make sure they dropped what they were supposed to, made sure there's no syntax error, etc. 

#### Additional context
This is part one, I'm already almost done with this json, I just figured I'd submit them in chunks.  In the end the PR is only like 60 lines, I thought it would be more, so maybe breaking it up like this wasn't necessary, idk.
<details>

<summary>List of Each Change and Reasoning</summary>

- **154 reinforced yoke and harness** is made from metal materials + a regular yoke and harness (4 planks worth of wood) yet it breaks_into steel only materials.  Replaced this with a combination of existing metal breaks_into PLUS splintered wood from the regular yoke (slightly tweaked as existing yoke breaks_into was a catchall splinter group for multiple items)

- **237 bed vehicle part** used a seat group to determine its breaks into. Although seats can be used as beds and theoretically they would all be the same size (IE: one tile), I believe a bed should have higher fabric count, less metal/no pipes (it’s literally just welding with no metal requirement and 1 mattress. This should probably be changed but I’m not doing this now… or maybe ever x_x).  Since the main metal would be coming from the mattress atm I have decided it should be few springs, mostly scrap metal, and maybe a couple wires. I have given them their own list to keep them from using the catchall seat group as it does not fit for beds in my opinion.

 - **267 handle** is made from 1 pipe, but breaks into 4-6 lump of steel, 4-6 chunk of steel, and 4-6 scrap.  However one pipe is made from either 2 chunks of steel (player) or 7 scrap metal (npc only).  I reduced the metal spawn significantly of the breaks_into group.

 - **304 light wooden handle** breaks_into to 10-15 long strings, but largest item used to craft is short rope which is 6 long strings, breaks_into is also not full value of deconstruction, so made it fewer long strings + some small strings, ranges for both.

 - **342 aisle** is made from 1 sheet metal and breaks_into a sheet metal group.  However the sheet metal group gives much more metal than a single sheet metal should be made from.  The sheet metal→ small sheet metal → scrap metal process is also pretty wonky. I have in general lowered the amount of steel obtained from a destroyed aisle.

 - **380 foldable aisle** is made of a foldable frame, which is roughly a standard frame but with 2 sticks, so increased the number of splinter drops slightly to the breaks_into field.

 - **410 floor trunk** is made from 3x sheet metal and 2 hinges but breaks_into the group assigned as a catchall for sheet metal.  Basing it off what I did for the aisle, breaking it into smaller metal bits, but due to 3 sheet metal there’s quite a lot there and added a possibility of a couple small sheet metals as well as the various scraps/lumps/chunks of steel.  3 sheet metal is a lot to start with.

 - **521 programmable autopilot** only gave a very small amount of metal and no electronics materials, this does not make sense, I have added some plastic, electronics scrap, copper wire, very small chance of a working piece (IE: chance of a RAM stick).  Decent amount of copper wire is due to electric motors being used, just the three motors and the item itself is a cost of 94 copper wire, so there’d be a fair bit left laying around.  And the high electronics scrap is because it’s the smallest electronics part that is literally miscellaneous electronics garbage that would come from almost every component of the autopilot.

 - **709 washing machine** presumably was based off of furniture version, as the furniture version came first.  However, there’s a bit of copper in the furniture version, in both tubing and copper wire, so I’ve added a tiny amount of copper and copper wire to the breaks_into list.

 - **747 dishwasher** is basically the same as the washing machine but with a few cotton patches, not sure why they’re even in that bash result for dishwashers, so I’ve just copied the washing machine values and ignored the fabric.

 - **780 autoclave** is identical to washing machine in terms of bash results, I don’t know if it should be, but as a result I have copied the washing machine vehicle part deconstruction since that’s apparently what someone decided is the base of it.

 - **871 travois** has the same issue as the light wooden handle, the breaks_into is 10-15 long strings despite the largest possible component (short rope) being made of 6 long strings.  Same mats as handle, copied.

 - **926 folding wood box** is made of a foldable frame, which has stick requirements, but gives the same splinter amount as the regular wood box, which does not have the stick requirement.  Increase splintered wood amount.

- **948 veh_table** is the RV table, and it has no deconstruction recipe (IE: you can’t go RV table → fancy table → wood).  Its breaks_into, however, read like a deconstruction recipe, giving up to six planks, which is not appropriate for a fully broken vehicle part.  I have removed the plank spawn with a possibility of a single plank at a low % spawn (idk if planks should be valid for breaks_into so I’ve made it a pretty low %), and increased splintered wood significantly.  I made a note to add a disassembly recipe for the fancy table later, I don’t know if I’ll actually follow through.

- **971 veh_table_wood** despite the naming convention, this is nearly identical to the above rv table, in terms of wood materials.  This one however is made from a non-fancy table.  Interestingly, a broken vehicle part of this table gives up to 50% more planks than actually proper disassembly of the item table.  So that’s nonsense.  I’ve copied the breaks_into from veh_table, as they are nearly identical in terms of material.

- **995 veh_table_foldable (flat packable table)** is odd because instead of using a table it’s just made from a single wooden frame.  As a result, I have changed its breaks_into to match the folding wood box (which I should use as a standard for all things made from foldable wooden frames)

</details>
