### PR TITLE
Modified functions and doc about open_container.

### DIFF
--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -4015,7 +4015,7 @@ Any Item can be a container. To add the ability to contain things to an item, yo
     "airtight": false,                // Default false. If true, can contain gas.
     "ablative": false,                // Default false. If true, this item holds a single ablative plate. Make sure to include a flag_restriction on the type of plate that can be added.
     "holster": false,                 // Default false. If true, only one stack of items can be placed inside this pocket, or one item if that item is not count_by_charges.
-    "open_container": false,          // Default false. If true, the contents of this pocket will spill if this item is placed into another item.
+    "open_container": false,          // Default false. If true, the contents of this pocket will spill if this item is worn by a character or placed into another item.
     "fire_protection": false,         // Default false. If true, the pocket protects the contained items from exploding if tossed into a fire.
     "transparent": false              // Default false. If true, the pocket is transparent, as you can see items inside it afar; in the future this would be used for light also
     "extra_encumbrance": 3,           // Additional encumbrance given to character, if this pocket is used

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -10218,7 +10218,8 @@ std::pair<item_location, item_pocket *> item::best_pocket( const item &it, item_
 
 bool item::spill_contents( Character &c )
 {
-    if( !is_container() || is_container_empty() ) {
+    if( ( !is_container() && !is_magazine() && !uses_magazine() ) || 
+        is_container_empty() ) {
         return true;
     }
 
@@ -10234,7 +10235,8 @@ bool item::spill_contents( Character &c )
 
 bool item::spill_contents( const tripoint &pos )
 {
-    if( !is_container() || is_container_empty() ) {
+    if( ( !is_container() && !is_magazine() && !uses_magazine() ) || 
+        is_container_empty() ) {
         return true;
     }
     return contents.spill_contents( pos );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -10218,7 +10218,7 @@ std::pair<item_location, item_pocket *> item::best_pocket( const item &it, item_
 
 bool item::spill_contents( Character &c )
 {
-    if( ( !is_container() && !is_magazine() && !uses_magazine() ) || 
+    if( ( !is_container() && !is_magazine() && !uses_magazine() ) ||
         is_container_empty() ) {
         return true;
     }
@@ -10235,7 +10235,7 @@ bool item::spill_contents( Character &c )
 
 bool item::spill_contents( const tripoint &pos )
 {
-    if( ( !is_container() && !is_magazine() && !uses_magazine() ) || 
+    if( ( !is_container() && !is_magazine() && !uses_magazine() ) ||
         is_container_empty() ) {
         return true;
     }

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -1374,7 +1374,7 @@ const item &item_contents::first_ammo() const
 bool item_contents::will_spill() const
 {
     for( const item_pocket &pocket : contents ) {
-        if( pocket.is_type( pocket_type::CONTAINER ) && pocket.will_spill() ) {
+        if( pocket.is_standard_type() && pocket.will_spill() ) {
             return true;
         }
     }
@@ -1384,8 +1384,7 @@ bool item_contents::will_spill() const
 bool item_contents::will_spill_if_unsealed() const
 {
     for( const item_pocket &pocket : contents ) {
-        if( pocket.is_type( pocket_type::CONTAINER )
-            && pocket.will_spill_if_unsealed() ) {
+        if( pocket.is_standard_type() && pocket.will_spill_if_unsealed() ) {
             return true;
         }
     }
@@ -1395,7 +1394,7 @@ bool item_contents::will_spill_if_unsealed() const
 bool item_contents::spill_open_pockets( Character &guy, const item *avoid )
 {
     for( item_pocket &pocket : contents ) {
-        if( pocket.is_type( pocket_type::CONTAINER ) && pocket.will_spill() ) {
+        if( pocket.is_standard_type() && pocket.will_spill() ) {
             pocket.handle_liquid_or_spill( guy, avoid );
             if( !pocket.empty() ) {
                 return false;
@@ -1408,7 +1407,7 @@ bool item_contents::spill_open_pockets( Character &guy, const item *avoid )
 void item_contents::handle_liquid_or_spill( Character &guy, const item *const avoid )
 {
     for( item_pocket &pocket : contents ) {
-        if( pocket.is_type( pocket_type::CONTAINER ) ) {
+        if( pocket.is_standard_type() ) {
             pocket.handle_liquid_or_spill( guy, avoid );
         }
     }


### PR DESCRIPTION
#### Summary
Infrastructure "Adjust how `open_container` affects `Character::dispose_item`"
#### Purpose of change
`open_container` should be able to affect all standard type pockets.
#### Describe the solution
Adjusted `will_spill` `spill_contents` etc, now `MAGAZINE` and `MAGAZINE_WELL` type pockets will also be considered.
Changed the doc to correctly reflect the use of `open_container` ("Spill contents and wear item" was ignored in the doc).
#### Describe alternatives you've considered
Only add `MAGAZINE` type container as an option.
#### Testing
Compiled and tested locally.
#### Additional context
Made this adjustment so I can apply changes to RAS weapon later.
![2024-05-15 195949](https://github.com/CleverRaven/Cataclysm-DDA/assets/78858975/4fa52a93-6d59-4efe-baea-7ec72a2f6a2a)
![2024-05-15 200041](https://github.com/CleverRaven/Cataclysm-DDA/assets/78858975/905127c0-e3a6-489f-9a4a-481e0e26832e)
