### PR TITLE
Correctly display the cost to learn the proficiency

### DIFF
--- a/src/talker_character.cpp
+++ b/src/talker_character.cpp
@@ -1097,7 +1097,8 @@ std::string talker_character_const::proficiency_training_text( const talker &stu
 
     if( cost > 0 ) {
         //~ Proficiency name: (current_practice) -> (next_practice) (cost in dollars)
-        return string_format( _( "%s: (%2.0f%%) -> (%s) (cost $%d)" ), name, pct_before, after_str, cost / 100 );
+        return string_format( _( "%s: (%2.0f%%) -> (%s) (cost $%d)" ), name, pct_before, after_str,
+                              cost / 100 );
     }
     //~ Proficiency name: (current_practice) -> (next_practice)
     return string_format( _( "%s: (%2.0f%%) -> (%s)" ), name, pct_before, after_str );

--- a/src/talker_character.cpp
+++ b/src/talker_character.cpp
@@ -1097,7 +1097,7 @@ std::string talker_character_const::proficiency_training_text( const talker &stu
 
     if( cost > 0 ) {
         //~ Proficiency name: (current_practice) -> (next_practice) (cost in dollars)
-        return string_format( _( "%s: (%2.0f%%) -> (%s) (cost $%d)" ), name, pct_before, after_str, cost );
+        return string_format( _( "%s: (%2.0f%%) -> (%s) (cost $%d)" ), name, pct_before, after_str, cost / 100 );
     }
     //~ Proficiency name: (current_practice) -> (next_practice)
     return string_format( _( "%s: (%2.0f%%) -> (%s)" ), name, pct_before, after_str );


### PR DESCRIPTION
#### Summary
Bugfixes "Correctly display the cost to learn the proficiency"
#### Purpose of change
Fix #74072 
#### Describe the solution
Simply add  the missing `/ 100` to `talker_character_const::proficiency_training_text`.
#### Describe alternatives you've considered
#### Testing
#### Additional context
https://github.com/CleverRaven/Cataclysm-DDA/issues/74072#issuecomment-2131187764