### PR TITLE
Allow using hotkeys to select spells in other categories

### DIFF
--- a/doc/MAGIC.md
+++ b/doc/MAGIC.md
@@ -964,5 +964,5 @@ Character status value  | Description
   { "value": "ARMOR_HEAT", "multiply": 0.4 }  // increases damage taken from fire by 40%
   { "value": "ARMOR_CUT", "add": 2 }          // increases incoming cut damage by 2
   { "value": "ARMOR_BIO", "multiply": -1.4 }  // subtracts 100 percent of incoming biological damage, heals for the remaining 40%
-  { "value": "ARMOR_ACID", "multiply": 1.4 }  // increases incoming acid damage by 140% 
+  { "value": "ARMOR_ACID", "multiply": 1.4 }  // increases incoming acid damage by 140%
 ```

--- a/doc/MAGIC.md
+++ b/doc/MAGIC.md
@@ -964,5 +964,5 @@ Character status value  | Description
   { "value": "ARMOR_HEAT", "multiply": 0.4 }  // increases damage taken from fire by 40%
   { "value": "ARMOR_CUT", "add": 2 }          // increases incoming cut damage by 2
   { "value": "ARMOR_BIO", "multiply": -1.4 }  // subtracts 100 percent of incoming biological damage, heals for the remaining 40%
-  { "value": "ARMOR_ACID", "multiply": 1.4 }  // increases incoming acid damage by 140%
+  { "value": "ARMOR_ACID", "multiply": 1.4 }  // increases incoming acid damage by 140% 
 ```

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2848,7 +2848,7 @@ int known_magic::select_spell( Character &guy )
     }
     reflesh_favorite( &spell_menu, known_spells );
 
-    spell_menu.query();
+    spell_menu.query(true, -1, true);
 
     casting_ignore = static_cast<spellcasting_callback *>( spell_menu.callback )->casting_ignore;
 

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2848,7 +2848,7 @@ int known_magic::select_spell( Character &guy )
     }
     reflesh_favorite( &spell_menu, known_spells );
 
-    spell_menu.query(true, -1, true);
+    spell_menu.query( true, -1, true );
 
     casting_ignore = static_cast<spellcasting_callback *>( spell_menu.callback )->casting_ignore;
 

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -1140,11 +1140,11 @@ void uilist::query( bool loop, int timeout, bool allow_unfiltered_hotkeys )
             }
             filterlist();
         } else if( iter != keymap.end() ) {
-            if ( allow_unfiltered_hotkeys ) {
-                    const bool enabled = entries[iter->second].enabled;
-                    if (enabled || allow_disabled) {
-                        ret = entries[iter->second].retval;
-                    }
+            if( allow_unfiltered_hotkeys ) {
+                const bool enabled = entries[iter->second].enabled;
+                if( enabled || allow_disabled ) {
+                    ret = entries[iter->second].retval;
+                }
             } else {
                 const auto it = std::find( fentries.begin(), fentries.end(), iter->second );
                 if( it != fentries.end() ) {

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -1029,7 +1029,7 @@ uilist::handle_mouse_result_t uilist::handle_mouse( const input_context &ctxt,
  * Handle input and update display
  *
  */
-void uilist::query( bool loop, int timeout )
+void uilist::query( bool loop, int timeout, bool allow_unfiltered_hotkeys )
 {
 #if defined(__ANDROID__)
     bool auto_pos = w_x_setup.fun == nullptr && w_y_setup.fun == nullptr &&
@@ -1140,19 +1140,26 @@ void uilist::query( bool loop, int timeout )
             }
             filterlist();
         } else if( iter != keymap.end() ) {
-            const auto it = std::find( fentries.begin(), fentries.end(), iter->second );
-            if( it != fentries.end() ) {
-                const bool enabled = entries[*it].enabled;
-                if( enabled || allow_disabled || hilight_disabled ) {
-                    // Change the selection to display correctly when this function
-                    // is called again.
-                    fselected = std::distance( fentries.begin(), it );
-                    selected = *it;
-                    if( enabled || allow_disabled ) {
-                        ret = entries[selected].retval;
+            if ( allow_unfiltered_hotkeys ) {
+                    const bool enabled = entries[iter->second].enabled;
+                    if (enabled || allow_disabled) {
+                        ret = entries[iter->second].retval;
                     }
-                    if( callback != nullptr ) {
-                        callback->select( this );
+            } else {
+                const auto it = std::find( fentries.begin(), fentries.end(), iter->second );
+                if( it != fentries.end() ) {
+                    const bool enabled = entries[*it].enabled;
+                    if( enabled || allow_disabled || hilight_disabled ) {
+                        // Change the selection to display correctly when this function
+                        // is called again.
+                        fselected = std::distance( fentries.begin(), it );
+                        selected = *it;
+                        if( enabled || allow_disabled ) {
+                            ret = entries[selected].retval;
+                        }
+                        if( callback != nullptr ) {
+                            callback->select( this );
+                        }
                     }
                 }
             }

--- a/src/ui.h
+++ b/src/ui.h
@@ -287,7 +287,7 @@ class uilist // NOLINT(cata-xy)
         void reposition( ui_adaptor &ui );
         void show( ui_adaptor &ui );
         bool scrollby( int scrollby );
-        void query( bool loop = true, int timeout = -1 );
+        void query( bool loop = true, int timeout = -1, bool allow_unfiltered_hotkeys = false );
         void filterlist();
         // In add_entry/add_entry_desc/add_entry_col, int k only support letters
         // (a-z, A-Z) and digits (0-9), MENU_AUTOASSIGN, and 0 or ' ' (disable


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Allow using hotkeys to select spells in other categories"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #72849
Currently you can only hotkey select spells within the visible spell category (eg when tabbed to magus only magus spells have functional hotkeys).
Since #72643 defaults the spellcasting tab to the favorites category, this means that you cannot use hotkeys to select non-favorite spells without manually switching back to the all category.
The expected usecase for spell hotkeys, eg open spellcasting menu then press hotkey to cast spell, doesn't currently work due to the interplay of these two factors.  In #73237 a solution to fix this was to revert the change to default to the favorites tab, but this solution can keep the favorites tab automatically selected while also not breaking hotkeys.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Alter the UI query method to allow hotkeys to ignore the filtered list of options with an optional parameter, and give said parameter to the spellcasting menu query.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
#73237 would be easier, but this option keeps the favorites tab default which does have a good use case while also allowing the expected hotkey use.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Able to cast spells using hotkeys outside of their category section
Tested both favorites, classless, and class categories to ensure that hotkeys work for all
Using an unassigned hotkey does nothing
Cannot cast invalid spell with hotkey (eg cannot cast spell with hotkey when character has no mana)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->



<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
