### PR TITLE
Reset wait popup on activity finish

### DIFF
--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -1792,7 +1792,7 @@ void advanced_inventory::display()
         player_character.inv->restack( player_character );
 
         recalc = true;
-        g->wait_popup.reset();
+        g->wait_popup_reset();
     }
 
     if( !ui ) {

--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -566,7 +566,7 @@ bool do_turn()
                 sounds::process_sound_markers( &u );
                 if( !u.activity && g->uquit != QUIT_WATCH
                     && ( !u.has_distant_destination() || calendar::once_every( 10_seconds ) ) ) {
-                    g->wait_popup.reset();
+                    g->wait_popup_reset();
                     ui_manager::redraw();
                 }
 
@@ -721,7 +721,7 @@ bool do_turn()
         }
     } else {
         // Nothing to wait for now
-        g->wait_popup.reset();
+        g->wait_popup_reset();
         g->first_redraw_since_waiting_started = true;
     }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -12965,6 +12965,11 @@ void game::display_om_pathfinding_progress( size_t /* open_set */, size_t /* kno
     inp_mngr.pump_events();
 }
 
+void game::wait_popup_reset()
+{
+    wait_popup.reset();
+}
+
 bool game::display_overlay_state( const action_id action )
 {
     return displaying_overlays && *displaying_overlays == action;

--- a/src/game.h
+++ b/src/game.h
@@ -142,7 +142,6 @@ bool cleanup_at_end();
 class game
 {
         friend class editmap;
-        friend class advanced_inventory;
         friend class main_menu;
         friend class exosuit_interact;
         friend achievements_tracker &get_achievements();
@@ -1247,6 +1246,8 @@ class game
 
         std::unique_ptr<static_popup> wait_popup; // NOLINT(cata-serialize)
     public:
+        void wait_popup_reset();
+
         /** Used to implement mouse "edge scrolling". Returns a
          *  tripoint which is a vector of the resulting "move", i.e.
          *  (0, 0, 0) if the mouse is not at the edge of the screen,

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -386,6 +386,7 @@ void player_activity::do_turn( Character &you )
             }
         }
         get_event_bus().send<event_type::character_finished_activity>( you.getID(), type, false );
+        g->wait_popup_reset();
         if( actor ) {
             actor->finish( *this, you );
         } else {
@@ -412,6 +413,7 @@ void player_activity::canceled( Character &who )
         actor->canceled( *this, who );
     }
     get_event_bus().send<event_type::character_finished_activity>( who.getID(), type, true );
+    g->wait_popup_reset();
 }
 
 float player_activity::exertion_level() const


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fixes #73810

#### Describe the solution

Reset wait popup on activity cancel/finish

Also clean up access to game::wait_popup and remove advanced_inventory friend from game as accessing wait_popup seems to be it's only use

#### Describe alternatives you've considered

#### Testing

Steps in the issue

#### Additional context
