### PR TITLE
Fix inconsistencies in corn and popcorn

### DIFF
--- a/data/json/items/comestibles/raw_grain.json
+++ b/data/json/items/comestibles/raw_grain.json
@@ -59,24 +59,29 @@
   },
   {
     "type": "COMESTIBLE",
+    "id": "popcorn_cob",
+    "name": { "str": "popcorn cob" },
+    "comestible_type": "FOOD",
+    "copy-from": "corn",
+    "fun": -2,
+    "description": "A popcorn cob full of popcorn kernels.  You can eat them on the cob or shell it for cooking.",
+    "use_action": { "type": "consume_drug", "used_up_item": "empty_corn_cob", "moves": 500 }
+  },
+  {
+    "type": "COMESTIBLE",
     "id": "popcorn_raw",
     "name": { "str_sp": "raw popcorn" },
-    "weight": "140 g",
+    "copy-from": "corn_kernels",
     "color": "light_green",
-    "spoils_in": "5 days",
     "comestible_type": "FOOD",
-    "symbol": "%",
     "calories": 120,
     "description": "A special variety of corn which could be used for making popcorn, after it's dried.  Unlike normal corn, it's not sweet and is more dry.",
     "price": "1 USD 70 cent",
-    "material": [ "veggy" ],
-    "volume": "195 ml",
     "fun": -2,
-    "vitamins": [ [ "vitC", 12 ], [ "iron", 4 ] ],
     "smoking_result": "kernels",
     "petfood": [ "CATTLEFOOD", "BIRDFOOD" ],
     "flags": [ "NUTRIENT_OVERRIDE", "EATEN_HOT", "SMOKABLE", "RAW", "PLANTABLE_SEED", "CATTLE", "BIRD", "RAT", "MOUSE" ],
-    "seed_data": { "plant_name": "popcorn", "fruit": "popcorn_raw", "seeds": false, "byproducts": [ "withered" ], "grow": "91 days" }
+    "seed_data": { "plant_name": "popcorn", "fruit": "popcorn_cob", "seeds": false, "byproducts": [ "withered" ], "grow": "91 days" }
   },
   {
     "type": "COMESTIBLE",
@@ -96,7 +101,7 @@
     "fun": -6,
     "petfood": [ "CATTLEFOOD", "BIRDFOOD" ],
     "flags": [ "NUTRIENT_OVERRIDE", "EDIBLE_FROZEN", "PLANTABLE_SEED", "INEDIBLE", "CATTLE", "BIRD", "RAT", "MOUSE" ],
-    "seed_data": { "plant_name": "popcorn", "fruit": "popcorn_raw", "seeds": false, "byproducts": [ "withered" ], "grow": "91 days" }
+    "seed_data": { "plant_name": "popcorn", "fruit": "popcorn_cob", "seeds": false, "byproducts": [ "withered" ], "grow": "91 days" }
   },
   {
     "type": "COMESTIBLE",

--- a/data/json/items/comestibles/seed.json
+++ b/data/json/items/comestibles/seed.json
@@ -1010,7 +1010,7 @@
     "container": "null",
     "extend": { "flags": [ "NUTRIENT_OVERRIDE" ] },
     "description": "A bunch of dry unpopped corn.  It's intended for planting, but could be put to other uses.",
-    "seed_data": { "plant_name": "popcorn", "fruit": "popcorn_raw", "seeds": false, "byproducts": [ "withered" ], "grow": "91 days" }
+    "seed_data": { "plant_name": "popcorn", "fruit": "popcorn_cob", "seeds": false, "byproducts": [ "withered" ], "grow": "91 days" }
   },
   {
     "type": "COMESTIBLE",

--- a/data/json/items/comestibles/veggy_dishes.json
+++ b/data/json/items/comestibles/veggy_dishes.json
@@ -1170,7 +1170,7 @@
     "vitamins": [ [ "vitC", 12 ], [ "iron", 4 ] ],
     "petfood": [ "CATTLEFOOD" ],
     "flags": [ "EDIBLE_FROZEN", "RAW", "INEDIBLE", "CATTLE", "PLANTABLE_SEED" ],
-    "seed_data": { "plant_name": "corn", "fruit": "corn", "byproducts": [ "withered" ], "grow": "80 days" }
+    "seed_data": { "plant_name": "corn", "fruit": "corn", "seeds": false, "byproducts": [ "withered" ], "grow": "80 days" }
   },
   {
     "type": "COMESTIBLE",

--- a/data/json/recipes/food/brewing.json
+++ b/data/json/recipes/food/brewing.json
@@ -91,7 +91,7 @@
     "//": "assuming grains are roasted, slightly variable weight roughly close to 20u flour, +10u for the junipers",
     "components": [
       [ [ "water_clean", 2 ] ],
-      [ [ "corn", 3 ], [ "cornmeal", 5 ], [ "barley", 1 ], [ "buckwheat", 1 ], [ "oats", 3 ] ],
+      [ [ "corn", 3 ], [ "popcorn_cob", 3 ], [ "cornmeal", 5 ], [ "barley", 1 ], [ "buckwheat", 1 ], [ "oats", 3 ] ],
       [ [ "juniper", 10 ] ]
     ],
     "//1": "Using 2x250ml of water, this should give us ~500ml of product. For brew_gin it is 7 charges",
@@ -232,7 +232,12 @@
     "qualities": [ { "id": "BOIL", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 60, "LIST" ] ] ],
     "//": "30u for corn and 30u to heat water & activate the yeast",
