### PR TITLE
Rename fd_reality_tear back to fd_fatigue (fix tilesets, migration)

### DIFF
--- a/data/json/artifact/altered_object_active.json
+++ b/data/json/artifact/altered_object_active.json
@@ -136,6 +136,6 @@
     "flags": [ "IGNORE_WALLS", "NO_PROJECTILE", "NO_EXPLOSION_SFX" ],
     "shape": "blast",
     "effect": "remove_field",
-    "effect_str": "fd_reality_tear"
+    "effect_str": "fd_fatigue"
   }
 ]

--- a/data/json/artifact/legacy_artifact_active.json
+++ b/data/json/artifact/legacy_artifact_active.json
@@ -386,7 +386,7 @@
     "effect": "attack",
     "message": "",
     "shape": "blast",
-    "field_id": "fd_reality_tear",
+    "field_id": "fd_fatigue",
     "field_chance": 1,
     "min_field_intensity": 2,
     "max_field_intensity": 2,

--- a/data/json/field_type.json
+++ b/data/json/field_type.json
@@ -887,7 +887,7 @@
     "display_field": true
   },
   {
-    "id": "fd_reality_tear",
+    "id": "fd_fatigue",
     "type": "field_type",
     "legacy_enum_id": 20,
     "intensity_levels": [

--- a/data/json/furniture_and_terrain/LIXA_furniture_and_terrain.json
+++ b/data/json/furniture_and_terrain/LIXA_furniture_and_terrain.json
@@ -309,7 +309,7 @@
     "type": "furniture",
     "id": "f_LIXA_unfold_barrier",
     "name": "wall of flat space",
-    "looks_like": "fd_reality_tear",
+    "looks_like": "fd_fatigue",
     "description": "From a distance, this looks like where the chamber ends; a flat wall, with a very detailed painting of a tunnel behind it.  But as you get closer, you can see how it ripples, like lazy water, and notice angles of the space beyond that a flat image could never give.",
     "symbol": "@",
     "color": "light_gray",

--- a/data/json/mapgen/lab/lab_floorplans_finale1level.json
+++ b/data/json/mapgen/lab/lab_floorplans_finale1level.json
@@ -168,7 +168,7 @@
       ],
       "palettes": [ "lab_palette", "lab_loot_research" ],
       "furniture": { "C": "f_machinery_electronic", "R": "f_rack", "D": "f_desk" },
-      "fields": { "Q": { "field": "fd_reality_tear", "intensity": 3 } },
+      "fields": { "Q": { "field": "fd_fatigue", "intensity": 3 } },
       "terrain": { "r": "t_metal_floor", "Y": "t_thconc_floor_olight", "p": "t_metal_floor" },
       "mapping": {
         "R": { "item": [ { "item": "dimensional_anchor" }, { "item": "phase_immersion_suit" } ] },

--- a/data/json/mapgen/mi-go/mi-go_portal.json
+++ b/data/json/mapgen/mi-go/mi-go_portal.json
@@ -46,7 +46,7 @@
           [ "f_null", 90 ]
         ]
       },
-      "fields": { "P": { "field": "fd_reality_tear", "intensity": 1, "age": 10 } },
+      "fields": { "P": { "field": "fd_fatigue", "intensity": 1, "age": 10 } },
       "place_monsters": [ { "monster": "GROUP_MI-GO_BASE_COMMON", "density": 0.1, "x": 8, "y": 10 } ],
       "nested": {
         "1": {

--- a/data/json/mapgen/microlab/microlab_special_tiles.json
+++ b/data/json/mapgen/microlab/microlab_special_tiles.json
@@ -252,7 +252,7 @@
       "palettes": [ "microlab" ],
       "terrain": { "G": "t_card_science", "9": "t_reinforced_glass_shutter" },
       "furniture": { "t": "f_counter", "p": "f_counter", "M": "f_server", "A": "f_xedra_antenna", "D": "f_desk" },
-      "fields": { "Q": { "field": "fd_reality_tear", "intensity": 3 } },
+      "fields": { "Q": { "field": "fd_fatigue", "intensity": 3 } },
       "item": {
         "D": [ { "item": "artifact_scp_doc", "chance": 30 }, { "item": "monitoring_equipment_doc", "chance": 30 } ],
         "m": { "item": "xedra_microphone", "chance": 90 },

--- a/data/json/mapgen_palettes/nether_monster_palette.json
+++ b/data/json/mapgen_palettes/nether_monster_palette.json
@@ -22,6 +22,6 @@
       "Z": "f_nm_nether_lichen"
     },
     "traps": { "P": "tr_portal" },
-    "fields": { "q": { "field": "fd_reality_tear", "intensity": 1 }, "Q": { "field": "fd_reality_tear", "intensity": 2 } }
+    "fields": { "q": { "field": "fd_fatigue", "intensity": 1 }, "Q": { "field": "fd_fatigue", "intensity": 2 } }
   }
 ]

