### PR TITLE
Backport updated release notes generation workflow to 0.H

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,8 +46,7 @@ jobs:
           npm install @actions/github
           node build-scripts/generate-release-notes.js '${{ secrets.GITHUB_TOKEN }}' '${{ steps.generate_env_vars.outputs.tag_name }}' "$(git log -1 --format='%H')" > notes.txt
       - run: |
-          gh release create ${{ steps.generate_env_vars.outputs.tag_name }} --notes-file notes.txt --prerelease --title "${{ steps.generate_env_vars.outputs.release_name }}" --target "$(git log -1 --for
-mat='%H')"
+          gh release create ${{ steps.generate_env_vars.outputs.tag_name }} --notes-file notes.txt --prerelease --title "${{ steps.generate_env_vars.outputs.release_name }}" --target "$(git log -1 --format='%H')"
 
   builds:
     needs: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
       - '.github/workflows/release.yml'
       - 'android/**'
       - 'build-data/**'
+      - 'build-scripts/generate-release-notes.js'
       - 'cataclysm-launcher'
       - 'data/**'
       - 'doc/**'
@@ -39,8 +40,14 @@ jobs:
           echo "tag_name=cdda-0.H-${{ steps.get-timestamp.outputs.time }}" >> $GITHUB_OUTPUT
           echo "release_name=Cataclysm-DDA 0.H release candidate ${{ steps.get-timestamp.outputs.time }}" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v3
+      - name: Generate Release Notes
+        id: generate-release-notes
+        run: |
+          npm install @actions/github
+          node build-scripts/generate-release-notes.js '${{ secrets.GITHUB_TOKEN }}' '${{ steps.generate_env_vars.outputs.tag_name }}' "$(git log -1 --format='%H')" > notes.txt
       - run: |
-          gh release create ${{ steps.generate_env_vars.outputs.tag_name }} --generate-notes --prerelease --title "${{ steps.generate_env_vars.outputs.release_name }}"
+          gh release create ${{ steps.generate_env_vars.outputs.tag_name }} --notes-file notes.txt --prerelease --title "${{ steps.generate_env_vars.outputs.release_name }}" --target "$(git log -1 --for
+mat='%H')"
 
   builds:
     needs: release

--- a/build-scripts/generate-release-notes.js
+++ b/build-scripts/generate-release-notes.js
@@ -1,0 +1,86 @@
+// ./tools/scripts/generate-release-notes.js
+
+const github = require('@actions/github');
+
+/**
+ * Generates the release notes for a github release.
+ *
+ * Arguments:
+ * 1 - github_token
+ * 2 - new version
+ * 3 - commit SHA of new release
+ */
+const token = process.argv[2];
+const version = process.argv[3];
+const comittish = process.argv[4];
+const repo = process.env.REPOSITORY_NAME
+const owner = process.env.GITHUB_REPOSITORY_OWNER
+
+async function main() {
+  const client = github.getOctokit(token);
+
+  const latestReleaseResponse = await client.request(
+    'GET /repos/{owner}/{repo}/releases',
+    {
+      owner: owner,
+      repo: repo,
+      headers: {
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    }
+  );
+
+  let previousTag = null;
+  if (latestReleaseResponse.data) {
+    for (const responseData of latestReleaseResponse.data) {
+      if (responseData.draft == false && responseData.prerelease == true) {
+        previousTag = responseData.tag_name;
+	break;
+      }
+    }
+  }
+
+  const response = await client.request(
+    'POST /repos/{owner}/{repo}/releases/generate-notes',
+    {
+      owner: owner,
+      repo: repo,
+      tag_name: version,
+      previous_tag_name: previousTag,
+      target_commitish: comittish,
+      headers: {
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    }
+  );
+
+  const noteSections = response.data.body?.split('\n\n');
+  const trimmedSections = [];
+  const githubNotesMaxCharLength = 125000;
+  const maxSectionLength = githubNotesMaxCharLength / noteSections.length;
+  for (let i = 0; i < noteSections.length; i++) {
+    if (noteSections[i].length > githubNotesMaxCharLength) {
+      const lastLineIndex =
+        noteSections[i].substring(0, maxSectionLength).split('\n').length - 1;
+      const trimmed =
+        noteSections[i]
+          .split('\n')
+          .slice(0, lastLineIndex - 1)
+          .join('\n') +
+        `\n... (+${
+          noteSections[i].split('\n').length - (lastLineIndex + 1)
+        } others)`;
+      trimmedSections.push(trimmed);
+      continue;
+    }
+
+    trimmedSections.push(noteSections[i]);
+  }
+
+  console.log(trimmedSections.join('\n\n'));
+}
+
+main().catch((e) => {
+  console.error(`Failed generating release notes with error: ${e}`);
+  process.exit(0);
+});


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Now that we have 0.H release candidates (attempting) generation, we discover that we don't have the release notes generation fixes from about two months ago.
See https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/9045961439/job/24856703376#step:5:7
This was several PRs, including #72504 #72509 #72516 but I might have missed some.

#### Describe the solution
Copied the pertinent changes from release.yml and the new javascript module from master to 0.H

#### Describe alternatives you've considered
Turning off release notes for backports? that seems useful though.

#### Testing
It's not going to be active at all until it hits the release workflow.
Some people have workflow stuff set up on their own repos but I haven't gotten around to it.