### PR TITLE
[MoM] Add Torrential Channeling, revamp Extended Channeling

### DIFF
--- a/data/mods/MindOverMatter/effectoncondition/eoc_mutations.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_mutations.json
@@ -294,7 +294,7 @@
       {
         "run_eocs": [
           {
-            "id": "EOC_PSI_EXTENDED_CHANNELING_ON_2"
+            "id": "EOC_PSI_EXTENDED_CHANNELING_ON_2",
             "condition": { "u_has_trait": "PSI_TORRENTIAL_CHANNELING_active" },
             "effect": [
               { "u_add_trait": "PSI_EXTENDED_CHANNELING_active" },
@@ -307,7 +307,7 @@
             ]
           }
         ]
-      }    
+      }
     ],
     "false_effect": [
       { "u_lose_trait": "PSI_EXTENDED_CHANNELING_active" },
@@ -322,7 +322,7 @@
       {
         "run_eocs": [
           {
-            "id": "EOC_PSI_TORRENTIAL_CHANNELING_ON_2"
+            "id": "EOC_PSI_TORRENTIAL_CHANNELING_ON_2",
             "condition": { "u_has_trait": "PSI_EXTENDED_CHANNELING_active" },
             "effect": [
               { "u_add_trait": "PSI_TORRENTIAL_CHANNELING_active" },
@@ -335,7 +335,7 @@
             ]
           }
         ]
-      }    
+      }
     ],
     "false_effect": [
       { "u_lose_trait": "PSI_TORRENTIAL_CHANNELING_active" },

--- a/data/mods/MindOverMatter/effectoncondition/eoc_mutations.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_mutations.json
@@ -285,5 +285,61 @@
       { "u_lose_trait": "TELEKINETIC_LIFTER_2" },
       { "u_lose_trait": "TELEKINETIC_LIFTER_1" }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PSI_EXTENDED_CHANNELING_ON",
+    "condition": { "not": { "u_has_trait": "PSI_EXTENDED_CHANNELING_active" } },
+    "effect": [
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_PSI_EXTENDED_CHANNELING_ON_2"
+            "condition": { "u_has_trait": "PSI_TORRENTIAL_CHANNELING_active" },
+            "effect": [
+              { "u_add_trait": "PSI_EXTENDED_CHANNELING_active" },
+              { "u_activate_trait": "PSI_TORRENTIAL_CHANNELING" },
+              { "u_message": "You begin to take more care in channeling your powers.", "type": "good" }
+            ],
+            "false_effect": [
+              { "u_add_trait": "PSI_EXTENDED_CHANNELING_active" },
+              { "u_message": "You begin to take more care in channeling your powers.", "type": "good" }
+            ]
+          }
+        ]
+      }    
+    ],
+    "false_effect": [
+      { "u_lose_trait": "PSI_EXTENDED_CHANNELING_active" },
+      { "u_message": "You return to your previous speed in channeling your powers.", "type": "neutral" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PSI_TORRENTIAL_CHANNELING_ON",
+    "condition": { "not": { "u_has_trait": "PSI_TORRENTIAL_CHANNELING_active" } },
+    "effect": [
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_PSI_TORRENTIAL_CHANNELING_ON_2"
+            "condition": { "u_has_trait": "PSI_EXTENDED_CHANNELING_active" },
+            "effect": [
+              { "u_add_trait": "PSI_TORRENTIAL_CHANNELING_active" },
+              { "u_activate_trait": "PSI_EXTENDED_CHANNELING" },
+              { "u_message": "You begin drawing deeply on the Nether.", "type": "good" }
+            ],
+            "false_effect": [
+              { "u_add_trait": "PSI_TORRENTIAL_CHANNELING_active" },
+              { "u_message": "You begin drawing deeply on the Nether.", "type": "good" }
+            ]
+          }
+        ]
+      }    
+    ],
+    "false_effect": [
+      { "u_lose_trait": "PSI_TORRENTIAL_CHANNELING_active" },
+      { "u_message": "The cut off the overflow of Nether power.", "type": "neutral" }
+    ]
   }
 ]

