### PR TITLE
Trigger rebuild of cataclysmdda.org when a 0.H release candidate is created

### DIFF
--- a/.github/workflows/gh-pages-rebuild.yml
+++ b/.github/workflows/gh-pages-rebuild.yml
@@ -4,7 +4,7 @@ on:
   workflow_run:
     workflows: ["Experimental Release"]
     types: [completed]
-    branches: [master]
+    branches: [master, 0.H-branch]
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
The 0.H release candidate builds don't trigger rebuilds of the cataclysmdda site, so the /experimental page listing the latest builds doesn't update.

#### Describe the solution
Add the 0.H-branch to the whitelist for the job that does this.

#### Describe alternatives you've considered
Regular build also incoprporate the 0.H release candidates, but this kees it from being sometimes behind.