### PR TITLE
Sane-ify in-vehicle movement size checks

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8017,63 +8017,6 @@ std::string Character::weapname_ammo() const
     }
 }
 
-// Tests to see if a character has room to enter a vehicle tile.
-bool Character::move_in_vehicle( Creature *c, const tripoint &dest_loc ) const
-{
-    map &m = get_map();
-    const optional_vpart_position vp_there = m.veh_at( dest_loc );
-    if( vp_there ) {
-        vehicle &veh = vp_there->vehicle();
-        units::volume capacity = 0_ml;
-        units::volume free_cargo = 0_ml;
-        auto cargo_parts = veh.get_parts_at( dest_loc, "CARGO", part_status_flag::any );
-        for( vehicle_part *&part : cargo_parts ) {
-            vehicle_stack contents = veh.get_items( *part );
-            const optional_vpart_position vp = m.veh_at( dest_loc );
-            // Check for obstacles and appliances to prevent squishing when the part is
-            // not a vehicle or when the player is not actually entering the tile IE grabbing.
-            if( !vp.part_with_feature( "CARGO_PASSABLE", false ) &&
-                !vp.part_with_feature( "APPLIANCE", false ) && !vp.part_with_feature( "OBSTACLE", false ) ) {
-                capacity += contents.max_volume();
-                free_cargo += contents.free_volume();
-            }
-        }
-        if( capacity > 0_ml ) {
-            // First, we'll try to squeeze in. Open-topped vehicle parts have more room for us.
-            if( !veh.enclosed_at( dest_loc ) ) {
-                free_cargo *= 1.2;
-            }
-            const creature_size size = get_size();
-            if( ( size == creature_size::tiny && free_cargo < 15625_ml ) ||
-                ( size == creature_size::small && free_cargo < 31250_ml ) ||
-                ( size == creature_size::medium && free_cargo < 62500_ml ) ||
-                ( size == creature_size::large && free_cargo < 125000_ml ) ||
-                ( size == creature_size::huge && free_cargo < 250000_ml ) ) {
-                if( ( size == creature_size::tiny && free_cargo < 11719_ml ) ||
-                    ( size == creature_size::small && free_cargo < 23438_ml ) ||
-                    ( size == creature_size::medium && free_cargo < 46875_ml ) ||
-                    ( size == creature_size::large && free_cargo < 93750_ml ) ||
-                    ( size == creature_size::huge && free_cargo < 187500_ml ) ) {
-                    add_msg_if_player( m_warning, _( "There's not enough room for you to fit there." ) );
-                    return false; // Even if we squeeze, there's no room.
-                }
-                c->add_effect( effect_cramped_space, 2_turns, true );
-                return true;
-            }
-        }
-        const optional_vpart_position vp = m.veh_at( dest_loc );
-        // Sufficiently gigantic characters aren't comfortable in stock seats, roof or no.
-        if( in_vehicle && get_size() == creature_size::huge && !vp.part_with_feature( "AISLE", false ) &&
-            !vp.part_with_feature( "HUGE_OK", false ) && !has_effect( effect_cramped_space ) ) {
-            add_msg_if_player( m_warning, _( "You barely fit in this tiny human vehicle." ) );
-            add_msg_if_npc( m_warning, _( "%s has to really cram their huge body to fit." ), c->disp_name() );
-            c->add_effect( effect_cramped_space, 2_turns, true );
-            return true;
-        }
-    }
-    return true;
-}
-
 void Character::on_hit( Creature *source, bodypart_id bp_hit,
                         float /*difficulty*/, dealt_projectile_attack const *const proj )
 {

--- a/src/character.h
+++ b/src/character.h
@@ -1437,9 +1437,6 @@ class Character : public Creature, public visitable
         void dismount();
         void forced_dismount();
 
-        /** Attempt to enter a tile in a vehicle */
-        bool move_in_vehicle( Creature *c, const tripoint &dest_loc ) const;
-
         bool is_deaf() const;
         bool is_mute() const;
         // Get the specified limb score. If bp is defined, only the scores from that body part type are summed.

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -87,7 +87,6 @@ static const damage_type_id damage_heat( "heat" );
 static const efftype_id effect_all_fours( "all_fours" );
 static const efftype_id effect_blind( "blind" );
 static const efftype_id effect_bounced( "bounced" );
-static const efftype_id effect_cramped_space( "cramped_space" );
 static const efftype_id effect_downed( "downed" );
 static const efftype_id effect_foamcrete_slow( "foamcrete_slow" );
 static const efftype_id effect_invisibility( "invisibility" );

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -87,6 +87,7 @@ static const damage_type_id damage_heat( "heat" );
 static const efftype_id effect_all_fours( "all_fours" );
 static const efftype_id effect_blind( "blind" );
 static const efftype_id effect_bounced( "bounced" );
+static const efftype_id effect_cramped_space( "cramped_space" );
 static const efftype_id effect_downed( "downed" );
 static const efftype_id effect_foamcrete_slow( "foamcrete_slow" );
 static const efftype_id effect_invisibility( "invisibility" );
@@ -190,6 +191,85 @@ void Creature::setpos( const tripoint &p )
     const tripoint_abs_ms old_loc = get_location();
     set_pos_only( p );
     on_move( old_loc );
+}
+
+static units::volume size_to_volume( creature_size size_class )
+{
+    if( size_class == creature_size::tiny ) {
+        return 7499_ml;
+    } else if( size_class == creature_size::small ) {
+        return 46249_ml;
+    } else if( size_class == creature_size::medium ) {
+        return 107999_ml;
+    } else if( size_class == creature_size::large ) {
+        return 483749_ml;
+    }
+    return DEFAULT_TILE_VOLUME - 1_ml;
+}
+
+bool Creature::can_move_to_vehicle_tile( const tripoint_abs_ms &loc, bool &cramped ) const
+{
+    map &here = get_map();
+    const optional_vpart_position vp_there = here.veh_at( loc );
+    if( !vp_there ) {
+        return true;
+    }
+
+    const monster *mon = as_monster();
+
+    vehicle &veh = vp_there->vehicle();
+
+    std::vector<vehicle_part *> cargo_parts;
+    cargo_parts = veh.get_parts_at( here.bub_from_abs( loc ), "CARGO", part_status_flag::any );
+
+    units::volume capacity = 0_ml;
+    units::volume free_cargo = 0_ml;
+    for( vehicle_part *part : cargo_parts ) {
+        vehicle_stack contents = veh.get_items( *part );
+        if( !vp_there.part_with_feature( "CARGO_PASSABLE", false ) &&
+            !vp_there.part_with_feature( "APPLIANCE", false ) &&
+            !vp_there.part_with_feature( "OBSTACLE", false ) ) {
+            capacity += contents.max_volume();
+            free_cargo += contents.free_volume();
+        }
+    }
+    if( capacity > 0_ml ) {
+        // First, we'll try to squeeze in. Open-topped vehicle parts have more room to step over cargo.
+        if( !veh.enclosed_at( here.getlocal( loc ) ) ) {
+            free_cargo *= 1.2;
+        }
+        const creature_size size = get_size();
+        units::volume critter_volume;
+        if( mon ) {
+            critter_volume = mon->get_volume();
+        } else {
+            critter_volume = size_to_volume( size );
+        }
+
+        if( critter_volume > free_cargo ) {
+            return false;
+        }
+
+        if( critter_volume > size_to_volume( creature_size::large ) &&
+            !vp_there.part_with_feature( "HUGE_OK", false ) ) {
+            return false;
+        }
+
+        if( critter_volume < free_cargo * 1.33 ) {
+            if( !mon || !( mon->type->bodytype == "snake" || mon->type->bodytype == "blob" ||
+                           mon->type->bodytype == "fish" ||
+                           has_flag( mon_flag_PLASTIC ) || has_flag( mon_flag_SMALL_HIDER ) ) ) {
+                cramped = true;
+            }
+        }
+
+        if( size == creature_size::huge && !vp_there.part_with_feature( "AISLE", false ) &&
+            !vp_there.part_with_feature( "HUGE_OK", false ) ) {
+            cramped = true;
+        }
+    }
+
+    return true;
 }
 
 void Creature::move_to( const tripoint_abs_ms &loc )

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -275,6 +275,12 @@ bool Creature::can_move_to_vehicle_tile( const tripoint_abs_ms &loc, bool &cramp
     return true;
 }
 
