### PR TITLE
Characters have actual volume, sane-ify sane-ified vehicle size checks. Enforce with unit tests

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -4862,15 +4862,10 @@
     "rating": "bad",
     "resist_traits": [ "BENDY1", "BENDY2", "BENDY3" ],
     "resist_effects": [ "incorporeal" ],
-    "pain_sizing": true,
-    "hurt_sizing": true,
     "base_mods": {
       "dex_mod": [ -2 ],
       "str_mod": [ -2 ],
-      "speed_mod": [ -20 ],
-      "pain_min": [ 2 ],
-      "pain_chance": [ 100, 500 ],
-      "pain_max_val": [ 35 ]
+      "speed_mod": [ -20 ]
     },
     "show_in_info": true
   },

--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -4862,11 +4862,7 @@
     "rating": "bad",
     "resist_traits": [ "BENDY1", "BENDY2", "BENDY3" ],
     "resist_effects": [ "incorporeal" ],
-    "base_mods": {
-      "dex_mod": [ -2 ],
-      "str_mod": [ -2 ],
-      "speed_mod": [ -20 ]
-    },
+    "base_mods": { "dex_mod": [ -2 ], "str_mod": [ -2 ], "speed_mod": [ -20 ] },
     "show_in_info": true
   },
   {

--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -5053,5 +5053,12 @@
     "material": [ "foodplace_foodstuff" ],
     "fun": 20,
     "monotony_penalty": 4
+  },
+  {
+    "type": "AMMO",
+    "id": "rock_volume_test",
+    "name": { "str": "10L rock" },
+    "copy-from": "rock",
+    "volume": "10 L"
   }
 ]

--- a/data/mods/TEST_DATA/vehicle.json
+++ b/data/mods/TEST_DATA/vehicle.json
@@ -564,5 +564,50 @@
       { "x": 0, "y": 1, "chance": 10, "item_groups": [ "snacks_fancy" ] },
       { "x": 0, "y": 1, "chance": 5, "item_groups": [ "female_underwear" ] }
     ]
+  },
+  {
+    "id": "character_volume_test_car",
+    "type": "vehicle",
+    "name": "DEBUG volume test car DEBUG",
+    "blueprint": [
+      [ "=====" ],
+      [ "=====" ],
+      [ "=====" ],
+      [ "=====" ],
+      [ "=====" ]
+    ],
+    "parts": [
+      { "x": -1, "y": -1, "parts": [ "frame", "aisle", "roof" ] },
+      { "x": 0, "y": -1, "parts": [ "frame", "aisle", "roof" ] },
+      { "x": 1, "y": -1, "parts": [ "frame", "aisle", "roof" ] },
+      { "x": -1, "y": 0, "parts": [ "frame", "aisle", "roof" ] },
+      { "x": 0, "y": 0, "parts": [ "frame", "aisle", "roof" ] },
+      { "x": 1, "y": 0, "parts": [ "frame", "aisle", "roof" ] },
+      { "x": -1, "y": 1, "parts": [ "frame", "aisle", "roof" ] },
+      { "x": 0, "y": 1, "parts": [ "frame", "aisle", "roof" ] },
+      { "x": 1, "y": 1, "parts": [ "frame", "aisle", "roof" ] },
+      { "x": -1, "y": 2, "parts": [ "frame", "aisle", "roof" ] },
+      { "x": 0, "y": 2, "parts": [ "frame", "aisle", "roof" ] },
+      { "x": 1, "y": 2, "parts": [ "frame", "aisle", "roof" ] },
+      { "x": 2, "y": 2, "parts": [ "frame", "aisle", "roof" ] },
+      { "x": 0, "y": -2, "parts": [ "frame", "aisle", "roof" ] },
+      { "x": 1, "y": -2, "parts": [ "frame", "aisle", "roof" ] },
+      { "x": 2, "y": -1, "parts": [ "frame", "aisle", "roof" ] },
+      { "x": 2, "y": 0, "parts": [ "frame", "aisle", "roof" ] },
+      { "x": 2, "y": 1, "parts": [ "frame", "aisle", "roof" ] },
+      { "x": -2, "y": -1, "parts": [ "frame", "aisle", "roof" ] },
+      { "x": -2, "y": 0, "parts": [ "frame", "aisle", "roof" ] },
+      { "x": -2, "y": -2, "parts": [ "frame", "aisle", "roof" ] },
+      { "x": -1, "y": -2, "parts": [ "frame", "aisle", "roof" ] },
+      { "x": 2, "y": -2, "parts": [ "frame", "aisle", "roof" ] },
+      { "x": -2, "y": 2, "parts": [ "frame", "aisle", "roof" ] },
+      { "x": -2, "y": 1, "parts": [ "frame", "aisle", "roof" ] }
+    ],
+    "items": [
+      { "x": 1, "y": 0, "chance": 100, "items": [ "rock_volume_test" ] },
+      { "x": -1, "y": 0, "chance": 100, "items": [ "rock_volume_test" ] },
+      { "x": 0, "y": 1, "chance": 100, "items": [ "rock_volume_test" ] },
+      { "x": 0, "y": -1, "chance": 100, "items": [ "rock_volume_test" ] }
+    ]
   }
 ]

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3090,6 +3090,27 @@ void Character::on_move( const tripoint_abs_ms &old_pos )
     }
 }
 
