### PR TITLE
Fix M27 melee damage

### DIFF
--- a/data/json/items/gun/223.json
+++ b/data/json/items/gun/223.json
@@ -174,6 +174,7 @@
       [ "stock accessory", 2 ],
       [ "stock", 1 ]
     ],
+    "melee_damage": { "bash": 12 },
     "flags": [ "NO_TURRET" ],
     "//3": "This should be removed once vehicle turrets are capable of mounting guns with mods attached. As it stands, trying to mount this style of weapon would require the player to remove the conversion kit, thus rendering it unusable anyhow."
   },


### PR DESCRIPTION
#### Summary

Bugfixes "Fix M27 melee damage"

#### Purpose of change

Commit #64934 removed the bashing damage on the M27, resulting in its damage not being visible unless a bayonet is attached, and not providing bashing damage. This reverts that mistake

#### Describe the solution

Re-adding it's original bashing damage.

#### Describe alternatives you've considered

Honestly I was thinking about how it might be useful to have a JSON tester that checks if an item has a specific set of parameters depending on its item type to prevent this kind of hard to see mistake. But this is outside of my scope, experience and skillset.

#### Testing

I checked to see if the other modular guns also have bashing damage, which they did. I also tested it in game to see if it worked, which it did.

#### Additional context

N/A

