### PR TITLE
Include vehicle roofs for map::draw_from_above

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -7330,7 +7330,7 @@ void map::draw_from_above( const catacurses::window &w, const tripoint &p,
         tercol = curr_furn.color();
     } else if( ( veh = veh_at_internal( p, part_below ) ) != nullptr ) {
         const vpart_position vpp( const_cast<vehicle &>( *veh ), part_below );
-        const vpart_display vd = veh->get_display_of_tile( vpp.mount(), true, true, false );
+        const vpart_display vd = veh->get_display_of_tile( vpp.mount(), true, true, true );
         const int roof = veh->roof_at_part( part_below );
         sym = vd.symbol_curses;
         tercol = roof >= 0 || vpp.obstacle_at_part() ? c_light_gray : c_light_gray_cyan;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fix #73029

#### Describe the solution

Flip a bool so curses renders vehicles roofs from z+1 correctly

#### Describe alternatives you've considered

#### Testing

Compile curses build, place vehicle near ramp, go on ramp - the debugmsg in the linked issue pops, doesn't pop after patch

#### Additional context
