### PR TITLE
Ski mask is now a tube scarf

### DIFF
--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -2988,38 +2988,12 @@
     "color": "dark_gray",
     "use_action": {
       "type": "transform",
-      "menu_text": "Loosen",
+      "menu_text": "Wear as collar",
       "msg": "You adjust your ski mask for less warmth.",
       "target": "mask_ski_loose"
     },
     "symbol": "[",
-    "description": "A warm wool mask that protects the head and face from the cold.  It has a full face opening that can be adjusted to set how much is exposed.",
-    "price": "18 USD",
-    "price_postapoc": "2 USD 50 cent",
-    "material": [ "wool" ],
-    "volume": "250 ml",
-    "warmth": 45,
-    "flags": [ "VARSIZE", "SKINTIGHT" ],
-    "material_thickness": 1,
-    "environmental_protection": 2,
-    "armor": [ { "encumbrance": 10, "coverage": 80, "covers": [ "head", "mouth" ] } ]
-  },
-  {
-    "type": "TOOL_ARMOR",
-    "id": "mask_ski_loose",
-    "name": { "str": "ski mask (open)", "str_pl": "ski masks (open)" },
-    "category": "clothing",
-    "weight": "86 g",
-    "color": "dark_gray",
-    "use_action": {
-      "type": "transform",
-      "menu_text": "Tighten",
-      "msg": "You adjust your ski mask for more warmth.",
-      "target": "mask_ski"
-    },
-    "revert_to": "mask_ski",
-    "symbol": "[",
-    "description": "A warm wool mask that protects the head and face from the cold.  It has a full face opening that can be adjusted to set how much is exposed.",
+    "description": "A warm wool mask that protects the head and face from the cold.  It covers most of your head and mouth, and can be adjusted to hang around your throat instead.",
     "price": "18 USD",
     "price_postapoc": "2 USD 50 cent",
     "material": [ "wool" ],
@@ -3027,8 +3001,48 @@
     "warmth": 25,
     "flags": [ "VARSIZE", "SKINTIGHT" ],
     "material_thickness": 1,
+    "environmental_protection": 2,
+    "armor": [
+      {
+        "encumbrance": 6,
+        "coverage": 100,
+        "covers": [ "head" ],
+        "//:": "not forehead or nape",
+        "specifically_covers": [ "head_crown", "head_ear_r", "head_ear_l", "head_throat" ]
+      },
+      {
+        "encumbrance": 10,
+        "coverage": 100,
+        "covers": [ "mouth" ],
+        "specifically_covers": [ "mouth_lips", "mouth_cheeks", "mouth_chin" ]
+      }
+    ]
+  },
+  {
+    "type": "TOOL_ARMOR",
+    "id": "mask_ski_loose",
+    "name": { "str": "ski mask (collar)", "str_pl": "ski masks (collar)" },
+    "category": "clothing",
+    "weight": "86 g",
+    "color": "dark_gray",
+    "use_action": {
+      "type": "transform",
+      "menu_text": "Wear around head",
+      "msg": "You adjust your ski mask for more warmth.",
+      "target": "mask_ski"
+    },
+    "revert_to": "mask_ski",
+    "symbol": "[",
+    "description": "A warm wool mask that protects the head and face from the cold.  It is wrapped around your throat, and can be adjusted to cover your mouth and more of your head.",
+    "price": "18 USD",
+    "price_postapoc": "2 USD 50 cent",
+    "material": [ "wool" ],
+    "volume": "250 ml",
+    "warmth": 25,
+    "flags": [ "VARSIZE", "SKINTIGHT", "COLLAR" ],
+    "material_thickness": 1,
     "environmental_protection": 1,
-    "armor": [ { "encumbrance": 10, "coverage": 60, "covers": [ "head", "mouth" ] } ]
+    "armor": [ { "encumbrance": 4, "coverage": 20, "covers": [ "head" ], "specifically_covers": [ "head_nape", "head_throat" ] } ]
   },
   {
     "type": "TOOL_ARMOR",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Ski mask has been sublimbed"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

The ski mask was not sufficiently sublimbed when I wanted to use it. The end result of my thoughts (and the help of [Karol giving input](https://discord.com/channels/598523535169945603/598523535169945607/1236943901844312095), a Discord link) made it make the most sense as being remodeled into a tube scarf.

Some shenanigans with my fork made me restart this from #73855

#### Describe the solution

The ski mask in its original form is largely unchanged, made to work with a gas mask to avoid a regression. The warmth value on that form was changed to work more nicely with how the "open" form, now using sublimbs, reduce that warmth via using less total sublimb coverage.

The "open" form pretends to be worn around the neck, allowing dragging it over your mouth when wanting to avoid being struck with a chilling gust of wind while skiing downhill, for example. I thought that made sense, with that being the way I use mine.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Making this another item, but the wacky non-limbed mouth has been bothering me too much.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

I give you my guarantee that all these things have been tested in regards to coverage, warmth, encumbrance values... I believe I've been thorough.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->

I would change the material, but recipes are scary.

The specific sublimbs covered are based on me wearing my own tube scarf. Thin and flexible, it pairs well with ski goggles and a helmet to keep my face free from frost (while making sure it's secured and won't fold inadvertently).

I would love to make the sprite for the collar form something akin to a scarf, but I do not know how.