### PR TITLE
godco predatory trader shouldn't be a random spawn for 0.H

### DIFF
--- a/data/json/npcs/godco/classes.json
+++ b/data/json/npcs/godco/classes.json
@@ -571,6 +571,7 @@
     "name": { "str": "Trader" },
     "job_description": "I'm collecting gear and selling it at a high interest.",
     "traits": [ { "group": "BG_survival_story_EVACUEE" }, { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
+    "common": false,
     "shopkeeper_item_group": [ { "group": "NC_EVAC_SHOPKEEP_misc", "rigid": true } ],
     "shopkeeper_price_rules": [
       { "item": "icon", "price": 100 },


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Testing 0.H I spawned in a shelter and a random locker had a huge pile of stuff in it:
![Screenshot from 2024-05-26 11-58-10](https://github.com/CleverRaven/Cataclysm-DDA/assets/860276/1128c8a7-e17e-4b29-9dc5-55915928b350)
![Screenshot from 2024-05-26 11-57-45](https://github.com/CleverRaven/Cataclysm-DDA/assets/860276/ec397935-fc4c-400a-a784-fb9e1f06243d)
This addresses the more root cause of this, which is that the godco "predatory trader" spawned with me in the evac shelter.
This shouldn't happen as this NPC is supposed to spawn with a shop as part of godco mapgen, which gives them somewhere to put their inventory.
The regular trader NPC can still spawn and that's fine as they don't have the boosted trading inventory of a trader with a shop.

#### Describe the solution
Give the NPC class the "common": false property which keeps them spawning outside their scenario.

#### Describe alternatives you've considered
None really, this trader just doesn't fit in the evac shelter, or worse wandering around on the map.