### PR TITLE
Bugfix cats_grace scaling

### DIFF
--- a/data/mods/Magiclysm/effects/effects.json
+++ b/data/mods/Magiclysm/effects/effects.json
@@ -279,7 +279,7 @@
     "remove_message": "Your reflexes return to normal.",
     "rating": "good",
     "removes_effects": [ "eagles_sight", "ogres_strength", "foxs_cunning" ],
-    "enchantments": [ { "values": [ { "value": "DEXTERITY", "add": { "math": [ "( u_spell_level('eagles_sight') / 4 ) + 2" ] } } ] } ]
+    "enchantments": [ { "values": [ { "value": "DEXTERITY", "add": { "math": [ "( u_spell_level('cats_grace') / 4 ) + 2" ] } } ] } ]
   },
   {
     "type": "effect_type",


### PR DESCRIPTION
#### Summary
Bugfixes "Correct scaling for cats_grace"

#### Purpose of change
Cat's Grace effect in Magiclysm was scaling of the level of Eagle's Sight instead of itself, this is meant to make it scale of itself instead.

#### Describe the solution
Changed eagles_sight to cats_grace in appropriate place.

#### Describe alternatives you've considered
Not fixing it and letting Cat's Grace be scaled of Eagle's Sight

#### Testing
Made changes in own build and tested a new character and Cat's Grace now scales of its own level instead of Eagle's Sight

#### Additional context
