### PR TITLE
Remove redundant emscripten build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -290,7 +290,7 @@ jobs:
           make -j$((`nproc`+0)) TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=1 LIBBACKTRACE=${{ matrix.libbacktrace }} PCH=0 bindist
           mv cataclysmdda-0.I.tar.gz cdda-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.tar.gz
       - name: Build CDDA (WebAssembly)
-        if: matrix.wasm
+        if: matrix.wasm && success()
         run: |
           ./build-scripts/build-emscripten.sh
           ./build-scripts/prepare-web.sh
@@ -391,8 +391,3 @@ jobs:
           fi
       - run: |
           gh release upload cdda-experimental-${{ needs.release.outputs.timestamp }} cdda-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.${{ matrix.ext }}
-  emscripten:
-    needs: [ builds ]
-    if: ${{ success() }}
-    uses: ./.github/workflows/emscripten.yml
-    secrets: inherit


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Turns out this was a redundant build.

#### Describe the solution
Just remove it, we can maybe look at making it depend on the other builds or something but for releases it's less of a big deal than for PRs anyway.