### PR TITLE
Better debug message on loading bad vehicle parts

### DIFF
--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3189,7 +3189,7 @@ void vehicle_part::deserialize( const JsonObject &data )
     }
 
     if( !pid.is_valid() ) {
-        data.throw_error_at( "id", "bad vehicle part" );
+        data.throw_error_at( "id", string_format( "bad vehicle part '%s'", pid.str() ) );
     }
     info_ = &pid.obj();
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Give slightly better message when loading a save with invalid vpart ids;
Instead of vomiting json dump give the invalid part id in the message, then vomit the json

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

Load old save that has no vpart migrations/modded game etc with invalid vpart id, the invalid id should be visible in the message itself

#### Additional context
