### PR TITLE
[MoM] Extended channeling lowers Nether Attunement event odds

### DIFF
--- a/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
@@ -302,7 +302,7 @@
         "run_eocs": [
           {
             "id": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES_CHECK_EXTENDED_2",
-            "condition": { "x_in_y_chance": { "x": { "math": [ "u_vitamin('vitamin_psionic_drain')" ] }, "y": 125 } },
+            "condition": { "x_in_y_chance": { "x": { "math": [ "u_effect_intensity('effect_disease_psionic_drain')" ] }, "y": 15 } },
             "effect": [ { "run_eocs": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES" } ]
           }
         ]

--- a/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
@@ -279,7 +279,7 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_PSIONICS_DRAIN_EVENTS",
+    "id": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES_SETUP",
     "eoc_type": "EVENT",
     "required_event": "spellcasting_finish",
     "condition": {
@@ -288,226 +288,248 @@
         { "math": [ "u_vitamin('vitamin_psionic_drain')", ">=", "15" ] }
       ]
     },
-    "//": "Switch statement below is to ensure there is always a chance of something happening.",
     "effect": [
       { "math": [ "u_latest_channeled_power_difficulty", "=", "_difficulty" ] },
+      { "run_eocs": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES_CHECK_EXTENDED" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES_CHECK_EXTENDED",
+    "condition": { "u_has_trait": "PSI_EXTENDED_CHANNELING_active" },
+    "effect": [
       {
-        "switch": { "math": [ "u_vitamin('vitamin_psionic_drain')" ] },
-        "cases": [
+        "run_eocs": [
           {
-            "case": 15,
-            "effect": {
-              "weighted_list_eocs": [
-                [ "EOC_DRAIN_EFFECT_CHECK_HEADACHE", 8 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_EXTRA_ATTUNEMENT", 6 ],
-                [ "EOC_NETHER_EFFECT_CHECK_COLD_WIND", 4 ]
-              ]
-            }
-          },
-          {
-            "case": 25,
-            "effect": {
-              "weighted_list_eocs": [
-                [ "EOC_DRAIN_EFFECT_CHECK_HEADACHE", 8 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_EXTRA_ATTUNEMENT", 6 ],
-                [ "EOC_NETHER_EFFECT_CHECK_COLD_WIND", 4 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_HEALTH_CHANGE", 4 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_NOSEBLEED", 8 ]
-              ]
-            }
-          },
-          {
-            "case": 50,
-            "effect": {
-              "weighted_list_eocs": [
-                [ "EOC_DRAIN_EFFECT_CHECK_HEADACHE", 8 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_EXTRA_ATTUNEMENT", 6 ],
-                [ "EOC_NETHER_EFFECT_CHECK_COLD_WIND", 4 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_HEALTH_CHANGE", 4 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_NOSEBLEED", 8 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_STAMINA_LOSS", 5 ]
-              ]
-            }
-          },
-          {
-            "case": 70,
-            "effect": {
-              "weighted_list_eocs": [
-                [ "EOC_DRAIN_EFFECT_CHECK_HEADACHE", 8 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_EXTRA_ATTUNEMENT", 6 ],
-                [ "EOC_NETHER_EFFECT_CHECK_COLD_WIND", 4 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_HEALTH_CHANGE", 4 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_NOSEBLEED", 8 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_STAMINA_LOSS", 5 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_SLEEPINESS", 3 ],
-                [ "EOC_NETHER_EFFECT_CHECK_ATTUNEMENT_RAISING_EFFECT", 7 ]
-              ]
-            }
-          },
-          {
-            "case": 85,
-            "effect": {
-              "weighted_list_eocs": [
-                [ "EOC_DRAIN_EFFECT_CHECK_HEADACHE", 8 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_EXTRA_ATTUNEMENT", 6 ],
-                [ "EOC_NETHER_EFFECT_CHECK_COLD_WIND", 4 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_HEALTH_CHANGE", 4 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_NOSEBLEED", 8 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_STAMINA_LOSS", 5 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_POWER_SURGE", 3 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_SLEEPINESS", 3 ],
-                [ "EOC_NETHER_EFFECT_CHECK_ATTUNEMENT_RAISING_EFFECT", 7 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_TELEPORT_LOCK", 3 ]
-              ]
-            }
-          },
-          {
-            "case": 100,
-            "effect": {
-              "weighted_list_eocs": [
-                [ "EOC_DRAIN_EFFECT_CHECK_HEADACHE", 8 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_EXTRA_ATTUNEMENT", 6 ],
-                [ "EOC_NETHER_EFFECT_CHECK_COLD_WIND", 4 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_HEALTH_CHANGE", 4 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_NOSEBLEED", 8 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_STAMINA_LOSS", 5 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_POWER_SURGE", 3 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_SLEEPINESS", 3 ],
-                [ "EOC_NETHER_EFFECT_CHECK_ATTUNEMENT_RAISING_EFFECT", 7 ],
-                [ "EOC_NETHER_EFFECT_CHECK_FEEDBACK", 5 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_TELEPORT_LOCK", 3 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_WEAKNESS", 3 ],
-                [ "EOC_NETHER_EFFECT_CHECK_BREATHING", 3 ]
-              ]
-            }
-          },
-          {
-            "case": 125,
-            "effect": {
-              "weighted_list_eocs": [
-                [ "EOC_DRAIN_EFFECT_CHECK_HEADACHE", 8 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_EXTRA_ATTUNEMENT", 6 ],
-                [ "EOC_NETHER_EFFECT_CHECK_COLD_WIND", 4 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_HEALTH_CHANGE", 4 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_NOSEBLEED", 8 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_STAMINA_LOSS", 5 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_POWER_SURGE", 3 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_SLEEPINESS", 3 ],
-                [ "EOC_NETHER_EFFECT_CHECK_ATTUNEMENT_RAISING_EFFECT", 7 ],
-                [ "EOC_NETHER_EFFECT_CHECK_FEEDBACK", 5 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_TELEPORT_LOCK", 3 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_WEAKNESS", 3 ],
-                [ "EOC_NETHER_EFFECT_CHECK_ATTENUATION", 5 ],
-                [ "EOC_NETHER_EFFECT_CHECK_BREATHING", 3 ],
-                [ "EOC_NETHER_EFFECT_CHECK_HALLUCINATIONS", 3 ],
-                [ "EOC_NETHER_EFFECT_CHECK_FORCE_WAVE", 3 ]
-              ]
-            }
-          },
-          {
-            "case": 150,
-            "effect": {
-              "weighted_list_eocs": [
-                [ "EOC_DRAIN_EFFECT_CHECK_HEADACHE", 8 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_EXTRA_ATTUNEMENT", 6 ],
-                [ "EOC_NETHER_EFFECT_CHECK_COLD_WIND", 4 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_HEALTH_CHANGE", 4 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_NOSEBLEED", 8 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_STAMINA_LOSS", 5 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_POWER_SURGE", 3 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_SLEEPINESS", 3 ],
-                [ "EOC_NETHER_EFFECT_CHECK_ATTUNEMENT_RAISING_EFFECT", 7 ],
-                [ "EOC_NETHER_EFFECT_CHECK_FEEDBACK", 5 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_TELEPORT_LOCK", 3 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_WEAKNESS", 3 ],
-                [ "EOC_NETHER_EFFECT_CHECK_ATTENUATION", 5 ],
-                [ "EOC_NETHER_EFFECT_CHECK_BREATHING", 3 ],
-                [ "EOC_NETHER_EFFECT_CHECK_HALLUCINATIONS", 3 ],
-                [ "EOC_NETHER_EFFECT_CHECK_FORCE_WAVE", 3 ],
-                [ "EOC_NETHER_EFFECT_CHECK_NO_PSIONICS", 2 ]
-              ]
-            }
-          },
-          {
-            "case": 175,
-            "effect": {
-              "weighted_list_eocs": [
-                [ "EOC_DRAIN_EFFECT_CHECK_HEADACHE", 8 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_EXTRA_ATTUNEMENT", 6 ],
-                [ "EOC_NETHER_EFFECT_CHECK_COLD_WIND", 4 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_HEALTH_CHANGE", 4 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_NOSEBLEED", 8 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_STAMINA_LOSS", 5 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_POWER_SURGE", 3 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_SLEEPINESS", 3 ],
-                [ "EOC_NETHER_EFFECT_CHECK_ATTUNEMENT_RAISING_EFFECT", 7 ],
-                [ "EOC_NETHER_EFFECT_CHECK_FEEDBACK", 5 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_TELEPORT_LOCK", 3 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_WEAKNESS", 3 ],
-                [ "EOC_NETHER_EFFECT_CHECK_ATTENUATION", 5 ],
-                [ "EOC_NETHER_EFFECT_CHECK_BREATHING", 3 ],
-                [ "EOC_NETHER_EFFECT_CHECK_HALLUCINATIONS", 3 ],
-                [ "EOC_NETHER_EFFECT_CHECK_FORCE_WAVE", 3 ],
-                [ "EOC_NETHER_EFFECT_CHECK_NETHER_LIGHTNING", 2 ],
-                [ "EOC_NETHER_EFFECT_CHECK_NO_PSIONICS", 2 ]
-              ]
-            }
-          },
-          {
-            "case": 200,
-            "effect": {
-              "weighted_list_eocs": [
-                [ "EOC_DRAIN_EFFECT_CHECK_HEADACHE", 8 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_EXTRA_ATTUNEMENT", 6 ],
-                [ "EOC_NETHER_EFFECT_CHECK_COLD_WIND", 4 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_HEALTH_CHANGE", 4 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_NOSEBLEED", 8 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_STAMINA_LOSS", 5 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_POWER_SURGE", 3 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_SLEEPINESS", 3 ],
-                [ "EOC_NETHER_EFFECT_CHECK_ATTUNEMENT_RAISING_EFFECT", 7 ],
-                [ "EOC_NETHER_EFFECT_CHECK_FEEDBACK", 5 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_TELEPORT_LOCK", 3 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_WEAKNESS", 3 ],
-                [ "EOC_NETHER_EFFECT_CHECK_ATTENUATION", 5 ],
-                [ "EOC_NETHER_EFFECT_CHECK_BREATHING", 3 ],
-                [ "EOC_NETHER_EFFECT_CHECK_FORCE_WAVE", 3 ],
-                [ "EOC_NETHER_EFFECT_CHECK_NETHER_LIGHTNING", 2 ],
-                [ "EOC_NETHER_EFFECT_CHECK_NO_PSIONICS", 2 ],
-                [ "EOC_NETHER_EFFECT_CHECK_SUMMON_HOUNDS", 1 ]
-              ]
-            }
-          },
-          {
-            "case": 235,
-            "effect": {
-              "weighted_list_eocs": [
-                [ "EOC_DRAIN_EFFECT_CHECK_HEADACHE", 12 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_EXTRA_ATTUNEMENT", 9 ],
-                [ "EOC_NETHER_EFFECT_CHECK_COLD_WIND", 6 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_HEALTH_CHANGE", 6 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_NOSEBLEED", 12 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_STAMINA_LOSS", 8 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_POWER_SURGE", 5 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_SLEEPINESS", 5 ],
-                [ "EOC_NETHER_EFFECT_CHECK_ATTUNEMENT_RAISING_EFFECT", 11 ],
-                [ "EOC_NETHER_EFFECT_CHECK_FEEDBACK", 8 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_TELEPORT_LOCK", 5 ],
-                [ "EOC_DRAIN_EFFECT_CHECK_WEAKNESS", 5 ],
-                [ "EOC_NETHER_EFFECT_CHECK_ATTENUATION", 8 ],
-                [ "EOC_NETHER_EFFECT_CHECK_BREATHING", 5 ],
-                [ "EOC_NETHER_EFFECT_CHECK_FORCE_WAVE", 5 ],
-                [ "EOC_NETHER_EFFECT_CHECK_NETHER_LIGHTNING", 3 ],
-                [ "EOC_NETHER_EFFECT_CHECK_NO_PSIONICS", 3 ],
-                [ "EOC_NETHER_EFFECT_CHECK_SUMMON_HOUNDS", 2 ],
-                [ "EOC_NETHER_EFFECT_CHECK_MUTATION", 2 ],
-                [ "EOC_NETHER_EFFECT_CHECK_RIFT", 1 ]
-              ]
-            }
+            "id": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES_CHECK_EXTENDED_2",
+            "condition": { "x_in_y_chance": { "x": { "math": [ "u_vitamin('vitamin_psionic_drain')" ] }, "y": 125 } },
+            "effect": [ { "run_eocs": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES" } ]
           }
         ]
       }
-    ]
+    ],
+    "false_effect": [ { "run_eocs": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES",
+    "//": "Switch statement below is to ensure there is always a chance of something happening.",
+    "effect": {
+      "switch": { "math": [ "u_vitamin('vitamin_psionic_drain')" ] },
+      "cases": [
+        {
+          "case": 15,
+          "effect": {
+            "weighted_list_eocs": [
+              [ "EOC_DRAIN_EFFECT_CHECK_HEADACHE", 8 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_EXTRA_ATTUNEMENT", 6 ],
+              [ "EOC_NETHER_EFFECT_CHECK_COLD_WIND", 4 ]
+            ]
+          }
+        },
+        {
+          "case": 25,
+          "effect": {
+            "weighted_list_eocs": [
+              [ "EOC_DRAIN_EFFECT_CHECK_HEADACHE", 8 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_EXTRA_ATTUNEMENT", 6 ],
+              [ "EOC_NETHER_EFFECT_CHECK_COLD_WIND", 4 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_HEALTH_CHANGE", 4 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_NOSEBLEED", 8 ]
+            ]
+          }
+        },
+        {
+          "case": 50,
+          "effect": {
+            "weighted_list_eocs": [
+              [ "EOC_DRAIN_EFFECT_CHECK_HEADACHE", 8 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_EXTRA_ATTUNEMENT", 6 ],
+              [ "EOC_NETHER_EFFECT_CHECK_COLD_WIND", 4 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_HEALTH_CHANGE", 4 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_NOSEBLEED", 8 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_STAMINA_LOSS", 5 ]
+            ]
+          }
+        },
+        {
+          "case": 70,
+          "effect": {
+            "weighted_list_eocs": [
+              [ "EOC_DRAIN_EFFECT_CHECK_HEADACHE", 8 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_EXTRA_ATTUNEMENT", 6 ],
+              [ "EOC_NETHER_EFFECT_CHECK_COLD_WIND", 4 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_HEALTH_CHANGE", 4 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_NOSEBLEED", 8 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_STAMINA_LOSS", 5 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_SLEEPINESS", 3 ],
+              [ "EOC_NETHER_EFFECT_CHECK_ATTUNEMENT_RAISING_EFFECT", 7 ]
+            ]
+          }
+        },
+        {
+          "case": 85,
+          "effect": {
+            "weighted_list_eocs": [
+              [ "EOC_DRAIN_EFFECT_CHECK_HEADACHE", 8 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_EXTRA_ATTUNEMENT", 6 ],
+              [ "EOC_NETHER_EFFECT_CHECK_COLD_WIND", 4 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_HEALTH_CHANGE", 4 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_NOSEBLEED", 8 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_STAMINA_LOSS", 5 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_POWER_SURGE", 3 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_SLEEPINESS", 3 ],
+              [ "EOC_NETHER_EFFECT_CHECK_ATTUNEMENT_RAISING_EFFECT", 7 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_TELEPORT_LOCK", 3 ]
+            ]
+          }
+        },
+        {
+          "case": 100,
+          "effect": {
+            "weighted_list_eocs": [
+              [ "EOC_DRAIN_EFFECT_CHECK_HEADACHE", 8 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_EXTRA_ATTUNEMENT", 6 ],
+              [ "EOC_NETHER_EFFECT_CHECK_COLD_WIND", 4 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_HEALTH_CHANGE", 4 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_NOSEBLEED", 8 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_STAMINA_LOSS", 5 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_POWER_SURGE", 3 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_SLEEPINESS", 3 ],
+              [ "EOC_NETHER_EFFECT_CHECK_ATTUNEMENT_RAISING_EFFECT", 7 ],
+              [ "EOC_NETHER_EFFECT_CHECK_FEEDBACK", 5 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_TELEPORT_LOCK", 3 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_WEAKNESS", 3 ],
+              [ "EOC_NETHER_EFFECT_CHECK_BREATHING", 3 ]
+            ]
+          }
+        },
+        {
+          "case": 125,
+          "effect": {
+            "weighted_list_eocs": [
+              [ "EOC_DRAIN_EFFECT_CHECK_HEADACHE", 8 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_EXTRA_ATTUNEMENT", 6 ],
+              [ "EOC_NETHER_EFFECT_CHECK_COLD_WIND", 4 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_HEALTH_CHANGE", 4 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_NOSEBLEED", 8 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_STAMINA_LOSS", 5 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_POWER_SURGE", 3 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_SLEEPINESS", 3 ],
+              [ "EOC_NETHER_EFFECT_CHECK_ATTUNEMENT_RAISING_EFFECT", 7 ],
+              [ "EOC_NETHER_EFFECT_CHECK_FEEDBACK", 5 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_TELEPORT_LOCK", 3 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_WEAKNESS", 3 ],
+              [ "EOC_NETHER_EFFECT_CHECK_ATTENUATION", 5 ],
+              [ "EOC_NETHER_EFFECT_CHECK_BREATHING", 3 ],
+              [ "EOC_NETHER_EFFECT_CHECK_HALLUCINATIONS", 3 ],
+              [ "EOC_NETHER_EFFECT_CHECK_FORCE_WAVE", 3 ]
+            ]
+          }
+        },
+        {
+          "case": 150,
+          "effect": {
+            "weighted_list_eocs": [
+              [ "EOC_DRAIN_EFFECT_CHECK_HEADACHE", 8 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_EXTRA_ATTUNEMENT", 6 ],
+              [ "EOC_NETHER_EFFECT_CHECK_COLD_WIND", 4 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_HEALTH_CHANGE", 4 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_NOSEBLEED", 8 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_STAMINA_LOSS", 5 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_POWER_SURGE", 3 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_SLEEPINESS", 3 ],
+              [ "EOC_NETHER_EFFECT_CHECK_ATTUNEMENT_RAISING_EFFECT", 7 ],
+              [ "EOC_NETHER_EFFECT_CHECK_FEEDBACK", 5 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_TELEPORT_LOCK", 3 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_WEAKNESS", 3 ],
+              [ "EOC_NETHER_EFFECT_CHECK_ATTENUATION", 5 ],
+              [ "EOC_NETHER_EFFECT_CHECK_BREATHING", 3 ],
+              [ "EOC_NETHER_EFFECT_CHECK_HALLUCINATIONS", 3 ],
+              [ "EOC_NETHER_EFFECT_CHECK_FORCE_WAVE", 3 ],
+              [ "EOC_NETHER_EFFECT_CHECK_NO_PSIONICS", 2 ]
+            ]
+          }
+        },
+        {
+          "case": 175,
+          "effect": {
+            "weighted_list_eocs": [
+              [ "EOC_DRAIN_EFFECT_CHECK_HEADACHE", 8 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_EXTRA_ATTUNEMENT", 6 ],
+              [ "EOC_NETHER_EFFECT_CHECK_COLD_WIND", 4 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_HEALTH_CHANGE", 4 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_NOSEBLEED", 8 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_STAMINA_LOSS", 5 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_POWER_SURGE", 3 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_SLEEPINESS", 3 ],
+              [ "EOC_NETHER_EFFECT_CHECK_ATTUNEMENT_RAISING_EFFECT", 7 ],
+              [ "EOC_NETHER_EFFECT_CHECK_FEEDBACK", 5 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_TELEPORT_LOCK", 3 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_WEAKNESS", 3 ],
+              [ "EOC_NETHER_EFFECT_CHECK_ATTENUATION", 5 ],
+              [ "EOC_NETHER_EFFECT_CHECK_BREATHING", 3 ],
+              [ "EOC_NETHER_EFFECT_CHECK_HALLUCINATIONS", 3 ],
+              [ "EOC_NETHER_EFFECT_CHECK_FORCE_WAVE", 3 ],
+              [ "EOC_NETHER_EFFECT_CHECK_NETHER_LIGHTNING", 2 ],
+              [ "EOC_NETHER_EFFECT_CHECK_NO_PSIONICS", 2 ]
+            ]
+          }
+        },
+        {
+          "case": 200,
+          "effect": {
+            "weighted_list_eocs": [
+              [ "EOC_DRAIN_EFFECT_CHECK_HEADACHE", 8 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_EXTRA_ATTUNEMENT", 6 ],
+              [ "EOC_NETHER_EFFECT_CHECK_COLD_WIND", 4 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_HEALTH_CHANGE", 4 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_NOSEBLEED", 8 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_STAMINA_LOSS", 5 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_POWER_SURGE", 3 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_SLEEPINESS", 3 ],
+              [ "EOC_NETHER_EFFECT_CHECK_ATTUNEMENT_RAISING_EFFECT", 7 ],
+              [ "EOC_NETHER_EFFECT_CHECK_FEEDBACK", 5 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_TELEPORT_LOCK", 3 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_WEAKNESS", 3 ],
+              [ "EOC_NETHER_EFFECT_CHECK_ATTENUATION", 5 ],
+              [ "EOC_NETHER_EFFECT_CHECK_BREATHING", 3 ],
+              [ "EOC_NETHER_EFFECT_CHECK_FORCE_WAVE", 3 ],
+              [ "EOC_NETHER_EFFECT_CHECK_NETHER_LIGHTNING", 2 ],
+              [ "EOC_NETHER_EFFECT_CHECK_NO_PSIONICS", 2 ],
+              [ "EOC_NETHER_EFFECT_CHECK_SUMMON_HOUNDS", 1 ]
+            ]
+          }
+        },
+        {
+          "case": 235,
+          "effect": {
+            "weighted_list_eocs": [
+              [ "EOC_DRAIN_EFFECT_CHECK_HEADACHE", 12 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_EXTRA_ATTUNEMENT", 9 ],
+              [ "EOC_NETHER_EFFECT_CHECK_COLD_WIND", 6 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_HEALTH_CHANGE", 6 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_NOSEBLEED", 12 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_STAMINA_LOSS", 8 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_POWER_SURGE", 5 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_SLEEPINESS", 5 ],
+              [ "EOC_NETHER_EFFECT_CHECK_ATTUNEMENT_RAISING_EFFECT", 11 ],
+              [ "EOC_NETHER_EFFECT_CHECK_FEEDBACK", 8 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_TELEPORT_LOCK", 5 ],
+              [ "EOC_DRAIN_EFFECT_CHECK_WEAKNESS", 5 ],
+              [ "EOC_NETHER_EFFECT_CHECK_ATTENUATION", 8 ],
+              [ "EOC_NETHER_EFFECT_CHECK_BREATHING", 5 ],
+              [ "EOC_NETHER_EFFECT_CHECK_FORCE_WAVE", 5 ],
+              [ "EOC_NETHER_EFFECT_CHECK_NETHER_LIGHTNING", 3 ],
+              [ "EOC_NETHER_EFFECT_CHECK_NO_PSIONICS", 3 ],
+              [ "EOC_NETHER_EFFECT_CHECK_SUMMON_HOUNDS", 2 ],
+              [ "EOC_NETHER_EFFECT_CHECK_MUTATION", 2 ],
+              [ "EOC_NETHER_EFFECT_CHECK_RIFT", 1 ]
+            ]
+          }
+        }
+      ]
+    }
   },
   {
     "type": "effect_on_condition",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Extended channeling lowers Nether Attunement event odds"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The same way that Torrential channeling ramps up the chance of Nether Attunement odds, Extended Channeling should lower it.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add a layer of abstraction between channeling a power and rolling for Nether Attunement odds. The EoCs check to see if you have Extended Channeling on and, if so, check your level of Nether Attunement and then make another roll. Only if you pass this roll are you sent on to check for consequences.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Hard to check with so much randomness but spent a while using psionics both with and without Extended Channeling on and there were definitely more attunement events with it off. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Huge diff is from inserting the interstitial EoC, the amount of actually-changed lines is minimal. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
