### PR TITLE
Aftershock: Urban farms

### DIFF
--- a/data/mods/Aftershock/field_type.json
+++ b/data/mods/Aftershock/field_type.json
@@ -115,12 +115,9 @@
     "decay_amount_factor": 5,
     "percent_spread": 30,
     "outdoor_age_speedup": "3 minutes",
-    "dirty_transparency_cache": true,
     "has_fume": true,
-    "immunity_data": {
-      "flags": [ "POISON_IMMUNE" ],
-      "body_part_env_resistance": [ [ "torso", 15 ], [ "leg", 15 ], [ "foot", 15 ], [ "mouth", 15 ], [ "sensor", 15 ] ]
-    },
+    "dirty_transparency_cache": true,
+    "immunity_data": { "body_part_env_resistance": [ [ "torso", 15 ], [ "leg", 15 ], [ "foot", 15 ], [ "mouth", 15 ], [ "sensor", 15 ] ] },
     "priority": 2,
     "half_life": "1 hours",
     "phase": "solid",

--- a/data/mods/Aftershock/itemgroups/clothing/civilian_blue_collar_sets.json
+++ b/data/mods/Aftershock/itemgroups/clothing/civilian_blue_collar_sets.json
@@ -1,6 +1,19 @@
 [
   {
     "type": "item_group",
+    "//": "Clothes for working in toxic environments.",
+    "id": "afs_civilian_hazard_outfit",
+    "subtype": "collection",
+    "entries": [
+      { "group": "afs_colonist_hazard_accessories", "prob": 50 },
+      { "group": "afs_colonist_outfit_underwear" },
+      { "item": "afs_hazard_suit" },
+      { "group": "afs_hard_hat", "prob": 15 },
+      { "group": "afs_colonist_shirt", "prob": 10 }
+    ]
+  },
+  {
+    "type": "item_group",
     "//": "Clothes for the future blue collar worker.  Just steal costumes from Alien.",
     "id": "afs_colonist_outfit",
     "subtype": "collection",

--- a/data/mods/Aftershock/itemgroups/tool_groups.json
+++ b/data/mods/Aftershock/itemgroups/tool_groups.json
@@ -146,6 +146,22 @@
   },
   {
     "type": "item_group",
+    "id": "afs_tools_agricultural_hazardous",
+    "//": "tools used by large farms",
+    "subtype": "distribution",
+    "items": [
+      {
+        "collection": [
+          { "item": "afs_foamgun", "prob": 100 },
+          { "item": "afs_foam_tank", "ammo-item": "afs_foamtoxic", "charges": 30, "prob": 100, "count": [ 1, 2 ] },
+          { "item": "prophylactic_antivenom", "prob": 1, "count": 5 }
+        ],
+        "prob": 10
+      }
+    ]
+  },
+  {
+    "type": "item_group",
     "id": "afs_tools_pocket",
     "//": "General use tools that fit in small pockets.",
     "subtype": "distribution",
@@ -196,6 +212,45 @@
       { "item": "emf_detector", "prob": 50 },
       { "group": "tools_lighting_industrial", "prob": 100 },
       { "item": "tskbem_master_keycard", "prob": 2 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "farming_tools",
+    "items": [
+      [ "hoe", 60 ],
+      [ "shovel", 60 ],
+      [ "g_shovel", 60 ],
+      [ "trimmer_off", 60 ],
+      [ "bucket", 40 ],
+      [ "bucket_5gal", 40 ],
+      [ "gloves_rubber", 60 ],
+      [ "fertilizer_liquid", 20 ],
+      { "group": "fertilizer_commercial_bag_canvas_60", "prob": 30 },
+      [ "fungicide", 20 ],
+      { "item": "chem_saltpetre", "prob": 15, "charges": [ 10, 50 ] },
+      [ "sickle", 40 ],
+      { "group": "tools_toolbox", "prob": 10 },
+      [ "bullwhip", 30 ],
+      [ "distaff_spindle", 2 ],
+      [ "carding_paddles", 2 ],
+      [ "scythe", 40 ],
+      [ "scythe_fake", 1 ],
+      [ "shears", 20 ],
+      [ "elec_shears", 10 ],
+      [ "tree_spile", 40 ],
+      { "group": "quicklime_bag", "prob": 30 },
+      [ "pitchfork", 40 ],
+      [ "v_plow_item", 41 ],
+      [ "v_planter_item", 41 ],
+      [ "v_reaper_item", 41 ],
+      [ "v_reaper_item_advanced", 8 ],
+      [ "v_planter_item_advanced", 8 ],
+      [ "rake", 40 ],
+      [ "rake_plastic", 50 ],
+      [ "shovel_snow", 40 ],
+      [ "shovel_snow_plastic", 50 ],
+      [ "hose_garden", 60 ]
     ]
   }
 ]

--- a/data/mods/Aftershock/items/ammo/foam.json
+++ b/data/mods/Aftershock/items/ammo/foam.json
@@ -35,6 +35,6 @@
     "ammo_type": "afs_foam",
     "range": 8,
     "count": 30,
-    "effects": [ "TOXIC_FOAM", "NEVER_MISFIRES", "JET", "NO_PENETRATE_OBSTACLES" ]
+    "effects": [ "TOXIC_FOAM", "NEVER_MISFIRES", "JET", "NO_PENETRATE_OBSTACLES", "NO_OVERSHOOT" ]
   }
 ]

