### PR TITLE
Cooldown fix and minor changes

### DIFF
--- a/data/mods/Xedra_Evolved/monster_special_attacks/monster_special_attacks.json
+++ b/data/mods/Xedra_Evolved/monster_special_attacks/monster_special_attacks.json
@@ -61,7 +61,6 @@
     "id": "ratatosks_curse",
     "cooldown": 10,
     "move_cost": 100,
-    "attack_chance": 50,
     "hitsize_min": 4,
     "attack_upper": false,
     "damage_max_instance": [ { "damage_type": "bash", "amount": 0 } ],

--- a/doc/MONSTER_SPECIAL_ATTACKS.md
+++ b/doc/MONSTER_SPECIAL_ATTACKS.md
@@ -44,7 +44,7 @@ Generally [hardcoded special attacks](#hardcoded-special-attacks) are declared t
 
 It contains either: 
 * An `id` of a [hardcoded special attack](#hardcoded-special-attacks), or a [JSON-declared attacks](/data/json/monster_special_attacks).
-* A `type` member (string) plus a `cooldown` member (integer) pair, for [partially hardcoded special attacks](#partially-hardcoded-special-attacks).
+* A `type` member (string) plus a `cooldown` member (integer or this can be a Variable Object, see the [doc](EFFECT_ON_CONDITION.md) for more info.) pair, for [partially hardcoded special attacks](#partially-hardcoded-special-attacks).
 * A spell (see [MAGIC.md](MAGIC.md)).
 
 Depending on the kind of attack, it may contain additional required members.  Example:
@@ -178,7 +178,7 @@ These special attacks are defined in [JSON](/data/json/monster_special_attacks),
 
 | field                       | description
 | ---                         | ---
-| `cooldown`			      | Integer, amount of turns between uses.
+| `cooldown`			      | Integer or Variable Object, see the [doc](EFFECT_ON_CONDITION.md) for more info, amount of turns between uses.
 | `damage_max_instance`       | Array of objects.  See also [MONSTERS.md#melee_damage](MONSTERS.md#melee_damage).
 | `min_mul`, `max_mul`        | Sets the bounds on the range of damage done.  For each attack, the above defined amount of damage will be multiplied by a
 |						      | randomly rolled multiplier between the values `min_mul` and `max_mul`.  Default 0.5 and 1.0, meaning each attack will do at least half of the defined damage.
@@ -284,7 +284,7 @@ Casts a separately-defined spell at the monster's target.  Spells with `target_s
 | ---                            | ------------------------------------------------------------------------------------------------------- |
 | `spell_data`                   | List of spell properties for the attack.                                                                |
 | `min_level`                    | The level at which the spell is cast. Spells cast by monsters do not gain levels like player spells.    |
-| `cooldown `                    | How often the monster can cast this spell.
+| `cooldown `                    | Integer or a Variable Object, see the [doc](EFFECT_ON_CONDITION.md) for more info. How often the monster can cast this spell.
 | `monster_message`              | Message to print when the spell is cast, replacing the `message` in the spell definition. Dynamic fields correspond to `<Monster Display Name> / <Spell Name> / <Target name>`. |
 | `condition`                    | Object, dialogue conditions enabling the attack.  See `NPCs.md` for the possible conditions, `u` refers to the casting monster and `npc` to the target unless the spell allows no target (in which case only self-conditions can be defined).
 | `allow_no_target`              | Bool, default `false`. If `true` the monster will cast it even without a hostile target.                |

--- a/src/mattack_actors.h
+++ b/src/mattack_actors.h
@@ -261,7 +261,7 @@ class gun_actor : public mattack_actor
         bool require_sunlight = false;
 
         bool try_target( monster &z, Creature &target ) const;
-        void shoot( monster &z, const tripoint &target, const gun_mode_id &mode,
+        bool shoot( monster &z, const tripoint &target, const gun_mode_id &mode,
                     int inital_recoil = 0 ) const;
         int get_max_range() const;
 

--- a/src/mattack_common.h
+++ b/src/mattack_common.h
@@ -28,9 +28,7 @@ class mattack_actor
         mattack_id id;
         bool was_loaded = false;
 
-        int cooldown = 0;
-        // Percent chance for the attack to happen if the mob tries it
-        int attack_chance = 100;
+        dbl_or_var cooldown;
 
         // Dialogue conditions of the attack
         std::function<bool( dialogue & )> condition;

--- a/src/mondefense.cpp
+++ b/src/mondefense.cpp
@@ -190,10 +190,10 @@ void mdefense::return_fire( monster &m, Creature *source, const dealt_projectile
                 continue;
             }
 
-            gunactor->shoot( m, fire_point, gun_mode_DEFAULT, dispersion );
-
-            // We only return fire once with one gun.
-            return;
+            if( gunactor->shoot( m, fire_point, gun_mode_DEFAULT, dispersion ) ) {
+                // We only return fire once with one gun.
+                return;
+            }
         }
     }
 }

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -291,9 +291,10 @@ monster::monster( const mtype_id &id ) : monster()
     moves = type->speed;
     Creature::set_speed_base( type->speed );
     hp = type->hp;
+    dialogue d( get_talker_for( this ), get_talker_for( get_avatar() ) );
     for( const auto &sa : type->special_attacks ) {
         mon_special_attack &entry = special_attacks[sa.first];
-        entry.cooldown = rng( 0, sa.second->cooldown );
+        entry.cooldown = rng( 0, sa.second->cooldown.evaluate( d ) );
     }
     anger = type->agro;
     morale = type->morale;
@@ -385,9 +386,10 @@ void monster::poly( const mtype_id &id )
     morale = type->morale;
     hp = static_cast<int>( hp_percentage * type->hp );
     special_attacks.clear();
+    dialogue d( get_talker_for( this ), get_talker_for( get_avatar() ) );
     for( const auto &sa : type->special_attacks ) {
         mon_special_attack &entry = special_attacks[sa.first];
-        entry.cooldown = sa.second->cooldown;
+        entry.cooldown = sa.second->cooldown.evaluate( d );
     }
     faction = type->default_faction;
     upgrades = type->upgrades;
@@ -2585,12 +2587,15 @@ void monster::reset_stats()
 
 void monster::reset_special( const std::string &special_name )
 {
-    set_special( special_name, type->special_attacks.at( special_name )->cooldown );
+    dialogue d( get_talker_for( this ), get_talker_for( get_avatar() ) );
+    set_special( special_name, type->special_attacks.at( special_name )->cooldown.evaluate( d ) );
 }
 
 void monster::reset_special_rng( const std::string &special_name )
 {
-    set_special( special_name, rng( 0, type->special_attacks.at( special_name )->cooldown ) );
+    dialogue d( get_talker_for( this ), get_talker_for( get_avatar() ) );
+    set_special( special_name, rng( 0,
+                                    type->special_attacks.at( special_name )->cooldown.evaluate( d ) ) );
 }
 
 void monster::set_special( const std::string &special_name, int time )

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -1463,8 +1463,6 @@ mtype_special_attack MonsterGenerator::create_actor( const JsonObject &obj,
 
 void mattack_actor::load( const JsonObject &jo, const std::string &src )
 {
-    bool strict = src == "dda";
-
     // Legacy support
     if( !jo.has_string( "id" ) ) {
         id = jo.get_string( "type" );

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -508,7 +508,7 @@ mtype MonsterGenerator::generate_fake_pseudo_dormant_monster( const mtype &mon )
     // first make a new mon_spellcasting_actor actor
     std::unique_ptr<mon_spellcasting_actor> new_actor( new mon_spellcasting_actor() );
     new_actor->allow_no_target = true;
-    new_actor->cooldown = 1;
+    new_actor->cooldown.min.dbl_val = 1;
     new_actor->spell_data.id = spell_pseudo_dormant_trap_setup;
     new_actor->spell_data.self = true;
 
@@ -1473,7 +1473,7 @@ void mattack_actor::load( const JsonObject &jo, const std::string &src )
         assign( jo, "id", id, false );
     }
 
-    assign( jo, "cooldown", cooldown, strict );
+    cooldown = get_dbl_or_var( jo, "cooldown", false, 0.0 );
 
     load_internal( jo, src );
     // Set was_loaded manually because we don't have generic_factory to do it for us
@@ -1527,7 +1527,14 @@ void mtype::add_special_attack( const JsonArray &inner, const std::string_view )
         }
     }
     mtype_special_attack new_attack = mtype_special_attack( iter->second );
-    new_attack.actor->cooldown = inner.get_int( 1 );
+    if( inner.has_array( 1 ) ) {
+        new_attack.actor->cooldown.min = get_dbl_or_var_part( inner.get_array( 1 )[0],
+                                         "special attack cooldown", 0.0 );
+        new_attack.actor->cooldown.max = get_dbl_or_var_part( inner.get_array( 1 )[1],
+                                         "special attack cooldown", 0.0 );
+    } else {
+        new_attack.actor->cooldown.min = get_dbl_or_var_part( inner[1], "special attack cooldown", 0.0 );
+    }
     special_attacks.emplace( name, new_attack );
     special_attacks_names.push_back( name );
 }

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2500,7 +2500,8 @@ void monster::load( const JsonObject &data )
                 if( ptimeout >= 0 ) {
                     entry.cooldown = ptimeout;
                 } else { // -1 means disabled, unclear what <-1 values mean in old saves
-                    entry.cooldown = type->special_attacks.at( aname )->cooldown;
+                    dialogue d( get_talker_for( this ), get_talker_for( get_avatar() ) );
+                    entry.cooldown = type->special_attacks.at( aname )->cooldown.evaluate( d );
                     entry.enabled = false;
                 }
             }
@@ -2523,7 +2524,8 @@ void monster::load( const JsonObject &data )
         const std::string &aname = sa.first;
         if( special_attacks.find( aname ) == special_attacks.end() ) {
             auto &entry = special_attacks[aname];
-            entry.cooldown = rng( 0, sa.second->cooldown );
+            dialogue d( get_talker_for( this ), get_talker_for( get_avatar() ) );
+            entry.cooldown = rng( 0, sa.second->cooldown.evaluate( d ) );
         }
     }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #73587
Removed attack_chance member which did nothing.
Changed gun special attacks to not consume moves if the creature is out of ammo.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Adding a flag to monster attacks to make them still able to waste time when out of ammo.  For ferals and whatnot it doesn't make sense for them to just sit there not throwing a rock but maybe turrets should?  I don't think it matters enough though.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Used line "cooldown": { "global_val": "test", "default": 3 }, in feral throw attack.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
