### PR TITLE
Retain non-solid contents when installing vehicle parts

### DIFF
--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -2130,7 +2130,10 @@ std::list<item> Character::consume_items( map &m, const comp_selection<item_comp
         }
     }
     for( item &it : ret ) {
-        it.spill_contents( *this );
+        // leave battery/liquids/gases in their containers, spill out solids
+        if( !it.contains_no_solids() ) {
+            it.spill_contents( *this );
+        }
         // todo: make a proper solution that overflows with the proper item_location
         it.overflow( pos() );
     }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Limit the spilling action of https://github.com/CleverRaven/Cataclysm-DDA/pull/64846 so batteries don't instantly discharge, tanks don't lose gasses/liquids etc when installing as parts to vehicles (or doing any other stuff that passes via crafting consuming).

#### Describe the solution

Spill contents only when solids are inside

#### Describe alternatives you've considered

#### Testing

Spawn/get a storage battery with some charge in it or a propane tank with some propane in it, install to vehicle, battery shouldn't instantly discharge, propane shouldn't spill

#### Additional context
