### PR TITLE
Auditing breaks_into of vehicle_parts.json Part Two

### DIFF
--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -193,7 +193,7 @@
       "removal": { "skills": [ [ "fabrication", 1 ] ], "time": "100 s", "using": [ [ "vehicle_weld_removal", 1 ] ] },
       "repair": { "skills": [ [ "fabrication", 1 ] ], "time": "5 m", "using": [ [ "repair_welding_standard", 1 ] ] }
     },
-    "breaks_into": [ { "item": "scrap", "count": [ 4, 6 ] } ],
+    "breaks_into": [ { "item": "scrap", "charges": [ 4, 6 ] } ],
     "flags": [
       "ENGINE",
       "BOARDABLE",
@@ -559,7 +559,7 @@
     "breaks_into": [
       { "item": "steel_lump", "prob": 50 },
       { "item": "steel_chunk", "count": [ 1, 2 ] },
-      { "item": "scrap", "count": [ 0, 3 ] }
+      { "item": "scrap", "charges": [ 0, 3 ] }
     ],
     "damage_reduction": { "all": 8, "bash": 10 },
     "variants": [ { "symbols": "O", "symbols_broken": "#" } ]
@@ -582,7 +582,7 @@
       "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "5 m", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 3 ] ] }
     },
     "flags": [ "HANDHELD_BATTERY_MOUNT" ],
-    "breaks_into": [ { "item": "power_supply", "prob": 50 }, { "item": "scrap", "count": [ 1, 4 ] } ],
+    "breaks_into": [ { "item": "power_supply", "prob": 50 }, { "item": "scrap", "charges": [ 1, 4 ] } ],
     "damage_reduction": { "all": 4, "bash": 5 },
     "variants": [ { "symbols": "O", "symbols_broken": "#" } ]
   },
@@ -645,7 +645,7 @@
     "breaks_into": [
       { "item": "steel_lump", "count": [ 6, 11 ] },
       { "item": "steel_chunk", "count": [ 6, 11 ] },
-      { "item": "scrap", "count": [ 6, 11 ] }
+      { "item": "scrap", "charges": [ 6, 11 ] }
     ],
     "damage_reduction": { "all": 50 },
     "variants": [ { "symbols": "O", "symbols_broken": "#" } ]
@@ -1016,11 +1016,12 @@
     },
     "flags": [ "CARGO", "BOARDABLE", "FLAT_SURF", "WORKBENCH" ],
     "breaks_into": [
-      { "item": "pipe", "count": [ 4, 6 ] },
-      { "item": "sheet_metal", "count": [ 0, 1 ] },
-      { "item": "sheet_metal_small", "count": [ 12, 24 ] },
-      { "item": "steel_chunk", "count": [ 4, 8 ] },
-      { "item": "scrap", "count": [ 12, 24 ] }
+      { "item": "pipe", "prob": 25 },
+      { "item": "sheet_metal", "prob": 5 },
+      { "item": "sheet_metal_small", "count": [ 5, 14 ] },
+      { "item": "steel_lump", "count": [ 1, 3 ] },
+      { "item": "steel_chunk", "count": [ 7, 12 ] },
+      { "item": "scrap", "charges": [ 15, 30 ] }
     ],
     "workbench": { "multiplier": 1.2, "mass": 300000, "volume": "30 L" },
     "damage_reduction": { "all": 29 },
@@ -1043,15 +1044,15 @@
     },
     "flags": [ "CARGO", "MOUNTABLE", "FLAT_SURF", "WORKBENCH", "ENABLED_DRAINS_EPOWER", "RECHARGE" ],
     "breaks_into": [
-      { "item": "pipe", "count": [ 4, 6 ] },
-      { "item": "sheet_metal", "count": [ 0, 1 ] },
-      { "item": "sheet_metal_small", "count": [ 12, 24 ] },
-      { "item": "steel_chunk", "count": [ 4, 8 ] },
-      { "item": "scrap", "count": [ 12, 24 ] },
+      { "item": "pipe", "prob": 25 },
+      { "item": "sheet_metal", "prob": 5 },
+      { "item": "sheet_metal_small", "count": [ 5, 14 ] },
+      { "item": "steel_lump", "count": [ 1, 3 ] },
+      { "item": "steel_chunk", "count": [ 7, 12 ] },
+      { "item": "scrap", "charges": [ 15, 30 ] },
       { "item": "plastic_chunk", "prob": 50 },
       { "item": "cable", "charges": [ 1, 4 ] },
-      { "item": "e_scrap", "count": [ 0, 2 ] },
-      { "item": "scrap", "count": [ 1, 3 ] }
+      { "item": "e_scrap", "count": [ 0, 2 ] }
     ],
     "size": "29500 ml",
     "workbench": { "volume": "29 L" },
@@ -1247,7 +1248,7 @@
       "repair": { "skills": [ [ "tailor", 1 ] ], "time": "150 s", "using": [ [ "sewing_standard", 50 ], [ "fabric_standard", 1 ] ] }
     },
     "flags": [ "ENGINE", "CONTROLS", "PROTRUSION", "E_STARTS_INSTANTLY", "WIND_POWERED", "STABLE", "UNMOUNT_ON_DAMAGE" ],
-    "breaks_into": [ { "item": "splinter", "count": [ 2, 4 ] }, { "item": "cotton_patchwork", "count": [ 5, 10 ] } ],
+    "breaks_into": [ { "item": "splinter", "count": [ 2, 4 ] }, { "item": "cotton_patchwork", "count": [ 1, 3 ] } ],
     "variants": [ { "symbols": "M", "symbols_broken": "#" } ]
   },
   {
@@ -1284,7 +1285,7 @@
     "breaks_into": [
       { "item": "steel_lump" },
       { "item": "steel_chunk", "count": [ 1, 3 ] },
-      { "item": "scrap", "count": [ 1, 3 ] },
+      { "item": "scrap", "charges": [ 1, 3 ] },
       { "item": "cable", "charges": [ 0, 4 ] }
     ],
     "damage_reduction": { "all": 6 },
@@ -1321,7 +1322,7 @@
       { "item": "rubber_tire_chunk", "count": [ 0, 1 ] },
       { "item": "rubber_tire_chunk", "count": [ 0, 8 ] },
       { "item": "clamp", "count": [ 0, 1 ] },
-      { "item": "scrap", "count": [ 0, 2 ] }
+      { "item": "scrap", "charges": [ 0, 2 ] }
     ],
     "variants": [ { "symbols": ",", "symbols_broken": "," } ]
   },
@@ -1363,7 +1364,12 @@
       "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "80 s", "using": [ [ "adhesive", 1 ] ] }
     },
     "flags": [ "CTRL_ELECTRONIC", "DOME_LIGHT", "ENABLED_DRAINS_EPOWER", "WATCH", "ALARMCLOCK", "CABLE_PORTS" ],
-    "breaks_into": [ { "group": "ig_vp_device", "count": [ 2, 3 ] } ],
+    "breaks_into": [
+      { "item": "cable", "charges": [ 0, 2 ] },
+      { "item": "plastic_chunk", "count": [ 4, 8 ] },
+      { "item": "e_scrap", "count": [ 1, 3 ] },
+      { "item": "scrap", "charges": [ 1, 2 ] }
+    ],
     "variants": [ { "symbols": "$", "symbols_broken": "$" } ]
   },
   {
@@ -1385,7 +1391,12 @@
     },
     "flags": [ "CTRL_ELECTRONIC", "ENABLED_DRAINS_EPOWER", "SPACE_HEATER" ],
     "emissions": [ "emit_heater_vehicle" ],
