### PR TITLE
Visual UI for changing vehicle part shapes

### DIFF
--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -843,6 +843,18 @@ void game::draw_cursor( const tripoint &p ) const
 }
 #endif
 
+void game::draw_cursor_unobscuring( const tripoint_bub_ms &p ) const
+{
+    const tripoint_rel_ms rp = relative_view_pos( *this, p );
+    mvwputch_inv( w_terrain, ( rp.xy() + point_north_east ).raw(), c_cyan, "↙" );
+    mvwputch_inv( w_terrain, ( rp.xy() + point_south_east ).raw(), c_cyan, "↖" );
+    mvwputch_inv( w_terrain, ( rp.xy() + point_north_west ).raw(), c_cyan, "↘" );
+    mvwputch_inv( w_terrain, ( rp.xy() + point_south_west ).raw(), c_cyan, "↗" );
+#if defined(TILES)
+    tilecontext->init_draw_cursor( p );
+#endif
+}
+
 #if defined(TILES)
 void game::draw_highlight( const tripoint_bub_ms &p )
 {

--- a/src/game.h
+++ b/src/game.h
@@ -782,6 +782,9 @@ class game
         // TODO: Get rid of untyped overload
         void draw_cursor( const tripoint &p ) const;
         void draw_cursor( const tripoint_bub_ms &p ) const;
+        // Tiles: equivalent to draw_cusor
+        // Curses: draws diagonal arrows pointing at the tile so the target tile isn't obscured
+        void draw_cursor_unobscuring( const tripoint_bub_ms &p ) const;
         // Draw a highlight graphic at p, for example when examining something.
         // TILES only, in curses this does nothing
         // TODO: Get rid of untyped overload

--- a/src/veh_interact.h
+++ b/src/veh_interact.h
@@ -172,7 +172,6 @@ class veh_interact
         void do_siphon();
         // Returns true if exiting the screen
         bool do_unload();
-        void do_change_shape();
         void do_assign_crew();
         void do_relabel();
         /*@}*/

--- a/src/veh_shape.cpp
+++ b/src/veh_shape.cpp
@@ -1,0 +1,254 @@
+#include "veh_shape.h"
+
+#include "animation.h"
+#include "avatar.h"
+#include "cached_options.h"
+#include "game.h"
+#include "options.h"
+#include "output.h"
+#include "player_activity.h"
+#include "veh_type.h"
+#include "veh_utils.h"
+#include "ui_manager.h"
+
+veh_shape::veh_shape( vehicle &vehicle ): veh( vehicle ) { }
+
+player_activity veh_shape::start( const tripoint_bub_ms &pos )
+{
+    avatar &you = get_avatar();
+    on_out_of_scope cleanup( []() {
+        get_map().invalidate_map_cache( get_avatar().view_offset.z );
+    } );
+    restore_on_out_of_scope<tripoint> view_offset_prev( you.view_offset );
+
+    cursor_allowed.clear();
+    for( const vpart_reference &part : veh.get_all_parts() ) {
+        cursor_allowed.insert( tripoint_bub_ms( part.pos() ) );
+    }
+
+    if( !set_cursor_pos( pos ) ) {
+        debugmsg( "failed to set cursor at given part" );
+        set_cursor_pos( tripoint_bub_ms( veh.global_part_pos3( 0 ) ) );
+    }
+
+    const auto target_ui_cb = make_shared_fast<game::draw_callback_t>(
+    [&]() {
+        const avatar &you = get_avatar();
+        g->draw_cursor_unobscuring( tripoint_bub_ms( you.pos() + you.view_offset ) );
+    } );
+    g->add_draw_callback( target_ui_cb );
+    ui_adaptor ui;
+    ui.mark_resize();
+    init_input();
+
+    std::string action = "CONFIRM";
+
+    while( true ) {
+        g->invalidate_main_ui_adaptor();
+        ui_manager::redraw();
+
+        if( action.empty() ) {
+            action = ctxt.handle_input( get_option<int>( "EDGE_SCROLL" ) );
+        }
+
+        if( handle_cursor_movement( action ) || ( action == "HELP_KEYBINDINGS" ) ) {
+            action.clear();
+            continue;
+        } else if( action == "CONFIRM" ) {
+            std::optional<vpart_reference> part;
+            do {
+                part = select_part_at_cursor( _( "Choose part to change shape" ),
+                                              _( "Confirm to select or quit to select another tile." ),
+                []( const vpart_reference & vp ) {
+                    if( vp.info().variants.size() <= 1 ) {
+                        return ret_val<void>::make_failure( _( "Only one shape" ) );
+                    } else if( vp.part_displayed() && vp.part_displayed()->part_index() != vp.part_index() ) {
+                        return ret_val<void>::make_success( _( "Part is obscured" ) );
+                    }
+                    return ret_val<void>::make_success();
+                }, part );
+                if( part.has_value() ) {
+                    change_part_shape( part.value() );
+                }
+            } while( part.has_value() );
+            action.clear();
+        } else if( action == "QUIT" ) {
+            return player_activity();
+        } else {
+            debugmsg( "here be dragons" );
+            return player_activity();
+        }
+    }
+}
+
+std::vector<vpart_reference> veh_shape::parts_under_cursor() const
+{
+    std::vector<vpart_reference> res;
+    // TODO: tons of methods getting parts from vehicle but all of them seem inadequate?
+    for( int part_idx = 0; part_idx < veh.part_count_real(); part_idx++ ) {
+        const vehicle_part &p = veh.part( part_idx );
+        if( veh.bub_part_pos( p ) == get_cursor_pos() && !p.is_fake ) {
+            res.emplace_back( veh, part_idx );
+        }
+    }
+    return res;
+}
+
+std::optional<vpart_reference> veh_shape::select_part_at_cursor(
+    const std::string &title, const std::string &extra_description,
+    const std::function<ret_val<void>( const vpart_reference & )> &predicate,
+    const std::optional<vpart_reference> &preselect ) const
+{
+    const std::vector<vpart_reference> parts = parts_under_cursor();
+    if( parts.empty() ) {
+        return std::nullopt;
+    }
+
+    uilist menu;
+    menu.desc_enabled = !extra_description.empty();
+    menu.desc_lines_hint = 1;
+    menu.hilight_disabled = true;
+    menu.w_x_setup = TERMX / 8;
+
+    for( const vpart_reference &pt : parts ) {
+        ret_val<void> predicate_result = predicate( pt );
+        uilist_entry entry( -1, true, MENU_AUTOASSIGN, pt.part().name(), "", predicate_result.str() );
+        entry.desc = extra_description;
+        entry.enabled = predicate_result.success();
+        entry.retval = predicate_result.success() ? menu.entries.size() : -2;
+        if( preselect && preselect->part_index() == pt.part_index() ) {
+            menu.selected = menu.entries.size();
+        }
+        menu.entries.push_back( entry );
+    }
+    menu.text = title;
+    menu.query();
+
+    return menu.ret >= 0 ? std::optional<vpart_reference>( parts[menu.ret] ) : std::nullopt;
+}
+
+void veh_shape::change_part_shape( vpart_reference vpr ) const
+{
+    vehicle_part &part = vpr.part();
+    const vpart_info &vpi = part.info();
+    veh_menu menu( this->veh, _( "Choose cosmetic variant:" ) );
+    std::string chosen_variant = part.variant; // support for cancel
+
+    do {
+        menu.reset( false );
+
+        for( const auto &[vvid, vv] : vpi.variants ) {
+            menu.add( vv.get_label() )
+            .text_color( ( part.variant == vvid ) ? c_light_green : c_light_gray )
+            .keep_menu_open()
+            .skip_locked_check()
+            .skip_theft_check()
+            .location( veh.global_part_pos3( part ) )
+            .select( part.variant == vvid )
+            .desc( _( "Confirm to save or exit to revert" ) )
+            .symbol( vv.get_symbol_curses( 0_degrees, false ) )
+            .symbol_color( vpi.color )
+            .on_select( [&part, variant_id = vvid]() {
+                part.variant = variant_id;
+            } )
+            .on_submit( [&chosen_variant, variant_id = vvid]() {
+                chosen_variant = variant_id;
+            } );
+        }
+
+        // An ordering of the line drawing symbols that does not result in
+        // connecting when placed adjacent to each other vertically.
+        menu.sort( []( const veh_menu_item & a, const veh_menu_item & b ) {
+            const static std::map<int, int> symbol_order = {
+                { LINE_XOXO, 0 }, { LINE_OXOX, 1 }, { LINE_XOOX, 2 }, { LINE_XXOO, 3 },
+                { LINE_XXXX, 4 }, { LINE_OXXO, 5 }, { LINE_OOXX, 6 },
+            };
+            const auto a_iter = symbol_order.find( a._symbol );
+            const auto b_iter = symbol_order.find( b._symbol );
+            if( a_iter != symbol_order.end() ) {
+                return ( b_iter == symbol_order.end() ) || ( a_iter->second < b_iter->second );
+            } else {
+                return ( b_iter == symbol_order.end() ) && ( a._symbol < b._symbol );
+            }
+        } );
+    } while( menu.query() );
+
+    part.variant = chosen_variant;
+}
+
+tripoint_bub_ms veh_shape::get_cursor_pos() const
+{
+    return cursor_pos;
+}
+
+bool veh_shape::set_cursor_pos( const tripoint_bub_ms &new_pos )
+{
+    avatar &you = get_avatar();
+
+    int z = std::max( { new_pos.z(), -fov_3d_z_range, -OVERMAP_DEPTH } );
+    z = std::min( {z, fov_3d_z_range, OVERMAP_HEIGHT } );
+
+    if( !allow_zlevel_shift ) {
+        z = cursor_pos.z();
+    }
+    tripoint_bub_ms target_pos( new_pos.xy(), z );
+
+    if( cursor_allowed.find( target_pos ) == cursor_allowed.cend() ) {
+        return false;
+    }
+
+    if( z != cursor_pos.z() ) {
+        get_map().invalidate_map_cache( z );
+    }
+    cursor_pos = target_pos;
+    you.view_offset = cursor_pos.raw() - you.pos();
+    return true;
+}
+
+bool veh_shape::handle_cursor_movement( const std::string &action )
+{
+    if( action == "MOUSE_MOVE" || action == "TIMEOUT" ) {
+        tripoint edge_scroll = g->mouse_edge_scrolling_terrain( ctxt );
+        set_cursor_pos( get_cursor_pos() + edge_scroll );
+    } else if( const std::optional<tripoint> delta = ctxt.get_direction( action ) ) {
+        set_cursor_pos( get_cursor_pos() + *delta ); // move cursor with directional keys
+    } else if( action == "zoom_in" ) {
+        g->zoom_in();
+    } else if( action == "zoom_out" ) {
+        g->zoom_out();
+    } else if( action == "SELECT" ) {
+        const std::optional<tripoint> mouse_pos = ctxt.get_coordinates( g->w_terrain );
+        if( !mouse_pos ) {
+            return false;
+        }
+        const tripoint_bub_ms mp( *mouse_pos );
+        if( get_cursor_pos() != mp ) {
+            set_cursor_pos( mp );
+        }
+    } else if( action == "LEVEL_UP" ) {
+        set_cursor_pos( get_cursor_pos() + tripoint_above );
+    } else if( action == "LEVEL_DOWN" ) {
+        set_cursor_pos( get_cursor_pos() + tripoint_below );
+    } else {
+        return false;
+    }
+
+    return true;
+}
+
+void veh_shape::init_input()
+{
+    ctxt = input_context( "VEH_SHAPES", keyboard_mode::keycode );
+    ctxt.set_iso( true );
+    ctxt.register_directions();
+    ctxt.register_action( "CONFIRM" );
+    ctxt.register_action( "SELECT" );
+    ctxt.register_action( "QUIT" );
+    ctxt.register_action( "HELP_KEYBINDINGS" );
+    ctxt.register_action( "MOUSE_MOVE" );
+    ctxt.register_action( "LEVEL_UP" );
+    ctxt.register_action( "LEVEL_DOWN" );
+    ctxt.register_action( "REMOVE" );
+    ctxt.register_action( "zoom_out" );
+    ctxt.register_action( "zoom_in" );
+}

--- a/src/veh_shape.h
+++ b/src/veh_shape.h
@@ -1,0 +1,49 @@
+#pragma once
+#ifndef CATA_SRC_VEH_SHAPE_H
+#define CATA_SRC_VEH_SHAPE_H
+
+#include "vehicle.h"
+
+class player_activity;
+
+class veh_shape
+{
+    public:
+        explicit veh_shape( vehicle &vehicle );
+
+        /// Starts vehicle ui loop, runs until canceled or activity is selected and returned
+        /// @param vehicle Vehicle to handle
+        /// @return Selected activity or player_activity( activity_id::NULL_ID() ) if cancelled
+        player_activity start( const tripoint_bub_ms &pos );
+
+    private:
+        input_context ctxt;
+
+        // vehicle being worked on
+        vehicle &veh;
+
+        // cursor handling
+        std::set<tripoint_bub_ms> cursor_allowed; // all points the cursor is allowed to be on
+        tripoint_bub_ms cursor_pos;
+        tripoint_bub_ms get_cursor_pos() const;
+        bool set_cursor_pos( const tripoint_bub_ms &new_pos );
+        bool handle_cursor_movement( const std::string &action );
+
+        /// Returns all parts under cursor (no filtering)
+        std::vector<vpart_reference> parts_under_cursor() const;
+
+        // break glass^W^W delete this in case multi-level vehicles are a thing
+        const bool allow_zlevel_shift = false;
+
+        void init_input();
+
+        // doing actual "maintenance"
+        std::optional<vpart_reference> select_part_at_cursor(
+            const std::string &title, const std::string &extra_description,
+            const std::function<ret_val<void>( const vpart_reference & )> &predicate,
+            const std::optional<vpart_reference> &preselect ) const;
+
+        void change_part_shape( vpart_reference vpr ) const;
+};
+
+#endif // CATA_SRC_VEH_SHAPE_H

--- a/src/veh_utils.cpp
+++ b/src/veh_utils.cpp
@@ -8,10 +8,12 @@
 #include <utility>
 #include <vector>
 
+#include "avatar.h"
 #include "calendar.h"
 #include "character.h"
 #include "craft_command.h"
 #include "enums.h"
+#include "game.h"
 #include "game_constants.h"
 #include "input_context.h"
 #include "inventory.h"
@@ -165,15 +167,39 @@ veh_menu_item &veh_menu_item::text( const std::string &text )
     return *this;
 }
 
