### PR TITLE
change JSON_INFO.md "inherits_flags"

### DIFF
--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -4033,7 +4033,7 @@ Any Item can be a container. To add the ability to contain things to an item, yo
 
     "sealed_data": { "spoil_multiplier": 0.0 } // If a pocket has sealed_data, it will be sealed when the item spawns.  The sealed version of the pocket will override the unsealed version of the same datatype.
 
-    "inherits_flags": true // if a pocket inherits flags it means any flags that the items inside have contribute to the item that has the pockets itself.
+    "inherits_flags": true // Items in this pocket pass their flags to the parent item.
   }
 ]
 ```


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

I couldn't read that doc line, it is way too complex.

#### Describe the solution

Copy pasted comment from code:
https://github.com/CleverRaven/Cataclysm-DDA/blob/8e6eac543380e4426fc966be096e1699c6e83214/src/item_pocket.h#L511 I hope it means the same thing, but I am not sure as I cannot read the docs line.

I looked at the code and it seems alright...?
https://github.com/CleverRaven/Cataclysm-DDA/blob/8e6eac543380e4426fc966be096e1699c6e83214/src/item.cpp#L6673-L6702

Maybe it should be

_Items in this pocket pass their flags to the ~parent item~ **this item**._

#### Describe alternatives you've considered

Remove it from my to-do and ignore it forever.

#### Testing

It is a docs change. I didn't test if the JSON does what I say it does.

#### Additional context

