### PR TITLE
[CR] Hordes don't wander to 0,0

### DIFF
--- a/data/json/monstergroups/misc.json
+++ b/data/json/monstergroups/misc.json
@@ -556,5 +556,11 @@
       { "monster": "mon_moose", "weight": 1 },
       { "monster": "mon_pig", "weight": 1 }
     ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_DEBUG_EXACTLY_ONE",
+    "//": "Hardcoded reference in debug() (debug_menu.cpp). Used for debugging, duh.",
+    "monsters": [ { "monster": "mon_zombie", "weight": 1, "cost_multiplier": 1, "pack_size": [ 1, 1 ] } ]
   }
 ]

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -144,6 +144,8 @@ static const faction_id faction_your_followers( "your_followers" );
 
 static const matype_id style_none( "style_none" );
 
+static const mongroup_id GROUP_DEBUG_EXACTLY_ONE( "GROUP_DEBUG_EXACTLY_ONE" );
+
 static const mtype_id mon_generator( "mon_generator" );
 
 static const trait_id trait_ASTHMA( "ASTHMA" );
@@ -198,6 +200,7 @@ std::string enum_to_string<debug_menu::debug_menu_index>( debug_menu::debug_menu
         case debug_menu::debug_menu_index::CONTROL_NPC: return "CONTROL_NPC";
         case debug_menu::debug_menu_index::SPAWN_ARTIFACT: return "SPAWN_ARTIFACT";
         case debug_menu::debug_menu_index::SPAWN_CLAIRVOYANCE: return "SPAWN_CLAIRVOYANCE";
+        case debug_menu::debug_menu_index::SPAWN_HORDE: return "SPAWN_HORDE";
         case debug_menu::debug_menu_index::MAP_EDITOR: return "MAP_EDITOR";
         case debug_menu::debug_menu_index::CHANGE_WEATHER: return "CHANGE_WEATHER";
         case debug_menu::debug_menu_index::WIND_DIRECTION: return "WIND_DIRECTION";
@@ -808,6 +811,7 @@ static int spawning_uilist()
         { uilist_entry( debug_menu_index::SPAWN_VEHICLE, true, 'v', _( "Spawn a vehicle" ) ) },
         { uilist_entry( debug_menu_index::SPAWN_ARTIFACT, true, 'a', _( "Spawn artifact" ) ) },
         { uilist_entry( debug_menu_index::SPAWN_CLAIRVOYANCE, true, 'c', _( "Spawn clairvoyance artifact" ) ) },
+        { uilist_entry( debug_menu_index::SPAWN_HORDE, true, 'H', _( "Spawn a dummy horde twenty submaps(10 OMTs) to the north" ) ) },
     };
 
     return uilist( _( "Spawning…" ), uilist_initializer );
@@ -3676,6 +3680,15 @@ void debug()
                     g->perhaps_add_random_npc( true );
                 }
             }
+        }
+        break;
+
+        case debug_menu_index::SPAWN_HORDE: {
+            const tripoint_abs_ms &player_abs_ms = get_player_character().get_location();
+            tripoint_abs_sm horde_dest = project_to<coords::sm>( player_abs_ms );
+            horde_dest = horde_dest + point{0, -20}; // 20 submaps to the north
+            overmap &om = overmap_buffer.get( project_to<coords::om>( player_abs_ms ).xy() );
+            om.debug_force_add_group( mongroup( GROUP_DEBUG_EXACTLY_ONE, horde_dest, 1 ) );
         }
         break;
 

