### PR TITLE
Food continues to rot at temp above 63C

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -7950,10 +7950,8 @@ float item::calc_hourly_rotpoints_at_temp( const units::temperature &temp ) cons
 {
     const units::temperature dropoff = units::from_fahrenheit( 38 ); // F, ~3 C
     const float max_rot_temp = 105; // F, ~41 C, Maximum rotting rate is at this temperature
-    const float safe_temp = 145; // F, ~63 C, safe temperature above which food stops rotting
 
-    if( temp <= temperatures::freezing ||
-        temp > units::from_fahrenheit( safe_temp ) ) {
+    if( temp <= temperatures::freezing ) {
         return 0.f;
     } else if( temp < dropoff ) {
         // ditch our fancy equation and do a linear approach to 0 rot from 38 F (3 C) -> 32 F (0 C)
@@ -7963,7 +7961,7 @@ float item::calc_hourly_rotpoints_at_temp( const units::temperature &temp ) cons
         // Exponential progress from 38 F (3 C) to 105 F (41 C)
         return 3600.f * std::exp2( ( units::to_fahrenheit( temp ) - 65.f ) / 16.f );
     } else {
-        // Constant rot from 105 F (41 C) to 145 F (63 C)
+        // Constant rot from 105 F (41 C) upwards
         // This is approximately 20364.67 rot/hour
         return 3600.f * std::exp2( ( max_rot_temp - 65.f ) / 16.f );
     }

--- a/tests/rot_test.cpp
+++ b/tests/rot_test.cpp
@@ -106,8 +106,9 @@ TEST_CASE( "Hourly_rotpoints", "[rot]" )
     // No rot below 32F/0C
     CHECK( normal_item.calc_hourly_rotpoints_at_temp( units::from_celsius( 0 ) ) == 0 );
 
-    // No rot above 145F/63C
-    CHECK( normal_item.calc_hourly_rotpoints_at_temp( units::from_celsius( 63 ) ) == 0 );
+    // Max rot above 145F/63C
+    CHECK( normal_item.calc_hourly_rotpoints_at_temp( units::from_celsius( 63 ) ) == Approx(
+               20364.67 ) );
 
     // Make sure no off by one error at the border
     CHECK( normal_item.calc_hourly_rotpoints_at_temp( units::from_celsius( 62 ) ) == Approx(


### PR DESCRIPTION
#### Summary
Balance "Food continues to rot at temp above 63C"

#### Purpose of change
It's possible to keep food permanently fresh by keeping it `(hot)`.

This is obviously impossible. Although food does not "rot" once you've killed all the microbes, it eventually *ceases being food*. Rotting is an acceptable mechanic to represent this.

#### Describe the solution
Uncap the rotting temperature. 

#### Describe alternatives you've considered
Apply periodic burnt to the item?

#### Testing
Load this save without patch, notice the nearly-rotted fish fillet in the fire remains edible for as long as the fire keeps it hot.

[permanent food-trimmed.tar.gz](https://github.com/CleverRaven/Cataclysm-DDA/files/15440771/permanent.food-trimmed.tar.gz)

Load save with the patch, notice that the fish fillet rots within the hour.

#### Additional context
