### PR TITLE
Fix: throwing items from outside the inventory

### DIFF
--- a/src/npc_attack.cpp
+++ b/src/npc_attack.cpp
@@ -727,7 +727,7 @@ npc_attack_rating npc_attack_throw::evaluate(
         // please don't throw your pants...
         return effectiveness;
     }
-    const inventory &available_weapons = source.crafting_inventory( -1 );
+    const inventory &available_weapons = source.crafting_inventory( tripoint_zero, -1 );
     if( &thrown_item == source.evaluate_best_weapon() &&
         available_weapons.amount_of( thrown_item.typeId() ) <= 1 &&
         available_weapons.charges_of( thrown_item.typeId() ) <= 1 ) {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

See this comment: https://github.com/CleverRaven/Cataclysm-DDA/pull/73498#discussion_r1608575124

#### Describe the solution

Call the right method.

#### Describe alternatives you've considered


#### Testing

This should be tested, if the problem existed and now it doesn't exist. I didn't test it but I would expect the test to go like this:
1. spawn NPC
2. spawn items 5 tiles from it
3. make it want to throw items
4. BUG: npc throws item that is 5 tiles from it at the target

I didn't test it because I don't know how to make step 3.

#### Additional context
Even if this doesn't fix anything, it at least fixes the warning in Microsoft Visual Studio.
