### PR TITLE
Quadraphract Can Shoot Robots

### DIFF
--- a/data/json/items/ranged/yrax_guns.json
+++ b/data/json/items/ranged/yrax_guns.json
@@ -30,7 +30,7 @@
     "barrel_length": "559 mm",
     "energy_drain": "0 kJ",
     "ammo_effects": [ "LASER", "FLAME" ],
-    "ranged_damage": { "damage_type": "heat", "amount": 1400, "armor_penetration": 120 },
+    "ranged_damage": { "damage_type": "stab", "amount": 1400, "armor_penetration": 120 },
     "flags": [ "PSEUDO", "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE", "NO_TURRET" ]
   }
 ]

--- a/data/json/items/ranged/yrax_guns.json
+++ b/data/json/items/ranged/yrax_guns.json
@@ -30,7 +30,7 @@
     "barrel_length": "559 mm",
     "energy_drain": "0 kJ",
     "ammo_effects": [ "LASER", "FLAME" ],
-    "ranged_damage": { "damage_type": "stab", "amount": 1400, "armor_penetration": 120 },
+    "ranged_damage": { "damage_type": "bullet", "amount": 1400, "armor_penetration": 120 },
     "flags": [ "PSEUDO", "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE", "NO_TURRET" ]
   }
 ]


### PR DESCRIPTION
#### Summary

Bugfixes "Quadraphract can now destroy robots"

#### Purpose of change

The Yrax Quadraphact’s main cannon does heat damage, which robots are completely immune to. I think that we can all agree that it’s a bit silly when a hyper-advanced alien spider tank that deals arbitrarily high damage is incapable of destroying a reprogrammed skitterbot. Kinda dampens the intimidation factor.

#### Describe the solution

Change heat to bullet damage.

#### Describe alternatives you've considered

N/A

#### Testing

N/A

#### Additional context

N/A