### PR TITLE
Propane shelved

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -597,8 +597,9 @@ ifeq ($(NATIVE), osx)
     endif
   endif
   ifeq ($(LOCALIZE), 1)
-    ifeq ($(MACPORTS), 1)
-      ifneq ($(TILES), 1)
+    ifneq ($(TILES), 1)
+      CXXFLAGS += -D_XOPEN_SOURCE_EXTENDED
+      ifeq ($(MACPORTS), 1)
         CXXFLAGS += -I$(shell ncursesw6-config --includedir)
         LDFLAGS += -L$(shell ncursesw6-config --libdir)
       endif

--- a/data/json/items/tool/workshop.json
+++ b/data/json/items/tool/workshop.json
@@ -1669,7 +1669,7 @@
     "id": "propane_torch",
     "type": "TOOL",
     "name": { "str": "propane torch", "str_pl": "propane torches" },
-    "description": "A compact tool kit intended for cutting metal, this portable propane torch includes a torch handle and cutting attachment in an easy-to-carry tote.  It needs to be connected to a pressurized propane cylinder before use.  While not appropriate for welding, you can activate it in order to destroy metal barriers.",
+    "description": "A compact tool kit intended for heating metal, this portable propane torch includes a torch handle and accessories in an easy-to-carry tote.  It needs to be connected to a pressurized propane cylinder before use.",
     "weight": "1600 g",
     "volume": "1 L",
     "price": "200 USD",
@@ -1678,10 +1678,6 @@
     "symbol": ";",
     "color": "red",
     "ammo": [ "propane" ],
