### PR TITLE
Party Rock is in the House Tonight

### DIFF
--- a/data/mods/CrazyCataclysm/crazy_attacks.json
+++ b/data/mods/CrazyCataclysm/crazy_attacks.json
@@ -1,0 +1,34 @@
+[
+  {
+    "type": "monster_attack",
+    "attack_type": "melee",
+    "id": "party_rocker_pipe",
+    "cooldown": 1,
+    "move_cost": 67,
+    "accuracy": 3,
+    "damage_max_instance": [ { "damage_type": "bash", "amount": 4 }, { "damage_type": "cut", "amount": 4 } ],
+    "condition": { "test_eoc": "is_disarmed" },
+    "hit_dmg_u": "%1$s hits your %2$s with a pipe!",
+    "hit_dmg_npc": "%1$s hits <npcname>'s %2$s with a pipe!",
+    "miss_msg_u": "%1$s tries to hit you, but you dodge!",
+    "miss_msg_npc": "%1$s tries to hit <npcname>, but they dodge!",
+    "no_dmg_msg_u": "%1$s hits your %2$s without penetrating your armor.",
+    "no_dmg_msg_npc": "%1$s hits <npcname>'s %2$s without penetrating their armor."
+  },
+  {
+    "type": "monster_attack",
+    "attack_type": "melee",
+    "id": "party_rocker_bottle",
+    "cooldown": 1,
+    "move_cost": 67,
+    "accuracy": 3,
+    "damage_max_instance": [ { "damage_type": "bash", "amount": 1 }, { "damage_type": "cut", "amount": 6 } ],
+    "condition": { "test_eoc": "is_disarmed" },
+    "hit_dmg_u": "%1$s hits your %2$s with a bottle!",
+    "hit_dmg_npc": "%1$s hits <npcname>'s %2$s with a bottle!",
+    "miss_msg_u": "%1$s tries to hit you, but you dodge!",
+    "miss_msg_npc": "%1$s tries to hit <npcname>, but they dodge!",
+    "no_dmg_msg_u": "%1$s hits your %2$s without penetrating your armor.",
+    "no_dmg_msg_npc": "%1$s hits <npcname>'s %2$s without penetrating their armor."
+  }
+]

--- a/data/mods/CrazyCataclysm/crazy_item_groups.json
+++ b/data/mods/CrazyCataclysm/crazy_item_groups.json
@@ -68,5 +68,76 @@
     "type": "item_group",
     "copy-from": "harddrugs",
     "extend": { "items": [ [ "flu_shot_fun", 50 ] ] }
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "party_rocker_death_drop",
+    "entries": [
+      {
+        "distribution": [
+          { "item": "speedo", "prob": 22 },
+          { "item": "shorts_denim", "prob": 16 },
+          { "item": "hot_pants", "prob": 20 },
+          { "item": "bikini_bottom_short", "prob": 20 },
+          { "item": "bikini_bottom", "prob": 12 },
+          { "item": "briefs", "prob": 5 },
+          { "item": "trunks", "prob": 5 }
+        ]
+      },
+      { "distribution": [ { "group": "harddrugs", "prob": 33 } ] },
+      {
+        "distribution": [
+          { "item": "flag_shirt", "prob": 6 },
+          { "item": "bikini_top", "prob": 19 },
+          { "item": "bra", "prob": 8 },
+          { "item": "binder_top", "prob": 5 },
+          { "item": "bikini_top_short", "prob": 16 },
+          { "item": "hoodie", "prob": 5 },
+          { "item": "halter_top", "prob": 20 },
+          { "item": "tshirt_cropped", "prob": 21 }
+        ]
+      },
+      { "distribution": [ { "item": "sunglasses", "prob": 80 }, { "item": "fancy_sunglasses", "prob": 20 } ] },
+      { "distribution": [ { "group": "alcohol", "prob": 50 } ] },
+      { "distribution": [ { "item": "mp3", "charges": [ 0, 100 ] } ] },
+      { "distribution": [ { "item": "lowtops", "prob": 80 }, { "item": "bastsandals", "prob": 20 } ] },
+      {
+        "distribution": [
+          { "group": "jewelry_accessories", "prob": 90 },
+          { "group": "rings_and_things", "prob": 90 },
+          { "group": "rings_and_things", "prob": 90 }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "party_rocker_death_drop_pipe",
+    "entries": [
+      {
+        "distribution": [
+          { "item": "crackpipe", "prob": 5, "damage": [ 1, 3 ] },
+          { "item": "pipe_glass", "prob": 60, "damage": [ 1, 3 ] },
+          { "item": "pipe_tobacco", "prob": 35, "damage": [ 2, 4 ] }
+        ]
+      },
+      { "group": "party_rocker_death_drop", "prob": 100, "damage": [ 1, 3 ] }
+    ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "party_rocker_death_drop_bottle",
+    "entries": [
+      {
+        "distribution": [
+          { "item": "bottle_metal", "prob": 40, "damage": [ 1, 3 ] },
+          { "item": "bottle_glass", "prob": 40, "damage": [ 3, 4 ] }
+        ]
+      },
+      { "group": "party_rocker_death_drop", "prob": 100, "damage": [ 1, 3 ] }
+    ]
   }
 ]

--- a/data/mods/CrazyCataclysm/crazy_items.json
+++ b/data/mods/CrazyCataclysm/crazy_items.json
@@ -401,5 +401,27 @@
     "material": [ "steel" ],
     "symbol": "#",
     "color": "light_gray"
+  },
+    {
+    "type": "AMMO",
+    "id": "party_rock",
+    "symbol": "*",
+    "color": "pink",
+    "name": { "str": "party rock", "str_pl": "party rocks" },
+    "description": ".",
+    "category": "spare_parts",
+    "material": [ "stone" ],
+    "ammo_type": "rock",
+    "flags": [ "TRADER_AVOID", "NPC_THROWN" ],
+    "weight": "657 g",
+    "volume": "250 ml",
+    "damage": { "damage_type": "bash", "amount": 7 },
+    "range": 10,
+    "dispersion": 14,
+    "loudness": 0,
+    "to_hit": -1,
+    "effects": [ "NEVER_MISFIRES", "NON_FOULING", "RECOVER_80", "PYROTECHNIC_DISPLAY" ],
+    "qualities": [ [ "HAMMER", 1 ] ],
+    "melee_damage": { "bash": 7 }
   }
 ]