-    "breaks_into": [ { "item": "steel_lump" }, { "item": "steel_chunk", "count": [ 1, 3 ] }, { "item": "scrap", "count": [ 1, 3 ] } ],
+    "breaks_into": [
+      { "item": "steel_lump" },
+      { "item": "steel_chunk", "count": [ 1, 3 ] },
+      { "item": "scrap", "charges": [ 1, 3 ] },
+      { "item": "element", "count": [ 0, 2 ] }
+    ],
     "damage_reduction": { "all": 15 },
     "variants": [ { "symbols": ";", "symbols_broken": ":" } ]
   },
@@ -1405,7 +1416,12 @@
     },
     "flags": [ "CTRL_ELECTRONIC", "ENABLED_DRAINS_EPOWER", "SPACE_HEATER" ],
     "emissions": [ "emit_hot_air2_stream" ],
-    "breaks_into": [ { "item": "steel_lump" }, { "item": "steel_chunk", "count": [ 1, 3 ] }, { "item": "scrap", "count": [ 1, 3 ] } ],
+    "breaks_into": [
+      { "item": "steel_lump" },
+      { "item": "steel_chunk", "count": [ 1, 3 ] },
+      { "item": "scrap", "charges": [ 1, 3 ] },
+      { "item": "element", "prob": 80 }
+    ],
     "damage_reduction": { "all": 15 }
   },
   {
@@ -1417,7 +1433,12 @@
     "location": "",
     "name": { "str": "small integrated heater" },
     "extend": { "flags": [ "NO_INSTALL_HIDDEN" ] },
-    "requirements": { "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "5 m", "qualities": [ { "id": "SAW_M", "level": 2 } ] } }
+    "requirements": { "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "5 m", "qualities": [ { "id": "SAW_M", "level": 2 } ] } },
+    "breaks_into": [
+      { "item": "steel_lump", "prob": 70 },
+      { "item": "steel_chunk", "count": [ 1, 2 ] },
+      { "item": "scrap", "charges": [ 1, 3 ] }
+    ]
   },
   {
     "id": "mountable_cooler",
@@ -1438,7 +1459,12 @@
     "flags": [ "CTRL_ELECTRONIC", "ENABLED_DRAINS_EPOWER", "COOLER" ],
     "emissions": [ "emit_cooler_vehicle" ],
     "exhaust": [ "emit_heater_vehicle" ],
-    "breaks_into": [ { "item": "steel_lump" }, { "item": "steel_chunk", "count": [ 1, 3 ] }, { "item": "scrap", "count": [ 1, 3 ] } ],
+    "breaks_into": [
+      { "item": "steel_lump" },
+      { "item": "steel_chunk", "count": [ 1, 3 ] },
+      { "item": "scrap", "charges": [ 1, 3 ] },
+      { "item": "cable", "charges": [ 2, 10 ] }
+    ],
     "damage_reduction": { "all": 15 },
     "variants": [ { "symbols": "C", "symbols_broken": ":" } ]
   },
@@ -1476,7 +1502,11 @@
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "80 s", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 10 ] ] }
     },
     "flags": [ "CTRL_ELECTRONIC", "DOME_LIGHT", "ENABLED_DRAINS_EPOWER", "CABLE_PORTS" ],
-    "breaks_into": "ig_vp_device",
+    "breaks_into": [
+      { "item": "cable", "charges": [ 0, 1 ] },
+      { "item": "plastic_chunk", "count": [ 2, 4 ] },
+      { "item": "e_scrap", "count": [ 1, 2 ] }
+    ],
     "damage_reduction": { "all": 6 },
     "variants": [ { "symbols": "$", "symbols_broken": "$" } ]
   },
@@ -1506,9 +1536,9 @@
     },
     "flags": [ "MUFFLER" ],
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 3, 5 ] },
-      { "item": "steel_chunk", "count": [ 3, 5 ] },
-      { "item": "scrap", "count": [ 3, 5 ] }
+      { "item": "steel_lump", "count": [ 1, 3 ] },
+      { "item": "steel_chunk", "count": [ 2, 4 ] },
+      { "item": "scrap", "charges": [ 4, 9 ] }
     ],
     "damage_reduction": { "all": 9 },
     "variants": [ { "symbols": "/", "symbols_broken": "/" } ]
@@ -1635,7 +1665,11 @@
       "repair": { "skills": [ [ "tailor", 1 ] ], "time": "150 s", "using": [ [ "sewing_standard", 50 ], [ "fabric_standard", 1 ] ] }
     },
     "flags": [ "OPENABLE", "OPENCLOSE_INSIDE", "OPAQUE", "CURTAIN", "MULTISQUARE", "NEEDS_WINDOW", "SIMPLE_PART" ],
-    "breaks_into": [  ],
+    "breaks_into": [
+      { "item": "sheet_cotton", "count": [ 1, 3 ] },
+      { "item": "cotton_patchwork", "count": [ 5, 11 ] },
+      { "item": "scrap_cotton", "count": [ 8, 19 ] }
+    ],
     "variants": [ { "symbols": "\"", "symbols_broken": "0" } ]
   },
   {
@@ -1661,7 +1695,11 @@
       "repair": { "skills": [ [ "tailor", 1 ] ], "time": "150 s", "using": [ [ "sewing_standard", 50 ], [ "fabric_standard", 1 ] ] }
     },
     "flags": [ "OPENABLE", "OPAQUE", "OPENCLOSE_INSIDE", "CURTAIN", "MULTISQUARE", "SIMPLE_PART" ],
-    "breaks_into": [  ],
+    "breaks_into": [
+      { "item": "sheet_cotton", "count": [ 1, 3 ] },
+      { "item": "cotton_patchwork", "count": [ 5, 11 ] },
+      { "item": "scrap_cotton", "count": [ 8, 19 ] }
+    ],
     "variants": [ { "symbols": "\"", "symbols_broken": "0" } ]
   },
   {
@@ -1683,7 +1721,14 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "250 s", "qualities": [ { "id": "WRENCH", "level": 1 } ] },
       "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "20 s", "using": [ [ "rope_natural_short", 1 ] ] }
     },
-    "breaks_into": [ { "item": "splinter", "count": [ 40, 60 ] } ],
+    "breaks_into": [
+      { "item": "splinter", "count": [ 40, 60 ] },
+      { "item": "steel_chunk", "count": [ 1, 3 ] },
+      { "item": "scrap", "charges": [ 6, 15 ] },
+      { "item": "cable", "charges": [ 90, 180 ] },
+      { "item": "nail", "charges": [ 21, 35 ] },
+      { "item": "nuts_bolts", "charges": [ 3, 6 ] }
+    ],
     "damage_reduction": { "all": 15, "stab": 6, "cut": 8 },
     "variants": [ { "symbols": "*", "symbols_broken": "x" } ]
   },
@@ -1707,7 +1752,15 @@
       "removal": { "skills": [ [ "mechanics", 4 ] ], "time": "750 s", "qualities": [ { "id": "WRENCH", "level": 1 } ] },
       "repair": { "skills": [ [ "mechanics", 5 ] ], "time": "60 s", "using": [ [ "rope_natural_short", 2 ] ] }
     },
-    "breaks_into": [ { "item": "splinter", "count": [ 60, 100 ] } ],
+    "breaks_into": [
+      { "item": "splinter", "count": [ 60, 100 ] },
+      { "item": "steel_lump", "count": [ 1, 3 ] },
+      { "item": "steel_chunk", "count": [ 4, 9 ] },
+      { "item": "scrap", "charges": [ 20, 35 ] },
+      { "item": "cable", "charges": [ 225, 400 ] },
+      { "item": "nail", "charges": [ 80, 130 ] },
+      { "item": "nuts_bolts", "charges": [ 5, 12 ] }
+    ],
     "damage_reduction": { "all": 16, "stab": 6, "cut": 8 },
     "variants": [ { "symbols": "o", "symbols_broken": "x" } ]
   },
