### PR TITLE
Don't access out of bounds

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -4138,6 +4138,9 @@ bool cata_tiles::draw_critter_above( const tripoint &p, lit_level ll, int &heigh
     // Search for a creature above
     while( pcritter == nullptr && !here.dont_draw_lower_floor( scan_p ) &&
            scan_p.z - you.pos().z <= fov_3d_z_range ) {
+        if( scan_p.z > OVERMAP_HEIGHT ) {
+            break;
+        }
         pcritter = get_creature_tracker().creature_at( scan_p, true );
         scan_p.z++;
     }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Fixes #73530

Trying to read tiles that can't possibly exist is never a good idea. 

From the linked issue: "Looks like it continues the while-loop even after reaching Z+10. I'm guessing it doesn't crash *all the time* because of how the memory is aligned - it only *sometimes* manages to escape valid memory and trigger the segfault. Still it shouldn't try to read anything past max height, there's definitely nothing there and it could end up reading bad data."

#### Describe the solution
Stop checking higher z-levels once we've passed OVERMAP_HEIGHT. That's as high as it goes!

#### Describe alternatives you've considered


#### Testing
Reproducing this crash with or without the patch is pure happenstance, so I have to just make an educated assumption about the possible cause.

#### Additional context
