### PR TITLE
Fix cata-static-string_id-constants in char_volume_test

### DIFF
--- a/tests/char_volume_test.cpp
+++ b/tests/char_volume_test.cpp
@@ -12,15 +12,15 @@
 #include "vehicle.h"
 #include "veh_type.h"
 
-static const itype_id backpack_giant( "backpack_giant" );
-static const itype_id rock_volume_test( "rock_volume_test" );
+static const itype_id itype_backpack_giant( "backpack_giant" );
+static const itype_id itype_rock_volume_test( "rock_volume_test" );
 
 static const trait_id trait_HUGE( "HUGE" );
 static const trait_id trait_LARGE( "LARGE" );
 static const trait_id trait_SMALL( "SMALL" );
 static const trait_id trait_SMALL2( "SMALL2" );
 
-static const vproto_id veh_character_volume_test_car( "character_volume_test_car" );
+static const vproto_id vehicle_prototype_character_volume_test_car( "character_volume_test_car" );
 
 static units::volume your_volume_with_trait( trait_id new_trait )
 {
@@ -73,7 +73,7 @@ TEST_CASE( "character_at_volume_can_or_cannot_enter_vehicle", "[volume]" )
 
 
     clear_vehicles(); // extra safety
-    here.add_vehicle( veh_character_volume_test_car, test_pos, 0_degrees, 0, 0 );
+    here.add_vehicle( vehicle_prototype_character_volume_test_car, test_pos, 0_degrees, 0, 0 );
     you.setpos( test_pos );
     const optional_vpart_position vp_there = here.veh_at( here.bub_from_abs( you.get_location() ) );
     REQUIRE( vp_there );
@@ -94,10 +94,10 @@ TEST_CASE( "character_at_volume_can_or_cannot_enter_vehicle", "[volume]" )
     cramped = false;
 
     // Empty aisle, but we've put on a backpack and a 10L rock in that backpack
-    item backpack( backpack_giant );
+    item backpack( itype_backpack_giant );
     auto worn_success = you.wear_item( backpack );
     CHECK( worn_success );
-    you.i_add( item( rock_volume_test ) );
+    you.i_add( item( itype_rock_volume_test ) );
     CHECK( 75_liter <= you.get_total_volume() );
     CHECK( you.get_total_volume() <= 100_liter );
     dest_loc = dest_loc + tripoint_north_west;


### PR DESCRIPTION
#### Summary
Bugfixes "Fix cata-static-string_id-constants in char_volume_test"
#### Purpose of change
Fix https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/9336061433/job/25696147234
#### Describe the solution
Apply clang-tidy suggestions.
#### Describe alternatives you've considered
#### Testing
#### Additional context