### PR TITLE
Fix crash when opening construction menu with no visible entries

### DIFF
--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -952,7 +952,7 @@ construction_id construction_menu( const bool blueprint )
 
         if( select < 0 || static_cast<size_t>( select ) >= constructs.size()
             || con_preview_group != constructs[select] ) {
-            con_preview_group = ( select >= 0 || static_cast<size_t>( select ) < constructs.size() )
+            con_preview_group = ( select >= 0 && static_cast<size_t>( select ) < constructs.size() )
                                 ? constructs[select] : construction_group_str_id::NULL_ID();
             if( con_preview_group.is_null() ) {
                 con_preview.clear();


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fixes #73718.

#### Describe the solution
Fix the typo (`&&` instead of `||`).

#### Describe alternatives you've considered

#### Testing
Opened construction menu, set a filter that matches no entries, and reopened the construction menu. Before this fix it crashed, and after this fix it did not crash.

#### Additional context
It does not crash until the construction menu is reopened, which is probably why I missed it in my original testing.