### PR TITLE
Add a make flag to produce a seperate debug archive

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -123,7 +123,6 @@ jobs:
             libbacktrace: 1
             native: linux64
             pch: 1
-            cxxflags: -gsplit-dwarf
             title: GCC 9, Curses, LTO
             # ~850MB in a clean build
             # ~370MB compressed

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,10 @@
 #  make RUNTESTS=1
 # Build source files in order of how often the matching header is included
 #  make HEADERPOPULARITY=1
+# Split debug symbols to seperate files. Can improve linker overheads.
+#  make SPLIT_DEBUG=1
+# Generate debug symbols even in release builds.
+#  make DEBUG_SYMBOLS=1
 
 # comment these to toggle them as one sees fit.
 # DEBUG is best turned on if you plan to debug in gdb -- please do!
@@ -479,6 +483,15 @@ else
     endif
   endif
   CXXFLAGS += $(OPTLEVEL)
+endif
+
+ifeq ($(SPLIT_DEBUG), 1)
+  # macos already does this by default.
+  ifneq ($(NATIVE), osx)
+    ifneq ($(LTO), 1)
+      CXX_OFLAGS = -gsplit-dwarf -gz=zlib
+    endif
+  endif
 endif
 
 ifeq ($(shell sh -c 'uname -o 2>/dev/null || echo not'),Cygwin)
@@ -1039,6 +1052,13 @@ all: version prefix $(CHECKS) $(TARGET) $(L10N) $(TESTSTARGET)
 
 $(TARGET): $(OBJS)
 	+$(LD) $(W32FLAGS) -o $(TARGET) $(OBJS) $(LDFLAGS)
+ifeq ($(SPLIT_DEBUG), 1)
+  ifneq ($(NATIVE), osx)
+    ifneq ($(LTO), 1)
+	+dwp --exec $(TARGET)
+    endif
+  endif
+endif
 ifeq ($(RELEASE), 1)
   ifndef DEBUG_SYMBOLS
     ifneq ($(BACKTRACE),1)
@@ -1089,13 +1109,13 @@ includes: $(OBJS:.o=.inc)
 	+make -C tests includes
 
 $(ODIR)/third-party/imgui/%.o: $(IMGUI_DIR)/%.cpp
-	$(CXX) $(CPPFLAGS) $(DEFINES) $(CXXFLAGS) -w -MMD -MP -c $< -o $@
+	$(CXX) $(CPPFLAGS) $(DEFINES) $(CXXFLAGS) $(CXX_OFLAGS) -w -MMD -MP -c $< -o $@
 
 $(ODIR)/third-party/imtui/%.o: $(IMTUI_DIR)/%.cpp
-	$(CXX) $(CPPFLAGS) $(DEFINES) $(CXXFLAGS) -w -MMD -MP -c $< -o $@
+	$(CXX) $(CPPFLAGS) $(DEFINES) $(CXXFLAGS) $(CXX_OFLAGS) -w -MMD -MP -c $< -o $@
 
 $(ODIR)/%.o: $(SRC_DIR)/%.cpp $(PCH_P)
-	$(CXX) $(CPPFLAGS) $(DEFINES) $(CXXFLAGS) -MMD -MP $(PCHFLAGS) -c $< -o $@
+	$(CXX) $(CPPFLAGS) $(DEFINES) $(CXXFLAGS) $(CXX_OFLAGS) -MMD -MP $(PCHFLAGS) -c $< -o $@
 
 $(ODIR)/%.o: $(SRC_DIR)/%.rc
 	$(RC) $(RFLAGS) $< -o $@
@@ -1129,7 +1149,7 @@ json-check: $(CHKJSON_BIN)
 	./$(CHKJSON_BIN)
 
 clean: clean-tests clean-object_creator clean-pch clean-lang
-	rm -rf *$(TARGET_NAME) *$(TILES_TARGET_NAME)
+	rm -rf *$(TARGET_NAME) *$(TILES_TARGET_NAME) *$(TARGET_NAME).dwp
 	rm -rf *$(TILES_TARGET_NAME).exe *$(TARGET_NAME).exe *$(TARGET_NAME).a
 	rm -rf *obj *objwin
 	rm -rf *$(BINDIST_DIR) *cataclysmdda-*.tar.gz *cataclysmdda-*.zip

--- a/build-scripts/gha_compile_only.sh
+++ b/build-scripts/gha_compile_only.sh
@@ -64,7 +64,7 @@ then
         ..
     make -j$num_jobs
 else
-    make -j "$num_jobs" CCACHE=1 CROSS="$CROSS_COMPILATION" LINTJSON=0 FRAMEWORK=1 UNIVERSAL_BINARY=1 DEBUG_SYMBOLS=1
+    make -j "$num_jobs" CCACHE=1 CROSS="$CROSS_COMPILATION" LINTJSON=0 FRAMEWORK=1 UNIVERSAL_BINARY=1 DEBUG_SYMBOLS=1 SPLIT_DEBUG=1
 
     # For CI on macOS, patch the test binary so it can find SDL2 libraries.
     if [[ ! -z "$OS" && "$OS" = "macos-12" ]]

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -56,6 +56,13 @@ tests: $(TEST_TARGET)
 
 $(TEST_TARGET): $(OBJS) $(CATA_LIB)
 	+$(CXX) $(W32FLAGS) -o $@ $(DEFINES) $(OBJS) $(CATA_LIB) $(CPPFLAGS) $(CXXFLAGS) $(LDFLAGS)
+ifeq ($(SPLIT_DEBUG), 1)
+  ifneq ($(NATIVE), osx)
+    ifneq ($(LTO), 1)
+	cd .. && dwp --exec tests/$(TEST_TARGET) -o tests/$(TEST_TARGET).dwp
+    endif
+  endif
+endif
 
 $(PCH_P): $(PCH_H)
 	-$(CXX) $(CPPFLAGS) $(DEFINES) $(CXXFLAGS) -MMD -MP -Wno-error -Wno-non-virtual-dtor -Wno-unused-macros -I. -c $(PCH_H) -o $(PCH_P)
@@ -84,7 +91,7 @@ $(shell mkdir -p $(ODIR))
 
 # Adding ../tests/ so that the directory appears in __FILE__ for log messages
 $(ODIR)/%.o: %.cpp $(PCH_P)
-	$(CXX) $(CPPFLAGS) $(DEFINES) $(CXXFLAGS) -MMD -MP $(subst main-pch,tests-pch,$(PCHFLAGS)) -c ../tests/$< -o $@
+	$(CXX) $(CPPFLAGS) $(DEFINES) $(CXXFLAGS) $(CXX_OFLAGS) -MMD -MP $(subst main-pch,tests-pch,$(PCHFLAGS)) -c ../tests/$< -o $@
 
 $(ODIR)/%.inc: %.cpp
 	$(CXX) $(CPPFLAGS) $(DEFINES) $(CXXFLAGS) -H -E $< -o /dev/null 2> $@


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Split debugging data into separate files.
This also reduces link time and memory utilization.
It also seems to decrease ccache disk utilization locally.

#### Describe the solution
Add a flag to the Makefile that splits debug data to .dwo files instead of writing them to .o files, and then bundles them into a .dwp file.
This .dwp file will need to be archived and such in CI so we can retrieve it for testing.
For testing and for build speed benefits I'm trying out enabling it on most CI builds.

#### Testing
Produces .dwo and .dwp files locally.
Launched cataclysm and cata_test under gdb, able to print full backtraces, step, print variable names, etc.
You shouldn't need to do *anything* to have this work on local builds.

#### Additional context
This will need some more follow up to bundle the new archive from CI.