### PR TITLE
Near-infinite loop fix for when crafter cannot continue (fixes #70530)

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3652,7 +3652,7 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
     const int assistants = crafter.available_assistant_count( craft.get_making() );
 
     if( crafting_speed <= 0.0f ) {
-        craft.erase_var("crafter");
+        craft.erase_var( "crafter" );
         crafter.cancel_activity();
         return;
     }

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3652,6 +3652,7 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
     const int assistants = crafter.available_assistant_count( craft.get_making() );
 
     if( crafting_speed <= 0.0f ) {
+        craft.erase_var("crafter");
         crafter.cancel_activity();
         return;
     }
@@ -3724,6 +3725,7 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
         if( !crafter.craft_consume_tools( craft, five_percent_steps, false ) ) {
             // So we don't skip over any tool comsuption
             craft.item_counter -= craft.item_counter % 500'000 + 1;
+            craft.erase_var("crafter");
             crafter.cancel_activity();
             return;
         }

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3725,7 +3725,7 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
         if( !crafter.craft_consume_tools( craft, five_percent_steps, false ) ) {
             // So we don't skip over any tool comsuption
             craft.item_counter -= craft.item_counter % 500'000 + 1;
-            craft.erase_var("crafter");
+            craft.erase_var( "crafter" );
             crafter.cancel_activity();
             return;
         }


### PR DESCRIPTION
#### Summary
Bugfixes "Fix for massive slowdown when NPC crafting speed drops below 0.0"

#### Purpose of change
This fix basically prevents the crafting loop from starting, stopping and restarting hundreds of times until the NPC runs out of moves.
Steps to reproduce:
1) Start a craft that an NPC does not have the skills to craft. Ideally, one that they have no hope of crafting.
2) Stop crafting, talk to NPC, tell him to work on in-progress craft.
3) Wait 3-5 turns. Game will freeze for anywhere from 1 to 5 minutes.

#### Describe the solution
In activity_actor.cpp, in craft_activity_actor::do_turn(), there are two points where we call crafter.cancel_activity(), one due to speed being less than 0.0 and the other where we run out of tools to continue crafting. The issue is that we are not clearing the crafter flag on the item when we cancel, so when we remove the activity and revert back to ACT_MULTIPLE_CRAFT, we end up just restarting the same craft since the craft is still there and still has the crafter's name on it.

My change simply erases the crafter's name from the item when we stop the activity, thus preventing the useless looping cycle.

#### Describe alternatives you've considered
I wanted to clear the crafter variable in in cancel_activity() instead of in do_turn(), but could not figure out how to reference the in-progress craft from that position in the code.


#### Testing
I've reproduced the scenario using a save before and after recompiling with the fix. Prior to the fix, it would freeze for 1-5 minutes, then unfreeze, and after another couple turns would freeze again. Post-fix, no freeze. I don't see any way that this can cause a regression. The way I isolated it was by adding debug messaging and basically stepping through it.

#### Additional context
None