--- a/data/json/monster_special_attacks/monster_deaths.json
+++ b/data/json/monster_special_attacks/monster_deaths.json
@@ -69,7 +69,7 @@
     "shape": "blast",
     "effect": "attack",
     "max_level": 2,
-    "field_id": "fd_reality_tear",
+    "field_id": "fd_fatigue",
     "field_chance": 1,
     "min_field_intensity": 1,
     "field_intensity_increment": 1,

--- a/data/mods/Aftershock/maps/furniture.json
+++ b/data/mods/Aftershock/maps/furniture.json
@@ -415,7 +415,7 @@
     "type": "furniture",
     "id": "f_translocator_buoy",
     "name": "translocator buoy",
-    "looks_like": "fd_reality_tear",
+    "looks_like": "fd_fatigue",
     "move_cost_mod": 0,
     "description": "A near undetectable spatial distortion field centered around a free floating golden mote.  Examining it from up close would let you encode it for use with a translocation device.",
     "symbol": ",",

--- a/data/mods/DinoMod/mapgen/DinoLabFinale.json
+++ b/data/mods/DinoMod/mapgen/DinoLabFinale.json
@@ -115,7 +115,7 @@
       ],
       "palettes": [ "lab_palette", "lab_loot_research" ],
       "furniture": { "C": "f_machinery_electronic", "R": "f_rack", "D": "f_desk" },
-      "fields": { "Q": { "field": "fd_reality_tear", "intensity": 3 } },
+      "fields": { "Q": { "field": "fd_fatigue", "intensity": 3 } },
       "terrain": { "r": "t_metal_floor", "Y": "t_thconc_floor_olight", "p": "t_metal_floor", "z": "t_strconc_floor" },
       "mapping": {
         "R": { "item": [ { "item": "dimensional_anchor" }, { "item": "phase_immersion_suit" } ] },
@@ -181,7 +181,7 @@
       ],
       "palettes": [ "lab_palette", "lab_loot_research" ],
       "furniture": { "C": "f_machinery_electronic", "R": "f_rack", "D": "f_desk" },
-      "fields": { "Q": { "field": "fd_reality_tear", "intensity": 3 } },
+      "fields": { "Q": { "field": "fd_fatigue", "intensity": 3 } },
       "terrain": { "r": "t_metal_floor", "Y": "t_thconc_floor_olight", "p": "t_metal_floor", "~": "t_water_sh", "z": "t_water_sh" },
       "mapping": {
         "R": { "item": [ { "item": "dimensional_anchor" }, { "item": "phase_immersion_suit" } ] },

--- a/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
@@ -1061,7 +1061,7 @@
       ]
     },
     "effect": [
-      { "u_set_field": "fd_reality_tear", "radius": 0, "intensity": 3, "hit_player": false },
+      { "u_set_field": "fd_fatigue", "radius": 0, "intensity": 3, "hit_player": false },
       { "u_message": "As you unleash your powers, the air around you twists and warps in on itself.", "type": "bad" }
     ]
   },

--- a/data/mods/MindOverMatter/mapgen/map_extras/glass_and_crystal.json
+++ b/data/mods/MindOverMatter/mapgen/map_extras/glass_and_crystal.json
@@ -65,7 +65,7 @@
       "rows": [ "X" ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "terrain": { "X": "t_nether_stone" },
-      "place_fields": [ { "field": "fd_reality_tear", "x": 0, "y": 0, "intensity": 3 } ]
+      "place_fields": [ { "field": "fd_fatigue", "x": 0, "y": 0, "intensity": 3 } ]
     }
   }
 ]

