### PR TITLE
Don't show gun without default ammo defined as an option in reload ui

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -14467,10 +14467,11 @@ template bool item::is_bp_comfortable<bodypart_id>( const bodypart_id &bp ) cons
 
 bool item::is_reloadable() const
 {
-    if( has_flag( flag_NO_RELOAD ) && !has_flag( flag_VEHICLE ) ) {
-        return false; // turrets ignore NO_RELOAD flag
-    } else if( is_gun() && !ammo_default() ) {
-        return false; // don't show guns without default ammo defined in reload ui
+    if( ( has_flag( flag_NO_RELOAD ) && !has_flag( flag_VEHICLE ) ) ||
+        ( is_gun() && !ammo_default() ) ) {
+        // turrets ignore NO_RELOAD flag
+        // don't show guns without default ammo defined in reload ui
+        return false;
     }
 
     for( const item_pocket *pocket : contents.get_all_reloadable_pockets() ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -14469,7 +14469,8 @@ bool item::is_reloadable() const
 {
     if( has_flag( flag_NO_RELOAD ) && !has_flag( flag_VEHICLE ) ) {
         return false; // turrets ignore NO_RELOAD flag
-
+    } else if( is_gun() && !ammo_default() ) {
+        return false; // don't show guns without default ammo defined in reload ui
     }
 
     for( const item_pocket *pocket : contents.get_all_reloadable_pockets() ) {


### PR DESCRIPTION
#### Summary
Interface "Don't show gun without default ammo defined as an option in reload ui"
#### Purpose of change
#73714 fixed the issue that you can reload a gun without default ammo type defined, but such kind of a gun is still shown as an option in reload ui even if you can not reload it.
#### Describe the solution
Gun without default ammo defined will no longer be shown as an option when pressing reload item, reload weapon, or reload wielded item keybindings.
#### Describe alternatives you've considered
N/A
#### Testing
Compiled and tested locally.
#### Additional context