### PR TITLE
Add RISK_EXTREME flag, audit RISK_HIGH and RISK_LOW

### DIFF
--- a/data/json/npcs/destination_locations.json
+++ b/data/json/npcs/destination_locations.json
@@ -116,6 +116,11 @@
   },
   {
     "type": "overmap_location",
+    "id": "risk_extreme",
+    "flags": [ "RISK_EXTREME" ]
+  },
+  {
+    "type": "overmap_location",
     "id": "risk_high",
     "flags": [ "RISK_HIGH" ]
   },

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -7135,7 +7135,7 @@
     "connections": [ { "point": [ 3, 3, 0 ], "terrain": "road", "connection": "local_road", "from": [ 3, 2, 0 ] } ],
     "city_distance": [ 0, 20 ],
     "occurrences": [ 5, 100 ],
-    "flags": [ "GLOBALLY_UNIQUE", "RISK_HIGH", "GENERIC_LOOT", "MAN_MADE" ]
+    "flags": [ "GLOBALLY_UNIQUE", "RISK_EXTREME", "GENERIC_LOOT", "MAN_MADE" ]
   },
   {
     "type": "overmap_special",

--- a/data/json/overmap/overmap_terrain/overmap_terrain.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain.json
@@ -31,7 +31,8 @@
     "sym": "^",
     "see_cost": 5,
     "extras": "build",
-    "mondensity": 2
+    "mondensity": 2,
+    "flags": [ "RISK_HIGH", "GENERIC_LOOT" ]
   },
   {
     "type": "overmap_terrain",
@@ -711,7 +712,7 @@
     "sym": "O",
     "color": "white",
     "see_cost": 5,
-    "flags": [ "RISK_LOW", "SOURCE_SAFETY", "SOURCE_FOOD" ]
+    "flags": [ "SOURCE_SAFETY", "SOURCE_FOOD" ]
   },
   {
     "type": "overmap_terrain",
@@ -874,7 +875,7 @@
     "sym": "#",
     "color": "brown",
     "see_cost": 5,
-    "flags": [ "NO_ROTATE", "RISK_HIGH" ]
+    "flags": [ "NO_ROTATE", "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -883,7 +884,7 @@
     "sym": "%",
     "color": "dark_gray",
     "see_cost": 5,
-    "flags": [ "NO_ROTATE", "RISK_HIGH" ]
+    "flags": [ "NO_ROTATE", "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -955,7 +956,7 @@
     "sym": "S",
     "color": "white",
     "see_cost": 3,
-    "flags": [ "RISK_HIGH" ]
+    "flags": [ "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -1015,7 +1016,7 @@
     "sym": "8",
     "color": "yellow",
     "see_cost": 3,
-    "flags": [ "RISK_HIGH" ]
+    "flags": [ "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_agricultural.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_agricultural.json
@@ -28,6 +28,7 @@
     "name": "rural building",
     "sym": "#",
     "color": "i_brown",
+    "delete": { "flags": [ "RISK_HIGH" ] },
     "extend": { "flags": [ "SOURCE_FOOD", "SOURCE_SAFETY", "RISK_LOW", "SOURCE_FARMING" ] }
   },
   {

--- a/data/json/overmap/overmap_terrain/overmap_terrain_aircraft_carrier.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_aircraft_carrier.json
@@ -129,7 +129,7 @@
     "color": "red",
     "see_cost": 5,
     "spawns": { "group": "GROUP_AIRCRAFT_CARRIER", "population": [ 20, 40 ], "chance": 100 },
-    "flags": [ "RISK_HIGH", "LAKE" ]
+    "flags": [ "RISK_EXTREME", "LAKE" ]
   },
   {
     "type": "overmap_terrain",
@@ -179,6 +179,6 @@
     "color": "red",
     "see_cost": 5,
     "spawns": { "group": "GROUP_AIRCRAFT_CARRIER_TECHNICIANS", "population": [ 20, 35 ], "chance": 100 },
-    "flags": [ "RISK_HIGH", "LAKE" ]
+    "flags": [ "RISK_EXTREME", "LAKE" ]
   }
 ]

--- a/data/json/overmap/overmap_terrain/overmap_terrain_ants.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_ants.json
@@ -6,7 +6,7 @@
     "sym": "%",
     "color": "brown",
     "see_cost": 2,
-    "flags": [ "KNOWN_DOWN", "RISK_HIGH", "REQUIRES_PREDECESSOR" ]
+    "flags": [ "KNOWN_DOWN", "RISK_EXTREME", "REQUIRES_PREDECESSOR" ]
   },
   {
     "type": "overmap_terrain",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_commercial.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_commercial.json
@@ -714,7 +714,7 @@
     "spawns": { "group": "GROUP_VANILLA", "population": [ 10, 20 ], "chance": 100 },
     "flags": [
       "SIDEWALK",
-      "RISK_HIGH",
+      "RISK_EXTREME",
       "SOURCE_FOOD",
       "SOURCE_DRINK",
       "SOURCE_GUN",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_fungal.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_fungal.json
@@ -7,7 +7,7 @@
     "color": "yellow",
     "see_cost": 3,
     "extras": "marloss",
-    "flags": [ "NO_ROTATE", "RISK_HIGH" ]
+    "flags": [ "NO_ROTATE", "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -17,7 +17,7 @@
     "color": "light_gray",
     "see_cost": 2,
     "extras": "marloss",
-    "flags": [ "NO_ROTATE", "RISK_HIGH" ]
+    "flags": [ "NO_ROTATE", "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -27,6 +27,6 @@
     "color": "cyan",
     "see_cost": 5,
     "extras": "marloss",
-    "flags": [ "NO_ROTATE", "RISK_HIGH" ]
+    "flags": [ "NO_ROTATE", "RISK_EXTREME" ]
   }
 ]

--- a/data/json/overmap/overmap_terrain/overmap_terrain_lab.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_lab.json
@@ -7,7 +7,7 @@
     "color": "light_blue",
     "spawns": { "group": "GROUP_LAB", "population": [ 0, 5 ], "chance": 20 },
     "see_cost": 5,
-    "flags": [ "NO_ROTATE", "RISK_HIGH" ]
+    "flags": [ "NO_ROTATE", "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -17,7 +17,7 @@
     "color": "blue",
     "see_cost": 5,
     "spawns": { "group": "GROUP_LAB", "population": [ 0, 5 ], "chance": 20 },
-    "flags": [ "KNOWN_DOWN", "NO_ROTATE", "RISK_HIGH" ]
+    "flags": [ "KNOWN_DOWN", "NO_ROTATE", "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -27,7 +27,7 @@
     "color": "light_blue",
     "spawns": { "group": "GROUP_LAB", "population": [ 0, 8 ], "chance": 30 },
     "see_cost": 5,
-    "flags": [ "NO_ROTATE", "RISK_HIGH" ]
+    "flags": [ "NO_ROTATE", "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -56,7 +56,7 @@
     "color": "light_blue",
     "spawns": { "group": "GROUP_LAB", "population": [ 0, 5 ], "chance": 20 },
     "see_cost": 5,
-    "flags": [ "NO_ROTATE", "RISK_HIGH" ]
+    "flags": [ "NO_ROTATE", "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -86,7 +86,7 @@
     "color": "light_blue",
     "spawns": { "group": "GROUP_LAB", "population": [ 0, 5 ], "chance": 20 },
     "see_cost": 5,
-    "flags": [ "NO_ROTATE", "RISK_HIGH" ]
+    "flags": [ "NO_ROTATE", "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -126,7 +126,7 @@
     "color": "light_blue",
     "see_cost": 5,
     "spawns": { "group": "GROUP_LAB", "population": [ 0, 5 ], "chance": 20 },
-    "flags": [ "NO_ROTATE", "RISK_HIGH" ]
+    "flags": [ "NO_ROTATE", "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -172,7 +172,7 @@
     "see_cost": 5,
     "extras": "subway",
     "spawns": { "group": "GROUP_LAB", "population": [ 0, 5 ], "chance": 20 },
-    "flags": [ "NO_ROTATE", "RISK_HIGH" ]
+    "flags": [ "NO_ROTATE", "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -190,7 +190,7 @@
     "sym": "F",
     "color": "green",
     "see_cost": 3,
-    "flags": [ "NO_ROTATE", "RISK_HIGH" ]
+    "flags": [ "NO_ROTATE", "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -208,7 +208,7 @@
     "sym": "L",
     "color": "cyan",
     "see_cost": 5,
-    "flags": [ "RISK_HIGH" ],
+    "flags": [ "RISK_EXTREME" ],
     "spawns": { "group": "GROUP_CENTRAL_LAB", "population": [ 0, 5 ], "chance": 20 }
   },
   {
@@ -359,7 +359,7 @@
     "extras": "research_facility_interior",
     "see_cost": 5,
     "mondensity": 2,
-    "flags": [ "RISK_HIGH" ]
+    "flags": [ "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -516,7 +516,7 @@
     "sym": "L",
     "color": "light_blue",
     "see_cost": 5,
-    "flags": [ "RISK_HIGH", "SOURCE_CHEMISTRY", "SOURCE_MEDICINE" ]
+    "flags": [ "RISK_EXTREME", "SOURCE_CHEMISTRY", "SOURCE_MEDICINE" ]
   },
   {
     "type": "overmap_terrain",
@@ -525,7 +525,7 @@
     "sym": "X",
     "color": "white",
     "see_cost": 5,
-    "flags": [ "RISK_HIGH" ]
+    "flags": [ "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -543,7 +543,7 @@
     "color": "yellow",
     "see_cost": 5,
     "spawns": { "group": "GROUP_VANILLA", "population": [ 1, 4 ], "chance": 30 },
-    "flags": [ "RISK_HIGH" ]
+    "flags": [ "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -568,7 +568,7 @@
     "color": "white",
     "see_cost": 5,
     "spawns": { "group": "GROUP_VANILLA", "population": [ 3, 15 ], "chance": 70 },
-    "flags": [ "RISK_HIGH" ]
+    "flags": [ "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -592,7 +592,7 @@
     "sym": "R",
     "color": "green",
     "see_cost": 5,
-    "flags": [ "RISK_HIGH" ]
+    "flags": [ "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -617,7 +617,7 @@
     "color": "light_gray",
     "see_cost": 5,
     "spawns": { "group": "GROUP_VANILLA", "population": [ 5, 15 ], "chance": 30 },
-    "flags": [ "RISK_HIGH" ]
+    "flags": [ "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -626,7 +626,7 @@
     "sym": "F",
     "color": "light_gray",
     "see_cost": 5,
-    "flags": [ "RISK_HIGH" ]
+    "flags": [ "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -636,7 +636,7 @@
     "color": "red",
     "see_cost": 5,
     "spawns": { "group": "GROUP_LAB_HOSPITAL", "population": [ 7, 15 ], "chance": 100 },
-    "flags": [ "RISK_HIGH", "SOURCE_CHEMISTRY", "SOURCE_MEDICINE" ]
+    "flags": [ "RISK_EXTREME", "SOURCE_CHEMISTRY", "SOURCE_MEDICINE" ]
   },
   {
     "type": "overmap_terrain",
@@ -645,7 +645,7 @@
     "sym": "M",
     "color": "red",
     "see_cost": 5,
-    "flags": [ "RISK_HIGH", "SOURCE_CHEMISTRY", "SOURCE_MEDICINE" ]
+    "flags": [ "RISK_EXTREME", "SOURCE_CHEMISTRY", "SOURCE_MEDICINE" ]
   },
   {
     "type": "overmap_terrain",
@@ -655,6 +655,6 @@
     "color": "cyan",
     "see_cost": 5,
     "spawns": { "group": "GROUP_LAB_MAINTENANCE", "population": [ 5, 10 ], "chance": 100 },
-    "flags": [ "RISK_HIGH" ]
+    "flags": [ "RISK_EXTREME" ]
   }
 ]

--- a/data/json/overmap/overmap_terrain/overmap_terrain_mall.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_mall.json
@@ -7,7 +7,7 @@
     "sym": "M",
     "see_cost": 5,
     "mondensity": 2,
-    "flags": [ "SIDEWALK", "RISK_HIGH", "SOURCE_FOOD", "SOURCE_DRINK", "SOURCE_MEDICINE", "SOURCE_FABRICATION" ]
+    "flags": [ "SIDEWALK", "RISK_EXTREME", "SOURCE_FOOD", "SOURCE_DRINK", "SOURCE_MEDICINE", "SOURCE_FABRICATION" ]
   },
   {
     "type": "overmap_terrain",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_mi-go.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_mi-go.json
@@ -6,7 +6,7 @@
     "sym": "<",
     "color": "dark_gray",
     "mondensity": 2,
-    "flags": [ "RISK_HIGH" ]
+    "flags": [ "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -15,7 +15,7 @@
     "sym": ">",
     "color": "light_gray",
     "mondensity": 2,
-    "flags": [ "RISK_HIGH" ]
+    "flags": [ "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -24,7 +24,7 @@
     "sym": ">",
     "color": "light_gray",
     "mondensity": 2,
-    "flags": [ "RISK_HIGH" ]
+    "flags": [ "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -33,7 +33,7 @@
     "sym": "_",
     "color": "light_gray",
     "mondensity": 2,
-    "flags": [ "RISK_HIGH" ]
+    "flags": [ "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -51,7 +51,7 @@
     "sym": ">",
     "color": "light_gray",
     "mondensity": 2,
-    "flags": [ "RISK_HIGH" ]
+    "flags": [ "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -60,6 +60,6 @@
     "sym": "=",
     "color": "dark_gray",
     "mondensity": 2,
-    "flags": [ "RISK_HIGH" ]
+    "flags": [ "RISK_EXTREME" ]
   }
 ]

--- a/data/json/overmap/overmap_terrain/overmap_terrain_microlab.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_microlab.json
@@ -6,7 +6,7 @@
     "sym": "L",
     "color": "light_blue",
     "see_cost": 5,
-    "flags": [ "NO_ROTATE", "RISK_HIGH", "SOURCE_CHEMISTRY", "SOURCE_MEDICINE" ]
+    "flags": [ "NO_ROTATE", "RISK_EXTREME", "SOURCE_CHEMISTRY", "SOURCE_MEDICINE" ]
   },
   {
     "type": "overmap_terrain",
@@ -30,7 +30,7 @@
     "sym": "S",
     "color": "light_blue",
     "see_cost": 5,
-    "flags": [ "RISK_HIGH", "SOURCE_CHEMISTRY", "SOURCE_MEDICINE" ]
+    "flags": [ "RISK_EXTREME", "SOURCE_CHEMISTRY", "SOURCE_MEDICINE" ]
   },
   {
     "type": "overmap_terrain",
@@ -60,7 +60,7 @@
     "sym": "L",
     "color": "cyan",
     "see_cost": 5,
-    "flags": [ "RISK_HIGH", "SOURCE_CHEMISTRY", "SOURCE_MEDICINE" ]
+    "flags": [ "RISK_EXTREME", "SOURCE_CHEMISTRY", "SOURCE_MEDICINE" ]
   },
   {
     "type": "overmap_terrain",
@@ -80,7 +80,7 @@
     "sym": "L",
     "color": "red",
     "see_cost": 5,
-    "flags": [ "RISK_HIGH" ]
+    "flags": [ "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -97,7 +97,7 @@
     "sym": "L",
     "color": "light_red",
     "see_cost": 5,
-    "flags": [ "RISK_HIGH" ]
+    "flags": [ "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -137,7 +137,7 @@
     "sym": "L",
     "color": "cyan",
     "see_cost": 5,
-    "flags": [ "RISK_HIGH" ]
+    "flags": [ "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -168,7 +168,7 @@
     "color": "green",
     "spawns": { "group": "GROUP_RATKIN_LAB", "population": [ 12, 25 ], "chance": 80 },
     "see_cost": 5,
-    "flags": [ "NO_ROTATE", "RISK_HIGH", "SOURCE_CHEMISTRY", "SOURCE_MEDICINE" ]
+    "flags": [ "NO_ROTATE", "RISK_EXTREME", "SOURCE_CHEMISTRY", "SOURCE_MEDICINE" ]
   },
   {
     "type": "overmap_terrain",
@@ -195,7 +195,7 @@
     "color": "green",
     "spawns": { "group": "GROUP_RATKIN_LAB", "population": [ 12, 25 ], "chance": 80 },
     "see_cost": 5,
-    "flags": [ "RISK_HIGH", "SOURCE_CHEMISTRY", "SOURCE_MEDICINE" ]
+    "flags": [ "RISK_EXTREME", "SOURCE_CHEMISTRY", "SOURCE_MEDICINE" ]
   },
   {
     "type": "overmap_terrain",
@@ -205,7 +205,7 @@
     "color": "green",
     "spawns": { "group": "GROUP_RATKIN_LAB", "population": [ 12, 25 ], "chance": 80 },
     "see_cost": 5,
-    "flags": [ "RISK_HIGH", "SOURCE_CHEMISTRY", "SOURCE_MEDICINE" ]
+    "flags": [ "RISK_EXTREME", "SOURCE_CHEMISTRY", "SOURCE_MEDICINE" ]
   },
   {
     "type": "overmap_terrain",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_military.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_military.json
@@ -7,7 +7,7 @@
     "color": "blue",
     "see_cost": 5,
     "extras": "build",
-    "flags": [ "RISK_HIGH", "SOURCE_GUN", "SOURCE_AMMO", "SOURCE_FOOD" ]
+    "flags": [ "RISK_EXTREME", "SOURCE_GUN", "SOURCE_AMMO", "SOURCE_FOOD" ]
   },
   {
     "type": "overmap_terrain",
@@ -17,7 +17,7 @@
     "color": "i_blue",
     "see_cost": 5,
     "extras": "build",
-    "flags": [ "RISK_HIGH", "SOURCE_GUN", "SOURCE_AMMO", "SOURCE_FOOD" ]
+    "flags": [ "RISK_EXTREME", "SOURCE_GUN", "SOURCE_AMMO", "SOURCE_FOOD" ]
   },
   {
     "type": "overmap_terrain",
@@ -267,7 +267,7 @@
     "sym": "B",
     "color": "red",
     "see_cost": 2,
-    "flags": [ "KNOWN_DOWN", "RISK_HIGH", "SOURCE_WEAPON", "SOURCE_AMMO" ]
+    "flags": [ "KNOWN_DOWN", "RISK_EXTREME", "SOURCE_WEAPON", "SOURCE_AMMO" ]
   },
   {
     "type": "overmap_terrain",
@@ -276,7 +276,7 @@
     "sym": "B",
     "color": "red",
     "see_cost": 2,
-    "flags": [ "KNOWN_UP", "RISK_HIGH", "SOURCE_WEAPON", "SOURCE_AMMO" ]
+    "flags": [ "KNOWN_UP", "RISK_EXTREME", "SOURCE_WEAPON", "SOURCE_AMMO" ]
   },
   {
     "type": "overmap_terrain",
@@ -285,7 +285,7 @@
     "sym": "B",
     "color": "red",
     "see_cost": 2,
-    "flags": [ "RISK_HIGH", "SOURCE_WEAPON", "SOURCE_AMMO" ]
+    "flags": [ "RISK_EXTREME", "SOURCE_WEAPON", "SOURCE_AMMO" ]
   },
   {
     "type": "overmap_terrain",
@@ -295,7 +295,7 @@
     "color": "red",
     "see_cost": 2,
     "extras": "build",
-    "flags": [ "RISK_HIGH", "SOURCE_WEAPON", "SOURCE_AMMO" ]
+    "flags": [ "RISK_EXTREME", "SOURCE_WEAPON", "SOURCE_AMMO" ]
   },
   {
     "type": "overmap_terrain",
@@ -305,7 +305,7 @@
     "color": "red",
     "see_cost": 2,
     "extras": "build",
-    "flags": [ "RISK_HIGH", "SOURCE_WEAPON", "SOURCE_AMMO" ]
+    "flags": [ "RISK_EXTREME", "SOURCE_WEAPON", "SOURCE_AMMO" ]
   },
   {
     "type": "overmap_terrain",
@@ -323,7 +323,7 @@
     "sym": "0",
     "color": "red",
     "see_cost": 2,
-    "flags": [ "NO_ROTATE", "RISK_HIGH" ]
+    "flags": [ "NO_ROTATE", "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -380,7 +380,7 @@
     "sym": "H",
     "color": "red",
     "see_cost": 5,
-    "flags": [ "SOURCE_FUEL", "SOURCE_GUN", "SOURCE_VEHICLES", "RISK_HIGH" ]
+    "flags": [ "SOURCE_FUEL", "SOURCE_GUN", "SOURCE_VEHICLES", "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_nether.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_nether.json
@@ -6,7 +6,7 @@
     "sym": " ",
     "color": "black",
     "see_cost": 10,
-    "flags": [ "RISK_HIGH" ]
+    "flags": [ "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -15,6 +15,6 @@
     "sym": " ",
     "color": "black",
     "see_cost": 10,
-    "flags": [ "RISK_HIGH" ]
+    "flags": [ "RISK_EXTREME" ]
   }
 ]

--- a/data/json/overmap/overmap_terrain/overmap_terrain_oil_platform.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_oil_platform.json
@@ -41,7 +41,7 @@
     "color": "red",
     "see_cost": 5,
     "spawns": { "group": "GROUP_OIL_PLATFORM", "population": [ 15, 20 ], "chance": 100 },
-    "flags": [ "RISK_HIGH", "OCEAN" ]
+    "flags": [ "RISK_HIGH", "OCEAN", "SOURCE_FUEL", "GENERIC_LOOT" ]
   },
   {
     "type": "overmap_terrain",
@@ -59,7 +59,7 @@
     "color": "red",
     "see_cost": 5,
     "spawns": { "group": "GROUP_OIL_PLATFORM", "population": [ 25, 35 ], "chance": 100 },
-    "flags": [ "RISK_HIGH", "OCEAN" ]
+    "flags": [ "RISK_HIGH", "OCEAN", "SOURCE_FUEL", "GENERIC_LOOT" ]
   },
   {
     "type": "overmap_terrain",
@@ -163,6 +163,6 @@
     "sym": "O",
     "color": "red",
     "see_cost": 5,
-    "flags": [ "RISK_HIGH", "OCEAN" ]
+    "flags": [ "RISK_HIGH", "OCEAN", "SOURCE_FUEL", "GENERIC_LOOT" ]
   }
 ]

--- a/data/json/overmap/overmap_terrain/overmap_terrain_private_resort.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_private_resort.json
@@ -7,7 +7,7 @@
     "color": "yellow",
     "see_cost": 5,
     "mondensity": 1,
-    "flags": [ "RISK_HIGH", "SOURCE_DRINK", "SOURCE_LUXURY" ]
+    "flags": [ "RISK_EXTREME", "SOURCE_DRINK", "SOURCE_LUXURY" ]
   },
   {
     "id": [ "p_resort_1nw", "p_resort_pm" ],

--- a/data/json/overmap/overmap_terrain/overmap_terrain_public_institutional.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_public_institutional.json
@@ -217,7 +217,7 @@
     "name": "hospital",
     "sym": "H",
     "color": "red",
-    "extend": { "flags": [ "RISK_HIGH", "SOURCE_MEDICINE", "SOURCE_CHEMISTRY" ] }
+    "extend": { "flags": [ "RISK_EXTREME", "SOURCE_MEDICINE", "SOURCE_CHEMISTRY" ] }
   },
   {
     "type": "overmap_terrain",
@@ -286,7 +286,7 @@
     "color": "light_blue",
     "see_cost": 5,
     "mondensity": 2,
-    "flags": [ "SIDEWALK", "RISK_HIGH", "SOURCE_BOOKS" ]
+    "flags": [ "SIDEWALK", "RISK_EXTREME", "SOURCE_BOOKS" ]
   },
   {
     "type": "overmap_terrain",
@@ -296,7 +296,7 @@
     "color": "light_blue",
     "see_cost": 5,
     "mondensity": 2,
-    "flags": [ "SIDEWALK", "RISK_HIGH", "SOURCE_BOOKS" ]
+    "flags": [ "SIDEWALK", "RISK_EXTREME", "SOURCE_BOOKS" ]
   },
   {
     "type": "overmap_terrain",
@@ -331,7 +331,7 @@
     "color": "light_blue",
     "see_cost": 5,
     "mondensity": 2,
-    "flags": [ "SOURCE_BOOKS", "RISK_HIGH" ]
+    "flags": [ "SOURCE_BOOKS", "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -350,7 +350,7 @@
     "sym": "p",
     "color": "i_light_blue",
     "see_cost": 5,
-    "flags": [ "RISK_HIGH" ]
+    "flags": [ "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_triffid.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_triffid.json
@@ -8,7 +8,7 @@
     "color": "light_red",
     "see_cost": 5,
     "mondensity": 2,
-    "flags": [ "KNOWN_UP", "KNOWN_DOWN", "RISK_HIGH", "REQUIRES_PREDECESSOR" ]
+    "flags": [ "KNOWN_UP", "KNOWN_DOWN", "RISK_EXTREME", "REQUIRES_PREDECESSOR" ]
   },
   {
     "type": "overmap_terrain",
@@ -19,7 +19,7 @@
     "see_cost": 5,
     "mondensity": 2,
     "spawns": { "group": "GROUP_TRIFFID", "population": [ 40, 45 ], "chance": 80 },
-    "flags": [ "KNOWN_UP", "KNOWN_DOWN", "RISK_HIGH" ]
+    "flags": [ "KNOWN_UP", "KNOWN_DOWN", "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -30,7 +30,7 @@
     "see_cost": 5,
     "mondensity": 2,
     "spawns": { "group": "GROUP_TRIFFID", "population": [ 40, 45 ], "chance": 80 },
-    "flags": [ "KNOWN_UP", "KNOWN_DOWN", "RISK_HIGH" ]
+    "flags": [ "KNOWN_UP", "KNOWN_DOWN", "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -41,7 +41,7 @@
     "see_cost": 5,
     "mondensity": 2,
     "spawns": { "group": "GROUP_TRIFFID", "population": [ 40, 45 ], "chance": 80 },
-    "flags": [ "KNOWN_UP", "KNOWN_DOWN", "RISK_HIGH" ]
+    "flags": [ "KNOWN_UP", "KNOWN_DOWN", "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -52,7 +52,7 @@
     "see_cost": 5,
     "mondensity": 2,
     "spawns": { "group": "GROUP_TRIFFID", "population": [ 40, 45 ], "chance": 80 },
-    "flags": [ "KNOWN_UP", "KNOWN_DOWN", "RISK_HIGH" ]
+    "flags": [ "KNOWN_UP", "KNOWN_DOWN", "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -63,7 +63,7 @@
     "see_cost": 5,
     "mondensity": 2,
     "spawns": { "group": "GROUP_TRIFFID", "population": [ 40, 45 ], "chance": 80 },
-    "flags": [ "KNOWN_UP", "KNOWN_DOWN", "RISK_HIGH" ]
+    "flags": [ "KNOWN_UP", "KNOWN_DOWN", "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -74,7 +74,7 @@
     "see_cost": 5,
     "mondensity": 2,
     "spawns": { "group": "GROUP_TRIFFID", "population": [ 40, 45 ], "chance": 80 },
-    "flags": [ "KNOWN_UP", "KNOWN_DOWN", "RISK_HIGH" ]
+    "flags": [ "KNOWN_UP", "KNOWN_DOWN", "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -85,7 +85,7 @@
     "see_cost": 5,
     "mondensity": 2,
     "spawns": { "group": "GROUP_TRIFFID", "population": [ 40, 45 ], "chance": 80 },
-    "flags": [ "KNOWN_UP", "KNOWN_DOWN", "RISK_HIGH" ]
+    "flags": [ "KNOWN_UP", "KNOWN_DOWN", "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -96,7 +96,7 @@
     "see_cost": 5,
     "mondensity": 2,
     "spawns": { "group": "GROUP_TRIFFID", "population": [ 40, 45 ], "chance": 80 },
-    "flags": [ "KNOWN_UP", "KNOWN_DOWN", "RISK_HIGH" ]
+    "flags": [ "KNOWN_UP", "KNOWN_DOWN", "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -107,7 +107,7 @@
     "see_cost": 5,
     "mondensity": 2,
     "spawns": { "group": "GROUP_TRIFFID", "population": [ 40, 45 ], "chance": 80 },
-    "flags": [ "KNOWN_UP", "KNOWN_DOWN", "RISK_HIGH" ]
+    "flags": [ "KNOWN_UP", "KNOWN_DOWN", "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -118,7 +118,7 @@
     "see_cost": 5,
     "mondensity": 2,
     "spawns": { "group": "GROUP_TRIFFID_HEARTGUARDS", "population": [ 50, 60 ], "chance": 80 },
-    "flags": [ "KNOWN_UP", "RISK_HIGH" ]
+    "flags": [ "KNOWN_UP", "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -127,7 +127,7 @@
     "sym": "T",
     "color": "light_red",
     "see_cost": 5,
-    "flags": [ "KNOWN_UP", "KNOWN_DOWN", "RISK_HIGH" ]
+    "flags": [ "KNOWN_UP", "KNOWN_DOWN", "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -136,7 +136,7 @@
     "sym": "T",
     "color": "light_red",
     "see_cost": 5,
-    "flags": [ "KNOWN_UP", "KNOWN_DOWN", "RISK_HIGH" ]
+    "flags": [ "KNOWN_UP", "KNOWN_DOWN", "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -145,7 +145,7 @@
     "sym": "T",
     "color": "light_red",
     "see_cost": 5,
-    "flags": [ "KNOWN_DOWN", "RISK_HIGH" ]
+    "flags": [ "KNOWN_DOWN", "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",

--- a/data/mods/Aftershock/maps/overmap_terrain.json
+++ b/data/mods/Aftershock/maps/overmap_terrain.json
@@ -96,7 +96,7 @@
     "color": "pink",
     "see_cost": 3,
     "extras": "marloss",
-    "flags": [ "NO_ROTATE", "RISK_HIGH" ]
+    "flags": [ "NO_ROTATE", "RISK_EXTREME" ]
   },
   {
     "id": "afs_crashed_cargo_shuttle",
@@ -114,7 +114,7 @@
     "sym": "s",
     "color": "light_green",
     "see_cost": 2,
-    "flags": [ "RISK_HIGH", "SOURCE_GUN", "SOURCE_AMMO" ]
+    "flags": [ "RISK_EXTREME", "SOURCE_GUN", "SOURCE_AMMO" ]
   },
   {
     "type": "overmap_terrain",

--- a/data/mods/Defense_Mode/mapgen/megastore.json
+++ b/data/mods/Defense_Mode/mapgen/megastore.json
@@ -27,7 +27,7 @@
     "see_cost": 5,
     "flags": [
       "SIDEWALK",
-      "RISK_HIGH",
+      "RISK_EXTREME",
       "SOURCE_FOOD",
       "SOURCE_DRINK",
       "SOURCE_GUN",

--- a/data/mods/DinoMod/overmap/overmap_terrain.json
+++ b/data/mods/DinoMod/overmap/overmap_terrain.json
@@ -25,7 +25,7 @@
     "color": "light_blue",
     "spawns": { "group": "GROUP_DINOLAB", "population": [ 40, 45 ], "chance": 80 },
     "see_cost": 5,
-    "flags": [ "NO_ROTATE", "RISK_HIGH", "SOURCE_CHEMISTRY", "SOURCE_MEDICINE" ]
+    "flags": [ "NO_ROTATE", "RISK_EXTREME", "SOURCE_CHEMISTRY", "SOURCE_MEDICINE" ]
   },
   {
     "type": "overmap_terrain",
@@ -64,6 +64,6 @@
     "sym": ">",
     "color": "light_gray",
     "mondensity": 2,
-    "flags": [ "RISK_HIGH" ]
+    "flags": [ "RISK_EXTREME" ]
   }
 ]

--- a/data/mods/Isolation-Protocol/Map/overmap.json
+++ b/data/mods/Isolation-Protocol/Map/overmap.json
@@ -14,7 +14,7 @@
     "sym": "L",
     "color": "light_red",
     "see_cost": 5,
-    "flags": [ "RISK_HIGH" ]
+    "flags": [ "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",

--- a/data/mods/Magiclysm/worldgen/overmap_specials.json
+++ b/data/mods/Magiclysm/worldgen/overmap_specials.json
@@ -292,7 +292,7 @@
     "city_sizes": [ 0, 20 ],
     "occurrences": [ 0, 2 ],
     "spawns": { "group": "GROUP_OGRE", "population": [ 1, 10 ], "radius": [ 1, 6 ] },
-    "flags": [ "WILDERNESS", "RISK_HIGH" ]
+    "flags": [ "WILDERNESS", "RISK_EXTREME" ]
   },
   {
     "type": "overmap_special",

--- a/data/mods/Magiclysm/worldgen/overmap_terrain.json
+++ b/data/mods/Magiclysm/worldgen/overmap_terrain.json
@@ -115,7 +115,7 @@
     "color": "c_light_cyan",
     "looks_like": "forest_water",
     "see_cost": 5,
-    "flags": [ "SOURCE_FORAGE", "RISK_HIGH" ]
+    "flags": [ "SOURCE_FORAGE", "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",

--- a/data/mods/MindOverMatter/overmap/overmap_terrain.json
+++ b/data/mods/MindOverMatter/overmap/overmap_terrain.json
@@ -113,7 +113,7 @@
     "extras": "phavian_lab_interior",
     "see_cost": 5,
     "mondensity": 2,
-    "flags": [ "RISK_HIGH" ]
+    "flags": [ "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",

--- a/data/mods/TropiCataclysm/overmap/overmap_terrain/overmap_terrain_nether.json
+++ b/data/mods/TropiCataclysm/overmap/overmap_terrain/overmap_terrain_nether.json
@@ -6,6 +6,6 @@
     "sym": "O",
     "color": "light_blue",
     "see_cost": 3,
-    "flags": [ "NO_ROTATE", "RISK_HIGH" ]
+    "flags": [ "NO_ROTATE", "RISK_EXTREME" ]
   }
 ]

--- a/data/mods/TropiCataclysm/overmap/overmap_terrain/overmap_terrain_termites.json
+++ b/data/mods/TropiCataclysm/overmap/overmap_terrain/overmap_terrain_termites.json
@@ -6,7 +6,7 @@
     "sym": "%",
     "color": "brown",
     "see_cost": 2,
-    "flags": [ "KNOWN_UP", "KNOWN_DOWN", "RISK_HIGH", "REQUIRES_PREDECESSOR" ]
+    "flags": [ "KNOWN_UP", "KNOWN_DOWN", "RISK_EXTREME", "REQUIRES_PREDECESSOR" ]
   },
   {
     "type": "overmap_terrain",
@@ -15,7 +15,7 @@
     "sym": "%",
     "color": "brown",
     "see_cost": 2,
-    "flags": [ "KNOWN_DOWN", "RISK_HIGH" ]
+    "flags": [ "KNOWN_DOWN", "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",

--- a/data/mods/TropiCataclysm/overmap/overmap_terrain/overmap_terrain_triffid.json
+++ b/data/mods/TropiCataclysm/overmap/overmap_terrain/overmap_terrain_triffid.json
@@ -6,7 +6,7 @@
     "sym": "T",
     "color": "magenta",
     "see_cost": 3,
-    "flags": [ "NO_ROTATE", "RISK_HIGH" ]
+    "flags": [ "NO_ROTATE", "RISK_EXTREME" ]
   },
   {
     "type": "overmap_terrain",
@@ -15,6 +15,6 @@
     "sym": "T",
     "color": "light_red",
     "see_cost": 3,
-    "flags": [ "NO_ROTATE", "RISK_HIGH" ]
+    "flags": [ "NO_ROTATE", "RISK_EXTREME" ]
   }
 ]

--- a/doc/JSON_FLAGS.md
+++ b/doc/JSON_FLAGS.md
@@ -1311,8 +1311,9 @@ See [Character](#character)
 - ```SOURCE_MEDICINE``` For NPC AI, this location may contain useful medicines for looting.
 - ```SOURCE_LUXURY``` For NPC AI, this location may contain valuable/feel-good items to sell/keep.
 - ```SOURCE_PEOPLE``` For NPC AI, this location may have other survivors.
-- ```RISK_HIGH``` For NPC AI, this location has a high risk associated with it (e.g. labs, superstores, etc.).
-- ```RISK_LOW``` For NPC AI, this location is secluded and remote, and appears to be safe.
+- ```RISK_EXTREME``` For NPC AI, this location is extremely risky to even approach. Location should almost always contain active portals, huge hordes of zombies, or other very lethal enemies. Some examples would labs, superstores, and mi-go structures.
+- ```RISK_HIGH``` For NPC AI, this location is risky to visit. This is the minimum amount of risk for locations inside of a city.
+- ```RISK_LOW``` For NPC AI, this location is specifically a place of safety. Such locations should be fortified, remote, or be controlled by a neutral faction that provides security. This flag should only be applied to specific areas of nearly-guaranteed safety. Wilderness should not receive this flag unless there is some sort of specific shelter (e.g. an uninhabitated cave).
 - ```GENERIC_LOOT``` This is a place that may contain any of the above, but at a lower frequency, usually a house.
 
 

--- a/src/omdata.h
+++ b/src/omdata.h
@@ -189,6 +189,7 @@ enum class oter_flags : int {
     ravine,
     ravine_edge,
     generic_loot,
+    risk_extreme,
     risk_high,
     risk_low,
     source_ammo,

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -696,6 +696,7 @@ std::string enum_to_string<oter_flags>( oter_flags data )
         case oter_flags::ravine: return "RAVINE";
         case oter_flags::ravine_edge: return "RAVINE_EDGE";
         case oter_flags::generic_loot: return "GENERIC_LOOT";
+        case oter_flags::risk_extreme: return "RISK_EXTREME";
         case oter_flags::risk_high: return "RISK_HIGH";
         case oter_flags::risk_low: return "RISK_LOW";
         case oter_flags::source_ammo: return "SOURCE_AMMO";


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
**Note: This system isn't actually in use currently. There is no functional change.**

The current OMT flags are lacking. A field is considered as risky as the average house (which is always inside of a city). A city is always far more dangerous than a random field.

#### Describe the solution
Expand the scale so our NPCs can be smarter in the future. The paradigm as it now stands goes like this:

RISK_EXTREME: Labs, malls, places with guaranteed hordes. If it looks like a death trap, treat it like one.

RISK_HIGH: All locations that spawn inside cities. Some other locations (swamps, rivers) if they are sufficiently dangerous.

(no flag): Wilderness, some rural locations with elements of risk. Because the wilderness is zombifying, random fields/forests cannot be treated as completely safe.

RISK_LOW: Specifically already-available shelter or third-party protection (e.g. godco).


Special note: RISK_HIGH and GENERIC_LOOT were added to the generic_city_building and generic_city_building_no_sidewalk abstracts. 

I was going to do more in this PR but I noticed it had already crept up to 31 changed files by the time I got here.


#### Describe alternatives you've considered


#### Testing
Game loads

#### Additional context
