### PR TITLE
Fix door on select, door controls should keep selection

### DIFF
--- a/src/veh_utils.cpp
+++ b/src/veh_utils.cpp
@@ -443,7 +443,9 @@ bool veh_menu::query()
     veh_menu_cb cb( locations );
 
     cb.on_select = [this, &menu]() {
-        items[menu.selected]._on_select();
+        if( items[menu.selected]._on_select ) {
+            items[menu.selected]._on_select();
+        }
     };
 
     if( locations.size() == items.size() ) { // all items have valid location attached
@@ -454,7 +456,7 @@ bool veh_menu::query()
     }
 
     if( last_selected.has_value() ) { // have selection from previous query
-        menu.selected = std::max( static_cast<int>( items.size() ), last_selected.value() );
+        menu.selected = std::min( static_cast<int>( items.size() ), last_selected.value() );
     } else { // find first element with select enabled
         for( menu.selected = 0; menu.selected < static_cast<int>( items.size() ); menu.selected++ ) {
             if( items[menu.selected]._selected ) {
@@ -484,6 +486,7 @@ bool veh_menu::query()
 
     veh.refresh();
     map &m = get_map();
+    m.invalidate_visibility_cache();
     m.invalidate_map_cache( m.get_abs_sub().z() );
 
     return chosen._keep_menu_open;

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -206,7 +206,7 @@ void vehicle::control_doors()
     veh_menu menu( this, _( "Select door to toggle" ) );
 
     do {
-        menu.reset();
+        menu.reset( /* keep_last_selected = */ true );
 
         menu.add( _( "Open all curtains" ) )
         .hotkey_auto()


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fix a couple oopses in veh_menu

Fixes #73763

#### Describe the solution

Fix crash from calling without checking std::function, fix selection resetting and visibility updating when opening/closing doors/curtains

#### Describe alternatives you've considered

#### Testing

Spawn luxury rv, add electronics controls in the main body, open/close the curtains via door motors, shouldn't crash, menu selection should remain in place when opening/closing curtains

#### Additional context
