### PR TITLE
document monster dodge balance

### DIFF
--- a/doc/GAME_BALANCE.md
+++ b/doc/GAME_BALANCE.md
@@ -42,8 +42,16 @@ Notable skill: 6 (competent/carnivore; bear, wolf, police/survivor zeds)
 
 Very high skill: 8 (dangerous opponent; dark wyrm, vinebeast)
 
-Maximal skill: 10 (highest for balance purposes; jabberwock, tribot, shoggoth, gracken)
+Maximal skill: 10 (highest for balance purposes; jabberwock, shoggoth, gracken)
 
+# Monster dodge skill scaling:
+Minimum skill: 0 (no dodge potential; zombie, turret, fungaloid, fused dragonfly)
+
+Nominal skill: 2 (clumsy dodger; cow, missile spider, horse, feral marine)
+
+Notable skill: 4 (natural dodging ability; wolf, feral soldier; mi-go, vinebeast)
+
+Maximal skill: 8 (highest for balance purposes; giant jumping spider, dermatik, liquid cat, atlantic salmon)
 
 # Monster maximum damage scaling:
 Minimum damage: 0 (no damage potential; spore cloud, hallucination)


### PR DESCRIPTION

#### Summary
Balance "document monster dodge balance"

#### Purpose of change

Begins to address #71957 with the wiggliest bit: dodge

#### Describe the solution

Documents dodge values in game to guide new contributions in the style I have used before. Also removes an existing reference to "tribot" which no longer appears to be a monster in the game

#### Describe alternatives you've considered

N/A

#### Testing

Not required, this is just documentation

#### Additional context

Thanks to @NetSysFire for getting the ball rolling here