-    "components": [ [ [ "water_clean", 15 ] ], [ [ "cornmeal", 12 ], [ "corn", 2 ] ], [ [ "sugar", 100 ] ], [ [ "yeast", 2 ] ] ],
+    "components": [
+      [ [ "water_clean", 15 ] ],
+      [ [ "cornmeal", 12 ], [ "corn", 2 ], [ "popcorn_cob", 2 ] ],
+      [ [ "sugar", 100 ] ],
+      [ [ "yeast", 2 ] ]
+    ],
     "//1": "Using 15x250ml of water, this should give us ~3750ml of product. For brew_moonshine it is 7 charges per 250ml.",
     "//2": "Hence 3750/250ml*7=105 charges",
     "charges": 105
@@ -505,7 +510,10 @@
     "book_learn": [ [ "brewing_cookbook", 4 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" } ],
     "qualities": [ { "id": "CONTAIN", "level": 1 } ],
-    "components": [ [ [ "water_clean", 1 ] ], [ [ "corn", 1 ], [ "barley", 1 ], [ "buckwheat", 1 ], [ "oats", 1 ], [ "wheat", 1 ] ] ],
+    "components": [
+      [ [ "water_clean", 1 ] ],
+      [ [ "corn", 1 ], [ "popcorn_cob", 1 ], [ "barley", 1 ], [ "buckwheat", 1 ], [ "oats", 1 ], [ "wheat", 1 ] ]
+    ],
     "charges": 1
   },
   {

--- a/data/json/recipes/food/corn.json
+++ b/data/json/recipes/food/corn.json
@@ -46,7 +46,7 @@
     "tools": [ [ [ "surface_heat", 15, "LIST" ] ] ],
     "//": "corncob weighs 690g, so about 14u heat + 1u for the oil ",
     "components": [
-      [ [ "corn", 1 ] ],
+      [ [ "corn", 1 ], [ "popcorn_cob", 1 ] ],
       [ [ "salt", 1 ], [ "seasoning_salt", 1 ], [ "soysauce", 1 ] ],
       [
         [ "seasoning_italian", 1 ],

--- a/data/json/recipes/recipe_food.json
+++ b/data/json/recipes/recipe_food.json
@@ -9145,6 +9145,7 @@
         [ "dry_lentils", 1 ],
         [ "dry_corn", 1 ],
         [ "corn", 1 ],
+        [ "popcorn_cob", 1 ],
         [ "seed_canola", 1 ],
         [ "corn_kernels", 1 ],
         [ "soybean", 2 ],
@@ -9182,6 +9183,7 @@
         [ "dry_lentils", 7 ],
         [ "dry_corn", 7 ],
         [ "corn", 7 ],
+        [ "popcorn_cob", 7 ],
         [ "seed_canola", 4 ],
         [ "corn_kernels", 4 ],
         [ "soybean", 14 ],
@@ -9219,6 +9221,7 @@
         [ "dry_lentils", 26 ],
         [ "dry_corn", 46 ],
         [ "corn", 46 ],
+        [ "popcorn_cob", 46 ],
         [ "seed_canola", 26 ],
         [ "corn_kernels", 46 ],
         [ "soybean", 107 ],
@@ -9830,7 +9833,6 @@
     "charges": 1,
     "batch_time_factors": [ 67, 5 ],
     "tools": [ [ [ "dehydrating_heat", 15, "LIST" ] ] ],
-    "//": "153g of corn to be turned into kernels",
     "components": [ [ [ "popcorn_raw", 1 ] ] ]
   },
   {

--- a/data/json/recipes/recipe_food.json
+++ b/data/json/recipes/recipe_food.json
@@ -9109,6 +9109,19 @@
     "components": [ [ [ "corn", 1 ] ] ]
   },
   {
+    "result": "popcorn_raw",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_FOOD",
+    "subcategory": "CSC_FOOD_OTHER",
+    "byproducts": [ [ "empty_corn_cob", 1 ] ],
+    "skill_used": "cooking",
+    "time": "20 s",
+    "autolearn": true,
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "popcorn_cob", 1 ] ] ]
+  },
+  {
     "result": "cattlefodder",
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",

--- a/data/mods/innawood/recipes/brewing.json
+++ b/data/mods/innawood/recipes/brewing.json
@@ -46,7 +46,7 @@
     "tools": [ [ [ "surface_heat", 6, "LIST" ] ] ],
     "components": [
       [ [ "water", 2 ], [ "water_clean", 2 ] ],
-      [ [ "corn", 3 ], [ "cornmeal", 3 ], [ "barley", 3 ], [ "buckwheat", 3 ], [ "oats", 3 ] ],
+      [ [ "corn", 3 ], [ "popcorn_cob", 3 ], [ "cornmeal", 3 ], [ "barley", 3 ], [ "buckwheat", 3 ], [ "oats", 3 ] ],
       [ [ "juniper", 10 ] ]
     ],
     "charges": 3
@@ -82,7 +82,7 @@
     "tools": [ [ [ "surface_heat", 30, "LIST" ] ] ],
     "components": [
       [ [ "water", 15 ], [ "water_clean", 15 ] ],
-      [ [ "cornmeal", 12 ], [ "corn", 2 ] ],
+      [ [ "cornmeal", 12 ], [ "corn", 2 ], [ "popcorn_cob", 2 ] ],
       [ [ "sugar", 100 ] ],
       [ [ "yeast", 2 ] ]
     ],
@@ -280,7 +280,7 @@
     "qualities": [ { "id": "CONTAIN", "level": 1 } ],
     "components": [
       [ [ "water", 1 ], [ "water_clean", 1 ] ],
-      [ [ "corn", 1 ], [ "barley", 1 ], [ "buckwheat", 1 ], [ "oats", 1 ], [ "wheat", 1 ] ]
+      [ [ "corn", 1 ], [ "popcorn_cob", 1 ], [ "barley", 1 ], [ "buckwheat", 1 ], [ "oats", 1 ], [ "wheat", 1 ] ]
     ],
     "charges": 1
   },


### PR DESCRIPTION
#### Summary
Bugfixes "Fix inconsistencies in corn and popcorn"
#### Purpose of change
The harvest result of corn was changed to corn cob, but there are some inconsistencies in corn and popcorn that were not changed.
#### Describe the solution
Remove dry_corn from the harvest result of dry_corn, to make the harvest result consistent with corn_kernels and seed_corn.
Add popcorn_cob, make it the harvest result of popcorns, add popcorn_cob to some recipes.
Change the weight of popcorn_raw.
#### Describe alternatives you've considered
No to do this.
#### Testing
Done
#### Additional context