### PR TITLE
Automation changes for 0.H release candidates

### DIFF
--- a/.github/workflows/gh-pages-rebuild.yml
+++ b/.github/workflows/gh-pages-rebuild.yml
@@ -4,7 +4,7 @@ on:
   workflow_run:
     workflows: ["Experimental Release"]
     types: [completed]
-    branches: [master]
+    branches: [master, 0.H-branch]
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gh-pages-rebuild.yml
+++ b/.github/workflows/gh-pages-rebuild.yml
@@ -4,7 +4,7 @@ on:
   workflow_run:
     workflows: ["Experimental Release"]
     types: [completed]
-    branches: [master, 0.H-branch]
+    branches: [master]
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -2,9 +2,9 @@ name: General build matrix
 
 on:
   push:
-    branches: [master, 0.H-branch]
+    branches: [0.H-branch]
   pull_request:
-    branches: [master, 0.H-branch]
+    branches: [0.H-branch]
     types: [opened, reopened, synchronize, ready_for_review]
 
 # We only care about the latest revision of a PR, so cancel all previous instances.
@@ -43,7 +43,7 @@ jobs:
       should_skip_code: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - id: skip_check
-        uses: fkirc/skip-duplicate-actions@
+        uses: fkirc/skip-duplicate-actions@master
         with:
           paths_ignore: '["android/**", "build-data/osx/**", "doc/**", "doxygen_doc/**", "lgtm/**", "msvc-**", "object_creator/**", "tools/**", "utilities/**", "data/**", "lang/**"]'
   skip-duplicates-data:
@@ -54,7 +54,7 @@ jobs:
       should_skip_data: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - id: skip_check
-        uses: fkirc/skip-duplicate-actions@
+        uses: fkirc/skip-duplicate-actions@master
         with:
           paths_ignore: '["android/**", "build-data/osx/**", "doc/**", "doxygen_doc/**", "lgtm/**", "msvc-**", "object_creator/**", "tools/**", "utilities/**"]'
   matrix-variables:
@@ -69,9 +69,9 @@ jobs:
     steps:
       - id: matrix_vars
         run: |
-          echo "fail_fast=$(([ "$GITHUB_REF_NAME" = "master" ] || [ "$GITHUB_REF_NAME" = "0.H-branch" ] ) && echo false || echo true)" >> $GITHUB_OUTPUT
-          echo "skip_tests=$(([ "$GITHUB_REF_NAME" = "master" ] || [ "$GITHUB_REF_NAME" = "0.H-branch" ] ) && echo true || echo false)" >> $GITHUB_OUTPUT
-          echo "max_parallel=$(([ "$GITHUB_REF_NAME" = "master" ] || [ "$GITHUB_REF_NAME" = "0.H-branch" ] ) && echo 20 || echo 1)" >> $GITHUB_OUTPUT
+          echo "fail_fast=$([ "$GITHUB_REF_NAME" = "0.H-branch" ] && echo false || echo true)" >> $GITHUB_OUTPUT
+          echo "skip_tests=$([ "$GITHUB_REF_NAME" = "0.H-branch" ] && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "max_parallel=$( [ "$GITHUB_REF_NAME" = "0.H-branch" ] && echo 20 || echo 1)" >> $GITHUB_OUTPUT
   varied_builds:
     needs: [ skip-duplicates-code, skip-duplicates-data, matrix-variables ]
     strategy:
@@ -303,7 +303,7 @@ jobs:
         # double-dash after compiler is not a typo, it is to disambiguate between g++-<date> and g++-11-<date> for restore key prefix matching
         key: ccache-${{ github.ref_name }}-${{ matrix.ccache_key }}--${{ steps.get-vars.outputs.datetime }}
         restore-keys: |
-          ccache-master-${{ matrix.ccache_key }}--
+          ccache-0.H-${{ matrix.ccache_key }}--
     - uses: ammaraskar/gcc-problem-matcher@master
     - name: build
       if: ${{ env.SKIP == 'false' }}
@@ -316,7 +316,7 @@ jobs:
         ccache -c
         ccache --show-stats --verbose
     - name: clear ccache on PRs
-      if: ${{ github.ref_name != 'master' && env.SKIP == 'false' && !failure() && (runner.os == 'Linux' || runner.os == 'macOS') }}
+      if: ${{ github.ref_name != '0.H-branch' && env.SKIP == 'false' && !failure() && (runner.os == 'Linux' || runner.os == 'macOS') }}
       run: |
         ccache -C
     # TODO: post ccache here, however actions/cache@v2 does not support manual upload step

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -2,11 +2,9 @@ name: General build matrix
 
 on:
   push:
