### PR TITLE
Add Deconstruction of Skunk Skull

### DIFF
--- a/data/json/recipes/recipe_deconstruction.json
+++ b/data/json/recipes/recipe_deconstruction.json
@@ -7314,6 +7314,15 @@
     "flags": [ "BLIND_EASY" ]
   },
   {
+    "result": "skull_skunk",
+    "type": "uncraft",
+    "activity_level": "MODERATE_EXERCISE",
+    "time": "1 m",
+    "qualities": [ { "id": "HAMMER", "level": 2 } ],
+    "components": [ [ [ "bone", 1 ] ] ],
+    "flags": [ "BLIND_EASY" ]
+  },
+  {
     "result": "deck_chair",
     "type": "uncraft",
     "activity_level": "LIGHT_EXERCISE",


### PR DESCRIPTION
#### Summary
Balance "You Can Smash Skunk Skulls"

#### Purpose of change
I noticed skulls had uncrafts, using a hammer to smash them to bones.  I recently added skunks/their skulls, so I realized you couldn't uncraft their little domes.

#### Describe the solution
Add Skunk uncraft.  Gives one bone because skunks actually have tiny heads, but whatever it's fine.

#### Describe alternatives you've considered
N/A

#### Testing
I literally didn't.

#### Additional context
Should I have made it bone meal instead of a bone? You'd have to work a lot harder to get bone meal out of it, but bones are so big.  Well whatever it's based on the other skull stuff, I'm sure it's fine.
