### PR TITLE
Adjust Copper Wire Deconstructions

### DIFF
--- a/data/json/recipes/recipe_deconstruction.json
+++ b/data/json/recipes/recipe_deconstruction.json
@@ -2016,10 +2016,18 @@
   {
     "result": "cable",
     "type": "uncraft",
-    "time": "2 m",
+    "time": "8 s",
     "//": "This may need to be modified, a plastic sheath would give plastic chunks, but there already is a plastic sheathed cable",
     "activity_level": "LIGHT_EXERCISE",
     "qualities": [ { "id": "CUT", "level": 2 } ],
+    "components": [ [ [ "copper_wire", 1 ] ] ]
+  },
+  {
+    "result": "copper_wire",
+    "type": "uncraft",
+    "time": "1 s",
+    "//": "I made this a near instant conversion.  Raw copper wire is essentially just copper and imo should be freely converted without a huge time investment or tool requirement, they are effectively identical items.",
+    "activity_level": "LIGHT_EXERCISE",
     "components": [ [ [ "copper", 1 ] ] ]
   },
   {


### PR DESCRIPTION

#### Summary
Balance "Adjust Copper Wire Deconstructions"

#### Purpose of change
As pointed out in #74278 copper wire did not disassemble into raw copper wire, it instead went straight to raw copper.  This meant there was no way to mass strip wire and convert it and just from a common sense perspective, it made sense to have the middle ground of converting to raw copper wire.  Additionally, strip time was 2m per single piece of copper wire, which is just absurd given how small they are.
#### Describe the solution
Essentially: 
- Copper wire converts to raw copper wire, 8 seconds each wire, requires cutting
- Raw wire converts to copper, 1 s each (raw wire is effectively raw copper, and their weight difference is negligible)
- And just for the sake of explanation there's no way to cheese this to get extra copper.  IE: making wire from scratch costs 200 copper effectively and you get 182 back if you were to then disassemble it all.

#### Describe alternatives you've considered
Adding some sort of plastic to the disassembly as per the comment that exists with the entry (but its too tiny to even give plastic chunks)
Adjusting the weight of copper wire/raw copper in an effort to balance their disassemblies (what a terrible idea this would have been, didnt do that, obviously)

#### Testing
Made sure it all worked and converted properly, checked that the time requirement is working properly.

#### Additional context
It was pointed out in the initial issue that I'll link here in a second that the weight of copper v copper wires is not perfect.  IE: you're converting wire into slightly more weight of copper.  But since we're working with such tiny masses, there's no way to easily fix this, and since copper IS the smallest form of copper we have, there is no alternative.  I do not have an issue with these slightly fudged numbers, but someone else might.

Unless they point something out, this should closes #74278