-    "charges_per_use": 64,
-    "//0": "above is for 1/2 kg of steel - currently a door is 7 kg of material to cut",
-    "//": "power usage: propane torch delivers about 2.5 kj per ml adjusted for efficiency, needs about 800 degrees c to ignite steel, which is specific heat 420j so to ignite a kg of steel, it is about 128 units of propane",
-    "use_action": [ "OXYTORCH" ],
     "flags": [ "ALLOWS_REMOTE_USE", "FIRESTARTER" ],
     "pocket_data": [
       {

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -165,46 +165,25 @@
     "id": "welding_standard",
     "type": "requirement",
     "//": "Crafting of steel/iron items or installation of vehicle parts, measured in 1 cm segments - assume roughly 360 cm per hour, 10 seconds per # of this quality",
-    "//1": "Arc welding is about 85% efficient, acetylene welding is about 40% efficient, propane welding is about 10% efficient",
-    "//2": "acetlyne is measured in grams while propane is measured in ml - this means acetlyene is roughly 2x as potent as propane per charge",
+    "//1": "Arc welding is about 85% efficient, acetylene welding is about 40% efficient",
     "qualities": [ { "id": "GLARE", "level": 1 } ],
-    "tools": [
-      [
-        [ "welder", 20 ],
-        [ "welding_kit", 20 ],
-        [ "welder_crude", 40 ],
-        [ "integrated_welder", 30 ],
-        [ "oxy_torch", 1 ],
-        [ "propane_torch", 8 ]
-      ]
-    ],
+    "tools": [ [ [ "welder", 20 ], [ "welding_kit", 20 ], [ "welder_crude", 40 ], [ "integrated_welder", 30 ], [ "oxy_torch", 1 ] ] ],
     "components": [ [ [ "welding_rod_steel", 1 ], [ "welding_wire_steel", 1 ], [ "brazing_rod_bronze", 1 ] ] ]
   },
   {
     "id": "welding_alloys",
     "type": "requirement",
     "//": "Crafting items made of aluminium alloy or installation of vehicle parts, currently making the same assumption for time/coverage as steel",
-    "//1": "Arc welding is about 85% efficient, acetylene welding is about 40% efficient, propane welding is about 10% efficient",
-    "//2": "acetlyne is measured in grams while propane is measured in ml - this means acetlyene is roughly 2x as potent as propane per charge",
+    "//1": "Arc welding is about 85% efficient, acetylene welding is about 40% efficient",
     "qualities": [ { "id": "GLARE", "level": 1 } ],
-    "tools": [
-      [
-        [ "welder", 20 ],
-        [ "welding_kit", 20 ],
-        [ "welder_crude", 40 ],
-        [ "integrated_welder", 30 ],
-        [ "oxy_torch", 1 ],
-        [ "propane_torch", 8 ]
-      ]
-    ],
+    "tools": [ [ [ "welder", 20 ], [ "welding_kit", 20 ], [ "welder_crude", 40 ], [ "integrated_welder", 30 ], [ "oxy_torch", 1 ] ] ],
     "components": [ [ [ "welding_rod_alloy", 1 ], [ "welding_wire_alloy", 1 ], [ "brazing_rod_alloy", 1 ] ] ]
   },
   {
     "id": "repair_welding_standard",
     "type": "requirement",
     "//": "Repair of steel/iron items - per 10 cm of weld (100 seconds each), done this way to use 1 chunk of steel per 10 cm",
-    "//1": "Arc welding is about 85% efficient, acetylene welding is about 40% efficient, propane welding is about 10% efficient",
-    "//2": "acetlyne is measured in grams while propane is measured in ml - this means acetlyene is roughly 2x as potent as propane per charge",
+    "//1": "Arc welding is about 85% efficient, acetylene welding is about 40% efficient",
     "qualities": [ { "id": "GLARE", "level": 1 }, { "id": "HAMMER", "level": 2 } ],
     "tools": [
       [
@@ -212,8 +191,7 @@
         [ "welding_kit", 200 ],
         [ "welder_crude", 400 ],
         [ "integrated_welder", 300 ],
-        [ "oxy_torch", 10 ],
-        [ "propane_torch", 80 ]
+        [ "oxy_torch", 10 ]
       ]
     ],
     "components": [
@@ -225,8 +203,7 @@
     "id": "repair_welding_alloys",
     "type": "requirement",
     "//": "Repair of aluminum items - per 10 cm of weld (100 seconds each), done this way to use 1 chunk of steel per 10 cm",
-    "//1": "Arc welding is about 85% efficient, acetylene welding is about 40% efficient, propane welding is about 10% efficient",
-    "//2": "acetlyne is measured in grams while propane is measured in ml - this means acetlyene is roughly 2x as potent as propane per charge",
+    "//1": "Arc welding is about 85% efficient, acetylene welding is about 40% efficient",
     "qualities": [ { "id": "GLARE", "level": 1 }, { "id": "HAMMER", "level": 2 } ],
     "tools": [
       [
@@ -234,8 +211,7 @@
         [ "welding_kit", 200 ],
         [ "welder_crude", 400 ],
         [ "integrated_welder", 300 ],
-        [ "oxy_torch", 10 ],
-        [ "propane_torch", 80 ]
+        [ "oxy_torch", 10 ]
       ]
     ],
     "components": [
@@ -247,12 +223,9 @@
     "id": "repair_welding_rebar",
     "type": "requirement",
     "//": "Repair of rebar items - per 10 cm of weld (100 seconds each), done this way to use 1 rebar per 40 cm - you should use new rebar instead of repairing individual rebars",
-    "//1": "Arc welding is about 85% efficient, acetylene welding is about 40% efficient, propane welding is about 10% efficient",
-    "//2": "acetlyne is measured in grams while propane is measured in ml - this means acetlyene is roughly 2x as potent as propane per charge",
+    "//1": "Arc welding is about 85% efficient, acetylene welding is about 40% efficient",
     "qualities": [ { "id": "GLARE", "level": 1 }, { "id": "SAW_M", "level": 2 } ],
-    "tools": [
-      [ [ "welder", 800 ], [ "welding_kit", 800 ], [ "welder_crude", 1600 ], [ "oxy_torch", 40 ], [ "propane_torch", 320 ] ]
-    ],
+    "tools": [ [ [ "welder", 800 ], [ "welding_kit", 800 ], [ "welder_crude", 1600 ], [ "oxy_torch", 40 ] ] ],
     "components": [ [ [ "welding_rod_steel", 10 ], [ "welding_wire_steel", 10 ], [ "brazing_rod_bronze", 10 ] ], [ [ "rebar", 1 ] ] ]
   },
   {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Noticed in #73690 that the propane torch is currently usable for welding.
Not sure why I never connected the dots before, but no, it's not remotely hot enough to weld any materials we're interested in, much less cut through steel doors.

#### Describe the solution
Removed propane torch from welding requirement groups and removed it's OXYTORCH use action.
Adjusted the description to match.

#### Additional context
Do let me know if there are sources indicating otherwise, but a quick search is very clear that no, this kind of propane torch is not usable for general metal welding or cutting.
To clarify something, you evidently CAN cut with propane with copious amounts of oxygen, but AFAIK that's not the kind of propane torch this is depicting, and that would require carting around propane plus oxygen (or fusing it together into some composite fuel?)
You definitely can't weld though for chemistry reasons.