### PR TITLE
Rework river generation

### DIFF
--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -4921,9 +4921,12 @@ void overmap::place_rivers( const overmap *north, const overmap *east, const ove
     std::vector<point_om_omt> river_start;
     std::vector<point_om_omt> river_end;
 
+    // Indentation from edge of overmap where neighbouring rivers and nodes aren't checked
+    // TODO: Why isn't this 0?
+    const int indent = 10;
     // Determine points where rivers should connect w/ adjacent maps
     if( north != nullptr ) {
-        for( int i = 10; i < OMAPX - 10; i++ ) {
+        for( int i = indent; i <= OMAPX - indent; i++ ) {
             const tripoint_om_omt p_neighbour( i, OMAPY - 1, 0 );
             const tripoint_om_omt p_mine( i, 0, 0 );
 
@@ -4936,7 +4939,7 @@ void overmap::place_rivers( const overmap *north, const overmap *east, const ove
         }
     }
     if( west != nullptr ) {
-        for( int i = 10; i < OMAPY - 10; i++ ) {
+        for( int i = indent; i <= OMAPY - indent; i++ ) {
             const tripoint_om_omt p_neighbour( OMAPX - 1, i, 0 );
             const tripoint_om_omt p_mine( 0, i, 0 );
 
@@ -4949,7 +4952,7 @@ void overmap::place_rivers( const overmap *north, const overmap *east, const ove
         }
     }
     if( south != nullptr ) {
-        for( int i = 10; i < OMAPX - 10; i++ ) {
+        for( int i = indent; i < OMAPX - indent; i++ ) {
             const tripoint_om_omt p_neighbour( i, 0, 0 );
             const tripoint_om_omt p_mine( i, OMAPY - 1, 0 );
 
@@ -4962,7 +4965,7 @@ void overmap::place_rivers( const overmap *north, const overmap *east, const ove
         }
     }
     if( east != nullptr ) {
-        for( int i = 10; i < OMAPY - 10; i++ ) {
+        for( int i = indent; i < OMAPY - indent; i++ ) {
             const tripoint_om_omt p_neighbour( 0, i, 0 );
             const tripoint_om_omt p_mine( OMAPX - 1, i, 0 );
 
@@ -5036,6 +5039,7 @@ void overmap::place_swamps()
     for( int x = 0; x < OMAPX; x++ ) {
         for( int y = 0; y < OMAPY; y++ ) {
             const tripoint_om_omt pos( x, y, 0 );
+            // TODO: Use is_river or similar not a ot match
             if( is_ot_match( "river", ter_unsafe( pos ), ot_match_type::contains ) ) {
                 std::vector<point_om_omt> buffered_points =
                     closest_points_first(

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -6374,9 +6374,8 @@ void overmap::good_river( const tripoint_om_omt &p )
     // Find and assign shores where they need to be.
     int mask = 0;
     int multiplier = 1;
-    // TODO: Rearrange river_ters so this can iterate NESW using four_adjacent_offsets or expand to eight_horizontal_neighbors dealing with corners here instead of afterwards
-    const std::array<point, 4> four_adjacent_offsets_alt{ point_north, point_west, point_east, point_south };
-    for( const point &offset : four_adjacent_offsets_alt ) {
+    // TODO: Expand to eight_horizontal_neighbors dealing with corners here instead of afterwards?
+    for( const point &offset : four_adjacent_offsets ) {
         const tripoint_om_omt p_offset = p + offset;
         // We check whether a river or lake is present, but if out of bounds and we are already a river then
         // assume that we were placed because of a neighbouring overmap river.
@@ -6387,24 +6386,23 @@ void overmap::good_river( const tripoint_om_omt &p )
     }
 
     auto river_ter = [&]() {
-        // TODO: Fill out comments
         const std::array<oter_str_id, 16> river_ters = {
             oter_forest_water, // 0 = no adjacent rivers.
-            oter_river_north, // 1 = N adjacent river
-            oter_river_west, // 2
-            oter_river_ne, // 3
-            oter_river_east, // 4
-            oter_river_nw, // 5
-            oter_forest_water, // 6 = No map for west and east
-            oter_river_north, // 7
-            oter_river_south, // 8
-            oter_forest_water, // 9 = No map for north and south
-            oter_river_se, // 10
-            oter_river_east, // 11
-            oter_river_sw, // 12
-            oter_river_west, // 13
-            oter_river_south, // 14
-            oter_river_center // 15 = N+E+S+W adjacent rivers.
+            oter_river_south, // 1 = N adjacent river
+            oter_river_west, // 2 = E adjacent river
+            oter_river_sw, // 3 = 1+2 = N+E adjacent rivers
+            oter_river_north, // 4 = S adjacent river
+            oter_forest_water, // 5 = 1+4 = N+S adjacent rivers, no map though
+            oter_river_nw, // 6 = 2+4 = E+S adjacent rivers
+            oter_river_west, // 7 = 1+2+4 = N+E+S adjacent rivers
+            oter_river_east, // 8 = W adjacent river
+            oter_river_se, // 9 = 1+8 = N+W adjacent rivers
+            oter_forest_water, // 10 = 2+8 = E+W adjacent rivers, no map though
+            oter_river_south, // 11 = 1+2+8 = N+E+W adjacent rivers
+            oter_river_ne, // 12 = 4+8 = S+W adjacent rivers
+            oter_river_east, // 13 = 1+4+8 = N+S+W adjacent rivers
+            oter_river_north, // 14 = 2+4+8 = E+S+W adjacent rivers
+            oter_river_center // 15 = 1+2+4+8 = N+E+S+W adjacent rivers.
         };
 
         if( mask == 15 ) {

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -4921,56 +4921,58 @@ void overmap::place_rivers( const overmap *north, const overmap *east, const ove
     std::vector<point_om_omt> river_start;
     std::vector<point_om_omt> river_end;
 
-    auto set_rivers_in = [&]( const overmap * neighbour, const tripoint_om_omt & p_neighbour_start,
-                              const tripoint_om_omt & p_mine_start, const om_direction::type direction,
-    int max_displacement, std::vector<point_om_omt> &river_list ) -> void {
-        for( int i = 0; i < max_displacement; i++ )
-        {
-            const tripoint_om_omt p_neighbour = p_neighbour_start + displace( direction, i );
-            const tripoint_om_omt p_mine = p_mine_start + displace( direction, i );
+    // Determine points where rivers should connect w/ adjacent maps
+    if( north != nullptr ) {
+        for( int i = 10; i < OMAPX - 10; i++ ) {
+            const tripoint_om_omt p_neighbour( i, OMAPY - 1, 0 );
+            const tripoint_om_omt p_mine( i, 0, 0 );
 
-            if( is_river( neighbour->ter( p_neighbour ) ) ) {
+            if( is_river( north->ter( p_neighbour ) ) ) {
                 ter_set( p_mine, oter_river_center );
             }
-            // TODO: Can a river node exist on non river?? Otherwise nest this above
-            if( neighbour->is_river_node( p_neighbour.xy() ) ) {
-                river_list.push_back( p_mine.xy() );
+            if( north->is_river_node( p_neighbour.xy() ) ) {
+                river_start.push_back( p_mine.xy() );
             }
         }
-    };
-
-    // Determine points where rivers should connect w/ adjacent maps
-    // Indent from the edge of the overmap to check for existing rivers
-    // TODO: Why can't this be 0
-    const int indent = 10;
-    if( !!north ) {
-        // Neighbouring tripoint to check
-        const tripoint_om_omt p_neighbour_start( indent, OMAPY - 1, 0 );
-        // Corresponding adjacent tripoint on this overmap
-        const tripoint_om_omt p_mine_start( indent, 0, 0 );
-        set_rivers_in( north, p_neighbour_start, p_mine_start, om_direction::type::east,
-                       OMAPX - ( 2 * indent ), river_start );
     }
-    if( !!west ) {
-        const tripoint_om_omt p_neighbour_start( OMAPX - 1, indent, 0 );
-        const tripoint_om_omt p_mine_start( 0, indent, 0 );
+    if( west != nullptr ) {
+        for( int i = 10; i < OMAPY - 10; i++ ) {
+            const tripoint_om_omt p_neighbour( OMAPX - 1, i, 0 );
+            const tripoint_om_omt p_mine( 0, i, 0 );
 
-        set_rivers_in( west, p_neighbour_start, p_mine_start, om_direction::type::south,
-                       OMAPY - ( 2 * indent ), river_start );
+            if( is_river( west->ter( p_neighbour ) ) ) {
+                ter_set( p_mine, oter_river_center );
+            }
+            if( west->is_river_node( p_neighbour.xy() ) ) {
+                river_start.push_back( p_mine.xy() );
+            }
+        }
     }
-    if( !!south ) {
-        const tripoint_om_omt p_neighbour_start( indent, 0, 0 );
-        const tripoint_om_omt p_mine_start( indent, OMAPY - 1, 0 );
+    if( south != nullptr ) {
+        for( int i = 10; i < OMAPX - 10; i++ ) {
+            const tripoint_om_omt p_neighbour( i, 0, 0 );
+            const tripoint_om_omt p_mine( i, OMAPY - 1, 0 );
 
-        set_rivers_in( south, p_neighbour_start, p_mine_start, om_direction::type::east,
-                       OMAPX - ( 2 * indent ), river_end );
+            if( is_river( south->ter( p_neighbour ) ) ) {
+                ter_set( p_mine, oter_river_center );
+            }
+            if( south->is_river_node( p_neighbour.xy() ) ) {
+                river_end.push_back( p_mine.xy() );
+            }
+        }
     }
-    if( !!east ) {
-        const tripoint_om_omt p_neighbour( 0, indent, 0 );
-        const tripoint_om_omt p_mine( OMAPX - 1, indent, 0 );
+    if( east != nullptr ) {
+        for( int i = 10; i < OMAPY - 10; i++ ) {
+            const tripoint_om_omt p_neighbour( 0, i, 0 );
+            const tripoint_om_omt p_mine( OMAPX - 1, i, 0 );
 
-        set_rivers_in( east, p_neighbour_start, p_mine_start, om_direction::type::south,
-                       OMAPY - ( 2 * indent ), river_end );
+            if( is_river( east->ter( p_neighbour ) ) ) {
+                ter_set( p_mine, oter_river_center );
+            }
+            if( east->is_river_node( p_neighbour.xy() ) ) {
+                river_end.push_back( p_mine.xy() );
+            }
+        }
     }
 
     // Even up river start and ends by generating new rivers.

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -4900,14 +4900,14 @@ bool overmap::is_river_node( const point_om_omt &p ) const
     return !!get_river_node_at( p );
 }
 
-std::optional<overmap_river_node> overmap::get_river_node_at( const point_om_omt &p ) const
+const overmap_river_node *overmap::get_river_node_at( const point_om_omt &p ) const
 {
     for( const overmap_river_node &n : rivers ) {
         if( n.p1 == p || n.p2 == p ) {
-            return n; //TODO: Would returning a pointer be more appropriate?
+            return &n;
         }
     }
-    return {};
+    return nullptr;
 }
 
 void overmap::place_rivers( const overmap *north, const overmap *east, const overmap *south,

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -4921,58 +4921,56 @@ void overmap::place_rivers( const overmap *north, const overmap *east, const ove
     std::vector<point_om_omt> river_start;
     std::vector<point_om_omt> river_end;
 
+    auto set_rivers_in = [&]( const overmap * neighbour, const tripoint_om_omt & p_neighbour_start,
+                              const tripoint_om_omt & p_mine_start, const om_direction::type direction,
+    int max_displacement, std::vector<point_om_omt> &river_list ) -> void {
+        for( int i = 0; i < max_displacement; i++ )
+        {
+            const tripoint_om_omt p_neighbour = p_neighbour_start + displace( direction, i );
+            const tripoint_om_omt p_mine = p_mine_start + displace( direction, i );
+
+            if( is_river( neighbour->ter( p_neighbour ) ) ) {
+                ter_set( p_mine, oter_river_center );
+            }
+            // TODO: Can a river node exist on non river?? Otherwise nest this above
+            if( neighbour->is_river_node( p_neighbour.xy() ) ) {
+                river_list.push_back( p_mine.xy() );
+            }
+        }
+    };
+
     // Determine points where rivers should connect w/ adjacent maps
-    if( north != nullptr ) {
-        for( int i = 10; i < OMAPX - 10; i++ ) {
-            const tripoint_om_omt p_neighbour( i, OMAPY - 1, 0 );
-            const tripoint_om_omt p_mine( i, 0, 0 );
-
-            if( is_river( north->ter( p_neighbour ) ) ) {
-                ter_set( p_mine, oter_river_center );
-            }
-            if( north->is_river_node( p_neighbour.xy() ) ) {
-                river_start.push_back( p_mine.xy() );
-            }
-        }
+    // Indent from the edge of the overmap to check for existing rivers
+    // TODO: Why can't this be 0
+    const int indent = 10;
+    if( !!north ) {
+        // Neighbouring tripoint to check
+        const tripoint_om_omt p_neighbour_start( indent, OMAPY - 1, 0 );
+        // Corresponding adjacent tripoint on this overmap
+        const tripoint_om_omt p_mine_start( indent, 0, 0 );
+        set_rivers_in( north, p_neighbour_start, p_mine_start, om_direction::type::east,
+                       OMAPX - ( 2 * indent ), river_start );
     }
-    if( west != nullptr ) {
-        for( int i = 10; i < OMAPY - 10; i++ ) {
-            const tripoint_om_omt p_neighbour( OMAPX - 1, i, 0 );
-            const tripoint_om_omt p_mine( 0, i, 0 );
+    if( !!west ) {
+        const tripoint_om_omt p_neighbour_start( OMAPX - 1, indent, 0 );
+        const tripoint_om_omt p_mine_start( 0, indent, 0 );
 
-            if( is_river( west->ter( p_neighbour ) ) ) {
-                ter_set( p_mine, oter_river_center );
-            }
-            if( west->is_river_node( p_neighbour.xy() ) ) {
-                river_start.push_back( p_mine.xy() );
-            }
-        }
+        set_rivers_in( west, p_neighbour_start, p_mine_start, om_direction::type::south,
+                       OMAPY - ( 2 * indent ), river_start );
     }
-    if( south != nullptr ) {
-        for( int i = 10; i < OMAPX - 10; i++ ) {
-            const tripoint_om_omt p_neighbour( i, 0, 0 );
-            const tripoint_om_omt p_mine( i, OMAPY - 1, 0 );
+    if( !!south ) {
+        const tripoint_om_omt p_neighbour_start( indent, 0, 0 );
+        const tripoint_om_omt p_mine_start( indent, OMAPY - 1, 0 );
 
-            if( is_river( south->ter( p_neighbour ) ) ) {
-                ter_set( p_mine, oter_river_center );
-            }
-            if( south->is_river_node( p_neighbour.xy() ) ) {
-                river_end.push_back( p_mine.xy() );
-            }
-        }
+        set_rivers_in( south, p_neighbour_start, p_mine_start, om_direction::type::east,
+                       OMAPX - ( 2 * indent ), river_end );
     }
-    if( east != nullptr ) {
-        for( int i = 10; i < OMAPY - 10; i++ ) {
-            const tripoint_om_omt p_neighbour( 0, i, 0 );
-            const tripoint_om_omt p_mine( OMAPX - 1, i, 0 );
+    if( !!east ) {
+        const tripoint_om_omt p_neighbour( 0, indent, 0 );
+        const tripoint_om_omt p_mine( OMAPX - 1, indent, 0 );
 
-            if( is_river( east->ter( p_neighbour ) ) ) {
-                ter_set( p_mine, oter_river_center );
-            }
-            if( east->is_river_node( p_neighbour.xy() ) ) {
-                river_end.push_back( p_mine.xy() );
-            }
-        }
+        set_rivers_in( east, p_neighbour_start, p_mine_start, om_direction::type::south,
+                       OMAPY - ( 2 * indent ), river_end );
     }
 
     // Even up river start and ends by generating new rivers.

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -107,6 +107,15 @@ struct overmap_special_placement {
     const overmap_special *special_details;
 };
 
+// Wrapper around a river node to contain river data.
+// Could be used to determine entry/exit points for boats across overmaps.
+// Could also contain name.
+struct overmap_river_node {
+    const point p1; // position, overmap origin node.
+    const point p2; // position, overmap exit node.
+    const size_t size; // total omt of this river
+};
+
 // A batch of overmap specials to place.
 class overmap_special_batch
 {
@@ -297,6 +306,12 @@ class overmap
          */
         bool is_omt_generated( const tripoint_om_omt &loc ) const;
 
+        /* Returns true if position is an entry/exit position of a river node. */
+        bool is_river_node( const point &p ) const;
+
+        /* Returns the overmap river node if the position is an entry/exit node of river. */
+        overmap_river_node get_river_node_at( const point &p ) const;
+
         /** Returns the (0, 0) corner of the overmap in the global coordinates. */
         point_abs_omt global_base_point() const;
 
@@ -323,6 +338,7 @@ class overmap
         std::map<int, om_vehicle> vehicles;
         std::vector<basecamp> camps;
         std::vector<city> cities;
+        std::vector<overmap_river_node> rivers;
         std::map<string_id<overmap_connection>, std::vector<tripoint_om_omt>> connections_out;
         std::optional<basecamp *> find_camp( const point_abs_omt &p );
         /// Adds the npc to the contained list of npcs ( @ref npcs ).
@@ -430,7 +446,7 @@ class overmap
         // code deduplication - calc ocean gradient
         float calculate_ocean_gradient( const point_om_omt &p, point_abs_om this_omt );
         // Overall terrain
-        void place_river( const point_om_omt &pa, const point_om_omt &pb );
+        void place_river( const point_om_omt &pa, const point_om_omt &pb, int river_scale = 1.0 );
         void place_forests();
         void place_lakes();
         void place_oceans();

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -111,8 +111,8 @@ struct overmap_special_placement {
 // Could be used to determine entry/exit points for boats across overmaps.
 // Could also contain name.
 struct overmap_river_node {
-    const point p1; // position, overmap origin node.
-    const point p2; // position, overmap exit node.
+    const point_om_omt p1; // position, overmap origin node.
+    const point_om_omt p2; // position, overmap exit node.
     const size_t size; // total omt of this river
 };
 
@@ -307,10 +307,10 @@ class overmap
         bool is_omt_generated( const tripoint_om_omt &loc ) const;
 
         /* Returns true if position is an entry/exit position of a river node. */
-        bool is_river_node( const point &p ) const;
+        bool is_river_node( const point_om_omt &p ) const;
 
         /* Returns the overmap river node if the position is an entry/exit node of river. */
-        overmap_river_node get_river_node_at( const point &p ) const;
+        std::optional<overmap_river_node> get_river_node_at( const point_om_omt &p ) const;
 
         /** Returns the (0, 0) corner of the overmap in the global coordinates. */
         point_abs_omt global_base_point() const;

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -310,7 +310,7 @@ class overmap
         bool is_river_node( const point_om_omt &p ) const;
 
         /* Returns the overmap river node if the position is an entry/exit node of river. */
-        std::optional<overmap_river_node> get_river_node_at( const point_om_omt &p ) const;
+        const overmap_river_node *get_river_node_at( const point_om_omt &p ) const;
 
         /** Returns the (0, 0) corner of the overmap in the global coordinates. */
         point_abs_omt global_base_point() const;

--- a/src/point.h
+++ b/src/point.h
@@ -347,6 +347,10 @@ inline constexpr std::array<point, 4> four_cardinal_directions{{
         point_west, point_east, point_north, point_south
     }};
 
+inline constexpr std::array<point, 4> four_intercardinal_directions{{
+        point_north_east, point_south_east, point_south_west, point_north_west
+    }};
+
 inline constexpr std::array<point, 5> five_cardinal_directions{{
         point_west, point_east, point_north, point_south, point_zero
     }};

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -498,29 +498,14 @@ void overmap::unserialize( const JsonObject &jsobj )
                 cities.push_back( new_city );
             }
         } else if( name == "rivers" ) {
-            jsin.start_array();
-            while( !jsin.end_array() ) {
-                jsin.start_object();
-
-                point p1;
-                point p2;
+            JsonArray rivers_json = om_member;
+            for( JsonObject river_json : rivers_json ) {
+                point_om_omt p1;
+                point_om_omt p2;
                 size_t size;
-
-                while( !jsin.end_object() ) {
-                    std::string river_member_name = jsin.get_member_name();
-
-                    if( river_member_name == "entry" ) {
-                        jsin.read( p1 );
-                    }
-
-                    if( river_member_name == "exit" ) {
-                        jsin.read( p2 );
-                    }
-
-                    if( river_member_name == "size" ) {
-                        jsin.read( size );
-                    }
-                }
+                mandatory( river_json, false, "entry", p1 );
+                mandatory( river_json, false, "exit", p2 );
+                mandatory( river_json, false, "size", size );
                 rivers.push_back( overmap_river_node{ p1, p2, size } );
             }
         } else if( name == "connections_out" ) {
@@ -1224,7 +1209,7 @@ void overmap::serialize( std::ostream &fout ) const
 
     json.member( "rivers" );
     json.start_array();
-    for( auto &i : rivers ) {
+    for( const overmap_river_node &i : rivers ) {
         json.start_object();
         json.member( "entry", i.p1 );
         json.member( "exit", i.p2 );

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -497,6 +497,32 @@ void overmap::unserialize( const JsonObject &jsobj )
                 }
                 cities.push_back( new_city );
             }
+        } else if( name == "rivers" ) {
+            jsin.start_array();
+            while( !jsin.end_array() ) {
+                jsin.start_object();
+
+                point p1;
+                point p2;
+                size_t size;
+
+                while( !jsin.end_object() ) {
+                    std::string river_member_name = jsin.get_member_name();
+
+                    if( river_member_name == "entry" ) {
+                        jsin.read( p1 );
+                    }
+
+                    if( river_member_name == "exit" ) {
+                        jsin.read( p2 );
+                    }
+
+                    if( river_member_name == "size" ) {
+                        jsin.read( size );
+                    }
+                }
+                rivers.push_back( overmap_river_node{ p1, p2, size } );
+            }
         } else if( name == "connections_out" ) {
             om_member.read( connections_out );
         } else if( name == "roads_out" ) {
@@ -1190,6 +1216,18 @@ void overmap::serialize( std::ostream &fout ) const
         json.member( "pos_om", i.pos_om );
         json.member( "pos", i.pos );
         json.member( "population", i.population );
+        json.member( "size", i.size );
+        json.end_object();
+    }
+    json.end_array();
+    fout << std::endl;
+
+    json.member( "rivers" );
+    json.start_array();
+    for( auto &i : rivers ) {
+        json.start_object();
+        json.member( "entry", i.p1 );
+        json.member( "exit", i.p2 );
         json.member( "size", i.size );
         json.end_object();
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Reworked river generation to be more natural"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Resurrect #38894
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Aims to get the nicer looking rivers from #38894 to a mergeable state
For now isn't attempting to solve #36630 / #59433
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Compiles and loads, yields similar rivers to original PRs screenshots
Having an occasional hang that VS's debugger isn't catching
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I do find it pretty amusing that the author of the original PR came out of nowhere, made 3 really impactful PRs then disappeared before any of the got merged https://github.com/CleverRaven/Cataclysm-DDA/pulls?q=author%3ADiabolus-Engi
Random other peeves with existing water related overmap scale world gen:
I don't like that lake logic is pretty much completely disconnected from rivers logic
I don't like that rivers don't slightly favour flowing towards the nearest ocean
The river nodes should probably be tracked per river on a world scale
Rivers should be able to realistically merge rather than just cross
Lakes and wide rivers and should have variable depths, currently rivers never go lower than z0 while lakes go straight to z-5 after the shore omt
Cities should be able to span rivers
Streams should be connections so they can path to rivers
Water should actually flow in a direction so boats are less like reskinned cars
1 omt wide rivers should be supported
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