--- a/data/mods/MindOverMatter/mapgen/microlab_rooms.json
+++ b/data/mods/MindOverMatter/mapgen/microlab_rooms.json
@@ -63,7 +63,7 @@
       "terrain": { "G": "t_card_science", "9": "t_reinforced_glass_shutter" },
       "furniture": { "t": "f_counter", "M": "f_server", "A": "f_xedra_antenna", "D": "f_portal_stabilizer" },
       "item": { "m": { "item": "xedra_microphone", "chance": 90 }, "s": { "item": "xedra_seismograph", "chance": 90 } },
-      "fields": { "Q": { "field": "fd_reality_tear", "intensity": 2 } },
+      "fields": { "Q": { "field": "fd_fatigue", "intensity": 2 } },
       "place_monster": [
         { "group": "GROUP_LAB", "x": [ 2, 21 ], "y": [ 2, 21 ], "chance": 60, "repeat": [ 1, 5 ] },
         { "group": "GROUP_FERAL_TELEPORTER", "x": [ 3, 20 ], "y": [ 3, 20 ], "chance": 30, "repeat": [ 1, 2 ] },

--- a/data/mods/MindOverMatter/mapgen/psi_surface_lab/psi_lab_surface_nested.json
+++ b/data/mods/MindOverMatter/mapgen/psi_surface_lab/psi_lab_surface_nested.json
@@ -2452,7 +2452,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_terrain": [ { "ter": "t_nether_water_sh", "x": 0, "y": 0 } ],
-      "place_fields": [ { "field": "fd_reality_tear", "x": 0, "y": 0, "intensity": 3 } ],
+      "place_fields": [ { "field": "fd_fatigue", "x": 0, "y": 0, "intensity": 3 } ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
     }
   },
@@ -2463,7 +2463,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_terrain": [ { "ter": "t_strconc_floor", "x": 0, "y": 0 } ],
-      "place_fields": [ { "field": "fd_reality_tear", "x": 0, "y": 0, "intensity": 3 } ],
+      "place_fields": [ { "field": "fd_fatigue", "x": 0, "y": 0, "intensity": 3 } ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
     }
   },
@@ -2474,7 +2474,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_terrain": [ { "ter": "t_floor", "x": 0, "y": 0 } ],
-      "place_fields": [ { "field": "fd_reality_tear", "x": 0, "y": 0, "intensity": 3 } ],
+      "place_fields": [ { "field": "fd_fatigue", "x": 0, "y": 0, "intensity": 3 } ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
     }
   }

--- a/data/mods/MindOverMatter/overmap/nether_crystal_field.json
+++ b/data/mods/MindOverMatter/overmap/nether_crystal_field.json
@@ -190,8 +190,8 @@
       "furniture": { "N": [ [ "f_nether_crystal_structure", 1 ], [ "f_null", 1 ] ] },
       "place_monsters": [ { "monster": "GROUP_CRYSTAL_FIELD_PSYCHOACTIVE", "x": [ 0, 1 ], "y": [ 0, 1 ], "chance": 50, "repeat": [ 1, 3 ] } ],
       "place_fields": [
-        { "field": "fd_reality_tear", "x": 0, "y": 1, "intensity": [ 2, 3 ] },
-        { "field": "fd_reality_tear", "x": 1, "y": 0, "intensity": [ 2, 3 ] }
+        { "field": "fd_fatigue", "x": 0, "y": 1, "intensity": [ 2, 3 ] },
+        { "field": "fd_fatigue", "x": 1, "y": 0, "intensity": [ 2, 3 ] }
       ]
     }
   },
@@ -210,8 +210,8 @@
       "furniture": { "N": [ [ "f_nether_crystal_structure", 1 ], [ "f_null", 1 ] ] },
       "place_monsters": [ { "monster": "GROUP_CRYSTAL_FIELD_PSYCHOACTIVE", "x": [ 0, 1 ], "y": [ 0, 1 ], "chance": 50, "repeat": [ 1, 3 ] } ],
       "place_fields": [
-        { "field": "fd_reality_tear", "x": 0, "y": 0, "intensity": [ 2, 3 ] },
-        { "field": "fd_reality_tear", "x": 1, "y": 1, "intensity": [ 2, 3 ] }
+        { "field": "fd_fatigue", "x": 0, "y": 0, "intensity": [ 2, 3 ] },
+        { "field": "fd_fatigue", "x": 1, "y": 1, "intensity": [ 2, 3 ] }
       ]
     }
   },

