### PR TITLE
Monster difficulty has a floor of 1

### DIFF
--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -383,6 +383,8 @@ void MonsterGenerator::finalize_mtypes()
         mon.difficulty *= ( mon.hp + mon.speed - mon.attack_cost + ( mon.morale + mon.agro ) * 0.1 ) * 0.01
                           + ( mon.vision_day + 2 * mon.vision_night ) * 0.01;
 
+        mon.difficulty = std::max( 1, mon.difficulty );
+
         if( mon.status_chance_multiplier < 0 ) {
             mon.status_chance_multiplier = 0;
         }


### PR DESCRIPTION
#### Summary
Bugfixes "Monster difficulty (and exp for killing them) cannot be lower than 1"

#### Purpose of change
* Fixes #74235

#### Describe the solution
Tell the computer difficulty should never be lower than 1


#### Describe alternatives you've considered


#### Testing
Load save --> 310 needed to gain level --> kill aphid --> 309 needed to gain level

#### Additional context
