### PR TITLE
fix spawn_rate being zero by default

### DIFF
--- a/src/item_category.cpp
+++ b/src/item_category.cpp
@@ -60,7 +60,7 @@ void item_category::load( const JsonObject &jo, const std::string_view )
     optional( jo, was_loaded, "priority_zones", zone_priority_ );
     optional( jo, was_loaded, "zone", zone_, std::nullopt );
     float spawn_rate = 1.0f;
-    optional( jo, was_loaded, "spawn_rate", spawn_rate );
+    optional( jo, was_loaded, "spawn_rate", spawn_rate, 1.0f );
     set_spawn_rate( spawn_rate );
 }
 


### PR DESCRIPTION
#### Summary
None
#### Describe the solution
#73268 added spawn_rate options, opened for EoC, but accidentally made it 0 by default. Ehug found it, posted a fix, i compiled, tested it, and confirmed it works 
#### Testing
Walked around the city, have significantly more loot than in current exp
#### Additional context
Let's just remove all items from the game shall we?