--- a/data/mods/CrazyCataclysm/crazy_items.json
+++ b/data/mods/CrazyCataclysm/crazy_items.json
@@ -402,25 +402,25 @@
     "symbol": "#",
     "color": "light_gray"
   },
-    {
+  {
     "type": "AMMO",
     "id": "party_rock",
     "symbol": "*",
     "color": "pink",
     "name": { "str": "party rock", "str_pl": "party rocks" },
-    "description": ".",
+    "description": "Party rock condensed into physical form.  This should be too much for any mere mortal to handle.",
     "category": "spare_parts",
     "material": [ "stone" ],
     "ammo_type": "rock",
     "flags": [ "TRADER_AVOID", "NPC_THROWN" ],
     "weight": "657 g",
     "volume": "250 ml",
-    "damage": { "damage_type": "bash", "amount": 7 },
+    "damage": { "damage_type": "bash", "amount": 2 },
     "range": 10,
     "dispersion": 14,
     "loudness": 0,
     "to_hit": -1,
-    "effects": [ "NEVER_MISFIRES", "NON_FOULING", "RECOVER_80", "PYROTECHNIC_DISPLAY" ],
+    "effects": [ "NEVER_MISFIRES", "NON_FOULING", "RECOVER_80" ],
     "qualities": [ [ "HAMMER", 1 ] ],
     "melee_damage": { "bash": 7 }
   }

--- a/data/mods/CrazyCataclysm/crazy_items.json
+++ b/data/mods/CrazyCataclysm/crazy_items.json
@@ -407,7 +407,7 @@
     "id": "party_rock",
     "symbol": "*",
     "color": "pink",
-    "name": { "str": "party rock", "str_pl": "party rocks" },
+    "name": { "str": "party rock" },
     "description": "Party rock condensed into physical form.  This should be too much for any mere mortal to handle.",
     "category": "spare_parts",
     "material": [ "stone" ],

--- a/data/mods/CrazyCataclysm/crazy_monsters.json
+++ b/data/mods/CrazyCataclysm/crazy_monsters.json
@@ -294,5 +294,93 @@
     "fear_triggers": [ "FIRE", "HURT" ],
     "flags": [ "SEES", "HEARS", "GRABS", "SMELLS", "KEENNOSE", "PATH_AVOID_DANGER_1", "ANIMAL", "PUSH_MON", "SWIMS" ],
     "armor": { "bash": 6, "cut": 8, "bullet": 6 }
+  },
+  {
+    "id": "mon_feral_human_pipe",
+    "type": "MONSTER",
+    "name": { "str": "party rocker" },
+    "copy-from": "mon_feral_human_pipe",
+    "description": "After the event on March 2nd, seemingly ordinary people started coming down with some odd, mass hysteria like dancing.  While some people may have scoffed it off as a silly dance craze, those in the know knew, it was the Party Rock Outbreak.  This one has a pipe of the non-smoking kind.",
+    "starting_ammo": { "party_rock": 30 },
+    "special_attacks": [
+      {
+        "type": "gun",
+        "cooldown": 5,
+        "move_cost": 150,
+        "gun_type": "feral_human_thrown_rock",
+        "ammo_type": "party_rock",
+        "no_ammo_sound": "",
+        "fake_skills": [ [ "throw", 3 ] ],
+        "fake_str": 8,
+        "condition": { "not": { "u_has_effect": "maimed_arm" } },
+        "require_targeting_player": false,
+        "ranges": [ [ 2, 5, "DEFAULT" ] ],
+        "description": "The party rocker party rocks!"
+      },
+      { "id": "party_rocker_pipe" },
+      [ "BROWSE", 100 ],
+      [ "EAT_FOOD", 100 ]
+    ],
+    "death_drops": "party_rocker_death_drop_pipe"
+  },
+  {
+    "id": "mon_feral_human_pipe_fungal_infected",
+    "type": "MONSTER",
+    "name": { "str": "party rocker" },
+    "copy-from": "mon_feral_human_pipe_fungal_infected",
+    "death_drops": "party_rocker_death_drop_pipe",
+    "description": "A party rocker who's not dancing with as much energy, and they seem to be stopping often to cough and catch their breath."
+  },
+  {
+    "id": "mon_feral_human_pipe_fungal_corpse",
+    "type": "MONSTER",
+    "name": { "str": "party rocker" },
+    "copy-from": "mon_feral_human_pipe_fungal_corpse",
+    "death_drops": "party_rocker_death_drop_pipe",
+    "description": "A party rocker who's grown painful mushroom stalks out of their body, writhing in pain as their last neurons still instruct them to dance."
+  },
+  {
+    "id": "mon_feral_human_crowbar",
+    "type": "MONSTER",
+    "name": { "str": "party rocker" },
+    "copy-from": "mon_feral_human_crowbar",
+    "description": "After the event on March 2nd, seemingly ordinary people started coming down with some odd, mass hysteria like dancing.  While some people may have scoffed it off as a silly dance craze, those in the know knew, it was the Party Rock Outbreak.  This one has a drink in hand.",
+    "starting_ammo": { "party_rock": 30 },
+    "special_attacks": [
+      {
+        "type": "gun",
+        "cooldown": 5,
+        "move_cost": 150,
+        "gun_type": "feral_human_thrown_rock",
+        "ammo_type": "party_rock",
+        "no_ammo_sound": "",
+        "fake_skills": [ [ "throw", 3 ] ],
+        "fake_str": 8,
+        "condition": { "not": { "u_has_effect": "maimed_arm" } },
+        "require_targeting_player": false,
+        "ranges": [ [ 2, 5, "DEFAULT" ] ],
+        "description": "The party rocker party rocks!"
+      },
+      { "id": "party_rocker_bottle" },
+      [ "BROWSE", 100 ],
+      [ "EAT_FOOD", 100 ]
+    ],
+    "death_drops": "party_rocker_death_drop_bottle"
+  },
+  {
+    "id": "mon_feral_human_crowbar_fungal_infected",
+    "type": "MONSTER",
+    "name": { "str": "party rocker" },
+    "copy-from": "mon_feral_human_pipe_fungal_infected",
+    "death_drops": "party_rocker_death_drop_pipe",
+    "description": "A party rocker who's not dancing with as much energy, and they seem to be stopping often to cough and catch their breath."
+  },
+  {
+    "id": "mon_feral_human_crowbar_fungal_corpse",
+    "type": "MONSTER",
+    "name": { "str": "party rocker" },
+    "copy-from": "mon_feral_human_pipe_fungal_corpse",
+    "death_drops": "party_rocker_death_drop_pipe",
+    "description": "A party rocker who's grown painful mushroom stalks out of their body, writhing in pain as their last neurons still instruct them to dance."
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Crazy Cataclysm has Party Rockers"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

CDDA had a distinct lack of party rock, so I sought to remedy this. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Replaces crowbar and pipe ferals with party rockers in Crazy Cataclysm.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Letting the world die out without party rock.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Spawns naturally!
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/78005870/9d3d470a-a5c2-497e-bcd3-77e968fca2f4)
Fungalizes!
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/78005870/20f97281-b181-4481-89b1-26f26ad50429)
They party rock!
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/78005870/8db96d6d-2b79-45a7-a9a2-62a32f7389ad)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/78005870/3a1f6c74-560e-45a2-90a4-def3fd35d937)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