@@ -1737,7 +1790,7 @@
     "breaks_into": [
       { "item": "steel_lump", "count": [ 2, 4 ] },
       { "item": "steel_chunk", "count": [ 2, 4 ] },
-      { "item": "scrap", "count": [ 2, 4 ] },
+      { "item": "scrap", "charges": [ 2, 4 ] },
       { "item": "solar_cell", "count": [ 1, 4 ] }
     ],
     "variants": [ { "symbols": "#", "symbols_broken": "x" } ]
@@ -1767,9 +1820,13 @@
     },
     "flags": [ "WIND_TURBINE" ],
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 2, 4 ] },
+      { "item": "steel_lump", "count": [ 1, 2 ] },
       { "item": "steel_chunk", "count": [ 2, 4 ] },
-      { "item": "scrap", "count": [ 2, 4 ] }
+      { "item": "scrap", "charges": [ 2, 6 ] },
+      { "item": "e_scrap", "count": [ 2, 4 ] },
+      { "item": "splinter", "count": [ 2, 8 ] },
+      { "item": "cable", "charges": [ 80, 115 ] },
+      { "item": "nail", "charges": [ 2, 6 ] }
     ],
     "damage_reduction": { "all": 8 },
     "variants": [ { "symbols": "T", "symbols_broken": "X" } ]
@@ -1801,9 +1858,14 @@
     },
     "flags": [ "WIND_TURBINE", "EXTRA_DRAG" ],
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 6, 12 ] },
-      { "item": "steel_chunk", "count": [ 6, 12 ] },
-      { "item": "scrap", "count": [ 6, 12 ] }
+      { "item": "steel_lump", "count": [ 1, 2 ] },
+      { "item": "steel_chunk", "count": [ 3, 6 ] },
+      { "item": "scrap", "charges": [ 10, 20 ] },
+      { "item": "e_scrap", "count": [ 8, 16 ] },
+      { "item": "splinter", "count": [ 25, 50 ] },
+      { "item": "cable", "charges": [ 300, 500 ] },
+      { "item": "nail", "charges": [ 8, 15 ] },
+      { "item": "nuts_bolts", "charges": [ 4, 7 ] }
     ],
     "damage_reduction": { "all": 9 },
     "variants": [ { "symbols": "Y", "symbols_broken": "X" } ]
@@ -1830,7 +1892,7 @@
     "breaks_into": [
       { "item": "steel_lump", "count": [ 4, 7 ] },
       { "item": "steel_chunk", "count": [ 4, 7 ] },
-      { "item": "scrap", "count": [ 4, 7 ] },
+      { "item": "scrap", "charges": [ 4, 7 ] },
       { "item": "solar_cell", "count": [ 1, 4 ] }
     ],
     "damage_reduction": { "all": 12 }
@@ -1855,7 +1917,7 @@
     "breaks_into": [
       { "item": "steel_lump", "count": [ 2, 4 ] },
       { "item": "steel_chunk", "count": [ 2, 4 ] },
-      { "item": "scrap", "count": [ 2, 4 ] },
+      { "item": "scrap", "charges": [ 2, 4 ] },
       { "item": "solar_cell_v2", "count": [ 1, 6 ] }
     ]
   },
@@ -1882,7 +1944,7 @@
     "breaks_into": [
       { "item": "steel_lump", "count": [ 4, 7 ] },
       { "item": "steel_chunk", "count": [ 4, 7 ] },
-      { "item": "scrap", "count": [ 4, 7 ] },
+      { "item": "scrap", "charges": [ 4, 7 ] },
       { "item": "solar_cell", "count": [ 1, 6 ] }
     ],
     "damage_reduction": { "all": 10 }
@@ -1911,7 +1973,7 @@
     },
     "flags": [ "OBSTACLE", "RADIOACTIVE", "COVERED", "PERPETUAL", "REACTOR" ],
     "breaks_into": [
-      { "item": "scrap", "count": [ 4, 16 ] },
+      { "item": "scrap", "charges": [ 4, 16 ] },
       { "item": "steel_chunk", "count": [ 1, 6 ] },
       { "item": "plutonium", "count": [ 0, 2 ] },
       { "item": "lead", "charges": [ 12, 18 ] }
@@ -1937,7 +1999,7 @@
       "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "5 m", "using": [ [ "repair_welding_standard", 1 ] ] }
     },
     "pseudo_tools": [ { "id": "water_faucet" } ],
-    "breaks_into": [ { "item": "scrap", "count": [ 1, 3 ] } ],
+    "breaks_into": [ { "item": "scrap", "charges": [ 1, 3 ] } ],
     "damage_reduction": { "all": 6 },
     "variants": [ { "symbols": "u", "symbols_broken": "-" } ]
   },
@@ -1960,7 +2022,7 @@
       "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "5 m", "using": [ [ "repair_welding_standard", 1 ] ] }
     },
     "pseudo_tools": [ { "id": "towel", "hotkey": "t" } ],
-    "breaks_into": [ { "item": "scrap", "count": [ 1, 3 ] }, { "item": "cotton_patchwork", "count": [ 1, 6 ] } ],
+    "breaks_into": [ { "item": "scrap", "charges": [ 1, 3 ] }, { "item": "cotton_patchwork", "count": [ 1, 6 ] } ],
     "variants": [ { "symbols": "h", "symbols_broken": "-" } ]
   },
   {
@@ -1979,7 +2041,12 @@
       "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "30 m", "using": [ [ "adhesive", 2 ] ] }
     },
     "flags": [ "ARMOR" ],
-    "breaks_into": "ig_vp_wood_plate",
+    "breaks_into": [
+      { "item": "splinter", "count": [ 4, 8 ] },
+      { "item": "string_36", "count": [ 2, 3 ] },
+      { "item": "string_6", "count": [ 3, 6 ] },
+      { "item": "nail", "charges": [ 1, 3 ] }
+    ],
     "damage_reduction": { "all": 16, "cut": 8, "stab": 8 },
     "variants": [ { "symbols": ")", "symbols_broken": ")" } ]
   },
@@ -2040,7 +2107,7 @@
     "breaks_into": [
       { "item": "steel_lump", "count": [ 4, 6 ] },
       { "item": "steel_chunk", "count": [ 4, 6 ] },
-      { "item": "scrap", "count": [ 4, 6 ] }
+      { "item": "scrap", "charges": [ 4, 6 ] }
     ],
     "damage_reduction": { "all": 56 },
     "variants": [ { "symbols": ")", "symbols_broken": ")" } ]
@@ -2073,10 +2140,10 @@
     },
     "flags": [ "ARMOR", "SHARP" ],
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 4, 6 ] },
-      { "item": "steel_chunk", "count": [ 4, 6 ] },
-      { "item": "scrap", "count": [ 4, 6 ] },
-      { "item": "spike", "count": [ 0, 2 ] }
+      { "item": "steel_lump", "count": [ 1, 2 ] },
+      { "item": "steel_chunk", "count": [ 2, 4 ] },
+      { "item": "scrap", "charges": [ 5, 8 ] },
+      { "item": "spike", "count": [ 1, 2 ] }
     ],
     "damage_reduction": { "all": 48 },
     "variants": [ { "symbols": ")", "symbols_broken": ")" } ]
