### PR TITLE
Liberty Bot

### DIFF
--- a/data/json/items/corpses/inactive_bots.json
+++ b/data/json/items/corpses/inactive_bots.json
@@ -321,6 +321,31 @@
     "melee_damage": { "bash": 8 }
   },
   {
+    "id": "bot_secubot_liberty",
+    "type": "TOOL",
+    "name": { "str": "inactive TALON UGV Liberty Edition" },
+    "description": "This bot has had tubes welded above the original guns that allow it to shoot fireworks in order to blind and stun attackers. With fireworks being harder to come by then the ammo for the original weapons, the best option would be to convert it back to it's original guns. It should be easy enough to give it back the use of the original M16A4.",
+    "weight": "40750 g",
+    "volume": "30 L",
+    "price": "7 kUSD 500 USD",
+    "price_postapoc": "25 USD",
+    "to_hit": -3,
+    "material": [ "steel" ],
+    "symbol": "F",
+    "color": "light_gray",
+    "use_action": {
+      "type": "place_monster",
+      "monster_id": "mon_secubot_america_refurbished",
+      "friendly_msg": "The security bot beeps affirmatively and begins scanning for hostiles.",
+      "hostile_msg": "You misprogram the security bot and it trains its gun on you.  RUN!",
+      "difficulty": 6,
+      "moves": 150,
+      "skills": [ "electronics", "computer", "fabrication" ]
+    },
+    "flags": [ "SINGLE_USE" ],
+    "melee_damage": { "bash": 8 }
+  },
+  {
     "id": "bot_nursebot",
     "type": "TOOL",
     "name": { "str": "inactive nurse bot" },

--- a/data/json/items/corpses/inactive_bots.json
+++ b/data/json/items/corpses/inactive_bots.json
@@ -323,8 +323,8 @@
   {
     "id": "bot_secubot_liberty",
     "type": "TOOL",
-    "name": { "str": "inactive TALON UGV Liberty Edition" },
-    "description": "This bot has had tubes welded above the original guns that allow it to shoot fireworks in order to blind and stun attackers. With fireworks being harder to come by then the ammo for the original weapons, the best option would be to convert it back to it's original guns. It should be easy enough to give it back the use of the original M16A4.",
+    "name": { "str": "inactive TALON UGV Liberty Edition", "str_pl": "inactive TALON UGVs Liberty Edition" },
+    "description": "This bot has had tubes welded above the original guns that allow it to shoot fireworks in order to blind and stun attackers.  With fireworks being harder to come by then the ammo for the original weapons, the best option would be to convert it back to it's original guns.  It should be easy enough to give it back the use of the original M16A4.",
     "weight": "40750 g",
     "volume": "30 L",
     "price": "7 kUSD 500 USD",

--- a/data/json/monsters/defense_bot.json
+++ b/data/json/monsters/defense_bot.json
@@ -156,7 +156,10 @@
   {
     "id": "mon_secubot_america_refurbished",
     "type": "MONSTER",
-    "name": { "str": "refurbished autonomous TALON UGV Liberty Edition", "str_pl": "refurbished autonomous TALON UGVs Liberty Edition" },
+    "name": {
+      "str": "refurbished autonomous TALON UGV Liberty Edition",
+      "str_pl": "refurbished autonomous TALON UGVs Liberty Edition"
+    },
     "description": "Once a Talon UGV bot converted to shoot fireworks at trespassers, this has been refurbished and uses it's M16A4 once more.  It still has the American flag decal from it's service as a trespass deterrent.",
     "default_faction": "defense_bot",
     "species": [ "ROBOT" ],

--- a/data/json/monsters/defense_bot.json
+++ b/data/json/monsters/defense_bot.json
@@ -156,8 +156,8 @@
   {
     "id": "mon_secubot_america_refurbished",
     "type": "MONSTER",
-    "name": { "str": "refurbished autonomous TALON UGV Liberty Edition" },
-    "description": "Once a Talon UGV bot converted to shoot fireworks at trespassers, this has been refurbished and uses it's M16A4 once more. It still has the American flag decal from it's service as a trespass deterrent.",
+    "name": { "str": "refurbished autonomous TALON UGV Liberty Edition", "str_pl": "refurbished autonomous TALON UGVs Liberty Edition" },
+    "description": "Once a Talon UGV bot converted to shoot fireworks at trespassers, this has been refurbished and uses it's M16A4 once more.  It still has the American flag decal from it's service as a trespass deterrent.",
     "default_faction": "defense_bot",
     "species": [ "ROBOT" ],
     "diff": 20,

--- a/data/json/monsters/defense_bot.json
+++ b/data/json/monsters/defense_bot.json
@@ -124,12 +124,12 @@
     "hp": 80,
     "speed": 40,
     "material": [ "steel" ],
-    "symbol": "R",
-    "color": "dark_gray",
+    "symbol": "F",
+    "color": "light_gray",
     "aggression": 100,
     "morale": 100,
     "vision_day": 50,
-    "revert_to_itype": "bot_secubot",
+    "revert_to_itype": "bot_secubot_liberty",
     "special_attacks": [
       {
         "type": "gun",
@@ -142,6 +142,55 @@
         "targeting_volume": 50,
         "description": "Fireworks explode out of the turret!",
         "no_ammo_sound": "an igniter clicks rapidly!"
+      }
+    ],
+    "death_drops": {  },
+    "death_function": {
+      "effect": { "id": "death_smokeburst", "hit_self": true },
+      "message": "Loud rock music blares as the %s explodes!",
+      "corpse_type": "NO_CORPSE"
+    },
+    "flags": [ "SEES", "HEARS", "ELECTRONIC", "COLDPROOF", "NO_BREATHE", "PATH_AVOID_DANGER_1", "LOUDMOVES", "STUN_IMMUNE" ],
+    "armor": { "bash": 14, "cut": 14, "bullet": 11 }
+  },
+  {
+    "id": "mon_secubot_america_refurbished",
+    "type": "MONSTER",
+    "name": { "str": "refurbished autonomous TALON UGV Liberty Edition" },
+    "description": "Once a Talon UGV bot converted to shoot fireworks at trespassers, this has been refurbished and uses it's M16A4 once more. It still has the American flag decal from it's service as a trespass deterrent.",
+    "default_faction": "defense_bot",
+    "species": [ "ROBOT" ],
+    "diff": 20,
+    "volume": "150 L",
+    "weight": "40750 g",
+    "hp": 80,
+    "speed": 40,
+    "material": [ "steel" ],
+    "symbol": "F",
+    "color": "light_gray",
+    "aggression": 100,
+    "morale": 100,
+    "vision_day": 50,
+    "revert_to_itype": "bot_secubot_liberty",
+    "special_attacks": [
+      {
+        "type": "gun",
+        "cooldown": 1,
+        "move_cost": 150,
+        "gun_type": "modular_m16a4",
+        "ammo_type": "556",
+        "fake_skills": [ [ "gun", 8 ], [ "rifle", 8 ] ],
+        "fake_dex": 12,
+        "ranges": [ [ 0, 30, "DEFAULT" ] ],
+        "require_targeting_npc": true,
+        "require_targeting_monster": true,
+        "target_moving_vehicles": true,
+        "laser_lock": false,
+        "targeting_cost": 200,
+        "targeting_timeout_extend": -10,
+        "targeting_sound": "\"Proud to be an American.\"",
+        "targeting_volume": 50,
+        "no_ammo_sound": "a chk!"
       }
     ],
     "death_drops": {  },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Gives an explanation for why the TALON UGV Liberty Edition turns into the regular TALON UGV M16A4."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Closes #65260
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adds a new item and new monster that gives a slight difference from the original M16A4 Talon bot.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Add fireworks to the game so you can reload the Liberty Bot and allow you to activate it as the Liberty Bot instead of the regular Talon bot.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I loaded the game, gave myself 10 in all skills, spawned a base liberty bot, used the HM12 Dazzle rifle to disable it, deactivated it, wielded it, then reactivated it. This gave me the refurbished Liberty bot as a friendly bot.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
First legit PR in a long time. Woot woot
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