--- a/data/mods/MindOverMatter/effectoncondition/eoc_mutations.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_mutations.json
@@ -297,8 +297,8 @@
             "id": "EOC_PSI_EXTENDED_CHANNELING_ON_2",
             "condition": { "u_has_trait": "PSI_TORRENTIAL_CHANNELING_active" },
             "effect": [
+              { "u_deactivate_trait": "PSI_TORRENTIAL_CHANNELING" },
               { "u_add_trait": "PSI_EXTENDED_CHANNELING_active" },
-              { "u_activate_trait": "PSI_TORRENTIAL_CHANNELING" },
               { "u_message": "You begin to take more care in channeling your powers.", "type": "good" }
             ],
             "false_effect": [
@@ -325,8 +325,8 @@
             "id": "EOC_PSI_TORRENTIAL_CHANNELING_ON_2",
             "condition": { "u_has_trait": "PSI_EXTENDED_CHANNELING_active" },
             "effect": [
+              { "u_deactivate_trait": "PSI_EXTENDED_CHANNELING" },
               { "u_add_trait": "PSI_TORRENTIAL_CHANNELING_active" },
-              { "u_activate_trait": "PSI_EXTENDED_CHANNELING" },
               { "u_message": "You begin drawing deeply on the Nether.", "type": "good" }
             ],
             "false_effect": [

--- a/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
@@ -226,7 +226,7 @@
         { "u_has_trait": "PSI_TORRENTIAL_CHANNELING_active" }
       ]
     },
