### PR TITLE
typified activity_actor

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -1342,7 +1342,7 @@ void hacksaw_activity_actor::do_turn( player_activity &/*act*/, Character &who )
             if( who.is_avatar() ) {
                 who.add_msg_if_player( m_bad, _( "Your %1$s ran out of charges." ), tool->tname() );
             } else { // who.is_npc()
-                add_msg_if_player_sees( who.pos(), _( "%1$s %2$s ran out of charges." ), who.disp_name( false, //###
+                add_msg_if_player_sees( who.pos_bub(), _( "%1$s %2$s ran out of charges." ), who.disp_name( false,
                                         true ), tool->tname() );
             }
             who.cancel_activity();
@@ -1365,7 +1365,7 @@ void hacksaw_activity_actor::do_turn( player_activity &/*act*/, Character &who )
             if( who.is_avatar() ) {
                 who.add_msg_if_player( m_bad, _( "Your %1$s ran out of charges." ), type.value()->nname( 1 ) );
             } else { // who.is_npc()
-                add_msg_if_player_sees( who.pos(), _( "%1$s %2$s ran out of charges." ), who.disp_name( false,//###
+                add_msg_if_player_sees( who.pos_bub(), _( "%1$s %2$s ran out of charges." ), who.disp_name( false,
                                         true ), type.value()->nname( 1 ) );
             }
             who.cancel_activity();
@@ -1608,7 +1608,7 @@ void glide_activity_actor::do_turn( player_activity &act, Character &you )
         act.set_to_null();
         return;
     }
-    Creature *creature_ahead = get_creature_tracker().creature_at( newpos.raw() );//###
+    Creature *creature_ahead = get_creature_tracker().creature_at( newpos );
     if( creature_ahead && creature_ahead->get_size() >= creature_size::medium &&
         you.get_size() >= creature_size::medium ) {
         // Zombies are too stupid to avoid midair collision
@@ -2563,7 +2563,7 @@ void boltcutting_activity_actor::do_turn( player_activity &/*act*/, Character &w
         if( who.is_avatar() ) {
             who.add_msg_if_player( m_bad, _( "Your %1$s ran out of charges." ), tool->tname() );
         } else { // who.is_npc()
-            add_msg_if_player_sees( who.pos(), _( "%1$s %2$s ran out of charges." ), who.disp_name( false,//###
+            add_msg_if_player_sees( who.pos_bub(), _( "%1$s %2$s ran out of charges." ), who.disp_name( false,
                                     true ), tool->tname() );
         }
         who.cancel_activity();
@@ -2894,13 +2894,9 @@ std::optional<tripoint_bub_ms> lockpick_activity_actor::select_location( avatar 
     }
 
     const ter_id terr_type = get_map().ter( *target );
-    std::optional<tripoint> work_around;//###
-    if( target.has_value() ) {
-        work_around = target.value().raw();
-    }
     if( *target == you.pos_bub() ) {
         you.add_msg_if_player( m_info, _( "You pick your nose and your sinuses swing open." ) );
-    } else if( get_creature_tracker().creature_at<npc>( *work_around ) ) {//###
+    } else if( get_creature_tracker().creature_at<npc>( *target ) ) {
         you.add_msg_if_player( m_info,
                                _( "You can pick your friends, and you can\npick your nose, but you can't pick\nyour friend's nose." ) );
     } else if( terr_type == ter_t_door_c ) {
@@ -4354,7 +4350,7 @@ void stash_activity_actor::do_turn( player_activity &, Character &who )
 {
     const tripoint_bub_ms pos = placement + who.pos_bub();
 
-    monster *pet = get_creature_tracker().creature_at<monster>( pos.raw() );//###
+    monster *pet = get_creature_tracker().creature_at<monster>( pos );
     if( pet != nullptr && pet->has_effect( effect_pet ) ) {
         stash_on_pet( obtain_activity_items( items, handler, who, current_bulk_unload ),
                       *pet, who );
@@ -4932,7 +4928,7 @@ void milk_activity_actor::do_turn( player_activity &act, Character &who )
     }
     map &here = get_map();
     const tripoint_bub_ms source_pos = here.bub_from_abs( monster_coords.at( 0 ) );
-    monster *source_mon = get_creature_tracker().creature_at<monster>( source_pos.raw() );//###
+    monster *source_mon = get_creature_tracker().creature_at<monster>( source_pos );
     if( source_mon == nullptr ) {
         // We might end up here if the creature dies while being milked
         who.add_msg_if_player( m_bad, _( "The udders slip out of your hands." ) );
@@ -4949,7 +4945,7 @@ void milk_activity_actor::finish( player_activity &act, Character &who )
     }
     map &here = get_map();
     const tripoint_bub_ms source_pos = here.bub_from_abs( monster_coords.at( 0 ) );
-    monster *source_mon = get_creature_tracker().creature_at<monster>( source_pos.raw() );//###
+    monster *source_mon = get_creature_tracker().creature_at<monster>( source_pos );
     if( source_mon == nullptr ) {
         debugmsg( "could not find source creature for liquid transfer" );
         return;
@@ -5339,7 +5335,7 @@ void oxytorch_activity_actor::do_turn( player_activity &/*act*/, Character &who 
         if( who.is_avatar() ) {
             who.add_msg_if_player( m_bad, _( "Your %1$s ran out of charges." ), tool->tname() );
         } else { // who.is_npc()
-            add_msg_if_player_sees( who.pos(), _( "%1$s %2$s ran out of charges." ), who.disp_name( false,//###
+            add_msg_if_player_sees( who.pos_bub(), _( "%1$s %2$s ran out of charges." ), who.disp_name( false,
                                     true ), tool->tname() );
         }
         who.cancel_activity();
@@ -5803,7 +5799,7 @@ void prying_activity_actor::do_turn( player_activity &/*act*/, Character &who )
         if( who.is_avatar() ) {
             who.add_msg_if_player( m_bad, _( "Your %1$s ran out of charges." ), tool->tname() );
         } else { // who.is_npc()
-            add_msg_if_player_sees( who.pos(), _( "%1$s %2$s ran out of charges." ), who.disp_name( false,//###
+            add_msg_if_player_sees( who.pos_bub(), _( "%1$s %2$s ran out of charges." ), who.disp_name( false,
                                     true ), tool->tname() );
         }
         who.cancel_activity();
@@ -6520,7 +6516,7 @@ void chop_tree_activity_actor::finish( player_activity &act, Character &who )
             tripoint_bub_ms proposed_to = pos + point( 3 * direc.x, 3 * direc.y );
             std::vector<tripoint_bub_ms> rough_tree_line = line_to( pos, proposed_to );
             for( const tripoint_bub_ms &elem : rough_tree_line ) {
-                if( creatures.creature_at( elem.raw() ) ) {//###
+                if( creatures.creature_at( elem ) ) {
                     cantuse = true;
                     break;
                 }

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -177,10 +177,10 @@ class gunmod_remove_activity_actor : public activity_actor
 class hacksaw_activity_actor : public activity_actor
 {
     public:
-        explicit hacksaw_activity_actor( const tripoint &target,
+        explicit hacksaw_activity_actor( const tripoint_bub_ms &target,
                                          const item_location &tool ) : target( target ), tool( tool ) {};
-        explicit hacksaw_activity_actor( const tripoint &target, const itype_id &type,
-                                         const tripoint &veh_pos ) : target( target ), type( type ), veh_pos( veh_pos ) {};
+        explicit hacksaw_activity_actor( const tripoint_bub_ms &target, const itype_id &type,
+                                         const tripoint_bub_ms &veh_pos ) : target( target ), type( type ), veh_pos( veh_pos ) {};
         activity_id get_type() const override {
             return activity_id( "ACT_HACKSAW" );
         }
@@ -199,10 +199,10 @@ class hacksaw_activity_actor : public activity_actor
         // debugmsg causes a backtrace when fired during cata_test
         bool testing = false;  // NOLINT(cata-serialize)
     private:
-        tripoint target;
+        tripoint_bub_ms target;
         item_location tool;
         std::optional<itype_id> type;
-        std::optional<tripoint> veh_pos;
+        std::optional<tripoint_bub_ms> veh_pos;
         bool can_resume_with_internal( const activity_actor &other,
                                        const Character &/*who*/ ) const override;
 };
@@ -323,7 +323,7 @@ class hotwire_car_activity_actor : public activity_actor
          * Position of first vehicle part; used to identify the vehicle
          * TODO: find something more reliable (to cover cases when vehicle is moved/damaged)
          */
-        tripoint target;
+        tripoint_abs_ms target;
 
         bool can_resume_with_internal( const activity_actor &other, const Character & ) const override {
             const hotwire_car_activity_actor &a = static_cast<const hotwire_car_activity_actor &>( other );
@@ -542,12 +542,12 @@ class pickup_activity_actor : public activity_actor
          * (e.g. if the player is in a moving vehicle). This should be null
          * if not grabbing from the ground.
          */
-        std::optional<tripoint> starting_pos;
+        std::optional<tripoint_bub_ms> starting_pos;
 
     public:
         pickup_activity_actor( const std::vector<item_location> &target_items,
                                const std::vector<int> &quantities,
-                               const std::optional<tripoint> &starting_pos,
+                               const std::optional<tripoint_bub_ms> &starting_pos,
                                bool autopickup ) : target_items( target_items ),
             quantities( quantities ), starting_pos( starting_pos ), stash_successful( true ),
             autopickup( autopickup ) {}
@@ -625,7 +625,7 @@ class lockpick_activity_actor : public activity_actor
         int moves_total;
         std::optional<item_location> lockpick;
         std::optional<item> fake_lockpick;
-        tripoint target;
+        tripoint_abs_ms target;
 
         lockpick_activity_actor(
             int moves_total,
@@ -656,7 +656,7 @@ class lockpick_activity_actor : public activity_actor
         void do_turn( player_activity &, Character & ) override {}
         void finish( player_activity &act, Character &who ) override;
 
-        static std::optional<tripoint> select_location( avatar &you );
+        static std::optional<tripoint_bub_ms> select_location( avatar &you );
 
         std::unique_ptr<activity_actor> clone() const override {
             return std::make_unique<lockpick_activity_actor>( *this );
@@ -977,7 +977,7 @@ class workout_activity_actor : public activity_actor
         bool disable_query = false; // disables query, continue as long as possible
         bool rest_mode = false; // work or rest during training session
         time_duration duration;
-        tripoint location;
+        tripoint_bub_ms location;
         time_point stop_time; // can resume if time apart is not above
         activity_id act_id = activity_id( "ACT_WORKOUT_LIGHT" ); // variable activities
         int intensity_modifier = 1;
@@ -1535,11 +1535,11 @@ class tent_deconstruct_activity_actor : public activity_actor
     private:
         int moves_total;
         int radius;
-        tripoint target;
+        tripoint_bub_ms target;
         itype_id tent;
 
     public:
-        tent_deconstruct_activity_actor( int moves_total, int radius, tripoint target,
+        tent_deconstruct_activity_actor( int moves_total, int radius, tripoint_bub_ms target,
                                          itype_id tent ) : moves_total( moves_total ), radius( radius ), target( target ), tent( tent ) {}
 
         activity_id get_type() const override {

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -1182,7 +1182,7 @@ bool advanced_inventory::move_all_items()
 
         do_return_entry();
 
-        const pickup_activity_actor act( target_items, quantities, player_character.pos(), false );
+        const pickup_activity_actor act( target_items, quantities, player_character.pos_bub(), false );
         player_character.assign_activity( act );
     } else {
         // Vehicle and map destinations are handled the same.
@@ -1472,9 +1472,9 @@ void advanced_inventory::start_activity(
             player_character.assign_activity(
                 wield_activity_actor( target_items.front(), quantities.front() ) );
         } else if( destarea == AIM_INVENTORY ) {
-            const std::optional<tripoint> starting_pos = from_vehicle
+            const std::optional<tripoint_bub_ms> starting_pos = from_vehicle
                     ? std::nullopt
-                    : std::optional<tripoint>( player_character.pos() );
+                    : std::optional<tripoint_bub_ms>( player_character.pos_bub() );
             const pickup_activity_actor act( target_items, quantities, starting_pos, false );
             player_character.assign_activity( act );
         } else {

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -1534,6 +1534,11 @@ bool avatar::invoke_item( item *used, const tripoint &pt, int pre_obtain_moves )
     return invoke_item( used, method, pt, pre_obtain_moves );
 }
 
+bool avatar::invoke_item( item *used, const tripoint_bub_ms &pt, int pre_obtain_moves )
+{
+    return avatar::invoke_item( used, pt.raw(), pre_obtain_moves );
+}
+
 bool avatar::invoke_item( item *used )
 {
     return Character::invoke_item( used );

--- a/src/avatar.h
+++ b/src/avatar.h
@@ -319,7 +319,9 @@ class avatar : public Character
                 advanced_inv_area &square );
 
         using Character::invoke_item;
+        // TODO: Get rid of untyped overload
         bool invoke_item( item *, const tripoint &pt, int pre_obtain_moves ) override;
+        bool invoke_item( item *, const tripoint_bub_ms &pt, int pre_obtain_moves ) override;
         bool invoke_item( item * ) override;
         bool invoke_item( item *, const std::string &, const tripoint &pt,
                           int pre_obtain_moves = -1 ) override;

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1028,7 +1028,8 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
         if( !is_avatar() ) {
             return false;
         }
-        std::optional<tripoint> target = lockpick_activity_actor::select_location( player_character );
+        std::optional<tripoint_bub_ms> target = lockpick_activity_actor::select_location(
+                player_character );
         if( target.has_value() ) {
             add_msg_activate();
             assign_activity( lockpick_activity_actor::use_bionic( here.getabs( *target ) ) );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7153,6 +7153,11 @@ bool Character::invoke_item( item *, const tripoint &, int )
     return false;
 }
 
+bool Character::invoke_item( item *, const tripoint_bub_ms &, int )
+{
+    return false;
+}
+
 bool Character::invoke_item( item *used, const std::string &method )
 {
     return invoke_item( used, method, pos() );

--- a/src/character.h
+++ b/src/character.h
@@ -1923,7 +1923,9 @@ class Character : public Creature, public visitable
          * Returns true if it destroys the item. Consumes charges from the item.
          * Multi-use items are ONLY supported when all use_methods are iuse_actor!
          */
+        // TODO: Get rid of untyped overload
         virtual bool invoke_item( item *, const tripoint &pt, int pre_obtain_moves = -1 );
+        virtual bool invoke_item( item *, const tripoint_bub_ms &pt, int pre_obtain_moves = -1 );
         /** As above, but with a pre-selected method. Debugmsg if this item doesn't have this method. */
         virtual bool invoke_item( item *, const std::string &, const tripoint &pt,
                                   int pre_obtain_moves = -1 );
@@ -3523,14 +3525,21 @@ class Character : public Creature, public visitable
         float morale_crafting_speed_multiplier( const recipe &rec ) const;
         float lighting_craft_speed_multiplier( const recipe &rec, const tripoint &p = tripoint_min ) const;
         float crafting_speed_multiplier( const recipe &rec ) const;
+        // TODO: Get rid of untyped overload
         float workbench_crafting_speed_multiplier( const item &craft,
                 const std::optional<tripoint> &loc )const;
+        float workbench_crafting_speed_multiplier( const item &craft,
+                const std::optional<tripoint_bub_ms> &loc )const;
         /** For use with in progress crafts.
          *  Workbench multiplier calculation (especially finding lifters nearby)
          *  is expensive when numorous items are around.
          *  So use pre-calculated cache if possible.
          */
+        // TODO: Get rid of untyped overload
         float crafting_speed_multiplier( const item &craft, const std::optional<tripoint> &loc,
+                                         bool use_cached_workbench_multiplier = false, float cached_workbench_multiplier = 0.0f
+                                       ) const;
+        float crafting_speed_multiplier( const item &craft, const std::optional<tripoint_bub_ms> &loc,
                                          bool use_cached_workbench_multiplier = false, float cached_workbench_multiplier = 0.0f
                                        ) const;
         int available_assistant_count( const recipe &rec ) const;
@@ -3584,7 +3593,9 @@ class Character : public Creature, public visitable
         float item_destruction_chance( const recipe &making ) const;
         craft_roll_data recipe_success_roll_data( const recipe &making ) const;
         craft_roll_data recipe_failure_roll_data( const recipe &making ) const;
+        // TODO: Get rid of untyped overload
         void complete_craft( item &craft, const std::optional<tripoint> &loc );
+        void complete_craft( item &craft, const std::optional<tripoint_bub_ms> &loc );
         /**
          * Check if the player meets the requirements to continue the in progress craft and if
          * unable to continue print messages explaining the reason.

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -628,7 +628,7 @@ void Character::pick_up( const drop_locations &what )
         quantities.emplace_back( dl.second );
     }
 
-    assign_activity( pickup_activity_actor( items, quantities, pos(), false ) );
+    assign_activity( pickup_activity_actor( items, quantities, pos_bub(), false ) );
 }
 
 invlets_bitset Character::allocated_invlets() const

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -120,6 +120,15 @@ void craft_command::execute( const std::optional<tripoint> &new_loc )
     execute();
 }
 
+void craft_command::execute( const std::optional<tripoint_bub_ms> &new_loc )
+{
+    std::optional<tripoint> tmp;
+    if( new_loc.has_value() ) {
+        tmp = new_loc.value().raw();
+    }
+    craft_command::execute( tmp );
+}
+
 void craft_command::execute( bool only_cache_comps )
 {
     if( empty() ) {

--- a/src/craft_command.h
+++ b/src/craft_command.h
@@ -72,7 +72,9 @@ class craft_command
          * Selects components to use for the craft, then assigns the crafting activity to 'crafter'.
          * Executes with supplied location, std::nullopt means crafting from inventory.
          */
+        // TODO: Get rid of untyped overload
         void execute( const std::optional<tripoint> &new_loc );
+        void execute( const std::optional<tripoint_bub_ms> &new_loc );
         /** Executes with saved location, NOT the same as execute( std::nullopt )! */
         void execute( bool only_cache_comps = false );
 

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -296,6 +296,16 @@ float Character::workbench_crafting_speed_multiplier( const item &craft,
     return multiplier;
 }
 
+float Character::workbench_crafting_speed_multiplier( const item &craft,
+        const std::optional<tripoint_bub_ms> &loc )const
+{
+    std::optional<tripoint> tmp;
+    if( loc.has_value() ) {
+        tmp = loc.value().raw();
+    }
+    return Character::workbench_crafting_speed_multiplier( craft, tmp );
+}
+
 float Character::crafting_speed_multiplier( const recipe &rec ) const
 {
 
@@ -384,6 +394,18 @@ float Character::crafting_speed_multiplier( const item &craft,
     }
 
     return total_multi;
+}
+
+float Character::crafting_speed_multiplier( const item &craft,
+        const std::optional<tripoint_bub_ms> &loc, bool use_cached_workbench_multiplier,
+        float cached_workbench_multiplier ) const
+{
+    std::optional<tripoint> tmp;
+    if( loc.has_value() ) {
+        tmp = loc.value().raw();
+    }
+    return Character::crafting_speed_multiplier( craft, tmp, use_cached_workbench_multiplier,
+            cached_workbench_multiplier );
 }
 
 bool Character::has_morale_to_craft() const
@@ -1548,6 +1570,15 @@ void Character::complete_craft( item &craft, const std::optional<tripoint> &loc 
             debugmsg( "Must use an activation eoc for a recipe.  If you don't want the effect_on_condition to happen on its own, remove the recurrence min and max.  Otherwise, create a non-recurring effect_on_condition for this recipe with its condition and effects, then have a recurring one queue it." );
         }
     }
+}
+
+void Character::complete_craft( item &craft, const std::optional<tripoint_bub_ms> &loc )
+{
+    std::optional<tripoint> tmp;
+    if( loc.has_value() ) {
+        tmp = loc.value().raw();
+    }
+    Character::complete_craft( craft, tmp );
 }
 
 bool Character::can_continue_craft( item &craft )

--- a/src/creature_tracker.cpp
+++ b/src/creature_tracker.cpp
@@ -452,19 +452,28 @@ template monster *creature_tracker::creature_at<monster>( const tripoint &, bool
 template monster *creature_tracker::creature_at<monster>( const tripoint_bub_ms &, bool );
 template monster *creature_tracker::creature_at<monster>( const tripoint_abs_ms &, bool );
 template const npc *creature_tracker::creature_at<npc>( const tripoint &, bool ) const;
+template const npc *creature_tracker::creature_at<npc>( const tripoint_bub_ms &, bool ) const;
 template const npc *creature_tracker::creature_at<npc>( const tripoint_abs_ms &, bool ) const;
 template npc *creature_tracker::creature_at<npc>( const tripoint &, bool );
+template npc *creature_tracker::creature_at<npc>( const tripoint_bub_ms &, bool );
 template npc *creature_tracker::creature_at<npc>( const tripoint_abs_ms &, bool );
 template const avatar *creature_tracker::creature_at<avatar>( const tripoint &, bool ) const;
+template const avatar *creature_tracker::creature_at<avatar>( const tripoint_bub_ms &, bool ) const;
 template const avatar *creature_tracker::creature_at<avatar>( const tripoint_abs_ms &, bool ) const;
 template avatar *creature_tracker::creature_at<avatar>( const tripoint &, bool );
+template avatar *creature_tracker::creature_at<avatar>( const tripoint_bub_ms &, bool );
 template avatar *creature_tracker::creature_at<avatar>( const tripoint_abs_ms &, bool );
 template const Character *creature_tracker::creature_at<Character>( const tripoint &, bool ) const;
+template const Character *creature_tracker::creature_at<Character>( const tripoint_bub_ms &,
+        bool ) const;
 template const Character *creature_tracker::creature_at<Character>( const tripoint_abs_ms &,
         bool ) const;
 template Character *creature_tracker::creature_at<Character>( const tripoint &, bool );
+template Character *creature_tracker::creature_at<Character>( const tripoint_bub_ms &, bool );
 template Character *creature_tracker::creature_at<Character>( const tripoint_abs_ms &, bool );
 template const Creature *creature_tracker::creature_at<Creature>( const tripoint &, bool ) const;
+template const Creature *creature_tracker::creature_at<Creature>( const tripoint_bub_ms &,
+        bool ) const;
 template const Creature *creature_tracker::creature_at<Creature>( const tripoint_abs_ms &,
         bool ) const;
 template Creature *creature_tracker::creature_at<Creature>( const tripoint &, bool );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10946,6 +10946,12 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool 
     return true;
 }
 
+bool game::walk_move( const tripoint_bub_ms &dest_loc, const bool via_ramp,
+                      const bool furniture_move )
+{
+    return game::walk_move( dest_loc.raw(), via_ramp, furniture_move );
+}
+
 point game::place_player( const tripoint &dest_loc, bool quick )
 {
     const optional_vpart_position vp1 = m.veh_at( dest_loc );

--- a/src/game.h
+++ b/src/game.h
@@ -872,7 +872,9 @@ class game
         bool phasing_move( const tripoint &dest, bool via_ramp = false );
         bool can_move_furniture( tripoint fdest, const tripoint &dp );
         // Regular movement. Returns false if it failed for any reason
+        // TODO: Get rid of untyped overload
         bool walk_move( const tripoint &dest, bool via_ramp = false, bool furniture_move = false );
+        bool walk_move( const tripoint_bub_ms &dest, bool via_ramp = false, bool furniture_move = false );
         void on_move_effects();
     private:
         // Game-start procedures

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -2240,6 +2240,16 @@ drop_locations game_menus::inv::pickup( avatar &you,
     return pick_s.execute();
 }
 
+drop_locations game_menus::inv::pickup( avatar &you,
+                                        const std::optional<tripoint_bub_ms> &target, const std::vector<drop_location> &selection )
+{
+    std::optional<tripoint> tmp;
+    if( target.has_value() ) {
+        tmp = target.value().raw();
+    }
+    return game_menus::inv::pickup( you, tmp, selection );
+}
+
 class smokable_selector_preset : public inventory_selector_preset
 {
     public:

--- a/src/game_inventory.h
+++ b/src/game_inventory.h
@@ -86,7 +86,11 @@ drop_locations multidrop( Character &you );
  * Otherwise, pick up items from the avatar's current location and all adjacent tiles.
  * @return A list of pairs of item_location, quantity.
  */
+// TODO: Get rid of untyped overload. Restore the target default while doing so (removed
+// to allow profiles to be distinguished.
 drop_locations pickup( avatar &you, const std::optional<tripoint> &target = std::nullopt,
+                       const std::vector<drop_location> &selection = {} );
+drop_locations pickup( avatar &you, const std::optional<tripoint_bub_ms> &target,
                        const std::vector<drop_location> &selection = {} );
 
 drop_locations smoke_food( Character &you, units::volume total_capacity,

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1394,7 +1394,7 @@ bool iexamine::can_hack( Character &you )
     return true;
 }
 
-bool iexamine::try_start_hacking( Character &you, const tripoint &examp )
+bool iexamine::try_start_hacking( Character &you, const tripoint_bub_ms &examp )
 {
     if( !can_hack( you ) ) {
         return false;
@@ -1429,7 +1429,7 @@ void iexamine::cardreader_foodplace( Character &you, const tripoint &examp )
         query_yn( _( "Press mask on the reader?" ) ) ) {
         you.mod_moves( -100 );
         map &here = get_map();
-        for( const tripoint &tmp : here.points_in_radius( examp, 3 ) ) {
+        for( const tripoint_bub_ms &tmp : here.points_in_radius( tripoint_bub_ms( examp ), 3 ) ) {
             if( here.ter( tmp ) == ter_t_door_metal_locked ) {
                 here.ter_set( tmp, ter_t_door_metal_c );
                 open = true;
@@ -1443,9 +1443,9 @@ void iexamine::cardreader_foodplace( Character &you, const tripoint &examp )
         } else {
             add_msg( _( "The nearby doors are already unlocked." ) );
             if( query_yn( _( "Lock doors?" ) ) ) {
-                for( const tripoint &tmp : here.points_in_radius( examp, 3 ) ) {
+                for( const tripoint_bub_ms &tmp : here.points_in_radius( tripoint_bub_ms( examp ), 3 ) ) {
                     if( here.ter( tmp ) == ter_t_door_metal_o || here.ter( tmp ) == ter_t_door_metal_c ) {
-                        if( you.pos() == tmp ) {
+                        if( you.pos_bub() == tmp ) {
                             you.add_msg_if_player( m_bad, _( "You are in the way of the door, move before trying again." ) );
                         } else {
                             here.ter_set( tmp, ter_t_door_metal_locked );
@@ -1464,7 +1464,7 @@ void iexamine::cardreader_foodplace( Character &you, const tripoint &examp )
                        _( "\"Your face is inadequate.  Please go away.\"" ), true,
                        "speech", "welcome" );
         if( can_hack( you ) && query_yn( _( "Attempt to hack this card-reader?" ) ) ) {
-            try_start_hacking( you, examp );
+            try_start_hacking( you, tripoint_bub_ms( examp ) );
         }
     }
 }
@@ -1706,7 +1706,8 @@ void iexamine::portable_structure( Character &you, const tripoint &examp )
         return;
     }
 
-    tent_deconstruct_activity_actor actor( to_moves<int>( 20_minutes ), radius, examp, dropped );
+    tent_deconstruct_activity_actor actor( to_moves<int>( 20_minutes ), radius,
+                                           tripoint_bub_ms( examp ), dropped );
     you.assign_activity( actor );
 }
 
@@ -1816,7 +1817,7 @@ void iexamine::safe( Character &you, const tripoint &examp )
 void iexamine::gunsafe_el( Character &you, const tripoint &examp )
 {
     if( query_yn( _( "Attempt to hack this safe?" ) ) ) {
-        try_start_hacking( you, examp );
+        try_start_hacking( you, tripoint_bub_ms( examp ) );
     }
 }
 
@@ -4771,7 +4772,7 @@ static void reload_furniture( Character &you, const tripoint &examp, bool allow_
                     if( itm->typeId() == ammo_itypeID ) {
                         if( you.can_stash( *itm ) ) {
                             std::vector<item_location> target_items{ item_location( map_cursor( examp ), &*itm ) };
-                            you.assign_activity( pickup_activity_actor( target_items, { 0 }, you.pos(), false ) );
+                            you.assign_activity( pickup_activity_actor( target_items, { 0 }, you.pos_bub(), false ) );
                             return;
                         } else {
                             // get handling cost before the item reference is invalidated
@@ -4963,11 +4964,11 @@ void iexamine::sign( Character &you, const tripoint &examp )
     }
 }
 
-static int getNearPumpCount( const tripoint &p, fuel_station_fuel_type &fuel_type )
+static int getNearPumpCount( const tripoint_bub_ms &p, fuel_station_fuel_type &fuel_type )
 {
     int result = 0;
     map &here = get_map();
-    for( const tripoint &tmp : here.points_in_radius( p, 12 ) ) {
+    for( const tripoint_bub_ms &tmp : here.points_in_radius( p, 12 ) ) {
         const ter_id t = here.ter( tmp );
         if( t == ter_t_gas_pump || t == ter_t_gas_pump_a ) {
             result++;
@@ -4980,15 +4981,16 @@ static int getNearPumpCount( const tripoint &p, fuel_station_fuel_type &fuel_typ
     return result;
 }
 
-std::optional<tripoint> iexamine::getNearFilledGasTank( const tripoint &center, int &fuel_units,
+std::optional<tripoint_bub_ms> iexamine::getNearFilledGasTank( const tripoint_bub_ms &center,
+        int &fuel_units,
         fuel_station_fuel_type &fuel_type )
 {
-    std::optional<tripoint> tank_loc;
+    std::optional<tripoint_bub_ms> tank_loc;
     int distance = INT_MAX;
     fuel_units = 0;
 
     map &here = get_map();
-    for( const tripoint &tmp : here.points_in_radius( center, SEEX * 2 ) ) {
+    for( const tripoint_bub_ms &tmp : here.points_in_radius( center, SEEX * 2 ) ) {
 
         furn_id check_for_fuel_tank = here.furn( tmp );
 
@@ -5088,11 +5090,11 @@ static int getGasPricePerLiter( int discount )
     }
 }
 
-std::optional<tripoint> iexamine::getGasPumpByNumber( const tripoint &p, int number )
+std::optional<tripoint_bub_ms> iexamine::getGasPumpByNumber( const tripoint_bub_ms &p, int number )
 {
     int k = 0;
     map &here = get_map();
-    for( const tripoint &tmp : here.points_in_radius( p, 12 ) ) {
+    for( const tripoint_bub_ms &tmp : here.points_in_radius( p, 12 ) ) {
         const ter_id t = here.ter( tmp );
         if( ( t == ter_t_gas_pump || t == ter_t_gas_pump_a
               || t == ter_t_diesel_pump || t == ter_t_diesel_pump_a ) && number == k++ ) {
@@ -5102,7 +5104,7 @@ std::optional<tripoint> iexamine::getGasPumpByNumber( const tripoint &p, int num
     return std::nullopt;
 }
 
-bool iexamine::toPumpFuel( const tripoint &src, const tripoint &dst, int units )
+bool iexamine::toPumpFuel( const tripoint_bub_ms &src, const tripoint_bub_ms &dst, int units )
 {
     map &here = get_map();
     map_stack items = here.i_at( src );
@@ -5129,7 +5131,7 @@ bool iexamine::toPumpFuel( const tripoint &src, const tripoint &dst, int units )
     return false;
 }
 
-static int fromPumpFuel( const tripoint &dst, const tripoint &src )
+static int fromPumpFuel( const tripoint_bub_ms &dst, const tripoint_bub_ms &src )
 {
     map &here = get_map();
     map_stack items = here.i_at( src );
@@ -5156,11 +5158,12 @@ static int fromPumpFuel( const tripoint &dst, const tripoint &src )
     return -1;
 }
 
-static void turnOnSelectedPump( const tripoint &p, int number, fuel_station_fuel_type &fuel_type )
+static void turnOnSelectedPump( const tripoint_bub_ms &p, int number,
+                                fuel_station_fuel_type &fuel_type )
 {
     int k = 0;
     map &here = get_map();
-    for( const tripoint &tmp : here.points_in_radius( p, 12 ) ) {
+    for( const tripoint_bub_ms &tmp : here.points_in_radius( p, 12 ) ) {
         const ter_id t = here.ter( tmp );
         if( fuel_type == FUEL_TYPE_GASOLINE ) {
             if( t == ter_t_gas_pump || t == ter_t_gas_pump_a ) {
@@ -5197,7 +5200,7 @@ void iexamine::pay_gas( Character &you, const tripoint &examp )
 
     fuel_station_fuel_type fuelType = FUEL_TYPE_NONE;
     std::string fuelTypeStr;
-    int pumpCount = getNearPumpCount( examp, fuelType );
+    int pumpCount = getNearPumpCount( tripoint_bub_ms( examp ), fuelType );
     fuelTypeStr = fuelType == FUEL_TYPE_GASOLINE ? _( "gasoline" ) : fuelType == FUEL_TYPE_DIESEL ?
                   _( "diesel" ) : "";
     if( pumpCount == 0 ) {
@@ -5206,12 +5209,13 @@ void iexamine::pay_gas( Character &you, const tripoint &examp )
     }
 
     int tankUnits;
-    const std::optional<tripoint> pTank_ = getNearFilledGasTank( examp, tankUnits, fuelType );
+    const std::optional<tripoint_bub_ms> pTank_ = getNearFilledGasTank( tripoint_bub_ms( examp ),
+            tankUnits, fuelType );
     if( !pTank_ ) {
         popup( str_to_illiterate_str( string_format( _( "Failure!  No %s tank found!" ), fuelTypeStr ) ) );
         return;
     }
-    const tripoint pTank = *pTank_;
+    const tripoint_bub_ms pTank = *pTank_;
 
     if( tankUnits == 0 ) {
         popup( str_to_illiterate_str(
@@ -5266,7 +5270,8 @@ void iexamine::pay_gas( Character &you, const tripoint &examp )
         for( int i = 0; i < pumpCount; i++ ) {
             amenu.addentry( i, true, -1,
                             str_to_illiterate_str( _( "Pump " ) ) + std::to_string( i + 1 ) );
-            pumps.emplace_back( getGasPumpByNumber( examp, i ).value_or( examp ) );
+            pumps.emplace_back( getGasPumpByNumber( tripoint_bub_ms( examp ),
+                                                    i ).value_or( tripoint_bub_ms( examp ) ).raw() );
         }
         pointmenu_cb callback( pumps );
         amenu.callback = &callback;
@@ -5280,7 +5285,7 @@ void iexamine::pay_gas( Character &you, const tripoint &examp )
 
         uistate.ags_pay_gas_selected_pump = choice;
 
-        turnOnSelectedPump( examp, uistate.ags_pay_gas_selected_pump, fuelType );
+        turnOnSelectedPump( tripoint_bub_ms( examp ), uistate.ags_pay_gas_selected_pump, fuelType );
 
         return;
 
@@ -5312,7 +5317,7 @@ void iexamine::pay_gas( Character &you, const tripoint &examp )
             liters = maximum_liters;
         }
 
-        const std::optional<tripoint> pGasPump = getGasPumpByNumber( examp,
+        const std::optional<tripoint_bub_ms> pGasPump = getGasPumpByNumber( tripoint_bub_ms( examp ),
                 uistate.ags_pay_gas_selected_pump );
         if( !pGasPump || !toPumpFuel( pTank, *pGasPump, liters * 1000 ) ) {
             return;
@@ -5331,7 +5336,7 @@ void iexamine::pay_gas( Character &you, const tripoint &examp )
     }
 
     if( hack == choice ) {
-        try_start_hacking( you, examp );
+        try_start_hacking( you, tripoint_bub_ms( examp ) );
     }
 
     if( refund == choice ) {
@@ -5341,7 +5346,7 @@ void iexamine::pay_gas( Character &you, const tripoint &examp )
             return;
         }
 
-        const std::optional<tripoint> pGasPump = getGasPumpByNumber( examp,
+        const std::optional<tripoint_bub_ms> pGasPump = getGasPumpByNumber( tripoint_bub_ms( examp ),
                 uistate.ags_pay_gas_selected_pump );
         int amount_fuel = pGasPump ? fromPumpFuel( pTank, *pGasPump ) : -1;
         if( amount_fuel < 0 ) {

--- a/src/iexamine.h
+++ b/src/iexamine.h
@@ -10,6 +10,7 @@
 #include <tuple>
 #include <vector>
 
+#include "coordinates.h"
 #include "ret_val.h"
 #include "type_id.h"
 
@@ -48,7 +49,7 @@ namespace iexamine
 
 bool can_hack( Character &you );
 
-bool try_start_hacking( Character &you, const tripoint &examp );
+bool try_start_hacking( Character &you, const tripoint_bub_ms &examp );
 
 void egg_sack_generic( Character &you, const tripoint &examp, const mtype_id &montype );
 
@@ -146,9 +147,9 @@ void workout( Character &you, const tripoint &examp );
 void invalid( Character &you, const tripoint &examp );
 
 bool pour_into_keg( const tripoint &pos, item &liquid );
-std::optional<tripoint> getGasPumpByNumber( const tripoint &p, int number );
-bool toPumpFuel( const tripoint &src, const tripoint &dst, int units );
-std::optional<tripoint> getNearFilledGasTank( const tripoint &center, int &fuel_units,
+std::optional<tripoint_bub_ms> getGasPumpByNumber( const tripoint_bub_ms &p, int number );
+bool toPumpFuel( const tripoint_bub_ms &src, const tripoint_bub_ms &dst, int units );
+std::optional<tripoint_bub_ms> getNearFilledGasTank( const tripoint_bub_ms &center, int &fuel_units,
         fuel_station_fuel_type &fuel_type );
 
 bool has_keg( const tripoint &pos );

--- a/src/iexamine_actors.cpp
+++ b/src/iexamine_actors.cpp
@@ -189,7 +189,7 @@ void cardreader_examine_actor::call( Character &you, const tripoint &examp ) con
         }
     } else if( allow_hacking && iexamine::can_hack( you ) &&
                query_yn( _( "Attempt to hack this card-reader?" ) ) ) {
-        iexamine::try_start_hacking( you, examp );
+        iexamine::try_start_hacking( you, tripoint_bub_ms( examp ) );
     }
 }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -10979,6 +10979,11 @@ int item::ammo_consume( int qty, const tripoint &pos, Character *carrier )
     return wanted_qty - qty;
 }
 
+int item::ammo_consume( int qty, const tripoint_bub_ms &pos, Character *carrier )
+{
+    return item::ammo_consume( qty, pos.raw(), carrier );
+}
+
 units::energy item::energy_consume( units::energy qty, const tripoint &pos, Character *carrier,
                                     float fuel_efficiency )
 {

--- a/src/item.h
+++ b/src/item.h
@@ -2487,7 +2487,9 @@ class item : public visitable
          * @param fuel_efficiency if this is a generator of some kind the efficiency at which it consumes fuel
          * @return amount of ammo consumed which will be between 0 and qty
          */
+        // TODO: Get rid of untyped overload
         int ammo_consume( int qty, const tripoint &pos, Character *carrier );
+        int ammo_consume( int qty, const tripoint_bub_ms &pos, Character *carrier );
 
         /**
          * Consume energy (if available) and return the amount of energy that was consumed

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -3070,12 +3070,12 @@ std::optional<int> iuse::pick_lock( Character *p, item *it, const tripoint &pos 
     }
     avatar &you = dynamic_cast<avatar &>( *p );
 
-    std::optional<tripoint> target;
+    std::optional<tripoint_bub_ms> target;
     // Prompt for a target lock to pick, or use the given tripoint
     if( pos == you.pos() ) {
         target = lockpick_activity_actor::select_location( you );
     } else {
-        target = pos;
+        target = tripoint_bub_ms( pos );
     }
     if( !target.has_value() ) {
         return std::nullopt;
@@ -4688,9 +4688,9 @@ std::optional<int> iuse::hacksaw( Character *p, item *it, const tripoint &it_pnt
     }
 
     map &here = get_map();
-    const std::function<bool( const tripoint & )> f =
-    [&here, p]( const tripoint & pnt ) {
-        if( pnt == p->pos() ) {
+    const std::function<bool( const tripoint_bub_ms & )> f =
+    [&here, p]( const tripoint_bub_ms & pnt ) {
+        if( pnt == p->pos_bub() ) {
             return false;
         } else if( here.has_furn( pnt ) ) {
             return here.furn( pnt )->hacksaw->valid();
@@ -4700,14 +4700,14 @@ std::optional<int> iuse::hacksaw( Character *p, item *it, const tripoint &it_pnt
         return false;
     };
 
-    const std::optional<tripoint> pnt_ = choose_adjacent_highlight(
-            _( "Cut up metal where?" ), _( "There is no metal to cut up nearby." ), f, false );
+    const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_highlight(
+                _( "Cut up metal where?" ), _( "There is no metal to cut up nearby." ), f, false );
     if( !pnt_ ) {
         return std::nullopt;
     }
-    const tripoint &pnt = *pnt_;
+    const tripoint_bub_ms &pnt = *pnt_;
     if( !f( pnt ) ) {
-        if( pnt == p->pos() ) {
+        if( pnt == p->pos_bub() ) {
             p->add_msg_if_player( m_info, _( "Why would you do that?" ) );
             p->add_msg_if_player( m_info, _( "You're not even chained to a boiler." ) );
         } else {
@@ -4718,7 +4718,7 @@ std::optional<int> iuse::hacksaw( Character *p, item *it, const tripoint &it_pnt
     if( p->pos() == it_pnt ) {
         p->assign_activity( hacksaw_activity_actor( pnt, item_location{ *p, it } ) );
     } else {
-        p->assign_activity( hacksaw_activity_actor( pnt, it->typeId(), it_pnt ) );
+        p->assign_activity( hacksaw_activity_actor( pnt, it->typeId(), tripoint_bub_ms( it_pnt ) ) );
     }
 
     return std::nullopt;
@@ -9187,4 +9187,10 @@ std::optional<int> use_function::call( Character *p, item &it,
                                        const tripoint &pos ) const
 {
     return actor->use( p, it, pos );
+}
+
+std::optional<int> use_function::call( Character *p, item &it,
+                                       const tripoint_bub_ms &pos ) const
+{
+    return use_function::call( p, it, pos.raw() );
 }

--- a/src/iuse.h
+++ b/src/iuse.h
@@ -327,7 +327,9 @@ struct use_function {
         use_function( const std::string &type, use_function_pointer f );
         explicit use_function( std::unique_ptr<iuse_actor> f ) : actor( std::move( f ) ) {}
 
+        // TODO: get rid of untyped overload
         std::optional<int> call( Character *, item &, const tripoint & ) const;
+        std::optional<int> call( Character *, item &, const tripoint_bub_ms & ) const;
         ret_val<void> can_call( const Character &, const item &, const tripoint &pos ) const;
 
         iuse_actor *get_actor_ptr() {

--- a/src/line.cpp
+++ b/src/line.cpp
@@ -8,7 +8,6 @@
 
 #include "cata_assert.h"
 #include "enums.h"
-//####include "line_coordinates.h"
 #include "math_defines.h"
 #include "output.h"
 #include "string_formatter.h"

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5228,7 +5228,7 @@ item_location map::add_item_ret_loc( const tripoint &pos, item obj, bool overflo
 
 item_location map::add_item_ret_loc( const tripoint_bub_ms &pos, item obj, bool overflow )
 {
-    return map::add_item_ret_loc( pos.raw(), obj, overflow );
+    return map::add_item_ret_loc( pos.raw(), std::move( obj ), overflow );
 }
 
 item &map::add_item_or_charges( const tripoint &pos, item obj, bool overflow )
@@ -5386,7 +5386,7 @@ item &map::add_item( const tripoint &p, item new_item )
 
 item &map::add_item( const tripoint_bub_ms &p, item new_item )
 {
-    return map::add_item( p.raw(), new_item );
+    return map::add_item( p.raw(), std::move( new_item ) );
 }
 
 item &map::add_item( const tripoint &p, item new_item, int copies )

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1392,6 +1392,11 @@ void map::board_vehicle( const tripoint &pos, Character *p )
     }
 }
 
+void map::board_vehicle( const tripoint_bub_ms &pos, Character *p )
+{
+    map::board_vehicle( pos.raw(), p );
+}
+
 void map::unboard_vehicle( const vpart_reference &vp, Character *passenger, bool dead_passenger )
 {
     // Mark the part as un-occupied regardless of whether there's a live passenger here.
@@ -1560,7 +1565,7 @@ bool map::displace_vehicle( vehicle &veh, const tripoint &dp, const bool adjust_
             // Place passenger on the new part location
             tripoint_bub_ms psgp( dst + next_pos + tripoint( 0, 0, psg_offset_z ) );
             // someone is in the way so try again
-            if( creatures.creature_at( psgp ) ) {
+            if( creatures.creature_at( psgp.raw() ) ) {//###
                 complete = false;
                 continue;
             }
@@ -1748,7 +1753,7 @@ bool map::furn_set( const tripoint &p, const furn_id &new_furniture, const bool 
         return false;
     }
     if( avoid_creatures ) {
-        Creature *c = get_creature_tracker().creature_at( tripoint_abs_ms( getabs( p ) ), true );
+        Creature *c = get_creature_tracker().creature_at( getglobal( p ), true );
         if( c ) {
             return false;
         }
@@ -2229,7 +2234,7 @@ bool map::ter_set( const tripoint &p, const ter_id &new_terrain, bool avoid_crea
         return false;
     }
     if( avoid_creatures ) {
-        Creature *c = get_creature_tracker().creature_at( tripoint_abs_ms( getabs( p ) ), true );
+        Creature *c = get_creature_tracker().creature_at( getglobal( p ), true );
         if( c ) {
             return false;
         }
@@ -2432,6 +2437,11 @@ bool map::is_open_air( const tripoint &p ) const
         return false;
     }
     return current_submap->is_open_air( l );
+}
+
+bool map::is_open_air( const tripoint_bub_ms &p ) const
+{
+    return map::is_open_air( p.raw() );
 }
 
 // Move cost: 3D
@@ -3273,9 +3283,19 @@ bool map::is_bashable_ter( const tripoint &p, const bool allow_floor ) const
     return ter_bash.str_max != -1 && ( !ter_bash.bash_below || allow_floor );
 }
 
+bool map::is_bashable_ter( const tripoint_bub_ms &p, const bool allow_floor ) const
+{
+    return map::is_bashable_ter( p.raw(), allow_floor );
+}
+
 bool map::is_bashable_furn( const tripoint &p ) const
 {
     return has_furn( p ) && furn( p ).obj().bash.str_max != -1;
+}
+
+bool map::is_bashable_furn( const tripoint_bub_ms &p ) const
+{
+    return map::is_bashable_furn( p.raw() );
 }
 
 bool map::is_bashable_ter_furn( const tripoint &p, const bool allow_floor ) const
@@ -3333,7 +3353,7 @@ int map::bash_rating( const int str, const tripoint &p, const bool allow_floor )
 
 // End of 3D bashable
 
-void map::make_rubble( const tripoint &p, const furn_id &rubble_type, const bool items,
+void map::make_rubble( const tripoint_bub_ms &p, const furn_id &rubble_type, const bool items,
                        const ter_id &floor_type, bool overwrite )
 {
     if( overwrite ) {
@@ -3752,7 +3772,7 @@ bool map::mop_spills( const tripoint_bub_ms &p )
     return retval;
 }
 
-int map::collapse_check( const tripoint &p ) const
+int map::collapse_check( const tripoint_bub_ms &p ) const
 {
     const bool collapses = has_flag( ter_furn_flag::TFLAG_COLLAPSES, p );
     const bool supports_roof = has_flag( ter_furn_flag::TFLAG_SUPPORTS_ROOF, p );
@@ -3764,11 +3784,11 @@ int map::collapse_check( const tripoint &p ) const
         return 0;
     }
 
-    int num_supports = p.z == OVERMAP_DEPTH ? 0 : -5;
+    int num_supports = p.z() == OVERMAP_DEPTH ? 0 : -5;
     // if there's support below, things are less likely to collapse
-    if( p.z > -OVERMAP_DEPTH ) {
-        const tripoint &pbelow = tripoint( p.xy(), p.z - 1 );
-        for( const tripoint &tbelow : points_in_radius( pbelow, 1 ) ) {
+    if( p.z() > -OVERMAP_DEPTH ) {
+        const tripoint_bub_ms &pbelow = tripoint_bub_ms( p.xy(), p.z() - 1 );
+        for( const tripoint_bub_ms &tbelow : points_in_radius( pbelow, 1 ) ) {
             if( has_flag( ter_furn_flag::TFLAG_SUPPORTS_ROOF, tbelow ) ) {
                 num_supports += 1;
                 if( has_flag( ter_furn_flag::TFLAG_WALL, tbelow ) ) {
@@ -3781,7 +3801,7 @@ int map::collapse_check( const tripoint &p ) const
         }
     }
 
-    for( const tripoint &t : points_in_radius( p, 1 ) ) {
+    for( const tripoint_bub_ms &t : points_in_radius( p, 1 ) ) {
         if( p == t ) {
             continue;
         }
@@ -3808,7 +3828,7 @@ int map::collapse_check( const tripoint &p ) const
 
 // there is still some odd behavior here and there and you can get floating chunks of
 // unsupported floor, but this is much better than it used to be
-void map::collapse_at( const tripoint &p, const bool silent, const bool was_supporting,
+void map::collapse_at( const tripoint_bub_ms &p, const bool silent, const bool was_supporting,
                        const bool destroy_pos )
 {
     const bool supports = was_supporting || has_flag( ter_furn_flag::TFLAG_SUPPORTS_ROOF, p );
@@ -3823,9 +3843,9 @@ void map::collapse_at( const tripoint &p, const bool silent, const bool was_supp
 
     // If something supporting the roof collapsed, see what else collapses
     if( supports && !still_supports ) {
-        for( const tripoint &t : points_in_radius( p, 1 ) ) {
+        for( const tripoint_bub_ms &t : points_in_radius( p, 1 ) ) {
             // If z-levels are off, tz == t, so we end up skipping a lot of stuff to avoid bugs.
-            const tripoint &tz = tripoint( t.xy(), t.z + 1 );
+            const tripoint_bub_ms &tz = tripoint_bub_ms( t.xy(), t.z() + 1 );
             // if nothing above us had the chance of collapsing, move on
             if( !one_in( collapse_check( tz ) ) ) {
                 continue;
@@ -3849,7 +3869,7 @@ void map::collapse_at( const tripoint &p, const bool silent, const bool was_supp
                 if( !has_flag( ter_furn_flag::TFLAG_WALL, t ) ) {
                     furn_set( tz, furn_str_id::NULL_ID() );
                     ter_set( tz, ter_t_open_air );
-                    Creature *critter = get_creature_tracker().creature_at( tz );
+                    Creature *critter = get_creature_tracker().creature_at( tz.raw() );//###
                     if( critter != nullptr ) {
                         creature_on_trap( *critter );
                     }
@@ -4292,7 +4312,7 @@ void map::bash_ter_furn( const tripoint &p, bash_params &params )
     }
 
     if( will_collapse && !has_flag( ter_furn_flag::TFLAG_SUPPORTS_ROOF, p ) ) {
-        collapse_at( p, params.silent, true, bash->explosive > 0 );
+        collapse_at( tripoint_bub_ms( p ), params.silent, true, bash->explosive > 0 );
     }
 
     params.did_bash = true;
@@ -4416,6 +4436,11 @@ void map::destroy( const tripoint &p, const bool silent )
     }
 }
 
+void map::destroy( const tripoint_bub_ms &p, const bool silent )
+{
+    map::destroy( p.raw(), silent );
+}
+
 void map::destroy_furn( const tripoint &p, const bool silent )
 {
     // Break if it takes more than 25 destructions to remove to prevent infinite loops
@@ -4440,10 +4465,10 @@ void map::batter( const tripoint &p, int power, int tries, const bool silent )
     }
 }
 
-void map::crush( const tripoint &p )
+void map::crush( const tripoint_bub_ms &p )
 {
     creature_tracker &creatures = get_creature_tracker();
-    Character *crushed_player = creatures.creature_at<Character>( p );
+    Character *crushed_player = creatures.creature_at<Character>( p.raw() );//###
 
     if( crushed_player != nullptr ) {
         bool player_inside = false;
@@ -4480,7 +4505,7 @@ void map::crush( const tripoint &p )
         }
     }
 
-    if( monster *const monhit = creatures.creature_at<monster>( p ) ) {
+    if( monster *const monhit = creatures.creature_at<monster>( p.raw() ) ) {//###
         // 25 ~= 60 * .45 (torso)
         monhit->deal_damage( nullptr, bodypart_id( "torso" ), damage_instance( damage_bash, rng( 0,
                              25 ) ) );
@@ -5161,6 +5186,13 @@ void map::spawn_item( const tripoint &p, const itype_id &type_id, const unsigned
     add_item_or_charges( p, new_item );
 }
 
+void map::spawn_item( const tripoint_bub_ms &p, const itype_id &type_id, const unsigned quantity,
+                      const int charges, const time_point &birthday, const int damlevel, const std::set<flag_id> &flags,
+                      const std::string &variant, const std::string &faction )
+{
+    map::spawn_item( p.raw(), type_id, quantity, charges, birthday, damlevel, flags, variant, faction );
+}
+
 units::volume map::max_volume( const tripoint &p )
 {
     return i_at( p ).max_volume();
@@ -5192,6 +5224,11 @@ item_location map::add_item_ret_loc( const tripoint &pos, item obj, bool overflo
     }
 
     return {};
+}
+
+item_location map::add_item_ret_loc( const tripoint_bub_ms &pos, item obj, bool overflow )
+{
+    return map::add_item_ret_loc( pos.raw(), obj, overflow );
 }
 
 item &map::add_item_or_charges( const tripoint &pos, item obj, bool overflow )
@@ -5346,6 +5383,12 @@ item &map::add_item( const tripoint &p, item new_item )
     int copies = 1;
     return add_item( p, std::move( new_item ), copies );
 }
+
+item &map::add_item( const tripoint_bub_ms &p, item new_item )
+{
+    return map::add_item( p.raw(), new_item );
+}
+
 item &map::add_item( const tripoint &p, item new_item, int copies )
 {
     if( item_is_blacklisted( new_item.typeId() ) ) {
@@ -10624,7 +10667,7 @@ static bool is_haulable( const item &it )
     return !it.made_of_from_type( phase_id::LIQUID );
 }
 
-bool map::has_haulable_items( const tripoint &pos )
+bool map::has_haulable_items( const tripoint_bub_ms &pos )
 {
     const map_stack items = i_at( pos );
     for( const item &it : items ) {
@@ -10646,6 +10689,11 @@ std::vector<item_location> map::get_haulable_items( const tripoint &pos )
         }
     }
     return target_items;
+}
+
+std::vector<item_location> map::get_haulable_items( const tripoint_bub_ms &pos )
+{
+    return map::get_haulable_items( pos.raw() );
 }
 
 tripoint_bub_ms drawsq_params::center() const

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1565,7 +1565,7 @@ bool map::displace_vehicle( vehicle &veh, const tripoint &dp, const bool adjust_
             // Place passenger on the new part location
             tripoint_bub_ms psgp( dst + next_pos + tripoint( 0, 0, psg_offset_z ) );
             // someone is in the way so try again
-            if( creatures.creature_at( psgp.raw() ) ) {//###
+            if( creatures.creature_at( psgp ) ) {
                 complete = false;
                 continue;
             }
@@ -3869,7 +3869,7 @@ void map::collapse_at( const tripoint_bub_ms &p, const bool silent, const bool w
                 if( !has_flag( ter_furn_flag::TFLAG_WALL, t ) ) {
                     furn_set( tz, furn_str_id::NULL_ID() );
                     ter_set( tz, ter_t_open_air );
-                    Creature *critter = get_creature_tracker().creature_at( tz.raw() );//###
+                    Creature *critter = get_creature_tracker().creature_at( tz );
                     if( critter != nullptr ) {
                         creature_on_trap( *critter );
                     }
@@ -4468,7 +4468,7 @@ void map::batter( const tripoint &p, int power, int tries, const bool silent )
 void map::crush( const tripoint_bub_ms &p )
 {
     creature_tracker &creatures = get_creature_tracker();
-    Character *crushed_player = creatures.creature_at<Character>( p.raw() );//###
+    Character *crushed_player = creatures.creature_at<Character>( p );
 
     if( crushed_player != nullptr ) {
         bool player_inside = false;
@@ -4505,7 +4505,7 @@ void map::crush( const tripoint_bub_ms &p )
         }
     }
 
-    if( monster *const monhit = creatures.creature_at<monster>( p.raw() ) ) {//###
+    if( monster *const monhit = creatures.creature_at<monster>( p ) ) {
         // 25 ~= 60 * .45 (torso)
         monhit->deal_damage( nullptr, bodypart_id( "torso" ), damage_instance( damage_bash, rng( 0,
                              25 ) ) );

--- a/src/map.h
+++ b/src/map.h
@@ -595,7 +595,9 @@ class map
         }
         bool is_wall_adjacent( const tripoint &center ) const;
 
+        // TODO: Get rid of untyped overload
         bool is_open_air( const tripoint & ) const;
+        bool is_open_air( const tripoint_bub_ms &p ) const;
 
         /**
         * Similar behavior to `move_cost()`, but ignores vehicles.
@@ -781,7 +783,9 @@ class map
         vehicle *veh_at_internal( const tripoint &p, int &part_num );
         const vehicle *veh_at_internal( const tripoint &p, int &part_num ) const;
         // Put player on vehicle at x,y
+        // TODO: get rid of untyped overload
         void board_vehicle( const tripoint &p, Character *pl );
+        void board_vehicle( const tripoint_bub_ms &p, Character *pl );
         // Remove given passenger from given vehicle part.
         // If dead_passenger, then null passenger is acceptable.
         void unboard_vehicle( const vpart_reference &, Character *passenger,
@@ -1089,12 +1093,16 @@ class map
             return is_bashable( tripoint( p, abs_sub.z() ) );
         }
         /** Returns true if the terrain at p is bashable */
+        // TODO: Get rid of untyped overload
         bool is_bashable_ter( const tripoint &p, bool allow_floor = false ) const;
+        bool is_bashable_ter( const tripoint_bub_ms &p, bool allow_floor = false ) const;
         bool is_bashable_ter( const point &p ) const {
             return is_bashable_ter( tripoint( p, abs_sub.z() ) );
         }
         /** Returns true if the furniture at p is bashable */
+        //TODO: Get rid of untyped overload
         bool is_bashable_furn( const tripoint &p ) const;
+        bool is_bashable_furn( const tripoint_bub_ms &p ) const;
         bool is_bashable_furn( const point &p ) const {
             return is_bashable_furn( tripoint( p, abs_sub.z() ) );
         }
@@ -1123,12 +1131,17 @@ class map
         // Rubble
         /** Generates rubble at the given location, if overwrite is true it just writes on top of what currently exists
          *  floor_type is only used if there is a non-bashable wall at the location or with overwrite = true */
-        void make_rubble( const tripoint &p, const furn_id &rubble_type, bool items,
+        void make_rubble( const tripoint_bub_ms &p, const furn_id &rubble_type, bool items,
                           const ter_id &floor_type, bool overwrite = false );
         void make_rubble( const tripoint &p, const furn_id &rubble_type, bool items ) {
-            make_rubble( p, rubble_type, items, ter_str_id( "t_dirt" ).id(), false );
+            make_rubble( tripoint_bub_ms( p ), rubble_type, items, ter_str_id( "t_dirt" ).id(), false );
         }
+        // TODO: Get rid of untyped overload
         void make_rubble( const tripoint &p ) {
+            make_rubble( tripoint_bub_ms( p ), furn_str_id( "f_rubble" ), false, ter_str_id( "t_dirt" ).id(),
+                         false );
+        }
+        void make_rubble( const tripoint_bub_ms &p ) {
             make_rubble( p, furn_str_id( "f_rubble" ), false, ter_str_id( "t_dirt" ).id(), false );
         }
 
@@ -1228,17 +1241,19 @@ class map
         /** bash a square for a set number of times at set power.  Does not destroy */
         void batter( const tripoint &p, int power, int tries = 1, bool silent = false );
         /** Keeps bashing a square until it can't be bashed anymore */
+        // TODO: Get rid of untyped overload
         void destroy( const tripoint &p, bool silent = false );
+        void destroy( const tripoint_bub_ms &p, bool silent = false );
         /** Keeps bashing a square until there is no more furniture */
         // TODO: fix point types (remove the first overload)
         void destroy_furn( const tripoint &p, bool silent = false );
         void destroy_furn( const tripoint_bub_ms &, bool silent = false );
-        void crush( const tripoint &p );
+        void crush( const tripoint_bub_ms &p );
         void shoot( const tripoint &p, projectile &proj, bool hit_items );
         /** Checks if a square should collapse, returns the X for the one_in(X) collapse chance */
-        int collapse_check( const tripoint &p ) const;
+        int collapse_check( const tripoint_bub_ms &p ) const;
         /** Causes a collapse at p, such as from destroying a wall */
-        void collapse_at( const tripoint &p, bool silent, bool was_supporting = false,
+        void collapse_at( const tripoint_bub_ms &p, bool silent, bool was_supporting = false,
                           bool destroy_pos = true );
         /** Tries to smash the items at the given tripoint. Used by the explosion code */
         void smash_items( const tripoint &p, int power, const std::string &cause_message );
@@ -1352,7 +1367,13 @@ class map
                              int power_level = 1000, int max_negative_power = -2000, bool is_resonant = false );
         void spawn_artifact( const tripoint_bub_ms &p, const relic_procgen_id &id, int max_attributes = 5,
                              int power_level = 1000, int max_negative_power = -2000, bool is_resonant = false );
+        // TODO: Get rid of untyped overload
         void spawn_item( const tripoint &p, const itype_id &type_id,
+                         unsigned quantity = 1, int charges = 0,
+                         const time_point &birthday = calendar::start_of_cataclysm, int damlevel = 0,
+                         const std::set<flag_id> &flags = {}, const std::string &variant = "",
+                         const std::string &faction = "" );
+        void spawn_item( const tripoint_bub_ms &p, const itype_id &type_id,
                          unsigned quantity = 1, int charges = 0,
                          const time_point &birthday = calendar::start_of_cataclysm, int damlevel = 0,
                          const std::set<flag_id> &flags = {}, const std::string &variant = "",
@@ -1401,6 +1422,7 @@ class map
          */
         // TODO: fix point types (remove the first overload)
         item_location add_item_ret_loc( const tripoint &pos, item obj, bool overflow = true );
+        item_location add_item_ret_loc( const tripoint_bub_ms &pos, item obj, bool overflow = true );
         item &add_item_or_charges( const tripoint &pos, item obj, bool overflow = true );
         item &add_item_or_charges( const tripoint &pos, item obj, int &copies_remaining,
                                    bool overflow = true );
@@ -1425,9 +1447,11 @@ class map
          * @returns The item that got added, or nulitem.
          */
         item &add_item( const tripoint &p, item new_item, int copies );
+        // TODO: Get rid of untyped overload
         item &add_item( const tripoint &p, item new_item );
+        item &add_item( const tripoint_bub_ms &p, item new_item );
         void add_item( const point &p, const item &new_item ) {
-            add_item( tripoint( p, abs_sub.z() ), new_item );
+            add_item( tripoint_bub_ms( p.x, p.y, abs_sub.z() ), new_item );
         }
 
         /**
@@ -1529,8 +1553,12 @@ class map
         * @param turn The birthday that the created items shall have.
         * @return Vector of pointers to placed items (can be empty, but no nulls).
         */
+        // TODO: Get rid of untyped overload
         std::vector<item *> put_items_from_loc(
             const item_group_id &group_id, const tripoint &p,
+            const time_point &turn = calendar::start_of_cataclysm );
+        std::vector<item *> put_items_from_loc(
+            const item_group_id &group_id, const tripoint_bub_ms &p,
             const time_point &turn = calendar::start_of_cataclysm );
 
         // Places a list of items, or nothing if the list is empty.
@@ -1879,7 +1907,10 @@ class map
         //                          can be overriden by VEHICLE_STATUS_AT_SPAWN EXTERNAL_OPTION
         // @param merge_wrecks      if true and vehicle overlaps another then both turn into wrecks
         //                          if false and vehicle will overlap aborts and returns nullptr
+        // TODO: Get rid of untyped overload
         vehicle *add_vehicle( const vproto_id &type, const tripoint &p, const units::angle &dir,
+                              int init_veh_fuel = -1, int init_veh_status = -1, bool merge_wrecks = true );
+        vehicle *add_vehicle( const vproto_id &type, const tripoint_bub_ms &p, const units::angle &dir,
                               int init_veh_fuel = -1, int init_veh_status = -1, bool merge_wrecks = true );
 
         // Light/transparency
@@ -2453,8 +2484,10 @@ class map
         const level_cache &access_cache( int zlev ) const;
         bool dont_draw_lower_floor( const tripoint &p ) const;
 
-        bool has_haulable_items( const tripoint &pos );
+        bool has_haulable_items( const tripoint_bub_ms &pos );
+        // TODO: Get rid of untyped overload
         std::vector<item_location> get_haulable_items( const tripoint &pos );
+        std::vector<item_location> get_haulable_items( const tripoint_bub_ms &pos );
 
 #if defined(TILES)
         bool draw_points_cache_dirty = true;
@@ -2722,7 +2755,7 @@ class tinymap : private map
         void collapse_at( const tripoint &p, bool silent,
                           bool was_supporting = false, // TODO: Make it typed
                           bool destroy_pos = true ) {
-            map::collapse_at( p, silent, was_supporting, destroy_pos );
+            map::collapse_at( tripoint_bub_ms( p ), silent, was_supporting, destroy_pos );
         }
         tripoint getlocal( const tripoint &p ) const {
             return map::getlocal( p );    // TODO: Make it typed

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -3130,7 +3130,7 @@ class jmapgen_make_rubble : public jmapgen_piece
                 debugmsg( "null floor type when making rubble" );
                 chosen_floor_type = ter_t_dirt;
             }
-            dat.m.make_rubble( tripoint( x.get(), y.get(), dat.zlevel() + z.get() ),
+            dat.m.make_rubble( tripoint_bub_ms( x.get(), y.get(), dat.zlevel() + z.get() ),
                                chosen_rubble_type, items, chosen_floor_type, overwrite );
         }
 
@@ -5830,7 +5830,7 @@ void map::draw_lab( mapgendata &dat )
                                 ( !one_in( 3 ) && ( i == 11 || i == 12 || j == 11 || j == 12 ) ) ||
                                 one_in( 4 ) ) {
                                 // bash and usually remove the rubble.
-                                make_rubble( { i, j, abs_sub.z() } );
+                                make_rubble( tripoint_bub_ms( i, j, abs_sub.z() ) );
                                 ter_set( point( i, j ), ter_t_rock_floor );
                                 if( !one_in( 3 ) ) {
                                     furn_set( point( i, j ), furn_str_id::NULL_ID() );
@@ -5840,7 +5840,7 @@ void map::draw_lab( mapgendata &dat )
                         } else if( one_in( 20 ) &&
                                    !has_flag_ter( ter_furn_flag::TFLAG_GOES_DOWN, p2 ) &&
                                    !has_flag_ter( ter_furn_flag::TFLAG_GOES_UP, p2 ) ) {
-                            destroy( { i, j, abs_sub.z() } );
+                            destroy( tripoint_bub_ms( i, j, abs_sub.z() ) );
                             // bashed squares can create dirt & floors, but we want rock floors.
                             const ter_id &floor_to_check_ter = ter( point( i, j ) );
                             if( floor_to_check_ter == ter_t_dirt || floor_to_check_ter == ter_t_floor ) {
@@ -5863,7 +5863,7 @@ void map::draw_lab( mapgendata &dat )
                     if( ( ( j <= tw || i >= rw ) && i >= j && ( EAST_EDGE - i ) <= j ) ||
                         ( ( j >= bw || i <= lw ) && i <= j && ( SOUTH_EDGE - j ) <= i ) ) {
                         if( one_in( 5 ) ) {
-                            make_rubble( tripoint( i,  j, abs_sub.z() ), furn_f_rubble_rock, true,
+                            make_rubble( tripoint_bub_ms( i,  j, abs_sub.z() ), furn_f_rubble_rock, true,
                                          ter_t_slime );
                         } else if( !one_in( 5 ) ) {
                             ter_set( point( i, j ), ter_t_slime );
@@ -5923,7 +5923,7 @@ void map::draw_lab( mapgendata &dat )
                                 ter_set( point( i, j ), fluid_type );
                             } else if( has_flag_ter( ter_furn_flag::TFLAG_DOOR, point( i, j ) ) && !one_in( 3 ) ) {
                                 // We want the actual debris, but not the rubble marker or dirt.
-                                make_rubble( { i, j, abs_sub.z() } );
+                                make_rubble( tripoint_bub_ms( i, j, abs_sub.z() ) );
                                 ter_set( point( i, j ), fluid_type );
                                 furn_set( point( i, j ), furn_str_id::NULL_ID() );
                             }
@@ -6674,6 +6674,13 @@ std::vector<item *> map::put_items_from_loc( const item_group_id &group_id, cons
     return spawn_items( p, items );
 }
 
+std::vector<item *> map::put_items_from_loc( const item_group_id &group_id,
+        const tripoint_bub_ms &p,
+        const time_point &turn )
+{
+    return map::put_items_from_loc( group_id, p.raw(), turn );
+}
+
 void map::add_spawn( const MonsterGroupResult &spawn_details, const tripoint_bub_ms &p )
 {
     add_spawn( spawn_details.name, spawn_details.pack_size, p, false, -1, -1, std::nullopt,
@@ -6762,6 +6769,12 @@ vehicle *map::add_vehicle( const vproto_id &type, const tripoint &p, const units
         placed_vehicle->place_zones( *this );
     }
     return placed_vehicle;
+}
+
+vehicle *map::add_vehicle( const vproto_id &type, const tripoint_bub_ms &p, const units::angle &dir,
+                           const int veh_fuel, const int veh_status, const bool merge_wrecks )
+{
+    return map::add_vehicle( type, p.raw(), dir, veh_fuel, veh_status, merge_wrecks );
 }
 
 /**

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -1011,6 +1011,11 @@ void add_msg_if_player_sees( const tripoint &target, std::string msg )
     }
 }
 
+void add_msg_if_player_sees( const tripoint_bub_ms &target, std::string msg )
+{
+    add_msg_if_player_sees( target.raw(), msg );
+}
+
 void add_msg_if_player_sees( const Creature &target, std::string msg )
 {
     if( get_player_view().sees( target ) ) {
@@ -1024,6 +1029,12 @@ void add_msg_if_player_sees( const tripoint &target, const game_message_params &
     if( get_player_view().sees( target ) ) {
         Messages::add_msg( params, std::move( msg ) );
     }
+}
+
+void add_msg_if_player_sees( const tripoint_bub_ms &target, const game_message_params &params,
+                             std::string msg )
+{
+    add_msg_if_player_sees( target.raw(), params, msg );
 }
 
 void add_msg_if_player_sees( const Creature &target, const game_message_params &params,

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -1013,7 +1013,7 @@ void add_msg_if_player_sees( const tripoint &target, std::string msg )
 
 void add_msg_if_player_sees( const tripoint_bub_ms &target, std::string msg )
 {
-    add_msg_if_player_sees( target.raw(), msg );
+    add_msg_if_player_sees( target.raw(), std::move( msg ) );
 }
 
 void add_msg_if_player_sees( const Creature &target, std::string msg )
@@ -1034,7 +1034,7 @@ void add_msg_if_player_sees( const tripoint &target, const game_message_params &
 void add_msg_if_player_sees( const tripoint_bub_ms &target, const game_message_params &params,
                              std::string msg )
 {
-    add_msg_if_player_sees( target.raw(), params, msg );
+    add_msg_if_player_sees( target.raw(), params, std::move( msg ) );
 }
 
 void add_msg_if_player_sees( const Creature &target, const game_message_params &params,

--- a/src/messages.h
+++ b/src/messages.h
@@ -100,11 +100,12 @@ inline void add_msg_if_player_sees( const tripoint &target, const char *const ms
     return add_msg_if_player_sees( target, string_format( msg, std::forward<Args>( args )... ) );
 }
 template<typename ...Args>
-//###inline void add_msg_if_player_sees(const tripoint_bub_ms& target, const char* const msg, Args &&... args)
-//###{
-//###    return add_msg_if_player_sees(target, string_format(msg, std::forward<Args>(args)...));
-//###}
-//###template<typename ...Args>
+inline void add_msg_if_player_sees( const tripoint_bub_ms &target, const char *const msg,
+                                    Args &&... args )
+{
+    return add_msg_if_player_sees( target, string_format( msg, std::forward<Args>( args )... ) );
+}
+template<typename ...Args>
 inline void add_msg_if_player_sees( const Creature &target, const char *const msg, Args &&... args )
 {
     return add_msg_if_player_sees( target, string_format( msg, std::forward<Args>( args )... ) );

--- a/src/messages.h
+++ b/src/messages.h
@@ -8,6 +8,7 @@
 #include <utility>
 #include <vector>
 
+#include "coordinates.h"
 #include "debug.h"
 #include "enums.h"
 #include "string_formatter.h"
@@ -77,7 +78,9 @@ inline void add_msg( const game_message_params &params, const char *const msg, A
     return add_msg( params, string_format( msg, std::forward<Args>( args )... ) );
 }
 
+// TODO: Get rid of untyped overload
 void add_msg_if_player_sees( const tripoint &target, std::string msg );
+void add_msg_if_player_sees( const tripoint_bub_ms &target, std::string msg );
 void add_msg_if_player_sees( const Creature &target, std::string msg );
 template<typename ...Args>
 inline void add_msg_if_player_sees( const tripoint &target, const std::string &msg,
@@ -97,6 +100,11 @@ inline void add_msg_if_player_sees( const tripoint &target, const char *const ms
     return add_msg_if_player_sees( target, string_format( msg, std::forward<Args>( args )... ) );
 }
 template<typename ...Args>
+//###inline void add_msg_if_player_sees(const tripoint_bub_ms& target, const char* const msg, Args &&... args)
+//###{
+//###    return add_msg_if_player_sees(target, string_format(msg, std::forward<Args>(args)...));
+//###}
+//###template<typename ...Args>
 inline void add_msg_if_player_sees( const Creature &target, const char *const msg, Args &&... args )
 {
     return add_msg_if_player_sees( target, string_format( msg, std::forward<Args>( args )... ) );
@@ -114,7 +122,10 @@ inline void add_msg_if_player_sees( const Creature &target, const translation &m
     return add_msg_if_player_sees( target, string_format( msg, std::forward<Args>( args )... ) );
 }
 
+// TODO: Get rid of untyped overload
 void add_msg_if_player_sees( const tripoint &target, const game_message_params &params,
+                             std::string msg );
+void add_msg_if_player_sees( const tripoint_bub_ms &target, const game_message_params &params,
                              std::string msg );
 void add_msg_if_player_sees( const Creature &target, const game_message_params &params,
                              std::string msg );

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -3236,6 +3236,11 @@ bool npc::invoke_item( item *used, const tripoint &pt, int )
     return false;
 }
 
+bool npc::invoke_item( item *used, const tripoint_bub_ms &pt, int pre_obtain_moves )
+{
+    return npc::invoke_item( used, pt.raw(), pre_obtain_moves );
+}
+
 bool npc::invoke_item( item *used, const std::string &method )
 {
     return Character::invoke_item( used, method );

--- a/src/npc.h
+++ b/src/npc.h
@@ -1112,7 +1112,9 @@ class npc : public Character
         void process_turn() override;
 
         using Character::invoke_item;
+        // TODO: Get rid of untyped overload
         bool invoke_item( item *, const tripoint &pt, int pre_obtain_moves ) override;
+        bool invoke_item( item *, const tripoint_bub_ms &pt, int pre_obtain_moves ) override;
         bool invoke_item( item *used, const std::string &method ) override;
         bool invoke_item( item * ) override;
 

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -437,7 +437,7 @@ void Pickup::autopickup( const tripoint &p )
         target_items.push_back( selected.first );
         quantities.push_back( it->count_by_charges() ? it->charges : 0 );
     }
-    pickup_activity_actor actor( target_items, quantities, player.pos(), true );
+    pickup_activity_actor actor( target_items, quantities, player.pos_bub(), true );
     player.assign_activity( actor );
 
     // Auto pickup will need to auto resume since there can be several of them on the stack.

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -315,6 +315,12 @@ void sounds::ambient_sound( const tripoint &p, int vol, sound_t category,
     sound( p, vol, category, description, true );
 }
 
+void sounds::ambient_sound( const tripoint_bub_ms &p, int vol, sound_t category,
+                            const std::string &description )
+{
+    sounds::ambient_sound( p.raw(), vol, category, description );
+}
+
 void sounds::sound( const tripoint &p, int vol, sound_t category, const std::string &description,
                     bool ambient, const std::string &id, const std::string &variant )
 {
@@ -2053,6 +2059,11 @@ int sfx::get_heard_volume( const tripoint &source )
     }
     heard_volume *= g_sfx_volume_multiplier;
     return heard_volume;
+}
+
+int sfx::get_heard_volume( const tripoint_bub_ms &source )
+{
+    return sfx::get_heard_volume( source.raw() );
 }
 
 units::angle sfx::get_heard_angle( const tripoint &source )

--- a/src/sounds.h
+++ b/src/sounds.h
@@ -68,7 +68,10 @@ void sound( const tripoint_bub_ms &p, int vol, sound_t category, const translati
             bool ambient = false, const std::string &id = "",
             const std::string &variant = "default" );
 /** Functions identical to sound(..., true). */
+// TODO: Get rid of untyped overload
 void ambient_sound( const tripoint &p, int vol, sound_t category, const std::string &description );
+void ambient_sound( const tripoint_bub_ms &p, int vol, sound_t category,
+                    const std::string &description );
 /** Creates a list of coordinates at which to draw footsteps. */
 void add_footstep( const tripoint &p, int volume, int distance, monster *source,
                    const std::string &footstep );
@@ -173,7 +176,9 @@ void generate_melee_sound( const tripoint &source, const tripoint &target, bool 
 void do_hearing_loss( int turns = -1 );
 void remove_hearing_loss();
 void do_projectile_hit( const Creature &target );
+// TODO: Get rid of untyped overload
 int get_heard_volume( const tripoint &source );
+int get_heard_volume( const tripoint_bub_ms &source );
 units::angle get_heard_angle( const tripoint &source );
 void do_footstep();
 void do_danger_music();

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1789,7 +1789,8 @@ class vehicle
         * @return amount of ammo in the `pseudo_magazine` or 0
         */
         int prepare_tool( item &tool ) const;
-        static bool use_vehicle_tool( vehicle &veh, const tripoint &vp_pos, const itype_id &tool_type,
+        static bool use_vehicle_tool( vehicle &veh, const tripoint_bub_ms &vp_pos,
+                                      const itype_id &tool_type,
                                       bool no_invoke = false );
         /**
         * if \p tool is not an itype with tool != nullptr this returns { itype::NULL_ID(), 0 } pair

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1778,7 +1778,8 @@ int vehicle::prepare_tool( item &tool ) const
     return ammo_count;
 }
 
-bool vehicle::use_vehicle_tool( vehicle &veh, const tripoint &vp_pos, const itype_id &tool_type,
+bool vehicle::use_vehicle_tool( vehicle &veh, const tripoint_bub_ms &vp_pos,
+                                const itype_id &tool_type,
                                 bool no_invoke )
 {
     item tool( tool_type, calendar::turn );
@@ -1803,7 +1804,7 @@ bool vehicle::use_vehicle_tool( vehicle &veh, const tripoint &vp_pos, const ityp
           tool_type == itype_large_repairkit
         ) ) {
         act.index = INT_MIN; // tell activity the item doesn't really exist
-        act.coords.push_back( vp_pos ); // tell it to search for the tool on `pos`
+        act.coords.push_back( vp_pos.raw() ); // tell it to search for the tool on `pos`
         act.str_values.push_back( tool_type.str() ); // specific tool on the rig
     }
 
@@ -2160,7 +2161,7 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint &p, bool with_
         .enable( ammo_amount >= tool_item.typeId()->charges_to_use() )
         .hotkey( hk )
         .skip_locked_check( tool_ammo.is_null() || tool_ammo->ammo->type != ammo_battery )
-        .on_submit( [this, vppos, tool_type] { use_vehicle_tool( *this, vppos, tool_type ); } );
+        .on_submit( [this, vppos, tool_type] { use_vehicle_tool( *this, tripoint_bub_ms( vppos ), tool_type ); } );
     }
 
     const std::optional<vpart_reference> vp_autoclave = vp.avail_part_with_feature( "AUTOCLAVE" );

--- a/tests/active_item_cache_test.cpp
+++ b/tests/active_item_cache_test.cpp
@@ -28,7 +28,7 @@ TEST_CASE( "place_active_item_at_various_coordinates", "[item]" )
             REQUIRE( here.get_submaps_with_active_items().empty() );
             REQUIRE( here.get_submaps_with_active_items().find( abs_loc ) ==
                      here.get_submaps_with_active_items().end() );
-            item &item_ref = here.add_item( { x, y, z }, active );
+            item &item_ref = here.add_item( tripoint_bub_ms( x, y, z ), active );
             here.update_submaps_with_active_items();
             REQUIRE( item_ref.active );
             REQUIRE_FALSE( here.get_submaps_with_active_items().empty() );

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -1020,7 +1020,8 @@ static int resume_craft()
     REQUIRE( crafts.size() == 1 );
     item *craft = crafts.front();
     set_time( midday ); // Ensure light for crafting
-    REQUIRE( player_character.crafting_speed_multiplier( *craft, std::nullopt ) == 1.0 );
+    REQUIRE( player_character.crafting_speed_multiplier( *craft,
+             std::optional<tripoint_bub_ms>( std::nullopt ) ) == 1.0 );
     REQUIRE( !player_character.activity );
     player_character.use( player_character.get_item_position( craft ) );
     REQUIRE( player_character.activity );

--- a/tests/fake_messages.cpp
+++ b/tests/fake_messages.cpp
@@ -70,6 +70,10 @@ void add_msg_if_player_sees( const tripoint &, std::string m )
 {
     Messages::add_msg( std::move( m ) );
 }
+void add_msg_if_player_sees( const tripoint_bub_ms &, std::string m )
+{
+    Messages::add_msg( std::move( m ) );
+}
 void add_msg_if_player_sees( const Creature &, std::string m )
 {
     Messages::add_msg( std::move( m ) );

--- a/tests/invlet_test.cpp
+++ b/tests/invlet_test.cpp
@@ -258,7 +258,7 @@ static void pick_up_from_feet( Character &you, const std::string &id )
 
     you.set_moves( 100 );
     const std::vector<item_location> target_items = { item_location( map_cursor( you.pos() ), found ) };
-    you.assign_activity( pickup_activity_actor( target_items, { 0 }, you.pos(), false ) );
+    you.assign_activity( pickup_activity_actor( target_items, { 0 }, you.pos_bub(), false ) );
     you.activity.do_turn( you );
 
     REQUIRE( items.size() == size_before - 1 );

--- a/tests/item_pocket_test.cpp
+++ b/tests/item_pocket_test.cpp
@@ -1833,7 +1833,7 @@ static void test_pickup_autoinsert_sub_sub( bool autopickup, bool wear, bool sof
     item_location cont2( map_cursor( u.pos() ), &m.add_item_or_charges( u.pos(), cont_nest_soft ) );
     item_location obj1( map_cursor( u.pos() ), &m.add_item_or_charges( u.pos(), rigid_obj ) );
     item_location obj2( map_cursor( u.pos() ), &m.add_item_or_charges( u.pos(), soft_obj ) );
-    pickup_activity_actor act_actor( { obj1, obj2 }, { 1, 1 }, u.pos(), autopickup );
+    pickup_activity_actor act_actor( { obj1, obj2 }, { 1, 1 }, u.pos_bub(), autopickup );
     u.assign_activity( act_actor );
 
     item_location pack;
@@ -2062,7 +2062,7 @@ static void test_pickup_autoinsert_sub_sub( bool autopickup, bool wear, bool sof
             item_location obj3( map_cursor( u.pos() ), &m.add_item_or_charges( u.pos(), stack ) );
             REQUIRE( obj3->charges == 300 );
             u.cancel_activity();
-            pickup_activity_actor new_actor( { obj3 }, { 300 }, u.pos(), autopickup );
+            pickup_activity_actor new_actor( { obj3 }, { 300 }, u.pos_bub(), autopickup );
             u.assign_activity( new_actor );
             THEN( ( soft_nested ? "pickup most, nested empty" : "pickup all, overflow into nested" ) ) {
                 if( soft_nested ) {
@@ -2090,10 +2090,10 @@ static void test_pickup_autoinsert_sub_sub( bool autopickup, bool wear, bool sof
         }
         WHEN( "item stack too large to fit in top-level container" ) {
             stack.charges = 300;
-            item_location obj3( map_cursor( u.pos() ), &m.add_item_or_charges( u.pos(), stack ) );
+            item_location obj3( map_cursor( u.pos() ), &m.add_item_or_charges( u.pos_bub(), stack ) );
             REQUIRE( obj3->charges == 300 );
             u.cancel_activity();
-            pickup_activity_actor new_actor( { obj3 }, { 300 }, u.pos(), autopickup );
+            pickup_activity_actor new_actor( { obj3 }, { 300 }, u.pos_bub(), autopickup );
             u.assign_activity( new_actor );
             THEN( "pickup most, nested empty" ) {
                 if( soft_nested ) {
@@ -2122,10 +2122,10 @@ static void test_pickup_autoinsert_sub_sub( bool autopickup, bool wear, bool sof
         obj2.remove_item();
         WHEN( "item stack too large to fit in top-level container" ) {
             stack.charges = 300;
-            item_location obj3( map_cursor( u.pos() ), &m.add_item_or_charges( u.pos(), stack ) );
+            item_location obj3( map_cursor( u.pos() ), &m.add_item_or_charges( u.pos_bub(), stack ) );
             REQUIRE( obj3->charges == 300 );
             u.cancel_activity();
-            pickup_activity_actor new_actor( { obj3 }, { 300 }, u.pos(), autopickup );
+            pickup_activity_actor new_actor( { obj3 }, { 300 }, u.pos_bub(), autopickup );
             u.assign_activity( new_actor );
             THEN( "pickup most, nested empty" ) {
                 if( soft_nested ) {

--- a/tests/player_activities_test.cpp
+++ b/tests/player_activities_test.cpp
@@ -842,7 +842,7 @@ TEST_CASE( "hacksaw", "[activity][hacksaw]" )
     };
 
     auto setup_activity = [&dummy]( const item_location & torch ) -> void {
-        hacksaw_activity_actor act{tripoint_zero, torch};
+        hacksaw_activity_actor act{tripoint_bub_ms( tripoint_zero ), torch};
         act.testing = true;
         dummy.assign_activity( act );
     };
@@ -1729,7 +1729,7 @@ static const std::vector<std::function<player_activity()>> test_activities {
     [] { return player_activity( shave_activity_actor() ); },
     //player_activity( shearing_activity_actor( north ) ),
     [] { return player_activity( stash_activity_actor() ); },
-    [] { return player_activity( tent_deconstruct_activity_actor( 1, 1, get_avatar().pos(), itype_tent_kit ) ); },
+    [] { return player_activity( tent_deconstruct_activity_actor( 1, 1, get_avatar().pos_bub(), itype_tent_kit ) ); },
     //player_activity( tent_placement_activity_actor() ),
     [] { return player_activity( try_sleep_activity_actor( time_duration::from_hours( 1 ) ) ); },
     [] { return player_activity( unload_activity_actor( 1, item_location() ) ); },

--- a/tests/vehicle_split_test.cpp
+++ b/tests/vehicle_split_test.cpp
@@ -85,10 +85,14 @@ TEST_CASE( "vehicle_split_section", "[vehicle]" )
 TEST_CASE( "conjoined_vehicles", "[vehicle]" )
 {
     map &here = get_map();
-    here.add_vehicle( vehicle_prototype_car, { 40, 40, here.get_abs_sub().z() }, 0_degrees );
-    here.add_vehicle( vehicle_prototype_car, { 42, 42, here.get_abs_sub().z() }, 0_degrees );
-    here.add_vehicle( vehicle_prototype_car, { 44, 44, here.get_abs_sub().z() }, 45_degrees );
-    here.add_vehicle( vehicle_prototype_car, { 48, 44, here.get_abs_sub().z() }, 45_degrees );
+    here.add_vehicle( vehicle_prototype_car, tripoint_bub_ms( 40, 40, here.get_abs_sub().z() ),
+                      0_degrees );
+    here.add_vehicle( vehicle_prototype_car, tripoint_bub_ms( 42, 42, here.get_abs_sub().z() ),
+                      0_degrees );
+    here.add_vehicle( vehicle_prototype_car, tripoint_bub_ms( 44, 44, here.get_abs_sub().z() ),
+                      45_degrees );
+    here.add_vehicle( vehicle_prototype_car, tripoint_bub_ms( 48, 44, here.get_abs_sub().z() ),
+                      45_degrees );
 }
 
 TEST_CASE( "crater_crash", "[vehicle]" )


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Use typed tripoints in another piece of code.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Look for tripoints in activity_actor.cpp and convert the code to use typed tripoint, including the change of the operations called (which typically resulted in a typed overload).

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Loaded a save and walked until a monster was detected.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I've gotten the help I needed with the issues mentioned here previously, so this is now ready for review. Many thanks @Qrox.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
