### PR TITLE
Aftershock: Update bug brewing nutrients to be equivalent to red meat.

### DIFF
--- a/data/mods/Aftershock/itemgroups/food_groups.json
+++ b/data/mods/Aftershock/itemgroups/food_groups.json
@@ -93,8 +93,8 @@
     "id": "afs_mealgrub_procesing",
     "entries": [
       { "item": "afs_mealgrub_jelly", "count": [ 5, 20 ] },
-      { "prob": 15, "count": [ 5, 25 ], "group": "afs_mealgrubs_wrapper_pr_5" },
-      { "prob": 5, "count": [ 5, 25 ], "group": "afs_mealgrubs_wrapper_pr_5" },
+      { "prob": 15, "count": [ 5, 25 ], "group": "afs_mealgrubs_afs_foil_bag_5" },
+      { "prob": 5, "count": [ 5, 25 ], "group": "afs_mealgrubs_afs_foil_bag_5" },
       { "item": "water", "prob": 10, "charges": [ 20, 40 ], "container-item": "jerrycan" }
     ]
   },
@@ -142,10 +142,10 @@
   },
   {
     "type": "item_group",
-    "id": "afs_mealgrubs_wrapper_pr_5",
+    "id": "afs_mealgrubs_afs_foil_bag_5",
     "subtype": "collection",
     "//": "This group was created automatically and may contain errors.",
-    "container-item": "wrapper_pr",
+    "container-item": "afs_foil_bag",
     "entries": [ { "item": "afs_mealgrubs", "container-item": "null", "count": 5 } ]
   }
 ]

--- a/data/mods/Aftershock/items/comestibles/bug_brew.json
+++ b/data/mods/Aftershock/items/comestibles/bug_brew.json
@@ -20,7 +20,7 @@
     "charges": 5,
     "category": "chems",
     "fun": -30,
-    "vitamins": [ [ "calcium", 2 ], [ "iron", 2 ], [ "bad_food", 1 ] ]
+    "vitamins": [ [ "calcium", 2 ], [ "iron", 12 ], [ "bad_food", 1 ] ]
   },
   {
     "type": "COMESTIBLE",
@@ -90,20 +90,24 @@
   {
     "id": "afs_mealgrubs",
     "type": "COMESTIBLE",
+    "comestible_type": "FOOD",
     "name": { "str_sp": "mealgrubs" },
     "symbol": "s",
-    "copy-from": "protein_bar_evac",
     "cooks_like": "jerky",
-    "color": "white",
+    "weight": "275 g",
+    "volume": "270 ml",
+    "color": "pink",
+    "price": "5 USD",
+    "price_postapoc": "5 USD",
     "spoils_in": "45 days",
     "material": [ "flesh" ],
+    "flags": [ "NUTRIENT_OVERRIDE" ],
     "calories": 360,
     "healthy": 3,
     "description": "A handful of edible and heavily genemoded grubs, each only slightly thinner than your thumb.  Engineered in the wake of the XXII century to feed an overpopulated Earth and its fledgling colonies these are a sturdy, easily grown and scalable crop.\n\nRemoved from their growth solution they'll quickly die and desiccate, as these already have.  They could be safely eaten with no further processing, for a nutritious if somewhat striking meal.",
     "fun": 0,
     "freezing_point": -9999,
-    "vitamins": [ [ "calcium", 2 ], [ "iron", 2 ], [ "bad_food", 1 ] ],
-    "volume": "44 ml"
+    "vitamins": [ [ "calcium", 2 ], [ "iron", 12 ], [ "bad_food", 1 ] ]
   },
   {
     "type": "recipe",
@@ -118,7 +122,7 @@
     "time": "20 m",
     "autolearn": true,
     "batch_time_factors": [ 80, 4 ],
-    "flags": [ "BLIND_HARD", "ALLOW_ROTTEN" ],
+    "flags": [ "BLIND_HARD", "ALLOW_ROTTEN", "NUTRIENT_OVERRIDE" ],
     "book_learn": { "afs_bugbrew_book": { "skill_level": 1 } },
     "qualities": [ { "id": "BOIL", "level": 1 }, { "id": "CHEM", "level": 2 }, { "id": "CUT", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 10, "LIST" ] ] ],


### PR DESCRIPTION
#### Summary
Mods "Aftershock: Update bug brewing nutrients to be equivalent to red meat."

#### Purpose of change
Mealgrubs are supposed to be meat equivalents when playing in the Exoplanet, but it came to my attention that both an issue with a missing nutrient override and a mistake in their portion size caused this to not be the case.

#### Describe the solution
Resize the item and audit its vitamins and add a nutrient override to ensure the nutritional value of mealgrubs remains equivalent to meat.

#### Describe alternatives you've considered
Making them nutritionally distinct to red meat, but that sounds like unwelcome complexity.

#### Testing
Loaded game.
