### PR TITLE
Don't try to get non-existent spellbook spells

### DIFF
--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2118,6 +2118,8 @@ spell &known_magic::get_spell( const spell_id &sp )
 {
     if( !knows_spell( sp ) ) {
         debugmsg( "ERROR: Tried to get unknown spell" );
+        static spell null_spell_reference( spell_id::NULL_ID() );
+        return null_spell_reference; // Don't make up new spells in our spellbook
     }
     spell &temp_spell = spellbook[ sp ];
     return temp_spell;

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -200,7 +200,7 @@ std::optional<std::string> player_activity::get_progress_message( const avatar &
         }
 
         if( type == ACT_SPELLCASTING ) {
-            const std::string spell_name = u.magic->get_spell( spell_id( name ) ).name();
+            const std::string spell_name = spell_id( name )->name.translated();
             extra_info = string_format( "%s …", spell_name );
         }
     }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Fixes #73749

#### Describe the solution
Don't bother accessing the player's spellbook or knowledge - just get the corresponding spell itself and return the translated name.

Add an additional bit of safety to known_magic::get_spell. It was returning a spell reference even if the reference was known to be bad. Return some dummy data instead. Trying to access the spellbook(std::map) that doesn't contain that requested key [inserts that key into the map.](https://stackoverflow.com/questions/59573278/cpp-accessing-a-map-with-a-non-existing-key)

#### Describe alternatives you've considered


#### Testing
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/afee6762-1447-445a-98f0-5007f6efdd52)

#### Additional context
