### PR TITLE
[DinoMod] camp hunting rebalance

### DIFF
--- a/data/mods/DinoMod/monstergroups/misc.json
+++ b/data/mods/DinoMod/monstergroups/misc.json
@@ -115,11 +115,7 @@
     "//": "Special group with hardcoded reference in basecamp::hunting_results. Does not actually spawn anywhere, used solely to determine returns from camp hunting mission.",
     "//1": "No heavier than 21 kg.",
     "//2": "This group always has a chance of being the result, regardless of mission type.",
-    "monsters": [
-      { "monster": "mon_coelophysis", "weight": 3 },
-      { "monster": "mon_velociraptor", "weight": 3 },
-      { "monster": "mon_dromaeosaurus", "weight": 3 }
-    ]
+    "monsters": [ { "monster": "mon_coelophysis", "weight": 3 }, { "monster": "mon_dromaeosaurus", "weight": 3 } ]
   },
   {
     "type": "monstergroup",

--- a/data/mods/DinoMod/monstergroups/misc.json
+++ b/data/mods/DinoMod/monstergroups/misc.json
@@ -113,61 +113,53 @@
     "type": "monstergroup",
     "name": "GROUP_CAMP_HUNTING",
     "//": "Special group with hardcoded reference in basecamp::hunting_results. Does not actually spawn anywhere, used solely to determine returns from camp hunting mission.",
-    "//1": "Can be overwritten by mods.",
+    "//1": "No heavier than 21 kg.",
     "//2": "This group always has a chance of being the result, regardless of mission type.",
     "monsters": [
-      { "monster": "mon_albertonykus", "weight": 10 },
-      { "monster": "mon_scutellosaurus", "weight": 5 },
-      { "monster": "mon_stegoceras", "weight": 3 },
-      { "monster": "mon_aquilops", "weight": 3 },
-      { "monster": "mon_leptoceratops", "weight": 3 },
-      { "monster": "mon_nanosaurus", "weight": 5 },
-      { "monster": "mon_thescelosaurus", "weight": 5 },
-      { "monster": "mon_dimorphodon", "weight": 5 }
+      { "monster": "mon_coelophysis", "weight": 3 },
+      { "monster": "mon_velociraptor", "weight": 3 },
+      { "monster": "mon_dromaeosaurus", "weight": 3 }
     ]
   },
   {
     "type": "monstergroup",
     "name": "GROUP_CAMP_TRAPPING",
     "//": "Special group with hardcoded reference in basecamp::hunting_results. Does not actually spawn anywhere, used solely to determine returns from camp hunting mission.",
-    "//1": "Can be overwritten by mods.",
+    "//1": "No heavier than 10 kg.",
     "//2": "This group can only be picked from when the trapping mission is used, in addition to GROUP_CAMP_HUNTING.",
     "monsters": [
-      { "monster": "mon_albertonykus", "weight": 10 },
-      { "monster": "mon_compsognathus", "weight": 5 },
-      { "monster": "mon_scutellosaurus", "weight": 5 },
-      { "monster": "mon_stegoceras", "weight": 3 },
-      { "monster": "mon_aquilops", "weight": 3 },
-      { "monster": "mon_leptoceratops", "weight": 3 },
-      { "monster": "mon_nanosaurus", "weight": 5 },
-      { "monster": "mon_pteranodon", "weight": 5 }
+      { "monster": "mon_tawa", "weight": 3 },
+      { "monster": "mon_albertonykus", "weight": 20 },
+      { "monster": "mon_saurornitholestes", "weight": 5 },
+      { "monster": "mon_scutellosaurus", "weight": 20 },
+      { "monster": "mon_aquilops", "weight": 12 },
+      { "monster": "mon_nanosaurus", "weight": 20 },
+      { "monster": "mon_dimorphodon", "weight": 5 }
     ]
   },
   {
     "type": "monstergroup",
     "name": "GROUP_CAMP_HUNTING_LARGE",
     "//": "Special group with hardcoded reference in basecamp::hunting_results. Does not actually spawn anywhere, used solely to determine returns from camp hunting mission.",
-    "//1": "Can be overwritten by mods.",
+    "//1": "No heavier than 400 kg.",
     "//2": "This group can only be picked from when the hunt large animals mission is used, in addition to GROUP_CAMP_HUNTING.",
     "monsters": [
-      { "monster": "mon_gallimimus", "weight": 5 },
-      { "monster": "mon_struthiomimus", "weight": 5 },
-      { "monster": "mon_ornithomimus", "weight": 5 },
+      { "monster": "mon_dilophosaurus", "weight": 3 },
+      { "monster": "mon_ornithomimus", "weight": 20 },
       { "monster": "mon_falcarius", "weight": 5 },
-      { "monster": "mon_pachycephalosaurus", "weight": 3 },
-      { "monster": "mon_tenontosaurus", "weight": 10 },
+      { "monster": "mon_anzu", "weight": 5 },
+      { "monster": "mon_deinonychus", "weight": 3 },
+      { "monster": "mon_stenonychosaurus", "weight": 3 },
+      { "monster": "mon_sarahsaurus", "weight": 4 },
+      { "monster": "mon_anchisaurus", "weight": 4 },
       { "monster": "mon_dryosaurus", "weight": 10 },
-      { "monster": "mon_camptosaurus", "weight": 10 },
-      { "monster": "mon_hadrosaurus", "weight": 10 },
-      { "monster": "mon_maiasaura", "weight": 10 },
-      { "monster": "mon_gryposaurus", "weight": 10 },
-      { "monster": "mon_prosaurolophus", "weight": 10 },
-      { "monster": "mon_saurolophus", "weight": 10 },
-      { "monster": "mon_edmontosaurus", "weight": 10 },
-      { "monster": "mon_parasaurolophus", "weight": 10 },
-      { "monster": "mon_lambeosaurus", "weight": 10 },
-      { "monster": "mon_corythosaurus", "weight": 10 },
-      { "monster": "mon_hypacrosaurus", "weight": 10 }
+      { "monster": "mon_stegoceras", "weight": 12 },
+      { "monster": "mon_leptoceratops", "weight": 12 },
+      { "monster": "mon_zuniceratops", "weight": 12 },
+      { "monster": "mon_oryctodromeus", "weight": 3 },
+      { "monster": "mon_thescelosaurus", "weight": 3 },
+      { "monster": "mon_pteranodon", "weight": 3 },
+      { "monster": "mon_quetzalcoatlus", "weight": 3 }
     ]
   }
 ]


### PR DESCRIPTION
#### Summary
Mods "[DinoMod] camp hunting rebalance"

#### Purpose of change

Balance, realism

#### Describe the solution

Rebalance monster spawn lists for the camp hunting to honor the weight caps of the existing list and document those caps. No more impossibly heavy dinos showing up after six hours of work.

#### Describe alternatives you've considered

Make the sauropods not spawn in winter. Add juveniles.

#### Testing

Simple JSON edits

#### Additional context

Thanks to [Ok-Club4634](https://www.reddit.com/user/Ok-Club4634) for flagging this issue