### PR TITLE
Switched Plasma Reload Speeds

### DIFF
--- a/data/json/items/ranged/energy.json
+++ b/data/json/items/ranged/energy.json
@@ -24,7 +24,7 @@
     "dispersion": 90,
     "durability": 6,
     "clip_size": 25,
-    "reload": 200,
+    "reload": 700,
     "valid_mod_locations": [
       [ "emitter", 1 ],
       [ "grip", 1 ],
@@ -62,7 +62,7 @@
     "durability": 8,
     "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "AUTO", "auto", 3 ] ],
     "clip_size": 25,
-    "reload": 700,
+    "reload": 200,
     "valid_mod_locations": [
       [ "emitter", 1 ],
       [ "grip", 1 ],


### PR DESCRIPTION
#### Summary

Balance "Switched Reload Speeds for Plasma Rifle and PPA"

#### Purpose of change

Against all reason, the plasma rifle takes more than twice as long to reload as the larger and more powerful PPA. From a balance perspective, this means that the strongest plasma weapon is relatively convenient to reload while the weakest one is inexplicably harder to use.

It seems obvious that the reload values are in the wrong order. The rifle’s unusual design should take twice as long as your average firearm to reload, while the accelerator’s role as an anti-tank weapon (and size to match) means it should be the one that takes seven times as long.

#### Describe the solution

Take the reload speeds of each item and switch. This should make the PPA less overpowered and make the plasma rifle’s full-auto setting not as useless.

#### Describe alternatives you've considered

N/A

#### Testing

N/A

#### Additional context
 
 N/A