### PR TITLE
Fix Electric Blanket Encumbrance Bug

### DIFF
--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -3598,6 +3598,7 @@
     "armor": [
       {
         "encumbrance": 35,
+        "volume_encumber_modifier": 0,
         "coverage": 100,
         "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
       }


### PR DESCRIPTION
#### Summary
Bugfixes "Fix Electric Blanket Encumbrance Bug"

#### Purpose of change
#73626 reported that Electric blankets had a 'when full encumbrance' of 800035, which fun fact is a bug.

Yeah, so this appears to be because the magazine pocket that specifies the battery it can hold interacts weirdly with armor.  This is also present on one of the exoskeletons I saw in testing, worn things with a magazine well seem to get bonkers encumbrance.

#### Describe the solution
Add a line for "volume_encumber_modifier", which is a modifier meant to be used in conjunction with pockets to add extra penalties.  However, for this case, we set that to 0, which makes the pocket reduce its 'enormous volume penalty' down to 0, which then leads to the overall encumbrance of the garment being 35 as intended.

#### Describe alternatives you've considered
Yeah, I assume this is not the 'correct' way to deal with this, I'm sure this is something in the code that can be corrected directly, I just don't have the time or desire to look into that.  And for the purposes of THIS PR, it doesn't actually matter as the blanket has no other pockets, so this is a fine fix.

#### Testing
Just sort of slapped it together and observed nothing bizarre happened.

#### Additional context
Closes #73626 
