### PR TITLE
[Magiclysm] Being grabbed makes SOMATIC spells harder to cast

### DIFF
--- a/data/mods/Magiclysm/eoc_spell_difficulty_modifiers.json
+++ b/data/mods/Magiclysm/eoc_spell_difficulty_modifiers.json
@@ -16,7 +16,7 @@
       ]
     },
     "effect": [
-      { "math": [ "u_spellcasting_adjustment('difficulty', 'flag_whitelist': 'SOMATIC' )", "=", "(u_effect_intensity('grabbed', 'bodypart': 'arm_l') + u_effect_intensity('grabbed', 'bodypart': 'arm_r') ) / 10" ] }
+      { "math": [ "u_spellcasting_adjustment('difficulty', 'mod': 'magiclysm', 'flag_whitelist': 'SOMATIC' )", "=", "(u_effect_intensity('grabbed', 'bodypart': 'arm_l') + u_effect_intensity('grabbed', 'bodypart': 'arm_r') ) / 10" ] }
     ]
   }
 ]

--- a/data/mods/Magiclysm/eoc_spell_difficulty_modifiers.json
+++ b/data/mods/Magiclysm/eoc_spell_difficulty_modifiers.json
@@ -1,0 +1,22 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_GRABBED_MAKES_SOMATIC_SPELLS_HARDER",
+    "eoc_type": "EVENT",
+    "required_event": "opens_spellbook",
+    "condition": {
+      "and": [
+        {
+          "or": [
+            { "u_has_effect": "grabbed", "bodypart": "arm_r" },
+            { "u_has_effect": "grabbed", "bodypart": "arm_l" },
+          ]
+        },
+        { "not": { "u_has_flag": "SUBTLE_SPELL" } }
+      ]
+    },
+    "effect": [
+      { "math": [ "u_spellcasting_adjustment('difficulty', 'flag_whitelist': 'SOMATIC' )", "=", "(u_effect_intensity('grabbed', 'bodypart': 'arm_l') + u_effect_intensity('grabbed', 'bodypart': 'arm_r') ) / 10" ] }
+    ]
+  }
+]

--- a/data/mods/Magiclysm/eoc_spell_difficulty_modifiers.json
+++ b/data/mods/Magiclysm/eoc_spell_difficulty_modifiers.json
@@ -1,22 +1,44 @@
 [
   {
     "type": "effect_on_condition",
-    "id": "EOC_GRABBED_MAKES_SOMATIC_SPELLS_HARDER",
+    "id": "EOC_GRABBED_ARMS_MAKES_SOMATIC_SPELLS_HARDER",
     "eoc_type": "EVENT",
     "required_event": "opens_spellbook",
     "condition": {
       "and": [
-        {
-          "or": [
-            { "u_has_effect": "grabbed", "bodypart": "arm_r" },
-            { "u_has_effect": "grabbed", "bodypart": "arm_l" },
-          ]
-        },
+        { "or": [ { "u_has_effect": "grabbed", "bodypart": "arm_r" }, { "u_has_effect": "grabbed", "bodypart": "arm_l" } ] },
         { "not": { "u_has_flag": "SUBTLE_SPELL" } }
       ]
     },
     "effect": [
-      { "math": [ "u_spellcasting_adjustment('difficulty', 'mod': 'magiclysm', 'flag_whitelist': 'SOMATIC' )", "=", "(u_effect_intensity('grabbed', 'bodypart': 'arm_l') + u_effect_intensity('grabbed', 'bodypart': 'arm_r') ) / 10" ] }
+      {
+        "math": [
+          "u_spellcasting_adjustment('difficulty', 'mod': 'magiclysm', 'flag_whitelist': 'SOMATIC' )",
+          "=",
+          "(u_effect_intensity('grabbed', 'bodypart': 'arm_l') + u_effect_intensity('grabbed', 'bodypart': 'arm_r') ) / 10"
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_GRABBED_HANDS_MAKES_SOMATIC_SPELLS_HARDER",
+    "eoc_type": "EVENT",
+    "required_event": "opens_spellbook",
+    "condition": {
+      "and": [
+        { "or": [ { "u_has_effect": "grabbed", "bodypart": "hand_r" }, { "u_has_effect": "grabbed", "bodypart": "hand_l" } ] },
+        { "not": { "u_has_flag": "SUBTLE_SPELL" } }
+      ]
+    },
+    "effect": [
+      {
+        "math": [
+          "u_spellcasting_adjustment('difficulty', 'mod': 'magiclysm', 'flag_whitelist': 'SOMATIC' )",
+          "=",
+          "(u_effect_intensity('grabbed', 'bodypart': 'hand_l') + u_effect_intensity('grabbed', 'bodypart': 'hand_r') ) / 5"
+        ]
+      }
     ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Magiclysm] Being grabbed makes SOMATIC spells harder to cast"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Follow up to being mute making VERBAL spells impossible
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Make an EoC that increases the Difficulty of spells from the Magiclysm schools by 10% of the total intensity of any arm grabs you're suffering. This equates to roughly +12% failure chance per 10 intensity of arm grabs.

A second EoC increases the Difficulty of spells from the Magiclysm schools by 20% of the total intensity of any hand grabs you're suffering. This equates to roughly +24% failure chance per 10 intensity of hand grabs. Hand grabs are generally pretty rare, but be careful if something gets a hold of your hands.

These stack. 

The SUBTLE_SPELL flag makes you immune to these increases.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Spells' casting Difficulty is properly increased. Only affects SOMATIC spells, only from Magiclysm (also tested with XE SOMATIC spells, which were unaffected), and only when arms or hands are grabbed.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I thought about doing a code solution like for the VERBAL flag, but I think there needs to be better JSON-derived supernatural power usage specifications first. For example, SOMATIC is used in both Magiclysm and Xedra Evolved, but for Magiclysm's wizards, I envision their spells requiring sweeping gestures that require completely free movement to be sure of execution. For Xedra Evolve's Paraclesian fae, SOMATIC is still appropriate because heavy gloves should penalize their spellcasting, but the actual movements are probably just a flick of the wrist or a single gesture. And meanwhile, Xedra Evolved's hedge wizards should probably be completely shut down by a grab of _any_ intensity.

This provides thematic space for someone to add the equivalent of Power Word spells (high Difficulty, high mana cost, sub-one-second cast time and doesn't have SOMATIC on them). It may well be me--I have some ideas already. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
