### PR TITLE
Add context to some snippets in `data/json/npcs/talk_tags.json`

### DIFF
--- a/data/json/npcs/talk_tags.json
+++ b/data/json/npcs/talk_tags.json
@@ -149,7 +149,7 @@
       "bitch",
       "bootlicker",
       "bugger",
-      "butchery refuse",
+      { "text": { "ctxt": "<name_b>", "str": "butchery refuse" } },
       "butthead",
       "butt-licker",
       "chucklefuck",
@@ -160,9 +160,9 @@
       "damned <name_b>",
       "dildo",
       "dimwit",
-      "dog",
+      { "text": { "ctxt": "<name_b>", "str": "dog" } },
       "dumbshit",
-      "dumpster",
+      { "text": { "ctxt": "<name_b>", "str": "dumpster" } },
       "dumpster fire",
       "dunderfuck",
       "effing <name_b>",
@@ -1876,7 +1876,7 @@
     "type": "snippet",
     "category": "<zombie>",
     "text": [
-      "zombie",
+      { "text": { "ctxt": "<zombie>", "str": "zombie" } },
       "Z",
       "shambler",
       "goo-puker",
@@ -2026,7 +2026,7 @@
   {
     "type": "snippet",
     "category": "<granny_name_g>",
-    "text": [ "child", "my child", "dear", "my dear", "friend", "survivor" ]
+    "text": [ { "text": { "ctxt": "<granny_name_g>", "str": "child" } }, "my child", "dear", "my dear", "friend", "survivor" ]
   },
   {
     "type": "snippet",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Add context to some talk tags to separate them from their item/monster/furniture name counterpart.

#### Describe the solution
Do it.

#### Describe alternatives you've considered
Not doing it.

#### Testing
The game loads.

#### Additional context