@@ -2108,8 +2175,8 @@
     "flags": [ "ARMOR" ],
     "breaks_into": [
       { "item": "steel_lump", "count": [ 4, 6 ] },
-      { "item": "steel_chunk", "count": [ 4, 6 ] },
-      { "item": "scrap", "count": [ 4, 6 ] }
+      { "item": "steel_chunk", "count": [ 5, 8 ] },
+      { "item": "scrap", "charges": [ 6, 12 ] }
     ],
     "damage_reduction": { "all": 70 },
     "variants": [ { "symbols": ")", "symbols_broken": ")" } ]
@@ -2141,7 +2208,7 @@
     "breaks_into": [
       { "item": "steel_lump", "count": [ 4, 6 ] },
       { "item": "steel_chunk", "count": [ 4, 6 ] },
-      { "item": "scrap", "count": [ 4, 6 ] },
+      { "item": "scrap", "charges": [ 4, 6 ] },
       { "item": "ceramic_armor", "count": [ 0, 4 ] }
     ],
     "damage_reduction": { "all": 60, "bullet": 105 },
@@ -2165,7 +2232,7 @@
       "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "20 s", "using": [ [ "adhesive", 1 ] ] }
     },
     "flags": [ "HORN" ],
-    "breaks_into": [ { "item": "scrap", "prob": 50 } ],
+    "breaks_into": [ { "item": "scrap_aluminum", "prob": 10 }, { "item": "plastic_chunk", "prob": 35 } ],
     "variants": [ { "symbols": "*", "symbols_broken": "*" } ]
   },
   {
@@ -2185,7 +2252,7 @@
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "20 s", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 1 ] ] }
     },
     "flags": [ "HORN" ],
-    "breaks_into": [ { "item": "scrap", "count": [ 0, 2 ] } ],
+    "breaks_into": [ { "item": "scrap", "charges": [ 0, 2 ] }, { "item": "plastic_chunk", "count": [ 1, 2 ] } ],
     "variants": [ { "symbols": "*", "symbols_broken": "*" } ]
   },
   {
@@ -2205,7 +2272,11 @@
       "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "20 s", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 2 ] ] }
     },
     "flags": [ "HORN" ],
-    "breaks_into": [ { "item": "steel_chunk", "prob": 50 } ],
+    "breaks_into": [
+      { "item": "steel_chunk", "prob": 50 },
+      { "item": "scrap", "charges": [ 0, 2 ] },
+      { "item": "plastic_chunk", "count": [ 1, 2 ] }
+    ],
     "variants": [ { "symbols": "*", "symbols_broken": "*" } ]
   },
   {
@@ -2257,9 +2328,12 @@
     },
     "flags": [ "BOARDABLE", "CARGO", "COVERED", "HUGE_OK" ],
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 6, 8 ] },
-      { "item": "steel_chunk", "count": [ 6, 8 ] },
-      { "item": "scrap", "count": [ 6, 8 ] }
+      { "item": "steel_lump", "count": [ 12, 19 ] },
+      { "item": "steel_chunk", "count": [ 7, 12 ] },
+      { "item": "scrap", "charges": [ 14, 25 ] },
+      { "item": "rope_6", "count": [ 0, 2 ] },
+      { "item": "string_36", "count": [ 10, 25 ] },
+      { "item": "string_6", "count": [ 15, 28 ] }
     ],
     "damage_reduction": { "all": 28 },
     "variants": [ { "symbols": "=", "symbols_broken": "#" } ]
@@ -2295,7 +2369,7 @@
     "breaks_into": [
       { "item": "steel_lump", "count": [ 6, 8 ] },
       { "item": "steel_chunk", "count": [ 6, 8 ] },
-      { "item": "scrap", "count": [ 6, 8 ] }
+      { "item": "scrap", "charges": [ 6, 8 ] }
     ],
     "damage_reduction": { "all": 30 },
     "variants": [ { "symbols": "=", "symbols_broken": "#" } ]
@@ -2310,7 +2384,7 @@
     "size": "50 L",
     "item": "animal_locker",
     "flags": [ "CARGO", "COVERED", "CAPTURE_MONSTER_VEH", "OBSTACLE" ],
-    "breaks_into": [ { "item": "steel_chunk", "count": [ 1, 2 ] }, { "item": "scrap", "count": [ 3, 4 ] } ]
+    "breaks_into": [ { "item": "steel_chunk", "count": [ 1, 2 ] }, { "item": "scrap", "charges": [ 3, 4 ] } ]
   },
   {
     "type": "vehicle_part",
@@ -2335,7 +2409,7 @@
     "folded_volume": "2 L",
     "breaks_into": [
       { "item": "steel_chunk", "count": [ 0, 2 ] },
-      { "item": "scrap", "count": [ 1, 2 ] },
+      { "item": "scrap", "charges": [ 1, 2 ] },
       { "item": "cable", "charges": [ 1, 3 ] }
     ],
     "damage_reduction": { "all": 10 },
@@ -2400,11 +2474,11 @@
     "flags": [ "CHIMES", "ENABLED_DRAINS_EPOWER" ],
     "location": "on_roof",
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 3, 5 ] },
-      { "item": "steel_chunk", "count": [ 3, 5 ] },
-      { "item": "scrap", "count": [ 3, 5 ] },
-      { "item": "cable", "count": [ 1, 3 ] },
-      { "item": "e_scrap", "count": [ 1, 2 ] }
+      { "item": "scrap", "charges": [ 3, 5 ] },
+      { "item": "cable", "charges": [ 2, 4 ] },
+      { "item": "e_scrap", "count": [ 1, 2 ] },
+      { "item": "scrap_aluminum", "prob": 80 },
+      { "item": "plastic_chunk", "count": [ 0, 2 ] }
     ],
     "variants": [ { "symbols": "&", "symbols_broken": "&" } ]
   },
@@ -2423,7 +2497,7 @@
     "item": "jumper_cable",
     "requirements": { "removal": { "time": "5 s" } },
     "flags": [ "NO_INSTALL_HIDDEN", "UNMOUNT_ON_DAMAGE", "POWER_TRANSFER" ],
