### PR TITLE
Add a crafting recipe for propane lanterns

### DIFF
--- a/data/json/recipes/tools/lights.json
+++ b/data/json/recipes/tools/lights.json
@@ -343,6 +343,24 @@
   },
   {
     "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "result": "propane_lantern",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_TOOLS",
+    "skill_used": "fabrication",
+    "difficulty": 5,
+    "time": "1 h",
+    "autolearn": true,
+    "qualities": [ { "id": "HAMMER", "level": 1 } ],
+    "components": [
+      [ [ "scrap", 1 ] ],
+      [ [ "cotton_patchwork", 1 ], [ "cordage_superior_short", 1, "LIST" ] ],
+      [ [ "bottle_glass", 1 ], [ "flask_glass", 1 ], [ "jar_glass_sealed", 1 ] ],
+      [ [ "clay_teapot", 1 ], [ "jug_clay", 1 ], [ "can_food", 1 ], [ "can_drink", 1 ], [ "canister_empty", 1 ] ]
+    ]
+  },
+  {
+    "type": "recipe",
     "activity_level": "ACTIVE_EXERCISE",
     "result": "headlight_reinforced",
     "category": "CC_OTHER",


### PR DESCRIPTION
#### Summary
Added a crafting recipe for propane lantern

#### Purpose of change
I was annoyed by not being able to find any and confused by gasoline lanterns being craftable.

#### Describe the solution
Copied the existing recipe for gasoline lantern and made it for propane lantern instead.

#### Describe alternatives you've considered
Making the spawnrate higher in sporting goods/hardware stores or in places with propane tank spawns

#### Testing
Loaded the game after making the change on my installation and crafted one to make sure it worked.

#### Additional context
![Screenshot 2024-05-16 181443](https://github.com/CleverRaven/Cataclysm-DDA/assets/46012267/18c871b7-9316-4c5e-847c-fcec21792de0)

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
