### PR TITLE
Avoid waddwstr() since macOS can't find it

### DIFF
--- a/src/third-party/imtui/imtui-impl-ncurses.cpp
+++ b/src/third-party/imtui/imtui-impl-ncurses.cpp
@@ -328,7 +328,7 @@ void create_destroy_curses_windows(std::vector<WINDOW*> &windows)
         windows.erase(windows.begin() + lastIndex, windows.end());
     }
 }
-wchar_t strTmp[] = {0, 0};
+
 void ImTui_ImplNcurses_DrawScreen( bool active )
 {
     ImTui::ImplImtui_Data* bd = ImTui::ImTui_Impl_GetBackendData();
@@ -364,8 +364,9 @@ void ImTui_ImplNcurses_DrawScreen( bool active )
                     wattron( cursesWin, COLOR_PAIR( colPairs[p].second ) );
                     lastp = p;
                 }
-                strTmp[0] = cell.ch;
-                waddwstr( cursesWin, strTmp );
+                std::string tmpStr;
+                wctomb( tmpStr.data(), cell.ch );
+                waddstr( cursesWin, tmpStr.c_str() );
                 
                 if(cell.chwidth > 1)
                 {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
The macOS release build is broken as can be seen in https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/9046935560/job/24858676569#step:27:370
This happened in #73414 and again we didn't catch it because we don't have a macOS/curses build in the test suite.

#### Describe the solution
Instead of using wchar_t as imtui provides it, unpack the wchar into a std::string and use the utf8 curses functions like we do elsewhere.

#### Describe alternatives you've considered
Abandon mac builds :bleh:
There might be a fix around passing some defines to the curses lib at build time?  Seems gross.

#### Testing
Run game and examine some windows drawn by IMGUI.
This is totally broken and I'm just putting it up as a draft.