--- a/data/mods/Aftershock/items/armor/civilian_blue_collar.json
+++ b/data/mods/Aftershock/items/armor/civilian_blue_collar.json
@@ -87,6 +87,32 @@
     "color": "brown"
   },
   {
+    "id": "afs_hazard_suit",
+    "copy-from": "robofac_enviro_suit",
+    "type": "ARMOR",
+    "name": { "str": "soft hazard suit" },
+    "description": "A brightly colored, standard-fab pattern environmental suit for use in industrial and medical settings.  Offers good protection from chemical and radioactive hazards, but is not insulated against heat or cold.  Requires a gasmask or sealed helmet for full protection.",
+    "use_action": {
+      "type": "transform",
+      "menu_text": "Wear casually",
+      "msg": "You slip out of the top of the suit and tie the sleeves around your waist.",
+      "target": "afs_hazard_suit_casual"
+    }
+  },
+  {
+    "id": "afs_hazard_suit_casual",
+    "copy-from": "robofac_enviro_suit_casual",
+    "type": "ARMOR",
+    "name": { "str": "soft hazard suit (casual)", "str_pl": "soft hazard suits (casual)" },
+    "description": "A brightly colored, standard-fab pattern environmental suit for use in industrial and medical settings.  The upper portion has been tied around the waist casually.",
+    "use_action": {
+      "type": "transform",
+      "menu_text": "Wear normally",
+      "msg": "You untie the sleeves and put back on the top of the suit.",
+      "target": "afs_hazard_suit"
+    }
+  },
+  {
     "id": "spacer_cap",
     "type": "ARMOR",
     "copy-from": "hat_cotton",

--- a/data/mods/Aftershock/items/corpses.json
+++ b/data/mods/Aftershock/items/corpses.json
@@ -45,6 +45,22 @@
   },
   {
     "type": "GENERIC",
+    "id": "broken_fumigator",
+    "symbol": ",",
+    "color": "green",
+    "name": { "str": "broken croplord drone" },
+    "category": "other",
+    "description": "This bloodhound won't be chasing anyone anymore.  Could be gutted for parts.",
+    "price": "10 USD",
+    "material": [ "steel", "plastic" ],
+    "volume": "1750 ml",
+    "weight": "1 kg",
+    "to_hit": -3,
+    "flags": [ "TRADER_AVOID", "NO_REPAIR" ],
+    "melee_damage": { "bash": 6, "cut": 6 }
+  },
+  {
+    "type": "GENERIC",
     "id": "broken_utilibot",
     "symbol": ",",
     "color": "light_gray",
@@ -101,6 +117,16 @@
     "type": "GENERIC",
     "id": "broken_utilibot_const",
     "copy-from": "broken_utilibot",
+    "color": "dark_gray",
+    "name": "broken Udarnik",
+    "volume": "680388 ml",
+    "weight": "680388 g",
+    "description": "A broken Udarnik, now wrecked and immobile.  Could be stripped down for parts."
+  },
+  {
+    "type": "GENERIC",
+    "id": "broken_utilibot_hostile",
+    "copy-from": "broken_utilibot_const",
     "color": "dark_gray",
     "name": "broken Udarnik",
     "description": "A broken Udarnik, now wrecked and immobile.  Could be stripped down for parts."

--- a/data/mods/Aftershock/maps/city_buildings.json
+++ b/data/mods/Aftershock/maps/city_buildings.json
@@ -115,6 +115,25 @@
     "locations": [ "land" ]
   },
   {
+    "type": "city_building",
+    "id": "afs_city_urban_farm_small",
+    "overmaps": [
+      { "point": [ 0, 1, 0 ], "overmap": "afs_modular_habitat_center_small_ground_level_north" },
+      { "point": [ 0, 1, 1 ], "overmap": "afs_modular_habitat_center_small_ground_level_above_north" },
+      { "point": [ 0, 1, 2 ], "overmap": "afs_modular_habitat_center_maintenance_tiny_north" },
+      { "point": [ 0, 1, 3 ], "overmap": "afs_modular_habitat_center_farm_north" },
+      { "point": [ 0, 1, 4 ], "overmap": "afs_modular_habitat_greenhouse_control_room_1s_north" },
+      { "point": [ 0, 1, 5 ], "overmap": "afs_modular_habitat_greenhouse_control_room_1s_roof_north" },
+      { "point": [ 0, 0, 0 ], "overmap": "afs_modular_habitat_pillars_ground_walkway_north" },
+      { "point": [ 0, 0, 1 ], "overmap": "afs_modular_habitat_end_pillars_above_walkway_north" },
+      { "point": [ 0, 0, 2 ], "overmap": "afs_modular_habitat_pillars_north" },
+      { "point": [ 0, 0, 3 ], "overmap": "afs_modular_habitat_greenhouse_north" },
+      { "point": [ 0, 0, 4 ], "overmap": "afs_modular_habitat_greenhouse_roof_north" },
+      { "point": [ 0, 0, 5 ], "overmap": "afs_modular_habitat_greenhouse_roof2_north" }
+    ],
+    "locations": [ "land" ]
+  },
+  {
     "id": "afs_house_1",
     "type": "city_building",
     "overmaps": [

--- a/data/mods/Aftershock/maps/furniture_and_terrain/furniture_habitat.json
+++ b/data/mods/Aftershock/maps/furniture_and_terrain/furniture_habitat.json
@@ -104,6 +104,30 @@
   },
   {
     "type": "furniture",
+    "id": "f_habitat_floodlight",
+    "name": "industrial_floodlight",
+    "description": "A wall mountable floodlight, designed to illuminate large areas with a bright, white light.  Still functional thanks to some unknown backup power source.",
+    "symbol": "!",
+    "color": "brown",
+    "move_cost_mod": 6,
+    "required_str": -1,
+    "light_emitted": 600,
+    "flags": [ "TRANSPARENT" ],
+    "bash": {
+      "str_min": 6,
+      "str_max": 30,
+      "sound": "smash!",
+      "sound_fail": "whump.",
+      "items": [
+        { "item": "cable", "charges": [ 1, 2 ] },
+        { "item": "plastic_chunk", "count": [ 1, 2 ] },
+        { "item": "scrap", "count": [ 1, 2 ] },
+        { "item": "steel_chunk", "count": [ 0, 1 ] }
+      ]
+    }
+  },
+  {
+    "type": "furniture",
     "id": "f_screenmirror",
     "name": "screen mirror",
     "symbol": "{",

--- a/data/mods/Aftershock/maps/furniture_and_terrain/furniture_habitat.json
+++ b/data/mods/Aftershock/maps/furniture_and_terrain/furniture_habitat.json
@@ -105,7 +105,7 @@
   {
     "type": "furniture",
     "id": "f_habitat_floodlight",
-    "name": "industrial_floodlight",
+    "name": "industrial floodlight",
     "description": "A wall mountable floodlight, designed to illuminate large areas with a bright, white light.  Still functional thanks to some unknown backup power source.",
     "symbol": "!",
     "color": "brown",

--- a/data/mods/Aftershock/maps/furniture_and_terrain/terrain.json
+++ b/data/mods/Aftershock/maps/furniture_and_terrain/terrain.json
@@ -46,7 +46,7 @@
     "symbol": "LINE_OXOX",
     "color": "light_cyan",
     "move_cost": 0,
-    "roof": "t_flat_roof",
+    "roof": "t_clearcrete_roof",
     "connect_groups": "WALL",
     "connects_to": "WALL",
     "flags": [ "TRANSPARENT", "ALARMED", "NOITEM", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "BLOCK_WIND", "NO_SHOOT" ],

--- a/data/mods/Aftershock/maps/furniture_and_terrain/terrain_habitat_floor.json
+++ b/data/mods/Aftershock/maps/furniture_and_terrain/terrain_habitat_floor.json
@@ -27,6 +27,25 @@
   },
   {
     "type": "terrain",
+    "id": "t_clearcrete_roof",
+    "name": "clearcrete skylight",
+    "description": "A roof made from transparent fiber-reinforced concrete, allowing light to pass through.  Often used to build greenhouses in unfavorable environments.",
+    "symbol": "o",
+    "looks_like": "t_glass_roof",
+    "color": "light_cyan",
+    "move_cost": 2,
+    "flags": [ "TRANSPARENT", "TRANSPARENT_FLOOR" ],
+    "bash": {
+      "str_min": 3,
+      "str_max": 6,
+      "sound": "stone shattering",
+      "sound_fail": "whunk!",
+      "ter_set": "t_null",
+      "items": [ { "item": "clearcrete_chunk", "count": [ 21, 29 ] } ]
+    }
+  },
+  {
+    "type": "terrain",
     "id": "t_metal_floor_olight_inactive",
     "name": "metal floor, with inactive overhead light",
     "description": "High-quality and tough checkered metal flooring to reduce the risk of slips and falls, with a still-functioning inactive light attached to the ceiling above.",

--- a/data/mods/Aftershock/maps/mapgen/habitats/habitat_center.json
+++ b/data/mods/Aftershock/maps/mapgen/habitats/habitat_center.json
@@ -1,0 +1,127 @@
+[
+  {
+    "type": "mapgen",
+    "om_terrain": "afs_modular_habitat_center_maintenance_tiny",
+    "method": "json",
+    "object": {
+      "fill_ter": "t_metal_floor_no_roof",
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "      }}}-----   -------",
+        "     }}##-cOT-}}}}-<}  -",
+        "     }##--.,.!####!,}  -",
+        "     }##!..,.-}}}}->}  -",
+        "     }##-%-]]-   -------",
+        "     }##---00-          ",
+        "     }}##-e00-          ",
+        "      }}}------         ",
+        "         -    -         ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        "
+      ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "palettes": [ "afs_habitat_structure", "afs_habitat_mech_furnishing" ],
+      "terrain": {
+        ".": "t_metal_floor_no_roof",
+        " ": "t_open_air",
+        "e": "t_elevator_control",
+        "0": "t_elevator",
+        "#": "t_bridge",
+        "}": "t_metal_railing"
+      }
+    }
+  },
+  {
+    "type": "mapgen",
+    "om_terrain": "afs_modular_habitat_center_small_ground_level_above",
+    "method": "json",
+    "object": {
+      "fill_ter": "t_metal_floor_no_roof",
+      "rows": [
+        " 1111                   ",
+        " 1111                   ",
+        " 1111                   ",
+        " 1111                   ",
+        " 1111                   ",
+        " 1111                   ",
+        "11111............-------",
+        "111111....--.....-->}  -",
+        "111111....--.....--,}  -",
+        "111111...........--<}  -",
+        "111111..------...-------",
+        "111111..---  -...       ",
+        " 1111    --  -...       ",
+        "         ------         ",
+        "         -    -         ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        "
+      ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "palettes": [ "afs_habitat_structure" ],
+      "terrain": { "1": "t_glass_roof", ".": "t_metal_floor_no_roof", "}": "t_metal_railing", " ": "t_open_air" }
+    }
+  },
+  {
+    "type": "mapgen",
+    "om_terrain": "afs_modular_habitat_center_small_ground_level",
+    "method": "json",
+    "object": {
+      "fill_ter": "t_metal_floor_no_roof",
+      "rows": [
+        " 1__1                   ",
+        " 1__1                   ",
+        " 1__1                   ",
+        "-1..1-                  ",
+        " 1__1                   ",
+        " 1__1      3          3 ",
+        " 1__1////////////-------",
+        " ]____=.=,.k./llll/<1  -",
+        " ]____],],.kh/.,..].1  -",
+        " 1____/c/..,,..,..1.1  -",
+        " 1..1///-%-]]-/!/-------",
+        " 1]]1   ---00-/~/     3 ",
+        "         -e00-///       ",
+        "         ------         ",
+        "         -    -         ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        "
+      ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "palettes": [ "afs_habitat_structure", "afs_habitat_mech_furnishing" ],
+      "terrain": {
+        "_": "t_metal_floor_no_roof",
+        "e": "t_elevator_control",
+        "0": "t_elevator",
+        "1": "t_wall_glass",
+        "}": "t_metal_railing"
+      },
+      "furniture": { "3": "f_habitat_floodlight" }
+    }
+  }
+]

--- a/data/mods/Aftershock/maps/mapgen/habitats/habitat_greenhouse.json
+++ b/data/mods/Aftershock/maps/mapgen/habitats/habitat_greenhouse.json
@@ -1,0 +1,300 @@
+[
+  {
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": "afs_modular_habitat_center_farm",
+    "object": {
+      "fill_ter": "t_metal_floor_no_roof",
+      "place_nested": [ { "chunks": [ "afs_modular_habitat_center_farm" ], "x": 0, "y": 0 } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": "afs_modular_habitat_greenhouse",
+    "object": {
+      "fill_ter": "t_metal_floor_no_roof",
+      "place_nested": [ { "chunks": [ "afs_modular_habitat_greenhouse" ], "x": 0, "y": 0 } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": "afs_modular_habitat_greenhouse_control_room_1s",
+    "object": {
+      "fill_ter": "t_metal_floor_no_roof",
+      "place_nested": [ { "chunks": [ "afs_modular_habitat_greenhouse_control_room_1s" ], "x": 0, "y": 0 } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "afs_modular_habitat_center_farm",
+    "method": "json",
+    "object": {
+      "mapgensize": [ 24, 24 ],
+      "rows": [
+        "..---------!!---------..",
+        "..-1 ú= VV    = hkh/ -..",
+        "//-1 ú=    ,, =  k //---",
+        "//-1  ]    ,, ]    /t t-",
+        "///////ú      //////t t-",
+        "/-----/ú   ,,  úúú/   t-",
+        "/-ííí-6           /+----",
+        "/-í  ¡     ,,     = }..-",
+        "/-----/!/  ,,     ],}..-",
+        "...../c /         =>}..-",
+        ".....//!-%-]]-///-------",
+        ".....}##---00-..........",
+        ".....}##/-e00-..........",
+        ".....}##/------.........",
+        ".....////-....-.........",
+        "........................",
+        "........................",
+        "........................",
+        "........................",
+        "........................",
+        "........................",
+        "........................",
+        "........................",
+        "........................"
+      ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "palettes": [ "afs_habitat_structure", "afs_habitat_residential_furnishing" ],
+      "terrain": {
+        ".": "t_open_air",
+        "e": "t_elevator_control",
+        "=": "t_wall_glass",
+        "#": "t_bridge",
+        "0": "t_elevator",
+        "6": "t_afs_industrial_card_reader",
+        " ": "t_metal_floor",
+        "}": "t_metal_railing",
+        "¡": "t_door_metal_locked"
+      },
+      "furniture": { "ú": "f_bench", "1": "f_locker", "Í": "f_rack", "8": "f_ancient_processor", "t": "f_rack" },
+      "items": {
+        "1": [ { "item": "afs_civilian_hazard_outfit", "chance": 60 }, { "item": "afs_colonist_outfit", "chance": 20 } ],
+        "í": { "item": "afs_tools_agricultural_hazardous", "chance": 90 },
+        "t": { "item": "farming_tools", "chance": 60, "repeat": [ 2, 3 ] }
+      },
+      "vendingmachines": { "V": { "item_group": "afs_vending_medicine", "reinforced": true } }
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "afs_modular_habitat_greenhouse",
+    "method": "json",
+    "object": {
+      "mapgensize": [ 24, 24 ],
+      "rows": [
+        "........................",
+        "...========..========...",
+        "...=______=..=______=...",
+        "...=__22  =..=  22__=...",
+        "..--__22  =..=  22__--..",
+        "..-___22  =..=  22___-..",
+        "..--__22  =..=  22__--..",
+        "...=__22  ====1 22__=...",
+        "...=____,,    ,,____=...",
+        "...=__22  2222  22__=...",
+        "..--__22  2222  22__--..",
+        "..-3__22  2222  22__3-..",
+        "..-3__22  2222  22__3-..",
+        "..--____,,    ,,____--..",
+        "...=__22  2222  22__=...",
+        "...=__22  2222  22__=...",
+        "...=__22  2222  22__=...",
+        "..--____,,    ,,____--..",
+        "..-___22  2222  22___-..",
+        "..--__22  2222  22__--..",
+        "...=     1          =...",
+        "...=                =...",
+        "...=4444|/===]/|4444=...",
+        "..//|||||      |||||//.."
+      ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "palettes": [ "afs_habitat_structure" ],
+      "terrain": {
+        ".": "t_open_air",
+        "=": "t_wall_clearcrete_h_alarm",
+        " ": "t_metal_floor",
+        "1": "t_metal_floor",
+        "_": "t_grass",
+        "4": "t_ramp_up_high"
+      },
+      "furniture": { "3": "f_drone_recharge_station" },
+      "sealed_item": { "2": { "item": { "item": "seed_tomato" }, "furniture": "f_planter_unharvested_overgrown", "chance": 100 } },
+      "monsters": { "2": { "monster": "GROUP_ROBOT_FARM_HOSTILE", "chance": 15, "density": 0.1 } }
+    }
+  },
+  {
+    "type": "mapgen",
+    "om_terrain": "afs_modular_habitat_greenhouse_roof",
+    "method": "json",
+    "object": {
+      "rows": [
+        "........................",
+        "...________..________...",
+        "...________..________...",
+        "...________..________...",
+        "..//_______.._______//..",
+        "../________..________/..",
+        "..//_______.._______//..",
+        "...__________________...",
+        "...__________________...",
+        "...__________________...",
+        "..//________________//..",
+        "../__________________/..",
+        "../__________________/..",
+        "..//________________//..",
+        "...__________________...",
+        "...__________________...",
+        "...__________________...",
+        "..//________________//..",
+        "../__________________/..",
+        "..//________________//..",
+        "...__________________...",
+        "...======______======...",
+        "...=4444=______=4444=...",
+        "..//5555|//__//|5555//.."
+      ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "palettes": [ "afs_habitat_structure" ],
+      "terrain": {
+        ".": "t_open_air",
+        "5": "t_ramp_down_high",
+        "4": "t_ramp_down_low",
+        "=": "t_wall_clearcrete_h_alarm",
+        "_": "t_clearcrete_roof"
+      }
+    }
+  },
+  {
+    "type": "mapgen",
+    "om_terrain": "afs_modular_habitat_greenhouse_roof2",
+    "method": "json",
+    "object": {
+      "rows": [
+        "........................",
+        "........................",
+        "........................",
+        "........................",
+        "........................",
+        "........................",
+        "........................",
+        "........................",
+        "........................",
+        "........................",
+        "........................",
+        "........................",
+        "........................",
+        "........................",
+        "........................",
+        "........................",
+        "........................",
+        "........................",
+        "........................",
+        "........................",
+        "........................",
+        "...______......______...",
+        "...______......______...",
+        "..____________________.."
+      ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "palettes": [ "afs_habitat_structure" ],
+      "terrain": { ".": "t_open_air", "_": "t_clearcrete_roof" }
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "afs_modular_habitat_greenhouse_control_room_1s",
+    "method": "json",
+    "object": {
+      "mapgensize": [ 24, 24 ],
+      "rows": [
+        "..//    |//==//|    //..",
+        "..=                  =..",
+        "//- 22 2   ,,   2 22 -//",
+        "/7  22 2   ,,   2 22   /",
+        "/7  22 2   ,,   2 22   /",
+        "/7                     /",
+        "///      / ,, /111111/!/",
+        "../333333/4   /888888/ }",
+        "..///------¡¡------/// }",
+        ".....-8__________8-    }",
+        ".....--___-4¡-___--}}}}}",
+        ".....-____-__-____-.....",
+        ".....=____-_5-____=.....",
+        ".....=____----____=.....",
+        ".....///________///.....",
+        "......./========/.......",
+        "........................",
+        "........................",
+        "........................",
+        "........................",
+        "........................",
+        "........................",
+        "........................",
+        "........................"
+      ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "palettes": [ "afs_habitat_structure" ],
+      "terrain": {
+        ".": "t_open_air",
+        "¡": "t_door_metal_locked",
+        "4": "t_afs_industrial_card_reader",
+        "1": "t_reinforced_glass",
+        "=": "t_wall_clearcrete_h_alarm",
+        "_": "t_metal_floor_no_roof",
+        " ": "t_metal_floor_no_roof",
+        "}": "t_metal_railing"
+      },
+      "furniture": {
+        "2": "f_planter",
+        "3": "f_drone_recharge_station",
+        "7": "f_habitat_storage_board",
+        "5": [ [ "f_drone_ai_core_broken", 20 ], [ "f_drone_ai_core", 1 ] ],
+        "8": "f_ancient_processor"
+      },
+      "items": { "7": [ { "item": "farming_tools", "chance": 60, "repeat": [ 2, 3 ] } ] },
+      "monsters": { "_": { "monster": "GROUP_ROBOT_FARM_HOSTILE", "chance": 15, "density": 0.1 } }
+    }
+  },
+  {
+    "type": "mapgen",
+    "om_terrain": "afs_modular_habitat_greenhouse_control_room_1s_roof",
+    "method": "json",
+    "object": {
+      "fill_ter": "t_metal_floor_no_roof",
+      "rows": [
+        "..____________________..",
+        "..____________________..",
+        "________________________",
+        "________________________",
+        "________________________",
+        "________________________",
+        "  /__________________/  ",
+        "../__________________/..",
+        "..////     __     ////..",
+        "...../____________/.....",
+        "...../   ______   /.....",
+        "....._____    _____.....",
+        "....._____    _____.....",
+        "....._____    _____.....",
+        ".....   ________   .....",
+        "....... ________ .......",
+        "........................",
+        "........................",
+        "........................",
+        "........................",
+        "........................",
+        "........................",
+        "........................",
+        "........................"
+      ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "palettes": [ "afs_habitat_structure" ],
+      "terrain": { ".": "t_open_air", "_": "t_clearcrete_roof", " ": "t_metal_floor_no_roof" }
+    }
+  }
+]

--- a/data/mods/Aftershock/maps/mapgen/habitats/habitat_structure.json
+++ b/data/mods/Aftershock/maps/mapgen/habitats/habitat_structure.json
@@ -1,0 +1,187 @@
+[
+  {
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": "afs_modular_habitat_pillars_ground_walkway",
+    "object": {
+      "fill_ter": "t_region_groundcover_urban",
+      "place_nested": [
+        {
+          "chunks": [
+            [ "null", 80 ],
+            [ "formless_ruins_empty1", 5 ],
+            [ "formless_ruins_empty2", 5 ],
+            [ "formless_ruins_empty3", 5 ],
+            [ "formless_ruins_empty4", 5 ]
+          ],
+          "x": 0,
+          "y": 0
+        },
+        {
+          "chunks": [
+            [ "null", 80 ],
+            [ "formless_ruins_empty1", 5 ],
+            [ "formless_ruins_empty2", 5 ],
+            [ "formless_ruins_empty3", 5 ],
+            [ "formless_ruins_empty4", 5 ]
+          ],
+          "x": 12,
+          "y": 0
+        },
+        {
+          "chunks": [
+            [ "null", 80 ],
+            [ "formless_ruins_empty1", 5 ],
+            [ "formless_ruins_empty2", 5 ],
+            [ "formless_ruins_empty3", 5 ],
+            [ "formless_ruins_empty4", 5 ]
+          ],
+          "x": 0,
+          "y": 12
+        },
+        {
+          "chunks": [
+            [ "null", 80 ],
+            [ "formless_ruins_empty1", 5 ],
+            [ "formless_ruins_empty2", 5 ],
+            [ "formless_ruins_empty3", 5 ],
+            [ "formless_ruins_empty4", 5 ]
+          ],
+          "x": 12,
+          "y": 12
+        },
+        { "chunks": [ "afs_modular_habitat_end_pillars_ground_walkway" ], "x": 0, "y": 0 }
+      ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": "afs_modular_habitat_end_pillars_above_walkway",
+    "object": {
+      "fill_ter": "t_open_air",
+      "place_nested": [ { "chunks": [ "afs_modular_habitat_end_pillars_above_walkway" ], "x": 0, "y": 0 } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": "afs_modular_habitat_pillars",
+    "object": { "fill_ter": "t_open_air", "place_nested": [ { "chunks": [ "afs_modular_habitat_end_pillars" ], "x": 0, "y": 0 } ] }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "afs_modular_habitat_end_pillars",
+    "method": "json",
+    "object": {
+      "mapgensize": [ 24, 24 ],
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "  //                //  ",
+        "  /                  /  ",
+        "  //                //  ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "  //                //  ",
+        "  /                  /  ",
+        "  /                  /  ",
+        "  //                //  ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "  //                //  ",
+        "  /                  /  ",
+        "  //                //  ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        "
+      ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "terrain": { "/": "t_wall_metal" }
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "afs_modular_habitat_end_pillars_ground_walkway",
+    "method": "json",
+    "object": {
+      "mapgensize": [ 24, 24 ],
+      "rows": [
+        "                        ",
+        " 1]]1                   ",
+        " 1__1                   ",
+        " 1__1                   ",
+        " /__/               //  ",
+        " /../2              2/  ",
+        " /__/               //  ",
+        " 1__1                   ",
+        "/1__1/                  ",
+        " 1__1                   ",
+        " /__/               //  ",
+        " /../                /  ",
+        " /../2              2/  ",
+        " /__/               //  ",
+        " 1__1                   ",
+        "/1__1/                  ",
+        " 1__1                   ",
+        " /__/               //  ",
+        " /../2              2/  ",
+        " /__/               //  ",
+        " 1__1                   ",
+        "/1__1/                  ",
+        " 1__1                   ",
+        " 1__1                   "
+      ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "terrain": {
+        "/": "t_wall_metal",
+        "1": "t_wall_glass",
+        "_": "t_metal_floor_no_roof",
+        "]": "t_door_glass_c",
+        ".": "t_metal_floor_olight"
+      },
+      "furniture": { "2": "f_habitat_floodlight" }
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "afs_modular_habitat_end_pillars_above_walkway",
+    "method": "json",
+    "object": {
+      "mapgensize": [ 24, 24 ],
+      "rows": [
+        "                        ",
+        " 1111                   ",
+        " 1111                   ",
+        " 1111                   ",
+        " 1//.               //  ",
+        " 1/..                /  ",
+        " 1//.               //  ",
+        " 1111                   ",
+        ".1111.                  ",
+        " 1111                   ",
+        " 1//.               //  ",
+        " 1/..                /  ",
+        " 1/..                /  ",
+        " 1//.               //  ",
+        " 1111                   ",
+        ".1111.                  ",
+        " 1111                   ",
+        " 1//.               //  ",
+        " 1/..                /  ",
+        " 1//.               //  ",
+        " 1111                   ",
+        ".1111.                  ",
+        " 1111                   ",
+        " 1111                   "
+      ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "terrain": { "/": "t_wall_metal", "1": "t_glass_roof", ".": "t_metal_floor_no_roof" }
+    }
+  }
+]

--- a/data/mods/Aftershock/maps/overmap_terrain/overmap_terrain_habitats.json
+++ b/data/mods/Aftershock/maps/overmap_terrain/overmap_terrain_habitats.json
@@ -1,0 +1,55 @@
+[
+  {
+    "type": "overmap_terrain",
+    "id": [ "afs_modular_habitat_center_small_ground_level_above", "afs_modular_habitat_center_small_ground_level" ],
+    "name": "habitat entrance",
+    "sym": "H",
+    "color": "light_blue",
+    "see_cost": 2,
+    "flags": [ "SIDEWALK" ]
+  },
+  {
+    "type": "overmap_terrain",
+    "id": [
+      "afs_modular_habitat_pillars_ground_walkway",
+      "afs_modular_habitat_end_pillars_above_walkway",
+      "afs_modular_habitat_pillars"
+    ],
+    "name": "habitat superstructure",
+    "sym": "+",
+    "color": "light_gray",
+    "see_cost": 2
+  },
+  {
+    "type": "overmap_terrain",
+    "id": [ "afs_modular_habitat_center_maintenance_tiny" ],
+    "name": "habitat maintenance level",
+    "sym": "+",
+    "color": "yellow",
+    "see_cost": 2
+  },
+  {
+    "type": "overmap_terrain",
+    "id": [ "afs_modular_habitat_center_farm", "afs_modular_habitat_greenhouse" ],
+    "name": "urban farm",
+    "sym": "f",
+    "color": "light_green",
+    "see_cost": 2
+  },
+  {
+    "type": "overmap_terrain",
+    "id": [ "afs_modular_habitat_greenhouse_roof2", "afs_modular_habitat_greenhouse_roof" ],
+    "name": "urban farm roof",
+    "sym": "f",
+    "color": "light_green",
+    "see_cost": 2
+  },
+  {
+    "type": "overmap_terrain",
+    "id": [ "afs_modular_habitat_greenhouse_control_room_1s", "afs_modular_habitat_greenhouse_control_room_1s_roof" ],
+    "name": "farm control room",
+    "sym": "o",
+    "color": "light_green",
+    "see_cost": 2
+  }
+]

--- a/data/mods/Aftershock/mobs/abstract_monsters.json
+++ b/data/mods/Aftershock/mobs/abstract_monsters.json
@@ -24,7 +24,16 @@
     "path_settings": { "max_dist": 5 },
     "death_drops": { "groups": [ [ "broken_robots", 1 ] ] },
     "death_function": { "corpse_type": "BROKEN" },
-    "flags": [ "SEES", "HEARS", "BASHES", "ELECTRONIC", "NO_BREATHE", "PRIORITIZE_TARGETS", "PATH_AVOID_DANGER_1" ],
+    "flags": [
+      "SEES",
+      "HEARS",
+      "BASHES",
+      "ELECTRONIC",
+      "NO_BREATHE",
+      "BIOLOGICALPROOF",
+      "PRIORITIZE_TARGETS",
+      "PATH_AVOID_DANGER_1"
+    ],
     "armor": { "bash": 12, "cut": 12, "stab": 6, "acid": 12, "heat": 5 }
   },
   {
@@ -54,7 +63,16 @@
     "path_settings": { "max_dist": 5 },
     "death_drops": { "groups": [ [ "broken_robots", 1 ] ] },
     "death_function": { "corpse_type": "BROKEN" },
-    "flags": [ "SEES", "HEARS", "BASHES", "ELECTRONIC", "NO_BREATHE", "PRIORITIZE_TARGETS", "PATH_AVOID_DANGER_1" ],
+    "flags": [
+      "SEES",
+      "HEARS",
+      "BASHES",
+      "ELECTRONIC",
+      "NO_BREATHE",
+      "BIOLOGICALPROOF",
+      "PRIORITIZE_TARGETS",
+      "PATH_AVOID_DANGER_1"
+    ],
     "armor": { "bash": 10, "cut": 10, "stab": 5, "acid": 10, "heat": 5 }
   },
   {

--- a/data/mods/Aftershock/mobs/monster_faction.json
+++ b/data/mods/Aftershock/mobs/monster_faction.json
@@ -36,6 +36,14 @@
   },
   {
     "type": "MONSTER_FACTION",
+    "name": "rampant_machine",
+    "base_faction": "robofac",
+    "neutral": [ "utility_bot" ],
+    "hate": [ "zombie", "fungus", "cult", "alien_predator", "triffid", "nether", "PrepNet", "moxie", "bio_machine", "reavers" ],
+    "by_mood": [ "human" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
     "name": "UICA_mil",
     "base_faction": "WraitheonRobotics"
   },

--- a/data/mods/Aftershock/mobs/monster_groups/robot_monster_groups.json
+++ b/data/mods/Aftershock/mobs/monster_groups/robot_monster_groups.json
@@ -32,5 +32,16 @@
       { "monster": "mon_skitterbot", "weight": 200, "cost_multiplier": 20 },
       { "monster": "mon_scavbot_needle", "weight": 100, "cost_multiplier": 70 }
     ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_ROBOT_FARM_HOSTILE",
+    "default": "mon_manhack",
+    "monsters": [
+      { "monster": "mon_utilibot_hostile", "weight": 500, "cost_multiplier": 70 },
+      { "monster": "mon_fumigator", "weight": 200, "cost_multiplier": 4, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_skitterbot", "weight": 200, "cost_multiplier": 20 },
+      { "monster": "mon_scavbot_needle", "weight": 3, "cost_multiplier": 70 }
+    ]
   }
 ]

--- a/data/mods/Aftershock/mobs/robots.json
+++ b/data/mods/Aftershock/mobs/robots.json
@@ -71,7 +71,7 @@
     "path_settings": { "max_dist": 10 },
     "special_attacks": [ [ "CHICKENBOT", 4 ] ],
     "death_function": { "corpse_type": "BROKEN" },
-    "flags": [ "SEES", "HEARS", "BASHES", "NO_BREATHE", "ELECTRONIC", "PRIORITIZE_TARGETS", "DROPS_AMMO" ],
+    "flags": [ "SEES", "HEARS", "BASHES", "NO_BREATHE", "BIOLOGICALPROOF", "ELECTRONIC", "PRIORITIZE_TARGETS", "DROPS_AMMO" ],
     "armor": { "bash": 18, "cut": 14, "bullet": 11 }
   },
   {
@@ -105,6 +105,7 @@
       "SEES",
       "HEARS",
       "GOODHEARING",
+      "BIOLOGICALPROOF",
       "NOHEAD",
       "BASHES",
       "DESTROYS",
@@ -161,7 +162,18 @@
     ],
     "death_drops": { "groups": [ [ "robots", 4 ], [ "tripod", 1 ] ] },
     "death_function": { "corpse_type": "BROKEN" },
-    "flags": [ "SEES", "HEARS", "GOODHEARING", "BASHES", "NO_BREATHE", "ELECTRONIC", "CLIMBS", "PRIORITIZE_TARGETS", "FIREPROOF" ],
+    "flags": [
+      "SEES",
+      "HEARS",
+      "GOODHEARING",
+      "BASHES",
+      "NO_BREATHE",
+      "BIOLOGICALPROOF",
+      "ELECTRONIC",
+      "CLIMBS",
+      "PRIORITIZE_TARGETS",
+      "FIREPROOF"
+    ],
     "armor": { "bash": 12, "cut": 8, "bullet": 6 }
   },
   {
@@ -207,6 +219,7 @@
       "SEES",
       "HEARS",
       "BASHES",
+      "BIOLOGICALPROOF",
       "ELECTRONIC",
       "NO_BREATHE",
       "PRIORITIZE_TARGETS",
@@ -262,7 +275,7 @@
     "vision_day": 50,
     "death_function": { "corpse_type": "BROKEN" },
     "death_drops": { "groups": [ [ "broken_robots", 3 ] ] },
-    "flags": [ "SEES", "HEARS", "ELECTRONIC", "NO_BREATHE", "PRIORITIZE_TARGETS", "PATH_AVOID_DANGER_1" ],
+    "flags": [ "SEES", "HEARS", "ELECTRONIC", "BIOLOGICALPROOF", "NO_BREATHE", "PRIORITIZE_TARGETS", "PATH_AVOID_DANGER_1" ],
     "armor": { "bash": 8, "cut": 8, "acid": 6, "heat": 4 }
   },
   {
@@ -287,10 +300,14 @@
     "name": "TsKBEM Udarnik",
     "description": "A highly customizable light industrial and agricultural robot.  Its original design dates back to the ancient Soviet Union; the aptly named Udarnik \"shock worker\" was the trigger behind the automation revolution, and with subsequent adaptations, became the workhorse of early human space colonization.  Although outdated by modern standards, the Udarnik is still commonly seen in frontier worlds - thanks to its easily obtainable fabrication schematics.\n\nThis particular version is equipped with a mix of construction and heavy cargo-handling tools and was likely involved in the construction of colony buildings.",
     "color": "yellow",
+    "volume": "680388 ml",
+    "weight": "680388 g",
     "luminance": 10,
     "melee_skill": 2,
     "melee_dice": 4,
     "melee_dice_sides": 6,
+    "hp": 400,
+    "armor": { "bash": 12, "cut": 20, "bullet": 12, "acid": 80, "heat": 20 },
     "melee_damage": [ { "damage_type": "cut", "amount": 1 } ],
     "starting_ammo": { "nail": 1000 },
     "special_attacks": [
@@ -304,6 +321,24 @@
       }
     ],
     "extend": { "flags": [ "DROPS_AMMO" ] }
+  },
+  {
+    "id": "mon_utilibot_hostile",
+    "type": "MONSTER",
+    "copy-from": "mon_utilibot",
+    "name": "rampant Udarnik",
+    "description": "An erratic and dangerous Udarnik that mistakenly attempts to hammer everything on its sights.  Although this corrupted robot is not built for combat, its sheer size and hydraulic strength make it extremely dangerous up close.",
+    "default_faction": "rampant_machine",
+    "color": "yellow",
+    "luminance": 10,
+    "melee_skill": 4,
+    "morale": 20,
+    "aggression": 50,
+    "melee_dice": 4,
+    "melee_dice_sides": 6,
+    "speed": 80,
+    "special_attacks": [ { "id": "smash", "throw_strength": 96 } ],
+    "extend": { "flags": [ "BASHES", "DESTROYS", "ATTACKMON" ] }
   },
   {
     "id": "mon_utilibot_fire",
@@ -331,6 +366,40 @@
     "extend": { "flags": [ "FIREPROOF", "BASHES" ] }
   },
   {
+    "id": "mon_fumigator",
+    "type": "MONSTER",
+    "copy-from": "base_drone",
+    "name": "Croplord 2SPL",
+    "description": "Twin linked rotors allow this ubiquitous EINAC drone to comfortably hover above fields and deploy pesticides at prodigious rates.  They have no ability to detect humans within their work areas and will readily disperse lethal pesticides near them.",
+    "default_faction": "rampant_machine",
+    "symbol": "y",
+    "diff": 40,
+    "speed": 100,
+    "volume": "1750 ml",
+    "weight": "1 kg",
+    "color": "green",
+    "melee_skill": 8,
+    "melee_dice": 1,
+    "melee_dice_sides": 6,
+    "morale": 20,
+    "starting_ammo": { "afs_foamtoxic": 400 },
+    "death_function": { "corpse_type": "BROKEN", "message": "The Croplord crahses into the ground." },
+    "special_attacks": [
+      {
+        "type": "gun",
+        "move_cost": 80,
+        "cooldown": 3,
+        "gun_type": "afs_foamgun",
+        "ammo_type": "afs_foamtoxic",
+        "fake_skills": [ [ "gun", 2 ], [ "launcher", 2 ] ],
+        "fake_dex": 8,
+        "ranges": [ [ 0, 6, "DEFAULT" ] ]
+      }
+    ],
+    "armor": { "stab": 6, "acid": 12, "bash": 20, "cut": 30, "heat": 15, "bullet": 35 },
+    "extend": { "flags": [ "DROPS_AMMO" ] }
+  },
+  {
     "id": "mon_medibot",
     "type": "MONSTER",
     "name": "faulty surgical droid",
@@ -356,7 +425,7 @@
     "anger_triggers": [ "FRIEND_ATTACKED", "PLAYER_WEAK", "HURT", "PLAYER_CLOSE" ],
     "death_function": { "corpse_type": "BROKEN" },
     "death_drops": { "groups": [ [ "broken_robots", 3 ] ] },
-    "flags": [ "SEES", "HEARS", "ELECTRONIC", "NO_BREATHE", "PRIORITIZE_TARGETS", "PATH_AVOID_DANGER_1" ],
+    "flags": [ "SEES", "HEARS", "ELECTRONIC", "BIOLOGICALPROOF", "NO_BREATHE", "PRIORITIZE_TARGETS", "PATH_AVOID_DANGER_1" ],
     "armor": { "bash": 6, "cut": 6, "acid": 6, "heat": 2 }
   },
   {
@@ -822,6 +891,7 @@
       "BASHES",
       "PUSH_MON",
       "ELECTRONIC",
+      "BIOLOGICALPROOF",
       "NO_BREATHE",
       "PET_MOUNTABLE",
       "PATH_AVOID_DANGER_2",

--- a/data/mods/Aftershock/npcs/Augustmoon_Salvors/augustmoon_outfitter.json
+++ b/data/mods/Aftershock/npcs/Augustmoon_Salvors/augustmoon_outfitter.json
@@ -38,6 +38,7 @@
       { "group": "afs_wintersuit_generic_advanced", "count": [ 1, 3 ] },
       { "group": "afs_basic_armor", "count": [ 0, 3 ] },
       { "group": "afs_colonist_outfit", "count": [ 1, 3 ] },
+      { "group": "afs_civilian_hazard_outfit", "count": [ 1, 3 ], "prob": 60 },
       { "group": "afs_pals_pieces", "count": [ 6, 12 ] },
       { "group": "afs_augustmoon_outfitter_bags", "count": [ 10, 28 ] }
     ]

--- a/data/mods/Aftershock/recipes/uncraft.json
+++ b/data/mods/Aftershock/recipes/uncraft.json
@@ -242,6 +242,33 @@
     ]
   },
   {
+    "result": "broken_utilibot_hostile",
+    "type": "uncraft",
+    "activity_level": "LIGHT_EXERCISE",
+    "time": "2 h",
+    "skill_used": "electronics",
+    "difficulty": 4,
+    "using": [ [ "soldering_standard", 20 ], [ "welding_standard", 5 ] ],
+    "qualities": [ { "id": "SCREW_FINE", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
+    "components": [
+      [ [ "ai_module", 1 ] ],
+      [ [ "robot_controls", 1 ] ],
+      [ [ "sensor_module", 1 ] ],
+      [ [ "utilibot_const_chassis", 1 ] ],
+      [ [ "afs_circuitry_1", 6 ] ],
+      [ [ "afs_circuitry_2", 4 ] ],
+      [ [ "afs_circuitry_3", 2 ] ],
+      [ [ "afs_energy_storage_3", 2 ] ],
+      [ [ "afs_energy_storage_4", 1 ] ],
+      [ [ "afs_material_1", 12 ] ],
+      [ [ "afs_material_2", 4 ] ],
+      [ [ "targeting_module", 1 ] ],
+      [ [ "gun_module", 2 ] ],
+      [ [ "nailgun", 1 ] ],
+      [ [ "welder", 1 ] ]
+    ]
+  },
+  {
     "result": "broken_utilibot_fire",
     "type": "uncraft",
     "activity_level": "LIGHT_EXERCISE",

--- a/data/mods/Aftershock/region_settings.json
+++ b/data/mods/Aftershock/region_settings.json
@@ -13,6 +13,7 @@
         "office_tower_large": 300,
         "office_tower_hiddenlab": 200,
         "afs_astrobiology_lab": 200,
+        "afs_city_urban_farm_small": 400,
         "mall": 100
       },
       "houses": { "afs_city_ruinfield": 200, "afs_formless_ruins_dynamic": 300, "afs_house_1": 100, "house_09": 20 }

--- a/data/mods/aftershock_exoplanet/region_settings.json
+++ b/data/mods/aftershock_exoplanet/region_settings.json
@@ -35,7 +35,12 @@
       "park_sigma": 80,
       "houses": { "afs_city_ruinfield": 400, "afs_formless_ruins_dynamic": 600, "afs_house_1": 300 },
       "parks": { "afs_city_ruinfield": 100, "afs_shuttle_pad": 10 },
-      "shops": { "afs_augmentation_clinic_1": 400, "afs_astrobiology_lab": 400, "afs_general_store_1": 400 }
+      "shops": {
+        "afs_augmentation_clinic_1": 400,
+        "afs_astrobiology_lab": 400,
+        "afs_general_store_1": 400,
+        "afs_city_urban_farm_small": 300
+      }
     },
     "weather": {
       "base_temperature": -50.0,


### PR DESCRIPTION
#### Summary
Mods "Aftershock: Add urban farms as town buildings"

#### Purpose of change
Adds a modular Cross shaped habitat structure for general use and future expansion within the mod. Right now only the base structure, and central modules are in, alongside a "greenhouse" wing for the structure. 

#### Describe the solution
The main greenhouse level and rogue bots within:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/5290912/2aaf3353-7024-4adf-802e-2cc89620ce34)

The upper control room
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/5290912/ab4c5de4-b1d4-468c-8b29-e53502db5eb5)

Mostly spawns tools alongside toxic pesticide that is great at killing anything that breathes. Includes some new clothing pieces too.

#### Testing

Visited the map a few times.