### PR TITLE
G80 Category

### DIFF
--- a/data/json/items/gun/12mm.json
+++ b/data/json/items/gun/12mm.json
@@ -29,9 +29,7 @@
       [ "stock accessory", 2 ],
       [ "underbarrel", 1 ]
     ],
-    "weapon_category": [
-      "AUTOMATIC_RIFLES"
-    ],
+    "weapon_category": [ "AUTOMATIC_RIFLES" ],
     "flags": [ "NEVER_JAMS", "USE_UPS" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "magazine_well": "250 ml", "item_restriction": [ "hk_g80mag" ] } ],
     "melee_damage": { "bash": 12 }

--- a/data/json/items/gun/12mm.json
+++ b/data/json/items/gun/12mm.json
@@ -19,6 +19,7 @@
     "dispersion": 45,
     "durability": 8,
     "energy_drain": "5 kJ",
+    "weapon_category": [ "AUTOMATIC_RIFLES" ],
     "valid_mod_locations": [
       [ "grip", 1 ],
       [ "mechanism", 2 ],
@@ -29,7 +30,6 @@
       [ "stock accessory", 2 ],
       [ "underbarrel", 1 ]
     ],
-    "weapon_category": [ "AUTOMATIC_RIFLES" ],
     "flags": [ "NEVER_JAMS", "USE_UPS" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "magazine_well": "250 ml", "item_restriction": [ "hk_g80mag" ] } ],
     "melee_damage": { "bash": 12 }

--- a/data/json/items/gun/12mm.json
+++ b/data/json/items/gun/12mm.json
@@ -29,6 +29,9 @@
       [ "stock accessory", 2 ],
       [ "underbarrel", 1 ]
     ],
+    "weapon_category": [
+      "AUTOMATIC_RIFLES"
+    ],
     "flags": [ "NEVER_JAMS", "USE_UPS" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "magazine_well": "250 ml", "item_restriction": [ "hk_g80mag" ] } ],
     "melee_damage": { "bash": 12 }


### PR DESCRIPTION
#### Summary
Bugfixes "Added a weapon category to the G80"

#### Purpose of change

For all intents and purposes, the H&K G80 is a semiautomatic marksman rifle that uses advanced technology made for humans. Its volume and dimensions are likewise comparable to heavier weapons in the Automatic Rifle category, such as the M14 EBR. And let’s not even get into how the Barrett is considered an Automatic Rifle. With so many formerly automatic guns in this category being converted to semiautomatic civilian versions, it’s a safe assessment that the criteria isn’t simply having an automatic setting. In other words, this is a military-grade rifle that functions reliably and accepts compact magazines like any other, which is why I see no reason why it should be incompatible with martial arts. 

Other weapons in the same situation like the plasma rifle are a more arguable case due to how the unconventional ammo might affect its ergonomics, but this specific example is fairly clear-cut and should draw the least argument.

#### Describe the solution

Add a flag to make the G80 compatible with Krav Maga.

#### Describe alternatives you've considered

Remove the category from all semiautomatics.

#### Testing

Plugged it into my JSON and tested the rifle with Krav Maga enabled.

#### Additional context

N/A