+bool Creature::can_move_to_vehicle_tile( const tripoint_abs_ms &loc ) const
+{
+    bool dummy = false;
+    return can_move_to_vehicle_tile( loc, dummy );
+}
+
 void Creature::move_to( const tripoint_abs_ms &loc )
 {
     const tripoint_abs_ms old_loc = get_location();

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -194,16 +194,20 @@ void Creature::setpos( const tripoint &p )
 
 static units::volume size_to_volume( creature_size size_class )
 {
+    // returns midpoint of size from volume_to_size, minus 1_ml
+    // e.g. max tiny size is 7500, max small size is 46250, we return
+    // 46250+7500 / 2 - 1_ml = 26875_ml - 1ml
+    // This is still stupid and both of these functions should be merged into one single source of truth.
     if( size_class == creature_size::tiny ) {
-        return 7499_ml;
+        return 3749_ml;
     } else if( size_class == creature_size::small ) {
-        return 46249_ml;
+        return 26874_ml;
     } else if( size_class == creature_size::medium ) {
-        return 107999_ml;
+        return 77124_ml;
     } else if( size_class == creature_size::large ) {
-        return 483749_ml;
+        return 295874_ml;
     }
-    return DEFAULT_TILE_VOLUME - 1_ml;
+    return 741874_ml;
 }
 
 bool Creature::can_move_to_vehicle_tile( const tripoint_abs_ms &loc, bool &cramped ) const

--- a/src/creature.h
+++ b/src/creature.h
@@ -318,8 +318,10 @@ class Creature : public viewer
             return get_location().z();
         }
         void setpos( const tripoint &p );
