### PR TITLE
Update Flatpak manifest to use clang and include the default soundpack

### DIFF
--- a/org.cataclysmdda.CataclysmDDA.json
+++ b/org.cataclysmdda.CataclysmDDA.json
@@ -1,5 +1,6 @@
 {
   "id": "org.cataclysmdda.CataclysmDDA",
+  "default-branch": "experimental",
   "runtime": "org.freedesktop.Platform",
   "runtime-version": "22.08",
   "sdk": "org.freedesktop.Sdk",

--- a/org.cataclysmdda.CataclysmDDA.json
+++ b/org.cataclysmdda.CataclysmDDA.json
@@ -3,6 +3,9 @@
   "runtime": "org.freedesktop.Platform",
   "runtime-version": "22.08",
   "sdk": "org.freedesktop.Sdk",
+  "sdk-extensions": [
+    "org.freedesktop.Sdk.Extension.llvm16"
+  ],
   "command": "cataclysm-tiles",
   "finish-args": [
     "--socket=pulseaudio",
@@ -16,10 +19,27 @@
       "name": "cataclysm-tiles",
       "buildsystem": "simple",
       "build-options": {
-        "env": { "MAKE_ARGS": "PREFIX=/app LANGUAGES=all USE_XDG_DIR=1 TILES=1 SOUND=1 RELEASE=1 TESTS=0 ASTYLE=0 LINTJSON=0" }
+        "append-path": "/usr/lib/sdk/llvm16/bin",
+        "prepend-ld-library-path": "/usr/lib/sdk/llvm16/lib",
+        "env": {
+          "MAKE_ARGS": "PREFIX=/app LANGUAGES=all CLANG=1 CCACHE=1 USE_XDG_DIR=1 TILES=1 SOUND=1 RELEASE=1 TESTS=0 ASTYLE=0 LINTJSON=0"
+        }
       },
-      "build-commands": [ "make -j $FLATPAK_BUILDER_N_JOBS $MAKE_ARGS", "make $MAKE_ARGS localization", "make $MAKE_ARGS install" ],
-      "sources": [ { "type": "git", "url": "https://github.com/CleverRaven/Cataclysm-DDA", "branch": "master" } ]
+      "build-commands": [
+        "mv soundpack/sound/CC-Sounds/ data/sound/",
+        "make -j $FLATPAK_BUILDER_N_JOBS $MAKE_ARGS",
+        "make $MAKE_ARGS localization",
+        "make $MAKE_ARGS install"
+      ],
+      "sources": [
+        { "type": "git", "url": "https://github.com/CleverRaven/Cataclysm-DDA", "branch": "master" },
+        {
+          "type": "git",
+          "url": "https://github.com/Fris0uman/CDDA-Soundpacks",
+          "branch": "main",
+          "dest": "soundpack"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Build "Update Flatpak manifest to use clang and include the default soundpack"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The use of clang and ccache optimizes builds for both testing and downstream distribution with the flatpak model. The soundpack normally wouldn't be included since github actions does the inclusion instead of make, so the manifest mimics the workflow's method of inclusion. The eventual intention is to backport this to stable in a form suitable for submission to Flathub, but this also works as-is for self-building the experimental branch.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Clang requires a common SDK addon --- since flatpak's builder resolves all of these as part of the build process, availability isn't an issue. Flatpak also optimizes for the use of ccache in its build process, making subsequent builds much quicker.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
In theory, the dynamic inclusion of the soundpack could be done by making github actions do build stuff to produce a GH pages-based flatpak repo, but that's way harder for little gain besides making experimental prebuilds available via flatpak and can always be done later. The soundpack could also be defined as an extension, but that would require a refactor of the manifests involved and add another one to the pile.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Start with flatpak installed. Ensure that a Cataclysm flatpak isn't already installed on the testing system.
`flatpak uninstall org.cataclysmdda.CataclysmDDA`

Ensure that Flathub is a remote so that the dependencies are automatically installed.
`flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo`

Run the (Flathub-standard) build command.
`flatpak run org.flatpak.Builder --force-clean --sandbox --user --install --install-deps-from=flathub --ccache --mirror-screenshots-url=https://dl.flathub.org/media/ --repo=repo build-dir org.cataclysmdda.CataclysmDDA.json`

Run Cataclysm as you normally would from your desktop environment, or use `flatpak run org.cataclysmdda.CataclysmDDA`. Note that the CC-Sounds soundpack is now available in the settings menu, and the game is fun.

No regressions noticed during testing.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