-    "breaks_into": [ { "item": "cable", "charges": [ 1, 10 ] }, { "item": "plastic_chunk", "count": [ 1, 2 ] } ],
+    "breaks_into": [ { "item": "cable", "charges": [ 10, 30 ] }, { "item": "plastic_chunk", "count": [ 1, 2 ] } ],
     "variants": [ { "symbols": "{", "symbols_broken": "*" } ]
   },
   {
@@ -2441,7 +2515,7 @@
     "item": "extension_cable",
     "requirements": { "removal": { "time": "5 s" } },
     "flags": [ "NO_INSTALL_HIDDEN", "UNMOUNT_ON_DAMAGE", "POWER_TRANSFER" ],
-    "breaks_into": [ { "item": "cable", "charges": [ 1, 10 ] }, { "item": "plastic_chunk", "count": [ 1, 2 ] } ],
+    "breaks_into": [ { "item": "cable", "charges": [ 45, 90 ] }, { "item": "plastic_chunk", "count": [ 2, 3 ] } ],
     "variants": [ { "symbols": "{", "symbols_broken": "*" } ]
   },
   {
@@ -2459,7 +2533,7 @@
     "item": "long_extension_cable",
     "requirements": { "removal": { "time": "5 s" } },
     "flags": [ "NO_INSTALL_HIDDEN", "UNMOUNT_ON_DAMAGE", "POWER_TRANSFER" ],
-    "breaks_into": [ { "item": "cable", "charges": [ 1, 10 ] }, { "item": "plastic_chunk", "count": [ 1, 2 ] } ],
+    "breaks_into": [ { "item": "cable", "charges": [ 135, 270 ] }, { "item": "plastic_chunk", "count": [ 4, 6 ] } ],
     "variants": [ { "symbols": "{", "symbols_broken": "*" } ]
   },
   {
@@ -2477,7 +2551,7 @@
     "item": "jumper_cable_heavy",
     "requirements": { "removal": { "time": "5 s" } },
     "flags": [ "NO_INSTALL_HIDDEN", "UNMOUNT_ON_DAMAGE", "POWER_TRANSFER" ],
-    "breaks_into": [ { "item": "wire", "count": [ 4, 8 ] }, { "item": "plastic_chunk", "count": [ 4, 8 ] } ],
+    "breaks_into": [ { "item": "cable", "charges": [ 97, 195 ] }, { "item": "plastic_chunk", "count": [ 4, 8 ] } ],
     "variants": [ { "symbols": "{", "symbols_broken": "*" } ]
   },
   {
@@ -2493,7 +2567,13 @@
     "item": "hd_tow_cable",
     "requirements": { "removal": { "time": "5 s" } },
     "flags": [ "NO_INSTALL_HIDDEN", "UNMOUNT_ON_DAMAGE", "TOW_CABLE" ],
-    "breaks_into": [ { "item": "scrap", "count": [ 4, 8 ] }, { "item": "grip_hook", "count": 1 }, { "item": "cable", "count": [ 1, 4 ] } ],
+    "breaks_into": [
+      { "item": "steel_lump", "count": [ 5, 10 ] },
+      { "item": "steel_chunk", "count": [ 7, 14 ] },
+      { "item": "scrap", "charges": [ 17, 34 ] },
+      { "item": "grip_hook", "prob": 80 },
+      { "item": "cable", "charges": [ 1, 3 ] }
+    ],
     "variants": [ { "symbols": "{", "symbols_broken": "*" } ]
   },
   {
@@ -2531,7 +2611,11 @@
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "rope_natural_short", 1 ] ] }
     },
     "flags": [ "SEAT", "BOARDABLE", "BELTABLE" ],
-    "breaks_into": [ { "item": "splinter", "count": [ 4, 6 ] } ],
+    "breaks_into": [
+      { "item": "splinter", "count": [ 4, 7 ] },
+      { "item": "string_36", "count": [ 3, 6 ] },
+      { "item": "string_6", "count": [ 9, 18 ] }
+    ],
     "damage_reduction": { "all": 6 },
     "variants": [ { "symbols": "#", "symbols_broken": "*" } ]
   },
@@ -2556,7 +2640,7 @@
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "adhesive", 2 ] ] }
     },
     "flags": [ "SEAT", "BOARDABLE", "BELTABLE", "CARGO" ],
-    "breaks_into": [ { "item": "splinter", "count": [ 7, 9 ] } ],
+    "breaks_into": [ { "item": "splinter", "count": [ 7, 9 ] }, { "item": "nail", "charges": [ 6, 12 ] } ],
     "damage_reduction": { "all": 8 },
     "variants": [ { "symbols": "#", "symbols_broken": "*" } ]
   },
@@ -2585,7 +2669,7 @@
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "adhesive", 2 ] ] }
     },
     "flags": [ "ROOF" ],
-    "breaks_into": [ { "item": "splinter", "count": [ 7, 9 ] } ],
+    "breaks_into": [ { "item": "splinter", "count": [ 7, 9 ] }, { "item": "nail", "charges": [ 6, 12 ] } ],
     "damage_reduction": { "all": 16 },
     "variants": [ { "symbols": "#", "symbols_broken": "#" } ]
   },
@@ -2604,7 +2688,13 @@
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "5 m", "using": [ [ "adhesive", 1 ] ] }
     },
     "flags": [ "ARMOR" ],
-    "breaks_into": [ { "item": "chitin_piece", "count": [ 5, 15 ] } ],
+    "breaks_into": [
+      { "item": "chitin_piece", "count": [ 4, 8 ] },
+      { "item": "meal_chitin_piece", "count": [ 2, 6 ] },
+      { "item": "rope_6", "prob": 75 },
+      { "item": "string_36", "count": [ 2, 4 ] },
+      { "item": "string_6", "count": [ 7, 14 ] }
+    ],
     "damage_reduction": { "all": 20 },
     "variants": [ { "symbols": ")", "symbols_broken": ")" } ]
   },
@@ -2615,7 +2705,13 @@
     "name": { "str": "biosilicified chitin plating" },
     "proportional": { "durability": 1.1 },
     "item": "acidchitin_plate",
-    "breaks_into": [ { "item": "acidchitin_piece", "count": [ 6, 19 ] } ],
+    "breaks_into": [
+      { "item": "acidchitin_piece", "count": [ 6, 19 ] },
+      { "item": "meal_chitin_piece", "count": [ 2, 6 ] },
+      { "item": "rope_6", "prob": 75 },
+      { "item": "string_36", "count": [ 2, 4 ] },
+      { "item": "string_6", "count": [ 7, 14 ] }
+    ],
     "damage_reduction": { "all": 24 }
   },
   {
@@ -2635,7 +2731,12 @@
       "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "30 m", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 3 ] ] }
     },
     "flags": [ "BOARD_INTERNAL", "DOOR_MOTOR", "UNMOUNT_ON_DAMAGE" ],
-    "breaks_into": [ { "item": "scrap", "count": [ 4, 6 ] } ],
+    "breaks_into": [
+      { "item": "scrap", "charges": [ 1, 3 ] },
+      { "item": "cable", "charges": [ 3, 7 ] },
+      { "item": "e_scrap", "prob": 75 },
+      { "item": "bearing", "count": [ 0, 2 ] }
+    ],
     "damage_reduction": { "all": 12 },
     "variants": [ { "symbols": "*", "symbols_broken": "#" } ]
   },
@@ -2692,7 +2793,11 @@
       "repair": { "skills": [ [ "mechanics", 4 ] ], "time": "60 m", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 2 ] ] }
     },
     "flags": [ "VISION", "CAMERA", "CAMERA_CONTROL", "ENABLED_DRAINS_EPOWER" ],
-    "breaks_into": [ { "item": "e_scrap", "count": [ 4, 10 ] }, { "item": "plastic_chunk", "count": [ 2, 8 ] } ],
+    "breaks_into": [
+      { "item": "e_scrap", "count": [ 4, 10 ] },
+      { "item": "plastic_chunk", "count": [ 2, 8 ] },
+      { "item": "cable", "charges": [ 2, 4 ] }
+    ],
     "variants": [ { "symbols": "#", "symbols_broken": "#" } ]
   },
   {
@@ -2717,7 +2822,12 @@
       "repair": { "skills": [ [ "mechanics", 5 ] ], "time": "60 m", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 3 ] ] }
     },
     "flags": [ "VISION", "CAMERA", "ENABLED_DRAINS_EPOWER" ],
-    "breaks_into": [ { "item": "e_scrap", "count": [ 4, 16 ] }, { "item": "plastic_chunk", "count": [ 2, 8 ] } ],
+    "breaks_into": [
+      { "item": "e_scrap", "count": [ 3, 7 ] },
+      { "item": "cable", "charges": [ 3, 7 ] },
+      { "item": "plastic_chunk", "count": [ 4, 10 ] },
+      { "item": "lens", "prob": 35 }
+    ],
     "variants": [ { "symbols": "o", "symbols_broken": "#" } ]
   },
   {
@@ -2735,7 +2845,13 @@
       "repair": { "skills": [ [ "mechanics", 5 ] ], "time": "60 m", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 4 ] ] }
     },
     "flags": [ "VISION", "CAMERA", "ENABLED_DRAINS_EPOWER" ],
