### PR TITLE
fix #73907   Stop Flip Flopping mutations in Alpha stomach chain

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -6995,7 +6995,6 @@
     "prereqs": [ "ROT1" ],
     "changes_to": [ "ROT3" ],
     "category": [ "CHIMERA", "ALPHA" ],
-    "threshreq": [ "THRESH_CHIMERA", "THRESH_ALPHA" ],
     "enchantments": [ { "values": [ { "value": "REGEN_HP", "multiply": -0.25 }, { "value": "REGEN_HP_AWAKE", "multiply": -0.266 } ] } ]
   },
   {

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -6988,7 +6988,6 @@
     "type": "mutation",
     "id": "ROT2",
     "name": { "str": "Deterioration" },
-    "points": -7,
     "bodytemp_modifiers": [ -750, -750 ],
     "description": "Your body is very slowly wasting away.",
     "types": [ "HEALING" ],

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -6988,6 +6988,7 @@
     "type": "mutation",
     "id": "ROT2",
     "name": { "str": "Deterioration" },
+    "points": -8,
     "bodytemp_modifiers": [ -750, -750 ],
     "description": "Your body is very slowly wasting away.",
     "types": [ "HEALING" ],

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -1203,7 +1203,7 @@
     "description": "Your genome has rapidly adapted to the Cataclysm and can handle the strain of mutation better.  Taking different kinds of mutagen won't result in more defective mutations than normal.",
     "starting_trait": true,
     "cancels": [ "CHAOTIC_BAD" ],
-    "category": [ "FISH", "SLIME", "ALPHA", "MEDICAL", "PLANT" ]
+    "category": [ "FISH", "SLIME", "MEDICAL", "PLANT" ]
   },
   {
     "type": "mutation",

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -6995,6 +6995,7 @@
     "prereqs": [ "ROT1" ],
     "changes_to": [ "ROT3" ],
     "category": [ "CHIMERA", "ALPHA" ],
+    "threshreq": [ "THRESH_CHIMERA", "THRESH_ALPHA" ],
     "enchantments": [ { "values": [ { "value": "REGEN_HP", "multiply": -0.25 }, { "value": "REGEN_HP_AWAKE", "multiply": -0.266 } ] } ]
   },
   {

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -4456,7 +4456,7 @@
     "type": "mutation",
     "id": "EATPOISON",
     "name": { "str": "Intestinal Fortitude" },
-    "points": 3,
+    "points": 2,
     "description": "Your guts have developed the ability to handle the toxic elements of mutated flesh.  Mostly.",
     "types": [ "CONSTITUTION" ],
     "changes_to": [ "EATDEAD" ],

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -1945,7 +1945,8 @@
     "starting_trait": true,
     "enchantments": [ { "values": [ { "value": "VOMIT_MUL", "multiply": 1 } ] } ],
     "types": [ "CONSTITUTION" ],
-    "changes_to": [ "NAUSEA" ],
+    "leads_to": [ "NAUSEA" ],
+    "changes_to": [ "EATPOISON" ],
     "category": [
       "ALPHA",
       "SLIME",
@@ -4459,9 +4460,9 @@
     "description": "Your guts have developed the ability to handle the toxic elements of mutated flesh.  Mostly.",
     "types": [ "CONSTITUTION" ],
     "changes_to": [ "EATDEAD" ],
-    "prereqs": [ "POISRESIST" ],
+    "prereqs": [ "WEAKSTOMACH" ],
+    "prereqs2": [ "VOMITOUS" ],
     "//": "Yes, you eventually got over the massive digestive upset.  Mutations aren't easy on a system!",
-    "prereqs2": [ "SAPROVORE", "TOLERANCE" ],
     "threshreq": [
       "THRESH_TROGLOBITE",
       "THRESH_CHIMERA",
@@ -6803,7 +6804,8 @@
     "description": "You have a major digestive disorder.  Though it causes you to vomit frequently, you have found that you can trigger your vomit reflex on demand, too.",
     "enchantments": [ { "values": [ { "value": "VOMIT_MUL", "multiply": 2 } ] } ],
     "types": [ "CONSTITUTION" ],
-    "prereqs": [ "NAUSEA" ],
+    "prereqs": [ "WEAKSTOMACH" ],
+    "prereqs2": [ "NAUSEA" ],
     "changes_to": [ "EATPOISON" ],
     "category": [
       "ALPHA",

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -6988,7 +6988,7 @@
     "type": "mutation",
     "id": "ROT2",
     "name": { "str": "Deterioration" },
-    "points": -8,
+    "points": -7,
     "bodytemp_modifiers": [ -750, -750 ],
     "description": "Your body is very slowly wasting away.",
     "types": [ "HEALING" ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Flip-flopping in acquisition of Intestinal Fortitude"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

bugfix #73907

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

Weak Stomach now leads to Nausea, that itself turns into Vomitous.

Intestinal Fortitude has its different prereqs replaced with Weak Stomach and Vomitous, the two of which are set to change into Intestinal Fortitude.

Removes Robust Genetics from Alpha.  Alpha should be a jealous category.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

It only go in one direction, and through a couple runs of mutating Rat, never observed Vomitous turning into Nausea.

Weak Stomach, Nausea and Vomitous successfully disappear after acquiring Intestinal Fortitude.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
