### PR TITLE
[Xedra Evolved] Make Paraclesian fae's magic easier in appropriate terrain

### DIFF
--- a/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_magic_terrain_adjustments.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_magic_terrain_adjustments.json
@@ -1,0 +1,134 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_ARVORE_ELEMENTAL_MAGIC_ADJUSTMENT",
+    "eoc_type": "EVENT",
+    "required_event": "opens_spellbook",
+    "condition": {
+      "and": [
+        {
+          "and": [
+            "u_is_outside",
+            {
+              "or": [
+                { "u_is_on_terrain_with_flag": "SHRUB" },
+                { "u_is_on_terrain_with_flag": "DIGGABLE" },
+                { "u_is_on_terrain_with_flag": "YOUNG" }
+              ]
+            },
+            { "not": { "u_near_om_location": "road_curved", "range": 1 } },
+            { "not": { "u_near_om_location": "road_four_way", "range": 1 } },
+            { "not": { "u_near_om_location": "road_tee", "range": 1 } },
+            { "not": { "u_near_om_location": "road_straight", "range": 1 } },
+            { "not": { "u_near_om_location": "road_end", "range": 1 } },
+            { "not": { "u_near_om_location": "road_sw", "range": 1 } },
+            { "not": { "u_near_om_location": "road_ne", "range": 1 } },
+            { "not": { "u_near_om_location": "road_ew", "range": 1 } },
+            { "not": { "u_near_om_location": "road_ns", "range": 1 } },
+            { "not": { "u_near_om_location": "road_nesw", "range": 1 } },
+            { "not": { "u_near_om_location": "road", "range": 1 } }
+          ]
+        },
+        { "u_has_trait": "ARVORE" }
+      ]
+    },
+    "effect": [ { "math": [ "u_spellcasting_adjustment('difficulty', 'school': 'ARVORE' )", "=", "-2" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_ARVORE_ELEMENTAL_MAGIC_ADJUSTMENT_HEAVY_FOREST",
+    "eoc_type": "EVENT",
+    "required_event": "opens_spellbook",
+    "condition": {
+      "and": [
+        {
+          "and": [
+            { "or": [ "u_is_outside", { "u_is_on_terrain": "t_barkfloor" } ] },
+            {
+              "or": [
+                { "u_at_om_location": "forest_thick" },
+                { "u_at_om_location": "arvore_genius_loci_NW" },
+                { "u_at_om_location": "arvore_genius_loci_NE" },
+                { "u_at_om_location": "arvore_genius_loci_SW" },
+                { "u_at_om_location": "arvore_genius_loci_SE" },
+                { "u_near_om_location": "great_tree_z0_nw", "range": 2 },
+                { "u_near_om_location": "great_tree_z0_se", "range": 2 },
+                { "u_near_om_location": "great_tree_z1_nw", "range": 2 },
+                { "u_near_om_location": "great_tree_z1_se", "range": 2 },
+                { "u_near_om_location": "great_tree_z2_nw", "range": 2 },
+                { "u_near_om_location": "great_tree_z2_se", "range": 2 },
+                { "u_near_om_location": "great_tree_z3_06", "range": 2 },
+                { "u_near_om_location": "great_tree_z3_11", "range": 2 },
+                { "u_near_om_location": "great_tree_z4_06", "range": 2 },
+                { "u_near_om_location": "great_tree_z4_11", "range": 2 },
+                { "u_near_om_location": "great_tree_z5_06", "range": 2 },
+                { "u_near_om_location": "great_tree_z5_11", "range": 2 },
+                { "u_near_om_location": "great_tree_z6_nw", "range": 2 },
+                { "u_near_om_location": "great_tree_z6_se", "range": 2 },
+                { "u_near_om_location": "great_tree_z6_n2", "range": 2 },
+                { "u_near_om_location": "great_tree_z6_se", "range": 2 },
+                { "u_near_om_location": "great_tree_z7_nw", "range": 2 },
+                { "u_near_om_location": "great_tree_z7_se", "range": 2 },
+                { "u_near_om_location": "great_tree_crown_06", "range": 2 },
+                { "u_near_om_location": "great_tree_crown_11", "range": 2 },
+                { "u_near_om_location": "great_tree_crown_top_01", "range": 2 },
+                { "u_near_om_location": "great_tree_crown_top_04", "range": 2 },
+                { "u_near_om_location": "great_tree_roots", "range": 2 },
+                { "u_near_om_location": "great_tree_roots_se", "range": 2 },
+                { "u_near_om_location": "great_tree_roots_nw", "range": 2 }
+              ]
+            },
+            { "not": { "u_near_om_location": "road_curved", "range": 1 } },
+            { "not": { "u_near_om_location": "road_four_way", "range": 1 } },
+            { "not": { "u_near_om_location": "road_tee", "range": 1 } },
+            { "not": { "u_near_om_location": "road_straight", "range": 1 } },
+            { "not": { "u_near_om_location": "road_end", "range": 1 } },
+            { "not": { "u_near_om_location": "road_sw", "range": 1 } },
+            { "not": { "u_near_om_location": "road_ne", "range": 1 } },
+            { "not": { "u_near_om_location": "road_ew", "range": 1 } },
+            { "not": { "u_near_om_location": "road_ns", "range": 1 } },
+            { "not": { "u_near_om_location": "road_nesw", "range": 1 } },
+            { "not": { "u_near_om_location": "road", "range": 1 } }
+          ]
+        },
+        { "u_has_trait": "ARVORE" }
+      ]
+    },
+    "effect": [ { "math": [ "u_spellcasting_adjustment('difficulty', 'school': 'ARVORE' )", "=", "-1" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_IERDE_ELEMENTAL_MAGIC_ADJUSTMENT",
+    "eoc_type": "EVENT",
+    "required_event": "opens_spellbook",
+    "condition": {
+      "and": [
+        {
+          "or": [
+            { "u_is_on_terrain_with_flag": "DIGGABLE" },
+            { "u_is_on_terrain": "t_rock_floor" },
+            { "u_is_on_terrain": "t_railroad_rubble" },
+            { "u_is_on_terrain": "t_dirt_underground" }
+          ]
+        },
+        { "not": { "u_is_on_terrain": "t_vitrified_sand" } },
+        { "not": { "u_is_on_terrain": "t_pit_corpsed" } },
+        { "not": { "u_is_on_terrain": "t_fungus" } },
+        { "not": { "u_is_on_terrain": "t_glassed_sand" } },
+        { "not": { "u_is_on_terrain": "t_rubber_mulch" } },
+        { "not": { "u_is_on_terrain": "t_swater_surf" } },
+        { "not": { "u_is_on_terrain": "t_woodchips" } },
+        { "u_has_trait": "IERDE" }
+      ]
+    },
+    "effect": [ { "math": [ "u_spellcasting_adjustment('difficulty', 'school': 'IERDE' )", "=", "-2" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_IERDE_ELEMENTAL_MAGIC_ADJUSTMENT_UNDERGROUND",
+    "eoc_type": "EVENT",
+    "required_event": "opens_spellbook",
+    "condition": { "and": [ { "math": [ "u_val('pos_z')", "<=", "-1" ] }, { "u_has_trait": "IERDE" } ] },
+    "effect": [ { "math": [ "u_spellcasting_adjustment('difficulty', 'school': 'IERDE' )", "=", "-1" ] } ]
+  }
+]

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_magic_terrain_adjustments.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_magic_terrain_adjustments.json
@@ -222,5 +222,62 @@
     "required_event": "opens_spellbook",
     "condition": { "and": [ "u_is_outside", { "u_has_trait": "SYLPH" } ] },
     "effect": [ { "math": [ "u_spellcasting_adjustment('difficulty', 'school': 'SYLPH' )", "=", "-2" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_UNDINE_ELEMENTAL_MAGIC_ADJUSTMENT_NEAR_WATER",
+    "eoc_type": "EVENT",
+    "required_event": "opens_spellbook",
+    "condition": {
+      "and": [
+        {
+          "or": [
+            { "u_is_on_terrain": "t_water_dp" },
+            { "u_is_on_terrain": "t_water_sh" },
+            { "u_is_on_terrain": "t_swater_dp" },
+            { "u_is_on_terrain": "t_swater_dp_underground" },
+            { "u_is_on_terrain": "t_water_dp_underground" },
+            { "u_is_on_terrain": "t_water_pool" },
+            { "u_is_on_terrain": "t_water_pool_outdoors" },
+            { "u_is_on_terrain": "t_swater_dp_underground" },
+            { "u_is_on_terrain": "t_water_hot" },
+            { "u_is_on_terrain": "t_water_murky" },
+            { "u_is_on_terrain": "t_water_sh_underground" },
+            { "u_is_on_terrain": "t_swater_dp_underground" },
+            { "u_is_on_terrain": "t_swater_sh_underground" },
+            { "u_is_on_terrain": "t_swater_sh" },
+            { "u_is_on_terrain": "t_water_pool_shallow" },
+            { "u_is_on_terrain": "t_water_pool_shallow_outdoors" },
+            { "u_is_on_terrain": "t_water_moving_dp" },
+            { "u_is_on_terrain": "t_water_moving_dp_underground" },
+            { "u_is_on_terrain": "t_water_sh_murky_underground" },
+            { "u_near_om_location": "generic_river_bank", "range": 1 },
+            { "u_near_om_location": "generic_river", "range": 1 },
+            { "u_near_om_location": "river_center", "range": 1 },
+            { "u_near_om_location": "river", "range": 1 },
+            { "u_near_om_location": "river_c_not_ne", "range": 1 },
+            { "u_near_om_location": "river_c_not_nw", "range": 1 },
+            { "u_near_om_location": "river_c_not_se", "range": 1 },
+            { "u_near_om_location": "river_c_not_sw", "range": 1 },
+            { "u_near_om_location": "river_ne", "range": 1 },
+            { "u_near_om_location": "river_se", "range": 1 },
+            { "u_near_om_location": "river_sw", "range": 1 },
+            { "u_near_om_location": "river_nw", "range": 1 },
+            { "u_near_om_location": "lake_shore", "range": 1 },
+            { "u_near_om_location": "lake_surface", "range": 1 }
+          ]
+        },
+        { "u_has_trait": "UNDINE" }
+      ]
+    },
+    "effect": [ { "math": [ "u_spellcasting_adjustment('difficulty', 'school': 'UNDINE' )", "=", "-2" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_UNDINE_ELEMENTAL_MAGIC_ADJUSTMENT_UNDERWATER",
+    "eoc_type": "EVENT",
+    "required_event": "opens_spellbook",
+    "condition": { "and": [ "u_is_underwater", { "u_has_trait": "UNDINE" } ] },
+    "effect": [ { "math": [ "u_spellcasting_adjustment('difficulty', 'school': 'UNDINE' )", "=", "-2" ] } ]
   }
 ]

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_magic_terrain_adjustments.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_magic_terrain_adjustments.json
@@ -206,5 +206,21 @@
       ]
     },
     "effect": [ { "math": [ "u_spellcasting_adjustment('difficulty', 'school': 'SALAMANDER' )", "=", "-2" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_SYLPH_ELEMENTAL_MAGIC_ADJUSTMENT_UP_HIGH",
+    "eoc_type": "EVENT",
+    "required_event": "opens_spellbook",
+    "condition": { "and": [ { "math": [ "u_val('pos_z')", ">=", "3" ] }, { "u_has_trait": "SYLPH" } ] },
+    "effect": [ { "math": [ "u_spellcasting_adjustment('difficulty', 'school': 'SYLPH' )", "=", "-2" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_SYLPH_ELEMENTAL_MAGIC_ADJUSTMENT_UNDER_THE_SKY",
+    "eoc_type": "EVENT",
+    "required_event": "opens_spellbook",
+    "condition": { "and": [ "u_is_outside", { "u_has_trait": "SYLPH" } ] },
+    "effect": [ { "math": [ "u_spellcasting_adjustment('difficulty', 'school': 'SYLPH' )", "=", "-2" ] } ]
   }
 ]

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_magic_terrain_adjustments.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_magic_terrain_adjustments.json
@@ -176,5 +176,35 @@
       ]
     },
     "effect": [ { "math": [ "u_spellcasting_adjustment('difficulty', 'school': 'IERDE' )", "=", "-2" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_SALAMANDER_ELEMENTAL_MAGIC_ADJUSTMENT_IN_FIRE",
+    "eoc_type": "EVENT",
+    "required_event": "opens_spellbook",
+    "condition": { "and": [ { "u_is_in_field": "fd_fire" }, { "u_has_trait": "SALAMANDER" } ] },
+    "effect": [ { "math": [ "u_spellcasting_adjustment('difficulty', 'school': 'SALAMANDER' )", "=", "-2" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_SALAMANDER_ELEMENTAL_MAGIC_ADJUSTMENT_IN_HEAT",
+    "eoc_type": "EVENT",
+    "required_event": "opens_spellbook",
+    "condition": {
+      "and": [
+        {
+          "or": [
+            { "u_is_in_field": "fd_hot_air1" },
+            { "u_is_in_field": "fd_hot_air2" },
+            { "u_is_in_field": "fd_hot_air3" },
+            { "u_is_in_field": "fd_hot_air4" },
+            { "u_is_in_field": "fd_fire" },
+            { "math": [ "weather('temperature')", ">=", "from_fahrenheit( 80 )" ] }
+          ]
+        },
+        { "u_has_trait": "SALAMANDER" }
+      ]
+    },
+    "effect": [ { "math": [ "u_spellcasting_adjustment('difficulty', 'school': 'SALAMANDER' )", "=", "-2" ] } ]
   }
 ]

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_magic_terrain_adjustments.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_magic_terrain_adjustments.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "effect_on_condition",
-    "id": "EOC_ARVORE_ELEMENTAL_MAGIC_ADJUSTMENT",
+    "id": "EOC_ARVORE_ELEMENTAL_MAGIC_ADJUSTMENT_IN_THE_WILDERNESS",
     "eoc_type": "EVENT",
     "required_event": "opens_spellbook",
     "condition": {
@@ -94,11 +94,65 @@
         { "u_has_trait": "ARVORE" }
       ]
     },
-    "effect": [ { "math": [ "u_spellcasting_adjustment('difficulty', 'school': 'ARVORE' )", "=", "-1" ] } ]
+    "effect": [ { "math": [ "u_spellcasting_adjustment('difficulty', 'school': 'ARVORE' )", "=", "-2" ] } ]
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_IERDE_ELEMENTAL_MAGIC_ADJUSTMENT",
+    "id": "EOC_HOMULLUS_MAGIC_ADJUSTMENT_IN_CIVILIZATION",
+    "eoc_type": "EVENT",
+    "required_event": "opens_spellbook",
+    "effect": [
+      {
+        "set_string_var": { "mutator": "loc_relative_u", "target": "(0,0,0)" },
+        "target_var": { "context_val": "homullus_location" }
+      },
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_HOMULLUS_MAGIC_ADJUSTMENT_IN_CIVILIZATION_2",
+            "//": "This EoC is required because map_in_city cannot check talker location directly.",
+            "condition": {
+              "or": [
+                { "u_near_om_location": "evac_center_13", "range": 3 },
+                { "u_near_om_location": "robofachq_surface_entrance", "range": 3 },
+                { "u_near_om_location": "isolated_road_field_0", "range": 2 },
+                { "u_near_om_location": "ranch_camp_41", "range": 3 },
+                { "u_near_om_location": "godco_5", "range": 3 },
+                { "u_at_om_location": "FACTION_CAMP_ANY" },
+                { "map_in_city": { "mutator": "loc_relative_u", "target": "(0,0,0)" } }
+              ]
+            },
+            "effect": [ { "math": [ "u_spellcasting_adjustment('difficulty', 'school': 'HOMULLUS' )", "=", "-2" ] } ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_HOMULLUS_MAGIC_ADJUSTMENT_NEARBY_PEOPLE",
+    "eoc_type": "EVENT",
+    "required_event": "opens_spellbook",
+    "condition": {
+      "math": [
+        "(u_characters_nearby('radius': 30, 'attitude': 'any') + u_monsters_nearby('mon_feral_cop', 'mon_feral_human_pipe', 'mon_feral_human_crowbar', 'mon_feral_jackboot', 'mon_feral_marine_bayonet', 'mon_feral_soldier', 'mon_feral_prepper_knife', 'mon_feral_sailor_axe', 'mon_feral_maid_knife', 'mon_feral_maid_candlestick', 'mon_feral_officer', 'mon_feral_sailor_lug_wrench', 'mon_feral_sailor_mop', 'mon_feral_maid_broom', 'mon_feral_sailor_wrench', 'mon_feral_swimmer_kickboard', 'mon_feral_armored_battleaxe', 'mon_feral_sapien_spear', 'mon_feral_armored_mace', 'mon_feral_human_tool', 'mon_feral_militia', 'mon_feral_fancy_rapier_fake', 'mon_feral_fancy_rapier', 'mon_feral_human_archaeologist', 'mon_feral_human_axe', 'mon_feral_labsecurity_flashlight', 'mon_feral_labsecurity_9mm',  'mon_feral_survivalist', 'mon_feral_scientist_scalpel', 'mon_feral_zebra_agent', 'mon_renfield', 'mon_renfield_9mm', 'mon_renfield_shotgun', 'mon_renfield_flamethrower', 'radius': 30, 'attitude': 'both'))",
+        ">=",
+        "10"
+      ]
+    },
+    "effect": [ { "math": [ "u_spellcasting_adjustment('difficulty', 'school': 'HOMULLUS' )", "=", "-2" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_IERDE_ELEMENTAL_MAGIC_ADJUSTMENT_UNDERGROUND",
+    "eoc_type": "EVENT",
+    "required_event": "opens_spellbook",
+    "condition": { "and": [ { "math": [ "u_val('pos_z')", "<=", "-1" ] }, { "u_has_trait": "IERDE" } ] },
+    "effect": [ { "math": [ "u_spellcasting_adjustment('difficulty', 'school': 'IERDE' )", "=", "-2" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_IERDE_ELEMENTAL_MAGIC_ADJUSTMENT_ON_DIRT_OR_STONE",
     "eoc_type": "EVENT",
     "required_event": "opens_spellbook",
     "condition": {
@@ -122,13 +176,5 @@
       ]
     },
     "effect": [ { "math": [ "u_spellcasting_adjustment('difficulty', 'school': 'IERDE' )", "=", "-2" ] } ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_IERDE_ELEMENTAL_MAGIC_ADJUSTMENT_UNDERGROUND",
-    "eoc_type": "EVENT",
-    "required_event": "opens_spellbook",
-    "condition": { "and": [ { "math": [ "u_val('pos_z')", "<=", "-1" ] }, { "u_has_trait": "IERDE" } ] },
-    "effect": [ { "math": [ "u_spellcasting_adjustment('difficulty', 'school': 'IERDE' )", "=", "-1" ] } ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Xedra Evolved] Make Paraclesian fae's magic easier in appropriate terrain"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I figured out an EoC-based way to do this.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add EoCs that reduce the effective Difficulty of spells based on local conditions. There are two types for each Paraclesian--each reduces the Difficulty by 2. These can stack, but won't always.

- Arvore: Being in the deep woods or near a great tree,  Being outdoors and away from civilization
- Homullus: Being surrounded by at least 10 living humans [ferals count], being in a city or stronghold of civilization
- Ierde: Being underground, being on diggable earth or stone
- Salamander: Standing in a fire, being in summer-hot temperatures or in hot air
- Sylph: Being at Z level 3 or above, being outdoors under the sky
- Undine: Being underwater; being near a pond, river, lake, or other large water source

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Tested each of the fae and the conditions work. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

It would be easy to add reverse version of these (i.e., Homullus's magic is harder in the wilderness, Sylph's magic is harder underground), but one thing at a time
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