-    "breaks_into": [ { "item": "e_scrap", "count": [ 6, 20 ] }, { "item": "plastic_chunk", "count": [ 2, 8 ] } ],
+    "breaks_into": [
+      { "item": "e_scrap", "count": [ 3, 7 ] },
+      { "item": "cable", "charges": [ 3, 7 ] },
+      { "item": "plastic_chunk", "count": [ 4, 10 ] },
+      { "item": "lens", "prob": 35 },
+      { "item": "scrap", "charges": [ 1, 3 ] }
+    ],
     "variants": [ { "symbols": "o", "symbols_broken": "#" } ]
   },
   {
@@ -2936,7 +3052,15 @@
     },
     "flags": [ "SCOOP", "CARGO", "ENABLED_DRAINS_EPOWER" ],
     "location": "under",
-    "breaks_into": [ { "item": "scrap", "count": [ 2, 5 ] }, { "item": "plastic_chunk", "count": [ 1, 5 ] } ],
+    "breaks_into": [
+      { "item": "sheet_metal_small", "count": [ 4, 8 ] },
+      { "item": "scrap", "charges": [ 21, 42 ] },
+      { "item": "bearing", "count": [ 1, 3 ] },
+      { "item": "e_scrap", "count": [ 2, 6 ] },
+      { "item": "cable", "charges": [ 300, 600 ] },
+      { "item": "plastic_chunk", "count": [ 1, 2 ] },
+      { "item": "nuts_bolts", "count": [ 2, 5 ] }
+    ],
     "damage_reduction": { "all": 24 },
     "variants": [ { "symbols": "R", "symbols_broken": ";" } ]
   },
@@ -2959,7 +3083,12 @@
     },
     "flags": [  ],
     "pseudo_tools": [ { "id": "water_purifier", "hotkey": "p" } ],
-    "breaks_into": [ { "item": "plastic_chunk", "count": [ 1, 2 ] } ],
+    "breaks_into": [
+      { "item": "scrap", "charges": [ 1, 3 ] },
+      { "item": "glass_shard", "count": [ 2, 5 ] },
+      { "item": "cable", "charges": [ 0, 2 ] },
+      { "item": "hose", "prob": 25 }
+    ],
     "damage_reduction": { "all": 26 },
     "variants": [ { "symbols": "&", "symbols_broken": "*" } ]
   },
@@ -2993,7 +3122,16 @@
       "repair": { "skills": [ [ "mechanics", 5 ] ], "time": "10 m", "using": [ [ "repair_welding_standard", 6 ] ] }
     },
     "flags": [ "TRANSFORM_TERRAIN", "PLOW", "EXTRA_DRAG" ],
-    "breaks_into": [ { "item": "plastic_chunk", "count": [ 1, 2 ] } ],
+    "breaks_into": [
+      { "item": "steel_lump", "count": [ 4, 7 ] },
+      { "item": "steel_chunk", "count": [ 21, 40 ] },
+      { "item": "scrap", "charges": [ 108, 215 ] },
+      { "item": "nuts_bolts", "count": [ 7, 15 ] },
+      { "item": "pipe_fittings", "prob": 30 },
+      { "item": "rubber_tire_chunk", "prob": 35 },
+      { "item": "chunk_rubber", "count": [ 8, 19 ] },
+      { "item": "shredded_rubber", "count": [ 8, 20 ] }
+    ],
     "damage_reduction": { "all": 46 },
     "variants": [ { "symbols": "&", "symbols_broken": "*" } ]
   },
@@ -3027,7 +3165,14 @@
       "repair": { "skills": [ [ "mechanics", 5 ] ], "time": "10 m", "using": [ [ "repair_welding_standard", 6 ] ] }
     },
     "flags": [ "PLANTER", "PROTRUSION", "CARGO", "EXTRA_DRAG", "CARGO_PASSABLE" ],
-    "breaks_into": [ { "item": "plastic_chunk", "count": [ 1, 2 ] }, { "item": "scrap", "count": [ 1, 2 ] } ],
+    "breaks_into": [
+      { "item": "sheet_metal_small", "count": [ 3, 6 ] },
+      { "item": "scrap", "charges": [ 10, 21 ] },
+      { "item": "nuts_bolts", "count": [ 3, 6 ] },
+      { "item": "rubber_tire_chunk", "prob": 80 },
+      { "item": "chunk_rubber", "count": [ 16, 38 ] },
+      { "item": "shredded_rubber", "count": [ 16, 40 ] }
+    ],
     "damage_reduction": { "all": 16 },
     "variants": [ { "symbols": "8", "symbols_broken": "*" } ]
   },
@@ -3065,7 +3210,12 @@
       { "item": "cable", "charges": [ 3, 6 ] },
       { "item": "e_scrap", "count": [ 4, 10 ] },
       { "item": "plastic_chunk", "count": [ 1, 2 ] },
-      { "item": "scrap", "count": [ 1, 2 ] }
+      { "item": "sheet_metal_small", "count": [ 3, 6 ] },
+      { "item": "scrap", "charges": [ 10, 21 ] },
+      { "item": "nuts_bolts", "count": [ 3, 6 ] },
+      { "item": "rubber_tire_chunk", "prob": 80 },
+      { "item": "chunk_rubber", "count": [ 16, 38 ] },
+      { "item": "shredded_rubber", "count": [ 16, 40 ] }
     ],
     "damage_reduction": { "all": 18 },
     "variants": [ { "symbols": "8", "symbols_broken": "*" } ]
@@ -3099,7 +3249,16 @@
       "repair": { "skills": [ [ "mechanics", 5 ] ], "time": "10 m", "using": [ [ "repair_welding_standard", 6 ] ] }
     },
     "flags": [ "REAPER", "PROTRUSION", "EXTRA_DRAG" ],
-    "breaks_into": [ { "item": "plastic_chunk", "count": [ 1, 2 ] }, { "item": "scrap", "count": [ 2, 4 ] } ],
+    "breaks_into": [
+      { "item": "steel_lump", "count": [ 3, 5 ] },
+      { "item": "steel_chunk", "count": [ 4, 8 ] },
+      { "item": "sheet_metal_small", "count": [ 3, 6 ] },
+      { "item": "scrap", "charges": [ 15, 30 ] },
+      { "item": "nuts_bolts", "count": [ 3, 6 ] },
+      { "item": "rubber_tire_chunk", "prob": 80 },
+      { "item": "chunk_rubber", "count": [ 16, 38 ] },
+      { "item": "shredded_rubber", "count": [ 16, 40 ] }
+    ],
     "damage_reduction": { "all": 10 },
     "variants": [ { "symbols": "/", "symbols_broken": "*" } ]
   },
@@ -3138,7 +3297,14 @@
       { "item": "cable", "charges": [ 3, 6 ] },
       { "item": "e_scrap", "count": [ 4, 10 ] },
       { "item": "plastic_chunk", "count": [ 1, 3 ] },
-      { "item": "scrap", "count": [ 2, 6 ] }
+      { "item": "steel_lump", "count": [ 3, 5 ] },
+      { "item": "steel_chunk", "count": [ 4, 8 ] },
+      { "item": "sheet_metal_small", "count": [ 3, 6 ] },
+      { "item": "scrap", "charges": [ 15, 30 ] },
+      { "item": "nuts_bolts", "count": [ 3, 6 ] },
+      { "item": "rubber_tire_chunk", "prob": 80 },
+      { "item": "chunk_rubber", "count": [ 16, 38 ] },
+      { "item": "shredded_rubber", "count": [ 16, 40 ] }
     ],
     "damage_reduction": { "all": 12 },
     "variants": [ { "symbols": "=", "symbols_broken": "*" } ]
@@ -3160,7 +3326,7 @@
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "6 m", "using": [ [ "adhesive", 1 ] ] }
     },
     "flags": [ "CARGO_LOCKING", "INTERNAL" ],
