### PR TITLE
Fix Concrete Pallet Smash Results

### DIFF
--- a/data/json/furniture_and_terrain/furniture-pallet.json
+++ b/data/json/furniture_and_terrain/furniture-pallet.json
@@ -78,7 +78,7 @@
       "items": [
         { "item": "material_cement", "container-item": "bag_canvas", "charges": 500, "count": [ 80, 90 ] },
         { "item": "material_cement", "charges": [ 500, 1500 ] },
-        { "item": "bag_canvas", "count": [ 2, 10 ], "damage": [ 1, 5 ] },
+        { "item": "bag_durasack", "count": [ 2, 10 ], "damage": [ 1, 5 ] },
         { "item": "pallet", "count": 1 }
       ]
     }


### PR DESCRIPTION
#### Summary
Bugfixes "Fix Concrete Pallet Smash Results"

#### Purpose of change
#74043 Deconstructing a concrete bag pallet gives the plastic durasack bags.  Smashing the same pallet gives you canvas_bags.  No make sense.

#### Describe the solution
Change the canvas bag to the durasack bag.  

#### Describe alternatives you've considered
Well if I'd been paying attention I would have made that last PR and this one into a single PR -_-
I also considered leaving them because some new person could do it, but its my night off and I have nothing constructive to do.
I also considered auditing the entirety of concrete bags and converting them to use durasack, but a lot of materials still come in the canvas bag and I'm not clear on what exactly the distinction would be.

#### Testing
It didn't start a fire, therefore acceptable.

#### Additional context
Closes #74043 
