### PR TITLE
Gave fingerless wool gloves XL and XS variants relevant PREFIX flags.

### DIFF
--- a/data/json/items/armor/gloves.json
+++ b/data/json/items/armor/gloves.json
@@ -1053,18 +1053,18 @@
   {
     "id": "xl_gloves_wool_fingerless",
     "type": "ARMOR",
-    "name": { "str": "pair of XL fingerless wool gloves", "str_pl": "pairs of XL fingerless wool gloves" },
+    "name": { "str": "pair of fingerless wool gloves", "str_pl": "pairs of fingerless wool gloves" },
     "copy-from": "gloves_wool_fingerless",
     "proportional": { "weight": 1.4, "volume": 1.4 },
-    "flags": [ "OVERSIZE" ]
+    "flags": [ "OVERSIZE", "PREFIX_XL" ]
   },
   {
     "id": "xs_gloves_wool_fingerless",
     "type": "ARMOR",
     "copy-from": "gloves_wool_fingerless",
-    "name": { "str": "pair of XS fingerless wool gloves", "str_pl": "pairs of XS fingerless wool gloves" },
+    "name": { "str": "pair of fingerless wool gloves", "str_pl": "pairs of fingerless wool gloves" },
     "proportional": { "weight": 0.75, "volume": 0.75 },
-    "flags": [ "UNDERSIZE" ]
+    "flags": [ "UNDERSIZE", "PREFIX_XS" ]
   },
   {
     "id": "gloves_work",


### PR DESCRIPTION
#### Summary
Bugfixes "xs_gloves_wool_fingerless and xl_gloves_wool_fingerless did not have relevant PREFIX flags."

#### Purpose of change
Whoops

#### Describe the solution

The gloves now have the relevant PREFIX flag as they should have.

#### Describe alternatives you've considered

Pretend that never happened and swipe it under the rag.

#### Testing

I mean, it wasn't exactly broken before, and it still isn't broken now, but yeah, it has the flags now.

#### Additional context

No