### PR TITLE
Correct Pile of Leaves Desconstruct/Bash

### DIFF
--- a/data/json/furniture_and_terrain/furniture-flora.json
+++ b/data/json/furniture_and_terrain/furniture-flora.json
@@ -324,14 +324,14 @@
     "comfort": 1,
     "floor_bedding_warmth": 50,
     "required_str": -1,
-    "deconstruct": { "items": [ { "item": "withered", "count": 50 } ] },
+    "deconstruct": { "items": [ { "item": "leaves", "count": 100 } ] },
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "ORGANIC", "MOUNTABLE", "SHORT", "EASY_DECONSTRUCT", "SMALL_HIDE" ],
     "bash": {
       "str_min": 2,
       "str_max": 6,
       "sound": "crunch!",
       "sound_fail": "whump.",
-      "items": [ { "item": "withered", "count": [ 45, 50 ] } ]
+      "items": [ { "item": "leaves", "count": [ 62, 75 ] } ]
     }
   },
   {


### PR DESCRIPTION
#### Summary
Balance "Adjust Pile of Leaves Deconstruct/Smash"

#### Purpose of change
Pile of leaves (construction/bed) was built of handful of leaves, but deconstructed/smashed into 100% withered plants.  This mean the player could rapidly convert handfuls of leaves (almost no value) to withered plants (more value), by the hundreds and in short periods of time.  It's also worth pointing out that withered plants reflect 'dead' leaves, which irl takes time and should not be the disassembly at all imo.
#### Describe the solution
I changed the disassembly/smash results to leaves instead of withered plants.
I also attempted to balance their numbers as the process should not 'cost' very many leaves in terms of damaged/removed.  So, for deconstruction, I made it give back 80% of the initial investment.  For Bash I gave it 50%-60% range on return.  We have no 'broken' leaf item, which realistically they would just shred or crumble to dust anyway so whatever.

#### Describe alternatives you've considered
Not doing it, or possibly adding some withered plants to the drops/deconstruct, I just feel them magically withering away makes no sense.

#### Testing
I did not test this, I just did math and changed like 3 words

#### Additional context
Closes #73932 