-    branches:
-    - master
+    branches: [master, 0.H-branch]
   pull_request:
-    branches:
-    - master
+    branches: [master, 0.H-branch]
     types: [opened, reopened, synchronize, ready_for_review]
 
 # We only care about the latest revision of a PR, so cancel all previous instances.
@@ -45,7 +43,7 @@ jobs:
       should_skip_code: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
+        uses: fkirc/skip-duplicate-actions@
         with:
           paths_ignore: '["android/**", "build-data/osx/**", "doc/**", "doxygen_doc/**", "lgtm/**", "msvc-**", "object_creator/**", "tools/**", "utilities/**", "data/**", "lang/**"]'
   skip-duplicates-data:
@@ -56,7 +54,7 @@ jobs:
       should_skip_data: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
+        uses: fkirc/skip-duplicate-actions@
         with:
           paths_ignore: '["android/**", "build-data/osx/**", "doc/**", "doxygen_doc/**", "lgtm/**", "msvc-**", "object_creator/**", "tools/**", "utilities/**"]'
   matrix-variables:
@@ -71,9 +69,9 @@ jobs:
     steps:
       - id: matrix_vars
         run: |
-          echo "fail_fast=$([ "$GITHUB_REF_NAME" = "master" ] && echo false || echo true)" >> $GITHUB_OUTPUT
-          echo "skip_tests=$([ "$GITHUB_REF_NAME" = "master" ] && echo true || echo false)" >> $GITHUB_OUTPUT
-          echo "max_parallel=$([ "$GITHUB_REF_NAME" = "master" ] && echo 20 || echo 1)" >> $GITHUB_OUTPUT
+          echo "fail_fast=$(([ "$GITHUB_REF_NAME" = "master" ] || [ "$GITHUB_REF_NAME" = "0.H-branch" ] ) && echo false || echo true)" >> $GITHUB_OUTPUT
+          echo "skip_tests=$(([ "$GITHUB_REF_NAME" = "master" ] || [ "$GITHUB_REF_NAME" = "0.H-branch" ] ) && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "max_parallel=$(([ "$GITHUB_REF_NAME" = "master" ] || [ "$GITHUB_REF_NAME" = "0.H-branch" ] ) && echo 20 || echo 1)" >> $GITHUB_OUTPUT
   varied_builds:
     needs: [ skip-duplicates-code, skip-duplicates-data, matrix-variables ]
     strategy:

--- a/.github/workflows/msvc-full-features.yml
+++ b/.github/workflows/msvc-full-features.yml
@@ -2,8 +2,7 @@ name: Cataclysm Windows build
 
 on:
   push:
-    branches:
-    - master
+    branches: [ 0.H-build ]
     paths-ignore:
     - 'android/**'
     - 'build-data/osx/**'
@@ -16,8 +15,7 @@ on:
     - '!tools/format/**'
     - 'utilities/**'
   pull_request:
-    branches:
-    - master
+    branches: [ 0.H-build ]
     paths-ignore:
     - 'android/**'
     - 'build-data/osx/**'
@@ -111,7 +109,7 @@ jobs:
         # double-dash after compiler is not a typo, it is to disambiguate between g++-<date> and g++-11-<date> for restore key prefix matching
         key: ccache-${{ github.ref_name }}-${{ runner.os }}-msvc--${{ steps.get-vars.outputs.datetime }}
         restore-keys: |
-          ccache-master-${{ runner.os }}-msvc--
+          ccache-0.H-build-${{ runner.os }}-msvc--
 
     - name: Configure ccache
       run: |
@@ -138,7 +136,7 @@ jobs:
         ${{ env.CDDA_CCACHE_PATH }}\ccache.exe -s -v
 
     - name: clear ccache on PRs
-      if: ${{ github.ref_name != 'master' }}
+      if: ${{ github.ref_name != '0.H-build' }}
       run: |
         ${{ env.CDDA_CCACHE_PATH }}\ccache.exe -C
 
@@ -162,20 +160,20 @@ jobs:
         }
 
     - name: Compile .mo files for localization
