### PR TITLE
Update furniture_fireplaces.json to include open roof rock floor fire ring

### DIFF
--- a/data/json/construction/furniture_fireplaces.json
+++ b/data/json/construction/furniture_fireplaces.json
@@ -40,6 +40,19 @@
   },
   {
     "type": "construction",
+    "id": "constr_firering_on_rock_no_roof",
+    "group": "build_fire_ring",
+    "category": "FURN",
+    "required_skills": [ [ "survival", 0 ] ],
+    "time": "10 m",
+    "components": [ [ [ "rock", 20 ] ] ],
+    "pre_note": "Can be deconstructed without tools.",
+    "dark_craftable": true,
+    "pre_terrain": "t_rock_floor_no_roof",
+    "post_terrain": "f_firering"
+  },
+  {
+    "type": "construction",
     "id": "constr_firering_underground",
     "group": "build_fire_ring",
     "category": "FURN",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

It was not possible to construct a fire ring on t_rock_floor_no_roof. I noticed this in my new Innawoods playthrough near a hotspring.

#### Describe the solution

Adding another construction variant to include t_rock_floor_no_roof.

#### Describe alternatives you've considered

Somehow making all hard and flat-ish terrain types able to support a fire ring? 

#### Testing

I reloaded my save after the change, the variant to construct the fire ring showed up and the construction was successful.

#### Additional context

None.
