### PR TITLE
Tainted meat is no longer craftable

### DIFF
--- a/data/json/recipes/recipe_food.json
+++ b/data/json/recipes/recipe_food.json
@@ -8098,23 +8098,6 @@
   {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
-    "result": "meat_tainted",
-    "category": "CC_FOOD",
-    "subcategory": "CSC_FOOD_MEAT",
-    "skill_used": "cooking",
-    "difficulty": 5,
-    "time": "1 h 30 m",
-    "book_learn": [ [ "recipe_creepy", 5 ], [ "recipe_serum", 6 ] ],
-    "qualities": [ { "id": "CONTAIN", "level": 1 }, { "id": "CUT", "level": 2 } ],
-    "components": [
-      [ [ "meat", 1 ], [ "mutant_meat", 1 ], [ "human_meat", 1, "LIST" ], [ "rehydrated_meat", 1 ] ],
-      [ [ "slime_scrap", 2 ] ],
-      [ [ "water", 1 ] ]
-    ]
-  },
-  {
-    "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
     "result": "royal_beef",
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_MEAT",


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

The recipe is not lore-friendly. Slime glop is not the Blob, and as such should not be used to make tainted meat. 

#### Describe the solution

The tainted meat recipe has been removed from the game, you will have to butcher zombies for your unique tastes.

#### Describe alternatives you've considered

Possibly introduce a different recipe for tainted meat, but that seems unnecessary due to how much tainted meat there is out in the world.

#### Testing

- Look inside game files
- No tainted meat recipe
- :)

#### Additional context

Recipe is bad and that's all you need to know.