### PR TITLE
[Aftershock] Add the Esper scenario

### DIFF
--- a/data/mods/Aftershock/EOC/esper_eoc.json
+++ b/data/mods/Aftershock/EOC/esper_eoc.json
@@ -197,5 +197,21 @@
       { "u_message": "As you unleash your powers, you feel enervated.", "type": "bad" },
       { "u_add_effect": "effect_afs_esper_health_penalty", "duration": "30 seconds" }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_AFS_PSI_SKILL_INCREASE_ON_USE_INITIALIZE",
+    "eoc_type": "EVENT",
+    "required_event": "spellcasting_finish",
+    "condition": { "test_eoc": "EOC_CONDITION_ESPER_TRAIT_AND_SCHOOL_LIST" },
+    "effect": [
+      { "math": [ "u_latest_channeled_power_difficulty", "=", "_difficulty" ] },
+      { "run_eocs": "EOC_AFS_PSI_SKILL_INCREASE_ON_USE_FINALIZE" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_AFS_PSI_SKILL_INCREASE_ON_USE_FINALIZE",
+    "effect": [ { "math": [ "u_skill_exp('metaphysics', 'format': 'raw')", "+=", "150 * u_latest_channeled_power_difficulty" ] } ]
   }
 ]

--- a/data/mods/Aftershock/EOC/esper_eoc.json
+++ b/data/mods/Aftershock/EOC/esper_eoc.json
@@ -98,5 +98,65 @@
         }
       ]
     }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_AFS_PSIONICS_ADVERSE_EVENTS",
