### PR TITLE
Aftershock: Basic Hacking EOCs

### DIFF
--- a/data/mods/Aftershock/EOC/_reusable_conditions.json
+++ b/data/mods/Aftershock/EOC/_reusable_conditions.json
@@ -1,0 +1,10 @@
+{
+  "type": "effect_on_condition",
+  "id": "EOC_CONDITION_can_hack",
+  "condition": {
+    "and": [ { "u_has_item": "electrohack" }, "u_can_see" ]
+  },
+  "effect": [
+    
+  ]
+}

--- a/data/mods/Aftershock/EOC/hacking_eoc.json
+++ b/data/mods/Aftershock/EOC/hacking_eoc.json
@@ -1,0 +1,61 @@
+[
+  {
+    "id": "ACT_afs_hack",
+    "type": "activity_type",
+    "activity_level": "NO_EXERCISE",
+    "verb": "hacking",
+    "based_on": "time",
+    "can_resume": false,
+    "completion_eoc": "EOC_finish_afs_hack"
+  },
+  {
+    "id": "EOC_finish_afs_hack",
+    "type": "effect_on_condition",
+    "effect": [ { "u_add_effect": "afs_hack_done", "duration": "3 seconds" }, { "turn_cost": "1 s" } ]
+  },
+  {
+    "type": "jmath_function",
+    "id": "afs_hack_skill",
+    "num_args": 1,
+    "return": "(u_skill('computer') + u_val('intelligence')/3 + u_hack_bonus) * (_0)"
+  },
+  {
+    "type": "jmath_function",
+    "id": "afs_hack_time_adjust",
+    "num_args": 3,
+    "return": "_0 - _1 * afs_hack_skill(1) < _2 ? _2 : _0 - _1* afs_hack_skill(1)"
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_afs_hack_unlock",
+    "condition": { "and": [ { "expects_vars": [ "furn_pos", "difficulty" ] }, { "u_has_effect": "afs_hack_done" } ] },
+    "effect": [
+      {
+        "run_eocs": [
+          {
+            "id": "_EOC_afs_hack_unlock",
+            "condition": { "roll_contested": { "math": [ "afs_hack_skill(1)" ] }, "die_size": 4, "difficulty": { "context_val": "difficulty" } },
+            "effect": [ { "u_transform_radius": 0, "ter_furn_transform": "afs_multi_unlock", "target_var": { "context_val": "furn_pos" } } ],
+            "false_effect": { "u_message": "You fail to override the device." }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_start_lock_hack",
+    "condition": { "and": [ { "expects_vars": [ "furn_pos", "t_delay", "difficulty" ] }, { "test_eoc": "EOC_CONDITION_can_hack" } ] },
+    "effect": [
+      { "math": [ "_t_delay", "=", "afs_hack_time_adjust(_t_delay, time('20s'), time('2m'))" ] },
+      { "u_message": "You connect to the lock controller." },
+      { "u_assign_activity": "ACT_afs_hack", "duration": { "context_val": "t_delay" } },
+      {
+        "queue_eoc_with": "EOC_afs_hack_unlock",
+        "time_in_future": { "context_val": "t_delay" },
+        "variables": { "furn_pos": { "context_val": "furn_pos" }, "difficulty": { "context_val": "difficulty" } }
+      }
+    ],
+    "false_effect": { "u_message": "You need either an electrohack or working computer to attempt a hack.", "popup": true }
+  }
+]

--- a/data/mods/Aftershock/effects.json
+++ b/data/mods/Aftershock/effects.json
@@ -249,6 +249,10 @@
   },
   {
     "type": "effect_type",
+    "id": "afs_hack_done"
+  },
+  {
+    "type": "effect_type",
     "id": "afs_combat_stims",
     "name": [ "Combat Stimulants" ],
     "desc": [ "You are under the effects of powerful military combat stimulants" ],

--- a/data/mods/Aftershock/maps/furniture_and_terrain/furniture_habitat.json
+++ b/data/mods/Aftershock/maps/furniture_and_terrain/furniture_habitat.json
@@ -157,7 +157,6 @@
     "required_str": 5,
     "crafting_pseudo_item": "mirror",
     "flags": [ "NOITEM", "BLOCKSDOOR" ],
-    "examine_action": "change_appearance",
     "deconstruct": {
       "items": [
         { "item": "large_lcd_screen", "count": 1 },
@@ -222,6 +221,22 @@
     "coverage": 60,
     "oxytorch": { "result": "f_intermodal_crate_open", "duration": "14 seconds" },
     "flags": [ "TRANSPARENT", "MOUNTABLE", "SHORT", "SMALL_HIDE", "PLACE_ITEM", "CONTAINER", "SEALED" ],
+    "examine_action": {
+      "type": "effect_on_condition",
+      "effect_on_conditions": [
+        {
+          "id": "eoc_unlock_elock",
+          "effect": [
+            { "math": [ "_t_delay", "=", "time('20 m')" ] },
+            {
+              "run_eoc_with": "EOC_start_lock_hack",
+              "variables": { "furn_pos": { "context_val": "pos" }, "t_delay": { "context_val": "t_delay" }, "difficulty": "9" },
+              "alpha_talker": "avatar"
+            }
+          ]
+        }
+      ]
+    },
     "bash": {
       "str_min": 40,
       "str_max": 200,

--- a/data/mods/Aftershock/maps/furniture_and_terrain/furniture_habitat.json
+++ b/data/mods/Aftershock/maps/furniture_and_terrain/furniture_habitat.json
@@ -225,7 +225,7 @@
       "type": "effect_on_condition",
       "effect_on_conditions": [
         {
-          "id": "eoc_unlock_elock",
+          "id": "EOC_unlock_afs_crate",
           "effect": [
             { "math": [ "_t_delay", "=", "time('20 m')" ] },
             {

--- a/data/mods/Aftershock/ter_fur_transform.json
+++ b/data/mods/Aftershock/ter_fur_transform.json
@@ -1,6 +1,19 @@
 [
   {
     "type": "ter_furn_transform",
+    "//": "Used for unlocking all hackable furniture in the mod.",
+    "id": "afs_multi_unlock",
+    "furniture": [
+      {
+        "result": "f_intermodal_crate_open",
+        "valid_furniture": [ "f_sealed_intermodal_crate" ],
+        "message": "The shipping crate bolts slide back and the lid pops open.",
+        "message_good": true
+      }
+    ]
+  },
+  {
+    "type": "ter_furn_transform",
     "id": "transform_gratings",
     "terrain": [
       {


### PR DESCRIPTION
#### Summary
Mods "Aftershock: Basic Hacking EOCs"

#### Purpose of change
Cyberpunk mods need more common hacking mechanics.
Plus it was requested with #73988

#### Describe the solution
This add a pair of generalized eocs and helper math functions that enable basic "transform map object to unlocked version" functionality. They start an activity of variable duration (that can depend both on the map object being hacked and player's skills and equipment), with success being checked only if that activity successfully concludes.

ATM only the sealed intermodal crates uses this "system"

#### Testing
Hacked a few crates open.

#### Additional context

- Needs more hacking tools and items that grant hacking bonuses. Atm the only tool this will check for are electrohacks. 
- Also the finger hack should be reworked or integrated into another bionic so its more general use in the mod.