### PR TITLE
Fixed tools/json_tools/table.py and this get clean csv file for tools/gfx_tools/tileset_coverage.py

### DIFF
--- a/tools/json_tools/table.py
+++ b/tools/json_tools/table.py
@@ -195,7 +195,7 @@ class CSVFormat:
         self.writer = csv.writer(sys.stdout)
 
     def to_utf8(self, lst):
-        return [str(elem).encode('utf-8') for elem in lst]
+        return [str(elem) for elem in lst]
 
     def header(self, columns):
         self.row(columns)


### PR DESCRIPTION
… #74282

The `tools/json_tools/table.py`  output bad csv:

```
$ less all_game_ids.csv
b'type',b'id',b'name',b'description',b'color',b'looks_like',b'copy-from',b'longest_side'
b'SPELL',b'dragon_inflatable',b'Inflatable Dragon',b'Creates a short-lived inflatable.',b'',b'',b'',b''
b'SPELL',b'ghost_inflatable',b'Inflatable Ghost',b'Creates a short-lived inflatable.',b'',b'',b'',b''
b'SPELL',b'fog_machine',b'Fog Ex Machina',b'You see fog bubbling out of the device.',b'',b'',b'',b''
b'SPELL',b'debug_kill_spell',b'Debug Kill Creature',"b""Deal damage equal to 100% of monster's HP.""",b'',b'',b'',b''
b'field_type',b'fd_ammo_loot_zone',b'',b'',b'',b'',b'',b''
b'field_type',b'fd_armor_loot_zone',b'',b'',b'',b'',b'',b''
b'field_type',b'fd_artifacts_loot_zone',b'',b'',b'',b'',b'',b''
b'field_type',b'fd_auto_drink_zone',b'',b'',b'',b'',b'',b''
b'field_type',b'fd_auto_eat_zone',b'',b'',b'',b'',b'',b''
b'field_type',b'fd_basecamp_food_zone',b'',b'',b'',b'',b'',b''
b'field_type',b'fd_basecamp_storage_zone',b'',b'',b'',b'',b'',b''
....
```

And `tools/gfx_tools/tileset_coverage.py` fails.

But with the change, the python script removed the doubled encoded, the string prefix `b'` :

```
$ less all_game_ids.csv
type,id,name,description,color,looks_like,copy-from,longest_side
SPELL,dragon_inflatable,Inflatable Dragon,Creates a short-lived inflatable.,,,,
SPELL,ghost_inflatable,Inflatable Ghost,Creates a short-lived inflatable.,,,,
SPELL,fog_machine,Fog Ex Machina,You see fog bubbling out of the device.,,,,
SPELL,debug_kill_spell,Debug Kill Creature,Deal damage equal to 100% of monster's HP.,,,,
field_type,fd_ammo_loot_zone,,,,,,
field_type,fd_armor_loot_zone,,,,,,
field_type,fd_artifacts_loot_zone,,,,,,
field_type,fd_auto_drink_zone,,,,,,
field_type,fd_auto_eat_zone,,,,,,
field_type,fd_basecamp_food_zone,,,,,,
field_type,fd_basecamp_storage_zone,,,,,,
field_type,fd_bionics_loot_zone,,,,,,
field_type,fd_books_loot_zone,,,,,,
field_type,fd_chemical_loot_zone,,,,,,
field_type,fd_chop_trees_zone,,,,,,
field_type,fd_clothing_loot_zone,,,,,,
field_type,fd_construction_blueprint_zone,,,,,,
```

I checked the github actions script and other script because the fix could break something, but not. It is only use the `table.py` for the  `tools/gfx_tools/tileset_coverage.py` .

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
3. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
4. Interface "Show crafting failure chances in the crafting interface"
5. Infrastructure "JSON-ize slot machines"
6. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->


#### Purpose of change

Fix the get csv file from tileset_coverage.py.

#### Describe the solution

Only, I removed the double encode utf8.

#### Describe alternatives you've considered

None.

#### Testing

Check the steps from header in the file ` tools/gfx_tools/tileset_coverage.py` .

#### Additional context

None.