-        /** Checks if the creature fits into a given tile */
+        /** Checks if the creature fits into a given tile. Set the boolean argument to true if the creature would barely fit. */
         bool can_move_to_vehicle_tile( const tripoint_abs_ms &loc, bool &cramped ) const;
+        /** Helper overload for when the boolean is discardable */
+        bool can_move_to_vehicle_tile( const tripoint_abs_ms &loc ) const;
         /** Moves the creature to the given location and calls the on_move() handler. */
         void move_to( const tripoint_abs_ms &loc );
 

--- a/src/creature.h
+++ b/src/creature.h
@@ -318,6 +318,8 @@ class Creature : public viewer
             return get_location().z();
         }
         void setpos( const tripoint &p );
+        /** Checks if the creature fits into a given tile */
+        bool can_move_to_vehicle_tile( const tripoint_abs_ms &loc, bool &cramped ) const;
         /** Moves the creature to the given location and calls the on_move() handler. */
         void move_to( const tripoint_abs_ms &loc );
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -245,6 +245,7 @@ static const efftype_id effect_asked_to_train( "asked_to_train" );
 static const efftype_id effect_blind( "blind" );
 static const efftype_id effect_bouldering( "bouldering" );
 static const efftype_id effect_contacts( "contacts" );
+static const efftype_id effect_cramped_space( "cramped_space" );
 static const efftype_id effect_docile( "docile" );
 static const efftype_id effect_downed( "downed" );
 static const efftype_id effect_fake_common_cold( "fake_common_cold" );
@@ -10724,7 +10725,9 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool 
     }
     u.set_underwater( false );
 
