### PR TITLE
Add turpentine, camphine to flammable fuel reicpe requirements group

### DIFF
--- a/data/json/requirements/explosives.json
+++ b/data/json/requirements/explosives.json
@@ -15,7 +15,9 @@
         [ "lamp_oil", 1 ],
         [ "motor_oil", 1 ],
         [ "jp8", 1 ],
-        [ "avgas", 1 ]
+        [ "avgas", 1 ],
+        [ "chem_turpentine", 1 ],
+        [ "camphine", 1 ]
       ]
     ]
   },
@@ -30,7 +32,8 @@
         [ "chem_methanol", 1 ],
         [ "ether", 1 ],
         [ "denat_alcohol", 1 ],
-        [ "avgas", 1 ]
+        [ "avgas", 1 ],
+        [ "chem_turpentine", 1 ]
       ]
     ]
   },
@@ -38,7 +41,7 @@
     "id": "fuel_liquid",
     "type": "requirement",
     "//": "This should contain all flammable liquids with a flash point above 30 degrees centigrade, 1 mL.",
-    "components": [ [ [ "diesel", 1 ], [ "biodiesel", 1 ], [ "lamp_oil", 1 ], [ "jp8", 1 ], [ "motor_oil", 1 ] ] ]
+    "components": [ [ [ "diesel", 1 ], [ "biodiesel", 1 ], [ "lamp_oil", 1 ], [ "jp8", 1 ], [ "motor_oil", 1 ], [ "camphine", 1 ] ] ]
   },
   {
     "id": "volatile_explosive",


### PR DESCRIPTION
#### Summary
Features "Add turpentine, camphine as flammable liquids for crafting"

#### Purpose of change
Despite being highly flammable, turpentine is not able to be used as an ingredient for creating Molotov cocktails.

#### Describe the solution
Add `chem_turpentine` to the "accelerant_liquid" requirement group. Currently this is only used by the Molotov recipe. The comment in the group specifies 'flash points below 30 deg C' only, and while turpentine sits somewhere around 35, it should be eligible as an ingredient for making Molotovs

Add `chem_camphine` to the "fuel_liquid" requirement group. I'm not as familiar with camphine and thus didn't want to add it to the accelerant group mistakenly, but it might fit better there.

Add both to the "flammable liquid" group since both are flammable liquids.

#### Describe alternatives you've considered
Making an IRL turpentine Molotov for science. Seems excessive.

#### Testing
Examine the recipient for Molotov. Observe turpentine as an allowed ingredient.

#### Additional context
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/6325435/aa1fad34-ed12-4145-ab66-a21bc83d3fea)