+veh_menu_item &veh_menu_item::text_color( const nc_color text_color )
+{
+    this->_text_color = text_color;
+    return *this;
+}
+
 veh_menu_item &veh_menu_item::desc( const std::string &desc )
 {
     this->_desc = desc;
     return *this;
 }
 
+veh_menu_item &veh_menu_item::symbol( const int symbol )
+{
+    this->_symbol = symbol;
+    return *this;
+}
+
+veh_menu_item &veh_menu_item::symbol_color( const nc_color symbol_color )
+{
+    this->_symbol_color = symbol_color;
+    return *this;
+}
+
 veh_menu_item &veh_menu_item::enable( const bool enable )
 {
     this->_enabled = enable;
+    return *this;
+}
+
+veh_menu_item &veh_menu_item::select( const bool select )
+{
+    this->_selected = select;
     return *this;
 }
 
@@ -231,6 +257,12 @@ veh_menu_item &veh_menu_item::on_submit( const std::function<void()> &on_submit 
     return *this;
 }
 
+veh_menu_item &veh_menu_item::on_select( const std::function<void()> &on_select )
+{
+    this->_on_select = on_select;
+    return *this;
+}
+
 veh_menu_item &veh_menu_item::keep_menu_open( const bool keep_menu_open )
 {
     this->_keep_menu_open = keep_menu_open;
@@ -271,6 +303,12 @@ std::vector<veh_menu_item> veh_menu::get_items() const
     return items;
 }
 
