### PR TITLE
Cataclysm Poem grammatical error fix

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,7 @@
  * Who knows
  */
 
-// KG: Yes, the above is inaccurate now. It's also a poem, its stays.
+// KG: Yes, the above is inaccurate now. It's also a poem, it stays.
 
 // IWYU pragma: no_include <sys/signal.h>
 #include <algorithm>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,7 @@
  * Who knows
  */
 
-// KG: Yes the above is inaccurate now, its also a poem, its stays.
+// KG: Yes, the above is inaccurate now. It's also a poem, its stays.
 
 // IWYU pragma: no_include <sys/signal.h>
 #include <algorithm>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,7 @@
  * Who knows
  */
 
-// KG: Yes the above is inaccurate now, it's also a poem, it's stays.
+// KG: Yes the above is inaccurate now, its also a poem, its stays.
 
 // IWYU pragma: no_include <sys/signal.h>
 #include <algorithm>


### PR DESCRIPTION
#### Summary

Bugfixes "Fixes a grammatical error within the cataclysm poem. It is now perfect."

#### Purpose of change

Continuation of #74123. It is complete.

#### Describe the solution

It's not its. 

#### Describe alternatives you've considered

Submit to Kevin's mind control and not fix the error.

#### Testing

I've read that sentence way too many times, I know it's correct. Its? No it's... right?

#### Additional context

