### PR TITLE
skip slow builds for draft PRs

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -19,6 +19,7 @@ on:
     - 'build-scripts/clang-tidy-wrapper.sh'
     - 'build-scripts/get_affected_files.py'
     - '.github/workflows/clang-tidy.yml'
+    types: [opened, reopened, synchronize, ready_for_review]
 
 # We only care about the latest revision of a PR, so cancel all previous instances.
 concurrency:

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -40,7 +40,7 @@ jobs:
           paths: '[ "**.cpp", "**.h", "**.c", "**/CMakeLists.txt", "**/Makefile", "**.hpp", "**.cmake", "build-scripts/clang-tidy.sh", "build-scripts/clang-tidy-wrapper.sh", "build-scripts/get_affected_files.py", ".github/workflows/clang-tidy.yml" ]'
   build:
     needs: skip-duplicates
-    if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && github.event_name != 'pull_request_target' || github.event.pull_request.draft == false }}
+    if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -40,7 +40,7 @@ jobs:
           paths: '[ "**.cpp", "**.h", "**.c", "**/CMakeLists.txt", "**/Makefile", "**.hpp", "**.cmake", "build-scripts/clang-tidy.sh", "build-scripts/clang-tidy-wrapper.sh", "build-scripts/get_affected_files.py", ".github/workflows/clang-tidy.yml" ]'
   build:
     needs: skip-duplicates
-    if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' || github.event_name == 'pull_request_target' && github.event.pull_request.draft == false }}
+    if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && github.event_name != 'pull_request_target' || github.event.pull_request.draft == false }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -40,7 +40,7 @@ jobs:
           paths: '[ "**.cpp", "**.h", "**.c", "**/CMakeLists.txt", "**/Makefile", "**.hpp", "**.cmake", "build-scripts/clang-tidy.sh", "build-scripts/clang-tidy-wrapper.sh", "build-scripts/get_affected_files.py", ".github/workflows/clang-tidy.yml" ]'
   build:
     needs: skip-duplicates
-    if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' }}
+    if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' || github.event_name == 'pull_request_target' && github.event.pull_request.draft == false }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/msvc-full-features.yml
+++ b/.github/workflows/msvc-full-features.yml
@@ -29,6 +29,7 @@ on:
     - 'tools/**'
     - '!tools/format/**'
     - 'utilities/**'
+    types: [opened, reopened, synchronize, ready_for_review]
 
 # We only care about the latest revision of a PR, so cancel previous instances.
 concurrency:

--- a/.github/workflows/msvc-full-features.yml
+++ b/.github/workflows/msvc-full-features.yml
@@ -55,6 +55,7 @@ jobs:
   build_catatclysm:
     name: Build
     runs-on: windows-2019
+    if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.draft == false }}
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/msvc-full-features.yml
+++ b/.github/workflows/msvc-full-features.yml
@@ -55,7 +55,7 @@ jobs:
   build_catatclysm:
     name: Build
     runs-on: windows-2019
-    if: ${{ github.event_name != 'pull_request_target' || github.event.pull_request.draft == false }}
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/msvc-full-features.yml
+++ b/.github/workflows/msvc-full-features.yml
@@ -55,7 +55,7 @@ jobs:
   build_catatclysm:
     name: Build
     runs-on: windows-2019
-    if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.draft == false }}
+    if: ${{ github.event_name != 'pull_request_target' || github.event.pull_request.draft == false }}
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
CI has been getting turbo clogged recently, with action queues in the 60s and 70s on a regular basis.

#### Describe the solution
This simply cancels windows and clang-tidy builds when a PR is in draft.
Then it does kick off another build when you take it out of draft, but if you push just a few times before taking it out of draft that easily comes out ahead.

#### Describe alternatives you've considered
It's possible we could use some kind of labelling to opt in or out instead?
We would get the same benefits by moving the windows and clang-tidy actions to the end of the matrix build job like in #73615 , that would also prevent these jobs from running in parallel, which should reduce time to first test run across all PRs.

#### Testing
It's just YAML what could go wrong.
Hah jk, I'll put this in draft and it should skip the heavy builds, which I THINK will run because I'm touching one of the workflow files.