### PR TITLE
Grammar/Spelling Fixers for Fliers Snippets

### DIFF
--- a/data/json/snippets/fliers.json
+++ b/data/json/snippets/fliers.json
@@ -209,7 +209,7 @@
       },
       {
         "id": "flier_53",
-        "text": "This is a flier for Red Ryder BB Guns.  On it a child is pulling a shining red wagon containing a cooked pheasant and a wooden rifle over one shoulder.  The child has a dog trailing beside him and a satisfied look on his face.  The caption reads \"When you chose Red Ryder, you invested in the American Dream.  You invested in our Independence.\""
+        "text": "This is a flier for Red Ryder BB Guns.  On it a child is pulling a shining red wagon containing a cooked pheasant, a wooden rifle held over one shoulder.  The child has a dog trailing beside him and a satisfied look on his face.  The caption reads \"When you chose Red Ryder, you invested in the American Dream.  You invested in our Independence.\""
       },
       {
         "id": "flier_54",
@@ -330,7 +330,7 @@
       },
       {
         "id": "flier_82",
-        "text": "Foodplace is advertising the \"Big Deal™\" on this flyer.  Plainly worded sentences on the distinct blue-and-magenta colored background try to convince the reader to buy their \"Delicious Food™\" in bulk to save money.  There is a picture showing a sample order at the bottom."
+        "text": "Foodplace is advertising the \"Big Deal™\" on this flier.  Plainly worded sentences on the distinct blue-and-magenta colored background try to convince the reader to buy their \"Delicious Food™\" in bulk to save money.  There is a picture showing a sample order at the bottom."
       },
       {
         "id": "flier_83",

--- a/data/json/snippets/fliers.json
+++ b/data/json/snippets/fliers.json
@@ -9,7 +9,7 @@
       },
       {
         "id": "flier_2",
-        "text": "This is an advertisement for an personal injury lawyer.  \"Had an accident while working?  Botched surgery gone wrong?  Relatives missing after the government investigated them?  There's only one solution to all of this; SUE!\""
+        "text": "This is an advertisement for a personal injury lawyer.  \"Had an accident while working?  Botched surgery gone wrong?  Relatives missing after the government investigated them?  There's only one solution to all of this; SUE!\""
       },
       {
         "id": "flier_4",
@@ -33,7 +33,7 @@
       },
       {
         "id": "flier_9",
-        "text": "This is an advertisement for a local church.  It looks like it was put together at the last minute.  \"Visit St Mary's on the River while it's not too late.  Repent, while you still can!\""
+        "text": "This is an advertisement for a local church.  It looks like it was put together at the last minute.  \"Visit St. Mary's on the River while it's not too late.  Repent while you still can!\""
       },
       {
         "id": "flier_10",
@@ -57,7 +57,7 @@
       },
       {
         "id": "flier_15",
-        "text": "This is a glossy, high quality flier.  \"What they don't want you to know!  Reading this may save your life.\"  Inside is a series of warnings recommending people avoid the evacuation shelters, and worse, the FEMA evacuation camps, along with some high-quality telephoto shots showing bodies being shoveled into huge pits by excavation machines."
+        "text": "This is a glossy, high-quality flier.  \"What they don't want you to know!  Reading this may save your life.\"  Inside is a series of warnings recommending people avoid the evacuation shelters, and worse, the FEMA evacuation camps, along with some high-quality telephoto shots showing bodies being shoveled into huge pits by excavation machines."
       },
       {
         "id": "flier_16",
@@ -73,15 +73,15 @@
       },
       {
         "id": "flier_19",
-        "text": "This is an advertisement for Rivtech brand handguns.  It shows a picture of a well armed couple in business suits with matching handguns facing down a legion of villainous looking characters.  The caption reads:  \"Protect yourself with the Rivtech caseless automagnum!\""
+        "text": "This is an advertisement for Rivtech brand handguns.  It shows a picture of a well-armed couple in business suits with matching handguns facing down a legion of villainous-looking characters.  The caption reads:  \"Protect yourself with the Rivtech caseless automagnum!\""
       },
       {
         "id": "flier_20",
-        "text": "This is an advertisement for Rivtech brand rifles.  It shows a picture of a smiling soldier with a futuristic looking rifle on her shoulder saluting the viewer.  The caption reads:  \"Rivtech caseless firearms proudly supports our Military.\""
+        "text": "This is an advertisement for Rivtech brand rifles.  It shows a picture of a smiling soldier with a futuristic-looking rifle on her shoulder saluting the viewer.  The caption reads:  \"Rivtech caseless firearms proudly supports our Military.\""
       },
       {
         "id": "flier_21",
-        "text": "This is an advertisement for Rivtech brand firearms.  It shows a picture of a trio of well armed hunters.  The three are each armed with different futuristic looking weapons and are shooting at a hostile crowd of approaching wildlife.  The caption reads:  \"Rivtech caseless firearms.  Superior stopping power.\""
+        "text": "This is an advertisement for Rivtech brand firearms.  It shows a picture of a trio of well-armed hunters.  The three are each armed with different futuristic-looking weapons and are shooting at a hostile crowd of approaching wildlife.  The caption reads:  \"Rivtech caseless firearms.  Superior stopping power.\""
       },
       {
         "id": "flier_22",
@@ -89,7 +89,7 @@
       },
       {
         "id": "flier_23",
-        "text": "This is a flier with the tour appearance dates of a small, niche-successful drum-and-bass/yodelling fusion band, the \"Ol' Yellers\".  The dates continue well past the end of the world; most likely, the tour was cut short."
+        "text": "This is a flier with the tour appearance dates of a small, niche-successful drum-and-bass/yodeling fusion band, the \"Ol' Yellers\".  The dates continue well past the end of the world; most likely, the tour was cut short."
       },
       {
         "id": "flier_24",
@@ -105,15 +105,15 @@
       },
       {
         "id": "flier_27",
-        "text": "This is an advertisement for SUDS Laundromat.  It shows words surrounded by bubbles that appear to be floating upward.  It reads: \"Tergitol Tuesdays!  50% off on all washers and driers!\""
+        "text": "This is an advertisement for SUDS Laundromat.  It shows words surrounded by bubbles that appear to be floating upward.  It reads: \"Tergitol Tuesdays!  50% off on all washers and dryers!\""
       },
       {
         "id": "flier_28",
-        "text": "This is a propaganda poster showing the Northrop Dispatch's military variant.  It depicts the iconic dark green, arachnoid dispatch, standing before a fence and facing away from the camera as blurring machines rush forward from its back towards black silhouettes menacing on the horizon.  It reads: \"WE ARE HERE TO PROTECT YOU.\""
+        "text": "This is a propaganda poster showing the Northrop Dispatch's military variant.  It depicts the iconic dark green, arachnoid Dispatch, standing before a fence and facing away from the camera as blurring machines rush forward from its back towards black silhouettes menacing on the horizon.  It reads: \"WE ARE HERE TO PROTECT YOU.\""
       },
       {
         "id": "flier_29",
-        "text": "This is an advertisement for Iron Gym.  It shows pictures of people performing various exercises such as running, yoga and weight lifting.  It reads: \"I lift things up and put them down!\""
+        "text": "This is an advertisement for Iron Gym.  It shows pictures of people performing various exercises such as running, yoga, and weight lifting.  It reads: \"I lift things up and put them down!\""
       },
       {
         "id": "flier_30",
@@ -137,7 +137,7 @@
       },
       {
         "id": "flier_35",
-        "text": "This is a public warning from an unnamed source.  Its rambling message, poorly-photocopied onto both sides of the page, reads: Don't believe the lies!  The Army is rounding up people in death camps and executing them at mass graves.  They cannot stop this.  Do not believe what the mainstream news-media is reporting.  All official evacuation points are death-traps.  Secure supplies and escape the cities while there is still time."
+        "text": "This is a public warning from an unnamed source.  Its rambling message, poorly-photocopied onto both sides of the page, reads: Don't believe the lies!  The Army is rounding up people in death camps and executing them at mass graves.  They cannot stop this.  Do not believe what the mainstream news media is reporting.  All official evacuation points are deathtraps.  Secure supplies and escape the cities while there is still time."
       },
       {
         "id": "flier_36",
@@ -153,11 +153,11 @@
       },
       {
         "id": "flier_39",
-        "text": "This is a soda advertisement.  On the front is a picture of a happy couple on a beach watching the sun set.  Between them are bottles of soda.  The poster reads, \"Cascade Cola, for those special moments\" in bold white letters."
+        "text": "This is a soda advertisement.  On the front is a picture of a happy couple on a beach watching the sunset.  Between them are bottles of soda.  The poster reads, \"Cascade Cola, for those special moments\" in bold white letters."
       },
       {
         "id": "flier_40",
-        "text": "This is a flier for a fast food chain.  In it, a man is placing an order with an attractive woman wearing a bright green shirt in the window with two happy children sitting in the back seat.  The flier reads \"Burgers, fries, and a Smile.\" Down in one corner is a company logo."
+        "text": "This is a flier for a fast food chain.  In it, a man is placing an order with an attractive woman wearing a bright green shirt in the window, with two happy children sitting in the back seat.  The flier reads \"Burgers, fries, and a Smile.\" Down in one corner is a company logo."
       },
       {
         "id": "flier_41",
@@ -165,15 +165,15 @@
       },
       {
         "id": "flier_42",
-        "text": "This is a flyer for a local pizza chain.  On it is a picture of a cartoon Italian holding a pizza, with the words \"It's a goooood pizza\" written above his head."
+        "text": "This is a flier for a local pizza chain.  On it is a picture of a cartoon Italian holding a pizza, with the words \"It's a goooood pizza\" written above his head."
       },
       {
         "id": "flier_43",
-        "text": "This is a poster advertising contact lenses.  On it is a picture of a blood shot eye with a rather long block of information beneath it making some fairly exaggerated claims about the product."
+        "text": "This is a poster advertising contact lenses.  On it is a picture of a bloodshot eye with a rather long block of information beneath it making some fairly exaggerated claims about the product."
       },
       {
         "id": "flier_44",
-        "text": "This is a flyer advertising a local radio station.  It has a lot of bright colors and patterns, but no definite message other than \"104.4 all the best, all the time!\" in big yellow letters."
+        "text": "This is a flier advertising a local radio station.  It has a lot of bright colors and patterns, but no definite message other than \"104.4 all the best, all the time!\" in big yellow letters."
       },
       {
         "id": "flier_45",
@@ -181,7 +181,7 @@
       },
       {
         "id": "flier_46",
-        "text": "This is an illustrated poster for a brand of solar car.  The vehicle is driving through a lush country side as small animals look on.  The slogan \"Improving the world, one tank at a time.\" is written across the top in small letters."
+        "text": "This is an illustrated poster for a brand of solar car.  The vehicle is driving through a lush countryside as small animals look on.  The slogan \"Improving the world, one tank at a time.\" is written across the top in small letters."
       },
       {
         "id": "flier_47",
@@ -189,7 +189,7 @@
       },
       {
         "id": "flier_48",
-        "text": "This is a flier for a fast food chain.  In it, a man is placing an order with an attractive woman wearing a bright green shirt in the window with two happy children in the back seat.  The flier reads \"Burgers, fries, and a Smile.\" down in one corner is a company logo.  Someone has gone to town on this one with a permanent marker.  It is now covered in rude images and racial epithets."
+        "text": "This is a flier for a fast food chain.  In it, a man is placing an order with an attractive woman wearing a bright green shirt in the window, with two happy children in the back seat.  The flier reads \"Burgers, fries, and a Smile.\" down in one corner is a company logo.  Someone has gone to town on this one with a permanent marker.  It is now covered in rude images and racial epithets."
       },
       {
         "id": "flier_49",
@@ -197,23 +197,23 @@
       },
       {
         "id": "flier_50",
-        "text": "This is a poster advertising contact lenses.  On it is a picture of a blood shot eye.  Someone has defaced this one.  The informative part has been torn off, and written in jagged letters across the top in red crayon are the words \"ALL HAIL THE CRIMSON KING!\""
+        "text": "This is a poster advertising contact lenses.  On it is a picture of a bloodshot eye.  Someone has defaced this one.  The informational part has been torn off, and written in jagged letters across the top in red crayon are the words \"ALL HAIL THE CRIMSON KING!\""
       },
       {
         "id": "flier_51",
-        "text": "This is an illustrated poster for a brand of solar car.  The vehicle is driving through a lush country side as small animals look on.  The slogan \"Improving the world, one tank at a time.\" is written across the top.  Someone used a blue pen to write \"who gives a shit\" across the slogan and put X's over the eyes of all the animals."
+        "text": "This is an illustrated poster for a brand of solar car.  The vehicle is driving through a lush countryside as small animals look on.  The slogan \"Improving the world, one tank at a time.\" is written across the top.  Someone used a blue pen to write \"who gives a shit\" across the slogan and put X's over the eyes of all the animals."
       },
       {
         "id": "flier_52",
-        "text": "This is high quality flier, mass produced with photocopying.  \"IF YOU ARE STUCK IN THE CITY, DO NOT LEAVE UNTIL NIGHTFALL, *THEY* WILL SEE YOU!\" The flier further discusses how to barricade your apartment, and to duct tape sheets to your windows."
+        "text": "This is high quality flier, mass produced with photocopying.  \"IF YOU ARE STUCK IN THE CITY, DO NOT LEAVE UNTIL NIGHTFALL, *THEY* WILL SEE YOU!\" The flier further discusses how to barricade your apartment and duct tape sheets to your windows."
       },
       {
         "id": "flier_53",
-        "text": "This is a flier for Red Ryder BB Guns.  On it a child is pulling a shining red wagon with a cooked pheasant on it and a wooden rifle over one shoulder.  The child has a dog trailing beside him and a satisfied look on his face.  The caption reads \"When you chose Red Ryder, you invested in the American Dream.  You invested in our Independence.\""
+        "text": "This is a flier for Red Ryder BB Guns.  On it a child is pulling a shining red wagon containing a cooked pheasant and a wooden rifle over one shoulder.  The child has a dog trailing beside him and a satisfied look on his face.  The caption reads \"When you chose Red Ryder, you invested in the American Dream.  You invested in our Independence.\""
       },
       {
         "id": "flier_54",
-        "text": "This is a flier for some kind of reality TV show that takes place in New Jersey.  The flier claims that the finale will 'blow your minds', and was to air the day the evacuation order was given."
+        "text": "This is a flier for some kind of reality TV show that takes place in New Jersey.  The flier claims that the finale will \"blow your mind\", and was to air the day the evacuation order was given."
       },
       {
         "id": "flier_55",
@@ -221,7 +221,7 @@
       },
       {
         "id": "flier_56",
-        "text": "This is an advertisement for the popular fast food chain, Foodplace.  On an unadorned blue-and-magenta background it shows clear, unmistakable depictions of their products and plainly stated prices.  The foodburger looks particularly nice."
+        "text": "This is an advertisement for the popular fast food chain, Foodplace.  On an unadorned blue-and-magenta background it shows clear, unmistakable depictions of their products and plainly stated prices.  The Foodburger looks particularly nice."
       },
       {
         "id": "flier_57",
@@ -241,7 +241,7 @@
       },
       {
         "id": "flier_62",
-        "text": "This advertisement reads \"Coffee of The Future… RIGHT NOW!  No one has really has the time to make great coffee, but now you don't have to!  CuppaTech gives you inexhaustible ATOMIC power!  To make boiling hot coffee the MINUTE you want it!  The Curie-G Atomic One-Cup Coffeemaker.\""
+        "text": "This advertisement reads \"Coffee of The Future… RIGHT NOW!  No one really has the time to make great coffee, but now you don't have to!  CuppaTech gives you inexhaustible ATOMIC power!  To make boiling hot coffee the MINUTE you want it!  The Curie-G Atomic One-Cup Coffeemaker.\""
       },
       {
         "id": "flier_63",
@@ -253,23 +253,23 @@
       },
       {
         "id": "flier_65",
-        "text": "GLAMOPOLITAN!  We've got ALL the latest tips!  Whether you want to know what the elite are eating, wearing or discussing, Glamopolitan is YOUR magazine!  So pick up a copy today and \"Sizzle Like A Star\"!"
+        "text": "GLAMOPOLITAN!  We've got ALL the latest tips!  Whether you want to know what the elite are eating, wearing, or discussing, Glamopolitan is YOUR magazine!  So, pick up a copy today and \"Sizzle Like A Star\"!"
       },
       {
         "id": "flier_66",
-        "text": "POPULAR MECHANICS: People say mechanics is boring?  We say, Prove them Wrong!  We've got all the articles that make it interesting to talk about, so you can \"Make Mechanics Popular\"!"
+        "text": "POPULAR MECHANICS: People say mechanics is boring?  We say prove them wrong!  We've got all the articles that make it interesting to talk about, so you can \"Make Mechanics Popular\"!"
       },
       {
         "id": "flier_67",
-        "text": "BIRDHOUSE MONTHLY….  Which wood would a woodpecker prefer?  This month we discuss hardwood versus soft woods, whether to lacquer, oil or paint, and which type of nails you should use!"
+        "text": "BIRDHOUSE MONTHLY….  Which wood would a woodpecker prefer?  This month we discuss hardwood versus soft woods, whether to lacquer, oil, or paint, and which type of nails you should use!"
       },
       {
         "id": "flier_68",
-        "text": "FEELING BLUE?  Try \"Greens\" for Magazines!  Your local Supermarket!  Nothing cheers you up like a good magazine… unless it's JUNK FOOD!  Or why not buy an MP3 PLAYER or a GAME CONSOLE?  Chase those Blues away at GREENS Supermarket."
+        "text": "FEELING BLUE?  Try Greens for Magazines!  Your local Supermarket!  Nothing cheers you up like a good magazine… unless it's JUNK FOOD!  Or why not buy an MP3 PLAYER or a GAME CONSOLE?  Chase those Blues away at GREENS Supermarket."
       },
       {
         "id": "flier_69",
-        "text": "…What do you know about surviving in the Wilderness?  If you can't make a snare you don't know TRAP!  Hunt down a copy of TRAPPERS' LIFE and learn about wildlife!  And how to kill it.  Classic BEAR TRAP returns in this issue!"
+        "text": "…What do you know about surviving in the Wilderness?  If you can't make a snare you don't know TRAP!  Hunt down a copy of TRAPPERS' LIFE and learn about wildlife!  And how to kill it.  Our classic BEAR TRAP schematic returns in this issue!"
       },
       {
         "id": "flier_70",
@@ -300,7 +300,7 @@
       },
       {
         "id": "flier_76",
-        "text": "This is a poster advertising a brand of a hybrid gas-electric vehicle.  Poster claims that hybrid car is the \"best of two worlds\" with the acceleration capabilities of a sport car and fuel consumption of a compact car.  Something called the \"Smart Controller®\" is mentioned several times, which, if you are to believe the poster, it is some kind of military technology adapted for civilian market and it works like magic.  In the bottom there is a slogan: \"Enjoy your optimal ride with the Smart Engine Controller!\""
+        "text": "This is a poster advertising a brand of a hybrid gas-electric vehicle.  It claims this hybrid car is the \"best of both worlds\" with the acceleration capabilities of a sport car and fuel consumption of a compact car.  Something called the \"Smart Controller®\" is mentioned several times, which, if you are to believe the poster, is some kind of military technology adapted for civilian market, and it works like magic.  At the bottom there is a slogan: \"Enjoy your optimal ride with the Smart Engine Controller!\""
       },
       {
         "id": "flier_77",
@@ -309,7 +309,7 @@
       {
         "id": "flier_78",
         "text": {
-          "str": "This scrap of paper appears to be an advertisement for a music venue dated a few days before the evacuation order. It's printed on bright neon green paper, with pictures of people dancing manically. It's main headliner features a locally famous DJ.",
+          "str": "This scrap of paper appears to be an advertisement for a music venue, dated a few days before the evacuation order. It's printed on bright neon green paper, with pictures of people dancing manically. It's main headliner features a famous local DJ.",
           "//NOLINT(cata-text-style)": "intentional format"
         }
       },
@@ -324,7 +324,7 @@
       {
         "id": "flier_81",
         "text": {
-          "str": "What you've got here is an old coupon insert for Marigold Market:\n\n - BOGO!  Cascade Cola six-packs!\n - ATOMIC POWER THIRST!  Now with 20% more FRUIT RU-238!\n - $2 MEAT! Aunt Janice's Pickled Meat now just $2.49!\n - 75% OFF! DaiZoom bars by SoyPelusa.",
+          "str": "This is an old coupon insert for Marigold Market:\n\n - BOGO!  Cascade Cola six-packs!\n - ATOMIC POWER THIRST!  Now with 20% more FRUIT RU-238!\n - $2 MEAT! Aunt Janice's Pickled Meat now just $2.49!\n - 75% OFF! DaiZoom bars by SoyPelusa.",
           "//NOLINT(cata-text-style)": "intentional format"
         }
       },


### PR DESCRIPTION
#### Summary
Bugfixes "Fix Various Typos/Mistakes in Flier Snippets"

#### Purpose of change
Several flier snippets had errors with hyphenated words, spaces in words that are actually just one word, missing oxford commas, etc.

#### Describe the solution
Most corrections were missing hyphens and similar small mistakes, I corrected these.

Some corrections were to American English (IE: yodelling to yodeling) even though it’s not inherently correct, just not the American English spelling.

I did not edit for content, in my opinion some of these are not so good, but it felt bad to arbitrarily change someone else’s fiction writing when it’s not wrong per se and just my opinion that they are poor quality or intentionally edgy, etc.
This includes complex sentences.  Some sentences in this file are very difficult to read aloud (my rule of thumb test for overly long or overly complex sentences).  Despite this, I did not change them for the same reason as above.

I did not correct the usage of single quotes.  It’s my opinion that all of this flier text that would use single quotes (outside of double quotes, I mean) should all be converted to double quotes, but google suggests that nowadays people use single quotes in that context.  I do it myself, just not in proper prose, but because of that I left it alone.  Hopefully that makes sense to whoever is reading this. TLDR I didn’t change single quotes.

In several places I have converted flyer to flier in order to maintain consistency, idk if flyer is correct or not, but the rest of the document spells it with an i so I made them all flier.

Flier 79 – Who the fuck knows what this is supposed to say, I just left it
Flier 83 – Intentional misspellings make me angry but I left it.


#### Describe alternatives you've considered

Having recreational free time

#### Testing
Brain tested if words made sense.

#### Additional context
Imagine not using the Oxford comma