--- a/src/field_type.cpp
+++ b/src/field_type.cpp
@@ -46,7 +46,7 @@ const field_type_str_id fd_last_known( "fd_last_known" );
 const field_type_str_id fd_nuke_gas( "fd_nuke_gas" );
 const field_type_str_id fd_plasma( "fd_plasma" );
 const field_type_str_id fd_push_items( "fd_push_items" );
-const field_type_str_id fd_reality_tear( "fd_reality_tear" );
+const field_type_str_id fd_fatigue( "fd_fatigue" );
 const field_type_str_id fd_relax_gas( "fd_relax_gas" );
 const field_type_str_id fd_sap( "fd_sap" );
 const field_type_str_id fd_shock_vent( "fd_shock_vent" );

--- a/src/field_type.h
+++ b/src/field_type.h
@@ -143,7 +143,7 @@ extern const field_type_str_id fd_dazzling;
 extern const field_type_str_id fd_electricity;
 extern const field_type_str_id fd_electricity_unlit;
 extern const field_type_str_id fd_extinguisher;
-extern const field_type_str_id fd_reality_tear;
+extern const field_type_str_id fd_fatigue;
 extern const field_type_str_id fd_fire;
 extern const field_type_str_id fd_fire_vent;
 extern const field_type_str_id fd_flame_burst;

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -852,15 +852,15 @@ static std::pair<field, tripoint> spell_remove_field( const spell &sp,
     return std::pair<field, tripoint> {field_removed, field_position};
 }
 
