### PR TITLE
Make faction camp meals not overfeed, nor starve

### DIFF
--- a/data/json/items/comestibles/other.json
+++ b/data/json/items/comestibles/other.json
@@ -1420,7 +1420,7 @@
     "volume": "250 ml",
     "price": "100 cent",
     "price_postapoc": "100 cent",
-    "material": [ "foodplace_foodstuff" ],
+    "material": [ "foodplace_foodstuff", "fake_dense_food" ],
     "symbol": "F",
     "color": "brown",
     "spoils_in": "300 days",

--- a/data/json/items/comestibles/other.json
+++ b/data/json/items/comestibles/other.json
@@ -1416,7 +1416,7 @@
     "id": "camp_meal_small",
     "name": { "str": "prepared meal (small)", "str_pl": "prepared meals (small)" },
     "description": "I am an item used in faction camps.  If you see this description, it is a bug.",
-    "weight": "250 g",
+    "weight": "1500 g",
     "volume": "250 ml",
     "price": "100 cent",
     "price_postapoc": "100 cent",
@@ -1432,7 +1432,7 @@
     "comestible_type": "FOOD",
     "id": "camp_meal_medium",
     "name": { "str": "prepared meal (medium)", "str_pl": "prepared meals (medium)" },
-    "weight": "600 g",
+    "weight": "2700 g",
     "volume": "600 ml",
     "copy-from": "camp_meal_small"
   },
@@ -1441,7 +1441,7 @@
     "comestible_type": "FOOD",
     "id": "camp_meal_large",
     "name": { "str": "prepared meal (large)", "str_pl": "prepared meals (large)" },
-    "weight": "1200 g",
+    "weight": "3000 g",
     "volume": "1200 ml",
     "copy-from": "camp_meal_small"
   },

--- a/data/json/materials.json
+++ b/data/json/materials.json
@@ -2281,6 +2281,13 @@
   },
   {
     "type": "material",
+    "id": "fake_dense_food",
+    "name": "pseudo dense food",
+    "edible": true,
+    "copy-from": "monolith"
+  },
+  {
+    "type": "material",
     "id": "superalloy",
     "name": "Superalloy",
     "//": "Density based on superalloy sheet",

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -1695,13 +1695,23 @@ void basecamp::choose_new_leader()
 
 void basecamp::player_eats_meal()
 {
-    int kcal_to_eat = 3000;
+    int kcal_to_eat = 500;
     Character &you = get_player_character();
+    // 83% of stomach capacity is the point where full jumps over to engorged. if the
+    // remaining space before that is less than the meal we're about to eat, downsize
+    units::volume stomach_left_to_engorged = 0.83 * you.stomach.capacity( you ) - you.stomach.contains();
     const int &food_available = fac()->food_supply.kcal();
     if( food_available <= 0 ) {
         popup( _( "You check storage for some food, but there is nothing but dust and cobwebs…" ) );
         return;
-    } else if( food_available <= kcal_to_eat ) {
+    } else if( stomach_left_to_engorged > 1200_ml ) {
+        // can the character eat a large meal
+        kcal_to_eat = 3000;
+    } else if( stomach_left_to_engorged > 600_ml ) {
+        // can the character eat a medium meal
+        kcal_to_eat = 1500;
+    }
+    if( food_available <= kcal_to_eat ) {
         add_msg( _( "There's only one meal left.  Guess that's dinner!" ) );
         kcal_to_eat = food_available;
     }

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -5660,7 +5660,7 @@ item basecamp::make_fake_food( const nutrients &to_use ) const
 {
     // This is dumb, but effective.
     std::string food_id = "camp_meal_small";
-    if( to_use.kcal() > 3000 ) {
+    if( to_use.kcal() > 2999 ) {
         food_id = "camp_meal_large";
     } else if( to_use.kcal() > 1000 ) {
         food_id = "camp_meal_medium";

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -1699,7 +1699,8 @@ void basecamp::player_eats_meal()
     Character &you = get_player_character();
     // 83% of stomach capacity is the point where full jumps over to engorged. if the
     // remaining space before that is less than the meal we're about to eat, downsize
-    units::volume stomach_left_to_engorged = 0.83 * you.stomach.capacity( you ) - you.stomach.contains();
+    units::volume stomach_left_to_engorged = 0.83 * you.stomach.capacity( you ) -
+            you.stomach.contains();
     const int &food_available = fac()->food_supply.kcal();
     if( food_available <= 0 ) {
         popup( _( "You check storage for some food, but there is nothing but dust and cobwebs…" ) );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Faction camp meal making the player engorged"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

Some dude complained, and I thought it was an interesting enough problem to tackle.

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/99511880/495aa333-9ccb-4b95-ba55-13ef96932406)

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/99511880/98f843d6-5cae-4c8d-b4f5-53f19f7ea14a)

~Current implementation has the side effect of putting 3000kcal into the player no matter what, so if you're barely not full, you will get a really compact meal.~ Also this doesn't handle player stomach sizes under 0.2 liters.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

- The faction camp meal size now downgrades if it would cause the player to become engorged.

- Via increasing the weight of the fake meal items, `Character::compute_effective_food_volume_ratio` no longer has the energy density make volume tend toward kcal amount.

- The large meal would previously never trigger, fixed that.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

For the "downgrade meal size" part, making the food volume much more dynamic (like Guardian was saying here) is desired, but alas would require... something?? to do with charges (I think they're being phased out?) as well as I suspect not dividing up small kcal amounts very well.

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/99511880/9b11dacc-1e76-4bf4-9e20-ce98008bb1fe)

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

For each of Very Tall, Very Short and lack of mutation:
1. reset needs
2. wait some turns
3. (reset needs again if hunger changed)
4. empty stomach
5. repeatedly eat meals
6. notice that you get sufficient warning before overeating

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->

~I assume NPCs have stomachs, so by the time this gets out of draft, I'll make it not try to fetch the player value, in case it matters when testing.~

~todo: add comments~