+    "eoc_type": "EVENT",
+    "required_event": "spellcasting_finish",
+    "condition": { "and": [ { "test_eoc": "EOC_CONDITION_ESPER_TRAIT_AND_SCHOOL_LIST" } ] },
+    "effect": [
+      { "math": [ "u_latest_channeled_power_difficulty", "=", "_difficulty" ] },
+      {
+        "weighted_list_eocs": [
+          [ "EOC_AFS_PSIONICS_ADVERSE_EVENT_NOSEBLEED", 1 ],
+          [ "EOC_AFS_PSIONICS_ADVERSE_EVENT_HEADACHE", 1 ],
+          [ "EOC_AFS_PSIONICS_ADVERSE_EVENT_HEALTH_PENALTY", 1 ]
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_AFS_PSIONICS_ADVERSE_EVENT_NOSEBLEED",
+    "condition": {
+      "x_in_y_chance": {
+        "x": { "math": [ "(u_esper_repeated_channeling_value * 4) + (u_latest_channeled_power_difficulty * 5)" ] },
+        "y": 1000
+      }
+    },
+    "effect": [
+      { "u_message": "As you unleash your powers, blood drips from your nose.", "type": "bad" },
+      { "u_add_effect": "bleed", "intensity": 1, "target_part": "head", "duration": "5 minutes" },
+      { "math": [ "u_hp('head')", "-=", "1" ] }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_AFS_PSIONICS_ADVERSE_EVENT_HEADACHE",
+    "condition": {
+      "x_in_y_chance": {
+        "x": { "math": [ "(u_esper_repeated_channeling_value * 3) + (u_latest_channeled_power_difficulty * 5)" ] },
+        "y": 1000
+      }
+    },
+    "effect": [
+      { "u_message": "As you unleash your powers, your head begins to throb.", "type": "bad" },
+      { "u_add_effect": "effect_afs_esper_headache", "duration": { "math": [ "rng(900,3600)" ] } }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_AFS_PSIONICS_ADVERSE_EVENT_HEALTH_PENALTY",
+    "condition": {
+      "x_in_y_chance": {
+        "x": { "math": [ "(u_esper_repeated_channeling_value * 2) + (u_latest_channeled_power_difficulty * 5)" ] },
+        "y": 1000
+      }
+    },
+    "effect": [
+      { "u_add_effect": "effect_afs_esper_health_penalty", "duration": "30 seconds" },
+      { "u_message": "As you unleash your powers, you feel enervated.", "type": "bad" }
+    ]
   }
 ]

--- a/data/mods/Aftershock/EOC/esper_eoc.json
+++ b/data/mods/Aftershock/EOC/esper_eoc.json
@@ -36,6 +36,22 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_AFS_ESPER_CHANNEL_COSTS_FOCUS",
+    "eoc_type": "EVENT",
+    "required_event": "spellcasting_finish",
+    "condition": { "and": [ { "test_eoc": "EOC_CONDITION_ESPER_TRAIT_AND_SCHOOL_LIST" }, { "math": [ "u_val('focus')", ">=", "15" ] } ] },
+    "effect": [ { "math": [ "u_val('focus')", "-=", "1" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_AFS_CONCENTRATION_COSTS_FOCUS",
+    "condition": {
+      "and": [ { "math": [ "u_vitamin('vitamin_afs_maintained_powers')", ">", "0" ] }, { "math": [ "u_val('focus')", ">=", "15" ] } ]
+    },
+    "effect": [ { "math": [ "u_val('focus')", "-=", "1" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_AFS_ESPER_CONSEQUENCES_VALUE_INCREASER",
     "eoc_type": "EVENT",
     "required_event": "spellcasting_finish",

--- a/data/mods/Aftershock/EOC/esper_eoc.json
+++ b/data/mods/Aftershock/EOC/esper_eoc.json
@@ -9,7 +9,7 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_ESPER_CONSEQUENCES_INCREASER",
+    "id": "EOC_ESPER_CONSEQUENCES_VALUE_INCREASER",
     "eoc_type": "EVENT",
     "required_event": "spellcasting_finish",
     "condition": { "test_eoc": "EOC_CONDITION_ESPER_TRAIT_AND_SCHOOL_LIST" },
@@ -17,7 +17,7 @@
       {
         "run_eocs": [
           {
-            "id": "EOC_ESPER_CONSEQUENCES_INCREASER_2",
+            "id": "EOC_ESPER_CONSEQUENCES_VALUE_INCREASER_2",
             "condition": { "math": [ "u_esper_repeated_channeling_value", "<", "20" ] },
             "effect": [ { "math": [ "u_esper_repeated_channeling_value", "+=", "rng(1,5)" ] } ]
           }
@@ -27,12 +27,22 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_NETHER_CONDUIT_VALUE_DECREASER",
-    "recurrence": [ "3 seconds", "15 seconds" ],
+    "id": "EOC_ESPER_CONSEQUENCES_VALUE_DECREASER",
+    "recurrence": [ "3 seconds", "30 seconds" ],
     "global": true,
     "run_for_npcs": true,
     "condition": { "math": [ "u_esper_repeated_channeling_value", ">", "0" ] },
     "effect": [ { "math": [ "u_esper_repeated_channeling_value", "-=", "1" ] } ],
     "false_effect": [ { "math": [ "u_esper_repeated_channeling_value", "=", "0" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_AFS_POWER_MAINTENANCE_PLUS_ONE",
+    "effect": [ { "math": [ "u_vitamin('vitamin_afs_maintained_powers')", "+=", "1" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_AFS_POWER_MAINTENANCE_MINUS_ONE",
+    "effect": [ { "math": [ "u_vitamin('vitamin_afs_maintained_powers')", "-=", "1" ] } ]
   }
 ]

--- a/data/mods/Aftershock/EOC/esper_eoc.json
+++ b/data/mods/Aftershock/EOC/esper_eoc.json
@@ -9,7 +9,34 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_ESPER_CONSEQUENCES_VALUE_INCREASER",
+    "id": "EOC_AFS_PSI_PRACTICE_FOCUS_MOD",
+    "condition": { "math": [ "u_val('focus')", ">=", "75" ] },
+    "effect": [ { "math": [ "u_val('focus')", "-=", "50" ] } ],
+    "false_effect": [ { "run_eocs": "EOC_AFS_PSI_PRACTICE_FOCUS_MOD_2" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_AFS_PSI_PRACTICE_FOCUS_MOD_2",
+    "condition": { "math": [ "u_val('focus')", ">=", "50" ] },
+    "effect": [ { "math": [ "u_val('focus')", "-=", "25" ] } ],
+    "false_effect": [ { "run_eocs": "EOC_AFS_PSI_PRACTICE_FOCUS_MOD_3" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_AFS_PSI_PRACTICE_FOCUS_MOD_3",
+    "condition": { "math": [ "u_val('focus')", ">=", "34" ] },
+    "effect": [ { "math": [ "u_val('focus')", "-=", "10" ] } ],
+    "false_effect": [ { "run_eocs": "EOC_AFS_PSI_PRACTICE_FOCUS_MOD_4" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_AFS_PSI_PRACTICE_FOCUS_MOD_4",
+    "condition": { "math": [ "u_val('focus')", ">=", "30" ] },
+    "effect": [ { "math": [ "u_val('focus')", "-=", "5" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_AFS_ESPER_CONSEQUENCES_VALUE_INCREASER",
     "eoc_type": "EVENT",
     "required_event": "spellcasting_finish",
     "condition": { "test_eoc": "EOC_CONDITION_ESPER_TRAIT_AND_SCHOOL_LIST" },
@@ -17,7 +44,7 @@
       {
         "run_eocs": [
           {
-            "id": "EOC_ESPER_CONSEQUENCES_VALUE_INCREASER_2",
+            "id": "EOC_AFS_ESPER_CONSEQUENCES_VALUE_INCREASER_2",
             "condition": { "math": [ "u_esper_repeated_channeling_value", "<", "20" ] },
             "effect": [ { "math": [ "u_esper_repeated_channeling_value", "+=", "rng(1,5)" ] } ]
           }
@@ -27,7 +54,7 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_ESPER_CONSEQUENCES_VALUE_DECREASER",
+    "id": "EOC_AFS_ESPER_CONSEQUENCES_VALUE_DECREASER",
     "recurrence": [ "3 seconds", "30 seconds" ],
     "global": true,
     "run_for_npcs": true,
@@ -65,7 +92,7 @@
     "condition": {
       "and": [
         { "not": { "u_has_proficiency": "prof_concentration_basic" } },
-        { "math": [ "u_vitamin('vitamin_maintained_powers')", ">", "0" ] }
+        { "math": [ "u_vitamin('vitamin_afs_maintained_powers')", ">", "0" ] }
       ]
     },
     "effect": [ { "math": [ "u_proficiency('prof_concentration_basic', 'format': 'percent')", "+=", "rand(4) / 24" ] } ],
@@ -77,7 +104,7 @@
           "condition": {
             "and": [
               { "not": { "u_has_proficiency": "prof_concentration_intermediate" } },
-              { "math": [ "u_vitamin('vitamin_maintained_powers')", ">", "0" ] }
+              { "math": [ "u_vitamin('vitamin_afs_maintained_powers')", ">", "0" ] }
             ]
           },
           "effect": [ { "math": [ "u_proficiency('prof_concentration_intermediate', 'format': 'percent')", "+=", "rand(4) / 48" ] } ],
@@ -88,7 +115,7 @@
                 "condition": {
                   "and": [
                     { "not": { "u_has_proficiency": "prof_concentration_master" } },
-                    { "math": [ "u_vitamin('vitamin_maintained_powers')", ">", "0" ] }
+                    { "math": [ "u_vitamin('vitamin_afs_maintained_powers')", ">", "0" ] }
                   ]
                 },
                 "effect": [ { "math": [ "u_proficiency('prof_concentration_master', 'format': 'percent')", "+=", "rand(4) / 96" ] } ]
@@ -121,7 +148,11 @@
     "id": "EOC_AFS_PSIONICS_ADVERSE_EVENT_NOSEBLEED",
     "condition": {
       "x_in_y_chance": {
-        "x": { "math": [ "(u_esper_repeated_channeling_value * 4) + (u_latest_channeled_power_difficulty * 5)" ] },
+        "x": {
+          "math": [
+            "(u_esper_repeated_channeling_value * 8) + (u_latest_channeled_power_difficulty * 3) + ((vitamin_afs_maintained_powers * 8) * vitamin_afs_maintained_powers)"
+          ]
+        },
         "y": 1000
       }
     },
@@ -136,7 +167,11 @@
     "id": "EOC_AFS_PSIONICS_ADVERSE_EVENT_HEADACHE",
     "condition": {
       "x_in_y_chance": {
-        "x": { "math": [ "(u_esper_repeated_channeling_value * 3) + (u_latest_channeled_power_difficulty * 5)" ] },
+        "x": {
+          "math": [
+            "(u_esper_repeated_channeling_value * 8) + (u_latest_channeled_power_difficulty * 3) + ((vitamin_afs_maintained_powers * 8) * vitamin_afs_maintained_powers)"
+          ]
+        },
         "y": 1000
       }
     },
@@ -150,13 +185,17 @@
     "id": "EOC_AFS_PSIONICS_ADVERSE_EVENT_HEALTH_PENALTY",
     "condition": {
       "x_in_y_chance": {
-        "x": { "math": [ "(u_esper_repeated_channeling_value * 2) + (u_latest_channeled_power_difficulty * 5)" ] },
+        "x": {
+          "math": [
+            "(u_esper_repeated_channeling_value * 8) + (u_latest_channeled_power_difficulty * 3) + ((vitamin_afs_maintained_powers * 8) * vitamin_afs_maintained_powers)"
+          ]
+        },
         "y": 1000
       }
     },
     "effect": [
-      { "u_add_effect": "effect_afs_esper_health_penalty", "duration": "30 seconds" },
-      { "u_message": "As you unleash your powers, you feel enervated.", "type": "bad" }
+      { "u_message": "As you unleash your powers, you feel enervated.", "type": "bad" },
+      { "u_add_effect": "effect_afs_esper_health_penalty", "duration": "30 seconds" }
     ]
   }
 ]

--- a/data/mods/Aftershock/EOC/esper_eoc.json
+++ b/data/mods/Aftershock/EOC/esper_eoc.json
@@ -44,5 +44,19 @@
     "type": "effect_on_condition",
     "id": "EOC_AFS_POWER_MAINTENANCE_MINUS_ONE",
     "effect": [ { "math": [ "u_vitamin('vitamin_afs_maintained_powers')", "-=", "1" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_AFS_END_PSI_POWERS_MAINTAINED",
+    "effect": [
+      {
+        "run_eocs": [
+          "EOC_AFS_TELEPATH_REMOVE_TELEPATHIC_SHIELD",
+          "EOC_AFS_TELEPATH_REMOVE_SENSE_MINDS",
+          "EOC_AFS_TELEPATH_REMOVE_TELEPATHIC_SUGGESTION"
+        ]
+      },
+      { "math": [ "u_vitamin('vitamin_afs_maintained_powers')", "=", "0" ] }
+    ]
   }
 ]

--- a/data/mods/Aftershock/EOC/esper_eoc.json
+++ b/data/mods/Aftershock/EOC/esper_eoc.json
@@ -58,5 +58,45 @@
       },
       { "math": [ "u_vitamin('vitamin_afs_maintained_powers')", "=", "0" ] }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CONCENTRATION_SUCCESS_PROFICIENCY",
+    "condition": {
+      "and": [
+        { "not": { "u_has_proficiency": "prof_concentration_basic" } },
+        { "math": [ "u_vitamin('vitamin_maintained_powers')", ">", "0" ] }
+      ]
+    },
+    "effect": [ { "math": [ "u_proficiency('prof_concentration_basic', 'format': 'percent')", "+=", "rand(4) / 24" ] } ],
+    "//": "adds 0% - 0.16% experience per run",
+    "false_effect": {
+      "run_eocs": [
+        {
+          "id": "EOC_CONCENTRATION_SUCCESS_PROFICIENCY_INT",
+          "condition": {
+            "and": [
+              { "not": { "u_has_proficiency": "prof_concentration_intermediate" } },
+              { "math": [ "u_vitamin('vitamin_maintained_powers')", ">", "0" ] }
+            ]
+          },
+          "effect": [ { "math": [ "u_proficiency('prof_concentration_intermediate', 'format': 'percent')", "+=", "rand(4) / 48" ] } ],
+          "false_effect": {
+            "run_eocs": [
+              {
+                "id": "EOC_CONCENTRATION_SUCCESS_PROFICIENCY_MASTER",
+                "condition": {
+                  "and": [
+                    { "not": { "u_has_proficiency": "prof_concentration_master" } },
+                    { "math": [ "u_vitamin('vitamin_maintained_powers')", ">", "0" ] }
+                  ]
+                },
+                "effect": [ { "math": [ "u_proficiency('prof_concentration_master', 'format': 'percent')", "+=", "rand(4) / 96" ] } ]
+              }
+            ]
+          }
+        }
+      ]
+    }
   }
 ]

--- a/data/mods/Aftershock/EOC/esper_eoc.json
+++ b/data/mods/Aftershock/EOC/esper_eoc.json
@@ -1,0 +1,38 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CONDITION_ESPER_TRAIT_AND_SCHOOL_LIST",
+    "condition": {
+      "and": [ { "u_has_trait": "ESPER" }, { "or": [ { "compare_string": [ "AFS_TELEPATH", { "context_val": "school" } ] } ] } ]
+    },
+    "effect": [  ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_ESPER_CONSEQUENCES_INCREASER",
+    "eoc_type": "EVENT",
+    "required_event": "spellcasting_finish",
+    "condition": { "test_eoc": "EOC_CONDITION_ESPER_TRAIT_AND_SCHOOL_LIST" },
+    "effect": [
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_ESPER_CONSEQUENCES_INCREASER_2",
+            "condition": { "math": [ "u_esper_repeated_channeling_value", "<", "20" ] },
+            "effect": [ { "math": [ "u_esper_repeated_channeling_value", "+=", "rng(1,5)" ] } ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_NETHER_CONDUIT_VALUE_DECREASER",
+    "recurrence": [ "3 seconds", "15 seconds" ],
+    "global": true,
+    "run_for_npcs": true,
+    "condition": { "math": [ "u_esper_repeated_channeling_value", ">", "0" ] },
+    "effect": [ { "math": [ "u_esper_repeated_channeling_value", "-=", "1" ] } ],
+    "false_effect": [ { "math": [ "u_esper_repeated_channeling_value", "=", "0" ] } ]
+  }
+]

--- a/data/mods/Aftershock/EOC/esper_recipe_learning_eoc.json
+++ b/data/mods/Aftershock/EOC/esper_recipe_learning_eoc.json
@@ -1,0 +1,59 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_AFS_TELEPATH_RECIPE_TEACHER",
+    "eoc_type": "EVENT",
+    "required_event": "game_begin",
+    "condition": { "u_has_trait": "AFS_TELEPATH" },
+    "effect": [ { "run_eocs": "EOC_TEACH_AFS_TELEPATH_CONTEMPLATE_RECIPES" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_TEACH_AFS_TELEPATH_CONTEMPLATE_RECIPES",
+    "effect": [
+      {
+        "run_eocs": [
+          "EOC_CHECK_GAMEBEGIN_AFS_TELEPATH_RECIPE_SHIELD",
+          "EOC_CHECK_GAMEBEGIN_AFS_TELEPATH_RECIPE_SUGGESTION",
+          "EOC_CHECK_GAMEBEGIN_AFS_TELEPATH_RECIPE_MIND_SENSE",
+          "EOC_CHECK_GAMEBEGIN_AFS_TELEPATH_RECIPE_CONFUSION",
+          "EOC_CHECK_GAMEBEGIN_AFS_TELEPATH_RECIPE_BLAST"
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CHECK_GAMEBEGIN_AFS_TELEPATH_RECIPE_SHIELD",
+    "condition": { "and": [ { "u_has_trait": "AFS_TELEPATH" }, { "math": [ "u_spell_level('afs_telepathic_shield')", ">=", "0" ] } ] },
+    "effect": [ { "u_learn_recipe": "practice_afs_telepathic_shield" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CHECK_GAMEBEGIN_AFS_TELEPATH_RECIPE_MIND_SENSE",
+    "condition": {
+      "and": [ { "u_has_trait": "AFS_TELEPATH" }, { "math": [ "u_spell_level('afs_telepathic_mind_sense')", ">=", "0" ] } ]
+    },
+    "effect": [ { "u_learn_recipe": "practice_afs_telepathic_mind_sense" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CHECK_GAMEBEGIN_AFS_TELEPATH_RECIPE_SUGGESTION",
+    "condition": {
+      "and": [ { "u_has_trait": "AFS_TELEPATH" }, { "math": [ "u_spell_level('afs_telepathic_suggestion')", ">=", "0" ] } ]
+    },
+    "effect": [ { "u_learn_recipe": "practice_afs_telepathic_suggestion" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CHECK_GAMEBEGIN_AFS_TELEPATH_RECIPE_CONFUSION",
+    "condition": { "and": [ { "u_has_trait": "AFS_TELEPATH" }, { "math": [ "u_spell_level('afs_telepathic_confusion')", ">=", "0" ] } ] },
+    "effect": [ { "u_learn_recipe": "practice_afs_telepathic_confusion" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CHECK_GAMEBEGIN_AFS_TELEPATH_RECIPE_BLAST",
+    "condition": { "and": [ { "u_has_trait": "AFS_TELEPATH" }, { "math": [ "u_spell_level('afs_telepathic_blast')", ">=", "0" ] } ] },
+    "effect": [ { "u_learn_recipe": "practice_afs_telepathic_blast" } ]
+  }
+]

--- a/data/mods/Aftershock/damage_types.json
+++ b/data/mods/Aftershock/damage_types.json
@@ -97,5 +97,117 @@
     "pet_prot_info": { "order": 301, "show_type": false },
     "melee_combat_info": { "order": 401, "show_type": false },
     "ablative_info": { "order": 301, "show_type": false }
+  },
+  {
+    "id": "psi_telepathic_damage",
+    "type": "damage_type",
+    "physical": false,
+    "magic_color": "white",
+    "name": "telepathic",
+    "skill": "metaphysics",
+    "immune_flags": { "character": [ "TEEPSHIELD", "PSYSHIELD_PROTECT" ], "monster": [ "TEEP_IMMUNE" ] },
+    "ondamage_eocs": [ "EOC_TELEPATHIC_DAMAGE_PSYSHIELD_CHECK", "EOC_TELEPATHIC_DAMAGE_STUN_HIVE_CHANCE" ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_TELEPATHIC_DAMAGE_PSYSHIELD_CHECK",
+    "condition": {
+      "and": [
+        { "npc_has_worn_with_flag": "PSYSHIELD_PARTIAL" },
+        { "math": [ "_damage_taken", ">", "-2" ] },
+        { "npc_has_effect": "effect_psyshield_protection" },
+        { "not": { "npc_has_flag": "HIVE_MIND" } },
+        { "not": { "npc_has_flag": "TEEP_IMMUNE" } },
+        { "not": { "npc_has_flag": "TEEPSHIELD" } }
+      ]
+    },
+    "effect": [
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_TELEPATHIC_DAMAGE_PSYSHIELD_CHECK_2",
+            "condition": { "x_in_y_chance": { "x": 1, "y": 2 } },
+            "effect": [
+              {
+                "npc_message": "Your head prickles.  It feels like spiders crawling across the surface of your brain.",
+                "type": "bad"
+              },
+              { "npc_lose_effect": "effect_psyshield_protection" }
+            ],
+            "false_effect": [
+              { "npc_lose_effect": "effect_psyshield_protection" },
+              { "npc_cast_spell": { "id": "telepathic_self_damage", "hit_self": true } },
+              { "npc_message": "Your minds reels!", "type": "bad" }
+            ]
+          }
+        ]
+      }
+    ],
+    "false_effect": [
+      {
+        "run_eocs": [ "EOC_TELEPATHIC_DAMAGE_STUN_CHANCE", "EOC_TELEPATHIC_DAMAGE_DAZED_CHANCE", "EOC_TELEPATHIC_DAMAGE_KNOCKDOWN_CHANCE" ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_TELEPATHIC_DAMAGE_KNOCKDOWN_CHANCE",
+    "condition": {
+      "and": [
+        { "x_in_y_chance": { "x": 1, "y": 20 } },
+        { "math": [ "_damage_taken", ">", "0" ] },
+        { "not": { "npc_has_flag": "HIVE_MIND" } },
+        { "not": { "npc_has_flag": "TEEP_IMMUNE" } },
+        { "not": { "npc_has_flag": "TEEPSHIELD" } }
+      ]
+    },
+    "effect": [ { "npc_add_effect": "downed", "duration": "1 s" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_TELEPATHIC_DAMAGE_STUN_CHANCE",
+    "condition": {
+      "and": [
+        { "x_in_y_chance": { "x": 1, "y": 3 } },
+        { "math": [ "_damage_taken", ">", "0" ] },
+        { "not": { "npc_has_flag": "HIVE_MIND" } },
+        { "not": { "npc_has_flag": "TEEP_IMMUNE" } },
+        { "not": { "npc_has_flag": "TEEPSHIELD" } }
+      ]
+    },
+    "effect": [ { "npc_add_effect": "psi_stunned", "duration": "1 s" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_TELEPATHIC_DAMAGE_DAZED_CHANCE",
+    "condition": {
+      "and": [
+        { "x_in_y_chance": { "x": 2, "y": 3 } },
+        { "math": [ "_damage_taken", ">", "0" ] },
+        { "not": { "npc_has_flag": "HIVE_MIND" } },
+        { "not": { "npc_has_flag": "TEEP_IMMUNE" } },
+        { "not": { "npc_has_flag": "TEEPSHIELD" } }
+      ]
+    },
+    "effect": [ { "npc_add_effect": "psi_dazed", "duration": "2 s" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_TELEPATHIC_DAMAGE_STUN_HIVE_CHANCE",
+    "condition": {
+      "and": [ { "x_in_y_chance": { "x": 1, "y": 6 } }, { "math": [ "_damage_taken", ">", "0" ] }, { "npc_has_flag": "HIVE_MIND" } ]
+    },
+    "effect": [ { "npc_add_effect": "psi_stunned", "duration": "5 s" } ]
+  },
+  {
+    "id": "psi_telepathic_damage",
+    "type": "damage_info_order",
+    "info_display": "detailed",
+    "verb": "mindblasting",
+    "bionic_info": { "order": 999900, "show_type": false },
+    "protection_info": { "order": 999900, "show_type": false },
+    "pet_prot_info": { "order": 999900, "show_type": false },
+    "melee_combat_info": { "order": 999900, "show_type": false },
+    "ablative_info": { "order": 999900, "show_type": false }
   }
 ]

--- a/data/mods/Aftershock/effects_esper.json
+++ b/data/mods/Aftershock/effects_esper.json
@@ -1,0 +1,80 @@
+[
+  {
+    "type": "effect_type",
+    "id": "effect_telepath_sense_minds",
+    "name": [ "Sensing Minds" ],
+    "desc": [ "You are looking out for other minds." ],
+    "apply_message": "",
+    "remove_message": "Your awareness of other minds fades away.",
+    "rating": "good",
+    "max_duration": "7 days",
+    "max_intensity": 50,
+    "enchantments": [
+      {
+        "values": [
+          {
+            "value": "SIGHT_RANGE_MINDS",
+            "add": {
+              "math": [
+                "( ( u_spell_level('telepathic_mind_sense') * 2) * (scaling_factor(u_val('intelligence') ) ) ) * u_nether_attunement_power_scaling"
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_telepathic_suggestion",
+    "name": [ "Mind Trick" ],
+    "desc": [
+      "You are editing out your most negative thoughts.  When you think about it, is being on this frozen hellhole really the worst thing that could have happened?"
+    ],
+    "apply_message": "",
+    "remove_message": "",
+    "rating": "good",
+    "max_duration": "7 days",
+    "enchantments": [
+      {
+        "values": [
+          {
+            "value": "SOCIAL_INTIMIDATE",
+            "add": { "math": [ "( (u_spell_level('afs_telepathic_suggestion') * 2.5) + 3) * (scaling_factor(u_val('intelligence') ) ) " ] }
+          },
+          {
+            "value": "SOCIAL_LIE",
+            "add": { "math": [ "( (u_spell_level('afs_telepathic_suggestion') * 2.5) + 3) * (scaling_factor(u_val('intelligence') ) ) " ] }
+          },
+          {
+            "value": "SOCIAL_PERSUADE",
+            "add": { "math": [ "( (u_spell_level('afs_telepathic_suggestion') * 2.5) + 3) * (scaling_factor(u_val('intelligence') ) ) " ] }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_telepathic_psi_armor",
+    "name": [ "Telepathic Shield" ],
+    "desc": [ "Your mind is warded against telepathic attack or detection." ],
+    "apply_message": "",
+    "remove_message": "Your thoughts are once again unguarded.",
+    "rating": "good",
+    "max_duration": "7 days",
+    "max_intensity": 17,
+    "removes_effects": [
+      "taint",
+      "tindrift",
+      "hallu",
+      "hallucination_attacks",
+      "visuals",
+      "fearparalyze",
+      "amigara",
+      "psi_stunned",
+      "telepathic_ignorance"
+    ],
+    "flags": [ "TEEPSHIELD" ]
+  }
+]

--- a/data/mods/Aftershock/effects_esper.json
+++ b/data/mods/Aftershock/effects_esper.json
@@ -28,9 +28,7 @@
     "type": "effect_type",
     "id": "effect_telepathic_suggestion",
     "name": [ "Mind Trick" ],
-    "desc": [
-      "You are editing out your most negative thoughts.  When you think about it, is being on this frozen hellhole really the worst thing that could have happened?"
-    ],
+    "desc": [ "You are preparing to influence the minds of others to make them more amenable to your point of view." ],
     "apply_message": "",
     "remove_message": "",
     "rating": "good",

--- a/data/mods/Aftershock/effects_esper.json
+++ b/data/mods/Aftershock/effects_esper.json
@@ -66,6 +66,19 @@
   },
   {
     "type": "effect_type",
+    "id": "psi_stunned",
+    "//": "Separate ID to allow telepaths and telepathy-immune monsters to defend against it.",
+    "name": [ "Stunned" ],
+    "desc": [ "Your mind is reeling." ],
+    "apply_message": "You're stunned!",
+    "rating": "bad",
+    "show_in_info": true,
+    "limb_score_mods": [ { "limb_score": "balance", "modifier": 0.2 }, { "limb_score": "reaction", "modifier": 0.0 } ],
+    "immune_flags": [ "TEEPSHIELD", "TEEP_IMMUNE" ],
+    "flags": [ "DISABLE_FLIGHT", "EFFECT_LIMB_SCORE_MOD", "NO_SPELLCASTING", "NO_PSIONICS" ]
+  },
+  {
+    "type": "effect_type",
     "id": "effect_telepath_sense_minds",
     "name": [ "Sensing Minds" ],
     "desc": [ "You are looking out for other minds." ],
@@ -79,11 +92,7 @@
         "values": [
           {
             "value": "SIGHT_RANGE_MINDS",
-            "add": {
-              "math": [
-                "( ( u_spell_level('telepathic_mind_sense') * 2) * (scaling_factor(u_val('intelligence') ) ) ) * u_nether_attunement_power_scaling"
-              ]
-            }
+            "add": { "math": [ "( ( u_spell_level('afs_telepathic_mind_sense') * 2) * (scaling_factor(u_val('intelligence') ) ) )" ] }
           }
         ]
       }

--- a/data/mods/Aftershock/effects_esper.json
+++ b/data/mods/Aftershock/effects_esper.json
@@ -1,6 +1,71 @@
 [
   {
     "type": "effect_type",
+    "id": "effect_afs_esper_headache",
+    "name": [
+      "Headache",
+      "Headache",
+      "Headache",
+      "Bad Headache",
+      "Bad Headache",
+      "Splitting Headache",
+      "Splitting Headache",
+      "Excruciating Headache",
+      "Excruciating Headache",
+      "Pure Agony"
+    ],
+    "desc": [
+      "Your head is pounding and you feel unwell.",
+      "Your head is pounding and you feel unwell.",
+      "Your head is pounding and you feel unwell.",
+      "Your head throbs and it's hard to see straight.",
+      "Your head throbs and it's hard to see straight.",
+      "You can barely think through the pain in your head.",
+      "You can barely think through the pain in your head.",
+      "Your skull feels like it's going to explode.",
+      "Your skull feels like it's going to explode.",
+      "The agony is the only thing in the world that matters."
+    ],
+    "rating": "bad",
+    "int_add_val": 1,
+    "max_intensity": 10,
+    "max_duration": "24 hours",
+    "base_mods": {
+      "per_mod": [ -1 ],
+      "pain_chance": [ 100 ],
+      "pain_min": [ 1 ],
+      "pain_max": [ 1 ],
+      "pain_max_val": [ 20 ],
+      "pain_tick": [ 200 ],
+      "vomit_chance": [ 100 ],
+      "vomit_tick": [ 200 ],
+      "hurt_chance": [ 300 ],
+      "hurt_amount": [ 0 ],
+      "hurt_tick": [ 200 ]
+    },
+    "scaling_mods": {
+      "per_mod": [ -0.8 ],
+      "int_mod": [ -0.6 ],
+      "pain_min": [ 0 ],
+      "pain_max": [ 0 ],
+      "pain_max_val": [ 5 ],
+      "vomit_chance": [ -2 ],
+      "hurt_chance": [ -5 ],
+      "hurt_amount": [ 2, 1 ],
+      "hurt_tick": [ -15 ]
+    }
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_afs_esper_health_penalty",
+    "name": [ "" ],
+    "desc": [ "" ],
+    "rating": "bad",
+    "max_duration": "30 seconds",
+    "base_mods": { "health_min": [ -1 ], "health_chance": [ 2 ] }
+  },
+  {
+    "type": "effect_type",
     "id": "effect_telepath_sense_minds",
     "name": [ "Sensing Minds" ],
     "desc": [ "You are looking out for other minds." ],

--- a/data/mods/Aftershock/effects_on_condition.json
+++ b/data/mods/Aftershock/effects_on_condition.json
@@ -103,5 +103,18 @@
       },
       "u_die"
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_ESPER_SCENARIO_SETUP",
+    "eoc_type": "SCENARIO_SPECIFIC",
+    "effect": [
+      { "math": [ "u_hp('head')", "-=", "rand(5)" ] },
+      { "math": [ "u_hp('torso')", "-=", "rand(5)" ] },
+      { "math": [ "u_hp('arm_r')", "-=", "rand(5)" ] },
+      { "math": [ "u_hp('arm_l')", "-=", "rand(5)" ] },
+      { "math": [ "u_hp('leg_l')", "-=", "rand(5)" ] },
+      { "math": [ "u_hp('leg_r')", "-=", "rand(5)" ] }
+    ]
   }
 ]

--- a/data/mods/Aftershock/flags.json
+++ b/data/mods/Aftershock/flags.json
@@ -7,5 +7,20 @@
   {
     "id": "HEAVY_TOOL",
     "type": "json_flag"
+  },
+  {
+    "id": "TEEPSHIELD",
+    "type": "json_flag",
+    "info": "You are immune to telepathy."
+  },
+  {
+    "id": "HIVE_MIND",
+    "type": "monster_flag",
+    "//": "This monster is part of a hive mind"
+  },
+  {
+    "id": "TEEP_IMMUNE",
+    "type": "monster_flag",
+    "//": "Immune to telepathic damage"
   }
 ]

--- a/data/mods/Aftershock/jmath.json
+++ b/data/mods/Aftershock/jmath.json
@@ -1,0 +1,20 @@
+[
+  {
+    "type": "jmath_function",
+    "id": "int_to_level",
+    "num_args": 1,
+    "return": "(u_val('intelligence') * 1.5) * (_0)"
+  },
+  {
+    "type": "jmath_function",
+    "id": "scaling_factor",
+    "num_args": 1,
+    "return": "( ( _0 + 10) / 20 )"
+  },
+  {
+    "type": "jmath_function",
+    "id": "maintenance_exp_factor",
+    "num_args": 1,
+    "return": "(_0 / 100) * 75 * ( ( u_val('intelligence') + 10) / 20 ) * min( ( 0.5 + ( u_skill('metaphysics') / 20) ), 1)"
+  }
+]

--- a/data/mods/Aftershock/jmath.json
+++ b/data/mods/Aftershock/jmath.json
@@ -16,5 +16,11 @@
     "id": "maintenance_exp_factor",
     "num_args": 1,
     "return": "(_0 / 100) * 75 * ( ( u_val('intelligence') + 10) / 20 ) * min( ( 0.5 + ( u_skill('metaphysics') / 20) ), 1)"
+  },
+  {
+    "type": "jmath_function",
+    "id": "contemplation_factor",
+    "num_args": 1,
+    "return": "(u_val('focus') * 18) * (_0)"
   }
 ]

--- a/data/mods/Aftershock/mutations/esper.json
+++ b/data/mods/Aftershock/mutations/esper.json
@@ -4,7 +4,7 @@
     "id": "ESPER",
     "name": "Esper",
     "points": 0,
-    "description": "The ability to read thoughts and influence others' minds.",
+    "description": "You are an esper, capable of accessing the hidden powers of the human mind.",
     "starting_trait": false,
     "purifiable": false,
     "valid": false

--- a/data/mods/Aftershock/mutations/esper.json
+++ b/data/mods/Aftershock/mutations/esper.json
@@ -1,0 +1,24 @@
+[
+  {
+    "type": "mutation",
+    "id": "ESPER",
+    "name": "Esper",
+    "points": 0,
+    "description": "The ability to read thoughts and influence others' minds.",
+    "starting_trait": false,
+    "purifiable": false,
+    "valid": false
+  },
+  {
+    "type": "mutation",
+    "id": "AFS_TELEPATH",
+    "name": "Telepath",
+    "points": 0,
+    "description": "The ability to read thoughts and influence others' minds.",
+    "starting_trait": false,
+    "purifiable": false,
+    "valid": false,
+    "player_display": false,
+    "spells_learned": [ [ "afs_classless_toggleable_concentration_end", 1 ] ]
+  }
+]

--- a/data/mods/Aftershock/player/professions.json
+++ b/data/mods/Aftershock/player/professions.json
@@ -641,8 +641,16 @@
     "id": "afs_esper_telepath",
     "name": "Telepath",
     "description": "You are a telepath, able to sense minds and influence thoughts.  You aren't entirely sure how you got your powers, but you seem to have an instinctive sense of how to use them.  That's not sinister at all, right?",
+    "traits": [ "AFS_TELEPATH" ],
     "flags": [ "SCEN_ONLY" ],
     "skills": [ { "level": 3, "name": "metaphysics" } ],
+    "spells": [
+      { "id": "afs_telepathic_shield", "level": 8 },
+      { "id": "afs_telepathic_mind_sense", "level": 6 },
+      { "id": "afs_telepathic_suggestion", "level": 6 },
+      { "id": "afs_telepathic_confusion", "level": 5 },
+      { "id": "afs_telepathic_blast", "level": 3 }
+    ],
     "items": {
       "both": {
         "entries": [

--- a/data/mods/Aftershock/player/professions.json
+++ b/data/mods/Aftershock/player/professions.json
@@ -643,7 +643,7 @@
     "description": "You are a telepath, able to sense minds and influence thoughts.  You aren't entirely sure how you got your powers, but you seem to have an instinctive sense of how to use them.  That's not sinister at all, right?",
     "traits": [ "AFS_TELEPATH" ],
     "flags": [ "SCEN_ONLY" ],
-    "skills": [ { "level": 3, "name": "metaphysics" } ],
+    "skills": [ { "level": 4, "name": "metaphysics" } ],
     "spells": [
       { "id": "afs_telepathic_shield", "level": 8 },
       { "id": "afs_telepathic_mind_sense", "level": 6 },
@@ -651,6 +651,7 @@
       { "id": "afs_telepathic_confusion", "level": 5 },
       { "id": "afs_telepathic_blast", "level": 3 }
     ],
+    "proficiencies": [ "prof_concentration_basic" ],
     "items": {
       "both": {
         "entries": [
@@ -658,13 +659,11 @@
           { "item": "spacer_cap" },
           { "item": "socks" },
           { "item": "boots" },
-          { "item": "duct_tape" },
-          { "item": "screwdriver" },
           { "item": "wristwatch" },
-          { "item": "hat_hard", "variant": "orange_hat_hard" },
-          { "item": "wrench", "container-item": "tool_belt" },
           { "item": "cream_prot_cold" },
-          { "item": "cream_prot_cold" }
+          { "item": "cream_prot_cold" },
+          { "group": "charged_smart_phone" },
+          { "item": "afs_40g_plasma_civ", "ammo-item": "afs_shydrogen", "charges": 40 }
         ]
       },
       "male": { "entries": [ { "item": "briefs" } ] },

--- a/data/mods/Aftershock/player/professions.json
+++ b/data/mods/Aftershock/player/professions.json
@@ -635,5 +635,32 @@
     "copy-from": "afs_rating",
     "name": "Escaping Crew",
     "description": "You awake in your cabin to the sound of emergency sirens and the ship's computer calmly announcing in a posh English voice 'Abandon the vessel immediately.', and then counting down from five minutes.  You've got just enough time to hit a supply locker before you need to activate the escape pod down the hall."
+  },
+  {
+    "type": "profession",
+    "id": "afs_esper_telepath",
+    "name": "Telepath",
+    "description": "You are a telepath, able to sense minds and influence thoughts.  You aren't entirely sure how you got your powers, but you seem to have an instinctive sense of how to use them.  That's not sinister at all, right?",
+    "flags": [ "SCEN_ONLY" ],
+    "skills": [ { "level": 3, "name": "metaphysics" } ],
+    "items": {
+      "both": {
+        "entries": [
+          { "item": "spacer_jumpsuit" },
+          { "item": "spacer_cap" },
+          { "item": "socks" },
+          { "item": "boots" },
+          { "item": "duct_tape" },
+          { "item": "screwdriver" },
+          { "item": "wristwatch" },
+          { "item": "hat_hard", "variant": "orange_hat_hard" },
+          { "item": "wrench", "container-item": "tool_belt" },
+          { "item": "cream_prot_cold" },
+          { "item": "cream_prot_cold" }
+        ]
+      },
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boy_shorts" } ] }
+    }
   }
 ]

--- a/data/mods/Aftershock/player/professions.json
+++ b/data/mods/Aftershock/player/professions.json
@@ -641,6 +641,7 @@
     "id": "afs_esper_telepath",
     "name": "Telepath",
     "description": "You are a telepath, able to sense minds and influence thoughts.  You aren't entirely sure how you got your powers, but you seem to have an instinctive sense of how to use them.  That's not sinister at all, right?",
+    "points": 7,
     "traits": [ "AFS_TELEPATH" ],
     "flags": [ "SCEN_ONLY" ],
     "skills": [ { "level": 4, "name": "metaphysics" } ],
@@ -663,7 +664,8 @@
           { "item": "cream_prot_cold" },
           { "item": "cream_prot_cold" },
           { "group": "charged_smart_phone" },
-          { "item": "afs_40g_plasma_civ", "ammo-item": "afs_shydrogen", "charges": 40 }
+          { "item": "XL_holster" },
+          { "item": "afs_cartridge", "ammo-item": "battery", "charges": [ 900, 1485 ], "container-item": "afs_v29" }
         ]
       },
       "male": { "entries": [ { "item": "briefs" } ] },

--- a/data/mods/Aftershock/player/proficiencies.json
+++ b/data/mods/Aftershock/player/proficiencies.json
@@ -12,5 +12,46 @@
     "name": { "str": "Armament License" },
     "can_learn": false,
     "description": "You have a license to own and operate military grade weaponry and can legally purchase such items without any difficulty."
+  },
+  {
+    "type": "proficiency_category",
+    "id": "prof_concentration",
+    "name": "Concentration",
+    "description": "Proficiencies that help with maintaining concentration even in the face of distractions."
+  },
+  {
+    "type": "proficiency",
+    "id": "prof_concentration_basic",
+    "category": "prof_concentration",
+    "name": { "str": "Concentration (Beginner)" },
+    "description": "You are capable of holding the same thing in mind even when sitting in an uncomfortable position or after skipping a meal.",
+    "can_learn": true,
+    "time_to_learn": "16 h",
+    "default_time_multiplier": 2,
+    "default_skill_penalty": 0.2
+  },
+  {
+    "type": "proficiency",
+    "id": "prof_concentration_intermediate",
+    "category": "prof_concentration",
+    "name": { "str": "Concentration (Expert)" },
+    "description": "You can maintain your concentration even if outside in winter without a coat or while in combat with a zombie.",
+    "can_learn": true,
+    "time_to_learn": "32 h",
+    "default_time_multiplier": 2.5,
+    "default_skill_penalty": 0.25,
+    "required_proficiencies": [ "prof_concentration_basic" ]
+  },
+  {
+    "type": "proficiency",
+    "id": "prof_concentration_master",
+    "category": "prof_concentration",
+    "name": { "str": "Concentration (Master)" },
+    "description": "You can maintain your concentration even when suffering crippling injuries or while on mind-altering substances.",
+    "can_learn": true,
+    "time_to_learn": "64 h",
+    "default_time_multiplier": 3,
+    "default_skill_penalty": 0.3,
+    "required_proficiencies": [ "prof_concentration_intermediate" ]
   }
 ]

--- a/data/mods/Aftershock/player/proficiencies.json
+++ b/data/mods/Aftershock/player/proficiencies.json
@@ -35,7 +35,7 @@
     "id": "prof_concentration_intermediate",
     "category": "prof_concentration",
     "name": { "str": "Concentration (Expert)" },
-    "description": "You can maintain your concentration even if outside in winter without a coat or while in combat with a zombie.",
+    "description": "You can maintain your concentration even if outside in winter without a coat or in the middle of a fight.",
     "can_learn": true,
     "time_to_learn": "32 h",
     "default_time_multiplier": 2.5,

--- a/data/mods/Aftershock/recipes/esper/telepathy_practice.json
+++ b/data/mods/Aftershock/recipes/esper/telepathy_practice.json
@@ -1,0 +1,158 @@
+[
+  {
+    "id": "afs_telepathy_practice",
+    "type": "nested_category",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_PRACTICE",
+    "subcategory": "CSC_PRACTICE_METAPHYSICS",
+    "name": "practice: telepathy",
+    "description": "Recipes related to practicing telepathy.",
+    "skill_used": "metaphysics",
+    "nested_category_data": [
+      "practice_afs_telepathic_shield",
+      "practice_afs_telepathic_mind_sense",
+      "practice_afs_telepathic_suggestion",
+      "practice_afs_telepathic_confusion",
+      "practice_afs_telepathic_blast"
+    ],
+    "difficulty": 1
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "name": "telepathic practice: telepathic shield",
+    "id": "practice_afs_telepathic_shield",
+    "description": "Contemplate your powers and improve the resilience of your mind.",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "metaphysics",
+    "difficulty": 1,
+    "time": "30 m",
+    "autolearn": false,
+    "flags": [ "SECRET", "BLIND_EASY", "NO_MANIP", "AFFECTED_BY_PAIN", "NO_BENCH", "NO_ENCHANTMENT" ],
+    "result_eocs": [
+      {
+        "id": "EOC_PRACTICE_AFS_TELEPATH_SHIELD",
+        "effect": [
+          {
+            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
+            "type": "good"
+          },
+          { "math": [ "u_spell_exp('afs_telepathic_shield')", "+=", "(contemplation_factor(1))" ] },
+          { "run_eocs": "EOC_AFS_PSI_PRACTICE_FOCUS_MOD" }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "name": "telepathic practice: mind sense",
+    "id": "practice_afs_telepathic_mind_sense",
+    "description": "Contemplate your powers and improve your ability to detect other minds.",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "metaphysics",
+    "difficulty": 2,
+    "time": "30 m",
+    "autolearn": false,
+    "flags": [ "SECRET", "BLIND_EASY", "NO_MANIP", "AFFECTED_BY_PAIN", "NO_BENCH", "NO_ENCHANTMENT" ],
+    "result_eocs": [
+      {
+        "id": "EOC_PRACTICE_AFS_TELEPATH_MIND_SENSE",
+        "effect": [
+          {
+            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
+            "type": "good"
+          },
+          { "math": [ "u_spell_exp('afs_telepathic_mind_sense')", "+=", "(contemplation_factor(1))" ] },
+          { "run_eocs": "EOC_AFS_PSI_PRACTICE_FOCUS_MOD" }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "name": "telepathic practice: telepathic suggestion",
+    "id": "practice_afs_telepathic_suggestion",
+    "description": "Contemplate your powers and improve your ability to persuade others.",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "metaphysics",
+    "difficulty": 3,
+    "time": "30 m",
+    "autolearn": false,
+    "flags": [ "SECRET", "BLIND_EASY", "NO_MANIP", "AFFECTED_BY_PAIN", "NO_BENCH", "NO_ENCHANTMENT" ],
+    "result_eocs": [
+      {
+        "id": "EOC_PRACTICE_AFS_TELEPATH_SUGGESTION",
+        "effect": [
+          {
+            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
+            "type": "good"
+          },
+          { "math": [ "u_spell_exp('afs_telepathic_suggestion')", "+=", "(contemplation_factor(1))" ] },
+          { "run_eocs": "EOC_AFS_PSI_PRACTICE_FOCUS_MOD" }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "name": "telepathic practice: sensory deprivation",
+    "id": "practice_afs_telepathic_confusion",
+    "description": "Contemplate your powers and improve your ability to confound your enemies's senses.",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "metaphysics",
+    "difficulty": 4,
+    "time": "30 m",
+    "autolearn": false,
+    "flags": [ "SECRET", "BLIND_EASY", "NO_MANIP", "AFFECTED_BY_PAIN", "NO_BENCH", "NO_ENCHANTMENT" ],
+    "result_eocs": [
+      {
+        "id": "EOC_PRACTICE_AFS_TELEPATH_CONFUSION",
+        "effect": [
+          {
+            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
+            "type": "good"
+          },
+          { "math": [ "u_spell_exp('afs_telepathic_confusion')", "+=", "(contemplation_factor(1))" ] },
+          { "run_eocs": "EOC_AFS_PSI_PRACTICE_FOCUS_MOD" }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "name": "telepathic practice: synaptic overload",
+    "id": "practice_afs_telepathic_blast",
+    "description": "Contemplate your powers and improve your mental strength to telepathically assault your enemies.",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "metaphysics",
+    "difficulty": 6,
+    "time": "30 m",
+    "autolearn": false,
+    "proficiencies": [ { "proficiency": "prof_contemplation_telepathy", "required": false } ],
+    "tools": [ [ [ "matrix_crystal_drained", -1 ], [ "black_nether_crystal_pseudo_tool", -1 ], [ "matrix_crystal_telepathy", -1 ] ] ],
+    "components": [ [ [ "matrix_crystal_telepath_dust", 1 ] ] ],
+    "flags": [ "SECRET", "BLIND_EASY", "NO_MANIP", "AFFECTED_BY_PAIN", "NO_BENCH", "NO_ENCHANTMENT" ],
+    "result_eocs": [
+      {
+        "id": "EOC_PRACTICE_TELEPATHIC_BLAST",
+        "effect": [
+          {
+            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
+            "type": "good"
+          },
+          { "math": [ "u_spell_exp('afs_telepathic_blast')", "+=", "(contemplation_factor(1))" ] },
+          { "run_eocs": "EOC_AFS_PSI_PRACTICE_FOCUS_MOD" }
+        ]
+      }
+    ]
+  }
+]

--- a/data/mods/Aftershock/recipes/esper/telepathy_practice.json
+++ b/data/mods/Aftershock/recipes/esper/telepathy_practice.json
@@ -4,8 +4,8 @@
     "type": "nested_category",
     "activity_level": "LIGHT_EXERCISE",
     "category": "CC_PRACTICE",
-    "subcategory": "CSC_PRACTICE_METAPHYSICS",
-    "name": "practice: telepathy",
+    "subcategory": "CSC_PRACTICE_PSI",
+    "name": "[Ψ]practice: telepathy",
     "description": "Recipes related to practicing telepathy.",
     "skill_used": "metaphysics",
     "nested_category_data": [
@@ -20,7 +20,7 @@
   {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
-    "name": "telepathic practice: telepathic shield",
+    "name": "[Ψ]telepathic shield",
     "id": "practice_afs_telepathic_shield",
     "description": "Contemplate your powers and improve the resilience of your mind.",
     "category": "CC_*",
@@ -47,7 +47,7 @@
   {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
-    "name": "telepathic practice: mind sense",
+    "name": "[Ψ]mind sense",
     "id": "practice_afs_telepathic_mind_sense",
     "description": "Contemplate your powers and improve your ability to detect other minds.",
     "category": "CC_*",
@@ -74,7 +74,7 @@
   {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
-    "name": "telepathic practice: telepathic suggestion",
+    "name": "[Ψ]telepathic suggestion",
     "id": "practice_afs_telepathic_suggestion",
     "description": "Contemplate your powers and improve your ability to persuade others.",
     "category": "CC_*",
@@ -101,7 +101,7 @@
   {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
-    "name": "telepathic practice: sensory deprivation",
+    "name": "[Ψ]sensory deprivation",
     "id": "practice_afs_telepathic_confusion",
     "description": "Contemplate your powers and improve your ability to confound your enemies's senses.",
     "category": "CC_*",
@@ -128,7 +128,7 @@
   {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
-    "name": "telepathic practice: synaptic overload",
+    "name": "[Ψ]synaptic overload",
     "id": "practice_afs_telepathic_blast",
     "description": "Contemplate your powers and improve your mental strength to telepathically assault your enemies.",
     "category": "CC_*",
@@ -137,9 +137,6 @@
     "difficulty": 6,
     "time": "30 m",
     "autolearn": false,
-    "proficiencies": [ { "proficiency": "prof_contemplation_telepathy", "required": false } ],
-    "tools": [ [ [ "matrix_crystal_drained", -1 ], [ "black_nether_crystal_pseudo_tool", -1 ], [ "matrix_crystal_telepathy", -1 ] ] ],
-    "components": [ [ [ "matrix_crystal_telepath_dust", 1 ] ] ],
     "flags": [ "SECRET", "BLIND_EASY", "NO_MANIP", "AFFECTED_BY_PAIN", "NO_BENCH", "NO_ENCHANTMENT" ],
     "result_eocs": [
       {

--- a/data/mods/Aftershock/recipes/recipes_categories.json
+++ b/data/mods/Aftershock/recipes/recipes_categories.json
@@ -11,5 +11,27 @@
       "CSC_ELECTRONIC_COMPONENTS",
       "CSC_ELECTRONIC_OTHER"
     ]
+  },
+  {
+    "type": "recipe_category",
+    "id": "CC_PRACTICE",
+    "recipe_subcategories": [
+      "CSC_ALL",
+      "CSC_PRACTICE_SCIENCE",
+      "CSC_PRACTICE_ELECTRONICS",
+      "CSC_PRACTICE_FABRICATION",
+      "CSC_PRACTICE_FOOD",
+      "CSC_PRACTICE_SURVIVAL",
+      "CSC_PRACTICE_TAILORING",
+      "CSC_PRACTICE_ATHLETICS",
+      "CSC_PRACTICE_COMPUTERS",
+      "CSC_PRACTICE_DEVICES",
+      "CSC_PRACTICE_HEALTH",
+      "CSC_PRACTICE_MECHANICS",
+      "CSC_PRACTICE_SOCIAL",
+      "CSC_PRACTICE_MELEE",
+      "CSC_PRACTICE_RANGED",
+      "CSC_PRACTICE_PSI"
+    ]
   }
 ]

--- a/data/mods/Aftershock/scenarios.json
+++ b/data/mods/Aftershock/scenarios.json
@@ -213,7 +213,7 @@
     "id": "afs_esper_start",
     "name": "Esper",
     "points": 1,
-    "description": "There are stories that before the Discontinuity, scientists had developed treatments to unlock the powers of the human mind.  To read thoughts, move objects at a distance, control computers by the power of will alone, and even stranger things.  Just one more lost secret of the Golden Age.\n\nOr so you thought, but recently you had heard some tantalizing rumors about espers, centered on a backwater planet on the edge of known civilization.  You remember buying a ticket to Salus, arriving at Port Augustmoon and buying supplies, and descending to the surface, and after that…things get hazy.  You're not entirely sure where you are, but somehow you've rediscovered that lost secret.  Now you just need to make it back alive.",
+    "description": "There are stories that before the Discontinuity, scientists had developed treatments to unlock the powers of the human mind.  To read thoughts, move objects at a distance, control computers by the power of will alone, and even stranger things.  Just one more lost secret of the Golden Age.\n\nOr so you thought, but recently you had heard some tantalizing rumors about espers, centered on a backwater planet on the edge of known civilization.  You remember buying passage to the Salus system, arriving at Port Augustmoon and buying supplies, and descending to the surface, and after that…things get hazy.  You're not entirely sure where you are, but somehow you've rediscovered that lost secret.  Now you just need to make it back alive.",
     "forced_traits": [ "ESPER" ],
     "allowed_locs": [ "sloc_afs_glacial_tunnels" ],
     "professions": [ "afs_esper_telepath" ],

--- a/data/mods/Aftershock/scenarios.json
+++ b/data/mods/Aftershock/scenarios.json
@@ -213,11 +213,12 @@
     "id": "afs_esper_start",
     "name": "Esper",
     "points": 1,
-    "description": "There are stories that before the Discontinuity, scientists had developed treatments to unlock the powers of the human mind.  To read thoughts, move objects at a distance, control computers by the power of will alone, and even stranger things.  Just one more lost secret of the Golden Age.\n\nOr so you thought, but recently you had heard some tantalizing rumors about espers, centered on a backwater planet on the edge of known civilization.  You remember buying passage to the Salus system, arriving at Port Augustmoon and buying supplies, and descending to the surface, and after that…things get hazy.  You're not entirely sure where you are, but somehow you've rediscovered that lost secret.  Now you just need to make it back alive.",
+    "description": "There are stories that before the Discontinuity, scientists had developed treatments to unlock the powers of the human mind.  To read thoughts, move objects at a distance, control computers by the power of will alone, and even stranger things.  Just one more lost secret of the Golden Age.\n\nOr so you thought, but recently you had heard some tantalizing rumors about espers, centered on a backwater planet on the edge of known civilization.  You remember buying passage to the Salus system, arriving at Port Augustmoon and buying supplies, and descending to the surface, and after that…things get hazy.  You're not entirely sure where you are, and you've clearly been through it, but somehow you've rediscovered that lost secret.  Now you just need to make it back alive.",
     "forced_traits": [ "ESPER" ],
     "allowed_locs": [ "sloc_afs_glacial_tunnels" ],
     "professions": [ "afs_esper_telepath" ],
     "flags": [ "LONE_START" ],
-    "start_name": "Lost on the Surface"
+    "start_name": "Lost on the Surface",
+    "eoc": [ "EOC_ESPER_SCENARIO_SETUP" ]
   }
 ]

--- a/data/mods/Aftershock/scenarios.json
+++ b/data/mods/Aftershock/scenarios.json
@@ -213,7 +213,7 @@
     "id": "afs_esper_start",
     "name": "Esper",
     "points": 1,
-    "description": "There are stories that before the Discontinuity, scientists had developed treatments to unlock the powers of the human mind.  To read thoughts, move objects at a distance, control computers by the power of will alone, and even stranger things.  Just one more lost secret of the Golden Age.\n\nOr so you thought, but recently you had heard a lot of rumors about espers, centered on a backwater planet on the edge of known civilization.  You remember buying a ticket to Salus, arriving at Port Augustmoon and buying supplies, and descending to the surface, and after that…things get hazy.  You're not entirely sure where you are, but somehow you've rediscovered that lost secret.  Now you just need to make it back alive.",
+    "description": "There are stories that before the Discontinuity, scientists had developed treatments to unlock the powers of the human mind.  To read thoughts, move objects at a distance, control computers by the power of will alone, and even stranger things.  Just one more lost secret of the Golden Age.\n\nOr so you thought, but recently you had heard some tantalizing rumors about espers, centered on a backwater planet on the edge of known civilization.  You remember buying a ticket to Salus, arriving at Port Augustmoon and buying supplies, and descending to the surface, and after that…things get hazy.  You're not entirely sure where you are, but somehow you've rediscovered that lost secret.  Now you just need to make it back alive.",
     "forced_traits": [ "ESPER" ],
     "allowed_locs": [ "sloc_afs_glacial_tunnels" ],
     "professions": [ "afs_esper_telepath" ],

--- a/data/mods/Aftershock/scenarios.json
+++ b/data/mods/Aftershock/scenarios.json
@@ -207,5 +207,17 @@
     "flags": [ "LONE_START", "HELI_CRASH" ],
     "start_name": "Crashing Ship",
     "eoc": [ "EOC_CRASHING_SHIP_SETUP" ]
+  },
+  {
+    "type": "scenario",
+    "id": "afs_esper_start",
+    "name": "Esper",
+    "points": 1,
+    "description": "There are stories that before the Discontinuity, scientists had developed treatments to unlock the powers of the human mind.  To read thoughts, move objects at a distance, control computers by the power of will alone, and even stranger things.  Just one more lost secret of the Golden Age.\n\nOr so you thought, but recently you had heard a lot of rumors about espers, centered on a backwater planet on the edge of known civilization.  You remember buying a ticket to Salus, arriving at Port Augustmoon and buying supplies, and descending to the surface, and after that…things get hazy.  You're not entirely sure where you are, but somehow you've rediscovered that lost secret.  Now you just need to make it back alive.",
+    "forced_traits": [ "ESPER" ],
+    "allowed_locs": [ "sloc_afs_glacial_tunnels" ],
+    "professions": [ "afs_esper_telepath" ],
+    "flags": [ "LONE_START" ],
+    "start_name": "Lost on the Surface"
   }
 ]

--- a/data/mods/Aftershock/skills.json
+++ b/data/mods/Aftershock/skills.json
@@ -9,5 +9,13 @@
     "display_category": "display_ranged",
     "sort_rank": 10500,
     "companion_skill_practice": [ { "skill": "combat", "weight": 25 } ]
+  },
+  {
+    "type": "skill",
+    "id": "metaphysics",
+    "name": { "str": "metaphysics" },
+    "display_category": "display_ranged",
+    "sort_rank": 14500,
+    "description": "Your ability to manipulate psionic energy."
   }
 ]

--- a/data/mods/Aftershock/spells/psionics/classless.json
+++ b/data/mods/Aftershock/spells/psionics/classless.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "afs_classless_toggleable_concentration_end",
+    "type": "SPELL",
+    "name": "[Ψ]Stop Concentrating",
+    "description": "End your concentration on all of your maintained powers.\n\nChanneling this power <color_green>always succeeds</color>.",
+    "message": "You stop concentrating.",
+    "teachable": false,
+    "valid_targets": [ "self" ],
+    "skill": "metaphysics",
+    "flags": [ "PSIONIC", "NO_FAIL", "SILENT", "NO_HANDS", "NO_LEGS" ],
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_AFS_END_PSI_POWERS_MAINTAINED",
+    "shape": "blast",
+    "max_level": 1,
+    "energy_source": "STAMINA",
+    "base_energy_cost": 0,
+    "base_casting_time": 0
+  }
+]

--- a/data/mods/Aftershock/spells/psionics/telepathy.json
+++ b/data/mods/Aftershock/spells/psionics/telepathy.json
@@ -1,0 +1,196 @@
+[
+  {
+    "id": "afs_telepathic_shield",
+    "type": "SPELL",
+    "name": "[Ψ]Telepathic Shield (C)",
+    "description": "You can protect your mind from the dangers of Salus IV.\n\nThis power <color_yellow>is maintained by concentration</color> and <color_red>may fail</color> if <color_yellow>concentration is interrupted</color>.",
+    "message": "",
+    "teachable": false,
+    "valid_targets": [ "self" ],
+    "spell_class": "AFS_TELEPATH",
+    "skill": "metaphysics",
+    "flags": [ "PSIONIC", "CONCENTRATE", "SILENT", "NO_HANDS", "NO_LEGS", "RANDOM_DURATION" ],
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_AFS_TELEPATH_SHIELD_INITIATE",
+    "shape": "blast",
+    "difficulty": 2,
+    "max_level": { "math": [ "int_to_level(1)" ] },
+    "min_duration": {
+      "math": [ "( (u_spell_level('afs_telepathic_shield') * 1500) + 18000) * (scaling_factor(u_val('intelligence') ) ) " ]
+    },
+    "max_duration": {
+      "math": [ "( (u_spell_level('afs_telepathic_shield') * 3600) + 72000) * (scaling_factor(u_val('intelligence') ) ) " ]
+    },
+    "energy_source": "STAMINA",
+    "base_energy_cost": {
+      "math": [
+        "u_effect_intensity('effect_telepathic_psi_armor') > -1 ? 0 : max((2500 - (u_spell_level('afs_telepathic_shield') * 125)), 500)"
+      ]
+    },
+    "base_casting_time": {
+      "math": [
+        "u_effect_intensity('effect_telepathic_psi_armor') > -1 ? 10 : max((100 -(u_spell_level('afs_telepathic_shield') * 6.5)), 10)"
+      ]
+    }
+  },
+  {
+    "id": "afs_telepathic_mind_sense",
+    "type": "SPELL",
+    "name": "[Ψ]Sense Minds (C)",
+    "description": "You can use your powers to detect the tell-tale hum of a living, sapient mind, no matter how strange or alien it may be.\n\nThis power <color_yellow>is maintained by concentration</color> and <color_red>may fail</color> if <color_yellow>concentration is interrupted</color>.",
+    "message": "",
+    "teachable": false,
+    "valid_targets": [ "self" ],
+    "spell_class": "AFS_TELEPATH",
+    "skill": "metaphysics",
+    "flags": [ "PSIONIC", "CONCENTRATE", "SILENT", "NO_HANDS", "NO_LEGS", "RANDOM_DURATION" ],
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_AFS_TELEPATH_SENSE_MINDS_INITIATE",
+    "shape": "blast",
+    "difficulty": 3,
+    "max_level": { "math": [ "int_to_level(1)" ] },
+    "min_duration": {
+      "math": [ "( (u_spell_level('afs_telepathic_mind_sense') * 2600) + 9000) * (scaling_factor(u_val('intelligence') ) ) " ]
+    },
+    "max_duration": {
+      "math": [ "( (u_spell_level('afs_telepathic_mind_sense') * 13100) + 60000) * (scaling_factor(u_val('intelligence') ) ) " ]
+    },
+    "energy_source": "STAMINA",
+    "base_energy_cost": {
+      "math": [
+        "u_effect_intensity('effect_telepath_sense_minds') > -1 ? 0 : max((3500 - (u_spell_level('afs_telepathic_mind_sense') * 115)), 1500)"
+      ]
+    },
+    "base_casting_time": { "math": [ "u_effect_intensity('effect_telepath_sense_minds') > -1 ? 10 : 500" ] }
+  },
+  {
+    "id": "afs_telepathic_suggestion",
+    "type": "SPELL",
+    "name": "[Ψ]Telepathic Suggestion (C)",
+    "description": "You can subtly influence the thoughts of others, making them more amenable to your point of view.\n\nThis power <color_yellow>is maintained by concentration</color> and <color_red>may fail</color> if <color_yellow>concentration is interrupted</color>.",
+    "message": "",
+    "teachable": false,
+    "valid_targets": [ "self" ],
+    "spell_class": "AFS_TELEPATH",
+    "skill": "metaphysics",
+    "flags": [ "PSIONIC", "CONCENTRATE", "SILENT", "NO_HANDS", "NO_LEGS", "RANDOM_DURATION" ],
+    "difficulty": 4,
+    "max_level": { "math": [ "int_to_level(1)" ] },
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_AFS_TELEPATH_SUGGESTION_INITIATE",
+    "shape": "blast",
+    "min_duration": {
+      "math": [ "( (u_spell_level('afs_telepathic_suggestion') * 38100) + 98100) * (scaling_factor(u_val('intelligence') ) ) " ]
+    },
+    "max_duration": {
+      "math": [ "( (u_spell_level('afs_telepathic_suggestion') * 89900) + 252000) * (scaling_factor(u_val('intelligence') ) ) " ]
+    },
+    "energy_source": "STAMINA",
+    "base_energy_cost": {
+      "math": [
+        "u_effect_intensity('effect_telepathic_suggestion') > -1 ? 0 : max((5000 - (u_spell_level('afs_telepathic_suggestion') * 125)), 2000)"
+      ]
+    },
+    "base_casting_time": {
+      "math": [
+        "u_effect_intensity('effect_telepathic_suggestion') > -1 ? 10 : max((300 -(u_spell_level('afs_telepathic_suggestion') * 9.5)), 150)"
+      ]
+    }
+  },
+  {
+    "id": "afs_telepathic_confusion",
+    "type": "SPELL",
+    "name": "[Ψ]Sensory Deprivation",
+    "description": "Disconnect a target's brain from its senses, leaving it blinded and confused.",
+    "message": "You lock your target's mind away!",
+    "teachable": false,
+    "valid_targets": [ "hostile" ],
+    "spell_class": "AFS_TELEPATH",
+    "skill": "metaphysics",
+    "flags": [ "PSIONIC", "CONCENTRATE", "NO_PROJECTILE", "SILENT", "NO_HANDS", "NO_LEGS", "RANDOM_DURATION" ],
+    "difficulty": 5,
+    "max_level": { "math": [ "int_to_level(1)" ] },
+    "effect": "attack",
+    "effect_str": "psi_stunned",
+    "extra_effects": [ { "id": "afs_telepathic_confusion_blind", "hit_self": false, "max_level": 20 } ],
+    "shape": "blast",
+    "min_duration": { "math": [ "( (u_spell_level('afs_telepathic_confusion') * 50) + 200) * (scaling_factor(u_val('intelligence') ) ) " ] },
+    "max_duration": {
+      "math": [ "( (u_spell_level('afs_telepathic_confusion') * 150) + 800) * (scaling_factor(u_val('intelligence') ) ) " ]
+    },
+    "min_range": {
+      "math": [ "min( (( (u_spell_level('afs_telepathic_confusion') * 1.1) + 3) * (scaling_factor(u_val('intelligence') ) ) ), 80)" ]
+    },
+    "max_range": 80,
+    "energy_source": "STAMINA",
+    "base_energy_cost": 3750,
+    "final_energy_cost": 1500,
+    "energy_increment": -150,
+    "base_casting_time": 90,
+    "final_casting_time": 40,
+    "casting_time_increment": -3.5,
+    "ignored_monster_species": [ "ROBOT", "NETHER_EMANATION", "LEECH_PLANT", "WORM", "FUNGUS", "SLIME" ]
+  },
+  {
+    "id": "afs_telepathic_confusion_blind",
+    "type": "SPELL",
+    "name": "[Ψ]Sensory Deprivation blind Effect",
+    "description": "The is the part of the Sensory Deprivation that blinds the target.  It's a bug if you have it.",
+    "valid_targets": [ "hostile" ],
+    "skill": "metaphysics",
+    "flags": [ "PSIONIC", "NO_PROJECTILE", "SILENT", "NO_HANDS", "NO_LEGS", "RANDOM_DURATION" ],
+    "max_level": { "math": [ "int_to_level(1)" ] },
+    "effect": "attack",
+    "effect_str": "blind",
+    "damage_type": "psi_telepathic_damage",
+    "shape": "blast",
+    "min_duration": {
+      "math": [ "( (u_spell_level('afs_telepathic_confusion') * 100) + 400) * (scaling_factor(u_val('intelligence') ) ) " ]
+    },
+    "max_duration": {
+      "math": [ "( (u_spell_level('afs_telepathic_confusion') * 100) + 2000) * (scaling_factor(u_val('intelligence') ) ) " ]
+    },
+    "min_range": { "math": [ "( (u_spell_level('afs_telepathic_confusion') * 2) + 3) * (scaling_factor(u_val('intelligence') ) ) " ] },
+    "ignored_monster_species": [ "ROBOT", "NETHER_EMANATION", "LEECH_PLANT", "WORM", "FUNGUS", "SLIME" ]
+  },
+  {
+    "id": "afs_telepathic_blast",
+    "type": "SPELL",
+    "name": "[Ψ]Synaptic Overload",
+    "description": "Short-circuit and overwhelm a target's brain, causing extreme damage or death.  Does not work on targets without living minds, such as robots.",
+    "message": "You assault the mind of your target!",
+    "teachable": false,
+    "valid_targets": [ "hostile" ],
+    "spell_class": "AFS_TELEPATH",
+    "skill": "metaphysics",
+    "flags": [
+      "PSIONIC",
+      "CONCENTRATE",
+      "NO_PROJECTILE",
+      "SILENT",
+      "RANDOM_DAMAGE",
+      "NO_HANDS",
+      "NO_LEGS",
+      "NO_EXPLOSION_SFX",
+      "PERCENTAGE_DAMAGE"
+    ],
+    "difficulty": 7,
+    "max_level": { "math": [ "int_to_level(1)" ] },
+    "effect": "attack",
+    "shape": "blast",
+    "damage_type": "psi_telepathic_damage",
+    "min_damage": { "math": [ "( (u_spell_level('afs_telepathic_blast') * 1.5) + 5) * (scaling_factor(u_val('intelligence') ) ) " ] },
+    "max_damage": { "math": [ "( (u_spell_level('afs_telepathic_blast') * 3) + 5) * (scaling_factor(u_val('intelligence') ) ) " ] },
+    "min_range": {
+      "math": [ "min( (( (u_spell_level('afs_telepathic_blast') * 1.1) + 3) * (scaling_factor(u_val('intelligence') ) ) ), 80)" ]
+    },
+    "max_range": 80,
+    "energy_source": "STAMINA",
+    "base_energy_cost": 5500,
+    "final_energy_cost": 1250,
+    "energy_increment": -125,
+    "base_casting_time": 75,
+    "final_casting_time": 25,
+    "casting_time_increment": -2.5
+  }
+]

--- a/data/mods/Aftershock/spells/psionics/telepathy_concentration_eocs.json
+++ b/data/mods/Aftershock/spells/psionics/telepathy_concentration_eocs.json
@@ -31,7 +31,8 @@
     "condition": { "u_has_effect": "effect_telepathic_psi_armor" },
     "effect": [
       { "math": [ "u_spell_exp('afs_telepathic_shield')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
-      { "run_eocs": "EOC_CONCENTRATION_SUCCESS_PROFICIENCY" },
+      { "math": [ "u_latest_channeled_power_difficulty", "=", "2" ] },
+      { "run_eocs": [ "EOC_CONCENTRATION_SUCCESS_PROFICIENCY", "EOC_AFS_PSI_SKILL_INCREASE_ON_USE_FINALIZE" ] },
       {
         "queue_eocs": "EOC_AFS_TELEPATH_SHIELD_MAINTENANCE",
         "time_in_future": [
@@ -76,7 +77,8 @@
     "condition": { "u_has_effect": "effect_telepath_sense_minds" },
     "effect": [
       { "math": [ "u_spell_exp('afs_telepathic_mind_sense')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
-      { "run_eocs": "EOC_CONCENTRATION_SUCCESS_PROFICIENCY" },
+      { "math": [ "u_latest_channeled_power_difficulty", "=", "3" ] },
+      { "run_eocs": [ "EOC_CONCENTRATION_SUCCESS_PROFICIENCY", "EOC_AFS_PSI_SKILL_INCREASE_ON_USE_FINALIZE" ] },
       {
         "queue_eocs": "EOC_AFS_TELEPATH_SENSE_MINDS_MAINTENANCE",
         "time_in_future": [
@@ -123,7 +125,8 @@
     "condition": { "u_has_effect": "effect_telepathic_suggestion" },
     "effect": [
       { "math": [ "u_spell_exp('afs_telepathic_suggestion')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
-      { "run_eocs": "EOC_CONCENTRATION_SUCCESS_PROFICIENCY" },
+      { "math": [ "u_latest_channeled_power_difficulty", "=", "4" ] },
+      { "run_eocs": [ "EOC_CONCENTRATION_SUCCESS_PROFICIENCY", "EOC_AFS_PSI_SKILL_INCREASE_ON_USE_FINALIZE" ] },
       {
         "queue_eocs": "EOC_AFS_TELEPATH_SUGGESTION_MAINTENANCE",
         "time_in_future": [

--- a/data/mods/Aftershock/spells/psionics/telepathy_concentration_eocs.json
+++ b/data/mods/Aftershock/spells/psionics/telepathy_concentration_eocs.json
@@ -1,0 +1,138 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_AFS_TELEPATH_SHIELD_INITIATE",
+    "condition": { "not": { "u_has_effect": "effect_telepathic_psi_armor" } },
+    "effect": [
+      { "u_message": "You begin shielding your thoughts.", "type": "good" },
+      { "run_eocs": "EOC_AFS_POWER_MAINTENANCE_PLUS_ONE" },
+      { "u_add_effect": "effect_telepathic_psi_armor", "duration": "PERMANENT" },
+      {
+        "queue_eocs": "EOC_AFS_TELEPATH_SHIELD_MAINTENANCE",
+        "time_in_future": [
+          { "math": [ "( (u_spell_level('afs_telepathic_shield') * 15) + 180) * (scaling_factor(u_val('intelligence') ) ) " ] },
+          {
+            "math": [ "( (u_spell_level('afs_telepathic_shield') * 36) + 720) * (scaling_factor(u_val('intelligence') ) ) " ]
+          }
+        ]
+      }
+    ],
+    "false_effect": [ { "run_eocs": "EOC_AFS_TELEPATH_REMOVE_TELEPATHIC_SHIELD" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_AFS_TELEPATH_REMOVE_TELEPATHIC_SHIELD",
+    "condition": { "u_has_effect": "effect_telepathic_psi_armor" },
+    "effect": [ { "run_eocs": "EOC_AFS_POWER_MAINTENANCE_MINUS_ONE" }, { "u_lose_effect": "effect_telepathic_psi_armor" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_AFS_TELEPATH_SHIELD_MAINTENANCE",
+    "condition": { "u_has_effect": "effect_telepathic_psi_armor" },
+    "effect": [
+      { "math": [ "u_spell_exp('afs_telepathic_shield')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      {
+        "queue_eocs": "EOC_AFS_TELEPATH_SHIELD_MAINTENANCE",
+        "time_in_future": [
+          { "math": [ "( (u_spell_level('afs_telepathic_shield') * 15) + 180) * (scaling_factor(u_val('intelligence') ) ) " ] },
+          {
+            "math": [ "( (u_spell_level('afs_telepathic_shield') * 36) + 720) * (scaling_factor(u_val('intelligence') ) ) " ]
+          }
+        ]
+      }
+    ],
+    "false_effect": [  ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_AFS_TELEPATH_SENSE_MINDS_INITIATE",
+    "condition": { "not": { "u_has_effect": "effect_telepath_sense_minds" } },
+    "effect": [
+      { "u_message": "You reach out with your powers, looking for nearby minds.", "type": "good" },
+      { "run_eocs": "EOC_AFS_POWER_MAINTENANCE_PLUS_ONE" },
+      { "u_add_effect": "effect_telepath_sense_minds", "duration": "PERMANENT" },
+      {
+        "queue_eocs": "EOC_AFS_TELEPATH_SENSE_MINDS_MAINTENANCE",
+        "time_in_future": [
+          { "math": [ "( (u_spell_level('afs_telepathic_mind_sense') * 26) + 90) * (scaling_factor(u_val('intelligence') ) ) " ] },
+          {
+            "math": [ "( (u_spell_level('afs_telepathic_mind_sense') * 131) + 600) * (scaling_factor(u_val('intelligence') ) ) " ]
+          }
+        ]
+      }
+    ],
+    "false_effect": [ { "run_eocs": "EOC_AFS_TELEPATH_REMOVE_SENSE_MINDS" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_AFS_TELEPATH_REMOVE_SENSE_MINDS",
+    "condition": { "u_has_effect": "effect_telepath_sense_minds" },
+    "effect": [ { "run_eocs": "EOC_AFS_POWER_MAINTENANCE_MINUS_ONE" }, { "u_lose_effect": "effect_telepath_sense_minds" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_AFS_TELEPATH_SENSE_MINDS_MAINTENANCE",
+    "condition": { "u_has_effect": "effect_telepath_sense_minds" },
+    "effect": [
+      { "math": [ "u_spell_exp('afs_telepathic_mind_sense')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      {
+        "queue_eocs": "EOC_AFS_TELEPATH_SENSE_MINDS_MAINTENANCE",
+        "time_in_future": [
+          { "math": [ "( (u_spell_level('afs_telepathic_mind_sense') * 26) + 90) * (scaling_factor(u_val('intelligence') ) ) " ] },
+          {
+            "math": [ "( (u_spell_level('afs_telepathic_mind_sense') * 131) + 600) * (scaling_factor(u_val('intelligence') ) ) " ]
+          }
+        ]
+      }
+    ],
+    "false_effect": [  ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_AFS_TELEPATH_SUGGESTION_INITIATE",
+    "condition": { "not": { "u_has_effect": "effect_telepathic_suggestion" } },
+    "effect": [
+      { "u_message": "You prepare to subtly influence others' thoughts.", "type": "good" },
+      { "run_eocs": "EOC_AFS_POWER_MAINTENANCE_PLUS_ONE" },
+      { "u_add_effect": "effect_telepathic_suggestion", "duration": "PERMANENT" },
+      {
+        "queue_eocs": "EOC_AFS_TELEPATH_SUGGESTION_MAINTENANCE",
+        "time_in_future": [
+          {
+            "math": [ "( (u_spell_level('afs_telepathic_suggestion') * 381) + 981) * (scaling_factor(u_val('intelligence') ) ) " ]
+          },
+          {
+            "math": [ "( (u_spell_level('afs_telepathic_suggestion') * 899) + 2520) * (scaling_factor(u_val('intelligence') ) ) " ]
+          }
+        ]
+      }
+    ],
+    "false_effect": [ { "run_eocs": "EOC_AFS_TELEPATH_REMOVE_TELEPATHIC_SUGGESTION" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_AFS_TELEPATH_REMOVE_TELEPATHIC_SUGGESTION",
+    "condition": { "u_has_effect": "effect_telepathic_suggestion" },
+    "effect": [ { "run_eocs": "EOC_AFS_POWER_MAINTENANCE_MINUS_ONE" }, { "u_lose_effect": "effect_telepathic_suggestion" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_AFS_TELEPATH_SUGGESTION_MAINTENANCE",
+    "condition": { "u_has_effect": "effect_telepathic_suggestion" },
+    "effect": [
+      { "math": [ "u_spell_exp('afs_telepathic_suggestion')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      {
+        "queue_eocs": "EOC_AFS_TELEPATH_SUGGESTION_MAINTENANCE",
+        "time_in_future": [
+          {
+            "math": [ "( (u_spell_level('afs_telepathic_suggestion') * 381) + 981) * (scaling_factor(u_val('intelligence') ) ) " ]
+          },
+          {
+            "math": [ "( (u_spell_level('afs_telepathic_suggestion') * 899) + 2520) * (scaling_factor(u_val('intelligence') ) ) " ]
+          }
+        ]
+      }
+    ],
+    "false_effect": [  ]
+  }
+]

--- a/data/mods/Aftershock/spells/psionics/telepathy_concentration_eocs.json
+++ b/data/mods/Aftershock/spells/psionics/telepathy_concentration_eocs.json
@@ -31,6 +31,7 @@
     "condition": { "u_has_effect": "effect_telepathic_psi_armor" },
     "effect": [
       { "math": [ "u_spell_exp('afs_telepathic_shield')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      { "run_eocs": "EOC_CONCENTRATION_SUCCESS_PROFICIENCY" },
       {
         "queue_eocs": "EOC_AFS_TELEPATH_SHIELD_MAINTENANCE",
         "time_in_future": [
@@ -75,6 +76,7 @@
     "condition": { "u_has_effect": "effect_telepath_sense_minds" },
     "effect": [
       { "math": [ "u_spell_exp('afs_telepathic_mind_sense')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      { "run_eocs": "EOC_CONCENTRATION_SUCCESS_PROFICIENCY" },
       {
         "queue_eocs": "EOC_AFS_TELEPATH_SENSE_MINDS_MAINTENANCE",
         "time_in_future": [
@@ -121,6 +123,7 @@
     "condition": { "u_has_effect": "effect_telepathic_suggestion" },
     "effect": [
       { "math": [ "u_spell_exp('afs_telepathic_suggestion')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
+      { "run_eocs": "EOC_CONCENTRATION_SUCCESS_PROFICIENCY" },
       {
         "queue_eocs": "EOC_AFS_TELEPATH_SUGGESTION_MAINTENANCE",
         "time_in_future": [

--- a/data/mods/Aftershock/spells/psionics/telepathy_concentration_eocs.json
+++ b/data/mods/Aftershock/spells/psionics/telepathy_concentration_eocs.json
@@ -32,7 +32,13 @@
     "effect": [
       { "math": [ "u_spell_exp('afs_telepathic_shield')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
       { "math": [ "u_latest_channeled_power_difficulty", "=", "2" ] },
-      { "run_eocs": [ "EOC_CONCENTRATION_SUCCESS_PROFICIENCY", "EOC_AFS_PSI_SKILL_INCREASE_ON_USE_FINALIZE" ] },
+      {
+        "run_eocs": [
+          "EOC_CONCENTRATION_SUCCESS_PROFICIENCY",
+          "EOC_AFS_PSI_SKILL_INCREASE_ON_USE_FINALIZE",
+          "EOC_AFS_CONCENTRATION_COSTS_FOCUS"
+        ]
+      },
       {
         "queue_eocs": "EOC_AFS_TELEPATH_SHIELD_MAINTENANCE",
         "time_in_future": [
@@ -78,7 +84,13 @@
     "effect": [
       { "math": [ "u_spell_exp('afs_telepathic_mind_sense')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
       { "math": [ "u_latest_channeled_power_difficulty", "=", "3" ] },
-      { "run_eocs": [ "EOC_CONCENTRATION_SUCCESS_PROFICIENCY", "EOC_AFS_PSI_SKILL_INCREASE_ON_USE_FINALIZE" ] },
+      {
+        "run_eocs": [
+          "EOC_CONCENTRATION_SUCCESS_PROFICIENCY",
+          "EOC_AFS_PSI_SKILL_INCREASE_ON_USE_FINALIZE",
+          "EOC_AFS_CONCENTRATION_COSTS_FOCUS"
+        ]
+      },
       {
         "queue_eocs": "EOC_AFS_TELEPATH_SENSE_MINDS_MAINTENANCE",
         "time_in_future": [
@@ -126,7 +138,13 @@
     "effect": [
       { "math": [ "u_spell_exp('afs_telepathic_suggestion')", "+=", "(maintenance_exp_factor(u_val('focus')))" ] },
       { "math": [ "u_latest_channeled_power_difficulty", "=", "4" ] },
-      { "run_eocs": [ "EOC_CONCENTRATION_SUCCESS_PROFICIENCY", "EOC_AFS_PSI_SKILL_INCREASE_ON_USE_FINALIZE" ] },
+      {
+        "run_eocs": [
+          "EOC_CONCENTRATION_SUCCESS_PROFICIENCY",
+          "EOC_AFS_PSI_SKILL_INCREASE_ON_USE_FINALIZE",
+          "EOC_AFS_CONCENTRATION_COSTS_FOCUS"
+        ]
+      },
       {
         "queue_eocs": "EOC_AFS_TELEPATH_SUGGESTION_MAINTENANCE",
         "time_in_future": [

--- a/data/mods/Aftershock/start_locations.json
+++ b/data/mods/Aftershock/start_locations.json
@@ -10,5 +10,11 @@
     "id": "sloc_afs_augmentation_clinic_n3",
     "name": "Augclinic",
     "terrain": [ "afs_augmentation_clinic_n3" ]
+  },
+  {
+    "type": "start_location",
+    "id": "sloc_afs_glacial_tunnels",
+    "name": "Somewhere Underground",
+    "terrain": [ "afs_tunnel" ]
   }
 ]

--- a/data/mods/Aftershock/vitamin.json
+++ b/data/mods/Aftershock/vitamin.json
@@ -20,5 +20,14 @@
     "max": 2500,
     "rate": "1 h",
     "disease_excess": [ [ 100, 500 ], [ 501, 2199 ], [ 2200, 2500 ] ]
+  },
+  {
+    "id": "vitamin_afs_maintained_powers",
+    "type": "vitamin",
+    "vit_type": "counter",
+    "name": { "str": "Aftershock Maintained Powers Counter" },
+    "min": 0,
+    "max": 100,
+    "rate": "0 h"
   }
 ]

--- a/data/mods/aftershock_exoplanet/setting_blacklists/scenario_blacklist.json
+++ b/data/mods/aftershock_exoplanet/setting_blacklists/scenario_blacklist.json
@@ -2,6 +2,6 @@
   {
     "type": "SCENARIO_BLACKLIST",
     "subtype": "whitelist",
-    "scenarios": [ "escape_pod", "crashing_ship", "augustmoon", "last_dance" ]
+    "scenarios": [ "escape_pod", "crashing_ship", "augustmoon", "last_dance", "afs_esper_start" ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Aftershock] Add the Esper scenario"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I'm just the brain powers guy, I guess. 🧠

This was originally going to be a modmod, but talked it over with John-Candlebury and figured out a good way to put it straight into Aftershock.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the Esper scenario, one profession for that scenario ("Telepath"), and infrastructure to support that profession--powers, psi infrastructure, etc.

Psi in Aftershock is going to be reminiscent of MoM (because I wrote MoM and I'm also writing this) but with some substantial changes. There's only four paths--clairsentience, electrokinesis, telekinesis, and telepathy. Psi isn't the result of the psychoactive properties of the Nether, it's due to 

<details><summary>Spoiler</summary>
Research into mi-go biotechnology during humanity's Golden Age, now being rediscovered.</details>

As such, much of the MoM-esque infrastructure is inappropriate and doesn't exist. You can still get headaches, nosebleeds, or weakness if you use a lot of powers in close succession and you're unlucky, but that's it (for now). There's no concentration limit, but concentrating on powers makes those headaches etc more likely.

On the flip side, the power level of psi is lower. Electrokinesis can let you zap people at close range, charge your devices, or manipulate robots, but not blast people with lightning or supercharge your nervous system. Telepathy can sense and influence other minds, and even assault them, but not control them. Telekinesis does not let you fly or shake the earth, and so on.

There will eventually be ways to gain psi in the game, but for the moment you have to start with it. In addition, you will only ever be able to get one path--becoming an Esper is a permanent decision.


<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Loaded the Esper scenario and picked Telepath, Loaded into game and checked equipment and starting location. Used each power, checking its effect, and practiced each power, checking that XP went to the appropriate place.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I was going to call it _Aftershock: Psychic Scream_
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