-    if( vp_there && !u.move_in_vehicle( static_cast<Creature *>( &u ), dest_loc ) ) {
+    bool cramped = false;
+    if( vp_there && !u.can_move_to_vehicle_tile( get_map().getglobal( dest_loc ), cramped ) ) {
+        add_msg( m_warning, _( "There's not enough room for you to fit there." ) );
         return false;
     }
 
@@ -10939,6 +10942,11 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool 
 
     if( u.is_hauling() ) {
         start_hauling( oldpos );
+    }
+
+    if( cramped ) { // passed by reference, can_move_to_vehicle_tile sets to true if actually cramped
+        add_msg( m_warning, _( "You barely fit in this tiny human vehicle." ) );
+        u.add_effect( effect_cramped_space, 2_turns, true );
     }
 
     on_move_effects();

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1633,8 +1633,7 @@ bool monster::bash_at( const tripoint &p )
         return false;
     }
 
-    bool dummy = false; //discard
-    const bool too_cramped = !can_move_to_vehicle_tile( get_map().getglobal( p ), dummy );
+    const bool too_cramped = !can_move_to_vehicle_tile( get_map().getglobal( p ) );
     bool try_bash = !can_move_to( p ) || one_in( 3 ) || too_cramped;
     if( !try_bash ) {
         return false;

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -132,64 +132,6 @@ static bool z_is_valid( int z )
     return z >= -OVERMAP_DEPTH && z <= OVERMAP_HEIGHT;
 }
 
-bool monster::monster_move_in_vehicle( const tripoint &p ) const
-{
-    map &m = get_map();
-    monster critter = *this;
-    const optional_vpart_position vp = m.veh_at( p );
-    if( vp.has_value() ) {
-        vehicle &veh = vp->vehicle();
-        units::volume capacity = 0_ml;
-        units::volume free_cargo = 0_ml;
-        auto cargo_parts = veh.get_parts_at( p, "CARGO", part_status_flag::any );
-        for( vehicle_part *&part : cargo_parts ) {
-            vehicle_stack contents = veh.get_items( *part );
-            if( !vp.part_with_feature( "CARGO_PASSABLE", false ) &&
-                !vp.part_with_feature( "APPLIANCE", false ) && !vp.part_with_feature( "OBSTACLE", false ) ) {
-                capacity += contents.max_volume();
-                free_cargo += contents.free_volume();
-            }
-        }
-        if( capacity > 0_ml ) {
-            // First, we'll try to squeeze in. Open-topped vehicle parts have more room to step over cargo.
-            if( !veh.enclosed_at( p ) ) {
-                free_cargo *= 1.2;
-            }
-            if( !veh.enclosed_at( p ) && flies() ) {
-                return true; // No amount of cargo will block a flying monster if there's no roof.
-            }
-            const creature_size size = get_size();
-            if( ( size == creature_size::tiny && free_cargo < 15625_ml ) ||
-                ( size == creature_size::small && free_cargo < 31250_ml ) ||
-                ( size == creature_size::medium && free_cargo < 62500_ml ) ||
-                ( size == creature_size::large && free_cargo < 125000_ml ) ||
-                ( size == creature_size::huge && free_cargo < 250000_ml ) ) {
-                if( ( size == creature_size::tiny && free_cargo < 11719_ml ) ||
-                    ( size == creature_size::small && free_cargo < 23438_ml ) ||
-                    ( size == creature_size::medium && free_cargo < 46875_ml ) ||
-                    ( size == creature_size::large && free_cargo < 93750_ml ) ||
-                    ( size == creature_size::huge && free_cargo < 187500_ml ) ||
-                    ( get_volume() > 850000_ml && !vp.part_with_feature( "HUGE_OK", false ) ) ) {
-                    return false; // Return false if there's just no room whatsoever. Anything over 850 liters will simply never fit in a vehicle part that isn't specifically made for it.
-                    // I'm sorry but you can't let a kaiju ride shotgun.
-                }
-                if( type->bodytype == "snake" || type->bodytype == "blob" || type->bodytype == "fish" ||
-                    has_flag( mon_flag_PLASTIC ) || has_flag( mon_flag_SMALL_HIDER ) ) {
-                    return true; // Return true if we're wiggly enough to be fine with cramped space.
-                }
-                critter.add_effect( effect_cramped_space, 2_turns, true );
-                return true; // Otherwise we add the effect and return true.
-            }
-            if( size == creature_size::huge && !vp.part_with_feature( "AISLE", false ) &&
-                !vp.part_with_feature( "HUGE_OK", false ) ) {
-                critter.add_effect( effect_cramped_space, 2_turns, true );
-                return true; // Sufficiently gigantic creatures have trouble in stock seats, roof or no.
-            }
-        }
-    }
-    return true;
-}
-
 bool monster::will_move_to( const tripoint &p ) const
 {
     map &here = get_map();
@@ -1872,7 +1814,8 @@ bool monster::move_to( const tripoint &p, bool force, bool step_on_critter,
         }
     }
 
