### PR TITLE
Replace Incorrect Bag Used in Map Xtra

### DIFF
--- a/data/json/mapgen/map_extras/roadblock.json
+++ b/data/json/mapgen/map_extras/roadblock.json
@@ -159,7 +159,7 @@
       ],
       "items": { "x": [ { "item": "corpses_verydead", "chance": 75 } ] },
       "item": {
-        "#": [ { "item": "bag_canvas", "amount": [ 2, 5 ] }, { "item": "material_sand", "amount": [ 300, 2400 ] } ],
+        "#": [ { "item": "bag_durasack", "amount": [ 2, 5 ] }, { "item": "material_sand", "amount": [ 300, 2400 ] } ],
         ".": [ { "item": "splinter", "chance": 100, "amount": [ 1, 3 ] }, { "item": "2x4", "chance": 25 } ]
       },
       "place_loot": [ { "group": "cop_armory", "x": [ 6, 10 ], "y": [ 15, 18 ], "chance": 100, "repeat": [ 4, 10 ] } ],


### PR DESCRIPTION
#### Summary
Bugfixes "Replace Incorrect Bag Used in Map Xtra"

#### Purpose of change
#74045 pointed out that the "broken sandbags" used in that location were giving canvas bags.  This was an old way of spawning them as destroyed bags with variable amounts of sands.  This was incorrect because sandbags no longer use canvas bags, they use bag_durasack

#### Describe the solution
Change canvas sack to durasack

#### Describe alternatives you've considered
I debated replacing it completely with the sandbag itemgroup, which already drops an assortment of bags and sand, but it was already set up and really all I had to do was change one id so yeah, I opted for the laziness.

#### Testing
Game didn't explode, change good.

#### Additional context
Closes #74045 



o_o sacks.
