### PR TITLE
Warn the player when auto features are off and user is setting an auto feature with a hotkey.

### DIFF
--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -666,6 +666,15 @@ static void close()
     }
 }
 
+static void auto_features_next( const std::string &option )
+{
+    get_options().get_option( option ).setNext();
+    get_options().save();
+    add_msg( _( "%s is now set to %s." ),
+             get_options().get_option( option ).getMenuText(),
+             get_options().get_option( option ).getValueName() );
+}
+
 static void auto_features_warn()
 {
     if( !get_option<bool>( "AUTO_FEATURES" ) ) {
@@ -2842,22 +2851,14 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             break;
 
         case ACTION_TOGGLE_AUTO_PULP_BUTCHER:
-            get_options().get_option( "AUTO_PULP_BUTCHER" ).setNext();
-            get_options().save();
             //~ Auto Pulp/Pulp Adjacent/Butcher is now set to x
-            add_msg( _( "%s is now set to %s." ),
-                     get_options().get_option( "AUTO_PULP_BUTCHER" ).getMenuText(),
-                     get_options().get_option( "AUTO_PULP_BUTCHER" ).getValueName() );
+            auto_features_next( "AUTO_PULP_BUTCHER" );
             auto_features_warn();
             break;
 
         case ACTION_TOGGLE_AUTO_MINING:
-            get_options().get_option( "AUTO_MINING" ).setNext();
-            get_options().save();
-            //~ Auto Mining is now ON/OFF
-            add_msg( _( "%s is now %s." ),
-                     get_options().get_option( "AUTO_MINING" ).getMenuText(),
-                     get_option<bool>( "AUTO_MINING" ) ? _( "ON" ) : _( "OFF" ) );
+            //~ Auto Mining is now set to x
+            auto_features_next( "AUTO_MINING" );
             auto_features_warn();
             break;
 
@@ -2885,22 +2886,14 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             break;
 
         case ACTION_TOGGLE_AUTO_FORAGING:
-            get_options().get_option( "AUTO_FORAGING" ).setNext();
-            get_options().save();
             //~ Auto Foraging is now set to x
-            add_msg( _( "%s is now set to %s." ),
-                     get_options().get_option( "AUTO_FORAGING" ).getMenuText(),
-                     get_options().get_option( "AUTO_FORAGING" ).getValueName() );
+            auto_features_next( "AUTO_FORAGING" );
             auto_features_warn();
             break;
 
         case ACTION_TOGGLE_AUTO_PICKUP:
-            get_options().get_option( "AUTO_PICKUP" ).setNext();
-            get_options().save();
             //~ Auto pickup is now set to x
-            add_msg( _( "%s is now set to %s." ),
-                     get_options().get_option( "AUTO_PICKUP" ).getMenuText(),
-                     get_options().get_option( "AUTO_PICKUP" ).getValueName() );
+            auto_features_next( "AUTO_PICKUP" );
             break;
 
         case ACTION_DISPLAY_SCENT:

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -666,6 +666,19 @@ static void close()
     }
 }
 
+static void auto_features_warn()
+{
+    if( !get_option<bool>( "AUTO_FEATURES" ) ) {
+        const options_manager::cOpt &auto_features = get_options().get_option( "AUTO_FEATURES" );
+        add_msg( _( "Warning: Options > %s > %s > %s set to %s." ),
+                 auto_features.getPage(),
+                 auto_features.getGroupName(),
+                 auto_features.getMenuText(),
+                 auto_features.getValueName()  // false in locale
+               );
+    }
+}
+
 // Establish or release a grab on a vehicle
 static void grab()
 {
@@ -2835,6 +2848,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             add_msg( _( "%s is now set to %s." ),
                      get_options().get_option( "AUTO_PULP_BUTCHER" ).getMenuText(),
                      get_options().get_option( "AUTO_PULP_BUTCHER" ).getValueName() );
+            auto_features_warn();
             break;
 
         case ACTION_TOGGLE_AUTO_MINING:
@@ -2844,6 +2858,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             add_msg( _( "%s is now %s." ),
                      get_options().get_option( "AUTO_MINING" ).getMenuText(),
                      get_option<bool>( "AUTO_MINING" ) ? _( "ON" ) : _( "OFF" ) );
+            auto_features_warn();
             break;
 
         case ACTION_TOGGLE_THIEF_MODE:
@@ -2876,6 +2891,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             add_msg( _( "%s is now set to %s." ),
                      get_options().get_option( "AUTO_FORAGING" ).getMenuText(),
                      get_options().get_option( "AUTO_FORAGING" ).getValueName() );
+            auto_features_warn();
             break;
 
         case ACTION_TOGGLE_AUTO_PICKUP:

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -934,6 +934,22 @@ int options_manager::cOpt::getIntPos( const int iSearch ) const
     return -1;
 }
 
+std::string options_manager::cOpt::getGroupName() const
+{
+    const std::string page_id = getPage();
+    for( Page &p : get_options().pages_ ) {
+        if( p.id_ == page_id ) {
+            for( const PageItem &i : p.items_ ) {
+                if( i.type == ItemType::Option && i.data == getName() ) {
+                    return get_options().find_group( i.group ).name_.translated();
+                }
+            }
+            break;
+        }
+    }
+    return "";
+}
+
 std::optional<options_manager::int_and_option> options_manager::cOpt::findInt(
     const int iSearch ) const
 {

--- a/src/options.h
+++ b/src/options.h
@@ -91,6 +91,8 @@ class options_manager
 
                 std::string getName() const;
                 std::string getPage() const;
+                /// The translated group name. If not in a group, an empty string.
+                std::string getGroupName() const;
                 /// The translated displayed option name.
                 std::string getMenuText() const;
                 /// The translated displayed option tool tip.


### PR DESCRIPTION
#### Summary
Interface "Warn on setting an auto feature when auto features are off"

#### Purpose of change

First commit:

Resolve #74300

Second commit:

Normalize the text, it isn't worse in my opinion, this was `ON`/`OFF`:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/38bfe7cf-6ad9-42a1-9ba4-3e203f97f547)


#### Describe the solution

The game will tell the player what @RenechCDDA told me (when relevant). That is `Warning: Options > general > Auto Features Options > Additional auto features set to False.`

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/9f4cd658-59bd-4b5d-92db-5b83544da08b)


#### Describe alternatives you've considered

 - Hardcode it harder.
 - Capitalize `general` in the warning text.
 - Make a new method to avoid nested loops:
```cpp
const options_manager::Page &options_manager::find_page( const std::string &page_id ) const
```

#### Testing
1. Set hotkeys.
2. Use them.
3. Check in `Options > general > Auto Features Options > ...` that the hotkeys did what they did before.


#### Additional context

