### PR TITLE
Cable pockets don't add extra encumbrance

### DIFF
--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -886,7 +886,11 @@ void Item_factory::finalize_post_armor( itype &obj )
         if( data.max_encumber == -1 ) {
             units::volume total_nonrigid_volume = 0_ml;
             for( const pocket_data &pocket : obj.pockets ) {
-                if( !pocket.rigid ) {
+                // Reimplementation of item_pocket::is_standard_type()
+                bool pocket_is_standard = pocket.type == pocket_type::CONTAINER ||
+                                          pocket.type == pocket_type::MAGAZINE ||
+                                          pocket.type == pocket_type::MAGAZINE_WELL;
+                if( !pocket.rigid && pocket_is_standard ) {
                     // include the modifier for each individual pocket
                     total_nonrigid_volume += pocket.max_contains_volume() * pocket.volume_encumber_modifier;
                 }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Fixes #73626
* Supersedes #73652

#### Describe the solution
Non-standard pockets are excluded from calculating extra encumbrance. They cannot be intentionally accessed like normal, so there shouldn't be any possible exploits from this...

#### Describe alternatives you've considered
#73652

#### Testing
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/28cb5ee1-3e27-45c7-8d41-4ae91a5e9d41)

Haven't run it against the tests, would like to see those pass.

Want to do some manual testing on this to be sure, but haven't got the time tonight


#### Additional context

