### PR TITLE
Hydration pack size fixes

### DIFF
--- a/data/json/items/armor/storage.json
+++ b/data/json/items/armor/storage.json
@@ -134,7 +134,7 @@
       {
         "//": "hydration pouch storage",
         "pocket_type": "CONTAINER",
-        "max_contains_volume": "3001 ml",
+        "max_contains_volume": "3250 ml",
         "max_contains_weight": "4 kg",
         "max_item_length": "30 cm",
         "moves": 500,
@@ -262,7 +262,7 @@
       {
         "//": "hydration pouch storage",
         "pocket_type": "CONTAINER",
-        "max_contains_volume": "3001 ml",
+        "max_contains_volume": "3250 ml",
         "max_contains_weight": "4 kg",
         "max_item_length": "30 cm",
         "moves": 500,
@@ -1927,7 +1927,7 @@
       {
         "//": "hydration pouch storage",
         "pocket_type": "CONTAINER",
-        "max_contains_volume": "3001 ml",
+        "max_contains_volume": "3250 ml",
         "max_contains_weight": "4 kg",
         "max_item_length": "30 cm",
         "moves": 500,
@@ -2018,7 +2018,7 @@
       {
         "//": "hydration pouch storage",
         "pocket_type": "CONTAINER",
-        "max_contains_volume": "3001 ml",
+        "max_contains_volume": "3250 ml",
         "max_contains_weight": "4 kg",
         "max_item_length": "30 cm",
         "moves": 500,
@@ -2109,7 +2109,7 @@
       {
         "//": "hydration pouch storage",
         "pocket_type": "CONTAINER",
-        "max_contains_volume": "3001 ml",
+        "max_contains_volume": "3250 ml",
         "max_contains_weight": "4 kg",
         "max_item_length": "30 cm",
         "moves": 500,
@@ -2380,7 +2380,7 @@
       {
         "//": "hydration pouch storage",
         "pocket_type": "CONTAINER",
-        "max_contains_volume": "3001 ml",
+        "max_contains_volume": "3250 ml",
         "max_contains_weight": "4 kg",
         "max_item_length": "30 cm",
         "moves": 500,

--- a/data/json/items/containers/containers.json
+++ b/data/json/items/containers/containers.json
@@ -1632,7 +1632,7 @@
     "description": "A slim and lightweight insulated plastic bladder worn on the back or within a hydration pouch in a backpack.  It has a large pocket and a capped mouth for filling with liquid, with a hose that allows the wearer to drink hands-free.",
     "ascii_picture": "camelbak",
     "weight": "286 g",
-    "volume": "3001 ml",
+    "volume": "250 ml",
     "price": "100 USD",
     "price_postapoc": "2 USD 50 cent",
     "to_hit": -1,

--- a/data/mods/Magiclysm/npc/TALK_FORGE_ARDELIA.json
+++ b/data/mods/Magiclysm/npc/TALK_FORGE_ARDELIA.json
@@ -68,17 +68,24 @@
   {
     "id": "TALK_FORGE_LORD_LIBRARIAN",
     "type": "talk_topic",
-    "dynamic_line": "I keep Valzain's books.  There are many floors of bookshelves in his pocket dimension.  These happen to be the ones I think it most likely he'll read soon.  I can sell some that we have copies of.",
+    "dynamic_line": "I keep Valzain's books.  There are many floors of bookshelves among his pocket dimensions, with more magic than a mortal mind like yours could comprehend.  These happen to be the ones I think it most likely he'll read soon.  I can sell some that we have extra copies of.",
     "responses": [
       { "text": "Let's trade.", "effect": "start_trade", "topic": "TALK_FORGE_LORD_LIBRARIAN" },
       { "text": "What are you doing here?", "topic": "TALK_FORGE_LIBRARIAN_DOING" },
+      { "text": "Do you have any more books in the back?", "topic": "TALK_FORGE_LIBRARIAN_ASK_INTERVAL" },
       { "text": "Well, bye.", "topic": "TALK_DONE" }
     ]
   },
   {
     "id": "TALK_FORGE_LIBRARIAN_DOING",
     "type": "talk_topic",
-    "dynamic_line": "I organize the books, I sell extra books, once when we still lent books I would hunt down those with late books to return.",
+    "dynamic_line": "I organize the books, I sell extra books, back when we still lent books I would hunt down those with late books to return.  I have done this for aeons past and I will continue to do this for aeons to come.",
     "responses": [ { "text": "Let's talk business then.", "topic": "TALK_FORGE_LORD_LIBRARIAN" } ]
+  },
+  {
+    "id": "TALK_FORGE_LIBRARIAN_ASK_INTERVAL",
+    "type": "talk_topic",
+    "dynamic_line": "It shouldn't take Valzain too long to read what he desires from what I have out. Check back in <interval> and I should have some new books set out.",
+    "responses": [ { "text": "Safe readings.", "topic": "TALK_FORGE_LORD_LIBRARIAN" } ]
   }
 ]

--- a/data/mods/Magiclysm/npc/TALK_FORGE_DIVINER.json
+++ b/data/mods/Magiclysm/npc/TALK_FORGE_DIVINER.json
@@ -42,7 +42,7 @@
   {
     "id": "TALK_FORGE_LORD_DIVINER",
     "type": "talk_topic",
-    "dynamic_line": "Are you looking for something in particular?",
+    "dynamic_line": "Are you looking for something? I can help with anything but your own stuff. You'll have to ask your mother for help with that.",
     "responses": [
       { "text": "Can you help me find something?", "topic": "TALK_FORGE_DIVINER_FIND_WHAT" },
       { "text": "What are you doing here?", "topic": "TALK_FORGE_DIVINER_DOING" },
@@ -52,7 +52,7 @@
   {
     "id": "TALK_FORGE_DIVINER_DOING",
     "type": "talk_topic",
-    "dynamic_line": "I specialize in scrying.  I can help you find any number of things.",
+    "dynamic_line": "What are any of us really doing here in this dead and dying world? I specialize in scrying, and while I wish I could say I'm in it to help lost souls find their way, the collective pockets of a thousand realities is a very good incentive. I can help you find any number of things, but I take no responsibility for what happens when you find what you're looking for.",
     "responses": [ { "text": "Let's talk business then.", "topic": "TALK_FORGE_LORD_DIVINER" } ]
   },
   {
@@ -93,10 +93,8 @@
       { "text": "A triffid grove.", "topic": "TALK_FORGE_LORD_DIVINER_TRIFFID" },
       { "text": "A kraken cave.", "topic": "TALK_FORGE_LORD_DIVINER_KRAKEN" },
       { "text": "A slime pit.", "topic": "TALK_FORGE_LORD_DIVINER_SLIME" },
-      { "text": "A goblin encampment.", "topic": "TALK_FORGE_LORD_DIVINER_GOBLIN" },
-      { "text": "An orc village.", "topic": "TALK_FORGE_LORD_DIVINER_ORC" },
+      { "text": "A goblin camp.", "topic": "TALK_FORGE_LORD_DIVINER_GOBLIN" },
       { "text": "A swamp dragon cave!", "topic": "TALK_FORGE_LORD_DIVINER_SWAMP_DRAGON" },
-      { "text": "Demon spiders", "topic": "TALK_FORGE_LORD_DIVINER_SPIDERS_DEMON" },
       { "text": "A balrog mine", "topic": "TALK_FORGE_LORD_DIVINER_BALROG" },
       { "text": "About something else…", "topic": "TALK_NONE" },
       { "text": "Nevermind.", "topic": "TALK_DONE" }
@@ -105,7 +103,7 @@
   {
     "id": "TALK_FORGE_LORD_DIVINER_MAN_MADE",
     "type": "talk_topic",
-    "dynamic_line": "Seeking to pick around your civilization's corpse?",
+    "dynamic_line": "Seeking to pick around your civilization's corpse? You're not the first and you won't be the last.",
     "responses": [
       { "text": "A lab.", "topic": "TALK_FORGE_LORD_DIVINER_LAB" },
       { "text": "An Exodii location.", "topic": "TALK_FORGE_LORD_DIVINER_EXODII" },
@@ -113,8 +111,7 @@
       { "text": "An attunement altar.", "topic": "TALK_FORGE_LORD_DIVINER_ATTUNEMENT" },
       { "text": "A magic academy.", "topic": "TALK_FORGE_LORD_DIVINER_ACADEMY" },
       { "text": "A wizard tower.", "topic": "TALK_FORGE_LORD_DIVINER_TOWER" },
-      { "text": "A goblin encampment.", "topic": "TALK_FORGE_LORD_DIVINER_GOBLIN" },
-      { "text": "An orc village.", "topic": "TALK_FORGE_LORD_DIVINER_ORC" },
+      { "text": "A goblin city.", "topic": "TALK_FORGE_LORD_DIVINER_GOBLIN" },
       { "text": "About something else…", "topic": "TALK_NONE" },
       { "text": "Nevermind.", "topic": "TALK_DONE" }
     ]
@@ -126,8 +123,7 @@
     "responses": [
       { "text": "A strange temple.", "topic": "TALK_FORGE_LORD_DIVINER_TEMPLE" },
       { "text": "An attunement altar.", "topic": "TALK_FORGE_LORD_DIVINER_ATTUNEMENT" },
-      { "text": "A goblin encampment.", "topic": "TALK_FORGE_LORD_DIVINER_GOBLIN" },
-      { "text": "An orc village.", "topic": "TALK_FORGE_LORD_DIVINER_ORC" },
+      { "text": "A goblin camp.", "topic": "TALK_FORGE_LORD_DIVINER_GOBLIN" },
       { "text": "About something else…", "topic": "TALK_NONE" },
       { "text": "Nevermind.", "topic": "TALK_DONE" }
     ]
@@ -135,7 +131,7 @@
   {
     "id": "TALK_FORGE_LORD_DIVINER_GEOLOGY",
     "type": "talk_topic",
-    "dynamic_line": "Sure.  Looking for a pretty vista, perhaps?",
+    "dynamic_line": "Sure.  Looking for a nice spot to watch the world end, perhaps?",
     "responses": [
       { "text": "A river.", "topic": "TALK_FORGE_LORD_DIVINER_RIVER" },
       { "text": "A clay deposit.", "topic": "TALK_FORGE_LORD_DIVINER_CLAY" },
@@ -169,7 +165,7 @@
   {
     "id": "TALK_FORGE_LORD_DIVINER_GET_MONEY",
     "type": "talk_topic",
-    "dynamic_line": "I see.  You could get some from trading with the merchants around here.  The librarian is crazy for beech nuts, for example.  I saw her trade away all her money and books for a literal truckload of the things in another reality earlier.  Not sure what she does with them.  You see, she's lined her private rooms with lead which blocks my scrying.  Almost like she doesn't trust me.  Not sure why.",
+    "dynamic_line": "I see.  You could get some from trading with the merchants around here.  The librarian is crazy for beech nuts, for example.  I saw her trade away all her money and books for a literal truckload of the things in another reality earlier.  Not sure what she does with them.  You see, she's lined her private rooms with lead which just so happens to block my scrying.  Almost like she doesn't trust me.  Not sure why.",
     "responses": [ { "text": "Fair enough.", "topic": "TALK_DONE" } ]
   },
   {
@@ -235,7 +231,7 @@
   {
     "id": "TALK_FORGE_LORD_DIVINER_SPIDERS",
     "type": "talk_topic",
-    "dynamic_line": "Spiders it is then.  But there are several different kinds of spiders out there.  Which type are you interested in?",
+    "dynamic_line": "Spiders it is then.  But of course, there are several different kinds of spiders out there.  Which type are you interested in?",
     "responses": [
       { "text": "Web spinners in a forest.", "topic": "TALK_FORGE_LORD_DIVINER_SPIDERS_WEB" },
       { "text": "A pit full of spiders.", "topic": "TALK_FORGE_LORD_DIVINER_SPIDERS_PIT" },
@@ -430,7 +426,7 @@
   {
     "id": "TALK_FORGE_LORD_DIVINER_TRIFFID",
     "type": "talk_topic",
-    "dynamic_line": "Right.  Extradimensional intelligent plants with a mean streak.  They seem to have a method of traveling from reality to reality without traversing the hazards between.  Interesting, no?    I'll mark one of their groves on your map for one denarius.",
+    "dynamic_line": "Right.  Extradimensional intelligent plants with a mean streak.  They seem to have a method of traveling from reality to reality without traversing the hazards between.  Interesting, no?  I'd ask them how they do it but I don't think I could get a word in edgewise before they cut me to pieces.  I'll mark one of their groves on your map for one denarius.",
     "responses": [
       {
         "text": "It's a deal.",
@@ -490,13 +486,24 @@
   {
     "id": "TALK_FORGE_LORD_DIVINER_GOBLIN",
     "type": "talk_topic",
-    "dynamic_line": "Good choice.  Small, angry creatures obsessed with trash, yet with a tendency to hoard some surprisingly valuable artefacts.  Just watch out for the mind goblin.  Actually, uh, never mind.  I'll mark one of their camps on your map for one denarius.",
+    "dynamic_line": "Good choice.  It seems that shortly before the world started to end, a few of them got it in their heads to just leave civilization alone for a bit and go live in the woods with other goblins. And wargs.  Not a terrible idea if you ask me.  Anyways, theres a few different types of places they gather, are you looking for an encampment or an outpost?",
+    "responses": [
+      { "text": "An encampment.", "topic": "TALK_FORGE_LORD_DIVINER_GOBLIN_ENCAMPMENT" },
+      { "text": "An outpost.", "topic": "TALK_FORGE_LORD_DIVINER_GOBLIN_OUTPOST" },
+      { "text": "On second thought…", "topic": "TALK_NONE" },
+      { "text": "Nevermind.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "TALK_FORGE_LORD_DIVINER_GOBLIN_ENCAMPMENT",
+    "type": "talk_topic",
+    "dynamic_line": "You've got a long walk deep into the forest ahead of you.  Oh, and did I mention the wargs?  They've got these wargs that are absolutely adorable. Of course they'll maul you if you try to pet them, but the temptation is always there.  I'll mark one of their camps on your map for one denarius.",
     "responses": [
       {
         "text": "It's a deal.",
         "topic": "TALK_DONE",
         "condition": { "u_has_item": "denarius" },
-        "effect": [ { "assign_mission": "MISSION_FORGE_DIVINER_GOBLIN" }, { "u_consume_item": "denarius" } ]
+        "effect": [ { "assign_mission": "MISSION_FORGE_DIVINER_GOBLIN_ENCAMPMENT" }, { "u_consume_item": "denarius" } ]
       },
       {
         "text": "I can't afford that right now.",
@@ -508,15 +515,15 @@
     ]
   },
   {
-    "id": "TALK_FORGE_LORD_DIVINER_ORC",
+    "id": "TALK_FORGE_LORD_DIVINER_GOBLIN_OUTPOST",
     "type": "talk_topic",
-    "dynamic_line": "Militaristic xenophobes, that bunch.  They are fairly good weapon smiths, and quite strong, so be careful.  Oh, and something about their physiology makes them extra super dangerous when raised as undead.  So you should probably try to not let that happen.  I'll mark one of their camps on your map for one denarius.",
+    "dynamic_line": "Contrary to popular belief, goblins are not actually orcs.  Its the other way around.  Orcs are goblins who have taken one too many unlabeled potions and lived to tell the tale.  Sometimes this awakens powers much like my own.  Well, not exactly, if it did I'd be out of a job faster than a Magus could cast Phase Door.  Luckily for you, you shouldn't have to delve too deep into a forest to see for yourself. I'll mark one of their outposts on your map for one denarius.",
     "responses": [
       {
         "text": "It's a deal.",
         "topic": "TALK_DONE",
         "condition": { "u_has_item": "denarius" },
-        "effect": [ { "assign_mission": "MISSION_FORGE_DIVINER_ORC" }, { "u_consume_item": "denarius" } ]
+        "effect": [ { "assign_mission": "MISSION_FORGE_DIVINER_GOBLIN_OUTPOST" }, { "u_consume_item": "denarius" } ]
       },
       {
         "text": "I can't afford that right now.",
@@ -703,7 +710,7 @@
   {
     "id": "TALK_FORGE_LORD_DIVINER_ATTUNEMENT",
     "type": "talk_topic",
-    "dynamic_line": "You know, if you've got the aptitude, you should go visit an attunement altar.  I'll mark one on your map for one denarius.",
+    "dynamic_line": "You know, if you've got the aptitude, you should go visit an attunement altar.  They help you combine your skills with different classes of magic to incredible effect.  I'll mark one on your map for one denarius.",
     "responses": [
       {
         "text": "It's a deal.",
@@ -723,7 +730,7 @@
   {
     "id": "TALK_FORGE_LORD_DIVINER_ACADEMY",
     "type": "talk_topic",
-    "dynamic_line": "This place used to teach magic before the whole Malignance business.  There is probably still spell scrolls and magical items to find there.  And golems.  I'll mark one on your map for one denarius.",
+    "dynamic_line": "This place used to teach magic before the whole Malignance business.  There are probably still spell scrolls and magical items to find there.  And golems.  Can't forget about the golems.  I'll mark one on your map for one denarius.",
     "responses": [
       {
         "text": "It's a deal.",
@@ -743,14 +750,20 @@
   {
     "id": "TALK_FORGE_LORD_DIVINER_TOWER",
     "type": "talk_topic",
-    "dynamic_line": "Seems like an eccentric wizard once lived here.  Not that there is any other kind of wizards, am I right?  But, uh, don't tell Valzain I said so.  But you know it's true.  Anyways, I'll mark the building on your map for one denarius.",
-    "//": "TODO: randomize between MISSION_FORGE_DIVINER_TOWER1 and MISSION_FORGE_DIVINER_TOWER2",
+    "dynamic_line": "Seems like an eccentric wizard once lived here.  Not that there are any other kind of wizards, am I right?  But, uh, don't tell Valzain I said so.  Or any other wizards for that matter.  But you know it's true.  Anyways, I'll mark the building on your map for one denarius.",
     "responses": [
       {
         "text": "It's a deal.",
         "topic": "TALK_DONE",
         "condition": { "u_has_item": "denarius" },
-        "effect": [ { "assign_mission": "MISSION_FORGE_DIVINER_TOWER1" }, { "u_consume_item": "denarius" } ]
+        "effect": [ 
+                    { 
+                      "if": { "one_in_chance": 2 },
+                      "then": { "assign_mission": "MISSION_FORGE_DIVINER_TOWER1" },
+                      "else": { "assign_mission": "MISSION_FORGE_DIVINER_TOWER2" }
+                    }, 
+                    { "u_consume_item": "denarius" } 
+                  ]
       },
       {
         "text": "I can't afford that right now.",
@@ -764,7 +777,7 @@
   {
     "id": "TALK_FORGE_LORD_DIVINER_RIVER",
     "type": "talk_topic",
-    "dynamic_line": "Rivers.  Water, sand, clay, fish, giant mutant bugs.  If you're having trouble finding one, I'll mark one on your map for one denarius.",
+    "dynamic_line": "Rivers.  Water, sand, clay, fish, giant mutant bugs.  Generally pretty big.  If you're still having trouble finding one, I'll mark one on your map for one denarius.",
     "responses": [
       {
         "text": "It's a deal.",
@@ -784,7 +797,7 @@
   {
     "id": "TALK_FORGE_LORD_DIVINER_CLAY",
     "type": "talk_topic",
-    "dynamic_line": "Digging clay is quintessential of the Earthshaper.  Forming it into useful tools is quintessential of the Technomancer.  I'll a place a mark on your map for one denarius, if you want.",
+    "dynamic_line": "Digging clay is quintessential of the Earthshaper.  Forming it into useful tools is quintessential of the Technomancer.  Showing you where you can find it is quintessential of me. For one denarius of course.",
     "responses": [
       {
         "text": "It's a deal.",

--- a/data/mods/Magiclysm/npc/TALK_FORGE_HELEN_TAVREL.json
+++ b/data/mods/Magiclysm/npc/TALK_FORGE_HELEN_TAVREL.json
@@ -103,6 +103,7 @@
     "responses": [
       { "text": "Let's trade.", "effect": "start_trade", "topic": "TALK_FORGE_LORD_REAGENT" },
       { "text": "What are you doing here?", "topic": "TALK_FORGE_REAGENT_DOING" },
+      { "text": "When are you getting new stuff?", "topic": "TALK_FORGE_REAGENT_ASK_INTERVAL" },
       { "text": "Well, bye.", "topic": "TALK_DONE" }
     ]
   },
@@ -115,5 +116,19 @@
       "no": "A lifetime of plunder has brought me many a strange item - that you can have for unbeatable prices!"
     },
     "responses": [ { "text": "Well, shiver me timbers then.", "topic": "TALK_FORGE_LORD_REAGENT" } ]
+  },
+  {
+    "id": "TALK_FORGE_REAGENT_ASK_INTERVAL",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "u_is_wearing": "badge_marshal",
+      "yes": [
+        "Do you think me a fool, to tell an officer of the law my current plans?",
+        "Not even trying to ask me that undercover? By the seventeen seas, officers of the law really ARE made worse these days.",
+        "The end of times is here and that's what you're worried about? You should get your priorities straight."
+      ],
+      "no": "Well you obviously aren't an officer so here's the deal. There's a mighty fine galleon making land in <interval>, I'm certain to have something good by then."
+    },
+    "responses": [ { "text": "May the seas be ever in your favor", "topic": "TALK_FORGE_LORD_REAGENT" } ]
   }
 ]

--- a/data/mods/Magiclysm/npc/TALK_FORGE_MERCHANT.json
+++ b/data/mods/Magiclysm/npc/TALK_FORGE_MERCHANT.json
@@ -92,6 +92,7 @@
       { "text": "Let's trade.", "effect": "start_trade", "topic": "TALK_FORGE_LORD" },
       { "text": "What are you doing here?", "topic": "TALK_FORGE_LORD_DOING" },
       { "text": "I have some stories for you.", "topic": "TALK_FORGE_LORD_BOOKS_DELIVER" },
+      [ "text": "Anything interesting being worked on?", "topic": "TALK_FORGE_LORD_ASK_INTERVAL" },
       { "text": "Well, bye.", "topic": "TALK_DONE" }
     ]
   },
@@ -135,7 +136,7 @@
       "u_has_var": "general_meeting_u_met_FORGE_LORD",
       "value": "yes",
       "no": "Well here and now I am the law, and the law here is that people purchase my goods, they take them out into the world and they die; or they return to buy more of my goods.  Either way, I write poetry about them.",
-      "yes": "Once I was lost in the throes of love, now I've built an empire of material goods."
+      "yes": "Once I was lost in the throes of love, now I've built an empire of material goods. I've found these two things are equally as powerful, and dangerous."
     },
     "responses": [
       {
@@ -145,5 +146,11 @@
         "topic": "TALK_FORGE_LORD"
       }
     ]
+  },
+  {
+    "id": "TALK_FORGE_LORD_ASK_INTERVAL",
+    "type": "talk_topic",
+    "dynamic_line": "My minions are busy putting the final touches on a few exciting projects, check back in <interval> and see what's new.",
+    "responses": [ { "text": "May your hammers be accurate.", "topic": "TALK_FORGE_LORD" } ]
   }
 ]

--- a/data/mods/Magiclysm/npc/forge_diviner_missions.json
+++ b/data/mods/Magiclysm/npc/forge_diviner_missions.json
@@ -225,13 +225,13 @@
     }
   },
   {
-    "id": "MISSION_FORGE_DIVINER_GOBLIN",
+    "id": "MISSION_FORGE_DIVINER_GOBLIN_ENCAMPMENT",
     "type": "mission_definition",
-    "name": { "str": "Visit the goblins" },
+    "name": { "str": "Visit the goblin encampment" },
     "goal": "MGOAL_GO_TO_TYPE",
     "difficulty": 0,
     "value": 0,
-    "description": "The diviner told you there would be goblins here.",
+    "description": "The diviner told you there would be a goblin encampment here.",
     "destination": "goblin_1A",
     "start": {
       "assign_mission_target": {
@@ -244,13 +244,13 @@
     }
   },
   {
-    "id": "MISSION_FORGE_DIVINER_ORC",
+    "id": "MISSION_FORGE_DIVINER_GOBLIN_OUTPOST",
     "type": "mission_definition",
-    "name": { "str": "Visit the orcs" },
+    "name": { "str": "Visit the goblin outpost" },
     "goal": "MGOAL_GO_TO_TYPE",
     "difficulty": 0,
     "value": 0,
-    "description": "The diviner told you there would be orcs here.",
+    "description": "The diviner told you there would be a goblin outpost here.",
     "destination": "orc_village",
     "start": {
       "assign_mission_target": { "om_terrain": "orc_village", "om_special": "orc_village", "reveal_radius": 3, "cant_see": true, "search_range": 180 }
@@ -442,7 +442,7 @@
     "goal": "MGOAL_GO_TO_TYPE",
     "difficulty": 0,
     "value": 0,
-    "description": "The diviner told you that there would be a wizard tower altar here.",
+    "description": "The diviner told you that there would be a wizard tower with an altar here.",
     "destination": "wizardtower2_ground",
     "start": {
       "assign_mission_target": { "om_terrain": "wizardtower2_ground", "reveal_radius": 3, "cant_see": true, "search_range": 180 }

--- a/data/mods/Xedra_Evolved/items/inventor/armor.json
+++ b/data/mods/Xedra_Evolved/items/inventor/armor.json
@@ -88,7 +88,7 @@
       {
         "//": "hydration pouch storage",
         "pocket_type": "CONTAINER",
-        "max_contains_volume": "3001 ml",
+        "max_contains_volume": "3250 ml",
         "max_contains_weight": "4 kg",
         "max_item_length": "30 cm",
         "moves": 500,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
"None"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
When hydration pack was changes from a rigid to a non-rigid container, its volume when empty was not changed accordingly, nor were the pockets in bags that contained it. Fixes #73508 , Fixes #73535 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Changes size of hydration pack and associated container pockets built for hydration pack in json.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Reverting hydration pack to being rigid (not realistic), or changing its empty volume to 0.001 L (also not realistic, see Hyperseeker's notes on #73535 and #73508 for both alternatives). 
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
None
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Also edited a pocket in Xedra Evolved, as the issue would have persisted there as well. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
