### PR TITLE
Fix Up Travel Toilets

### DIFF
--- a/data/json/construction/furniture_seats.json
+++ b/data/json/construction/furniture_seats.json
@@ -97,6 +97,30 @@
   },
   {
     "type": "construction",
+    "id": "constr_place_travel_toilet",
+    "group": "place_travel_toilet",
+    "category": "FURN",
+    "required_skills": [ [ "fabrication", 0 ] ],
+    "time": "1 m",
+    "components": [ [ [ "toilet_travel", 1 ] ] ],
+    "pre_special": "check_empty",
+    "post_terrain": "f_bullettrailer_toilet",
+    "activity_level": "LIGHT_EXERCISE"
+  },
+  {
+    "type": "construction",
+    "id": "constr_place_folded_travel_toilet",
+    "group": "place_travel_toilet",
+    "category": "FURN",
+    "required_skills": [ [ "fabrication", 0 ] ],
+    "time": "1 m",
+    "components": [ [ [ "toilet_travel_folded", 1 ] ] ],
+    "pre_special": "check_empty",
+    "post_terrain": "f_bullettrailer_toilet",
+    "activity_level": "LIGHT_EXERCISE"
+  },
+  {
+    "type": "construction",
     "id": "constr_stool",
     "group": "build_stool",
     "category": "FURN",

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -1876,6 +1876,11 @@
   },
   {
     "type": "construction_group",
+    "id": "place_travel_toilet",
+    "name": "Place Travel Toilet"
+  },
+  {
+    "type": "construction_group",
     "id": "place_oxygen_concentrator",
     "name": "Place Oxygen Concentrator"
   },

--- a/data/json/furniture_and_terrain/special_use/bullet_trailer.json
+++ b/data/json/furniture_and_terrain/special_use/bullet_trailer.json
@@ -250,7 +250,18 @@
     "description": "A tiny plastic toilet for use in a travel trailer.  Unlike a normal toilet, it doesn't store water locally for you to siphon out.",
     "symbol": "b",
     "color": "white",
-    "copy-from": "f_toilet"
+    "move_cost_mod": 2,
+    "coverage": 15,
+    "required_str": 6,
+    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "MOUNTABLE", "EASY_DECONSTRUCT" ],
+    "deconstruct": { "items": [ { "item": "toilet_travel", "count": 1 } ] },
+    "bash": {
+      "str_min": 6,
+      "str_max": 15,
+      "sound": "plastic cracking!",
+      "sound_fail": "whump!",
+      "items": [ { "item": "plastic_chunk", "count": [ 4, 8 ] } ]
+    }
   },
   {
     "type": "furniture",

--- a/data/json/items/tool/misc.json
+++ b/data/json/items/tool/misc.json
@@ -827,6 +827,53 @@
     "melee_damage": { "bash": 6, "stab": 4 }
   },
   {
+    "id": "toilet_travel",
+    "type": "TOOL",
+    "name": { "str": "travel toilet" },
+    "description": "A portable plastic toilet, designed to use plastic bags for waste instead of plumbing.",
+    "weight": "1587 g",
+    "volume": "27651 ml",
+    "longest_side": "33 cm",
+    "price": "25 USD",
+    "price_postapoc": "4 USD",
+    "material": [ "plastic" ],
+    "symbol": ";",
+    "color": "white",
+    "use_action": {
+      "menu_text": "Collapse",
+      "type": "transform",
+      "target": "toilet_travel_folded",
+      "msg": "You collapse the toilet for transport."
+    },
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "watertight": false,
+        "rigid": true,
+        "open_container": true,
+        "max_item_length": "28 cm",
+        "max_contains_volume": "22712 ml",
+        "max_contains_weight": "6 kg"
+      }
+    ],
+    "flags": [ "COLLAPSE_CONTENTS" ]
+  },
+  {
+    "id": "toilet_travel_folded",
+    "type": "TOOL",
+    "name": { "str": "folded travel toilet" },
+    "description": "A portable plastic toilet.  It has been collapsed for easy transport.",
+    "weight": "1587 g",
+    "volume": "2 L",
+    "longest_side": "28 cm",
+    "price": "25 USD",
+    "price_postapoc": "4 USD",
+    "material": [ "plastic" ],
+    "symbol": ";",
+    "color": "white",
+    "use_action": { "menu_text": "Collapse", "type": "transform", "target": "toilet_travel", "msg": "You unfold the travel toilet." }
+  },
+  {
     "id": "testflames",
     "type": "TOOL",
     "name": { "str": "Flaming Chunk of Steel +2", "str_pl": "Flaming Chunks of Steel +2" },


### PR DESCRIPTION
#### Summary
Balance "Fix Up Travel Toilets"

#### Purpose of change
Well it started by noticing that travel toilets (portable plastic toilets) smashed for various metal pieces.  And that didn't make sense.  Unfortunately, I ended up going down the rabbit hole and changing a lot more.
#### Describe the solution
 - Edit travel toilet furniture in general to fix all the copy-from toilet stuff that doesn’t make sense
     - add drag-ability
     - remove flag for spawning with toilet water
     - Allow for simple deconstruction
     - change bash str/sound/materials/etc – It’s 3.5 lb there’s about 28-ish plastic chunks there, figure 15-30% for bash results. IE: 4-8 plastic chunks
 - Create travel toilet as an item
	Item was based on: https://www.amazon.com/PAHTTO-Portable-Retractable-Waterproof-Carrying/dp/B0B6YXPP4J
     - Volume = 13”x 11”x 11.8” + an online calculator = 27.651 liters.
     - Weight listed 3.5 lb (1587 grams).
     - Originally planned to let it hold water, but this one appears foldable/collapsible.  They’re all meant to use bags but some are watertight, this one does not appear to be.  So, no pocket for liquids.  Pocket for non liquids, based on the 6-8 gallon bags used, I’ll call it 6 gallons, as this puts it slightly below the overall items volume.
     - Pocket max-weight, well, it’s not designed for containing heavy objects, its rated for 400 lb on top but that's not the same as containing? and it’s collapsible, so let’s say…  6 kg?  This might be super wrong.
 - Add folded travel toilet as an item.
     - No idea what to make the volume honestly, figured it’s about the same ‘height’ (let’s pretend the lid doesn’t come off), the pictures don’t show this version as fully collapsed, only partly folded.  I have no idea how to math this so I’ll pick an arbitrary thickness and say each panel is foldable into one stack, let’s call it two liters.
 - Allow folded and unfolded toilets to be constructed into the furniture version through construction menu.
 - Put them in the same group so it's not more clutter than necessary.

#### Describe alternatives you've considered
Just changing the metal drops from bashing as initially intended.  I don't know the rules about cosmetic only furniture, but it already existed so why not let us take it down and place it ourselves?

#### Testing
This actually took me forever because I didn't really know what I was doing, so I tested to make sure everything works, transforms correctly, is constructable/deconstructable using simple deconstruct, etc.  I saw no issues.

#### Additional context
idk man I didn't even want to do this.  I just wanted to use the portable toilet in a mapgen location and noticed the materials were messed up and it snowballed into this.  But as I've been playing House Flipper, I like the idea of being able to carry and construct this furniture for my base, even if it doesn't have actual functionality, especially since this furniture already existed.  Might as well be able to construct it.

Pictures:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/41651793/e63723d9-be63-488e-9abd-056f499b633d)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/41651793/0446a7ce-f178-4fec-8543-4083484d106c)