-    "breaks_into": [ { "item": "clockworks", "count": [ 0, 2 ] }, { "item": "scrap", "count": [ 2, 6 ] } ],
+    "breaks_into": [ { "item": "clockworks", "prob": 15 }, { "item": "scrap", "prob": 75 } ],
     "damage_reduction": { "all": 60 },
     "variants": [ { "symbols": "+", "symbols_broken": "+" } ]
   },
@@ -3185,7 +3351,15 @@
       "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "3 m", "using": [ [ "repair_welding_standard", 1 ] ] }
     },
     "flags": [ "TURRET_MOUNT" ],
-    "breaks_into": [ { "item": "scrap", "count": [ 1, 4 ] } ],
+    "breaks_into": [
+      { "item": "cable", "charges": [ 10, 20 ] },
+      { "item": "e_scrap", "count": [ 1, 2 ] },
+      { "item": "plastic_chunk", "count": [ 1, 2 ] },
+      { "item": "bearing", "count": [ 1, 3 ] },
+      { "item": "steel_chunk", "count": [ 2, 4 ] },
+      { "item": "scrap", "charges": [ 6, 12 ] },
+      { "item": "nuts_bolts", "count": [ 3, 6 ] }
+    ],
     "damage_reduction": { "all": 54 },
     "variants": [ { "symbols": "X", "symbols_broken": "X" } ]
   },
@@ -3210,7 +3384,7 @@
       "repair": { "skills": [ [ "mechanics", 2 ], [ "traps", 1 ] ], "time": "12 m", "using": [ [ "soldering_standard", 3 ] ] }
     },
     "flags": [ "BOARD_INTERNAL", "DOOR_LOCKING", "UNMOUNT_ON_DAMAGE" ],
-    "breaks_into": [ { "item": "clockworks", "count": [ 0, 3 ] }, { "item": "scrap", "count": [ 2, 6 ] } ],
+    "breaks_into": [ { "item": "clockworks", "prob": 30 }, { "item": "scrap", "prob": 75 } ],
     "damage_reduction": { "all": 60 }
   },
   {
@@ -3266,7 +3440,7 @@
       "repair": { "skills": [ [ "mechanics", 5 ] ], "time": "10 m", "using": [ [ "repair_welding_alloys", 6 ] ] }
     },
     "flags": [ "FLOATS" ],
-    "breaks_into": "ig_vp_sheet_metal",
+    "breaks_into": [ { "item": "scrap_aluminum", "count": [ 6, 14 ] } ],
     "damage_reduction": { "all": 18 },
     "variants": [ { "symbols": "o", "symbols_broken": "x" } ]
   },


### PR DESCRIPTION
#### Summary
Balance "Finished Auditing vehicle parts json for breaks_into"

#### Purpose of change
I started auditing these previously, finally finished this massive 3000+ line audit.  #73630 was the original, my reasonings are the same, breaks_into made no sense for the majority of vehicle parts, many of these probably existed before half our materials did, so they needed an update.

#### Describe the solution
Here's what I wrote initially: 
<details>

<summary>My Rambling Thoughts/Why I Did Things</summary>

For vehicle parts breaking into other parts, I did have to sort of pick these just based on common sense.  I didn’t see anything about % of base material that should still be there after being destroyed, many of them gave more materials than the items they’re made from, and a lot were using identical catchall groups.  I only fixed those that were clearly incorrect, some were close enough and I also left the catchall itemgroups because they are probably connected to some things still/valuable. I also believe that many things used count instead of charges for scrap metal, which caused them to spawn in increments of 10. 

Many vehicle parts are made from 1 sheet metal, which has its own vp_sheet_metal itemgroup specifically for it.  This is also true for frames/heavy duty frames. I have left this the same for larger/beefier things made of sheet metal or whatever, but I did change some of them, like I felt the aisle should produce less metal and changed it.  However, after this I largely left them alone because I realized someone probably mathed out that group initially and set it how they thought was appropriate.  I may change this group directly, it gives too much material for 1 sheet metal, based on deconstruction materials.

I didn’t touch any solar panels or anything to do with radiation/reactors because I don’t know shit about them and for some reason I found it intimidating.

So, apologies if these are not perfect, but I believe all the changes I’ve made are improvements overall, and it is generally a small part of the game that no one’s particularly passionate about changing/working on, so yeah, I’m doing it, idk.
</details>

#### Describe alternatives you've considered
None, I was already committed at this point.


#### Testing
At first I tested lots of vehicle parts to make sure they were producing proper amounts.  By the end I basically was just checking there were no syntax errors, so the tests might kick me some issues, but it passed linting.

#### Additional context

<details>

<summary>List of Each Change and Reasoning</summary>

- **1026 workbench** gave an enormous amount of pipes and metal sheets, more than the % most vehicle parts give when destroyed.  I also think that pipes/sheet_metal are too likely to be damaged by the part being fully destroyed, and should be reduced to component metals. I was very nervous changing this for some reason, but I’ve reduced the overall higher tier metal components, reducing it to mostly chunks, scrap, and smaller sheet metals.

- **1054 workbench with battery recharger** is based on the same logic as the workbench above, but with the addition of electronics materials.  The electronics material listed seems correct, just the workbench part was insanely generous, so I’ve copied the metal from the above entry (workbench).

- **1259 sail** breaks_into up to 10 cotton patches but the largest material useable in making it would yield 8 patches maximum.  Reduced cotton_patch spawn.

- **1375 dashboard** used the generic vp_device group, calling it 2-3 times.  This is not ideal as it provides a range outside of what it should be dropping.  I’ve made a bespoke group, primarily to increase plastic chunk drops and reduce e_scrap drops/scrap drops.  Despite all materials being plastic, the part itself is 50% steel, so I’ve left some scrap, though I think I should have just fully removed that.

- **1402 vehicle-mounted heater** is made from a heater that includes 12 heating elements, it seemed plausible some of these might survive the destruction of the overall part. Added 0-2 heating elements, they are small, low value parts, so I think it’s both plausible and not interfering with game balance.

- **1419 small vehicle-mounted heater** same logic above but uses a smaller heater that contains 8 heating elements. Added heating element drop, not sure how to do this with a lot of control, just made it a 80% chance of dropping 1.

- **1437 small integrated heater** was copy-from’d small vehicle mounted heater previously, so I gave it its own drops.  Those other heaters contain heating elements, whereas the integrated heater is just a metal ‘tube’ that draws heat from the engine into the vehicle.  Assuming there’s a fan or whatever in there too, I gave it roughly the same metal as the heaters above, but slightly less, and no heating element drop.

- **1462 vehicle mounted cooler** involves 2 electric motors so I added some copper wire to the drops, left metal alone.

- **1505 electronics control unit** is basically just a dashboard with less plastic and copper wire, so I’ve copied my changes from the dashboard and reduced plastic/cable spawns to compensate.  Also removed metal spawns as it’s all plastic.

- **1538 mufflers** gave a huge amount of lumps/chunks of steel despite being made from a couple pipes and sheet metal (even manufactured mufflers aren’t much more than that).  Reduced their chunk/lump drops, increased scrap metal drop

- **security system** Ultimately decided not to touch this, ignore me plz

- **1668 curtain and 1699 aisle curtain** did not break into anything despite being made from a full sheet. Changed to give various cotton pieces.

- ** 1724 water wheel** broke into a lot of splinters and nothing else.  However, water wheels include electric motors, wheels that are banded in metal, lots of nails/nuts and bolts, and a few pipe fittings. This merits some scrap metal materials (due to small sizes, mostly scrap metal not lumps/chunks), tons of copper wire from the electric motor, and misc spawns of nails/nutsbolts, so I’ve added them.

