### PR TITLE
Introduce half face gas mask

### DIFF
--- a/data/json/itemgroups/Clothing_Gear/clothing.json
+++ b/data/json/itemgroups/Clothing_Gear/clothing.json
@@ -711,7 +711,11 @@
     "type": "item_group",
     "//": "Protective masks often worn by technicians and tradesmen.",
     "subtype": "distribution",
-    "entries": [ { "item": "mask_dust", "prob": 90 }, { "item": "mask_filter", "prob": 10, "charges": [ 0, 100 ] }, { "item": "mask_gas_half", "prob": 10, "charges": [ 0, 100 ] } ]
+    "entries": [
+      { "item": "mask_dust", "prob": 90 },
+      { "item": "mask_filter", "prob": 10, "charges": [ 0, 100 ] },
+      { "item": "mask_gas_half", "prob": 10, "charges": [ 0, 100 ] }
+    ]
   },
   {
     "id": "clothing_work_pants",

--- a/data/json/itemgroups/Clothing_Gear/clothing.json
+++ b/data/json/itemgroups/Clothing_Gear/clothing.json
@@ -711,7 +711,7 @@
     "type": "item_group",
     "//": "Protective masks often worn by technicians and tradesmen.",
     "subtype": "distribution",
-    "entries": [ { "item": "mask_dust", "prob": 90 }, { "item": "mask_filter", "prob": 10, "charges": [ 0, 100 ] } ]
+    "entries": [ { "item": "mask_dust", "prob": 90 }, { "item": "mask_filter", "prob": 10, "charges": [ 0, 100 ] }, { "item": "mask_gas_half", "prob": 10, "charges": [ 0, 100 ] } ]
   },
   {
     "id": "clothing_work_pants",
@@ -784,6 +784,7 @@
       [ "attachable_ear_muffs", 5 ],
       [ "mask_dust", 30 ],
       { "item": "mask_filter", "prob": 30, "charges": [ 0, 100 ] },
+      { "item": "mask_gas_half", "prob": 30, "charges": [ 0, 100 ] },
       [ "glasses_safety", 30 ],
       [ "ear_plugs", 35 ],
       [ "apron_cut_resistant", 5 ],
@@ -885,7 +886,7 @@
     "//": "Full face protection worn with hazmat suits",
     "items": [
       { "collection": [ { "item": "glasses_safety" }, { "item": "mask_filter", "charges": [ 0, -1 ] } ], "prob": 40 },
-      { "item": "mask_gas", "prob": 60, "charges": [ 0, -1 ] }
+      { "item": "mask_gas", "prob": 60, "charges": [ 0, -1 ] }, { "item": "mask_gas_half", "prob": 60, "charges": [ 0, -1 ] }
     ]
   },
   {
@@ -3100,6 +3101,7 @@
       { "item": "mask_bunker", "prob": 70, "charges": [ 0, -1 ] },
       [ "mask_dust", 30 ],
       { "item": "mask_gas", "prob": 20, "charges": [ 0, -1 ] },
+      { "item": "mask_gas_half", "prob": 20, "charges": [ 0, -1 ] }
       { "item": "mask_filter", "prob": 10, "charges": [ 0, -1 ] },
       { "item": "goggles_nv", "prob": 2, "charges": [ 0, 100 ] },
       { "item": "goggles_ir", "prob": 1, "charges": [ 0, 100 ] }
@@ -3335,6 +3337,7 @@
       [ "mask_bal", 14 ],
       [ "mask_hockey", 26 ],
       { "item": "mask_gas", "prob": 24, "charges": [ 0, 100 ] },
+      { "item": "mask_gas_half", "prob": 24, "charges": [ 0, 100 ] },
       { "item": "mask_filter", "prob": 12, "charges": [ 0, 100 ] },
       [ "mask_bunker", 2 ],
       [ "mask_fsurvivor", 2 ],

--- a/data/json/itemgroups/Clothing_Gear/clothing.json
+++ b/data/json/itemgroups/Clothing_Gear/clothing.json
@@ -890,7 +890,8 @@
     "//": "Full face protection worn with hazmat suits",
     "items": [
       { "collection": [ { "item": "glasses_safety" }, { "item": "mask_filter", "charges": [ 0, -1 ] } ], "prob": 40 },
-      { "item": "mask_gas", "prob": 60, "charges": [ 0, -1 ] }, { "item": "mask_gas_half", "prob": 60, "charges": [ 0, -1 ] }
+      { "item": "mask_gas", "prob": 60, "charges": [ 0, -1 ] },
+      { "item": "mask_gas_half", "prob": 60, "charges": [ 0, -1 ] }
     ]
   },
   {

--- a/data/json/itemgroups/Clothing_Gear/clothing.json
+++ b/data/json/itemgroups/Clothing_Gear/clothing.json
@@ -3101,7 +3101,7 @@
       { "item": "mask_bunker", "prob": 70, "charges": [ 0, -1 ] },
       [ "mask_dust", 30 ],
       { "item": "mask_gas", "prob": 20, "charges": [ 0, -1 ] },
-      { "item": "mask_gas_half", "prob": 20, "charges": [ 0, -1 ] }
+      { "item": "mask_gas_half", "prob": 20, "charges": [ 0, -1 ] },
       { "item": "mask_filter", "prob": 10, "charges": [ 0, -1 ] },
       { "item": "goggles_nv", "prob": 2, "charges": [ 0, 100 ] },
       { "item": "goggles_ir", "prob": 1, "charges": [ 0, 100 ] }

--- a/data/json/itemgroups/Locations_MapExtras/locations.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations.json
@@ -391,6 +391,7 @@
       [ "crowbar", 15 ],
       [ "gloves_work", 45 ],
       { "item": "mask_filter", "prob": 30, "charges": [ 0, 100 ] },
+      { "item": "mask_gas_half", "prob": 25, "charges": [ 0, 100 ] },
       [ "glasses_safety", 40 ],
       [ "hat_hard", 50 ],
       [ "hat_hard_hooded", 25 ],

--- a/data/json/itemgroups/tools.json
+++ b/data/json/itemgroups/tools.json
@@ -739,6 +739,7 @@
       [ "mask_dust", 5 ],
       { "item": "mask_filter", "prob": 5, "charges": [ 0, 100 ] },
       { "item": "gasfilter_sm", "prob": 5, "charges": [ 0, 100 ] },
+      { "item": "mask_gas_half", "prob": 5, "charges": [ 0, 100 ] },
       [ "glasses_safety", 5 ],
       { "item": "UPS_OFF", "prob": 3, "charges": [ 0, 1000 ] },
       [ "microscope", 5 ],

--- a/data/json/mapgen/cs_open_sewer_small.json
+++ b/data/json/mapgen/cs_open_sewer_small.json
@@ -44,6 +44,7 @@
       [ "glasses_safety", 30 ],
       [ "crowbar", 15 ],
       [ "mask_filter", 30 ],
+      { "item": "mask_gas_half", "prob": 25, "charges": [ 0, 100 ] },
       [ "electric_lantern", 30 ]
     ]
   },

