### PR TITLE
Serialize game and test build to ease pressure on RAM, especially in CI

### DIFF
--- a/build-scripts/gha_compile_only.sh
+++ b/build-scripts/gha_compile_only.sh
@@ -64,7 +64,7 @@ then
         ..
     make -j$num_jobs
 else
-    make -j "$num_jobs" CCACHE=1 CROSS="$CROSS_COMPILATION" LINTJSON=0 FRAMEWORK=1 UNIVERSAL_BINARY=1 DEBUG_SYMBOLS=1
+    make -j "$num_jobs" CCACHE=1 CROSS="$CROSS_COMPILATION" LINTJSON=0 FRAMEWORK=1 UNIVERSAL_BINARY=1 DEBUG_SYMBOLS=1 SERIALIZE_TEST_BUILD=1
 
     # For CI on macOS, patch the test binary so it can find SDL2 libraries.
     if [[ ! -z "$OS" && "$OS" = "macos-12" ]]


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Some chatter on discord brought some build failures like https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/9078930225/job/24950004752#step:14:746 to my attention, looks like memory exhaustion?

#### Describe the solution
This adds an "ordering only" dependency on the test executable to new clones of the test and check targets in the makefile, along with an option to enable this behavior.
The effect of this is the test part of the build will not start until the game executable is fully linked, which should ease our memory pressure, ESPECIALLY if the test builds are flying through compilation due to high ccache hit rates and it starts linking the test exe befire the link of the game exe is done.

#### Describe alternatives you've considered
There are a number of options, potentially splitting the test exe into several pieces could work to limit the peak amount of rAM usage on each link job.
It's possible that building a .so of the game code instead of a .a would reduce the overhead of the test link job?
As for how to structure this feature, it's not TOTALLY necessary to add this to the Makefile, you can invoke it like make -j X bla bla bla cataclysm && make -j X bla bla tests, and you can do that locally or in the tests
I'm not totally against doing it this way, but right now I really want to get some idea of whether this will fix the problem at all.

#### Testing
The acid test will be if the GCC 9 LTO job passes, but also it might need several runs because I don't know what the pass rate recently is.

#### Additional context
I've been seeing this a lot on my local system as well, if I end up linking the game and test exe at the same time my computer locks up, this is why I'm working this into the Makefile instead of just editing the gha_compile_only.sh to do the build in stages.
