### PR TITLE
Load sound-triggered traps with more safety

### DIFF
--- a/data/json/traps.json
+++ b/data/json/traps.json
@@ -1170,18 +1170,6 @@
   },
   {
     "type": "trap",
-    "id": "tr_noisetest",
-    "name": "noise test trap",
-    "color": "light_cyan",
-    "symbol": "_",
-    "visibility": 0,
-    "avoidance": 8,
-    "difficulty": 0,
-    "action": "sound_detect",
-    "sound_threshold": [ 15, 25 ]
-  },
-  {
-    "type": "trap",
     "id": "tr_teeth",
     "name": "scattered monster teeth",
     "color": "light_cyan",

--- a/src/trap.cpp
+++ b/src/trap.cpp
@@ -429,6 +429,12 @@ void trap::check_consistency()
                 debugmsg( "trap %s has unknown item as component %s", t.id.str(), item_type.str() );
             }
         }
+        if( t.sound_threshold.first > t.sound_threshold.second ) {
+            debugmsg( "trap %s has higher min sound threshold than max and can never trigger", t.id.str() );
+        }
+        if( ( t.sound_threshold.first > 0 ) != ( t.sound_threshold.second > 0 ) ) {
+            debugmsg( "trap %s has bad sound threshold of 0 and will trigger on anything", t.id.str() );
+        }
     }
 }
 

--- a/src/trap.h
+++ b/src/trap.h
@@ -65,7 +65,7 @@ bool map_regen( const tripoint &p, Creature *c, item *i );
 bool drain( const tripoint &p, Creature *c, item *i );
 bool snake( const tripoint &p, Creature *c, item *i );
 bool cast_spell( const tripoint &p, Creature *critter, item * );
-bool sound_detect( const tripoint &p, Creature *, item * );
+bool dummy_trap( const tripoint &p, Creature *critter, item * );
 } // namespace trapfunc
 
 struct vehicle_handle_trap_data {

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -1636,13 +1636,8 @@ bool trapfunc::snake( const tripoint &p, Creature *, item * )
     return true;
 }
 
-/**
- * Made to test sound-triggered traps.
- * Warning: generating a sound can trigger sound-triggered traps.
- */
-bool trapfunc::sound_detect( const tripoint &p, Creature *, item * )
+bool trapfunc::dummy_trap( const tripoint &, Creature *, item * )
 {
-    sounds::sound( p, 10, sounds::sound_t::alert, _( "Sound Detected!" ), false, "misc" );
     return true;
 }
 
@@ -1690,7 +1685,7 @@ const trap_function &trap_function_from_string( const std::string &function_name
             { "drain", trapfunc::drain },
             { "spell", trapfunc::cast_spell },
             { "snake", trapfunc::snake },
-            { "sound_detect", trapfunc::sound_detect }
+            { "dummy_trap", trapfunc::dummy_trap }
         }
     };
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
An enterprising modder was trying to use the `character_triggers_trap` event for eoc scripting and found out that sound_detect traps didn't actually require a sound threshold to trigger. 

Further investigation found that sound_detect is a (rather confusingly named!) vestigial trapfunc used only for initial testing sound-triggered traps. Sound-triggered traps definitely work, and we have an existing trap type (tr_dormant_zombie) which uses them.

#### Describe the solution
-Delete sound_detect trapfunc and associated trap. These were not encounterable outside of the debug menu and the trapfunc itself did nothing besides verify its function, so this shouldn't impact mods. No migration or save handling was provided (if a save does have them it will delete  the trap on load after throwing an error about being unable to find it).

-Add some safety to our loading by throwing errors when invalid sound_thresholds are detected.

-Add dummy_trap function which always counts as triggering when called (thus calling the event bus) for our enterprising modder.
--I had originally added a dummy trap to traps.json as a sort of in-json documentation, but on reflection I found it hypocritical to be adding an unused trap in the same PR I was removing one. Maybe we should separate out the traps documentation from json_info.md and list(just list, not describe) the hardcoded trapfuncs so people can reasonably know they exist?

#### Describe alternatives you've considered
Actual documentation for traps?

Unit test for sound-triggered traps?

#### Testing
Game loads, dummy trap calls event bus when stepped on

#### Additional context
```
  {
    "type": "trap",
    "id": "tr_dummy_always_triggers",
    "name": "noise test trap",
    "color": "light_cyan",
    "symbol": "_",
    "visibility": 0,
    "avoidance": 99,
    "difficulty": 99,
    "action": "dummy_trap"
  },
  ```