### PR TITLE
skip emscripten build for draft PRs

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -347,5 +347,5 @@ jobs:
   emscripten:
     needs: [ varied_builds ]
     uses: ./.github/workflows/emscripten.yml
-    if: ${{ github.event.pull_request.draft == false }}
+    if: ${{ success() && github.event.pull_request.draft == false }}
     secrets: inherit

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -347,4 +347,5 @@ jobs:
   emscripten:
     needs: [ varied_builds ]
     uses: ./.github/workflows/emscripten.yml
+    if: ${{ github.event.pull_request.draft == false }}
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -391,3 +391,7 @@ jobs:
           fi
       - run: |
           gh release upload cdda-experimental-${{ needs.release.outputs.timestamp }} cdda-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.${{ matrix.ext }}
+  emscripten:
+    needs: [ builds ]
+    uses: ./.github/workflows/emscripten.yml
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -393,5 +393,6 @@ jobs:
           gh release upload cdda-experimental-${{ needs.release.outputs.timestamp }} cdda-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.${{ matrix.ext }}
   emscripten:
     needs: [ builds ]
+    if: ${{ success() }}
     uses: ./.github/workflows/emscripten.yml
     secrets: inherit


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Sloooooow PR builds
I also noticed the enscripten build got removed from release builds. 

#### Describe the solution
Skip the emscripten build if the pr is marked as a draft
Add a call to the enscripten build to the release workflow

#### Testing
Marking this draft, it should skip emscripten.