### PR TITLE
Remove Railgun Fouling

### DIFF
--- a/data/json/items/gun/12mm.json
+++ b/data/json/items/gun/12mm.json
@@ -30,7 +30,7 @@
       [ "stock accessory", 2 ],
       [ "underbarrel", 1 ]
     ],
-    "flags": [ "NEVER_JAMS", "USE_UPS" ],
+    "flags": [ "NEVER_JAMS", "NON_FOULING", "USE_UPS" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "magazine_well": "250 ml", "item_restriction": [ "hk_g80mag" ] } ],
     "melee_damage": { "bash": 12 }
   }

--- a/data/json/items/gun/12mm.json
+++ b/data/json/items/gun/12mm.json
@@ -30,7 +30,7 @@
       [ "stock accessory", 2 ],
       [ "underbarrel", 1 ]
     ],
-    "flags": [ "NEVER_JAMS", "NON_FOULING", "USE_UPS" ],
+    "flags": [ "NEVER_JAMS", "NON_FOULING", "NEEDS_NO_LUBE", "USE_UPS" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "magazine_well": "250 ml", "item_restriction": [ "hk_g80mag" ] } ],
     "melee_damage": { "bash": 12 }
   }


### PR DESCRIPTION
#### Summary

Bugfixes "Removes Railgun Fouling"

#### Purpose of change

Railguns, as a general rule, don’t use chemical propellant. Propellant is what causes fouling. 12mm slugs in the game don’t even have a casing for propellant.

#### Describe the solution

Add a flag to stop fouling and nonexistent casings getting stuck in the barrel.

#### Describe alternatives you've considered

Rewrite the G80 as some kind of “chemrail” hybrid.

#### Testing

N/A

#### Additional context

N/A