### PR TITLE
[Magiclysm]Fix Proficiency Scaling in "jmath.json"

### DIFF
--- a/data/mods/Magiclysm/jmath.json
+++ b/data/mods/Magiclysm/jmath.json
@@ -9,7 +9,7 @@
     "type": "jmath_function",
     "id": "evocation_proficiency_negate_calculate",
     "num_args": 2,
-    "return": "_0 - ((((u_proficiency('prof_magic_evocation_beginner', 'format': 'percent') * 1) / 10) - ((u_proficiency('prof_magic_evocation_apprentice', 'format': 'percent') * 1) / 10) - ((u_proficiency('prof_magic_evocation_master', 'format': 'percent') * 1) / 10)) * _1 )"
+    "return": "_0 - ((((u_proficiency('prof_magic_evocation_beginner', 'format': 'percent') * 1) / 10) + ((u_proficiency('prof_magic_evocation_apprentice', 'format': 'percent') * 1) / 10) + ((u_proficiency('prof_magic_evocation_master', 'format': 'percent') * 1) / 10)) * _1 )"
   },
   {
     "type": "jmath_function",
@@ -33,7 +33,7 @@
     "type": "jmath_function",
     "id": "summoning_proficiency_negate_calculate",
     "num_args": 2,
-    "return": "_0 - (((((u_proficiency('prof_magic_summon_beginner', 'format': 'percent') * 1) / 10) - ((u_proficiency('prof_magic_summon_apprentice', 'format': 'percent') * 1) / 10) - ((u_proficiency('prof_magic_summon_master', 'format': 'percent') * 1) / 10))) * _1 )"
+    "return": "_0 - (((((u_proficiency('prof_magic_summon_beginner', 'format': 'percent') * 1) / 10) + ((u_proficiency('prof_magic_summon_apprentice', 'format': 'percent') * 1) / 10) + ((u_proficiency('prof_magic_summon_master', 'format': 'percent') * 1) / 10))) * _1 )"
   },
   {
     "type": "jmath_function",
@@ -46,7 +46,7 @@
     "id": "enhancement_proficiency_negate_calculate",
     "//": "As a general rule, this jmath should give a 20% bonus to a spell when all 3 proficiencies are at max level.",
     "num_args": 2,
-    "return": "_0 - (((((u_proficiency('prof_magic_enhancement_beginner', 'format': 'percent') * 1) / 10) - ((u_proficiency('prof_magic_enhancement_apprentice', 'format': 'percent') * 1) / 10) - ((u_proficiency('prof_magic_enhancement_master', 'format': 'percent') * 1) / 10))) * _1 )"
+    "return": "_0 - (((((u_proficiency('prof_magic_enhancement_beginner', 'format': 'percent') * 1) / 10) + ((u_proficiency('prof_magic_enhancement_apprentice', 'format': 'percent') * 1) / 10) + ((u_proficiency('prof_magic_enhancement_master', 'format': 'percent') * 1) / 10))) * _1 )"
   },
   {
     "type": "jmath_function",
@@ -58,6 +58,6 @@
     "type": "jmath_function",
     "id": "conveyance_proficiency_negate_calculate",
     "num_args": 2,
-    "return": "_0 - (((((u_proficiency('prof_magic_conveyance_beginner', 'format': 'percent') * 1) / 10) - ((u_proficiency('prof_magic_conveyance_apprentice', 'format': 'percent') * 1) / 10) - ((u_proficiency('prof_magic_conveyance_master', 'format': 'percent') * 1) / 10))) * _1 )"
+    "return": "_0 - (((((u_proficiency('prof_magic_conveyance_beginner', 'format': 'percent') * 1) / 10) + ((u_proficiency('prof_magic_conveyance_apprentice', 'format': 'percent') * 1) / 10) + ((u_proficiency('prof_magic_conveyance_master', 'format': 'percent') * 1) / 10))) * _1 )"
   }
 ]


### PR DESCRIPTION
#### Summary
Mods "Fixed jmath in magiclysm to prevent reverse-scaling due to proficiency increases"

#### Purpose of change

When the jmath functions were changed to account for new scaling changes, some of the the "-"s weren't changed to "+"s. If they're left as "-"s, they'll end up adding to the referenced value, rather than subtracting from it. 

#### Describe the solution

I changed the "-"s to "+"s. 

#### Describe alternatives you've considered

Could separate out the individual values, instead of grouping them in "()"s. That'd be a bit annoying though, and it'd diverge from the formatting of the other variables. 

Could leave it as is, but then some spells will receive _increased_ cast times/energy costs/ect. as characters gain proficiency. Since that's the opposite of what's supposed to happen, the "do nothing" approach doesn't seem like a reasonable option. 

#### Testing

Before these edits - Made a test world and gave myself the bless spell at level 0 using debug. Cast time was 100. Added "Novice Enhancement" proficiency(at 100%) using debug. Cast time became 90. Added "Apprentice Enhancement" proficiency(at 100%) using debug. Cast time became 100. Added "Master Enhancement" proficiency(at 100%) using debug. Cast time became 110. 

After these edits - Adding "Novice Enhancement" proficiency decreased cast time to 90. Adding "Apprentice Enhancement" proficiency decreased cast time to 80. Adding "Master Enhancement" proficiency decreased cast time to 70. 

That seemed good enough for me. 

#### Additional context

N/A
