### PR TITLE
Wool staple recipe now needs 7 felt patches.

### DIFF
--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -610,7 +610,7 @@
     "time": "10 m",
     "autolearn": true,
     "tools": [ [ [ "carding_paddles", -1 ] ] ],
-    "components": [ [ [ "felt_patch", 1 ] ] ]
+    "components": [ [ [ "felt_patch", 7 ] ] ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION
#### Summary
Bugfixes "The old wool staple recipe resulted in mass and yarn duplication. We respect the law of conservation of energy here. "

#### Purpose of change

The wool staple recipe originally need 1 felt patch to make 1 wool staple. However, wool staple takes up more volume and weight, this resulted in mass appearing out of nowhere. This could lead to a survivor creating thousands of yarn by salvaging woolly items for felt patches and then making wool staples out of them. Nuh uh, not anymore.

#### Describe the solution

Wool staples now need 7 felt patches to be crafted.

#### Describe alternatives you've considered

Let survivors continue to create energy and mass out of nowhere.

#### Testing

1. Salvage wool gloves and get 32 felt patches.
2. Craft as many wool staples as I can
3. I get 4, which can only make 40 yarn.

Great success!

#### Additional context

How did nobody notice until recently?