### PR TITLE
#include vector in cata_imgui.h

### DIFF
--- a/src/cata_imgui.h
+++ b/src/cata_imgui.h
@@ -2,6 +2,7 @@
 #include <cstddef>
 #include <memory>
 #include <string>
+#include <vector>
 
 class nc_color;
 struct input_event;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
The release curses builds broke as of #73554 but went unnoticed because the *test* builds are fine <_<
See https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/9044505100/job/24853263567#step:18:71

#### Describe the solution
Include the missing header.
This is clearly erroneous but it's getting papered over in the test build somehow?
My guess is <vector> is getting indirectly pulled in by some other std lib header in the test curses builds (Clang 10, gcc 9, gcc 11) but not in the release build.

#### Describe alternatives you've considered
Sideline everything else I'm doing to get IWYU working everywhere.
Overhaul the test and release suite to insure that every build configuration in the release build is included in the test builds (yay 5 hour CI runs!)

#### Testing
It's only breaking on release so I'd need to either reproduce the release system configuration or just push it, guess.