### PR TITLE
Make Skunks Less Bloodthirsty

### DIFF
--- a/data/json/monsters/mammal.json
+++ b/data/json/monsters/mammal.json
@@ -2669,7 +2669,7 @@
     "material": [ "flesh" ],
     "symbol": "s",
     "color": "black_white",
-    "//": "Aggression note - No matter what anger triggers I gave the skunk they would never spray, HAD to raise aggression. Its not a perfect solution but don't lower their aggression or they won't spray anymore",
+    "//": "Note on Aggression and triggers, keeping player_close as both anger and fear triggers gives me the desired result, I don't know if it causes issues somehow but it's the hacky way I found to get them to behave properly with spraying 'defensively'.",
     "aggression": 7,
     "morale": 10,
     "melee_dice": 1,
@@ -2691,6 +2691,7 @@
     "harvest": "skunk_with_skull",
     "families": [ "prof_intro_biology", "prof_physiology" ],
     "anger_triggers": [ "FRIEND_ATTACKED", "HURT", "PLAYER_CLOSE" ],
+    "fear_triggers": [ "PLAYER_CLOSE" ],
     "flags": [
       "SEES",
       "HEARS",

--- a/data/json/monsters/mammal.json
+++ b/data/json/monsters/mammal.json
@@ -2670,7 +2670,7 @@
     "symbol": "s",
     "color": "black_white",
     "//": "Aggression note - No matter what anger triggers I gave the skunk they would never spray, HAD to raise aggression. Its not a perfect solution but don't lower their aggression or they won't spray anymore",
-    "aggression": 15,
+    "aggression": 7,
     "morale": 10,
     "melee_dice": 1,
     "melee_dice_sides": 4,
@@ -2690,8 +2690,7 @@
     "stomach_size": 50,
     "harvest": "skunk_with_skull",
     "families": [ "prof_intro_biology", "prof_physiology" ],
-    "anger_triggers": [ "FRIEND_ATTACKED", "HURT" ],
-    "fear_triggers": [ "PLAYER_CLOSE" ],
+    "anger_triggers": [ "FRIEND_ATTACKED", "HURT", "PLAYER_CLOSE" ],
     "flags": [
       "SEES",
       "HEARS",


### PR DESCRIPTION
#### Summary
Bugfixes "Make Skunks Less Bloodthirsty"

#### Purpose of change
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/41651793/38e34201-2d13-43d8-a432-f688fcbfd88a)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/41651793/045b50d2-2c94-4760-8040-4b4c6fd464d6)



#### Describe the solution
I lowered their aggression to 7 and changed player close to be an anger trigger.  While this is still not a perfect solution (the perfect solution is to allow monsters to use targeted spells while not hostile, or actually that would probably make a lot of other things worse but it would fix THIS difficulty) it does make it so that skunks are not hostile, actively move away from the player, but when the player gets close they will spray/attack.  After about 2-3 turns of no followup action from the player, the skunk reverts to being neutral and tries to flee.  This is much better than them mauling everything at all times.

#### Describe alternatives you've considered
I really couldn't think of any other way to do this while maintaining their ability to spray, which is pretty much the one thing skunks are known for.

#### Testing
Mostly just tested to verify they behave more naturally and that they revert to neutral after a couple turns of being approached, if the player backs off or does not attack them.

#### Additional context
Like I said, no idea how else to do this, open to feedback if it's within my ability to do things.