-static void handle_remove_fd_reality_tear_field( const std::pair<field, tripoint>
-        &fd_reality_tear_field,
+static void handle_remove_fd_fatigue_field( const std::pair<field, tripoint>
+        &fd_fatigue_field,
         Creature &caster )
 {
     for( const std::pair<const field_type_id, field_entry> &fd : std::get<0>
-         ( fd_reality_tear_field ) ) {
+         ( fd_fatigue_field ) ) {
         const int &intensity = fd.second.get_field_intensity();
         const translation &intensity_name = fd.second.get_intensity_level().name;
-        const tripoint &field_position = std::get<1>( fd_reality_tear_field );
+        const tripoint &field_position = std::get<1>( fd_fatigue_field );
         const bool sees_field = caster.sees( field_position );
 
         switch( intensity ) {
@@ -912,8 +912,8 @@ void spell_effect::remove_field( const spell &sp, Creature &caster, const tripoi
         if( fd.first.is_valid() && !fd.first.id().is_null() ) {
             sp.make_sound( caster.pos(), caster );
 
-            if( fd.first.id() == fd_reality_tear ) {
-                handle_remove_fd_reality_tear_field( field_removed, caster );
+            if( fd.first.id() == fd_fatigue ) {
+                handle_remove_fd_fatigue_field( field_removed, caster );
             } else {
                 caster.add_msg_if_player( m_neutral, _( "The %s dissipates." ),
                                           fd.second.get_intensity_level().name );

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -1029,7 +1029,7 @@ static bool mx_portal_in( map &m, const tripoint &abs_sub )
     switch( rng( 1, 6 ) ) {
         //Mycus spreading through the portal
         case 1: {
-            m.add_field( portal_location, fd_reality_tear, 3 );
+            m.add_field( portal_location, fd_fatigue, 3 );
             fungal_effects fe;
             for( const tripoint_bub_ms &loc : m.points_in_radius( portal_location, 5 ) ) {
                 if( one_in( 3 ) ) {
@@ -1043,7 +1043,7 @@ static bool mx_portal_in( map &m, const tripoint &abs_sub )
         }
         //Netherworld monsters spawning around the portal
         case 2: {
-            m.add_field( portal_location, fd_reality_tear, 3 );
+            m.add_field( portal_location, fd_fatigue, 3 );
             for( const tripoint_bub_ms &loc : m.points_in_radius( portal_location, 5 ) ) {
                 m.place_spawns( GROUP_NETHER_PORTAL, 15, loc.xy(), loc.xy(), loc.z(), 1, true );
             }
@@ -1051,7 +1051,7 @@ static bool mx_portal_in( map &m, const tripoint &abs_sub )
         }
         //Several cracks in the ground originating from the portal
         case 3: {
-            m.add_field( portal_location, fd_reality_tear, 3 );
+            m.add_field( portal_location, fd_fatigue, 3 );
             for( int i = 0; i < rng( 1, 10 ); i++ ) {
                 tripoint_bub_ms end_location = { rng( 0, SEEX * 2 - 1 ), rng( 0, SEEY * 2 - 1 ), abs_sub.z };
                 std::vector<tripoint_bub_ms> failure = line_to( portal_location, end_location );
@@ -1063,7 +1063,7 @@ static bool mx_portal_in( map &m, const tripoint &abs_sub )
         }
         //Radiation from the portal killed the vegetation
         case 4: {
-            m.add_field( portal_location, fd_reality_tear, 3 );
+            m.add_field( portal_location, fd_fatigue, 3 );
             const int rad = 5;
             for( int i = p.x() - rad; i <= p.x() + rad; i++ ) {
                 for( int j = p.y() - rad; j <= p.y() + rad; j++ ) {
@@ -1104,7 +1104,7 @@ static bool mx_portal_in( map &m, const tripoint &abs_sub )
                 }
 
                 const tripoint portal_location = { p1 + tripoint( extra, abs_sub.z ) };
-                m.add_field( portal_location, fd_reality_tear, 3 );
+                m.add_field( portal_location, fd_fatigue, 3 );
 
                 std::set<point> ignited;
                 place_fumarole( m, p1, p2, ignited );
@@ -1124,7 +1124,7 @@ static bool mx_portal_in( map &m, const tripoint &abs_sub )
         }
         //Anomaly caused by the portal and spawned an artifact
         case 6: {
-            m.add_field( portal_location, fd_reality_tear, 3 );
+            m.add_field( portal_location, fd_fatigue, 3 );
             artifact_natural_property prop =
                 static_cast<artifact_natural_property>( rng( ARTPROP_NULL + 1, ARTPROP_MAX - 1 ) );
             m.create_anomaly( portal_location, prop );

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -1673,7 +1673,7 @@ void map::player_in_field( Character &you )
                 }
             }
         }
-        if( ft == fd_reality_tear ) {
+        if( ft == fd_fatigue ) {
             // Assume the rift is on the ground for now to prevent issues with the player being unable access vehicle controls on the same tile due to teleportation.
             if( !you.in_vehicle ) {
                 // Teleports you... somewhere.
@@ -1993,7 +1993,7 @@ void map::monster_in_field( monster &z )
                                                     cur.get_field_intensity() ) );
             z.deal_damage( nullptr, bodypart_id( "torso" ), damage_instance( damage_electric, field_dmg ) );
         }
-        if( cur_field_type == fd_reality_tear ) {
+        if( cur_field_type == fd_fatigue ) {
             if( rng( 0, 2 ) < cur.get_field_intensity() ) {
                 dam += cur.get_field_intensity();
                 teleport::teleport( z );

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -1567,7 +1567,7 @@ void suffer::from_artifact_resonance( Character &you, int amt )
                 you.add_msg_player_or_npc( m_bad, _( "Reality gives way under your feet like rotten scaffolding." ),
                                            _( "Reality gives way under <npcname>'s feet like rotten scaffolding." ) );
                 map &here = get_map();
-                here.add_field( you.pos(), fd_reality_tear, 1 );
+                here.add_field( you.pos(), fd_fatigue, 1 );
             } else if( rng_outcome == 3 ) {
                 you.add_msg_player_or_npc( m_bad, _( "You suddenly lose all substance and corporeality." ),
                                            _( "<npcname> suddenly loses all substance and corporeality." ) );

--- a/tests/magic_spell_effect_test.cpp
+++ b/tests/magic_spell_effect_test.cpp
@@ -75,7 +75,7 @@ TEST_CASE( "line_attack", "[magic]" )
     }
 }
 
-TEST_CASE( "remove_field_fd_reality_tear", "[magic]" )
+TEST_CASE( "remove_field_fd_fatigue", "[magic]" )
 {
     // Test relies on lighting conditions, so ensure we control the level of
     // daylight.
@@ -93,15 +93,15 @@ TEST_CASE( "remove_field_fd_reality_tear", "[magic]" )
         CAPTURE( with_light );
         CHECK( dummy.get_location() == player_initial_pos );
 
-        // create fd_reality_tear of each intensity near player
+        // create fd_fatigue of each intensity near player
         tripoint_abs_ms p1 = player_initial_pos + tripoint_east * 10;
         tripoint_abs_ms p2 = player_initial_pos + tripoint_east * 11;
         tripoint_abs_ms p3 = player_initial_pos + tripoint_east * 12;
         tripoint_abs_ms p4 = player_initial_pos + tripoint_east * 13;
-        m.add_field( m.getlocal( p1 ), fd_reality_tear, 1, 1_hours );
-        m.add_field( m.getlocal( p2 ), fd_reality_tear, 2, 1_hours );
-        m.add_field( m.getlocal( p3 ), fd_reality_tear, 3, 1_hours );
-        m.add_field( m.getlocal( p4 ), fd_reality_tear, 3, 1_hours );
+        m.add_field( m.getlocal( p1 ), fd_fatigue, 1, 1_hours );
+        m.add_field( m.getlocal( p2 ), fd_fatigue, 2, 1_hours );
+        m.add_field( m.getlocal( p3 ), fd_fatigue, 3, 1_hours );
+        m.add_field( m.getlocal( p4 ), fd_fatigue, 3, 1_hours );
 
         if( with_light ) {
             player_add_headlamp();
@@ -114,7 +114,7 @@ TEST_CASE( "remove_field_fd_reality_tear", "[magic]" )
         dummy.recalc_sight_limits();
 
         CHECK( m.getglobal( dummy.pos() ) == player_initial_pos );
-        CHECK( count_fields_near( p1, fd_reality_tear ) == std::set<tripoint_abs_ms> { p1, p2, p3, p4 } );
+        CHECK( count_fields_near( p1, fd_fatigue ) == std::set<tripoint_abs_ms> { p1, p2, p3, p4 } );
 
         spell_effect::remove_field( sp, dummy, m.getlocal( player_initial_pos ) );
         calendar::turn += 1_turns;
@@ -123,7 +123,7 @@ TEST_CASE( "remove_field_fd_reality_tear", "[magic]" )
         m.process_fields();
 
         CHECK( m.getglobal( dummy.pos() ) == player_initial_pos );
-        CHECK( count_fields_near( p1, fd_reality_tear ) == std::set<tripoint_abs_ms> { p2, p3, p4 } );
+        CHECK( count_fields_near( p1, fd_fatigue ) == std::set<tripoint_abs_ms> { p2, p3, p4 } );
 
         spell_effect::remove_field( sp, dummy, m.getlocal( player_initial_pos ) );
         calendar::turn += 1_turns;
@@ -132,7 +132,7 @@ TEST_CASE( "remove_field_fd_reality_tear", "[magic]" )
         m.process_fields();
 
         CHECK( m.getglobal( dummy.pos() ) == player_initial_pos );
-        CHECK( count_fields_near( p1, fd_reality_tear ) == std::set<tripoint_abs_ms> { p3, p4 } );
+        CHECK( count_fields_near( p1, fd_fatigue ) == std::set<tripoint_abs_ms> { p3, p4 } );
 
         spell_effect::remove_field( sp, dummy, m.getlocal( player_initial_pos ) );
         calendar::turn += 1_turns;
@@ -140,7 +140,7 @@ TEST_CASE( "remove_field_fd_reality_tear", "[magic]" )
         calendar::turn += 1_turns;
         m.process_fields();
 
-        CHECK( count_fields_near( p1, fd_reality_tear ) == std::set<tripoint_abs_ms> { p4 } );
+        CHECK( count_fields_near( p1, fd_fatigue ) == std::set<tripoint_abs_ms> { p4 } );
     };
 
     setup_and_remove_fields( true );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
fd_fatigue was renamed to fd_reality_tear in #72708, but we do not have any migration handling for fields. This causes existing instances of the field to throw errors on load **and disappear** (as a valid field cannot be found for them). 

Additionally, because the ID has changed the tilesets no longer have an entry for them. This causes them to revert to their `looks_like` of smoke. The actual graphics are pretty cool, so I'd like to keep them.

#### Describe the solution
Revert this naming change.

#### Describe alternatives you've considered
Implement migration handling and figure out the tileset incantations to move its sprites around?

#### Testing
Load this save without the patch, notice field errors and no tears in reality exist on load:
[FIELDS NAME-trimmed.tar.gz](https://github.com/CleverRaven/Cataclysm-DDA/files/15376066/FIELDS.NAME-trimmed.tar.gz)

(Without saving) Load after patch, notice fields exist and look like they should on all tiles builds with in-repo tilesets

#### Additional context
This causes the reverse problem for builds created between April 4th and the merging of this PR, in that fd_reality_tear generated in saves between them will disappear. This is not ideal, but the issue will not occur for anyone moving from 0.H--->a hypothetical future 0.I, which is desirable.