### PR TITLE
Define _XOPEN_SOURCE_EXTENDED on mac localized curses builds for wchar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -597,8 +597,9 @@ ifeq ($(NATIVE), osx)
     endif
   endif
   ifeq ($(LOCALIZE), 1)
-    ifeq ($(MACPORTS), 1)
-      ifneq ($(TILES), 1)
+    ifneq ($(TILES), 1)
+      CXXFLAGS += -D_XOPEN_SOURCE_EXTENDED
+      ifeq ($(MACPORTS), 1)
         CXXFLAGS += -I$(shell ncursesw6-config --includedir)
         LDFLAGS += -L$(shell ncursesw6-config --libdir)
       endif


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
The macOS release build is broken as can be seen in https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/9046935560/job/24858676569#step:27:370
This happened in https://github.com/CleverRaven/Cataclysm-DDA/pull/73414 and again we didn't catch it because we don't have a macOS/curses build in the test suite.

#### Describe the solution
I stumbled across this incantation that might soothe the foul beast.

#### Describe alternatives you've considered
Tried to unpack wchar into utf8 strings in #73694 but I can't get that to work.

#### Testing
Can't test locally, it's up to the release osx curses build.