### PR TITLE
Add Craft, Uncraft, Furniture version, and Construction to Fancy Tables

### DIFF
--- a/data/json/construction/furniture_surfaces.json
+++ b/data/json/construction/furniture_surfaces.json
@@ -61,6 +61,18 @@
   },
   {
     "type": "construction",
+    "id": "constr_place_table_fancy",
+    "group": "place_table",
+    "category": "FURN",
+    "required_skills": [ [ "fabrication", 0 ] ],
+    "time": "1 m",
+    "components": [ [ [ "v_table", 1 ] ] ],
+    "pre_special": "check_empty",
+    "post_terrain": "f_table_fancy",
+    "activity_level": "LIGHT_EXERCISE"
+  },
+  {
+    "type": "construction",
     "id": "constr_place_workbench",
     "group": "place_workbench",
     "category": "FURN",

--- a/data/json/furniture_and_terrain/furniture-surfaces.json
+++ b/data/json/furniture_and_terrain/furniture-surfaces.json
@@ -295,6 +295,35 @@
   },
   {
     "type": "furniture",
+    "id": "f_table_fancy",
+    "name": "fancy table",
+    "description": "A fancy table for a fancy person.  Functions as both a table and status symbol.",
+    "symbol": "#",
+    "color": "red",
+    "looks_like": "f_table",
+    "move_cost_mod": 2,
+    "coverage": 50,
+    "required_str": 5,
+    "crafting_pseudo_item": "medium_surface_pseudo",
+    "flags": [ "TRANSPARENT", "FLAMMABLE", "ORGANIC", "MOUNTABLE", "SHORT", "FLAT_SURF", "SMALL_HIDE", "EASY_DECONSTRUCT" ],
+    "deconstruct": { "items": [ { "item": "v_table", "count": 1 } ] },
+    "bash": {
+      "str_min": 12,
+      "str_max": 50,
+      "sound": "smash!",
+      "sound_fail": "whump.",
+      "items": [
+        { "item": "2x4", "count": [ 1, 3 ] },
+        { "item": "wood_panel", "prob": 30 },
+        { "item": "nail", "charges": [ 4, 8 ] },
+        { "item": "splinter", "count": [ 3, 6 ] }
+      ]
+    },
+    "examine_action": "workbench",
+    "workbench": { "multiplier": 1.1, "mass": 200000, "volume": "75 L" }
+  },
+  {
+    "type": "furniture",
     "id": "f_coffee_table",
     "name": "coffee table",
     "description": "A low table usually found in living rooms, it makes an ideal surface for playing games, showing off some tasteful books, or presumably for putting coffee cups on.  No one cares if you use a coaster anymore.",

--- a/data/json/items/vehicle/tables.json
+++ b/data/json/items/vehicle/tables.json
@@ -3,7 +3,7 @@
     "type": "GENERIC",
     "id": "v_table",
     "name": { "str": "fancy table" },
-    "description": "A very fancy table from a very fancy RV.  If times were better, it might be useful for something other than firewood.",
+    "description": "A very fancy table for those with fancy lives.  If times were better, it might be useful for something other than firewood.",
     "weight": "9071 g",
     "to_hit": -8,
     "color": "red",

--- a/data/json/recipes/recipe_deconstruction.json
+++ b/data/json/recipes/recipe_deconstruction.json
@@ -7337,6 +7337,14 @@
     ]
   },
   {
+    "result": "v_table",
+    "type": "uncraft",
+    "activity_level": "LIGHT_EXERCISE",
+    "time": "30 m",
+    "qualities": [ { "id": "PRY", "level": 1 } ],
+    "components": [ [ [ "2x4", 4 ] ], [ [ "nail", 14 ] ], [ [ "wood_panel", 1 ] ], [ [ "plank_short", 1 ] ], [ [ "splinter", 4 ] ] ]
+  },
+  {
     "result": "chair_wood",
     "type": "uncraft",
     "activity_level": "MODERATE_EXERCISE",

--- a/data/json/recipes/recipe_others.json
+++ b/data/json/recipes/recipe_others.json
@@ -615,6 +615,22 @@
   },
   {
     "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "result": "v_table",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_PARTS",
+    "skill_used": "fabrication",
+    "difficulty": 2,
+    "time": "35 m",
+    "decomp_learn": 1,
+    "autolearn": true,
+    "proficiencies": [ { "proficiency": "prof_carpentry_basic" }, { "proficiency": "prof_carving" } ],
+    "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "SAW_W", "level": 1 }, { "id": "CHISEL_WOOD", "level": 1 } ],
+    "components": [ [ [ "2x4", 5 ] ], [ [ "wood_panel", 1 ] ], [ [ "nails", 14, "LIST" ] ] ],
+    "byproducts": [ [ "splinter", 5 ] ]
+  },
+  {
+    "type": "recipe",
     "activity_level": "MODERATE_EXERCISE",
     "result": "workbench",
     "category": "CC_OTHER",


### PR DESCRIPTION
#### Summary
Balance "Add Craft, Uncraft, Furniture version, and Construction to Fancy Tables"

#### Purpose of change
While auditing the breaks_into for various vehicle parts, I discovered the ‘fancy table’.  Installed in a vehicle this is just a table, but when removed gives a fancy table.  Fancy table did not have a disassembly or crafting recipe, and could not be placed or crafted in the construction menu.  There’s no reason I found that its not disassemblyablebl, and it not being place-able also makes no sense.  It's worth noting that the wooden table also becomes a 'table' in a vehicle, but can be placed/used as a proper table through construction, so I sought to make something similar.

#### Describe the solution
Steps I took/Notes:
- [x] Remove ‘from a very fancy RV’ from the item description – it’s currently found in limos, tour buses, and the luxury RV, so the description is already inaccurate.  My changes will make it even less accurate, so I’ll change this.  Also add looks_like w_table just so it has something to point at if either would ever get a sprite. EDIT: Chose not to add looks_like because it looks like some things copy-from this and it might cause issues?
- [X] Add Recipe – line 615 ish recipes/recipe_others.json
- [X] Add Disassembly Recipe – Slightly different return since some wood is lost from carving/shaping and put it wherever in recipes/recipes_deconstruction.json no other tables listed
- [X] Add Furniture version of fancy table – after f_table around 295 in furniture_and_terrain/furniture-surfaces.json
- [X] Add Construction for placing fancy table around 2258 under place_table in construction.json

Change the ID? It’s tagged as v_table, which makes it seem vehicle only… idk I’m so lazy… I didn’t do it x_x

I have added a crafting and disassembly recipe, for those that want to make a fancier version of a table or use it in their vehicle for whatever reason.  I’ve added a place construction to set down an existing fancy table.  Although this is basically the same functionality as any other table, since the item already exists we might as well make it use-able in all those circumstances, so I did.  Slightly higher skills/prof required due to it being ‘fancy’, I’ve tweaked the description to make it sound fancier and justify the proficiencies.  I chose not to add a construction recipe for making it from scratch, as you can just make it using the recipe (which requires proficiencies and etc. that cannot be attached to constructions (that I saw?)), this prevented it from having two entries in construction, the only one I added was to place the existing item, turning it into the furniture version, which can then be taken down using simple deconstruct to return it to item form. I placed the 'place' construction in the same group as a standard table to avoid clutter.



#### Describe alternatives you've considered
None, this is a masterful solution of which we can all be proud.

#### Testing
I tested each aspect of this as I went along, made sure no typos/syntax issues, didn't accidentally overspawn materials, etc, made sure it still made sense/was reasonable with proficiencies, etc. etc.

#### Additional context
So fancy your eyes will bleed