### PR TITLE
Add tarot cards and Ouija board

### DIFF
--- a/data/json/items/fluff.json
+++ b/data/json/items/fluff.json
@@ -650,7 +650,7 @@
   "id": "ouija",
     "type": "GENERIC",
     "category": "other",
-    "name": { "str": "Ouija board, "str_pl": "sets of Ouija boards" },
+    "name": { "str": "Ouija board" },
     "description": "A wooden board with the alphabet and numbers on its face. Commonly used for communing with spirits of the dead. A planchette is included in the set.",
     "weight": "357 g",
     "volume": "1000 ml",
@@ -661,8 +661,7 @@
     "symbol": "?",
     "color": "red",
     "flags": [ "NO_REPAIR" ],
-    "use_action": [ "PLAY_GAME" ],
-    "//": "Based on https://www.amazon.com/Medium-Wooden-Ouija-Board-Planchette/dp/B08HKW8WP2
+    "use_action": [ "PLAY_GAME" ]
   },
   {
     "id": "dnd",

--- a/data/json/items/fluff.json
+++ b/data/json/items/fluff.json
@@ -63,7 +63,7 @@
       },
       {
         "id": "deck_of_tarot_cards",
-        "name": { "str": "deck of tarot cards", "str_pl": "decks tarot of cards" },
+        "name": { "str": "deck of tarot cards", "str_pl": "decks of tarot cards" },
         "description": "A deck of tarot cards. Commonly used for the practice of divination. Each card has a unique and highly symbolic picture.",
         "weight": 2
       },

--- a/data/json/items/fluff.json
+++ b/data/json/items/fluff.json
@@ -64,7 +64,7 @@
       {
         "id": "deck_of_tarot_cards",
         "name": { "str": "deck of tarot cards", "str_pl": "decks of tarot cards" },
-        "description": "A deck of tarot cards. Commonly used for the practice of divination. Each card has a unique and highly symbolic picture.",
+        "description": "A deck of tarot cards.  Commonly used for the practice of divination.  Each card has a unique and highly symbolic picture.",
         "weight": 2
       },
       {

--- a/data/json/items/fluff.json
+++ b/data/json/items/fluff.json
@@ -62,7 +62,7 @@
         "weight": 2
       },
       {
-      "id": "deck_of_tarot_cards",
+        "id": "deck_of_tarot_cards",
         "name": { "str": "deck of tarot cards", "str_pl": "decks tarot of cards" },
         "description": "A deck of tarot cards. Commonly used for the practice of divination. Each card has a unique and highly symbolic picture.",
         "weight": 2

--- a/data/json/items/fluff.json
+++ b/data/json/items/fluff.json
@@ -647,7 +647,7 @@
     "use_action": [ "PLAY_GAME" ]
   },
   {
-  "id": "ouija",
+    "id": "ouija",
     "type": "GENERIC",
     "category": "other",
     "name": { "str": "Ouija board" },

--- a/data/json/items/fluff.json
+++ b/data/json/items/fluff.json
@@ -63,7 +63,7 @@
       },
       {
       "id": "deck_of_tarot_cards",
-        "name": { "str": "Deck of tarot cards", "str_pl": "Decks tarot of cards" },
+        "name": { "str": "deck of tarot cards", "str_pl": "decks tarot of cards" },
         "description": "A deck of tarot cards. Commonly used for the practice of divination. Each card has a unique and highly symbolic picture.",
         "weight": 2
       },
@@ -658,7 +658,7 @@
     "price": "20 USD",
     "price_postapoc": "5 USD",
     "material": [ "wood" ],
-    "symbol": "o",
+    "symbol": "?",
     "color": "red",
     "flags": [ "NO_REPAIR" ],
     "use_action": [ "PLAY_GAME" ],

--- a/data/json/items/fluff.json
+++ b/data/json/items/fluff.json
@@ -651,7 +651,7 @@
     "type": "GENERIC",
     "category": "other",
     "name": { "str": "Ouija board" },
-    "description": "A wooden board with the alphabet and numbers on its face. Commonly used for communing with spirits of the dead. A planchette is included in the set.",
+    "description": "A wooden board with the alphabet and numbers on its face.  Commonly used for communing with spirits of the dead.  A planchette is included in the set.",
     "weight": "357 g",
     "volume": "1000 ml",
     "longest_side": "36 cm",

--- a/data/json/items/fluff.json
+++ b/data/json/items/fluff.json
@@ -62,6 +62,12 @@
         "weight": 2
       },
       {
+      "id": "deck_of_tarot_cards",
+        "name": { "str": "Deck of tarot cards", "str_pl": "Decks tarot of cards" },
+        "description": "A deck of tarot cards. Commonly used for the practice of divination. Each card has a unique and highly symbolic picture.",
+        "weight": 2
+      },
+      {
         "id": "deck_of_cards_makeshift",
         "name": { "str": "makeshift deck of cards", "str_pl": "makeshift decks of cards" },
         "description": "A deck of 52 makeshift cards, made out of cardboard rectangles with simple designs drawn on them.",
@@ -639,6 +645,24 @@
     "color": "red",
     "flags": [ "NO_REPAIR" ],
     "use_action": [ "PLAY_GAME" ]
+  },
+  {
+  "id": "ouija",
+    "type": "GENERIC",
+    "category": "other",
+    "name": { "str": "Ouija board, "str_pl": "sets of Ouija boards" },
+    "description": "A wooden board with the alphabet and numbers on its face. Commonly used for communing with spirits of the dead. A planchette is included in the set.",
+    "weight": "357 g",
+    "volume": "1000 ml",
+    "longest_side": "36 cm",
+    "price": "20 USD",
+    "price_postapoc": "5 USD",
+    "material": [ "wood" ],
+    "symbol": "o",
+    "color": "red",
+    "flags": [ "NO_REPAIR" ],
+    "use_action": [ "PLAY_GAME" ],
+    "//": "Based on https://www.amazon.com/Medium-Wooden-Ouija-Board-Planchette/dp/B08HKW8WP2
   },
   {
     "id": "dnd",


### PR DESCRIPTION
#### Summary
Content "Added tarot cards as a variant of playing cards and added Ouija board as a playable board game."

#### Purpose of change
I noticed a lack of mystically inclined games and decided to add them. 

#### Describe the solution

Added these games into Cataclysm.

#### Describe alternatives you've considered

Not having these games. Nothing horrible would happen but it would be an opportunity not taken.

#### Testing

Used the debug menu to spawn in both the tarot cards and Ouija board. Successfully played them like any other game.

#### Additional context

First time contributing anything. We'll see how it goes.