+units::volume Character::get_total_volume() const
+{
+    item_location wep = get_wielded_item();
+    units::volume wep_volume = wep ? wep->volume() : 0_ml;
+    // Note: Does not measure volume of worn items that do not themselves contain anything
+    return get_base_volume() + volume_carried() + wep_volume;
+}
+
+units::volume Character::get_base_volume() const
+{
+    const int your_height = height(); // avg 175cm
+    // Arbitrary number picked relative to aisle (100L), not necessarily accurate
+    const units::volume avg_human_volume = 70_liter;
+
+    // Very scientific video game size to metric human volume calculation. Avg height == avg_human_volume;
+    units::volume your_base_volume = units::from_liter( static_cast<double>( your_height ) / 2.5 );
+    double volume_proport = units::to_liter( your_base_volume ) / units::to_liter( avg_human_volume );
+
+    return std::pow( volume_proport, 3.0 ) * avg_human_volume;
+}
+
 units::mass Character::weight_carried() const
 {
     if( cached_weight_carried ) {

--- a/src/character.h
+++ b/src/character.h
@@ -2225,6 +2225,11 @@ class Character : public Creature, public visitable
         // weapon + worn (for death, etc)
         std::vector<item *> inv_dump();
         std::vector<const item *> inv_dump() const;
+
+        // TODO: Cache this like weight carried?
+        units::volume get_total_volume() const;
+        units::volume get_base_volume() const;
+
         units::mass weight_carried() const;
         units::volume volume_carried() const;
 

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -197,24 +197,6 @@ void Creature::setpos( const tripoint_bub_ms &p )
     Creature::setpos( p.raw() );
 }
 
-static units::volume size_to_volume( creature_size size_class )
-{
-    // returns midpoint of size from volume_to_size, minus 1_ml
-    // e.g. max tiny size is 7500, max small size is 46250, we return
-    // 46250+7500 / 2 - 1_ml = 26875_ml - 1ml
-    // This is still stupid and both of these functions should be merged into one single source of truth.
-    if( size_class == creature_size::tiny ) {
-        return 3749_ml;
-    } else if( size_class == creature_size::small ) {
-        return 26874_ml;
-    } else if( size_class == creature_size::medium ) {
-        return 77124_ml;
-    } else if( size_class == creature_size::large ) {
-        return 295874_ml;
-    }
-    return 741874_ml;
-}
-
 bool Creature::can_move_to_vehicle_tile( const tripoint_abs_ms &loc, bool &cramped ) const
 {
     map &here = get_map();
@@ -250,15 +232,15 @@ bool Creature::can_move_to_vehicle_tile( const tripoint_abs_ms &loc, bool &cramp
         units::volume critter_volume;
         if( mon ) {
             critter_volume = mon->get_volume();
-        } else {
-            critter_volume = size_to_volume( size );
+        } else if( const Character *you = as_character() )  {
+            you->get_total_volume();
         }
 
         if( critter_volume > free_cargo ) {
             return false;
         }
 
-        if( critter_volume > size_to_volume( creature_size::large ) &&
+        if( size == creature_size::huge &&
             !vp_there.part_with_feature( "HUGE_OK", false ) ) {
             return false;
         }

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -263,7 +263,8 @@ bool Creature::can_move_to_vehicle_tile( const tripoint_abs_ms &loc, bool &cramp
             return false;
         }
 
-        if( critter_volume < free_cargo * 1.33 ) {
+        // free_cargo * 0.75 < critter_volume && critter_volume <= free_cargo
+        if( free_cargo * 0.75 < critter_volume ) {
             if( !mon || !( mon->type->bodytype == "snake" || mon->type->bodytype == "blob" ||
                            mon->type->bodytype == "fish" ||
                            has_flag( mon_flag_PLASTIC ) || has_flag( mon_flag_SMALL_HIDER ) ) ) {

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -233,7 +233,7 @@ bool Creature::can_move_to_vehicle_tile( const tripoint_abs_ms &loc, bool &cramp
         if( mon ) {
             critter_volume = mon->get_volume();
         } else if( const Character *you = as_character() )  {
-            you->get_total_volume();
+            critter_volume = you->get_total_volume();
         }
 
         if( critter_volume > free_cargo ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10947,8 +10947,9 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool 
     if( cramped ) { // passed by reference, can_move_to_vehicle_tile sets to true if actually cramped
         if( u.get_size() == creature_size::huge ) {
             add_msg( m_warning, _( "You barely fit in this tiny human vehicle." ) );
-        } else {
-            add_msg( m_warning, _( "You can barely move around in here." ) );
+        } else if( u.get_total_volume() > u.get_base_volume() )  {
+            add_msg( m_warning,
+                     _( "All the stuff you're carrying isn't making it any easier to move in here." ) );
         }
         u.add_effect( effect_cramped_space, 2_turns, true );
     }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10945,7 +10945,11 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool 
     }
 
     if( cramped ) { // passed by reference, can_move_to_vehicle_tile sets to true if actually cramped
-        add_msg( m_warning, _( "You barely fit in this tiny human vehicle." ) );
+        if( u.get_size() == creature_size::huge ) {
+            add_msg( m_warning, _( "You barely fit in this tiny human vehicle." ) );
+        } else {
+            add_msg( m_warning, _( "You can barely move around in here." ) );
+        }
         u.add_effect( effect_cramped_space, 2_turns, true );
     }
 

--- a/tests/char_volume_test.cpp
+++ b/tests/char_volume_test.cpp
@@ -1,0 +1,127 @@
+#include <memory>
+#include <utility>
+
+#include "avatar.h"
+#include "cata_catch.h"
+#include "character.h"
+#include "game.h"
+#include "map.h"
+#include "map_helpers.h"
+#include "mutation.h"
+#include "player_helpers.h"
+#include "vehicle.h"
+#include "veh_type.h"
+
+static const itype_id backpack_giant( "backpack_giant" );
+static const itype_id rock_volume_test( "rock_volume_test" );
+
+static const trait_id trait_HUGE( "HUGE" );
+static const trait_id trait_LARGE( "LARGE" );
+static const trait_id trait_SMALL( "SMALL" );
+static const trait_id trait_SMALL2( "SMALL2" );
+
+static const vproto_id veh_character_volume_test_car( "character_volume_test_car" );
+
+static units::volume your_volume_with_trait( trait_id new_trait )
+{
+    clear_avatar();
+    Character &you = get_player_character();
+    you.set_mutation( new_trait );
+    return you.get_base_volume();
+}
+
+static int your_height_with_trait( trait_id new_trait )
+{
+    clear_avatar();
+    Character &you = get_player_character();
+    you.set_mutation( new_trait );
+    return you.height();
+}
+
+TEST_CASE( "character_baseline_volumes", "[volume]" )
+{
+    clear_avatar();
+    Character &you = get_player_character();
+    REQUIRE( you.get_mutations().empty() );
+    REQUIRE( you.height() == 175 );
+    CHECK( you.get_base_volume() == 70_liter );
+
+    REQUIRE( your_height_with_trait( trait_SMALL2 ) == 70 );
+    CHECK( your_volume_with_trait( trait_SMALL2 ) == 4480_ml );
+
+    REQUIRE( your_height_with_trait( trait_SMALL ) == 122 );
+    CHECK( your_volume_with_trait( trait_SMALL ) == 23717_ml );
+
+    REQUIRE( your_height_with_trait( trait_LARGE ) == 227 );
+    CHECK( your_volume_with_trait( trait_LARGE ) == 152778_ml );
+
+    REQUIRE( your_height_with_trait( trait_HUGE ) == 280 );
+    CHECK( your_volume_with_trait( trait_HUGE ) == 286720_ml );
+}
+
+TEST_CASE( "character_at_volume_can_or_cannot_enter_vehicle", "[volume]" )
+{
+    clear_avatar();
+    clear_map();
+    map &here = get_map();
+    Character &you = get_player_character();
+    REQUIRE( you.get_mutations().empty() );
+    REQUIRE( you.get_base_volume() == 70_liter );
+    REQUIRE( you.get_total_volume() == 70_liter );
+
+    tripoint test_pos = tripoint{10, 10, 0 };
+
+
+    clear_vehicles(); // extra safety
+    here.add_vehicle( veh_character_volume_test_car, test_pos, 0_degrees, 0, 0 );
+    you.setpos( test_pos );
+    const optional_vpart_position vp_there = here.veh_at( here.bub_from_abs( you.get_location() ) );
+    REQUIRE( vp_there );
+    tripoint_abs_ms dest_loc = you.get_location();
+
+    // Empty aisle
+    dest_loc = dest_loc + tripoint_north_west;
+    bool cramped = false;
+    CHECK( you.can_move_to_vehicle_tile( dest_loc, cramped ) );
+    CHECK( !cramped );
+    dest_loc = you.get_location(); //reset
+
+    // Aisle with 10L rock, a tight fit but not impossible
+    dest_loc = dest_loc + tripoint_north;
+    CHECK( you.can_move_to_vehicle_tile( dest_loc, cramped ) );
+    CHECK( cramped );
+    dest_loc = you.get_location(); //reset
+    cramped = false;
+
+    // Empty aisle, but we've put on a backpack and a 10L rock in that backpack
+    item backpack( backpack_giant );
+    auto worn_success = you.wear_item( backpack );
+    CHECK( worn_success );
+    you.i_add( item( rock_volume_test ) );
+    CHECK( 75_liter <= you.get_total_volume() );
+    CHECK( you.get_total_volume() <= 100_liter );
+    dest_loc = dest_loc + tripoint_north_west;
+    CHECK( you.can_move_to_vehicle_tile( dest_loc, cramped ) );
+    CHECK( cramped );
+    dest_loc = you.get_location(); //reset
+    cramped = false;
+
+    // Try the cramped aisle with a rock again, but now we are tiny, so it is easy.
+    CHECK( your_volume_with_trait( trait_SMALL2 ) == 4480_ml );
+    you.setpos( test_pos ); // set our position again, clear_avatar() moved us
+    dest_loc = dest_loc + tripoint_north;
+    CHECK( you.can_move_to_vehicle_tile( dest_loc, cramped ) );
+    CHECK( !cramped );
+    dest_loc = you.get_location(); //reset
+
+    // Same aisle, but now we have HUGE GUTS. We will never fit.
+    CHECK( your_volume_with_trait( trait_HUGE ) == 286720_ml );
+    you.setpos( test_pos ); // set our position again, clear_avatar() moved us
+    dest_loc = dest_loc + tripoint_north;
+    CHECK( !you.can_move_to_vehicle_tile( dest_loc ) );
+    dest_loc = you.get_location(); //reset
+
+    // And finally, check that our HUGE body won't fit even into an empty aisle.
+    dest_loc = dest_loc + tripoint_north_west;
+    CHECK( !you.can_move_to_vehicle_tile( dest_loc ) );
+}


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fixes #74068

Please stop pinging me. Yes I saw the first one

#### Describe the solution
Give characters actual volume

Remove pain from cramped space

Completely different volume calculation for characters, not related to monster calculation

(this is a big one)

--- >**Character volume includes carried volume, including their weapon** < ---

(big one up above!)

Flip an oopsie greater than

Embrace testing, testing is good


#### Describe alternatives you've considered
*Revert*?

#### Testing
~~my own unit test is currently failing.~~ it passes now

#### Additional context
Character size to volume is based on height, but here is a (better) graph plotted to the average heights for each size class:

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/35a8ff22-306e-4e41-849f-dbff194e724e)

**Note:** There still might be some json weirdness where volumes don't match up to what is 'expected'. I would expect some seats to be cramped, this is intended. Cramped space no longer gives pain and a penalty to fighting inside a restricted vehicle space makes sense to me. So yes, if you can't swing your broadsword 100% effectively from the driver's seat that is intended behavior.

If you find a vehicle part that looks wrong, please feel free to PR a fix. I did not exhaustively review each and every cargo vehicle part.