- **1755 large water wheel** has the same logic as the water wheel above, but with amended materials.  Notably, this uses 3 small electric motors which means this water wheel has like 1500+ copper wire in it, a fair bit of which would be recoverable. These are player-made only, so it’s not like people will be exploiting them or duping materials or anything, it’s fine.

- **1822 wind turbine** gave only metal pieces but contains a motor (so should have copper wire), and several planks so should have wood. Added these things.

- **1859 large wind turbine** same logic as the wind turbine but with substantially more copper wire and splinters, etc.

- **2044 wooden armor** previously only gave splintered wood.  However installing it requires nails, and the crafting of the base item requires rope, so I’ve given it some nail drops and cordage drops.

- **2142 spiked plating** previously gave too much metal (technically max was more than 100% materials from crafting the item).  To keep the materials the same and allow it to give spikes, I have lowered the misc metals but still allowed for spikes to exist.

- **2176 hard plating** Gives slightly less metal than I would expect, added a few extra chunks and more scrap, since again this is a fully broken item that should be largely rendered down to small broken pieces.

- **2235 bicycle horn** disassembles into scrap aluminum (only 1 for some reason, I might change this) but the vehicle part would break into scrap metal.  This should also be scrap aluminum, so I have changed scrap metal to scrap aluminum with a very small chance of getting it (since disassembly only gives 1).  Also added plastic chunk at a less than 100% chance for 1, same reasoning.

- **2326 cargo space** is staggering at 4 steel frames and 4 long ropes yet had relatively low metal yields and no rope/string of any kind. I’ve changed this.

- **animal carrier** was not changed in this PR, the two recipes for it make no sense and use massive amounts of metal for one, and very little for the other, it makes no sense to me and I want to change the breaks_into but don’t know which to base it on.

- **2472 chimes** looks like it was made with the idea that it’s comprised of metal chimes (gives lots of metal), however they’re actually made from chime loudspeakers that PLAY chime sounds.  As a result I removed almost all metal from their breaks_into and more or less left everything else. A tiny bit of aluminum because some of the materials are aluminum, also some plastic added.

- **2496 jumper_cable** these disassemble to 100 copper wire, but break_into between 1-10% of that value.  For most of these deconstructions I was aiming for 15-40% low-tier materials, and most pre-existing/catchall groups give a higher %.  So I’ve increased copper wire drops here to be more balanced beside the other parts.

- **2514 extension cord** same deal as above (jumper cable), except extension cords disassemble into 300 copper wire, so I’ve increased their values to 15% to 30% for breaks_into.

- **2532 outdoor extension cord** is thicker AND longer than above extension cord, and gives a staggering 900 copper wire when disassembled.  So I’ve increased their copper wire drops SUBSTANTIALLY.

- **2550 heavyduty jumper cable** is thicker/longer version of jumper cable, previously incorrectly gave wire instead of copper wire. I fixed that, and based its breaks_into on 15-30% of its disassembly values.

- **2566 heavy duty tow cable** 64 lumps of steel worth of metal to craft the 8 chains in the recipe and yet it only gave a little scrap metal.  I’ve assessed the metal drops to increase them, and adding lumps/chunks as well. I debated removing the hook but idk someone put it here for a reason and I’m not familiar with it so I’ll leave it.  I’ve been using 15-30% materials as a baseline, so 10-20 lumps basically.  I mathed it out so all the metal material (minute the hook) come out to 10-20 lumps total metal.  The description suggests that it’s coated in plastic, but since it’s a player craft (with no plastic) I did not want to create a situation where you could make something and deconstruct it for more materials than you put in.

- **2610 seat wood flimsy** is made of foldable wooden frame, so I gave it the normal drop I’ve been giving those parts.  Requires ropes to be installed (2) AND to craft the frame (3), so I’ve added some strings to the list.

- **2643 wooden seat** uses nails to craft the frame and to install, but no nails present.  Added nails.

- **2672 wooden roof** Same as wooden seat, added nails.

- **2691 chitin plating** breaks into too much chitin, I’ve reduced this somewhat and added chitin powder to reflect damage (what chitin breaks down to).  The armor kit required to make this also requires long and short ropes, so I have added string.  However, the installation uses glue/adhesive so I’m not sure if the ropes are actually still used or if they just poof out of existence when installed.  So I’ve kept the string numbers much lower than they ‘should’ be to try and find a middle ground.

- **2708 biosilicified chitin plating** is more or less the same as the above chitin plating.  This chiting stuff is making me nervous, we don’t have many chitin pieces and Im fuzzy on he rope/string stuff, doing my best here.

 - **2734 door motor** broke into more scrap metal than metal put in, reduced significantly.  Added small amount of copper wire to reflect the internals of the tiny electric motor used.  Chance of e-scrap and ball bearing.

- **drive by wire controls** although I hate that it gives a full tiny motor when broken, I didn’t know how to tackle this one.  I left it alone, but it should probably be changed, I don’t know, the electronics stuff, I don’t know how to break it down.

- **2796 camera control system** seemed okay, although I personally feel the numbers are a little generous at the high end.  Regardless, I just added a little copper wire to it.

- **2825 security camera and 2848 reinforced security camera** broke into more pieces than its crafting recipe required.  It also broke into more escrap than the 10 LCD screens and etc. of the above control system.  Knocked down e-scrap considerably, added some misc pieces as potential drops, including a small chance to retrieve an unbroken lens.  For reinforced, added small amount of scrap metal (it uses 4 wires as reinforcement)

- **3055 vehicle scoop** only gave a tiny amount of scrap and plastic, despite containing 2 full electric motors, sheet metal, etc.  For example, one sheet metal breaks down to over 100 scrap metal on its own, but the breaks_into gave 5 max. I increased the base materials, added a lot of copper wire (2k total in the electric motors, less in the breaks_into obviously) to reflect the motors, and allowed recovery of a few nuts and bolts.

- **3086 water purifier** gave a tiny amount of plastic chunks despite primarily being made from glass bottles and heating elements.  Added broken glass and some metal.  Small chance of getting a rubber hose, tiny amount of copper wire.

- **3125 plow** despite being a giant metal plow only broke into 1-2 plastic chunks. Idk even what to say x_x.  Changed it to a berjillion pieces of metal.  Added wheel destruction materials.

- **3168 seeder** is sadly another neglected farm part that is amusingly under-represented in terms of the material drops.  Overhauled all the metal stuff, mathing these is starting to get annoying I’m ready to be done with this audit at this point -_-;

- **3209 advanced seed drill** is just a seed drill but with electronics components.  Since there’s some plastic, e-scrap and copper wire already, I’ll just slap on the metal/rubber harvests from the seeder to this one as well and call it acceptable.


- **3252 reaper** has very similar materials to the seeder above, but with a little more metal, so basically just copied and tweaked that breaks_into to this one.

- **3295 advanced reaper** kept existing electronics pieces and added the metal/rubber from the standard reaper.

- **3329 cargo_lock** gives basically the amount of metal that is required for construction (more actually), so I reduced these to almost nothing.  By volume honestly I should have hit it even harder

- **3354 turret mount** Overall missing a lot, added a variety of materials from the components.

- **3387 door lock** same issue as the cargo lock above, changed the same way.

- **turret control unit** this shits complicated and I don’t know what to do with it.  It needs fixed but I can’t be asked.

- **3443 aluminum boat hulls** broke down into steel, but are made 100% from aluminum.  Fixed it to give scrap aluminum.

Left the stowed appliances alone, they look more recent and based on the deconstruction of those various appliances.

</details>

By the end I wanted to die, I don't know how you do it Karol, audits suck.