### PR TITLE
Spellbook doesn't try to load invalid spells

### DIFF
--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1949,6 +1949,10 @@ void known_magic::deserialize( const JsonObject &data )
         std::string id = jo.get_string( "id" );
         spell_id sp = spell_id( id );
         int xp = jo.get_int( "xp" );
+        if( !sp.is_valid() ) {
+            DebugLog( D_WARNING, D_MAIN ) << "Tried to load bad spell: " << sp.c_str();
+            continue;
+        }
         if( knows_spell( sp ) ) {
             spellbook[sp].set_exp( xp );
         } else {


### PR DESCRIPTION
#### Summary
Bugfixes "Characters' spellbooks will not load invalid spells"

#### Purpose of change
* Fixes #73922
* Fixes #73915

I just kind of assumed our spell infrastructure would cancel loading  the spell when it found an invalid spell. Uh, it doesn't.

#### Describe the solution
Now it does. Also adds a message to debug.log to track these, in case of future issues.

#### Describe alternatives you've considered
N/A

#### Testing
Load the save from #73922, notice no invalid spell id error. Open spellbook. All the real spells are there, the bad spell is not.

#### Additional context
