### PR TITLE
Civilianize the SIG 553

### DIFF
--- a/data/json/itemgroups/Weapons_Mods_Ammo/guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/guns.json
@@ -405,7 +405,6 @@
       { "group": "nested_rm51_assault_rifle", "prob": 1 },
       { "group": "nested_rm614_lmg", "prob": 1 },
       { "group": "nested_rm88_battle_rifle", "prob": 1 },
-      { "group": "nested_sig_assault_rifle", "prob": 50 },
       { "group": "nested_scar_l", "prob": 50 },
       { "group": "nested_scar_h", "prob": 50 },
       { "group": "nested_m110a1", "prob": 50 },

--- a/data/json/itemgroups/Weapons_Mods_Ammo/guns_by_calibre.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/guns_by_calibre.json
@@ -623,7 +623,8 @@
       { "group": "nested_m16_auto_rifle", "prob": 25 },
       { "group": "nested_zpapm90", "prob": 1 },
       { "group": "nested_zpap85", "prob": 1 },
-      { "group": "nested_mdrx", "prob": 30 }
+      { "group": "nested_mdrx", "prob": 30 },
+      { "group": "nested_sig_assault_rifle", "prob": 25 }
     ]
   },
   {
@@ -710,7 +711,8 @@
     "items": [
       { "group": "mdrx", "prob": 10 },
       { "group": "nested_ar15_with_kits", "prob": 19 },
-      { "group": "nested_mdrx_with_kits", "prob": 10 }
+      { "group": "nested_mdrx_with_kits", "prob": 10 },
+      { "group": "nested_sig_assault_rifle", "prob": 3 }
     ]
   },
   {

--- a/data/json/items/gun/223.json
+++ b/data/json/items/gun/223.json
@@ -498,23 +498,23 @@
   {
     "//": "Name changed to match the non-branded version. Also changed to the SIG 553, as the 552 is discontinued and the 553 is still in production and is identical to the 552.",
     "id": "sig_assault_rifle",
-    "copy-from": "rifle_auto",
+    "copy-from": "rifle_semi",
     "looks_like": "modular_ar15",
     "type": "GUN",
-    "name": { "str": "SIG assault rifle" },
-    "description": "A compact selective fire automatic rifle designed for the Swiss military.  It features a three-round burst mode and an integrated folding stock.  It is chambered in 5.56x45mm and accepts STANAG magazines.",
-    "weight": "3200 g",
-    "volume": "2950 ml",
-    "longest_side": "741 mm",
-    "barrel_length": "348 mm",
+    "name": { "str": "SIG civilian rifle" },
+    "description": "A civilian clone of an automatic swiss rifle for military service.  Accepts STANAG magazines.",
+    "weight": "4100 g",
+    "volume": "3146 ml",
+    "longest_side": "1020 mm",
+    "barrel_length": "406 mm",
     "price": "3 kUSD 200 USD",
-    "price_postapoc": "60 USD",
+    "price_postapoc": "30 USD",
     "variant_type": "gun",
     "variants": [
       {
         "id": "sig553",
-        "name": { "str": "SIG 553" },
-        "description": "A compact selective fire automatic rifle designed for the Swiss military.  It features a three-round burst mode and an integrated folding stock."
+        "name": { "str": "SIG SG 556" },
+        "description": "The SG 556 is a civilian model of the SG550 series.  It lacks any automatic fire capability and has a 16 inch barrel, but still retains a folding stock, and has the feature of feeding from STANAG magazines instead of the SG 550 series magazines."
       }
     ],
     "to_hit": -1,
@@ -523,7 +523,7 @@
     "dispersion": 180,
     "durability": 9,
     "min_cycle_recoil": 1350,
-    "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "BURST", "3 rd.", 3 ], [ "AUTO", "auto", 4 ] ],
+    "modes": [ [ "DEFAULT", "semi-auto", 1 ] ],
     "built_in_mods": [ "folding_stock" ],
     "pocket_data": [
       {

--- a/data/json/items/gun/223.json
+++ b/data/json/items/gun/223.json
@@ -496,7 +496,7 @@
     "melee_damage": { "bash": 12 }
   },
   {
-    "//": "Name changed to match the non-branded version. Also changed to the SIG 553, as the 552 is discontinued and the 553 is still in production and is identical to the 552.",
+    "//": "Changed from SG 553, which itself was originally the Sig 550, to the civilian legal copy",
     "id": "sig_assault_rifle",
     "copy-from": "rifle_semi",
     "looks_like": "modular_ar15",

--- a/data/json/items/gun/223.json
+++ b/data/json/items/gun/223.json
@@ -502,7 +502,7 @@
     "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "SIG civilian rifle" },
-    "description": "A civilian clone of an automatic Swiss rifle for military service.  Accepts STANAG magazines.",
+    "description": "A civilian variant of an automatic Swiss rifle for military service.  Accepts STANAG magazines.",
     "weight": "4100 g",
     "volume": "3146 ml",
     "longest_side": "1020 mm",

--- a/data/json/items/gun/223.json
+++ b/data/json/items/gun/223.json
@@ -502,7 +502,7 @@
     "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "SIG civilian rifle" },
-    "description": "A civilian clone of an automatic swiss rifle for military service.  Accepts STANAG magazines.",
+    "description": "A civilian clone of an automatic Swiss rifle for military service.  Accepts STANAG magazines.",
     "weight": "4100 g",
     "volume": "3146 ml",
     "longest_side": "1020 mm",
@@ -514,7 +514,7 @@
       {
         "id": "sig553",
         "name": { "str": "SIG SG 556" },
-        "description": "The SG 556 is a civilian model of the SG550 series.  It lacks any automatic fire capability and has a 16 inch barrel, but still retains a folding stock, and has the feature of feeding from STANAG magazines instead of the SG 550 series magazines."
+        "description": "The SG 556 is a civilian model of the Swiss SIG SG 550 series, manufactured in New Hampshire.  It lacks any automatic fire capability and has a 16 inch barrel, but still retains a folding stock, with the feature of feeding from STANAG magazines instead of the SG 550 series magazines."
       }
     ],
     "to_hit": -1,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Makes the SG 553 into 556"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The SIG 553 was a military location only firearm, and took stanag magazines. This is an issue as the SIG 553 doesn't actually take stanag magazines, it only takes its proprietary magazines. A non-STANAG foreign military rifle shouldn't be found in military locations, I'm unsure why someone would have that instead of a regular M16/M4 pattern.
<!-- If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

I've changed it to the Sig SG 556, a civilian legal copy manufactured in New England, specifically New Hampshire. Longer barrel, still has the folding stock, takes STANAG magazines and has no automatic fire.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Removing it outright.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Booted up the game, worked fine, item groups worked fine as well.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

The SIG SG 556 alone doesn't have enough hits on gunbroker, but lumped in with the other results for different models such as a 550, 551, etc, does.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
