### PR TITLE
[Xedra Evolved] Update Homullus civilization checker to run once per OMT

### DIFF
--- a/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_eocs.json
@@ -1,69 +1,52 @@
 [
   {
     "type": "effect_on_condition",
-    "id": "EOC_HOMULLUS_IN_CIVILIZATION_CHECK_CIVILIZATION_ON_OMT_ENTER",
+    "id": "EOC_CONDITION_CHECK_HOMULLUS_IN_CIVILIZATION_ON_OMT_ENTER",
     "eoc_type": "EVENT",
     "required_event": "avatar_enters_omt",
-    "//": "map_in_city cannot check talker location directly, so this is a substitute for enchantment conditions until that is possible.  It does work on random roads in the middle of nowhere, but that's not such a bad thing.",
-    "condition": {
-      "and": [
-        {
-          "or": [
-            {
+    "condition": { "u_has_trait": "HOMULLUS" },
+    "effect": [
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_CONDITION_CHECK_HOMULLUS_IN_CIVILIZATION_ON_OMT_ENTER_2",
+            "condition": {
               "or": [
-                { "u_near_om_location": "FACTION_CAMP_ANY", "range": 6 },
-                { "u_near_om_location": "evac_center_18", "range": 6 },
-                { "u_near_om_location": "isolated_road_field_0", "range": 6 },
-                { "u_near_om_location": "lumbermill_0_0_ocu", "range": 6 },
-                { "u_near_om_location": "ranch_camp_41", "range": 6 },
-                { "u_near_om_location": "godco_5", "range": 6 },
-                { "u_near_om_location": "smallscrapyard_ocu", "range": 4 },
-                { "u_near_om_location": "robofachq_surface_entrance", "range": 6 }
+                { "test_eoc": "EOC_CONDITION_HOMULLUS_NEAR_FACTION" },
+                { "map_in_city": { "mutator": "loc_relative_u", "target": "(0,0,0)" } }
               ]
             },
-            {
-              "and": [
-                {
-                  "or": [
-                    { "u_near_om_location": "road_curved", "range": 3 },
-                    { "u_near_om_location": "road_four_way", "range": 3 },
-                    { "u_near_om_location": "road_tee", "range": 3 },
-                    { "u_near_om_location": "road_straight", "range": 3 },
-                    { "u_near_om_location": "road_end", "range": 3 },
-                    { "u_near_om_location": "road_sw", "range": 3 },
-                    { "u_near_om_location": "road_ne", "range": 3 },
-                    { "u_near_om_location": "road_ew", "range": 3 },
-                    { "u_near_om_location": "road_ns", "range": 3 },
-                    { "u_near_om_location": "road_nesw", "range": 3 },
-                    { "u_near_om_location": "road", "range": 3 },
-                    { "u_near_om_location": "dirt_road", "range": 3 },
-                    { "u_near_om_location": "subway", "range": 3 }
-                  ]
-                },
-                {
-                  "and": [
-                    { "not": { "u_at_om_location": "field" } },
-                    { "not": { "u_at_om_location": "forest" } },
-                    { "not": { "u_at_om_location": "forest_thick" } },
-                    { "not": { "u_at_om_location": "forest_water" } },
-                    { "not": { "u_at_om_location": "lake_surface" } },
-                    { "not": { "u_at_om_location": "river_center" } }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        { "u_has_trait": "HOMULLUS" }
+            "effect": [ { "math": [ "u_homullus_is_in_civilization", "=", "1" ] } ],
+            "false_effect": [ { "math": [ "u_homullus_is_in_civilization", "=", "0" ] } ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CONDITION_HOMULLUS_NEAR_FACTION",
+    "condition": {
+      "or": [
+        { "u_near_om_location": "FACTION_CAMP_ANY", "range": 2 },
+        { "u_near_om_location": "evac_center_13", "range": 3 },
+        { "u_near_om_location": "evac_center_18", "range": 6 },
+        { "u_near_om_location": "isolated_road_field_0", "range": 2 },
+        { "u_near_om_location": "horse_farm_isherwood_9", "range": 3 },
+        { "u_near_om_location": "farm_isherwood_2", "range": 3 },
+        { "u_near_om_location": "dairy_farm_isherwood_SW", "range": 3 },
+        { "u_near_om_location": "lumbermill_0_0_ocu", "range": 1 },
+        { "u_near_om_location": "ranch_camp_41", "range": 6 },
+        { "u_near_om_location": "godco_5", "range": 3 },
+        { "u_near_om_location": "smallscrapyard_ocu", "range": 1 },
+        { "u_near_om_location": "robofachq_surface_entrance", "range": 4 }
       ]
     },
-    "effect": [ { "math": [ "u_homullus_is_in_civilization", "=", "1" ] } ],
-    "false_effect": [ { "math": [ "u_homullus_is_in_civilization", "=", "0" ] } ]
+    "effect": [  ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_HOMULLUS_IN_CIVILIZATION_CHECKER_CONDITION",
-    "//": "map_in_city cannot check talker location directly, so this is a substitute for enchantment conditions until that is possible.  It does work on random roads in the middle of nowhere, but that's not such a bad thing.",
     "condition": { "math": [ "u_homullus_is_in_civilization", "==", "1" ] },
     "effect": [  ]
   },
@@ -155,33 +138,9 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_HOMULLUS_GOBLIN_FRUIT",
-    "effect": [
-      {
-        "set_string_var": { "mutator": "loc_relative_u", "target": "(0,0,0)" },
-        "target_var": { "context_val": "homullus_location" }
-      },
-      {
-        "run_eocs": [
-          {
-            "id": "EOC_HOMULLUS_GOBLIN_FRUIT_2",
-            "//": "This EoC is required because map_in_city cannot check talker location directly.",
-            "condition": {
-              "or": [
-                { "u_near_om_location": "evac_center_13", "range": 3 },
-                { "u_near_om_location": "robofachq_surface_entrance", "range": 3 },
-                { "u_near_om_location": "isolated_road_field_0", "range": 2 },
-                { "u_near_om_location": "ranch_camp_41", "range": 3 },
-                { "u_near_om_location": "godco_5", "range": 3 },
-                { "u_at_om_location": "FACTION_CAMP_ANY" },
-                { "map_in_city": { "mutator": "loc_relative_u", "target": "(0,0,0)" } }
-              ]
-            },
-            "effect": [ { "u_cast_spell": { "id": "cultivate_goblin_fruit_real" } } ],
-            "false_effect": [ { "u_message": "You must be in the remnants of civilization to call forth a goblin fruit.", "type": "bad" } ]
-          }
-        ]
-      }
-    ]
+    "condition": { "test_eoc": "EOC_HOMULLUS_IN_CIVILIZATION_CHECKER_CONDITION" },
+    "effect": [ { "u_cast_spell": { "id": "cultivate_goblin_fruit_real" } } ],
+    "false_effect": [ { "u_message": "You must be in the remnants of civilization to call forth a goblin fruit.", "type": "bad" } ]
   },
   {
     "type": "effect_on_condition",
@@ -379,17 +338,7 @@
       "and": [
         {
           "or": [
-            { "u_near_om_location": "evac_center_13", "range": 3 },
-            { "u_near_om_location": "evac_center_09", "range": 3 },
-            { "u_near_om_location": "robofachq_surface_entrance", "range": 3 },
-            { "u_near_om_location": "isolated_road_field_0", "range": 1 },
-            { "u_near_om_location": "lumbermill_0_0_ocu", "range": 1 },
-            { "u_near_om_location": "ranch_camp_41", "range": 3 },
-            { "u_near_om_location": "ranch_camp_35", "range": 3 },
-            { "u_near_om_location": "ranch_camp_22", "range": 3 },
-            { "u_near_om_location": "ranch_camp_11", "range": 3 },
-            { "u_near_om_location": "godco_5", "range": 3 },
-            { "u_at_om_location": "FACTION_CAMP_ANY" },
+            { "test_eoc": "EOC_CONDITION_HOMULLUS_NEAR_FACTION" },
             { "math": [ "u_characters_nearby('radius': 50, 'attitude': 'any')", ">=", "15" ] }
           ]
         }

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_eocs.json
@@ -13,6 +13,7 @@
             "condition": {
               "or": [
                 { "test_eoc": "EOC_CONDITION_HOMULLUS_NEAR_FACTION" },
+                { "u_near_om_location": "FACTION_CAMP_ANY", "range": 2 },
                 { "map_in_city": { "mutator": "loc_relative_u", "target": "(0,0,0)" } }
               ]
             },
@@ -28,7 +29,6 @@
     "id": "EOC_CONDITION_HOMULLUS_NEAR_FACTION",
     "condition": {
       "or": [
-        { "u_near_om_location": "FACTION_CAMP_ANY", "range": 2 },
         { "u_near_om_location": "evac_center_13", "range": 3 },
         { "u_near_om_location": "evac_center_18", "range": 6 },
         { "u_near_om_location": "isolated_road_field_0", "range": 2 },

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_eocs.json
@@ -57,8 +57,8 @@
         { "u_has_trait": "HOMULLUS" }
       ]
     },
-    "effect": [ { "math": [ "u_homullus_is_in_civilization", "=", "1" ] }  ],
-    "false_effect":  [ { "math": [ "u_homullus_is_in_civilization", "=", "0" ] }]
+    "effect": [ { "math": [ "u_homullus_is_in_civilization", "=", "1" ] } ],
+    "false_effect": [ { "math": [ "u_homullus_is_in_civilization", "=", "0" ] } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_eocs.json
@@ -1,56 +1,71 @@
 [
   {
     "type": "effect_on_condition",
-    "id": "EOC_HOMULLUS_IN_CIVILIZATION_CHECKER_CONDITION",
+    "id": "EOC_HOMULLUS_IN_CIVILIZATION_CHECK_CIVILIZATION_ON_OMT_ENTER",
+    "eoc_type": "EVENT",
+    "required_event": "avatar_enters_omt",
     "//": "map_in_city cannot check talker location directly, so this is a substitute for enchantment conditions until that is possible.  It does work on random roads in the middle of nowhere, but that's not such a bad thing.",
     "condition": {
-      "or": [
+      "and": [ 
         {
           "or": [
-            { "u_near_om_location": "FACTION_CAMP_ANY", "range": 6 },
-            { "u_near_om_location": "evac_center_18", "range": 6 },
-            { "u_near_om_location": "isolated_road_field_0", "range": 6 },
-            { "u_near_om_location": "lumbermill_0_0_ocu", "range": 6 },
-            { "u_near_om_location": "ranch_camp_41", "range": 6 },
-            { "u_near_om_location": "godco_5", "range": 6 },
-            { "u_near_om_location": "smallscrapyard_ocu", "range": 4 },
-            { "u_near_om_location": "robofachq_surface_entrance", "range": 6 }
-          ]
-        },
-        {
-          "and": [
             {
               "or": [
-                { "u_near_om_location": "road_curved", "range": 3 },
-                { "u_near_om_location": "road_four_way", "range": 3 },
-                { "u_near_om_location": "road_tee", "range": 3 },
-                { "u_near_om_location": "road_straight", "range": 3 },
-                { "u_near_om_location": "road_end", "range": 3 },
-                { "u_near_om_location": "road_sw", "range": 3 },
-                { "u_near_om_location": "road_ne", "range": 3 },
-                { "u_near_om_location": "road_ew", "range": 3 },
-                { "u_near_om_location": "road_ns", "range": 3 },
-                { "u_near_om_location": "road_nesw", "range": 3 },
-                { "u_near_om_location": "road", "range": 3 },
-                { "u_near_om_location": "dirt_road", "range": 3 },
-                { "u_near_om_location": "subway", "range": 3 }
+                { "u_near_om_location": "FACTION_CAMP_ANY", "range": 6 },
+                { "u_near_om_location": "evac_center_18", "range": 6 },
+                { "u_near_om_location": "isolated_road_field_0", "range": 6 },
+                { "u_near_om_location": "lumbermill_0_0_ocu", "range": 6 },
+                { "u_near_om_location": "ranch_camp_41", "range": 6 },
+                { "u_near_om_location": "godco_5", "range": 6 },
+                { "u_near_om_location": "smallscrapyard_ocu", "range": 4 },
+                { "u_near_om_location": "robofachq_surface_entrance", "range": 6 }
               ]
             },
             {
               "and": [
-                { "not": { "u_at_om_location": "field" } },
-                { "not": { "u_at_om_location": "forest" } },
-                { "not": { "u_at_om_location": "forest_thick" } },
-                { "not": { "u_at_om_location": "forest_water" } },
-                { "not": { "u_at_om_location": "lake_surface" } },
-                { "not": { "u_at_om_location": "river_center" } }
+                {
+                  "or": [
+                    { "u_near_om_location": "road_curved", "range": 3 },
+                    { "u_near_om_location": "road_four_way", "range": 3 },
+                    { "u_near_om_location": "road_tee", "range": 3 },
+                    { "u_near_om_location": "road_straight", "range": 3 },
+                    { "u_near_om_location": "road_end", "range": 3 },
+                    { "u_near_om_location": "road_sw", "range": 3 },
+                    { "u_near_om_location": "road_ne", "range": 3 },
+                    { "u_near_om_location": "road_ew", "range": 3 },
+                    { "u_near_om_location": "road_ns", "range": 3 },
+                    { "u_near_om_location": "road_nesw", "range": 3 },
+                    { "u_near_om_location": "road", "range": 3 },
+                    { "u_near_om_location": "dirt_road", "range": 3 },
+                    { "u_near_om_location": "subway", "range": 3 }
+                  ]
+                },
+                {
+                  "and": [
+                    { "not": { "u_at_om_location": "field" } },
+                    { "not": { "u_at_om_location": "forest" } },
+                    { "not": { "u_at_om_location": "forest_thick" } },
+                    { "not": { "u_at_om_location": "forest_water" } },
+                    { "not": { "u_at_om_location": "lake_surface" } },
+                    { "not": { "u_at_om_location": "river_center" } }
+                  ]
+                }
               ]
             }
           ]
-        }
+        },
+        { "u_has_trait": "HOMULLUS" }
       ]
     },
-    "effect": [  ]
+    "effect": [ { "math": [ "u_homullus_is_in_civilization", "=", "1" ] }  ],
+    "false_effect":  [ { "math": [ "u_homullus_is_in_civilization", "=", "0" ] }]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_HOMULLUS_IN_CIVILIZATION_CHECKER_CONDITION",
+    "//": "map_in_city cannot check talker location directly, so this is a substitute for enchantment conditions until that is possible.  It does work on random roads in the middle of nowhere, but that's not such a bad thing.",
+    "condition": { "math": [ "u_homullus_is_in_civilization", "==", "1" ] },
+    "effect": []
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_eocs.json
@@ -6,7 +6,7 @@
     "required_event": "avatar_enters_omt",
     "//": "map_in_city cannot check talker location directly, so this is a substitute for enchantment conditions until that is possible.  It does work on random roads in the middle of nowhere, but that's not such a bad thing.",
     "condition": {
-      "and": [ 
+      "and": [
         {
           "or": [
             {

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_eocs.json
@@ -65,7 +65,7 @@
     "id": "EOC_HOMULLUS_IN_CIVILIZATION_CHECKER_CONDITION",
     "//": "map_in_city cannot check talker location directly, so this is a substitute for enchantment conditions until that is possible.  It does work on random roads in the middle of nowhere, but that's not such a bad thing.",
     "condition": { "math": [ "u_homullus_is_in_civilization", "==", "1" ] },
-    "effect": []
+    "effect": [  ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_spell_learning_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_spell_learning_eocs.json
@@ -26,26 +26,13 @@
     "deactivate_condition": { "not": { "u_has_trait": "HOMULLUS" } },
     "effect": [
       {
-        "set_string_var": { "mutator": "loc_relative_u", "target": "(0,0,0)" },
-        "target_var": { "context_val": "homullus_location" }
-      },
-      {
         "run_eocs": [
           {
             "id": "EOC_HOMULLUS_SPELL_EXPERIENCE_INCREASER_2",
-            "//": "This EoC is required because map_in_city cannot check talker location directly.",
             "condition": {
               "or": [
-                { "u_at_om_location": "FACTION_CAMP_ANY" },
-                { "u_near_om_location": "evac_center_13", "range": 3 },
-                { "u_near_om_location": "robofachq_surface_entrance", "range": 3 },
-                { "u_near_om_location": "isolated_road_field_0", "range": 2 },
-                { "u_near_om_location": "ranch_camp_41", "range": 3 },
-                { "u_near_om_location": "godco_5", "range": 3 },
-                { "u_at_om_location": "homullus_genius_loci_NW" },
-                { "u_at_om_location": "homullus_genius_loci_NE" },
-                { "u_at_om_location": "homullus_genius_loci_SW" },
-                { "u_at_om_location": "homullus_genius_loci_SE" },
+                { "test_eoc": "EOC_CONDITION_HOMULLUS_NEAR_FACTION" },
+                { "u_near_om_location": "FACTION_CAMP_ANY", "range": 2 },
                 { "map_in_city": { "mutator": "loc_relative_u", "target": "(0,0,0)" } }
               ]
             },

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_magic_terrain_adjustments.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_magic_terrain_adjustments.json
@@ -160,32 +160,8 @@
     "id": "EOC_HOMULLUS_MAGIC_ADJUSTMENT_IN_CIVILIZATION",
     "eoc_type": "EVENT",
     "required_event": "opens_spellbook",
-    "effect": [
-      {
-        "set_string_var": { "mutator": "loc_relative_u", "target": "(0,0,0)" },
-        "target_var": { "context_val": "homullus_location" }
-      },
-      {
-        "run_eocs": [
-          {
-            "id": "EOC_HOMULLUS_MAGIC_ADJUSTMENT_IN_CIVILIZATION_2",
-            "//": "This EoC is required because map_in_city cannot check talker location directly.",
-            "condition": {
-              "or": [
-                { "u_near_om_location": "evac_center_13", "range": 3 },
-                { "u_near_om_location": "robofachq_surface_entrance", "range": 3 },
-                { "u_near_om_location": "isolated_road_field_0", "range": 2 },
-                { "u_near_om_location": "ranch_camp_41", "range": 3 },
-                { "u_near_om_location": "godco_5", "range": 3 },
-                { "u_at_om_location": "FACTION_CAMP_ANY" },
-                { "map_in_city": { "mutator": "loc_relative_u", "target": "(0,0,0)" } }
-              ]
-            },
-            "effect": [ { "math": [ "u_spellcasting_adjustment('difficulty', 'school': 'HOMULLUS' )", "=", "-2" ] } ]
-          }
-        ]
-      }
-    ]
+    "condition": { "test_eoc": "EOC_HOMULLUS_IN_CIVILIZATION_CHECKER_CONDITION" },
+    "effect": [ { "math": [ "u_spellcasting_adjustment('difficulty', 'school': 'HOMULLUS' )", "=", "-2" ] } ]
   },
   {
     "type": "effect_on_condition",
@@ -210,14 +186,7 @@
       "and": [
         {
           "and": [
-            "u_is_outside",
-            {
-              "or": [
-                { "u_is_on_terrain_with_flag": "SHRUB" },
-                { "u_is_on_terrain_with_flag": "DIGGABLE" },
-                { "u_is_on_terrain_with_flag": "YOUNG" }
-              ]
-            },
+            { "not": { "test_eoc": "EOC_HOMULLUS_IN_CIVILIZATION_CHECKER_CONDITION" } },
             { "not": { "u_near_om_location": "road_curved", "range": 1 } },
             { "not": { "u_near_om_location": "road_four_way", "range": 1 } },
             { "not": { "u_near_om_location": "road_tee", "range": 1 } },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Xedra Evolved] Update Homullus civilization checker to run once per OMT"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Previous version ran every second, which isn't necessary at all. 

Fixes #74142
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Following GuardianDII's suggestion, have an event EoC that checks when the Homullus enters a new OMT and sets a variable that determines whether that tile counts as "in civilization" or not, and repurpose the previous `test_eoc` conditional EoC for use in checking the variable. This also allows the use of `map_in_city` to set the variable, since that was previously checked on the OMT level anyway. This unifies the Homullus civilization conditions into one place, making them easier to maintain as new locations are added. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

It works properly. 

However, it's a little unclear what exactly counts as a city. See #74177

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I should come up with `test_eoc` conditions for Arvore, Undine, etc too for ease of maintainability, but in another PR. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
