### PR TITLE
Mute much-mutated mutant mouths

### DIFF
--- a/data/json/effects_on_condition/mutation_eocs/mutation_effect_eocs.json
+++ b/data/json/effects_on_condition/mutation_eocs/mutation_effect_eocs.json
@@ -144,7 +144,7 @@
       { "u_lose_trait": "MUTE_SLIME" },
       { "u_add_trait": "MUTE_SLIME_OK" },
       {
-        "u_message": "You realize you don't need to grow anything nearly as complicated as your old insides - one vesicle per word will suffice, but you needed a long time to learn the right rhytm."
+        "u_message": "You realize you don't need to grow anything nearly as complicated as your old insides - one vesicle per word will suffice, but you needed a long time to learn the right rhythm."
       },
       { "u_forget_recipe": "prac_unmute_slime" }
     ],

--- a/data/json/effects_on_condition/mutation_eocs/mutation_effect_eocs.json
+++ b/data/json/effects_on_condition/mutation_eocs/mutation_effect_eocs.json
@@ -6,33 +6,72 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "mute_bird_gain",
+    "id": "EOC_MUTE_BIRD_GAIN",
     "eoc_type": "EVENT",
     "required_event": "gains_mutation",
-    "condition": { "compare_string": [ "MUTE_BIRD", { "context_val": "trait" } ] },
-    "effect": { "u_learn_recipe": "prac_unmute_bird" }
+    "//": "Slightly dirty category check, since in vanilla both use the same trait.",
+    "condition": {
+      "and": [
+        { "compare_string": [ "BEAK", { "context_val": "trait" } ] },
+        { "math": [ "u_vitamin('mutagen_bird')", ">", "u_vitamin('mutagen_cephalopod')" ] }
+      ]
+    },
+    "effect": [ { "u_learn_recipe": "prac_unmute_bird" }, { "u_add_trait": "MUTE_BIRD" } ]
   },
   {
     "type": "effect_on_condition",
-    "id": "mute_cephalopod_gain",
+    "id": "EOC_MUTE_CEPHALOPOD_GAIN",
     "eoc_type": "EVENT",
     "required_event": "gains_mutation",
-    "condition": { "compare_string": [ "MUTE_CEPHALOPOD", { "context_val": "trait" } ] },
-    "effect": { "u_learn_recipe": "prac_unmute_ceph" }
+    "condition": {
+      "and": [
+        { "compare_string": [ "BEAK", { "context_val": "trait" } ] },
+        { "math": [ "u_vitamin('mutagen_bird')", "<", "u_vitamin('mutagen_cephalopod')" ] }
+      ]
+    },
+    "effect": [ { "u_learn_recipe": "prac_unmute_ceph" }, { "u_add_trait": "MUTE_CEPH" } ]
   },
   {
     "type": "effect_on_condition",
-    "id": "mute_slime_gain",
+    "id": "EOC_MUTE_GASTROPOD_GAIN",
     "eoc_type": "EVENT",
     "required_event": "gains_mutation",
-    "condition": { "compare_string": [ "MUTE_SLIME", { "context_val": "trait" } ] },
-    "effect": { "u_learn_recipe": "prac_unmute_slime" }
+    "//": "Automatically gain the mute trait when first mutating rasping tongue, check that we didn't already learn speech from earlier (slightly more complicated logic since harpoon tongues are purifiable)",
+    "condition": {
+      "and": [
+        { "compare_string": [ "GASTROPOD_EXTREMITY2", { "context_val": "trait" } ] },
+        { "not": { "u_has_trait": "MUTE_GASTROPOD_OK" } },
+        { "not": { "u_has_trait": "MUTE_GASTROPOD" } }
+      ]
+    },
+    "effect": [ { "u_learn_recipe": "prac_unmute_gastropod" }, { "u_add_trait": "MUTE_GASTROPOD" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_MUTE_INSECT_GAIN",
+    "eoc_type": "EVENT",
+    "required_event": "gains_mutation",
+    "condition": { "compare_string": [ "PROBOSCIS", { "context_val": "trait" } ] },
+    "effect": [ { "u_learn_recipe": "prac_unmute_insect" }, { "u_add_trait": "MUTE_INSECT" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_MUTE_SLIME_GAIN",
+    "eoc_type": "EVENT",
+    "required_event": "gains_mutation",
+    "condition": { "compare_string": [ "AMORPHOUS", { "context_val": "trait" } ] },
+    "effect": [ { "u_learn_recipe": "prac_unmute_slime" }, { "u_add_trait": "MUTE_SLIME" } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_UNMUTE_BIRD",
     "condition": { "math": [ "u_progress_unmute_bird", ">=", "7" ] },
-    "effect": [ { "u_mutate_towards": "MUTE_BIRD_OK" }, { "u_message": "What's that made of?  Glass.  That will have to do." } ],
+    "effect": [
+      { "u_lose_trait": "MUTE_BIRD" },
+      { "u_add_trait": "MUTE_BIRD_OK" },
+      { "u_message": "What's that made of?  Glass.  That will have to do." },
+      { "u_forget_recipe": "prac_unmute_bird" }
+    ],
     "false_effect": [
       { "math": [ "u_progress_unmute_bird", "++" ] },
       {
@@ -45,10 +84,12 @@
     "id": "EOC_UNMUTE_CEPH",
     "condition": { "math": [ "u_progress_unmute_ceph", ">=", "7" ] },
     "effect": [
-      { "u_mutate_towards": "MUTE_CEPH_OK" },
+      { "u_lose_trait": "MUTE_CEPH" },
+      { "u_add_trait": "MUTE_CEPH_OK" },
       {
         "u_message": "Your sentences are short, and you can't quite control your beak's clicking as you tire.  Still, they will understand, if they want to."
-      }
+      },
+      { "u_forget_recipe": "prac_unmute_ceph" }
     ],
     "false_effect": [
       { "math": [ "u_progress_unmute_ceph", "++" ] },
@@ -59,13 +100,53 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_UNMUTE_GASTROPOD",
+    "condition": { "math": [ "u_progress_unmute_gastropod", ">=", "10" ] },
+    "effect": [
+      { "u_lose_trait": "MUTE_GASTROPOD" },
+      { "u_add_trait": "MUTE_GASTROPOD_OK" },
+      {
+        "u_message": "As your tongues files down from use the pitch of the different sounds changes, but you have managed to get a few short, raspy sentences out."
+      },
+      { "u_forget_recipe": "prac_unmute_gastropod" }
+    ],
+    "false_effect": [
+      { "math": [ "u_progress_unmute_gastropod", "++" ] },
+      {
+        "u_message": "If you rub your tongue against your palate like this is makes a `th` - or at least, a `thrksrkkk`, but it's a start.  Ignore the taste of blood, there's work to be done."
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_UNMUTE_INSECT",
+    "condition": { "math": [ "u_progress_unmute_insect", ">=", "7" ] },
+    "effect": [
+      { "u_lose_trait": "MUTE_INSECT" },
+      { "u_add_trait": "MUTE_INSECT_OK" },
+      {
+        "u_message": "You decide on the next few words, cramp your maxillae, and inhale deeply.  With some imagination you can understand the words in the whistling, before your mouthparts fall limp and you need a pause.  Larva steps."
+      },
+      { "u_forget_recipe": "prac_unmute_insect" }
+    ],
+    "false_effect": [
+      { "math": [ "u_progress_unmute_insect", "++" ] },
+      {
+        "u_message": "You have all these new moving parts in your not-mouth, but they are struggling under the strain you put them under."
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_UNMUTE_SLIME",
     "condition": { "math": [ "u_progress_unmute_slime", ">=", "15" ] },
     "effect": [
-      { "u_mutate_towards": "MUTE_SLIME_OK" },
+      { "u_lose_trait": "MUTE_SLIME" },
+      { "u_add_trait": "MUTE_SLIME_OK" },
       {
         "u_message": "You realize you don't need to grow anything nearly as complicated as your old insides - one vesicle per word will suffice, but you needed a long time to learn the right rhytm."
-      }
+      },
+      { "u_forget_recipe": "prac_unmute_slime" }
     ],
     "false_effect": [
       { "math": [ "u_progress_unmute_slime", "++" ] },
@@ -76,27 +157,59 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "mute_bird_lose",
+    "id": "EOC_MUTE_BEAK_LOSE_1",
     "eoc_type": "EVENT",
     "required_event": "loses_mutation",
-    "condition": { "compare_string": [ "MUTE_BIRD", { "context_val": "trait" } ] },
-    "effect": { "u_forget_recipe": "prac_unmute_bird" }
+    "condition": { "and": [ { "compare_string": [ "BEAK", { "context_val": "trait" } ] } ] },
+    "effect": { "queue_eocs": "EOC_MUTE_BEAK_LOSE_2", "time_in_future": 1 }
   },
   {
     "type": "effect_on_condition",
-    "id": "mute_cephalopod_lose",
-    "eoc_type": "EVENT",
-    "required_event": "loses_mutation",
-    "condition": { "compare_string": [ "MUTE_CEPHALOPOD", { "context_val": "trait" } ] },
-    "effect": { "u_forget_recipe": "prac_unmute_ceph" }
+    "id": "EOC_MUTE_BEAK_LOSE_2",
+    "condition": { "not": { "u_has_any_trait": [ "BEAK_HUM", "BEAK_PECK" ] } },
+    "//": "Beaks are purifiable and we need to clean up both possible mutisms (unless we gained a non-purifiable beak in the process)",
+    "effect": [
+      { "u_forget_recipe": "prac_unmute_bird" },
+      { "u_forget_recipe": "prac_unmute_ceph" },
+      { "u_lose_trait": "MUTE_BIRD" },
+      { "u_lose_trait": "MUTE_BIRD_OK" },
+      { "u_lose_trait": "MUTE_CEPH" },
+      { "u_lose_trait": "MUTE_CEPH_OK" },
+      { "math": [ "u_progress_unmute_bird", "=", "0" ] },
+      { "math": [ "u_progress_unmute_ceph", "=", "0" ] },
+      {
+        "u_message": "You grasp at the base of your beak and feel the familiar contours of your old mouth.  You give it a try and your voice sounds almost like before."
+      }
+    ]
   },
   {
     "type": "effect_on_condition",
-    "id": "mute_slime_lose",
+    "id": "EOC_MUTE_GASTROPOD_LOSE_1",
     "eoc_type": "EVENT",
     "required_event": "loses_mutation",
-    "condition": { "compare_string": [ "MUTE_SLIME", { "context_val": "trait" } ] },
-    "effect": { "u_forget_recipe": "prac_unmute_bird" }
+    "//": "If we lose either trait check if we end up in a mute state via the queued EoC",
+    "condition": {
+      "or": [
+        { "compare_string": [ "GASTROPOD_EXTREMITY2", { "context_val": "trait" } ] },
+        { "compare_string": [ "GASTROPOD_EXTREMITY3", { "context_val": "trait" } ] }
+      ]
+    },
+    "effect": [ { "queue_eocs": "EOC_MUTE_GASTROPOD_LOSE_2", "time_in_future": 1 } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_MUTE_GASTROPOD_LOSE_2",
+    "//": "If we lost our lower trait and didn't gain the higher one / lost the higher trait without gaining the lower one in the process remove mutism or the compensatory traits (and progress thereof)",
+    "condition": {
+      "and": [ { "not": { "u_has_trait": "GASTROPOD_EXTREMITY3" } }, { "not": { "u_has_trait": "GASTROPOD_EXTREMITY_2" } } ]
+    },
+    "effect": [
+      { "u_forget_recipe": "prac_unmute_gastropod" },
+      { "u_lose_trait": "MUTE_GASTROPOD" },
+      { "u_lose_trait": "MUTE_GASTROPOD_OK" },
+      { "u_message": "You cough up a lot of off-color blood, but you swear in your own old voice again afterwards." },
+      { "math": [ "u_progress_unmute_gastropod", "=", "0" ] }
+    ]
   },
   {
     "type": "effect_on_condition",

--- a/data/json/effects_on_condition/mutation_eocs/mutation_effect_eocs.json
+++ b/data/json/effects_on_condition/mutation_eocs/mutation_effect_eocs.json
@@ -6,6 +6,100 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "mute_bird_gain",
+    "eoc_type": "EVENT",
+    "required_event": "gains_mutation",
+    "condition": { "compare_string": [ "MUTE_BIRD", { "context_val": "trait" } ] },
+    "effect": { "u_learn_recipe": "prac_unmute_bird" }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "mute_cephalopod_gain",
+    "eoc_type": "EVENT",
+    "required_event": "gains_mutation",
+    "condition": { "compare_string": [ "MUTE_CEPHALOPOD", { "context_val": "trait" } ] },
+    "effect": { "u_learn_recipe": "prac_unmute_ceph" }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "mute_slime_gain",
+    "eoc_type": "EVENT",
+    "required_event": "gains_mutation",
+    "condition": { "compare_string": [ "MUTE_SLIME", { "context_val": "trait" } ] },
+    "effect": { "u_learn_recipe": "prac_unmute_slime" }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_UNMUTE_BIRD",
+    "condition": { "math": [ "u_progress_unmute_bird", ">=", "7" ] },
+    "effect": [ { "u_mutate_towards": "MUTE_BIRD_OK" }, { "u_message": "What's that made of?  Glass.  That will have to do." } ],
+    "false_effect": [
+      { "math": [ "u_progress_unmute_bird", "++" ] },
+      {
+        "u_message": "Restricting your range to the apes' feels demeaning, and you decide to take a break before you start plucking out your feathers in frustration."
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_UNMUTE_CEPH",
+    "condition": { "math": [ "u_progress_unmute_ceph", ">=", "7" ] },
+    "effect": [
+      { "u_mutate_towards": "MUTE_CEPH_OK" },
+      {
+        "u_message": "Your sentences are short, and you can't quite control your beak's clicking as you tire.  Still, they will understand, if they want to."
+      }
+    ],
+    "false_effect": [
+      { "math": [ "u_progress_unmute_ceph", "++" ] },
+      {
+        "u_message": "Draw air into your mantle, close your throat, rehearse your sentence, exhale and contort your beak just so."
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_UNMUTE_SLIME",
+    "condition": { "math": [ "u_progress_unmute_slime", ">=", "15" ] },
+    "effect": [
+      { "u_mutate_towards": "MUTE_SLIME_OK" },
+      {
+        "u_message": "You realize you don't need to grow anything nearly as complicated as your old insides - one vesicle per word will suffice, but you needed a long time to learn the right rhytm."
+      }
+    ],
+    "false_effect": [
+      { "math": [ "u_progress_unmute_slime", "++" ] },
+      {
+        "u_message": "Do you need teeth, lungs?  You fall back into your resting shape in exasperation.  This will take long."
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "mute_bird_lose",
+    "eoc_type": "EVENT",
+    "required_event": "loses_mutation",
+    "condition": { "compare_string": [ "MUTE_BIRD", { "context_val": "trait" } ] },
+    "effect": { "u_forget_recipe": "prac_unmute_bird" }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "mute_cephalopod_lose",
+    "eoc_type": "EVENT",
+    "required_event": "loses_mutation",
+    "condition": { "compare_string": [ "MUTE_CEPHALOPOD", { "context_val": "trait" } ] },
+    "effect": { "u_forget_recipe": "prac_unmute_ceph" }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "mute_slime_lose",
+    "eoc_type": "EVENT",
+    "required_event": "loses_mutation",
+    "condition": { "compare_string": [ "MUTE_SLIME", { "context_val": "trait" } ] },
+    "effect": { "u_forget_recipe": "prac_unmute_bird" }
+  },
+  {
+    "type": "effect_on_condition",
     "id": "mut_eyestalk",
     "recurrence": [ "2 hours 15 minutes", "10 hours 15 minutes" ],
     "condition": {

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -7080,6 +7080,7 @@
     "description": "You've gotten rid of that terribly imprecise mouth and now imbibe your food like a proper person.  Chewing was tiresome anyway.",
     "purifiable": false,
     "prereqs": [ "MANDIBLES" ],
+    "prereqs2": [ "CHITIN", "CHITIN2", "CHITIN2_MOLTED" ],
     "category": [ "INSECT" ],
     "active": true,
     "restricts_gear": [ "mouth" ]
@@ -9660,7 +9661,8 @@
     "category": [ "BIRD" ],
     "prereqs": [ "BEAK", "BEAK_PECK", "BEAK_HUM" ],
     "flags": [ "MUTE" ],
-    "changes_to": [ "MUTE_BIRD_OK" ]
+    "valid": false,
+    "purifiable": false
   },
   {
     "type": "mutation",
@@ -9681,7 +9683,8 @@
     "description": "Your beak and new lungs have diverged too much from your human form to be capable of human speech.  <color_red>Look for a new practice recipe to lose this setback.</color>",
     "category": [ "CEPHALOPOD" ],
     "prereqs": [ "BEAK" ],
-    "changes_to": [ "MUTE_CEPH_OK" ],
+    "valid": false,
+    "purifiable": false,
     "flags": [ "MUTE" ]
   },
   {
@@ -9697,13 +9700,61 @@
   },
   {
     "type": "mutation",
+    "id": "MUTE_GASTROPOD",
+    "name": { "str": "Mute (Snail)" },
+    "points": -2,
+    "description": "Just losing your teeth would have been an adjustment, but with your new tongue human speech is straight-up impossible.  <color_red>Look for a new practice recipe to lose this setback.</color>",
+    "category": [ "GASTROPOD" ],
+    "prereqs": [ "GASTROPOD_EXTREMITY2", "GASTROPOD_EXTREMITY3" ],
+    "changes_to": [ "MUTE_GASTROPOD_OK" ],
+    "valid": false,
+    "purifiable": false,
+    "flags": [ "MUTE" ]
+  },
+  {
+    "type": "mutation",
+    "id": "MUTE_GASTROPOD_OK",
+    "name": { "str": "Speech Mimicry (Snail)" },
+    "points": 0,
+    "description": "Fine control of your radula was hard to learn, but now that you mapped out which calcified not-tooth on there makes what pitch you can open your mouth and…speak.  Yes, let's call it speaking.",
+    "category": [ "GASTROPOD" ],
+    "prereqs": [ "MUTE_GASTROPOD" ],
+    "valid": false,
+    "purifiable": false
+  },
+  {
+    "type": "mutation",
+    "id": "MUTE_INSECT",
+    "name": { "str": "Mute (Insect)" },
+    "points": -2,
+    "description": "Your mandibles already made speech hard, but now that you don't even have a tongue…<color_red>Look for a new practice recipe to lose this setback.</color>",
+    "category": [ "INSECT" ],
+    "prereqs": [ "PROBOSCIS" ],
+    "flags": [ "MUTE" ],
+    "valid": false,
+    "purifiable": false
+  },
+  {
+    "type": "mutation",
+    "id": "MUTE_INSECT_OK",
+    "name": { "str": "Speech Mimicry (Insect)" },
+    "points": 0,
+    "description": "Using all this new anatomy cramps you up, and there's spittle flying everywhere, but you can manage short sentences of whistling almost-words.",
+    "category": [ "INSECT" ],
+    "prereqs": [ "MUTE_INSECT" ],
+    "valid": false,
+    "purifiable": false
+  },
+  {
+    "type": "mutation",
     "id": "MUTE_SLIME",
     "name": { "str": "Mute (Slime)" },
     "points": -2,
     "description": "Your mouth is gone.  Oh, wait, there's one, isn't there?  If only it stopped moving around you might start to relearn something like human speech.  <color_red>Look for a new practice recipe to lose this setback.</color>",
     "category": [ "SLIME" ],
     "prereqs": [ "AMORPHOUS" ],
-    "changes_to": [ "MUTE_SLIME_OK" ],
+    "valid": false,
+    "purifiable": false,
     "flags": [ "MUTE" ]
   },
   {

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -9657,7 +9657,7 @@
     "id": "MUTE_BIRD",
     "name": { "str": "Mute (Bird)" },
     "points": -2,
-    "description": "Your beak and voicebox have changed irreversibly, rendering you incapable of human speech.  With enough practice you could relearn imitating their weird ape chirps, but it will take time.  <color_red>Look for a new practice recipe to lose this setback.</color>",
+    "description": "Your mouth and larynx have changed dramatically, rendering you incapable of human speech.  With enough practice you could relearn imitating their weird ape chirps, but it will take time.  <color_red>Look for a new practice recipe to lose this setback.</color>",
     "category": [ "BIRD" ],
     "prereqs": [ "BEAK", "BEAK_PECK", "BEAK_HUM" ],
     "flags": [ "MUTE" ],

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -9673,7 +9673,18 @@
     "category": [ "BIRD" ],
     "prereqs": [ "MUTE_BIRD" ],
     "valid": false,
-    "purifiable": false
+    "purifiable": false,
+    "//": "Least punishing social malus, but still not nothing",
+    "enchantments": [
+      {
+        "skills": [ { "value": "speech", "add": -4 } ],
+        "values": [
+          { "value": "SOCIAL_LIE", "multiply": -0.4 },
+          { "value": "SOCIAL_PERSUADE", "multiply": -0.4 },
+          { "value": "SOCIAL_INTIMIDATE", "multiply": -0.4 }
+        ]
+      }
+    ]
   },
   {
     "type": "mutation",
@@ -9696,7 +9707,17 @@
     "category": [ "CEPHALOPOD" ],
     "prereqs": [ "MUTE_CEPH" ],
     "valid": false,
-    "purifiable": false
+    "purifiable": false,
+    "enchantments": [
+      {
+        "skills": [ { "value": "speech", "add": -6 } ],
+        "values": [
+          { "value": "SOCIAL_LIE", "multiply": -0.6 },
+          { "value": "SOCIAL_PERSUADE", "multiply": -0.6 },
+          { "value": "SOCIAL_INTIMIDATE", "multiply": -0.6 }
+        ]
+      }
+    ]
   },
   {
     "type": "mutation",
@@ -9720,7 +9741,17 @@
     "category": [ "GASTROPOD" ],
     "prereqs": [ "MUTE_GASTROPOD" ],
     "valid": false,
-    "purifiable": false
+    "purifiable": false,
+    "enchantments": [
+      {
+        "skills": [ { "value": "speech", "add": -7 } ],
+        "values": [
+          { "value": "SOCIAL_LIE", "multiply": -0.7 },
+          { "value": "SOCIAL_PERSUADE", "multiply": -0.7 },
+          { "value": "SOCIAL_INTIMIDATE", "multiply": -0.7 }
+        ]
+      }
+    ]
   },
   {
     "type": "mutation",
@@ -9743,7 +9774,17 @@
     "category": [ "INSECT" ],
     "prereqs": [ "MUTE_INSECT" ],
     "valid": false,
-    "purifiable": false
+    "purifiable": false,
+    "enchantments": [
+      {
+        "skills": [ { "value": "speech", "add": -7 } ],
+        "values": [
+          { "value": "SOCIAL_LIE", "multiply": -0.7 },
+          { "value": "SOCIAL_PERSUADE", "multiply": -0.7 },
+          { "value": "SOCIAL_INTIMIDATE", "multiply": -0.7 }
+        ]
+      }
+    ]
   },
   {
     "type": "mutation",
@@ -9766,7 +9807,17 @@
     "category": [ "SLIME" ],
     "prereqs": [ "MUTE_SLIME" ],
     "valid": false,
-    "purifiable": false
+    "purifiable": false,
+    "enchantments": [
+      {
+        "skills": [ { "value": "speech", "add": -9 } ],
+        "values": [
+          { "value": "SOCIAL_LIE", "multiply": -0.9 },
+          { "value": "SOCIAL_PERSUADE", "multiply": -0.9 },
+          { "value": "SOCIAL_INTIMIDATE", "multiply": -0.9 }
+        ]
+      }
+    ]
   },
   {
     "type": "mutation",

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -9653,6 +9653,72 @@
   },
   {
     "type": "mutation",
+    "id": "MUTE_BIRD",
+    "name": { "str": "Mute (Bird)" },
+    "points": -2,
+    "description": "Your beak and voicebox have changed irreversibly, rendering you incapable of human speech.  With enough practice you could relearn imitating their weird ape chirps, but it will take time.  <color_red>Look for a new practice recipe to lose this setback.</color>",
+    "category": [ "BIRD" ],
+    "prereqs": [ "BEAK", "BEAK_PECK", "BEAK_HUM" ],
+    "flags": [ "MUTE" ],
+    "changes_to": [ "MUTE_BIRD_OK" ]
+  },
+  {
+    "type": "mutation",
+    "id": "MUTE_BIRD_OK",
+    "name": { "str": "Speech Mimicry (Bird)" },
+    "points": 0,
+    "description": "Your throat cramps, your beak twitches, but you can speak human again if you want.",
+    "category": [ "BIRD" ],
+    "prereqs": [ "MUTE_BIRD" ],
+    "valid": false,
+    "purifiable": false
+  },
+  {
+    "type": "mutation",
+    "id": "MUTE_CEPH",
+    "name": { "str": "Mute (Cephalopod)" },
+    "points": -2,
+    "description": "Your beak and new lungs have diverged too much from your human form to be capable of human speech.  <color_red>Look for a new practice recipe to lose this setback.</color>",
+    "category": [ "CEPHALOPOD" ],
+    "prereqs": [ "BEAK" ],
+    "changes_to": [ "MUTE_CEPH_OK" ],
+    "flags": [ "MUTE" ]
+  },
+  {
+    "type": "mutation",
+    "id": "MUTE_CEPH_OK",
+    "name": { "str": "Speech Mimicry (Cephalopod)" },
+    "points": 0,
+    "description": "Contorting your voice to match your surroundings is just as necessary as changing your color, even if learning it was a pain.",
+    "category": [ "CEPHALOPOD" ],
+    "prereqs": [ "MUTE_CEPH" ],
+    "valid": false,
+    "purifiable": false
+  },
+  {
+    "type": "mutation",
+    "id": "MUTE_SLIME",
+    "name": { "str": "Mute (Slime)" },
+    "points": -2,
+    "description": "Your mouth is gone.  Oh, wait, there's one, isn't there?  If only it stopped moving around you might start to relearn something like human speech.  <color_red>Look for a new practice recipe to lose this setback.</color>",
+    "category": [ "SLIME" ],
+    "prereqs": [ "AMORPHOUS" ],
+    "changes_to": [ "MUTE_SLIME_OK" ],
+    "flags": [ "MUTE" ]
+  },
+  {
+    "type": "mutation",
+    "id": "MUTE_SLIME_OK",
+    "name": { "str": "Speech Mimicry (Slime)" },
+    "points": 0,
+    "description": "Each word its own custom bubble under your membrane, waiting for its turn to pop.  It sounds like something small and furry drowning in sourdough, but if you manage to convince somebody to listen to you they will probably understand.",
+    "category": [ "SLIME" ],
+    "prereqs": [ "MUTE_SLIME" ],
+    "valid": false,
+    "purifiable": false
+  },
+  {
+    "type": "mutation",
     "id": "NOMAD",
     "name": { "str": "Nomad" },
     "points": -1,

--- a/data/json/recipes/practice/social.json
+++ b/data/json/recipes/practice/social.json
@@ -28,5 +28,44 @@
     "autolearn": [ [ "speech", 5 ] ],
     "book_learn": [ [ "textbook_speech", 4 ] ],
     "tools": [ [ "mirror" ] ]
+  },
+  {
+    "type": "practice",
+    "id": "prac_unmute_bird",
+    "activity_level": "NO_EXERCISE",
+    "category": "CC_PRACTICE",
+    "subcategory": "CSC_PRACTICE_SOCIAL",
+    "name": "relearn ape chirps",
+    "description": "Debase your beautiful new voice with trying to imitate human speech.  Still more enjoyable than trying to make them sing, in any case.",
+    "skill_used": "speech",
+    "time": "1 h",
+    "practice_data": { "min_difficulty": 0, "max_difficulty": 0, "skill_limit": 1 },
+    "result_eocs": [ "EOC_UNMUTE_BIRD" ]
+  },
+  {
+    "type": "practice",
+    "id": "prac_unmute_ceph",
+    "activity_level": "NO_EXERCISE",
+    "category": "CC_PRACTICE",
+    "subcategory": "CSC_PRACTICE_SOCIAL",
+    "name": "relearn human speech",
+    "description": "Your mantle struggles, and you need to contort your throat in ways that strain even your new, flexible form.  Still, having a shoal is preferable to going it alone.",
+    "skill_used": "speech",
+    "time": "1 h",
+    "practice_data": { "min_difficulty": 0, "max_difficulty": 0, "skill_limit": 1 },
+    "result_eocs": [ "EOC_UNMUTE_CEPH" ]
+  },
+  {
+    "type": "practice",
+    "id": "prac_unmute_slime",
+    "activity_level": "NO_EXERCISE",
+    "category": "CC_PRACTICE",
+    "subcategory": "CSC_PRACTICE_SOCIAL",
+    "name": "relearn human speech",
+    "description": "Couldn't you use some pheromones?  A packet of injected slime rewiring their brain?  Anything less demeaning than trying to ape the apes.",
+    "skill_used": "speech",
+    "time": "1 h",
+    "practice_data": { "min_difficulty": 0, "max_difficulty": 0, "skill_limit": 1 },
+    "result_eocs": [ "EOC_UNMUTE_SLIME" ]
   }
 ]

--- a/data/json/recipes/practice/social.json
+++ b/data/json/recipes/practice/social.json
@@ -57,6 +57,32 @@
   },
   {
     "type": "practice",
+    "id": "prac_unmute_gastropod",
+    "activity_level": "NO_EXERCISE",
+    "category": "CC_PRACTICE",
+    "subcategory": "CSC_PRACTICE_SOCIAL",
+    "name": "relearn human speech",
+    "description": "You don't have any teeth to stop airflow, and with your new tongue even closing your mouth feels unnaturally cramped.  However, rubbing different areas of your radula makes for an interesting cacophony - that might be a solution, if only you get the pitch just right.",
+    "skill_used": "speech",
+    "time": "1 h",
+    "practice_data": { "min_difficulty": 0, "max_difficulty": 0, "skill_limit": 1 },
+    "result_eocs": [ "EOC_UNMUTE_GASTROPOD" ]
+  },
+  {
+    "type": "practice",
+    "id": "prac_unmute_insect",
+    "activity_level": "NO_EXERCISE",
+    "category": "CC_PRACTICE",
+    "subcategory": "CSC_PRACTICE_SOCIAL",
+    "name": "relearn human speech",
+    "description": "Maybe you could rub your chitin together?  No, the apes need their vowels.",
+    "skill_used": "speech",
+    "time": "1 h",
+    "practice_data": { "min_difficulty": 0, "max_difficulty": 0, "skill_limit": 1 },
+    "result_eocs": [ "EOC_UNMUTE_INSECT" ]
+  },
+  {
+    "type": "practice",
     "id": "prac_unmute_slime",
     "activity_level": "NO_EXERCISE",
     "category": "CC_PRACTICE",

--- a/doc/MUTATIONS.md
+++ b/doc/MUTATIONS.md
@@ -135,7 +135,7 @@ Note that **all new traits that can be obtained through mutation must be purifia
   "prereqs2": [ "CEPH_EYES", "LIZ_EYE" ],
   "threshreq": [ "THRESH_SPIDER" ],           // Required threshold for this mutation to be possible.
   "cancels": [ "ROT1", "ROT2", "ROT3" ],      // Cancels these mutations when mutating.
-  "changes_to": [ "FASTHEALER2" ],            // Can change into these mutations when mutating further.
+  "changes_to": [ "FASTHEALER2" ],            // Can change into these mutations when mutating further, provided the new trait has this as its prerequisite.
   "leads_to": [ ],                            // Mutations that add to this one.
   "wet_protection": [ { "part": "head", "good": 1 } ],    // Wet Protection on specific bodyparts.  Possible values: "neutral/good/ignored".  Good increases pos and cancels neg, neut cancels neg, ignored cancels both.
   "vitamin_rates": [ [ "vitC", -1200 ] ],     // How much extra vitamins do you consume, one point per this many seconds.  Negative values mean production.

--- a/tools/spell_checker/dictionary.txt
+++ b/tools/spell_checker/dictionary.txt
@@ -3290,6 +3290,7 @@ LARP
 LARPing
 Larry
 Larson
+larynx
 Las
 lategame
 Latin
@@ -4920,6 +4921,7 @@ radiants
 radiobeacon
 radiogenic
 radiophile
+radula
 rafflesias
 raggiana
 Ragnarok


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Mute very divergent mouth mutations"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
As always, mutations act like they change your character in huge ways but tend to ignore some consequences.
In this case, speech: it needs some very nifty biomechanics, and a lot of our mouth mutations should be more of a problem than they are currently. 

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
- Added ~~three~~ ~~four~~ five specific mute traits for Slime (Amorphous), Bird (Beaks), and Cephalopod (Beak), Snail (Rasping Tongue), Insect (Proboscis)
- Added practice recipes to relearn speech and the EoC framework to handle it
- Added specific replacement trait for succeeding in your mimicry practice

TODO:
- [x] Check the bird beak-switching situation explicitly
- [x] More testing
- [x] Decide if any more lines get hit with the ugly stick
- [x] Add some social maluses for sounding like a crime against nature
 - Maluses scale from relevant `*0,6 rolls / - 4 social` (Bird) to the debilitating `*,1 / - 9 social` for Slimes. Hope you made friends before becoming weird!

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
~~Include the bug lines, but mandibles are described as "surrounding" your mouth. Might swing back around on it.~~
Both Proboscis and a radula are divergent enough to get hit by the mute stick.
Have them as a valid trait to gain after you gain the base part but getting to speak until you mutate again was pretty janky and  event EoCs do the trick well enough.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
Gained the traits, got muted.
Did the practice, got unmuted, lost the traits.
Lost the traits (base Beak and the Snail tongues are purifiable), traits got removed and progress cleaned up.
Gained the upgraded parts, mute trait stayed.
Tested both using completely vanilla mutation and debug menu trait gaining.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
Obviously part of limbing the mouths, but having the base traits in vanilla will help keep the line count down.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
