### PR TITLE
Prevent gun variant script identifiers from being cut off

### DIFF
--- a/tools/json_tools/gun_variant_validator.py
+++ b/tools/json_tools/gun_variant_validator.py
@@ -828,11 +828,19 @@ def check_identifiers(all_guns):
             # multiple guns, those guns all take the same mags, etc
             print("The following valid identifiers were found.",
                   "Please check to ensure they make sense.")
-            good_tokens = []
+            good_tokens = [[]]
+            idx = 0
+            len_so_far = 0
             for token in good_token_list:
                 guns_str = string_listify(good_token_list[token], " ")
-                good_tokens.append(f"{token} ({guns_str})")
-            print(string_listify(good_tokens, ", "))
+                good_tokens[idx].append(f"{token} ({guns_str})")
+                len_so_far += len(good_tokens[idx][-1])
+                if len_so_far > 100:
+                    len_so_far = 0
+                    idx += 1
+                    good_tokens.append([])
+            for string in good_tokens:
+                print(" -", string_listify(string, ", "))
 
     return len(bad_tokens) > 0
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
The github CI will cut off lines over a certain length.

#### Describe the solution
Manually cut off the lines before then so that doesn't happen.

#### Testing
`tools/json_tools/gun_variant_validator.py -cin -v data/json`
