### PR TITLE
rename `acetylene` -> `oxyacetylene` to avoid name collision

### DIFF
--- a/data/json/items/ammo/weldgas.json
+++ b/data/json/items/ammo/weldgas.json
@@ -3,7 +3,7 @@
     "//": "roughly 35grams of acetylene per cubic foot at STP. Volume given is when compressed - B tank has 9.17 L tank and holds 40 cubic feet.",
     "id": "oxyacetylene",
     "type": "AMMO",
-    "name": { "str_sp": "acetylene" },
+    "name": { "str_sp": "oxyacetylene" },
     "description": "Pressurized, dangerous acetylene gas.  Can be used for welding or cutting with a torch.",
     "weight": "1 g",
     "volume": "250 ml",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Resolve #74252

Definitely see the issue for the short discussion.

#### Describe the solution

Rename it back to oxyacetylene for now.

#### Describe alternatives you've considered

It is better to tell items apart than to wait for realism.

#### Testing

Works in the game.

#### Additional context

