### PR TITLE
No smithy in a box for 0.H

### DIFF
--- a/data/json/itemgroups/tools.json
+++ b/data/json/itemgroups/tools.json
@@ -17,42 +17,6 @@
     ]
   },
   {
-    "id": "tools_simple_blacksmith",
-    "type": "item_group",
-    "//": "Tools commonly used by amateur blacksmiths. A subset of blacksmiths tools",
-    "items": [ { "group": "basic_metalworking_a", "prob": 40 }, { "group": "basic_metalworking_b", "prob": 60 } ]
-  },
-  {
-    "id": "basic_metalworking_a",
-    "type": "item_group",
-    "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
-    "container-item": "box_large",
-    "entries": [
-      { "item": "anvil", "count": 1 },
-      { "item": "chisel", "count": 1 },
-      { "item": "metal_file", "count": 1 },
-      { "item": "hotcut", "count": 1 },
-      { "item": "metalworking_tongs", "count": 1 },
-      { "item": "hammer", "count": 1 },
-      { "item": "sandpaper", "count": 1 }
-    ]
-  },
-  {
-    "id": "basic_metalworking_b",
-    "type": "item_group",
-    "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
-    "container-item": "box_large",
-    "entries": [
-      { "item": "anvil", "count": 1 },
-      { "item": "metal_file", "count": 1 },
-      { "item": "metalworking_tongs", "count": 1 },
-      { "item": "hammer", "count": 1 },
-      { "item": "sandpaper", "count": 1 }
-    ]
-  },
-  {
     "id": "tools_carpentry",
     "type": "item_group",
     "//": "Portable tools used for carpentry",
@@ -209,7 +173,6 @@
       { "group": "tools_lighting_industrial", "prob": 100 },
       { "group": "tools_mechanic", "prob": 20 },
       { "group": "tools_plumbing", "prob": 20 },
-      { "group": "tools_simple_blacksmith", "prob": 10 },
       [ "jumper_cable_heavy", 2 ],
       [ "lug_wrench", 20 ],
       [ "jerrycan", 10 ],


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Testing 0.H I spawned in a shelter and a random locker had a huge pile of stuff in it:
![Screenshot from 2024-05-26 11-58-10](https://github.com/CleverRaven/Cataclysm-DDA/assets/860276/1128c8a7-e17e-4b29-9dc5-55915928b350)
![Screenshot from 2024-05-26 11-57-45](https://github.com/CleverRaven/Cataclysm-DDA/assets/860276/ec397935-fc4c-400a-a784-fb9e1f06243d)
I'm specifically addressing the box of blacksmithing tools here (including an ANVIL?).
This was added in #68673 and was not thought through.
One, I don't think anyone sells an entire smithy in a box INCLUDING AN ANVIL in a cardboard box.
Two, this item group wasn't and isn't only included in locations that would have these things for sale, it spawns all over the place, including home workshops and trader inventories.

#### Describe the solution
Revert

#### Describe alternatives you've considered
Given both points one and two above, trying to meet the original goals of this PR is essentially re-doing it from scratch, I'm not tackling that as part of a bugfix.