-    "effect": [ { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rand(2 + (u_nether_conduit_repeated_channeling_value / 4 ) )" ] } ]
+    "effect": [ { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rand(3 + (u_nether_conduit_repeated_channeling_value / 5 ) )" ] } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
@@ -226,7 +226,11 @@
         { "u_has_trait": "PSI_TORRENTIAL_CHANNELING_active" }
       ]
     },
-    "effect": [ { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rand(3 + (u_nether_conduit_repeated_channeling_value / 5 ) )" ] } ]
+    "effect": [
+      {
+        "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rand(3 + (u_nether_conduit_repeated_channeling_value / 5 ) )" ]
+      }
+    ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
@@ -166,7 +166,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_RAISE_ATTUNEMENT_BELOW_THRESHOLD_MAINTENANCE",
-    "condition": { "u_has_effect": "effect_noetic_resilience" },
+    "condition": { "or": [ { "u_has_effect": "effect_noetic_resilience" }, { "u_has_trait": "PSI_EXTENDED_CHANNELING_active" } ] },
     "effect": [
       { "u_message": "As you concentrate on your powers, you feel a strange tingling sensation.", "type": "mixed" },
       {
@@ -183,7 +183,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_RAISE_ATTUNEMENT_ABOVE_THRESHOLD_MAINTENANCE",
-    "condition": { "u_has_effect": "effect_noetic_resilience" },
+    "condition": { "or": [ { "u_has_effect": "effect_noetic_resilience" }, { "u_has_trait": "PSI_EXTENDED_CHANNELING_active" } ] },
     "effect": [
       { "u_message": "As you concentrate on your powers, you feel a strange tingling sensation.", "type": "mixed" },
       {

--- a/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
@@ -207,6 +207,20 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_TORRENTIAL_active",
+    "eoc_type": "EVENT",
+    "required_event": "spellcasting_finish",
+    "condition": {
+      "and": [
+        { "test_eoc": "EOC_CONDITION_SPELLCASTING_FINISH_TRAIT_AND_SCHOOL_LIST" },
+        { "u_has_trait": "PSI_TORRENTIAL_CHANNELING_active" }
+      ]
+    },
+    "effect": [ { "math": [ "u_nether_conduit_repeated_channeling_value", "+=", "rand(3)" ] } ]
+  },
+  }
+  {
+    "type": "effect_on_condition",
     "id": "EOC_NETHER_CONDUIT_VALUE_DECREASER",
     "recurrence": [ "3 seconds", "15 seconds" ],
     "global": true,

--- a/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
@@ -226,7 +226,7 @@
         { "u_has_trait": "PSI_TORRENTIAL_CHANNELING_active" }
       ]
     },
-    "effect": [ { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rand(3)" ] } ]
+    "effect": [ { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rand(2 + (u_nether_conduit_repeated_channeling_value / 4 ) )" ] } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
@@ -221,23 +221,44 @@
     "eoc_type": "EVENT",
     "required_event": "opens_spellbook",
     "condition": { "not": { "u_has_effect": "effect_noetic_resilience" } },
-    "effect": {
-      "switch": { "math": [ "u_vitamin('vitamin_psionic_drain')" ] },
-      "cases": [
-        { "case": 0, "effect": { "math": [ "u_nether_attunement_power_scaling", "=", "0.75" ] } },
-        { "case": 15, "effect": { "math": [ "u_nether_attunement_power_scaling", "=", "1" ] } },
-        { "case": 35, "effect": { "math": [ "u_nether_attunement_power_scaling", "=", "1.05" ] } },
-        { "case": 55, "effect": { "math": [ "u_nether_attunement_power_scaling", "=", "1.1" ] } },
-        { "case": 85, "effect": { "math": [ "u_nether_attunement_power_scaling", "=", "1.17" ] } },
-        { "case": 115, "effect": { "math": [ "u_nether_attunement_power_scaling", "=", "1.25" ] } },
-        { "case": 145, "effect": { "math": [ "u_nether_attunement_power_scaling", "=", "1.35" ] } },
-        { "case": 175, "effect": { "math": [ "u_nether_attunement_power_scaling", "=", "1.5" ] } },
-        { "case": 195, "effect": { "math": [ "u_nether_attunement_power_scaling", "=", "1.75" ] } },
-        { "case": 215, "effect": { "math": [ "u_nether_attunement_power_scaling", "=", "2" ] } },
-        { "case": 235, "effect": { "math": [ "u_nether_attunement_power_scaling", "=", "3" ] } },
-        { "case": 245, "effect": { "math": [ "u_nether_attunement_power_scaling", "=", "4" ] } }
-      ]
-    },
+    "effect": [
+      {
+        "run_eocs": 
+        [
+          {
+            "id": "EOC_PSIONICS_SET_NETHER_ATTUNEMENT_BOOST_2"
+            "condition": { "not": { "u_has_trait": "PSI_TORRENTIAL_CHANNELING_active" } },
+            "effect": {
+              "switch": { "math": [ "u_vitamin('vitamin_psionic_drain')" ] },
+              "cases": [
+                { "case": 0, "effect": { "math": [ "u_nether_attunement_power_scaling", "=", "0.75" ] } },
+                { "case": 15, "effect": { "math": [ "u_nether_attunement_power_scaling", "=", "1" ] } },
+                { "case": 35, "effect": { "math": [ "u_nether_attunement_power_scaling", "=", "1.05" ] } },
+                { "case": 55, "effect": { "math": [ "u_nether_attunement_power_scaling", "=", "1.1" ] } },
+                { "case": 85, "effect": { "math": [ "u_nether_attunement_power_scaling", "=", "1.17" ] } },
+                { "case": 115, "effect": { "math": [ "u_nether_attunement_power_scaling", "=", "1.25" ] } },
+                { "case": 145, "effect": { "math": [ "u_nether_attunement_power_scaling", "=", "1.35" ] } },
+                { "case": 175, "effect": { "math": [ "u_nether_attunement_power_scaling", "=", "1.5" ] } },
+                { "case": 195, "effect": { "math": [ "u_nether_attunement_power_scaling", "=", "1.75" ] } },
+                { "case": 215, "effect": { "math": [ "u_nether_attunement_power_scaling", "=", "2" ] } },
+                { "case": 235, "effect": { "math": [ "u_nether_attunement_power_scaling", "=", "3" ] } },
+                { "case": 245, "effect": { "math": [ "u_nether_attunement_power_scaling", "=", "4" ] } }
+              ]
+            },
+            "false_effect": {
+              "switch": { "math": [ "u_vitamin('vitamin_psionic_drain')" ] },
+              "cases": [
+                { "case": 0, "effect": { "math": [ "u_nether_attunement_power_scaling", "=", "1.5" ] } },
+                { "case": 195, "effect": { "math": [ "u_nether_attunement_power_scaling", "=", "1.75" ] } },
+                { "case": 215, "effect": { "math": [ "u_nether_attunement_power_scaling", "=", "2" ] } },
+                { "case": 235, "effect": { "math": [ "u_nether_attunement_power_scaling", "=", "3" ] } },
+                { "case": 245, "effect": { "math": [ "u_nether_attunement_power_scaling", "=", "4" ] } }
+              ]
+            }
+          }
+        ]
+      }
+    ],
     "false_effect": { "math": [ "u_nether_attunement_power_scaling", "=", "1.05" ] }
   },
   {

--- a/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
@@ -78,7 +78,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_RAISE_ATTUNEMENT_BELOW_THRESHOLD",
-    "condition": { "u_has_effect": "effect_noetic_resilience" },
+    "condition": { "or": [ { "u_has_effect": "effect_noetic_resilience" }, { "u_has_trait": "PSI_EXTENDED_CHANNELING_active" } ] },
     "effect": [
       { "u_message": "As you unleash your powers, you feel a strange tingling sensation.", "type": "mixed" },
       {
@@ -95,7 +95,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_RAISE_ATTUNEMENT_ABOVE_THRESHOLD",
-    "condition": { "u_has_effect": "effect_noetic_resilience" },
+    "condition": { "or": [ { "u_has_effect": "effect_noetic_resilience" }, { "u_has_trait": "PSI_EXTENDED_CHANNELING_active" } ] },
     "effect": [
       { "u_message": "As you unleash your powers, you feel a strange tingling sensation.", "type": "mixed" },
       {
@@ -207,20 +207,6 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_TORRENTIAL_active",
-    "eoc_type": "EVENT",
-    "required_event": "spellcasting_finish",
-    "condition": {
-      "and": [
-        { "test_eoc": "EOC_CONDITION_SPELLCASTING_FINISH_TRAIT_AND_SCHOOL_LIST" },
-        { "u_has_trait": "PSI_TORRENTIAL_CHANNELING_active" }
-      ]
-    },
-    "effect": [ { "math": [ "u_nether_conduit_repeated_channeling_value", "+=", "rand(3)" ] } ]
-  },
-  }
-  {
-    "type": "effect_on_condition",
     "id": "EOC_NETHER_CONDUIT_VALUE_DECREASER",
     "recurrence": [ "3 seconds", "15 seconds" ],
     "global": true,
@@ -231,16 +217,28 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_TORRENTIAL_active",
+    "eoc_type": "EVENT",
+    "required_event": "spellcasting_finish",
+    "condition": {
+      "and": [
+        { "test_eoc": "EOC_CONDITION_SPELLCASTING_FINISH_TRAIT_AND_SCHOOL_LIST" },
+        { "u_has_trait": "PSI_TORRENTIAL_CHANNELING_active" }
+      ]
+    },
+    "effect": [ { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rand(3)" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_PSIONICS_SET_NETHER_ATTUNEMENT_BOOST",
     "eoc_type": "EVENT",
     "required_event": "opens_spellbook",
     "condition": { "not": { "u_has_effect": "effect_noetic_resilience" } },
     "effect": [
       {
-        "run_eocs": 
-        [
+        "run_eocs": [
           {
-            "id": "EOC_PSIONICS_SET_NETHER_ATTUNEMENT_BOOST_2"
+            "id": "EOC_PSIONICS_SET_NETHER_ATTUNEMENT_BOOST_2",
             "condition": { "not": { "u_has_trait": "PSI_TORRENTIAL_CHANNELING_active" } },
             "effect": {
               "switch": { "math": [ "u_vitamin('vitamin_psionic_drain')" ] },

--- a/data/mods/MindOverMatter/effectoncondition/eoc_power_effects.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_power_effects.json
@@ -179,11 +179,19 @@
     "id": "EOC_PSI_EXTENDED_CHANNELING",
     "eoc_type": "EVENT",
     "required_event": "opens_spellbook",
-    "condition": { "u_has_trait": "PSI_EXTENDED_CHANNELING_ON" },
+    "condition": { "u_has_trait": "PSI_EXTENDED_CHANNELING_active" },
     "effect": [
       { "math": [ "u_spellcasting_adjustment('casting_time', 'flag_whitelist': 'PSIONIC')", "=", "25" ] },
       { "math": [ "u_spellcasting_adjustment('concentration', 'flag_whitelist': 'PSIONIC' )", "=", "-1" ] }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PSI_TORRENTIAL_CHANNELING",
+    "eoc_type": "EVENT",
+    "required_event": "opens_spellbook",
+    "condition": { "u_has_trait": "PSI_TORRENTIAL_CHANNELING_active" },
+    "effect": [ { "math": [ "u_spellcasting_adjustment('concentration', 'flag_whitelist': 'PSIONIC' )", "=", "0.75" ] } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/MindOverMatter/mutations/traits.json
+++ b/data/mods/MindOverMatter/mutations/traits.json
@@ -187,12 +187,42 @@
     "id": "PSI_EXTENDED_CHANNELING_ON",
     "name": { "str": "Extended Channeling" },
     "points": 0,
-    "description": "You are taking more time and care in channeling your powers.  It takes 25x as long to evoke them, but your Focus has no effect on their chance of success.",
+    "description": "You are taking more time and care in channeling your powers.  It takes 25x as long to evoke them, but it is much easier to activate them and you are less likely to gain Nether Attunement while doing so.",
     "active": true,
     "valid": false,
     "transform": {
       "target": "PSI_EXTENDED_CHANNELING",
       "msg_transform": "Your return to channeling your powers as fast as you can.",
+      "active": false,
+      "moves": 0
+    }
+  },
+  {
+    "type": "mutation",
+    "id": "PSI_TORRENTIAL_CHANNELING",
+    "name": { "str": "Restrained Channeling" },
+    "points": 0,
+    "description": "You are channeling your powers with a normal amount of control.",
+    "active": true,
+    "valid": false,
+    "transform": {
+      "target": "PSI_TORRENTIAL_CHANNELING_ON",
+      "msg_transform": "You begin drawing deeply on the Nether.",
+      "active": true,
+      "moves": 0
+    }
+  },
+  {
+    "type": "mutation",
+    "id": "PSI_TORRENTIAL_CHANNELING_ON",
+    "name": { "str": "Torrential Channeling" },
+    "points": 0,
+    "description": "You are drawing deeply on the Nether as you channel your powers.  This makes them stronger but less predictable.",
+    "active": true,
+    "valid": false,
+    "transform": {
+      "target": "PSI_TORRENTIAL_CHANNELING",
+      "msg_transform": "Your rein in your use of your powers.",
       "active": false,
       "moves": 0
     }

--- a/data/mods/MindOverMatter/mutations/traits.json
+++ b/data/mods/MindOverMatter/mutations/traits.json
@@ -181,7 +181,7 @@
   },
   {
     "type": "mutation",
-    "id": "PSI_EXTENDED_CHANNELING_ACTIVE",
+    "id": "PSI_EXTENDED_CHANNELING_active",
     "name": { "str": "Extended Channeling Active" },
     "points": 0,
     "description": "The active trait for Extended Channeling.  It's a bug if you can see it.",
@@ -203,7 +203,7 @@
   },
   {
     "type": "mutation",
-    "id": "PSI_TORRENTIAL_CHANNELING_ACTIVE",
+    "id": "PSI_TORRENTIAL_CHANNELING_active",
     "name": { "str": "Torrential Channeling Active" },
     "points": 0,
     "description": "The active trait for Torrential Channeling.  It's a bug if you can see it.",

--- a/data/mods/MindOverMatter/mutations/traits.json
+++ b/data/mods/MindOverMatter/mutations/traits.json
@@ -185,16 +185,15 @@
     "name": { "str": "Extended Channeling Active" },
     "points": 0,
     "description": "The active trait for Extended Channeling.  It's a bug if you can see it.",
-    "active": true,
     "valid": false,
-    "player_disply": false
+    "player_display": false
   },
   {
     "type": "mutation",
     "id": "PSI_TORRENTIAL_CHANNELING",
     "name": { "str": "Torrential Channeling" },
     "points": 0,
-    "description": "You can draw deeply on the Nether, increasing the strength of your powers making making them harder to initiate and control.",
+    "description": "You can draw deeply on the Nether, increasing the strength of your powers but making making them harder to initiate and control.",
     "active": true,
     "activated_is_setup": true,
     "valid": false,
@@ -207,8 +206,7 @@
     "name": { "str": "Torrential Channeling Active" },
     "points": 0,
     "description": "The active trait for Torrential Channeling.  It's a bug if you can see it.",
-    "active": true,
     "valid": false,
-    "player_disply": false
+    "player_display": false
   }
 ]

--- a/data/mods/MindOverMatter/mutations/traits.json
+++ b/data/mods/MindOverMatter/mutations/traits.json
@@ -170,61 +170,45 @@
   {
     "type": "mutation",
     "id": "PSI_EXTENDED_CHANNELING",
-    "name": { "str": "Standard Channeling" },
+    "name": { "str": "Extended Channeling" },
     "points": 0,
-    "description": "You are channeling your powers as quickly as you can.",
+    "description": "You can take more time and care in channeling your powers.  It will take 25x as long to evoke them, but it will be much easier to activate them and you will be less likely to gain Nether Attunement while doing so.",
     "active": true,
+    "activated_is_setup": true,
     "valid": false,
-    "transform": {
-      "target": "PSI_EXTENDED_CHANNELING_ON",
-      "msg_transform": "You start to take more care in channeling your powers.",
-      "active": true,
-      "moves": 0
-    }
+    "activated_eocs": [ "EOC_PSI_EXTENDED_CHANNELING_ON" ],
+    "deactivated_eocs": [ "EOC_PSI_EXTENDED_CHANNELING_OFF" ],
   },
   {
     "type": "mutation",
-    "id": "PSI_EXTENDED_CHANNELING_ON",
-    "name": { "str": "Extended Channeling" },
+    "id": "PSI_EXTENDED_CHANNELING_ACTIVE",
+    "name": { "str": "Extended Channeling Active" },
     "points": 0,
-    "description": "You are taking more time and care in channeling your powers.  It takes 25x as long to evoke them, but it is much easier to activate them and you are less likely to gain Nether Attunement while doing so.",
+    "description": "The active trait for Extended Channeling.  It's a bug if you can see it.",
     "active": true,
     "valid": false,
-    "transform": {
-      "target": "PSI_EXTENDED_CHANNELING",
-      "msg_transform": "Your return to channeling your powers as fast as you can.",
-      "active": false,
-      "moves": 0
-    }
+    "player_disply": false
   },
   {
     "type": "mutation",
     "id": "PSI_TORRENTIAL_CHANNELING",
-    "name": { "str": "Restrained Channeling" },
+    "name": { "str": "Torrential Channeling" },
     "points": 0,
-    "description": "You are channeling your powers with a normal amount of control.",
+    "description": "You can draw deeply on the Nether, increasing the strength of your powers making making them harder to initiate and control.",
     "active": true,
+    "activated_is_setup": true,
     "valid": false,
-    "transform": {
-      "target": "PSI_TORRENTIAL_CHANNELING_ON",
-      "msg_transform": "You begin drawing deeply on the Nether.",
-      "active": true,
-      "moves": 0
-    }
+    "activated_eocs": [ "EOC_PSI_TORRENTIAL_CHANNELING_ON" ],
+    "deactivated_eocs": [ "EOC_PSI_TORRENTIAL_CHANNELING_OFF" ],
   },
   {
     "type": "mutation",
-    "id": "PSI_TORRENTIAL_CHANNELING_ON",
-    "name": { "str": "Torrential Channeling" },
+    "id": "PSI_TORRENTIAL_CHANNELING_ACTIVE",
+    "name": { "str": "Torrential Channeling Active" },
     "points": 0,
-    "description": "You are drawing deeply on the Nether as you channel your powers.  This makes them stronger but less predictable.",
+    "description": "The active trait for Torrential Channeling.  It's a bug if you can see it.",
     "active": true,
     "valid": false,
-    "transform": {
-      "target": "PSI_TORRENTIAL_CHANNELING",
-      "msg_transform": "Your rein in your use of your powers.",
-      "active": false,
-      "moves": 0
-    }
+    "player_disply": false
   }
 ]

--- a/data/mods/MindOverMatter/mutations/traits.json
+++ b/data/mods/MindOverMatter/mutations/traits.json
@@ -177,7 +177,7 @@
     "activated_is_setup": true,
     "valid": false,
     "activated_eocs": [ "EOC_PSI_EXTENDED_CHANNELING_ON" ],
-    "deactivated_eocs": [ "EOC_PSI_EXTENDED_CHANNELING_OFF" ],
+    "deactivated_eocs": [ "EOC_PSI_EXTENDED_CHANNELING_ON" ],
   },
   {
     "type": "mutation",
@@ -199,7 +199,7 @@
     "activated_is_setup": true,
     "valid": false,
     "activated_eocs": [ "EOC_PSI_TORRENTIAL_CHANNELING_ON" ],
-    "deactivated_eocs": [ "EOC_PSI_TORRENTIAL_CHANNELING_OFF" ],
+    "deactivated_eocs": [ "EOC_PSI_TORRENTIAL_CHANNELING_ON" ],
   },
   {
     "type": "mutation",

--- a/data/mods/MindOverMatter/mutations/traits.json
+++ b/data/mods/MindOverMatter/mutations/traits.json
@@ -177,7 +177,7 @@
     "activated_is_setup": true,
     "valid": false,
     "activated_eocs": [ "EOC_PSI_EXTENDED_CHANNELING_ON" ],
-    "deactivated_eocs": [ "EOC_PSI_EXTENDED_CHANNELING_ON" ],
+    "deactivated_eocs": [ "EOC_PSI_EXTENDED_CHANNELING_ON" ]
   },
   {
     "type": "mutation",
@@ -199,7 +199,7 @@
     "activated_is_setup": true,
     "valid": false,
     "activated_eocs": [ "EOC_PSI_TORRENTIAL_CHANNELING_ON" ],
-    "deactivated_eocs": [ "EOC_PSI_TORRENTIAL_CHANNELING_ON" ],
+    "deactivated_eocs": [ "EOC_PSI_TORRENTIAL_CHANNELING_ON" ]
   },
   {
     "type": "mutation",

--- a/data/mods/MindOverMatter/obsolete/temporary.json
+++ b/data/mods/MindOverMatter/obsolete/temporary.json
@@ -40,5 +40,17 @@
     "id": "PHOTOKINETIC_CAMOUFLAGE_6",
     "//": "remove after 0.I",
     "remove": true
+  },
+  {
+    "type": "TRAIT_MIGRATION",
+    "id": "PSI_EXTENDED_CHANNELING_ON",
+    "//": "remove after 0.I",
+    "trait": "PSI_EXTENDED_CHANNELING",
+  },
+  {
+    "type": "TRAIT_MIGRATION",
+    "id": "PSI_EXTENDED_CHANNELING_ON",
+    "//": "remove after 0.I",
+    "trait": "PSI_EXTENDED_CHANNELING",
   }
 ]

--- a/data/mods/MindOverMatter/obsolete/temporary.json
+++ b/data/mods/MindOverMatter/obsolete/temporary.json
@@ -46,11 +46,5 @@
     "id": "PSI_EXTENDED_CHANNELING_ON",
     "//": "remove after 0.I",
     "trait": "PSI_EXTENDED_CHANNELING",
-  },
-  {
-    "type": "TRAIT_MIGRATION",
-    "id": "PSI_EXTENDED_CHANNELING_ON",
-    "//": "remove after 0.I",
-    "trait": "PSI_EXTENDED_CHANNELING",
   }
 ]

--- a/data/mods/MindOverMatter/obsolete/temporary.json
+++ b/data/mods/MindOverMatter/obsolete/temporary.json
@@ -45,6 +45,6 @@
     "type": "TRAIT_MIGRATION",
     "id": "PSI_EXTENDED_CHANNELING_ON",
     "//": "remove after 0.I",
-    "trait": "PSI_EXTENDED_CHANNELING",
+    "trait": "PSI_EXTENDED_CHANNELING"
   }
 ]

--- a/data/mods/MindOverMatter/recipes/research.json
+++ b/data/mods/MindOverMatter/recipes/research.json
@@ -197,7 +197,7 @@
         "condition": { "and": [ { "roll_contested": { "math": [ "u_skill('metaphysics')" ] }, "difficulty": 8 } ] },
         "effect": [
           {
-            "u_message": "You've figured it out.  The concept of \"taking more time\" wasn't exactly hard to grasp, but maintain the images in your mind, keeping your focus on a single train of thought, that was harder.  Now you've got it down, though.  If you take meticulous care in channeling your powers, it will take much longer but you'll be more likely to succeed.",
+            "u_message": "You've figured it out.  The concept of \"taking more time\" wasn't exactly hard to grasp, but maintaining the images in your mind, keeping your focus on a single train of thought, that was harder.  Now you've got it down, though.  If you take meticulous care in channeling your powers, it will take much longer but you'll be more likely to succeed.",
             "type": "good"
           },
           { "u_add_trait": "PSI_EXTENDED_CHANNELING" },
@@ -209,6 +209,47 @@
             "u_message": "There's just something you're not grasping.  You need more practice before you can get it down.",
             "type": "bad"
           },
+          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "MODERATE_EXERCISE",
+    "name": "research torrential channeling",
+    "id": "psi_research_torrential_channeling",
+    "description": "You have more of an understanding of the way the Nether ebbs and flows, sometimes surging forth like a flood when you least expect it.  There has to be a way to direct that more purposefully, to call forth more energy than you need and direct it into your powers instead of letting it wash over you.  It might be risky, sure, but you need every edge you can get in this post-Cataclysmic world.",
+    "category": "CC_PSIONIC",
+    "subcategory": "CSC_PSIONIC_OTHER",
+    "skill_used": "metaphysics",
+    "difficulty": 6,
+    "time": "14 h",
+    "autolearn": true,
+    "proficiencies": [
+      { "proficiency": "prof_psionic_basic", "required": true },
+      { "proficiency": "prof_psionic_ritual", "required": false }
+    ],
+    "flags": [ "SECRET", "BLIND_HARD" ],
+    "result_eocs": [
+      {
+        "id": "EOC_UNLOCK_TORRENTIAL_CHANNELING",
+        "condition": { "and": [ { "roll_contested": { "math": [ "u_skill('metaphysics')" ] }, "difficulty": 13 } ] },
+        "effect": [
+          {
+            "u_message": "You've figured it out.  Your first few attempts were overwhelming, a raging crush of power than nearly knocked you unconscious…or perhaps worse.  But after you recovered, you tried again, and again, and you gained more and more control over the flood and now you can tame its flow.  Mostly.",
+            "type": "good"
+          },
+          { "u_add_trait": "PSI_TORRENTIAL_CHANNELING" },
+          { "u_forget_recipe": "psi_research_torrential_channeling" },
+          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+        ],
+        "false_effect": [
+          {
+            "u_message": "There's just something you're not grasping.  You need more practice before you can get it down…but you might want to wait.  The flow of Nether energy hasn't completely stopped.",
+            "type": "bad"
+          },
+          { "u_add_effect": "effect_nether_attunement_raiser", "duration": "24 hours" },
           { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
         ]
       }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Add Torrential Channeling, revamp Extended Channeling"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Extended Channeling has been in kind of a weird place since I revamped the channeling success formula for psionic powers.  It used to be a way to ensure success for powers with a high fail chance, but now fail chance if you have good skill and no pain is pretty close to zero, so it needs a new niche. And just like there's a way to be more careful when channeling, there should be a way to be more reckless if you need more power. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the Torrential Channeling trait, with a recipe to discover it unlocked at Metaphysics 6. Torrential Channeling and Extended channeling now do the following:

Torrential Channeling:
- Your minimum power boost from Nether Attunement is set to +50%.  This is double the default (since the default at 0 attunement is -25% when compared to the JSON values), the equivalent of Nether Attunement level 8. It can still go higher than that if you have higher Nether Attunement. 
- Low Focus has 75% more of an effect on the chance of successful channeling (aka low Focus is much more punishing).
- _Every_ power you use increases your Nether Attunement, and even faster if you use many powers in quick succession.

Extended Channeling:
- Your powers take 25x longer to use.
- You gain no power boost from Nether Attunement.
- Focus has 0 effects on your success chances.
- When you do gain Nether Attunement, you gain less of it. 

You cannot have both active at once (activating one automatically turns the other off, if it's active)

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Traits work as advertised. Torrential channeling is autolearnable and can be unlocked. Activating one trait deactivates the other (if active). 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