+void veh_menu::sort( const std::function<int( const veh_menu_item &a, const veh_menu_item &b )>
+                     &comparer )
+{
+    std::sort( items.begin(), items.end(), comparer );
+}
+
 std::vector<tripoint> veh_menu::get_locations() const
 {
     std::vector<tripoint> locations;
@@ -286,7 +324,7 @@ std::vector<tripoint> veh_menu::get_locations() const
 
 void veh_menu::reset( bool keep_last_selected )
 {
-    last_selected = keep_last_selected ? last_selected : 0;
+    last_selected = keep_last_selected ? last_selected : std::nullopt;
     items.clear();
 }
 
@@ -306,6 +344,11 @@ std::vector<uilist_entry> veh_menu::get_uilist_entries() const
         entry.retval = static_cast<int>( i );
         entry.desc = it._desc;
         entry.enabled = it._enabled;
+        entry.text_color = it._text_color;
+        if( it._symbol != 0 ) {
+            entry.extratxt.color = it._symbol_color;
+            entry.extratxt.sym = it._symbol;
+        }
 
         if( it._check_locked && veh.is_locked ) {
             entry.enabled = false;
@@ -320,6 +363,56 @@ std::vector<uilist_entry> veh_menu::get_uilist_entries() const
 
     return entries;
 }
+
+class veh_menu_cb : public uilist_callback
+{
+    public:
+        explicit veh_menu_cb( const std::vector<tripoint> &pts ) : points( pts ) {
+            last = INT_MIN;
+            avatar &player_character = get_avatar();
+            last_view = player_character.view_offset;
+            terrain_draw_cb = make_shared_fast<game::draw_callback_t>( [this, &player_character]() {
+                if( draw_trail && last >= 0 && static_cast<size_t>( last ) < points.size() ) {
+                    g->draw_trail_to_square( player_character.view_offset, true );
+                }
+            } );
+            g->add_draw_callback( terrain_draw_cb );
+        }
+
+        ~veh_menu_cb() override {
+            get_avatar().view_offset = last_view;
+        }
+
+        std::function<void()> on_select;
+        bool draw_trail;
+    private:
+        const std::vector< tripoint > &points;
+        int last; // to suppress redrawing
+        tripoint last_view; // to reposition the view after selecting
+        shared_ptr_fast<game::draw_callback_t> terrain_draw_cb;
+
+        void select( uilist *menu ) override {
+            if( last == menu->selected ) {
+                return;
+            }
+            last = menu->selected;
+            avatar &player_character = get_avatar();
+            if( menu->selected < 0 || menu->selected >= static_cast<int>( points.size() ) ) {
+                player_character.view_offset = tripoint_zero;
+            } else {
+                const tripoint &center = points[menu->selected];
+                player_character.view_offset = center - player_character.pos();
+                // Remove next line if/when it's wanted/safe to shift view to other zlevels
+                player_character.view_offset.z = 0;
+            }
+            g->invalidate_main_ui_adaptor();
+            if( on_select ) {
+                on_select();
+                map &m = get_map();
+                m.invalidate_map_cache( m.get_abs_sub().z() );
+            }
+        }
+};
 
 bool veh_menu::query()
 {
@@ -347,15 +440,28 @@ bool veh_menu::query()
     menu.hilight_disabled = true;
 
     const std::vector<tripoint> locations = get_locations();
-    pointmenu_cb callback( locations );
+    veh_menu_cb cb( locations );
+
+    cb.on_select = [this, &menu]() {
+        items[menu.selected]._on_select();
+    };
+
     if( locations.size() == items.size() ) { // all items have valid location attached
-        menu.callback = &callback;
+        menu.callback = &cb;
         menu.w_x_setup = 4; // move menu to the left so more space around vehicle is visible
     } else {
         menu.callback = nullptr;
     }
 
-    menu.selected = last_selected;
+    if( last_selected.has_value() ) { // have selection from previous query
+        menu.selected = std::max( static_cast<int>( items.size() ), last_selected.value() );
+    } else { // find first element with select enabled
+        for( menu.selected = 0; menu.selected < static_cast<int>( items.size() ); menu.selected++ ) {
+            if( items[menu.selected]._selected ) {
+                break; // found first selected element
+            }
+        }
+    }
     menu.query();
     last_selected = menu.selected;
 

--- a/src/veh_utils.h
+++ b/src/veh_utils.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "point.h"
+#include "color.h"
 #include "type_id.h"
 
 class Character;
@@ -34,24 +35,34 @@ bool repair_part( vehicle &veh, vehicle_part &pt, Character &who );
 struct veh_menu_item {
     std::string _text;
     std::string _desc;
+    int _symbol = 0;
+    nc_color _symbol_color = get_all_colors().get( def_c_light_gray );
+    nc_color _text_color = get_all_colors().get( def_c_light_gray );
     std::optional<tripoint> _location = std::nullopt;
     bool _enabled = true;
+    bool _selected = true;
     bool _check_theft = true;
     bool _check_locked = true;
     bool _keep_menu_open = false;
     std::optional<char> _hotkey_char = std::nullopt;
     std::optional<std::string> _hotkey_action = std::nullopt;
     std::function<void()> _on_submit;
+    std::function<void()> _on_select;
 
     veh_menu_item &text( const std::string &text );
+    veh_menu_item &text_color( nc_color text_color );
     veh_menu_item &desc( const std::string &desc );
+    veh_menu_item &symbol( int symbol );
+    veh_menu_item &symbol_color( nc_color symbol_color );
     veh_menu_item &enable( bool enable );
+    veh_menu_item &select( bool select );
     veh_menu_item &skip_theft_check( bool skip_theft_check = true );
     veh_menu_item &skip_locked_check( bool skip_locked_check = true );
     veh_menu_item &hotkey( char hotkey_char );
     veh_menu_item &hotkey( const std::string &action );
     veh_menu_item &hotkey_auto();
     veh_menu_item &on_submit( const std::function<void()> &on_submit );
+    veh_menu_item &on_select( const std::function<void()> &on_select );
     veh_menu_item &keep_menu_open( bool keep_menu_open = true );
     veh_menu_item &location( const std::optional<tripoint> &location );
 };
@@ -67,6 +78,7 @@ class veh_menu
 
         size_t get_items_size() const;
         std::vector<veh_menu_item> get_items() const;
+        void sort( const std::function<int( const veh_menu_item &a, const veh_menu_item &b )> &comparer );
 
         int desc_lines_hint = 0;
 
@@ -84,7 +96,7 @@ class veh_menu
         std::vector<uilist_entry> get_uilist_entries() const;
         std::vector<tripoint> get_locations() const;
 
-        int last_selected = 0;
+        std::optional<int> last_selected = std::nullopt;
 };
 
 #endif // CATA_SRC_VEH_UTILS_H


### PR DESCRIPTION
#### Summary
Interface "Provide a visual UI for changing vehicle part shapes"

#### Purpose of change

Changing vehicle part shapes is almost entirely guesswork for tiles mode right now, this aims to improve it by providing visual feedback as you browse the shapes, should also work in curses

#### Describe the solution

Implements a separate menu, demo video attached

#### Describe alternatives you've considered

#### Testing

Almost entirely a UI change so testing is manually poking the menus

#### Additional context

https://github.com/CleverRaven/Cataclysm-DDA/assets/6560075/d7859e9b-6006-493c-b90f-1d0a5128a8e8

