### PR TITLE
Display ordered NPC path on map, move TALK_GOTO_LOCATION to top-level menu

### DIFF
--- a/data/json/npcs/common_chat/TALK_COMMON_ALLY.json
+++ b/data/json/npcs/common_chat/TALK_COMMON_ALLY.json
@@ -51,6 +51,7 @@
         "topic": "TALK_FRIEND",
         "effect": "reveal_stats"
       },
+      { "text": "Please go to this location.", "topic": "TALK_GOTO_LOCATION", "effect": "goto_location" },
       { "text": "There's something I want you to do.", "topic": "TALK_ALLY_ORDERS" },
       { "text": "I just wanted to talk for a bit.", "topic": "TALK_ALLY_SOCIAL" },
       { "text": "Can you help me understand something?  (HELP/TUTORIAL)", "topic": "TALK_ALLY_TUTORIAL" },
@@ -1017,7 +1018,10 @@
   {
     "id": "TALK_GOTO_LOCATION",
     "type": "talk_topic",
-    "dynamic_line": "Sure thing, I'll make my way there.",
+    "dynamic_line": {
+      "npc_is_travelling": "Sure thing, I'll make my way there.",
+      "no": "All right, tell me if you want me to go somewhere."
+    },
     "responses": [ { "text": "Affirmative.", "topic": "TALK_DONE" } ]
   },
   {
@@ -1036,12 +1040,6 @@
         "condition": { "npc_at_om_location": "FACTION_CAMP_ANY" },
         "topic": "TALK_FRIEND_GUARD",
         "effect": "assign_camp"
-      },
-      {
-        "text": "Please go to this location.",
-        "topic": "TALK_GOTO_LOCATION",
-        "condition": { "or": [ "is_by_radio", "u_has_camp" ] },
-        "effect": "goto_location"
       },
       {
         "text": "I want you to build a camp here.",

--- a/doc/NPCs.md
+++ b/doc/NPCs.md
@@ -961,6 +961,8 @@ Condition | Type | Description
 `"has_available_mission" or "u_has_available_mission" or "npc_has_available_mission"` | simple string | `true` if u or the NPC has one job available for the player character.
 `"has_many_available_missions"` | simple string | `true` if the NPC has several jobs available for the player character.
 `"mission_goal" or "npc_mission_goal" or "u_mission_goal"` | string or [variable object](#variable-object) | `true` if u or the NPC's current mission has the same goal as `mission_goal`.
+`"u_has_activity" or "npc_has_activity" | simple string | `true` if the [selected talker](EFFECT_ON_CONDITION.md#alpha-and-beta-talkers) is currently performing an [activity](PLAYER_ACTIVITY.md).
+`"u_is_travelling" or "npc_is_travelling" | simple string | `true` if the [selected talker](EFFECT_ON_CONDITION.md#alpha-and-beta-talkers) has a current destination. Note that this just checks the destination exists, not whether u or npc is actively moving to it.
 `"mission_complete" or "npc_mission_complete" or "u_mission_complete"` | simple string | `true` if u or the NPC has completed the other's current mission.
 `"mission_incomplete" or "npc_mission_incomplete" or "u_mission_incomplete"` | simple string | `true` if u or the NPC hasn't completed the other's current mission.
 `"mission_failed" or "npc_mission_failed" or "u_mission_failed"` | simple string | `true` if u or the NPC has failed the other's current mission.

--- a/lang/string_extractor/parsers/talk_topic.py
+++ b/lang/string_extractor/parsers/talk_topic.py
@@ -22,6 +22,7 @@ dynamic_line_string_keys = [
     "npc_available", "npc_following", "npc_friend", "npc_hostile",
     "npc_train_skills", "npc_train_styles", "npc_train_spells",
     "at_safe_space", "is_day", "npc_has_activity",
+    "u_is_travelling", "npc_is_travelling",
     "is_outside", "u_is_outside", "npc_is_outside", "u_has_camp",
     "u_can_stow_weapon", "npc_can_stow_weapon", "u_can_drop_weapon",
     "npc_can_drop_weapon", "u_has_weapon", "npc_has_weapon",

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -1099,6 +1099,17 @@ conditional_t::func f_npc_role_nearby( const JsonObject &jo, std::string_view me
     };
 }
 
+conditional_t::func f_npc_is_travelling( bool is_npc )
+{
+    return [is_npc]( dialogue const & d ) {
+        const Character *traveller = d.actor( is_npc )->get_character();
+        if( !traveller ) {
+            return false;
+        }
+        return !traveller->omt_path.empty();
+    };
+}
+
 conditional_t::func f_npc_allies( const JsonObject &jo, std::string_view member )
 {
     dbl_or_var dov = get_dbl_or_var( jo, member );
@@ -2487,6 +2498,7 @@ std::vector<condition_parser>
 parsers_simple = {
     {"u_male", "npc_male", &conditional_fun::f_is_male },
     {"u_female", "npc_female", &conditional_fun::f_is_female },
+    {"u_is_travelling", "npc_is_travelling", &conditional_fun::f_npc_is_travelling },
     {"has_no_assigned_mission", &conditional_fun::f_no_assigned_mission },
     {"has_assigned_mission", &conditional_fun::f_has_assigned_mission },
     {"has_many_assigned_missions", &conditional_fun::f_has_many_assigned_missions },

--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -654,7 +654,7 @@ bool do_turn()
     // consider a stripped down cache just for monsters.
     m.build_map_cache( levz, true );
     monmove();
-    if( calendar::once_every( 5_minutes ) ) {
+    if( calendar::once_every( time_between_npc_OM_moves ) ) {
         overmap_npc_move();
     }
     if( calendar::once_every( 10_seconds ) ) {

--- a/src/game.h
+++ b/src/game.h
@@ -1155,7 +1155,7 @@ class game
         bool debug_pathfinding = false; // NOLINT(cata-serialize)
 
         //Ugly kludge to pass info to tile overmaps
-        npc *follower_path_to_show = nullptr;
+        npc *follower_path_to_show = nullptr; // NOLINT(cata-serialize)
 
         /* tile overlays */
         // Toggle all other overlays off and flip the given overlay on/off.

--- a/src/game.h
+++ b/src/game.h
@@ -1154,6 +1154,9 @@ class game
         // show NPC pathfinding on overmap ui
         bool debug_pathfinding = false; // NOLINT(cata-serialize)
 
+        //Ugly kludge to pass info to tile overmaps
+        npc *follower_path_to_show = nullptr;
+
         /* tile overlays */
         // Toggle all other overlays off and flip the given overlay on/off.
         void display_toggle_overlay( action_id );

--- a/src/game_constants.h
+++ b/src/game_constants.h
@@ -4,6 +4,7 @@
 
 #include <map>
 #include <string>
+#include "calendar.h"
 #include "units.h"
 
 // Fixed window sizes.
@@ -144,6 +145,9 @@ constexpr int BIO_CQB_LEVEL = 5;
 
 // Minimum size of a horde to show up on the minimap.
 constexpr int HORDE_VISIBILITY_SIZE = 3;
+
+// How often a NPC can move one tile on the overmap
+constexpr time_duration time_between_npc_OM_moves = 5_minutes;
 
 /**
  * Average annual temperature in Kelvin used for climate, weather and temperature calculation.

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -373,7 +373,7 @@ void talk_function::goto_location( npc &p )
         camps.push_back( temp_camp );
     }
     for( const basecamp *iter : camps ) {
-        //~ %1$s: camp name, %2$d and %3$d: coordinates
+        //~ %1$s: camp name, %2$s: coordinates of the camp
         selection_menu.addentry( i++, true, MENU_AUTOASSIGN, pgettext( "camp", "%1$s at %2$s" ),
                                  iter->camp_name(), iter->camp_omt_pos().to_string() );
     }
@@ -410,7 +410,12 @@ void talk_function::goto_location( npc &p )
     g->follower_path_to_show = &p; // Necessary for overmap display in tiles version...
     ui::omap::display_npc_path( p.global_omt_location(), p.omt_path );
     g->follower_path_to_show = nullptr;
-    if( !query_yn( _( "Is this path and destination acceptable?" ) ) ) {
+    int tiles_to_travel = p.omt_path.size();
+    time_duration ETA = time_between_npc_OM_moves * tiles_to_travel;
+    ETA = ETA * rng_float( 0.8, 1.2 ); // Add +-20% variance in our estimate
+    if( !query_yn(
+            _( "Estimated time to arrival: %1$s  \nTiles to travel: %2$s  \nIs this path and destination acceptable?" ),
+            to_string_approx( ETA ), tiles_to_travel ) ) {
         p.goal = npc::no_goal_point;
         p.omt_path.clear();
         return;

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -49,6 +49,7 @@
 #include "npctrade.h"
 #include "output.h"
 #include "overmap.h"
+#include "overmap_ui.h"
 #include "overmapbuffer.h"
 #include "pimpl.h"
 #include "player_activity.h"
@@ -404,6 +405,12 @@ void talk_function::goto_location( npc &p )
         p.goal = npc::no_goal_point;
         p.omt_path.clear();
         add_msg( m_info, _( "That is not a valid destination for %s." ), p.disp_name() );
+        return;
+    }
+    ui::omap::display_npc_path( p.global_omt_location(), p.omt_path );
+    if( !query_yn( _( "Is this path and destination acceptable?" ) ) ) {
+        p.goal = npc::no_goal_point;
+        p.omt_path.clear();
         return;
     }
     p.set_mission( NPC_MISSION_TRAVELLING );

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -407,7 +407,9 @@ void talk_function::goto_location( npc &p )
         add_msg( m_info, _( "That is not a valid destination for %s." ), p.disp_name() );
         return;
     }
+    g->follower_path_to_show = &p; // Necessary for overmap display in tiles version...
     ui::omap::display_npc_path( p.global_omt_location(), p.omt_path );
+    g->follower_path_to_show = nullptr;
     if( !query_yn( _( "Is this path and destination acceptable?" ) ) ) {
         p.goal = npc::no_goal_point;
         p.omt_path.clear();

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -539,7 +539,7 @@ static void draw_ascii(
     const catacurses::window &w, const tripoint_abs_omt &center,
     const tripoint_abs_omt &orig, bool blink, bool show_explored, bool /* fast_scroll */,
     input_context * /* inp_ctxt */, const draw_data_t &data,
-    std::vector<tripoint_abs_omt> display_path )
+    const std::vector<tripoint_abs_omt> &display_path )
 {
 
     const int om_map_width = OVERMAP_WINDOW_WIDTH;
@@ -691,7 +691,7 @@ static void draw_ascii(
             followers.push_back( npc_to_add );
         }
         if( !display_path.empty() ) {
-            for( auto &elem : display_path ) {
+            for( const tripoint_abs_omt &elem : display_path ) {
                 npc_path_route.insert( elem );
             }
         }
@@ -1263,7 +1263,8 @@ tiles_redraw_info redraw_info;
 static void draw(
     ui_adaptor &ui, const tripoint_abs_omt &center, const tripoint_abs_omt &orig,
     bool blink, bool show_explored, bool fast_scroll,
-    input_context *inp_ctxt, const draw_data_t &data, std::vector<tripoint_abs_omt> display_path )
+    input_context *inp_ctxt, const draw_data_t &data,
+    const std::vector<tripoint_abs_omt> &display_path )
 {
     draw_om_sidebar( ui, g->w_omlegend, center, orig, blink, fast_scroll, inp_ctxt, data );
 #if defined( TILES )
@@ -2080,7 +2081,7 @@ void ui::omap::display()
 }
 
 void ui::omap::display_npc_path( tripoint_abs_omt starting_pos,
-                                 std::vector<tripoint_abs_omt> display_path )
+                                 const std::vector<tripoint_abs_omt> &display_path )
 {
     overmap_ui::display( starting_pos, overmap_ui::draw_data_t(), display_path );
 }

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1895,9 +1895,9 @@ static tripoint_abs_omt display( const tripoint_abs_omt &orig,
             // We go faster per-tile the more we have to go
             cursor_advance_time = std::chrono::milliseconds( 1000 ) / display_path.size();
             cursor_advance_time = std::max( cursor_advance_time, std::chrono::milliseconds( 1 ) );
-            curs = *display_path_iter;
             if( now > last_advance + cursor_advance_time ) {
                 if( display_path_iter != display_path.rend() ) {
+                    curs = *display_path_iter;
                     last_advance = now;
                     display_path_iter++;
                 } else if( now > last_advance + cursor_advance_time * 10 ) {

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1898,19 +1898,8 @@ static tripoint_abs_omt display( const tripoint_abs_omt &orig,
             curs = *display_path_iter;
             if( now > last_advance + cursor_advance_time ) {
                 if( display_path_iter != display_path.rend() ) {
-                    std::chrono::nanoseconds time_since_last = now - last_advance;
-                    // If we would have gone over multiple cursors since the last process
-                    // then advance that many (max 5) instead of just 1
-                    int num_to_advance = std::chrono::duration_cast<std::chrono::milliseconds>
-                                         ( time_since_last ) / cursor_advance_time;
                     last_advance = now;
-                    num_to_advance = std::clamp( num_to_advance, 1, 5 );
-                    for( int i = 0; i < num_to_advance; i++ ) {
-                        if( display_path_iter != display_path.rend() ) {
-                            display_path_iter++;
-                        }
-                    }
-                    continue;
+                    display_path_iter++;
                 } else if( now > last_advance + cursor_advance_time * 10 ) {
                     action = "QUIT";
                     break;

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -538,7 +538,8 @@ static bool get_and_assign_los( int &los, avatar &player_character, const tripoi
 static void draw_ascii(
     const catacurses::window &w, const tripoint_abs_omt &center,
     const tripoint_abs_omt &orig, bool blink, bool show_explored, bool /* fast_scroll */,
-    input_context * /* inp_ctxt */, const draw_data_t &data )
+    input_context * /* inp_ctxt */, const draw_data_t &data,
+    std::vector<tripoint_abs_omt> display_path )
 {
 
     const int om_map_width = OVERMAP_WINDOW_WIDTH;
@@ -688,6 +689,11 @@ static void draw_ascii(
             }
             npc *npc_to_add = npc_to_get.get();
             followers.push_back( npc_to_add );
+        }
+        if( !display_path.empty() ) {
+            for( auto &elem : display_path ) {
+                npc_path_route.insert( elem );
+            }
         }
         // get all traveling NPCs for the debug menu to show pathfinding routes.
         if( g->debug_pathfinding ) {
@@ -1257,7 +1263,7 @@ tiles_redraw_info redraw_info;
 static void draw(
     ui_adaptor &ui, const tripoint_abs_omt &center, const tripoint_abs_omt &orig,
     bool blink, bool show_explored, bool fast_scroll,
-    input_context *inp_ctxt, const draw_data_t &data )
+    input_context *inp_ctxt, const draw_data_t &data, std::vector<tripoint_abs_omt> display_path )
 {
     draw_om_sidebar( ui, g->w_omlegend, center, orig, blink, fast_scroll, inp_ctxt, data );
 #if defined( TILES )
@@ -1269,7 +1275,8 @@ static void draw(
         return;
     }
 #endif // TILES
-    draw_ascii( g->w_overmap, center, orig, blink, show_explored, fast_scroll, inp_ctxt, data );
+    draw_ascii( g->w_overmap, center, orig, blink, show_explored, fast_scroll, inp_ctxt, data,
+                display_path );
 }
 
 static void create_note( const tripoint_abs_omt &curs )
@@ -1773,7 +1780,7 @@ static bool try_travel_to_destination( avatar &player_character, const tripoint_
 }
 
 static tripoint_abs_omt display( const tripoint_abs_omt &orig,
-                                 const draw_data_t &data = draw_data_t() )
+                                 const draw_data_t &data = draw_data_t(), std::vector<tripoint_abs_omt> display_path = {} )
 {
     const int previous_zoom = g->get_zoom();
     g->set_zoom( overmap_zoom_level );
@@ -1861,10 +1868,13 @@ static tripoint_abs_omt display( const tripoint_abs_omt &orig,
     int fast_scroll_offset = get_option<int>( "FAST_SCROLL_OFFSET" );
     std::optional<tripoint> mouse_pos;
     std::chrono::time_point<std::chrono::steady_clock> last_blink = std::chrono::steady_clock::now();
+    std::chrono::time_point<std::chrono::steady_clock> last_advance = std::chrono::steady_clock::now();
+    auto display_path_iter = display_path.rbegin();
+    std::chrono::milliseconds cursor_advance_time = std::chrono::milliseconds( 0 );
 
     ui.on_redraw( [&]( ui_adaptor & ui ) {
         draw( ui, curs, orig, uistate.overmap_show_overlays,
-              show_explored, fast_scroll, &ictxt, data );
+              show_explored, fast_scroll, &ictxt, data, display_path );
     } );
 
     do {
@@ -1880,6 +1890,33 @@ static tripoint_abs_omt display( const tripoint_abs_omt &orig,
 #else
         action = ictxt.handle_input( get_option<int>( "BLINK_SPEED" ) );
 #endif
+        if( !display_path.empty() ) {
+            std::chrono::time_point<std::chrono::steady_clock> now = std::chrono::steady_clock::now();
+            // We go faster per-tile the more we have to go
+            cursor_advance_time = std::chrono::milliseconds( 1000 ) / display_path.size();
+            cursor_advance_time = std::max( cursor_advance_time, std::chrono::milliseconds( 1 ) );
+            curs = *display_path_iter;
+            if( now > last_advance + cursor_advance_time ) {
+                if( display_path_iter != display_path.rend() ) {
+                    std::chrono::nanoseconds time_since_last = now - last_advance;
+                    // If we would have gone over multiple cursors since the last process
+                    // then advance that many (max 5) instead of just 1
+                    int num_to_advance = std::chrono::duration_cast<std::chrono::milliseconds>
+                                         ( time_since_last ) / cursor_advance_time;
+                    last_advance = now;
+                    num_to_advance = std::clamp( num_to_advance, 1, 5 );
+                    for( int i = 0; i < num_to_advance; i++ ) {
+                        if( display_path_iter != display_path.rend() ) {
+                            display_path_iter++;
+                        }
+                    }
+                    continue;
+                } else if( now > last_advance + cursor_advance_time * 10 ) {
+                    action = "QUIT";
+                    break;
+                }
+            }
+        }
         if( const std::optional<tripoint> vec = ictxt.get_direction( action ) ) {
             int scroll_d = fast_scroll ? fast_scroll_offset : 1;
             curs += vec->xy() * scroll_d;
@@ -2051,6 +2088,12 @@ static tripoint_abs_omt display( const tripoint_abs_omt &orig,
 void ui::omap::display()
 {
     overmap_ui::display( get_player_character().global_omt_location(), overmap_ui::draw_data_t() );
+}
+
+void ui::omap::display_npc_path( tripoint_abs_omt starting_pos,
+                                 std::vector<tripoint_abs_omt> display_path )
+{
+    overmap_ui::display( starting_pos, overmap_ui::draw_data_t(), display_path );
 }
 
 void ui::omap::display_hordes()

--- a/src/overmap_ui.h
+++ b/src/overmap_ui.h
@@ -32,6 +32,10 @@ namespace omap
  */
 void display();
 /**
+ * Display overmap centered at the given NPC's position and visually move across their intended OMT path.
+ */
+void display_npc_path( tripoint_abs_omt starting_pos, std::vector<tripoint_abs_omt> display_path );
+/**
  * Display overmap like with @ref display() and display hordes.
  */
 void display_hordes();

--- a/src/overmap_ui.h
+++ b/src/overmap_ui.h
@@ -34,7 +34,8 @@ void display();
 /**
  * Display overmap centered at the given NPC's position and visually move across their intended OMT path.
  */
-void display_npc_path( tripoint_abs_omt starting_pos, std::vector<tripoint_abs_omt> display_path );
+void display_npc_path( tripoint_abs_omt starting_pos,
+                       const std::vector<tripoint_abs_omt> &display_path );
 /**
  * Display overmap like with @ref display() and display hordes.
  */

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -979,6 +979,15 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
             }
         }
 
+        if( g->follower_path_to_show ) {
+            for( const tripoint_abs_omt &pos : g->follower_path_to_show->omt_path ) {
+                if( pos.z() == center_abs_omt.z() ) {
+                    draw_from_id_string( "highlight", global_omt_to_draw_position( pos ), 0, 0, lit_level::LIT,
+                                         false );
+                }
+            }
+        }
+
         // only draw in full tiles so it doesn't get cut off
         const std::optional<std::pair<tripoint_abs_omt, std::string>> mission_arrow =
                     get_mission_arrow( full_om_tile_area, center_abs_omt );


### PR DESCRIPTION
#### Summary
Balance "Display ordered NPC path on map, NPCs refuse to go to dangerous locations "

#### Purpose of change
NPC followers are ~~suicidally loyal and~~ hard to keep track of

`Camp ( 312, 555, 0)` where the heck is that? Dang it I knew I shouldn't have named all of my camps `Camp`.

#### Describe the solution
-Display the route automatically at the time of ordering the movement.
--The map automatically pans over the route and pauses at the end

-Move the "TALK_GOTO_LOCATION" topic to the top-level menu, instead of burying it 2 menus deep in a camp topic(?!)

-Display an estimated time of arrival and a query so you know you sent the NPC to the right place

#### Describe alternatives you've considered


#### Testing

https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/41487ed7-2322-44b3-a6e0-6cbdb86df546


#### Additional context

Plans for pathfinding changes were pushed out to future PRs, see edit record/followup message

Known issues:
The highlighted red path sometimes does not display on the opened map, depending on when the last blink was shown.
(It will still step through each tile as appropriately, it just won't have a visible trail it's following)

The speed at which it advances through the tiles is rather slow, limited by how often the frames are redrawn rather than the actual code limitations I've applied.
--Moving the mouse causes it to go very fast, because mouse inputs trigger new frames to be drawn.
--Regardless, you can exit the overmap ui at any time, so you don't have to wait to see. But you can.