--- a/data/json/monsterdrops/zombie_survivor.json
+++ b/data/json/monsterdrops/zombie_survivor.json
@@ -353,6 +353,7 @@
       [ "goggles_swim", 5 ],
       [ "goggles_ski", 10 ],
       { "item": "mask_gas", "prob": 60, "charges": [ 0, 100 ] },
+      { "item": "mask_gas_half", "prob": 60, "charges": [ 0, 100 ] },
       [ "mask_hockey", 10 ],
       [ "mask_bal", 1 ],
       [ "mask_rioter", 5 ]


### PR DESCRIPTION
#### Summary
Features "Introduce half face gas masks"
#### Purpose of change

For some reason the half-face gas mask exists as an item in the games directory but it was set to no spawn groups whatsoever. So I introduced them to some loot pools so it may now generate in game.

#### Describe the solution

Added the half-face gas mask to different loot pools that are appropriate for the item.

#### Describe alternatives you've considered

Leave the half-face gas mask out of any loot pool.

#### Testing

Spawned into a world with no error messages on entry. Killed zombie technicians to confirm that it is interacting with their loot pools. Teleported to a home improvement store and saw a half-face gas mask on a shelf to confirm it is interacting with loot pools out in the world.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

My reasoning for the loot pools I have introduced the half-face gas mask in to:

Clothing.json
"id": "clothing_work_mask", "id": "hardware_clothing", "id": "hazmat_masks", "id": "fireman_mask". The half-face gas mask seems appropriate as it is related to professions that work with hardware equipment and hazardous substances.
"id": "survivorzed_extra". Same as the full gas mask, the half-face gas mask would be sought after by survivors looking to protect themselves.

cs_open_sewer_small.json-"id": "os_items". The open sewer is a construction sight. The half-face gas mask seems appropriate to add to the workers lockers.

zombie_survivor.json-"id": "survivor_basic_face". Same reason as survivorized_extra. Survivors would look for protection from gas and chemical attacks in times of uncertainty. Some of them would die.

locations.json-"id": "oa_ig_rd_lockers". Hardware locker equipment for the regional dump.

tools.json-"id": "tools_science". Chemical protection for scientists handling hazardous substances.