### PR TITLE
Variant Undies: Boxer Briefs and Boxer Shorts

### DIFF
--- a/data/json/items/armor/undergarment.json
+++ b/data/json/items/armor/undergarment.json
@@ -331,28 +331,28 @@
       },
       {
         "id": "boxer_brief_makeshift",
-        "name": { "str": "boxer briefs, homemade" },
+        "name": { "str": "homemade boxer briefs" },
         "description": "A pair of homemade boxer briefs, a marvel of basic sewing skills.",
         "expand_snippets": true,
         "weight": 0
       },
       {
         "id": "boxer_brief_color",
-        "name": { "str": "boxer briefs, colored" },
+        "name": { "str": "solid boxer briefs" },
         "description": "A pair of boxer briefs, these are a solid <color> color.",
         "expand_snippets": true,
         "weight": 300
       },
       {
         "id": "boxer_brief_hearts",
-        "name": { "str": "boxer briefs, hearts" },
+        "name": { "str": "heart boxer briefs" },
         "description": "A pair of boxer briefs, adorned with little <color> hearts.",
         "expand_snippets": true,
         "weight": 100
       },
       {
         "id": "boxer_brief_day",
-        "name": { "str": "boxer briefs, day" },
+        "name": { "str": "day boxer briefs" },
         "description": "A pair of boxer briefs.  Printed across the bottom, in bubble letters, is the word \"<day>.\"",
         "expand_snippets": true,
         "weight": 30
@@ -398,49 +398,49 @@
       },
       {
         "id": "boxer_shorts_makeshift",
-        "name": { "str": "boxer shorts, homemade" },
+        "name": { "str": "homemade boxer shorts" },
         "description": "A pair of homemade boxer shorts, a marvel of basic sewing skills.",
         "expand_snippets": true,
         "weight": 0
       },
       {
         "id": "boxer_shorts_color",
-        "name": { "str": "boxer shorts, colored" },
+        "name": { "str": "solid boxer shorts" },
         "description": "A pair of boxer shorts, these are a solid <color> color.",
         "expand_snippets": true,
         "weight": 400
       },
       {
         "id": "boxer_shorts_hearts",
-        "name": { "str": "boxer shorts, hearts" },
+        "name": { "str": "heart boxer shorts" },
         "description": "A pair of boxer shorts, adorned with little <color> hearts.",
         "expand_snippets": true,
         "weight": 200
       },
       {
         "id": "boxer_shorts_day",
-        "name": { "str": "boxer shorts, day" },
+        "name": { "str": "day boxer shorts" },
         "description": "A pair of boxer shorts.  Printed across the bottom, in bubble letters, is the word \"<day>.\"",
         "expand_snippets": true,
         "weight": 30
       },
       {
         "id": "boxer_shorts_money",
-        "name": { "str": "boxer shorts, money" },
+        "name": { "str": "money boxer shorts" },
         "description": "A pair of boxer shorts adorned with images of hundred dollar bills.",
         "expand_snippets": true,
         "weight": 70
       },
       {
         "id": "boxer_shorts_animal",
-        "name": { "str": "boxer shorts, animal" },
+        "name": { "str": "animal boxer shorts" },
         "description": "A pair of boxer shorts, these are adorned with little <animals> in a pattern across the entire garment.",
         "expand_snippets": true,
         "weight": 70
       },
       {
         "id": "boxer_shorts_cartoon",
-        "name": { "str": "boxer shorts, cartoon" },
+        "name": { "str": "cartoon boxer shorts" },
         "description": "A pair of boxer shorts, merchandise for a famous cartoon.  It features <cartoon_blanket>.",
         "expand_snippets": true,
         "weight": 70

--- a/data/json/items/armor/undergarment.json
+++ b/data/json/items/armor/undergarment.json
@@ -320,7 +320,44 @@
     "warmth": 5,
     "material_thickness": 0.1,
     "flags": [ "VARSIZE", "SKINTIGHT" ],
-    "armor": [ { "coverage": 100, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_hip_l", "leg_hip_r" ] } ]
+    "armor": [ { "coverage": 100, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_hip_l", "leg_hip_r" ] } ],
+    "variants": [
+      {
+        "id": "boxer_brief_basic",
+        "name": { "str": "boxer briefs" },
+        "description": "The age-old question, boxers or briefs?  Your answer?  Yes.",
+        "expand_snippets": true,
+        "weight": 100
+      },
+      {
+        "id": "boxer_brief_makeshift",
+        "name": { "str": "boxer briefs, homemade" },
+        "description": "A pair of homemade boxer briefs, a marvel of basic sewing skills.",
+        "expand_snippets": true,
+        "weight": 0
+      },
+      {
+        "id": "boxer_brief_color",
+        "name": { "str": "boxer briefs, colored" },
+        "description": "A pair of boxer briefs, these are a solid <color> color.",
+        "expand_snippets": true,
+        "weight": 300
+      },
+      {
+        "id": "boxer_brief_hearts",
+        "name": { "str": "boxer briefs, hearts" },
+        "description": "A pair of boxer briefs, adorned with little <color> hearts.",
+        "expand_snippets": true,
+        "weight": 100
+      },
+      {
+        "id": "boxer_brief_day",
+        "name": { "str": "boxer briefs, day" },
+        "description": "A pair of boxer briefs.  Printed across the bottom, in bubble letters, is the word \"<day>.\"",
+        "expand_snippets": true,
+        "weight": 30
+      }
+    ]
   },
   {
     "id": "xlboxer_briefs",
@@ -356,7 +393,57 @@
         "id": "flag_boxer_shorts",
         "name": { "str": "star-spangled boxer shorts", "str_pl": "pairs of star-spangled boxer shorts" },
         "description": "This pair has been printed with the pattern of an American flag, with stars and miniature eagles embroidered at strategic positions.",
-        "append": true
+        "append": true,
+        "weight": 100
+      },
+      {
+        "id": "boxer_shorts_makeshift",
+        "name": { "str": "boxer shorts, homemade" },
+        "description": "A pair of homemade boxer shorts, a marvel of basic sewing skills.",
+        "expand_snippets": true,
+        "weight": 0
+      },
+      {
+        "id": "boxer_shorts_color",
+        "name": { "str": "boxer shorts, colored" },
+        "description": "A pair of boxer shorts, these are a solid <color> color.",
+        "expand_snippets": true,
+        "weight": 400
+      },
+      {
+        "id": "boxer_shorts_hearts",
+        "name": { "str": "boxer shorts, hearts" },
+        "description": "A pair of boxer shorts, adorned with little <color> hearts.",
+        "expand_snippets": true,
+        "weight": 200
+      },
+      {
+        "id": "boxer_shorts_day",
+        "name": { "str": "boxer shorts, day" },
+        "description": "A pair of boxer shorts.  Printed across the bottom, in bubble letters, is the word \"<day>.\"",
+        "expand_snippets": true,
+        "weight": 30
+      },
+      {
+        "id": "boxer_shorts_money",
+        "name": { "str": "boxer shorts, money" },
+        "description": "A pair of boxer shorts adorned with hundred dollar bills.",
+        "expand_snippets": true,
+        "weight": 70
+      },
+      {
+        "id": "boxer_shorts_animal",
+        "name": { "str": "boxer shorts, animal" },
+        "description": "A pair of boxer shorts, these are adorned with little <animals> in a pattern across the entire garment.",
+        "expand_snippets": true,
+        "weight": 70
+      },
+      {
+        "id": "boxer_shorts_cartoon",
+        "name": { "str": "boxer shorts, cartoon" },
+        "description": "A pair of boxer shorts, merchandise for a famous cartoon.  It features <cartoon_blanket>.",
+        "expand_snippets": true,
+        "weight": 70
       }
     ],
     "weight": "42 g",

--- a/data/json/items/armor/undergarment.json
+++ b/data/json/items/armor/undergarment.json
@@ -324,35 +324,35 @@
     "variants": [
       {
         "id": "boxer_brief_basic",
-        "name": { "str": "boxer briefs" },
+        "name": { "str": "boxer briefs", "str_pl": "pairs of boxer briefs" },
         "description": "The age-old question, boxers or briefs?  Your answer?  Yes.",
         "expand_snippets": true,
         "weight": 100
       },
       {
         "id": "boxer_brief_makeshift",
-        "name": { "str": "homemade boxer briefs" },
+        "name": { "str": "homemade boxer briefs", "str_pl": "pairs of homemade boxer briefs" },
         "description": "A pair of homemade boxer briefs, a marvel of basic sewing skills.",
         "expand_snippets": true,
         "weight": 0
       },
       {
         "id": "boxer_brief_color",
-        "name": { "str": "solid boxer briefs" },
+        "name": { "str": "solid boxer briefs", "str_pl": "pairs of solid boxer briefs" },
         "description": "A pair of boxer briefs, these are a solid <color> color.",
         "expand_snippets": true,
         "weight": 300
       },
       {
         "id": "boxer_brief_hearts",
-        "name": { "str": "heart boxer briefs" },
+        "name": { "str": "heart boxer briefs", "str_pl": "pairs of heart boxer briefs" },
         "description": "A pair of boxer briefs, adorned with little <color> hearts.",
         "expand_snippets": true,
         "weight": 100
       },
       {
         "id": "boxer_brief_day",
-        "name": { "str": "day boxer briefs" },
+        "name": { "str": "day boxer briefs", "str_pl": "pairs of day boxer briefs" },
         "description": "A pair of boxer briefs.  Printed across the bottom, in bubble letters, is the word \"<day>.\"",
         "expand_snippets": true,
         "weight": 30
@@ -398,49 +398,49 @@
       },
       {
         "id": "boxer_shorts_makeshift",
-        "name": { "str": "homemade boxer shorts" },
+        "name": { "str": "homemade boxer shorts", "str_pl": "pairs of homemade boxer shorts" },
         "description": "A pair of homemade boxer shorts, a marvel of basic sewing skills.",
         "expand_snippets": true,
         "weight": 0
       },
       {
         "id": "boxer_shorts_color",
-        "name": { "str": "solid boxer shorts" },
+        "name": { "str": "solid boxer shorts", "str_pl": "pairs of solid boxer shorts" },
         "description": "A pair of boxer shorts, these are a solid <color> color.",
         "expand_snippets": true,
         "weight": 400
       },
       {
         "id": "boxer_shorts_hearts",
-        "name": { "str": "heart boxer shorts" },
+        "name": { "str": "heart boxer shorts", "str_pl": "pairs of heart boxer shorts" },
         "description": "A pair of boxer shorts, adorned with little <color> hearts.",
         "expand_snippets": true,
         "weight": 200
       },
       {
         "id": "boxer_shorts_day",
-        "name": { "str": "day boxer shorts" },
+        "name": { "str": "day boxer shorts", "str_pl": "pairs of day boxer shorts" },
         "description": "A pair of boxer shorts.  Printed across the bottom, in bubble letters, is the word \"<day>.\"",
         "expand_snippets": true,
         "weight": 30
       },
       {
         "id": "boxer_shorts_money",
-        "name": { "str": "money boxer shorts" },
+        "name": { "str": "money boxer shorts", "str_pl": "pairs of money boxer shorts" },
         "description": "A pair of boxer shorts adorned with images of hundred dollar bills.",
         "expand_snippets": true,
         "weight": 70
       },
       {
         "id": "boxer_shorts_animal",
-        "name": { "str": "animal boxer shorts" },
+        "name": { "str": "animal boxer shorts", "str_pl": "pairs of animal boxer shorts" },
         "description": "A pair of boxer shorts, these are adorned with little <animals> in a pattern across the entire garment.",
         "expand_snippets": true,
         "weight": 70
       },
       {
         "id": "boxer_shorts_cartoon",
-        "name": { "str": "cartoon boxer shorts" },
+        "name": { "str": "cartoon boxer shorts", "str_pl": "pairs of cartoon boxer shorts" },
         "description": "A pair of boxer shorts, merchandise for a famous cartoon.  It features <cartoon_blanket>.",
         "expand_snippets": true,
         "weight": 70

--- a/data/json/items/armor/undergarment.json
+++ b/data/json/items/armor/undergarment.json
@@ -427,7 +427,7 @@
       {
         "id": "boxer_shorts_money",
         "name": { "str": "boxer shorts, money" },
-        "description": "A pair of boxer shorts adorned with hundred dollar bills.",
+        "description": "A pair of boxer shorts adorned with images of hundred dollar bills.",
         "expand_snippets": true,
         "weight": 70
       },

--- a/data/json/recipes/armor/legs.json
+++ b/data/json/recipes/armor/legs.json
@@ -137,9 +137,9 @@
     "using": [ [ "tailoring_cotton", 3 ] ],
     "byproducts": [ [ "cotton_patchwork", 6 ], [ "scrap_cotton", 3 ] ]
   },
- {
+  {
     "result": "boxer_briefs",
-  	"variant": "boxer_brief_makeshift",
+    "variant": "boxer_brief_makeshift",
     "type": "recipe",
     "copy-from": "boy_shorts"
   },

--- a/data/json/recipes/armor/legs.json
+++ b/data/json/recipes/armor/legs.json
@@ -137,15 +137,16 @@
     "using": [ [ "tailoring_cotton", 3 ] ],
     "byproducts": [ [ "cotton_patchwork", 6 ], [ "scrap_cotton", 3 ] ]
   },
-  {
+ {
     "result": "boxer_briefs",
+  	"variant": "boxer_brief_makeshift",
     "type": "recipe",
     "copy-from": "boy_shorts"
   },
   {
     "result": "xsboxer_briefs",
     "type": "recipe",
-    "copy-from": "boxer_briefs"
+    "copy-from": "boy_shorts"
   },
   {
     "result": "xlboxer_briefs",
@@ -154,13 +155,14 @@
   },
   {
     "result": "boxer_shorts",
+    "variant": "boxer_shorts_makeshift",
     "type": "recipe",
     "copy-from": "boy_shorts"
   },
   {
     "result": "xsboxer_shorts",
     "type": "recipe",
-    "copy-from": "boxer_shorts"
+    "copy-from": "boy_shorts"
   },
   {
     "result": "xlboxer_shorts",

--- a/data/json/snippets/clothing.json
+++ b/data/json/snippets/clothing.json
@@ -16,7 +16,7 @@
   {
     "type": "snippet",
     "category": "<animals>",
-	"//": "This category was originally made for underwear, so should be appropriate animals that appear on boxers, for example.  Should be plural.",
+    "//": "This category was originally made for underwear, so should be appropriate animals that appear on boxers, for example.  Should be plural.",
     "text": [
       { "id": "dolphins", "text": "dolphins" },
       { "id": "chickens", "text": "chickens" },

--- a/data/json/snippets/clothing.json
+++ b/data/json/snippets/clothing.json
@@ -1,0 +1,30 @@
+[
+{
+    "type": "snippet",
+    "category": "<day>",
+	"//": "This is a snippet category originally made for undergarments, containing the days of the week.",
+    "text": [
+      { "id": "monday", "text": "Monday" },
+      { "id": "tuesday", "text": "Tuesday" },
+      { "id": "wednesday", "text": "Wednesday" },
+      { "id": "thursday", "text": "Thursday" },
+      { "id": "friday", "text": "Friday" },
+      { "id": "saturday", "text": "Saturday" },
+      { "id": "sunday", "text": "Sunday" }
+    ]
+  },
+  {
+    "type": "snippet",
+    "category": "<animals>",
+	"//": "This category was originally made for underwear, so should be appropriate animals that appear on boxers, for example.  Should be plural.",
+    "text": [
+      { "id": "dolphins", "text": "dolphins" },
+      { "id": "chickens", "text": "chickens" },
+      { "id": "cows", "text": "cows" },
+      { "id": "horses", "text": "horses" },
+	  { "id": "kittens", "text": "kittens" },
+	  { "id": "mice", "text": "mice" },
+	  { "id": "puppies", "text": "puppies" }
+    ]
+  }
+]

--- a/data/json/snippets/clothing.json
+++ b/data/json/snippets/clothing.json
@@ -2,7 +2,7 @@
   {
     "type": "snippet",
     "category": "<day>",
-	"//": "This is a snippet category originally made for undergarments, containing the days of the week.",
+    "//": "This is a snippet category originally made for undergarments, containing the days of the week.",
     "text": [
       { "id": "monday", "text": "Monday" },
       { "id": "tuesday", "text": "Tuesday" },

--- a/data/json/snippets/clothing.json
+++ b/data/json/snippets/clothing.json
@@ -1,5 +1,5 @@
 [
-{
+  {
     "type": "snippet",
     "category": "<day>",
 	"//": "This is a snippet category originally made for undergarments, containing the days of the week.",

--- a/data/json/snippets/clothing.json
+++ b/data/json/snippets/clothing.json
@@ -22,9 +22,9 @@
       { "id": "chickens", "text": "chickens" },
       { "id": "cows", "text": "cows" },
       { "id": "horses", "text": "horses" },
-	  { "id": "kittens", "text": "kittens" },
-	  { "id": "mice", "text": "mice" },
-	  { "id": "puppies", "text": "puppies" }
+      { "id": "kittens", "text": "kittens" },
+      { "id": "mice", "text": "mice" },
+      { "id": "puppies", "text": "puppies" }
     ]
   }
 ]


### PR DESCRIPTION
#### Summary
Content "Add variants for boxer briefs and boxer shorts"

#### Purpose of change

#74201 requested variants for socks and underwear.  I had just done some variable snippets for blankets and then a WIP for photos, so I figured I'd look at it.  I decided I don't care about socks, so underwear it is.

#### Describe the solution

This PR adds variants for boxer briefs and boxer shorts, including makeshift variants that the recipes now point to so the player isn't making full on pre cdda manufactured underwear out of scraps and thread.

#### Describe alternatives you've considered
Starting with something else.  In the end, I want to do panties/boyshorts/etc, brassieres, and tights as well.

#### Testing
The usual basic testing, making sure it doesn't throw errors, that the snippets are properly variable, that the recipes work, that the weights seem appropriate, did a quick grammar check blah blah you get it.  

#### Additional context
Regarding the new file - Unfortunately, snippets do not have many files that are misc or catchall style files.  The only one really is snippet.json which is mainly dogtag snippets (but also I put blankets in there).  In hindsight, most of these files are specific to specific items (IE: child notes, fliers, home_pictures, etc).  So, I decided to make a new file so we have a place to put clothing related snippets.  It’s only currently 2 snippet groups in the file, but I plan to add at least one more, probably 2-3 in followup Prs for underwear/tights/etc.  My goal initially was to shove them into snippet.json and move them later, but Karol suggested this is bad because of blame and that I should just make the new file.  I wish I had done this for the blanket snippets as well, but moving them now would also affect blame.  

I'll do more later, but I really should work on finishing my photo PR, so I might as well submit these and then I can come back for the other garments in the future.