--- a/src/debug_menu.h
+++ b/src/debug_menu.h
@@ -44,6 +44,7 @@ enum class debug_menu_index : int {
     CONTROL_NPC,
     SPAWN_ARTIFACT,
     SPAWN_CLAIRVOYANCE,
+    SPAWN_HORDE,
     MAP_EDITOR,
     CHANGE_WEATHER,
     WIND_DIRECTION,

--- a/src/mongroup.h
+++ b/src/mongroup.h
@@ -136,7 +136,8 @@ struct mongroup {
               unsigned int ppop )
         : type( ptype )
         , abs_pos( ppos )
-        , population( ppop ) {
+        , population( ppop )
+        , target( abs_pos.xy() ) {
     }
     mongroup( const std::string &ptype, const tripoint_abs_sm &ppos,
               unsigned int ppop, point_abs_sm ptarget, int pint, bool pdie, bool phorde ) :

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -7243,9 +7243,9 @@ void overmap::spawn_mon_group( const mongroup &group, int radius )
     add_mon_group( group, radius );
 }
 
-void overmap::debug_force_add_group(const mongroup & group)
+void overmap::debug_force_add_group( const mongroup &group )
 {
-	add_mon_group( group, 1 );
+    add_mon_group( group, 1 );
 }
 
 void overmap::add_mon_group( const mongroup &group )

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -7243,6 +7243,11 @@ void overmap::spawn_mon_group( const mongroup &group, int radius )
     add_mon_group( group, radius );
 }
 
+void overmap::debug_force_add_group(const mongroup & group)
+{
+	add_mon_group( group, 1 );
+}
+
 void overmap::add_mon_group( const mongroup &group )
 {
     zg.emplace( group.rel_pos(), group );

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -510,6 +510,9 @@ class overmap
         std::vector<tripoint_om_omt> place_special(
             const overmap_special &special, const tripoint_om_omt &p, om_direction::type dir,
             const city &cit, bool must_be_unexplored, bool force );
+
+        // DEBUG ONLY!
+        void debug_force_add_group( const mongroup &group );
     private:
         /**
          * Iterate over the overmap and place the quota of specials.

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -368,12 +368,19 @@ void overmap::load_monster_groups( const JsonArray &jsin )
     for( JsonArray mongroup_with_tripoints : jsin ) {
         mongroup new_group;
         new_group.deserialize( mongroup_with_tripoints.next_object() );
+        bool reset_target = false;
+        if( new_group.target ==  point_abs_sm() ) { // Remove after 0.I
+            reset_target = true;
+        }
 
         JsonArray tripoints_json = mongroup_with_tripoints.next_array();
         tripoint_om_sm temp;
         for( JsonValue tripoint_json : tripoints_json ) {
             temp.deserialize( tripoint_json );
             new_group.abs_pos = project_combine( pos(), temp );
+            if( reset_target ) { // Remove after 0.I
+                new_group.set_target( new_group.abs_pos.xy() );
+            }
             add_mon_group( new_group );
         }
 


### PR DESCRIPTION
#### Summary
Bugfixes "Hordes won't wander without a reason"

#### Purpose of change
* Fixes #73725

Hordes(mongroup) would most often be initialized without specifying a target. This meant that the default value would be used - 0,0.
https://github.com/CleverRaven/Cataclysm-DDA/blob/de4ec39f57b1be19b9975e42971671b609c37bf9/src/mongroup.h#L135-L140

With wandering hordes set to on, hordes would receive a new target every 2.5 minutes. However, if wandering hordes was set to *off*... that never happened. (Most*) every horde would be laser-targeted as tripoint_abs_sm 0,0. Thus, depending on your orientation from 0,0 they would run in a specific direction.... this is why the reports were so confused.

#### Describe the solution
Don't rely on default constructed value of 0,0 to set the target of the horde. 

Don't rely on wandering hordes being set to on, either...

Construct the default target of the horde as its position if target is unspecified.

For existing savegames, check if their targets are 0,0 and set target to the current position if so.

#### Describe alternatives you've considered
Get rid of the wandering hordes option, force it always on.

#### Testing
Load the provided save from #73725, check nearby hordes with debug. Their targets are all their current position instead of 0,0.

#### Additional context
Our monster group serialization (overmap::load_monster_groups specifically) will probably not like this very much? As each group will have a separate target, instead of serializing them all into one object they'll each need a separate object as they have different targets.

The debug menu additions were actually not at all helpful here, but no reason to throw them out.