-      if: ${{ github.ref_name != 'master' }}
+      if: ${{ github.ref_name != '0.H-build' }}
       run: |
           & "C:\msys64\mingw64\bin\mingw32-make" -C lang -j2
           mkdir -p ./data/mods/TEST_DATA/lang/mo/ru/LC_MESSAGES -ErrorAction SilentlyContinue
           msgfmt -f -o ./data/mods/TEST_DATA/lang/mo/ru/LC_MESSAGES/TEST_DATA.mo ./data/mods/TEST_DATA/lang/po/ru.po
 
     - name: Enable GitHub Actions problem matchers
-      if: ${{ github.ref_name != 'master' }}
+      if: ${{ github.ref_name != '0.H-build' }}
       run: |
           Write-Output "::add-matcher::build-scripts/problem-matchers/catch2.json"
           Write-Output "::add-matcher::build-scripts/problem-matchers/debugmsg.json"
 
     - name: Run tests
-      if: ${{ github.ref_name != 'master' }}
+      if: ${{ github.ref_name != '0.H-build' }}
       run: |
           .\Cataclysm-test-vcpkg-static-Release-x64.exe --min-duration 20 --rng-seed time
 
@@ -196,7 +194,7 @@ jobs:
       shell: bash
 
     - name: Don't upload vcpkg cache on failure or PRs
-      if: ${{ failure() || cancelled() || github.ref_name != 'master' }}
+      if: ${{ failure() || cancelled() || github.ref_name != '0.H-build' }}
       run: |
         echo "RUNVCPKG_NO_CACHE=1" >> $GITHUB_ENV
       shell: bash

--- a/.github/workflows/msvc-full-features.yml
+++ b/.github/workflows/msvc-full-features.yml
@@ -109,7 +109,7 @@ jobs:
         # double-dash after compiler is not a typo, it is to disambiguate between g++-<date> and g++-11-<date> for restore key prefix matching
         key: ccache-${{ github.ref_name }}-${{ runner.os }}-msvc--${{ steps.get-vars.outputs.datetime }}
         restore-keys: |
-          ccache-0.H-build-${{ runner.os }}-msvc--
+          ccache-0.H-${{ runner.os }}-msvc--
 
     - name: Configure ccache
       run: |

--- a/.github/workflows/pr-validator.yml
+++ b/.github/workflows/pr-validator.yml
@@ -2,7 +2,7 @@ name: PR Validator
 on:
   pull_request:
     branches:
-    - master
+    - 0.H-build
     types: [opened, edited, synchronize]
 jobs:
   validate:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ concurrency: release
 on:
   push:
     branches:
-      - master
+      - 0.H-branch
     paths:
       - '.github/workflows/release.yml'
       - 'android/**'
@@ -36,8 +36,8 @@ jobs:
       - name: Generate environmental variables
         id: generate_env_vars
         run: |
-          echo "tag_name=cdda-experimental-${{ steps.get-timestamp.outputs.time }}" >> $GITHUB_OUTPUT
-          echo "release_name=Cataclysm-DDA experimental build ${{ steps.get-timestamp.outputs.time }}" >> $GITHUB_OUTPUT
+          echo "tag_name=cdda-0.H-${{ steps.get-timestamp.outputs.time }}" >> $GITHUB_OUTPUT
+          echo "release_name=Cataclysm-DDA 0.H release candidate ${{ steps.get-timestamp.outputs.time }}" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v3
       - run: |
           gh release create ${{ steps.generate_env_vars.outputs.tag_name }} --generate-notes --prerelease --title "${{ steps.generate_env_vars.outputs.release_name }}"

--- a/.github/workflows/text-changes-analyzer.yml
+++ b/.github/workflows/text-changes-analyzer.yml
@@ -4,7 +4,7 @@ name: Text Changes Analyzer
 on:
   pull_request:
     branches:
-      - master
+      - 0.H-branch
     paths:
       - '.github/workflows/text-changes-analyzer.yml'
       - 'tools/pot_diff.py'


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
In order to make the process of backporting changes to the 0.H branch easier and perform release candidate releases, I'm making some adjustments to the build workflows to make them trigger when targeting 0.H-branch

#### Describe the solution
Mostly this is just adjusting branch: clauses to include 0.H-branch in addition to master, but there might be some other changes that need to be made.

#### Describe alternatives you've considered
Not doing CI for the stable release process? ugh

#### Testing
Once this is done most of the tests should run (do we need clang-tidy? I'm thinking no) on PRs targeting 0.H-branch
Pushes to this branch should also create release candidates in https://github.com/CleverRaven/Cataclysm-DDA/releases
Probably need some name changes for the releases.
