### PR TITLE
Random NPCs have the same starting skills and proficiencies as the average new character

### DIFF
--- a/data/json/profession_groups.json
+++ b/data/json/profession_groups.json
@@ -2,6 +2,7 @@
   {
     "type": "profession_group",
     "id": "adult_basic_background",
+    "//": "Default selection when creating new characters. Also applied to randomized NPCs. Hardcoded reference in Character::add_default_background()",
     "professions": [
       "driving_license",
       "simple_home_cooking",

--- a/data/mods/Aftershock/profession_groups.json
+++ b/data/mods/Aftershock/profession_groups.json
@@ -1,0 +1,25 @@
+[
+  {
+    "type": "profession_group",
+    "id": "adult_basic_background",
+    "professions": [
+      "driving_license",
+      "simple_home_cooking",
+      "computer_literate",
+      "social_skills",
+      "high_school_graduate",
+      "mundane_survival",
+      "bionic_interface"
+    ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "bionic_interface",
+    "name": "Standard Bionic Interface",
+    "//": "Universal data link is just fluff, to explain why you have the other bits. Does not exist ingame.",
+    "description": "Like most people on Earth you have previously received cybernetic enhancement to make life easier.  Your enhancements include a universal data link, some basic power storage, and a charging cable to top up.",
+    "CBMs": [ "bio_power_storage_mkII", "bio_cable" ],
+    "points": 0
+  }
+]

--- a/data/mods/aftershock_exoplanet/profession_groups.json
+++ b/data/mods/aftershock_exoplanet/profession_groups.json
@@ -1,0 +1,25 @@
+[
+  {
+    "type": "profession_group",
+    "id": "adult_basic_background",
+    "professions": [
+      "driving_license",
+      "simple_home_cooking",
+      "computer_literate",
+      "social_skills",
+      "high_school_graduate",
+      "mundane_survival",
+      "bionic_interface"
+    ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "bionic_interface",
+    "name": "Standard Bionic Interface",
+    "//": "Universal data link is just fluff, to explain why you have the other bits. Does not exist ingame.",
+    "description": "Like most people on Salus IV you have previously received cybernetic enhancement to make life easier.  Your enhancements include a universal data link, some basic power storage, and a charging cable to top up.",
+    "CBMs": [ "bio_power_storage_mkII", "bio_cable" ],
+    "points": 0
+  }
+]

--- a/doc/NPCs.md
+++ b/doc/NPCs.md
@@ -34,7 +34,7 @@ Format:
   "id": "NC_EXAMPLE",                                                      // Mandatory, unique id that refers to this class.
   "name": { "str": "Example NPC" },                                        // Mandatory, display name for this class.
   "job_description": "I'm helping you learn the game.",                    // Mandatory
-  "common": false,                                                         // Optional. Whether or not this class can appear via random generation.
+  "common": false,                                                         // Optional, defaults true. Whether or not this class can appear via random generation. Randomly generated NPCs will have skills, proficiencies, and bionics applied to them as a default new player character would.
   "sells_belongings": false,                                               // Optional. See [Shopkeeper NPC configuration](#shopkeeper-npc-configuration)
   "bonus_str": { "rng": [ -4, 0 ] },                                       // Optional. Modifies stat by the given value. This example shows a random distribution between -4 and 0.
   "bonus_dex": 100,                                                        // Optional. This example always adds exactly 100 to the stat.
@@ -72,6 +72,7 @@ Format:
   ],
   "shopkeeper_blacklist": "test_blacklist",
   "restock_interval": "6 days",
+  "proficiencies": [ "prof_gunsmithing_basic", "prof_spotting" ],         // Optional. Note that prereqs do not need to be defined. NPCs of this class will learn this proficiency *and all pre-requesite proficiencies*.
   "traits": [ { "group": "BG_survival_story_EVACUEE" }, { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ]     // Optional
 }
 ```

--- a/src/character.h
+++ b/src/character.h
@@ -2458,7 +2458,8 @@ class Character : public Creature, public visitable
         float get_proficiency_practice( const proficiency_id &prof ) const;
         time_duration get_proficiency_practiced_time( const proficiency_id &prof ) const;
         bool has_prof_prereqs( const proficiency_id &prof ) const;
-        void add_proficiency( const proficiency_id &prof, bool ignore_requirements = false );
+        void add_proficiency( const proficiency_id &prof, bool ignore_requirements = false,
+                              bool recursive = false );
         void lose_proficiency( const proficiency_id &prof, bool ignore_requirements = false );
         bool practice_proficiency( const proficiency_id &prof, const time_duration &amount,
                                    const std::optional<time_duration> &max = std::nullopt );

--- a/src/character.h
+++ b/src/character.h
@@ -2449,7 +2449,7 @@ class Character : public Creature, public visitable
         /** Returns a value used when attempting to intimidate NPC's */
         int intimidation() const;
 
-        void set_skills_from_hobbies();
+        void set_skills_from_hobbies( bool no_override = false );
 
         void set_bionics_from_hobbies();
 

--- a/src/character_proficiency.cpp
+++ b/src/character_proficiency.cpp
@@ -45,13 +45,14 @@ bool Character::has_prof_prereqs( const proficiency_id &prof ) const
     return _proficiencies->has_prereqs( prof );
 }
 
-void Character::add_proficiency( const proficiency_id &prof, bool ignore_requirements )
+void Character::add_proficiency( const proficiency_id &prof, bool ignore_requirements,
+                                 bool recursive )
 {
     if( ignore_requirements ) {
         _proficiencies->direct_learn( prof );
         return;
     }
-    _proficiencies->learn( prof );
+    _proficiencies->learn( prof, recursive );
 }
 
 void Character::lose_proficiency( const proficiency_id &prof, bool ignore_requirements )

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -796,7 +796,7 @@ bool avatar::create( character_type type, const std::string &tempname )
     return true;
 }
 
-void Character::set_skills_from_hobbies()
+void Character::set_skills_from_hobbies( bool no_override )
 {
     // 2 for an average person
     float catchup_modifier = 1.0f + ( 2.0f * get_int() + get_per() ) / 24.0f;
@@ -805,6 +805,9 @@ void Character::set_skills_from_hobbies()
     // Grab skills from hobbies and train
     for( const profession *profession : hobbies ) {
         for( const profession::StartingSkill &e : profession->skills() ) {
+            if( no_override && get_skill_level( e.first ) != 0 ) {
+                continue;
+            }
             // Train our skill
             const int skill_xp_bonus = calculate_cumulative_experience( e.second );
             get_skill_level_object( e.first ).train( skill_xp_bonus, catchup_modifier,

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -688,7 +688,7 @@ void npc::randomize( const npc_class_id &type, const npc_template_id &tem_id )
     }
     // Add proficiencies
     for( const proficiency_id &prof : myclass->_starting_proficiencies ) {
-        add_proficiency( prof );
+        add_proficiency( prof, false, true );
     }
     if( myclass->is_common() ) {
         add_default_background();

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -607,16 +607,15 @@ void npc::randomize( const npc_class_id &type, const npc_template_id &tem_id )
         myclass = type;
     }
 
-    const npc_class &the_class = myclass.obj();
-    str_max += the_class.roll_strength();
-    dex_max += the_class.roll_dexterity();
-    int_max += the_class.roll_intelligence();
-    per_max += the_class.roll_perception();
+    str_max += myclass->roll_strength();
+    dex_max += myclass->roll_dexterity();
+    int_max += myclass->roll_intelligence();
+    per_max += myclass->roll_perception();
 
-    personality.aggression += the_class.roll_aggression();
-    personality.bravery += the_class.roll_bravery();
-    personality.collector += the_class.roll_collector();
-    personality.altruism += the_class.roll_altruism();
+    personality.aggression += myclass->roll_aggression();
+    personality.bravery += myclass->roll_bravery();
+    personality.collector += myclass->roll_collector();
+    personality.altruism += myclass->roll_altruism();
 
     personality.aggression = std::clamp( personality.aggression, NPC_PERSONALITY_MIN,
                                          NPC_PERSONALITY_MAX );
@@ -674,27 +673,27 @@ void npc::randomize( const npc_class_id &type, const npc_template_id &tem_id )
     generate_personality_traits();
 
     // Run mutation rounds
-    for( const auto &mr : type->mutation_rounds ) {
+    for( const auto &mr : myclass->mutation_rounds ) {
         int rounds = mr.second.roll();
         for( int i = 0; i < rounds; ++i ) {
             mutate_category( mr.first );
         }
     }
     // Add bionics
-    for( const auto &bl : type->bionic_list ) {
+    for( const auto &bl : myclass->bionic_list ) {
         int chance = bl.second;
         if( rng( 0, 100 ) <= chance ) {
             add_bionic( bl.first );
         }
     }
     // Add proficiencies
-    for( const proficiency_id &prof : type->_starting_proficiencies ) {
+    for( const proficiency_id &prof : myclass->_starting_proficiencies ) {
         add_proficiency( prof );
     }
     // Add martial arts
     learn_ma_styles_from_traits();
     // Add spells for magiclysm mod
-    for( std::pair<spell_id, int> spell_pair : type->_starting_spells ) {
+    for( std::pair<spell_id, int> spell_pair : myclass->_starting_spells ) {
         this->magic->learn_spell( spell_pair.first, *this, true );
         spell &sp = this->magic->get_spell( spell_pair.first );
         while( sp.get_level() < spell_pair.second && !sp.is_max_level( *this ) ) {

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -690,6 +690,13 @@ void npc::randomize( const npc_class_id &type, const npc_template_id &tem_id )
     for( const proficiency_id &prof : myclass->_starting_proficiencies ) {
         add_proficiency( prof );
     }
+    if( myclass->is_common() ) {
+        add_default_background();
+        set_skills_from_hobbies( true ); // Only trains skills that are still at 0 at this point
+        set_proficiencies_from_hobbies();
+        set_bionics_from_hobbies(); // Just in case, for mods
+    }
+
     // Add martial arts
     learn_ma_styles_from_traits();
     // Add spells for magiclysm mod

--- a/src/npc_class.cpp
+++ b/src/npc_class.cpp
@@ -172,6 +172,11 @@ void npc_class::check_consistency()
     }
 }
 
+bool npc_class::is_common() const
+{
+    return common;
+}
+
 static distribution load_distribution( const JsonObject &jo )
 {
     if( jo.has_float( "constant" ) ) {

--- a/src/npc_class.h
+++ b/src/npc_class.h
@@ -138,6 +138,8 @@ class npc_class
         const time_duration &get_shop_restock_interval() const;
         faction_price_rule const *get_price_rules( item const &it, npc const &guy ) const;
 
+        bool is_common() const;
+
         void load( const JsonObject &jo, std::string_view src );
 
         static const npc_class_id &from_legacy_int( int i );

--- a/src/proficiency.cpp
+++ b/src/proficiency.cpp
@@ -365,11 +365,13 @@ void proficiency_set::set_time_practiced( const proficiency_id &practicing,
     current.practiced = amount;
 }
 
-void proficiency_set::learn( const proficiency_id &learned )
+void proficiency_set::learn( const proficiency_id &learned, bool recursive )
 {
     for( const proficiency_id &req : learned->required_proficiencies() ) {
-        if( !has_learned( req ) ) {
+        if( !has_learned( req ) && !recursive ) {
             return;
+        } else if( recursive ) {
+            learn( req, recursive );
         }
     }
     known.insert( learned );

--- a/src/proficiency.h
+++ b/src/proficiency.h
@@ -132,7 +132,7 @@ class proficiency_set
         // True if the proficiency is learned;
         bool practice( const proficiency_id &practicing, const time_duration &amount,
                        float remainder, const std::optional<time_duration> &max );
-        void learn( const proficiency_id &learned );
+        void learn( const proficiency_id &learned, bool recursive = false );
         void remove( const proficiency_id &lost );
 
         // Ignore requirements, made for debugging


### PR DESCRIPTION
#### Summary
Balance "Random NPCs have the same starting skills and proficiencies as the average new character"

#### Purpose of change
Players got buffed, but our NPCs are still churls without driver's licenses?!

Maintainability for NPCs is poor, let's fix that.

#### Describe the solution
-Fix a pretty bad bug with bad variable handling. Proficiencies and a few other values were being set by the passed argument `type`... this was in all cases npc_class_id::NULL_ID(). `myclass` was set by randomizing from a common NPC class
https://github.com/CleverRaven/Cataclysm-DDA/blob/96401952f59e5afa30f1815da298904cbf97b746/src/npc.cpp#L605

...but `myclass` was not used to determine the resulting proficiency/other values. Always the empty `type`. This meant that if the new NPC randomized into a class with proficiencies... it didn't get the proficiencies, because the null `type` has no proficiencies. Enormous sigh.

-Apply the default starting character background to NPCs if they are randomly generated (unique classes can still do whatever they want). Add a special modifier so that the skills gained from these backgrounds don't interfere with existing skill definitions, they only raise the bare minimum. Basically this means random NPCs start proficient in driving and home cooking with very basic *skill levels*, just like the player character. ~~NPCs have learned how to drive! Hooray!~~ **Not yet.**

Because this draws form the same starting background as the player character it should automatically track any future changes without any specific handling. Maintainability!

-In the interests of maintainability and ease of contributing, make their proficiency learning **recursive** instead of simply failing if a pre-req is missing. This means that if our proficiency trees change in the future (by adding a new proficiency or removing an existing link into a new tree), contributors will not to go through and laboriously re-verify every NPC class' proficiencies. They simply define the top-level ones they should have, and all the pre-reqs fill in from there.


#### Describe alternatives you've considered
Completely combining professions and NPC classes? That is a suggestion which has been put forth before...

`common` is maybe not the optimal way to determine if the adult_basic_background should be applied, but bumping that out to a new json value is incredibly simple if any problems arise.

#### Testing
Many newly generated NPCs, all of which had driving, food prep, and minimum skill levels. Here's one:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/c189fff8-f4f4-4549-b379-f25d3a94bd5c)


#### Additional context
