### PR TITLE
clamp the multiplicative speed bonus

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10393,8 +10393,8 @@ std::vector<run_cost_effect> Character::run_cost_effects( float &movecost ) cons
     run_cost_effect_add( enchantment_cache->get_value_add( enchant_vals::mod::MOVE_COST ),
                          _( "Enchantments" ) );
     run_cost_effect_mul( std::max( 0.01,
-                                   1.0 + enchantment_cache->get_value_multiply( enchant_vals::mod::MOVE_COST ),
-                                   _( "Enchantments" ) ) );
+                                   1.0 + enchantment_cache->get_value_multiply( enchant_vals::mod::MOVE_COST ) ),
+                         _( "Enchantments" ) );
 
     run_cost_effect_mul( 1.0 / get_modifier( character_modifier_stamina_move_cost_mod ),
                          _( "Stamina" ) );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10392,8 +10392,8 @@ std::vector<run_cost_effect> Character::run_cost_effects( float &movecost ) cons
 
     run_cost_effect_add( enchantment_cache->get_value_add( enchant_vals::mod::MOVE_COST ),
                          _( "Enchantments" ) );
-    run_cost_effect_mul( 1.0 + enchantment_cache->get_value_multiply( enchant_vals::mod::MOVE_COST ),
-                         _( "Enchantments" ) );
+    run_cost_effect_mul( std::max( 0.01, 1.0 + enchantment_cache->get_value_multiply( enchant_vals::mod::MOVE_COST ),
+                         _( "Enchantments" ) ) );
 
     run_cost_effect_mul( 1.0 / get_modifier( character_modifier_stamina_move_cost_mod ),
                          _( "Stamina" ) );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10392,8 +10392,9 @@ std::vector<run_cost_effect> Character::run_cost_effects( float &movecost ) cons
 
     run_cost_effect_add( enchantment_cache->get_value_add( enchant_vals::mod::MOVE_COST ),
                          _( "Enchantments" ) );
-    run_cost_effect_mul( std::max( 0.01, 1.0 + enchantment_cache->get_value_multiply( enchant_vals::mod::MOVE_COST ),
-                         _( "Enchantments" ) ) );
+    run_cost_effect_mul( std::max( 0.01,
+                                   1.0 + enchantment_cache->get_value_multiply( enchant_vals::mod::MOVE_COST ),
+                                   _( "Enchantments" ) ) );
 
     run_cost_effect_mul( 1.0 / get_modifier( character_modifier_stamina_move_cost_mod ),
                          _( "Stamina" ) );


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fix #73471
#### Describe the solution
Clamp the move cost bonus so it can't go lower than zero
#### Additional context
Not ideal solution of course, but at least it prevent za warudo