### PR TITLE
Use dummy parser for attack_vector to fix string extraction script error

### DIFF
--- a/lang/string_extractor/parser.py
+++ b/lang/string_extractor/parser.py
@@ -104,6 +104,7 @@ parsers = {
     "anatomy": dummy_parser,
     "armor": parse_generic,
     "ascii_art": dummy_parser,
+    "attack_vector": dummy_parser,
     "battery": parse_generic,
     "behavior": dummy_parser,
     "bionic": parse_bionic,


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
The string extraction script is failing in the CI.

#### Describe the solution
Use dummy parser for the recently added `attack_vector`.

#### Describe alternatives you've considered

#### Testing
Ran the script locally.

#### Additional context
