### PR TITLE
Oops - remove cramped space when no longer cramped

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -11070,7 +11070,7 @@ void Character::process_effects()
     }
 
     // Being stuck in tight spaces sucks. TODO: could be expanded to apply to non-vehicle conditions.
-    bool cramped = has_effect( effect_cramped_space );
+    bool cramped = false;
     // return is intentionally discarded, sets cramped if appropriate
     can_move_to_vehicle_tile( get_map().getglobal( pos() ), cramped );
     if( cramped ) {
@@ -11078,6 +11078,8 @@ void Character::process_effects()
             npc &as_npc = dynamic_cast<npc &>( *this );
             as_npc.complain_about( "cramped_vehicle", 30_minutes, "<cramped_vehicle>", false );
         }
+    } else {
+        remove_effect( effect_cramped_space );
     }
 
     Creature::process_effects();


### PR DESCRIPTION
#### Summary
Bugfixes "Oops - remove cramped space when no longer cramped"

#### Purpose of change
* Fixes #74030

#### Describe the solution
I was thinking about making this little section of code tidier, and I honestly forgot to come back to it. 2 turns duration (with permanent set) is 2 turns duration, right? (Nope)

There was never any code to remove the permanent effect, so it would never be removed, even after the duration had ticked down. Add the little bit of code saying that if we're not in a cramped space, it's time to remove the cramped space effect.

#### Describe alternatives you've considered


#### Testing
Just to be sure!
https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/c0915eae-799d-46e0-86ba-7e178f91ecb3


#### Additional context
A contributing factor in this mistake is that effects can have both a "duration" and a "permanent" boolean. If the permanent bool is set, the duration is not an actual duration. This is rather unintuitive and not obvious when looking at a call to `add_effect`. 