### PR TITLE
Aftershock: Replace radioactive gas with ominous radioactive glow.

### DIFF
--- a/data/mods/Aftershock/emit.json
+++ b/data/mods/Aftershock/emit.json
@@ -14,5 +14,13 @@
     "intensity": 3,
     "qty": 60,
     "chance": 100
+  },
+  {
+    "id": "heavy_rad_glimmer",
+    "type": "emit",
+    "field": "fd_rad_glimmer",
+    "intensity": 3,
+    "chance": 70,
+    "qty": 70
   }
 ]

--- a/data/mods/Aftershock/field_type.json
+++ b/data/mods/Aftershock/field_type.json
@@ -124,5 +124,29 @@
     "display_items": true,
     "display_field": true,
     "looks_like": "fd_nuke_gas"
+  },
+  {
+    "id": "fd_rad_glimmer",
+    "type": "field_type",
+    "intensity_levels": [
+      { "name": "radiative glimmer", "color": "light_red_yellow", "sym": "#", "light_emitted": 5, "extra_radiation_max": 1 },
+      { "name": "radiative glimmer", "color": "light_red_yellow", "extra_radiation_max": 2, "concentration": 2 },
+      {
+        "name": "intense radiative glimmer",
+        "color": "light_red_yellow",
+        "light_emitted": 10,
+        "extra_radiation_max": 15,
+        "radiation_hurt_damage_min": 1,
+        "radiation_hurt_damage_max": 2,
+        "radiation_hurt_message": "You feel a painful burning sensation."
+      }
+    ],
+    "description_affix": "illuminated_by",
+    "priority": 4,
+    "half_life": "1 turns",
+    "phase": "plasma",
+    "display_items": false,
+    "display_field": true,
+    "looks_like": "fd_laser"
   }
 ]

--- a/data/mods/Aftershock/items/grenades.json
+++ b/data/mods/Aftershock/items/grenades.json
@@ -172,7 +172,7 @@
     "use_action": { "type": "message", "message": "You've already pulled the %s's pin, try throwing it instead.", "name": "Pull pin" },
     "countdown_action": {
       "type": "explosion",
-      "fields_type": "fd_nuke_gas",
+      "fields_type": "fd_rad_glimmer",
       "fields_radius": 3,
       "fields_min_intensity": 3,
       "fields_max_intensity": 3,

--- a/data/mods/Aftershock/items/items.json
+++ b/data/mods/Aftershock/items/items.json
@@ -230,7 +230,7 @@
     "type": "GENERIC",
     "id": "afs_fusion_engine_core",
     "name": { "str_sp": "fusion drive powerplant" },
-    "description": "A very heavy sphere of radiation shielding completely obscures the inner working of this hyperspace-age device.  Any experienced salvor knows that opening it would completely ruin it.",
+    "description": "A very heavy sphere of radiation shielding completely obscures the inner workings of this hyperspace-age device.  Any experienced salvor knows that opening it would completely ruin it.",
     "symbol": "o",
     "color": "yellow",
     "weight": "14 kg",

--- a/data/mods/Aftershock/maps/furniture_and_terrain/furniture_spaceship_machinery.json
+++ b/data/mods/Aftershock/maps/furniture_and_terrain/furniture_spaceship_machinery.json
@@ -85,5 +85,32 @@
         { "item": "ammonia_liquid", "prob": 100, "count": [ 4, 8 ] }
       ]
     }
+  },
+  {
+    "type": "furniture",
+    "id": "f_afs_reactor_meltdown",
+    "name": "radioactive slag",
+    "description": "A pile of melted slag from a destroyed spaceship reactor.  Incandescently hot and highly radioactive, you'd need a purposefully armored suit to even approach it.",
+    "looks_like": "t_nuclear_reactor",
+    "symbol": "#",
+    "color": "light_green",
+    "move_cost_mod": 6,
+    "max_volume": "750 L",
+    "required_str": -1,
+    "emissions": [ "heavy_rad_glimmer" ],
+    "flags": [
+      "TRANSPARENT",
+      "UNSTABLE",
+      "ROUGH",
+      "SHARP",
+      "PLACE_ITEM",
+      "MOUNTABLE",
+      "CONTAINER",
+      "SEALED",
+      "ALLOW_FIELD_EFFECT",
+      "SMALL_HIDE",
+      "SHORT",
+      "RUBBLE"
+    ]
   }
 ]

--- a/data/mods/Aftershock/maps/mapgen/crashsites.json
+++ b/data/mods/Aftershock/maps/mapgen/crashsites.json
@@ -41,7 +41,7 @@
         "#": "t_dirtmound"
       },
       "furniture": {
-        "R": "f_reactor_meltdown",
+        "R": "f_afs_reactor_meltdown",
         "#": [ [ "f_wreckage", 1 ], [ "f_null", 15 ] ],
         "I": "f_afs_shuttle_fusion_engine",
         "0": "f_afs_shuttle_manuevering_thruster"
@@ -94,7 +94,7 @@
         "#": "t_dirtmound"
       },
       "furniture": {
-        "R": "f_reactor_meltdown",
+        "R": "f_afs_reactor_meltdown",
         "#": [ [ "f_wreckage", 1 ], [ "f_null", 15 ] ],
         "I": "f_afs_shuttle_fusion_engine",
         "0": "f_afs_shuttle_manuevering_thruster"

--- a/data/mods/Aftershock/spells.json
+++ b/data/mods/Aftershock/spells.json
@@ -52,7 +52,7 @@
     "effect": "attack",
     "shape": "blast",
     "valid_targets": [ "self" ],
-    "field_id": "fd_nuke_gas",
+    "field_id": "fd_rad_glimmer",
     "field_chance": 60,
     "min_field_intensity": 2,
     "max_field_intensity": 2,


### PR DESCRIPTION
#### Summary
Mods "Aftershock: Replace radioactive gas with ominous radioactive glow."


#### Purpose of change
Several places and mechanics in Aftershock use radioactive gas as a way to create irradiation dangers, even when the objects in question shouldnt really be capable of emitting any gas.

This creates a "glimmer" field that can serve the same purpose when its implausible the technology in question would use pressurized gasses.

#### Describe the solution
The field is a mix between the glow and radioactive gas fields. It has replaced radioactive gas in the following places:

- Broken shuttle reactors
- Shield radiation effect
- Cryogrenades

Plasma weapons still leak rad gas on overheat (implied to be the weapon's coolant)

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Used a geiger counter after spawning radiative glimmer fields
