### PR TITLE
Craftable chest freezer

### DIFF
--- a/data/json/recipes/recipe_appliance.json
+++ b/data/json/recipes/recipe_appliance.json
@@ -104,6 +104,7 @@
     "subcategory": "CSC_APPLIANCE_UTILITY",
     "copy-from": "minifreezer",
     "skills_required": [ "fabrication", 4 ],
+    "using": [ [ "welding_standard", 600 ] ],
     "proficiencies": [
       { "proficiency": "prof_plasticworking", "required": false, "time_multiplier": 1.1, "learning_time_multiplier": 0.1 },
       { "proficiency": "prof_appliance_repair", "required": false, "skill_penalty": 0 }
@@ -119,9 +120,9 @@
       [ [ "sheet_metal", 30 ] ],
       [ [ "condensor_coil", 1 ] ],
       [ [ "evaporator_coil", 1 ] ],
-      [ [ "cable", 3 ] ],
+      [ [ "cable", 5 ] ],
       [ [ "hose", 1 ] ],
-      [ [ "pipe_fittings", 6 ] ],
+      [ [ "pipe_fittings", 9 ] ],
       [ [ "thermostat", 1 ] ],
       [ [ "motor_tiny", 1 ] ],
       [ [ "refrigerant_tank", 1 ] ],

--- a/data/json/recipes/recipe_appliance.json
+++ b/data/json/recipes/recipe_appliance.json
@@ -97,6 +97,38 @@
     ]
   },
   {
+    "result": "chest_freezer",
+    "type": "recipe",
+    "activity_level": "MODERATE_EXERCISE",
+    "category": "CC_APPLIANCE",
+    "subcategory": "CSC_APPLIANCE_UTILITY",
+    "copy-from": "minifreezer",
+    "skills_required": [ "fabrication", 4 ],
+    "proficiencies": [
+      { "proficiency": "prof_plasticworking", "required": false, "time_multiplier": 1.1, "learning_time_multiplier": 0.1 },
+      { "proficiency": "prof_appliance_repair", "required": false, "skill_penalty": 0 }
+    ],
+    "qualities": [
+      { "id": "HAMMER", "level": 2 },
+      { "id": "SAW_M", "level": 1 },
+      { "id": "DRILL", "level": 1 },
+      { "id": "SCREW", "level": 1 },
+      { "id": "WRENCH", "level": 1 }
+    ],
+    "components": [
+      [ [ "sheet_metal", 30 ] ],
+      [ [ "condensor_coil", 1 ] ],
+      [ [ "evaporator_coil", 1 ] ],
+      [ [ "cable", 3 ] ],
+      [ [ "hose", 1 ] ],
+      [ [ "pipe_fittings", 6 ] ],
+      [ [ "thermostat", 1 ] ],
+      [ [ "motor_tiny", 1 ] ],
+      [ [ "refrigerant_tank", 1 ] ],
+      [ [ "plastic_chunk", 30 ] ]
+    ]
+  },
+  {
     "result": "wall_light",
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Adds a crafting recipe for chest freezers"

#### Purpose of change

Adds a crafting recipe for chest freezers. Chest freezers were replaced by the current household freezers, and are in the most reductive terms just a household freezer turned onto its side, so it makes sense to be able to craft these, given all components are readily accessible.

#### Describe the solution

Added in the recipe. Requirements are based upon the relative surface area between the chest freezer and the household freezer. Chest freezer has a surface area of roughly +50% so several components have had their requirements increased by 50% for this recipe. 

#### Describe alternatives you've considered

Leaving the recipe out entirely.

Amending the crafting recipe to use welding proficiency. I still think this might be useful, but as this is my first contribution I wanted to keep it simple stuip

#### Testing

Confirmed that the recipe was accessible in game using debug to give myself the required skills, books and components.

#### Additional context

It may be useful to recipe audit refrigeration appliances at some point, as the recipes seem to be a little odd compared to the results. This seemed like too large of a scope for me right now, but many refrigeration appliances have been changed by #73048 and the recipes might need to be reworked as a result.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
