### PR TITLE
Add Unholy Debug Angel Cake

### DIFF
--- a/data/json/items/comestibles/junkfood.json
+++ b/data/json/items/comestibles/junkfood.json
@@ -565,7 +565,7 @@
     "spoils_in": "4 days",
     "copy-from": "jihelucake",
     "calories": 10000,
-    "description": "An unholy confection of delight packing a heavenly amount of calories, in each, single, bite.  For debug use only.",
+    "description": "This unholy confection of delight does not lie, it packs a heavenly amount of calories in each sinful bite.  For debug use only.",
     "fun": 20
   },
   {

--- a/data/json/items/comestibles/junkfood.json
+++ b/data/json/items/comestibles/junkfood.json
@@ -560,6 +560,16 @@
   },
   {
     "type": "COMESTIBLE",
+    "id": "debug_calories",
+    "name": { "str": "unholy debug angel cake" },
+    "spoils_in": "4 days",
+    "copy-from": "jihelucake",
+    "calories": 10000,
+    "description": "An unholy confection of delight packing a heavenly amount of calories, in each, single, bite.  For debug use only.",
+    "fun": 20
+  },
+  {
+    "type": "COMESTIBLE",
     "id": "choco_coffee_beans",
     "name": { "str_sp": "chocolate-covered coffee beans" },
     "weight": "30 g",


### PR DESCRIPTION
#### Summary
Features "Unholy Debug Angel Cake added to the game. 10k calories for easy calories gain and for basecamp companions"

#### Purpose of change

The holy SPAM of debugging while useful, is disgusting and cannot be used if the survivor has the picky eater trait and cannot be used for basecamps as it has -8 joy. The unholy debug angel cake fixes this issue but leaves the debug SPAM useful for vitamins.

#### Describe the solution

Bring about an avatar of unholy confection goodness.

#### Describe alternatives you've considered

Make the debug spam not disgusting.

#### Testing

Finally, some gourmet debug.

#### Additional context