-    if( here.veh_at( p ).part_with_feature( VPFLAG_CARGO, true ) && !monster_move_in_vehicle( p ) ) {
+    bool cramped = false; // applies an effect if monster does end up moving there
+    if( !can_move_to_vehicle_tile( here.getglobal( p ), cramped ) ) {
         return false;
     }
 
@@ -1970,6 +1913,9 @@ bool monster::move_to( const tripoint &p, bool force, bool step_on_critter,
     optional_vpart_position vp_dest = here.veh_at( destination );
     if( vp_dest ) {
         vp_dest->vehicle().invalidate_mass();
+        if( cramped ) {
+            add_effect( effect_cramped_space, 2_turns, true );
+        }
     }
     if( is_hallucination() ) {
         //Hallucinations don't do any of the stuff after this point

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1633,7 +1633,9 @@ bool monster::bash_at( const tripoint &p )
         return false;
     }
 
-    bool try_bash = !can_move_to( p ) || one_in( 3 );
+    bool dummy = false; //discard
+    const bool too_cramped = !can_move_to_vehicle_tile( get_map().getglobal( p ), dummy );
+    bool try_bash = !can_move_to( p ) || one_in( 3 ) || too_cramped;
     if( !try_bash ) {
         return false;
     }
@@ -1643,7 +1645,7 @@ bool monster::bash_at( const tripoint &p )
     }
 
     map &here = get_map();
-    if( !( here.is_bashable_furn( p ) || here.veh_at( p ).obstacle_at_part() ) ) {
+    if( !( here.is_bashable_furn( p ) || here.veh_at( p ).obstacle_at_part() || too_cramped ) ) {
         // if the only thing here is road or flat, rarely bash it
         bool flat_ground = here.has_flag( ter_furn_flag::TFLAG_ROAD, p ) ||
                            here.has_flag( ter_furn_flag::TFLAG_FLAT, p );

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3357,54 +3357,10 @@ void monster::process_effects()
         }
     }
 
-    // Apply or remove the cramped_space effect, which needs specific information about the monster's surroundings.
-    map &here = get_map();
-    const tripoint z_pos = pos();
-    const optional_vpart_position vp = here.veh_at( z_pos );
-    if( has_effect( effect_cramped_space ) && !vp.has_value() ) {
-        remove_effect( effect_cramped_space );
-    }
-    if( vp.has_value() ) {
-        vehicle &veh = vp->vehicle();
-        units::volume capacity = 0_ml;
-        units::volume free_cargo = 0_ml;
-        auto cargo_parts = veh.get_parts_at( z_pos, "CARGO", part_status_flag::any );
-        for( vehicle_part *&part : cargo_parts ) {
-            vehicle_stack contents = veh.get_items( *part );
-            const vpart_info &vpinfo = part->info();
-            if( !vp.part_with_feature( "CARGO_PASSABLE", false ) ) {
-                capacity += vpinfo.size;
-                free_cargo += contents.free_volume();
-            }
-        }
-        const creature_size size = get_size();
-        if( capacity > 0_ml ) {
-            // Open-topped vehicle parts have more room, and are always free space for fliers.
-            if( !veh.enclosed_at( z_pos ) ) {
-                free_cargo *= 1.2;
-                if( flies() ) {
-                    remove_effect( effect_cramped_space );
-                    return;
-                }
-            }
-            if( ( size == creature_size::tiny && free_cargo < 15625_ml ) ||
-                ( size == creature_size::small && free_cargo < 31250_ml ) ||
-                ( size == creature_size::medium && free_cargo < 62500_ml ) ||
-                ( size == creature_size::large && free_cargo < 125000_ml ) ||
-                ( size == creature_size::huge && free_cargo < 250000_ml ) ) {
-                if( !has_effect( effect_cramped_space ) ) {
-                    add_effect( effect_cramped_space, 2_turns, true );
-                }
-                return;
-            }
-        }
-        if( get_size() == creature_size::huge && !vp.part_with_feature( "AISLE", false ) &&
-            !vp.part_with_feature( "HUGE_OK", false ) ) {
-            if( !has_effect( effect_cramped_space ) ) {
-                add_effect( effect_cramped_space, 2_turns, true );
-            }
-            return;
-        }
+    bool cramped = false;
+    // return is intentionally discarded, sets cramped if appropriate
+    can_move_to_vehicle_tile( get_map().getglobal( pos() ), cramped );
+    if( !cramped ) {
         remove_effect( effect_cramped_space );
     }
 

--- a/src/monster.h
+++ b/src/monster.h
@@ -214,8 +214,6 @@ class monster : public Creature
         bool will_move_to( const tripoint &p ) const;
         bool know_danger_at( const tripoint &p ) const;
 
-        bool monster_move_in_vehicle( const tripoint &p ) const;
-
         bool will_reach( const point &p ); // Do we have plans to get to (x, y)?
         int  turns_to_reach( const point &p ); // How long will it take?
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -3346,9 +3346,8 @@ std::unordered_set<tripoint> npc::get_path_avoid() const
     }
 
     // Why is this in path avoid if they can't move there at all?
-    bool dummy = false; // handled elsewhere
     for( const tripoint &p : here.points_in_radius( pos(), 6 ) ) {
-        if( !can_move_to_vehicle_tile( here.getglobal( p ), dummy ) ) {
+        if( !can_move_to_vehicle_tile( here.getglobal( p ) ) ) {
             ret.insert( p );
         }
     }

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -3340,8 +3340,15 @@ std::unordered_set<tripoint> npc::get_path_avoid() const
     }
 
     for( const tripoint &p : here.points_in_radius( pos(), 6 ) ) {
-        if( sees_dangerous_field( p ) || ( here.veh_at( p ).part_with_feature( VPFLAG_CARGO, true ) &&
-                                           !move_in_vehicle( const_cast<npc *>( this ), p ) ) ) {
+        if( sees_dangerous_field( p ) ) {
+            ret.insert( p );
+        }
+    }
+
+    // Why is this in path avoid if they can't move there at all?
+    bool dummy = false; // handled elsewhere
+    for( const tripoint &p : here.points_in_radius( pos(), 6 ) ) {
+        if( !can_move_to_vehicle_tile( here.getglobal( p ), dummy ) ) {
             ret.insert( p );
         }
     }

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -404,8 +404,7 @@ bool npc::could_move_onto( const tripoint &p ) const
     if( !here.passable( p ) ) {
         return false;
     }
-    bool dummy = false; // handled elsewhere
-    if( !can_move_to_vehicle_tile( here.getglobal( p ), dummy ) ) {
+    if( !can_move_to_vehicle_tile( here.getglobal( p ) ) ) {
         return false;
     }
 
@@ -2900,8 +2899,7 @@ void npc::move_to( const tripoint &pt, bool no_bashing, std::set<tripoint> *nomo
         }
     }
 
-    bool dummy = false; //Handled further down due to possible branching logic
-    if( !can_move_to_vehicle_tile( here.getglobal( p ), dummy ) ) {
+    if( !can_move_to_vehicle_tile( here.getglobal( p ) ) ) {
         auto other_points = here.get_dir_circle( pos(), p );
         for( const tripoint &ot : other_points ) {
             if( could_move_onto( ot ) && ( nomove == nullptr || nomove->find( ot ) == nomove->end() ) ) {

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -119,6 +119,7 @@ static const efftype_id effect_bite( "bite" );
 static const efftype_id effect_bleed( "bleed" );
 static const efftype_id effect_bouldering( "bouldering" );
 static const efftype_id effect_catch_up( "catch_up" );
+static const efftype_id effect_cramped_space( "cramped_space" );
 static const efftype_id effect_disinfected( "disinfected" );
 static const efftype_id effect_hit_by_player( "hit_by_player" );
 static const efftype_id effect_hypovolemia( "hypovolemia" );
@@ -403,7 +404,8 @@ bool npc::could_move_onto( const tripoint &p ) const
     if( !here.passable( p ) ) {
         return false;
     }
-    if( !move_in_vehicle( const_cast<npc *>( this ), p ) ) {
+    bool dummy = false; // handled elsewhere
+    if( !can_move_to_vehicle_tile( here.getglobal( p ), dummy ) ) {
         return false;
     }
 
@@ -2898,7 +2900,8 @@ void npc::move_to( const tripoint &pt, bool no_bashing, std::set<tripoint> *nomo
         }
     }
 
-    if( here.veh_at( p ).part_with_feature( VPFLAG_CARGO, true ) && !move_in_vehicle( this, p ) ) {
+    bool dummy = false; //Handled further down due to possible branching logic
+    if( !can_move_to_vehicle_tile( here.getglobal( p ), dummy ) ) {
         auto other_points = here.get_dir_circle( pos(), p );
         for( const tripoint &ot : other_points ) {
             if( could_move_onto( ot ) && ( nomove == nullptr || nomove->find( ot ) == nomove->end() ) ) {
@@ -3141,6 +3144,17 @@ void npc::move_to( const tripoint &pt, bool no_bashing, std::set<tripoint> *nomo
         }
         here.creature_on_trap( *this );
         here.creature_in_field( *this );
+
+        bool cramped = false;
+        if( !can_move_to_vehicle_tile( here.getglobal( p ), cramped ) ) {
+            debugmsg( "NPC %s somehow moved to a too-cramped vehicle tile", disp_name() );
+        } else if( cramped ) { //set by above call to Creature::can_move_to_vehicle_tile
+            if( !has_effect( effect_cramped_space ) ) {
+                add_msg_if_player_sees( *this, m_warning,
+                                        string_format( _( "%s has to really cram their huge body to fit." ), disp_name() ) );
+            }
+            add_effect( effect_cramped_space, 2_turns, true );
+        }
     }
 }
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/469fccec-e05e-4d92-9827-555a2b48c4bf)
(in multiple places)

NPC magically acquires cramped space effect because of vehicle 3 tiles away
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/88803200-ea7a-4075-b555-f639745399bd)

Wall of trunks with cargo is invincible to the zombie hordes (waited one hour)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/c9c6252d-9983-4d9f-9e8d-485ef076c72f)


#### Describe the solution
De-duplicate code

Concentrate all checks in one creature function instead of repeating it all over the place

Use tripoint_abs_ms instead of raw tripoints

Don't apply cramped space effects when **evaluating** places to move to (that's why the function is const...)

FUNCTIONAL CHANGES:

Removed the flying bypass for open top vehicle tiles, since it did not check the actual z-level above or anything. I'm not interested in writing a bunch of checks for this and it's just plain incorrect.

Make monsters bash the vehicle if they can't move through it, ~~they're trying to bash the terrain right now~~ by checking creature::can_move_to_vehicle_tile again... I don't like this but it doesn't seem to explode anything in testing

Because the calculation changed to sane-ify volume, some vehicle parts which previously were free to traverse might now give the cramped space effect.

#### Describe alternatives you've considered
Lots of reverting.

#### Testing
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/9052990b-08f8-4ba1-8870-ef5075a11658)


#### Additional context
There should be no functional changes aside from that which is noted