### PR TITLE
Make options fail faster, fix silent errors

### DIFF
--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -666,11 +666,11 @@ static void close()
     }
 }
 
-static void auto_features_next( const std::string &option )
+static void set_next_option( const std::string &option )
 {
     get_options().get_option( option ).setNext();
     get_options().save();
-    add_msg( _( "%s is now set to %s." ),
+    add_msg( _( "Set %s to %s." ),
              get_options().get_option( option ).getMenuText(),
              get_options().get_option( option ).getValueName() );
 }
@@ -2664,10 +2664,8 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             break;
 
         case ACTION_TOGGLE_AUTOSAFE: {
-            options_manager::cOpt &autosafemode_option = get_options().get_option( "AUTOSAFEMODE" );
-            add_msg( m_info, autosafemode_option.value_as<bool>()
-                     ? _( "Auto safe mode OFF!" ) : _( "Auto safe mode ON!" ) );
-            autosafemode_option.setNext();
+            // Set Auto reactivate safe mode to x
+            set_next_option( "AUTOSAFEMODE" );
             break;
         }
 
@@ -2842,23 +2840,19 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             break;
 
         case ACTION_TOGGLE_AUTO_FEATURES:
-            get_options().get_option( "AUTO_FEATURES" ).setNext();
-            get_options().save();
-            //~ Auto Features are now ON/OFF
-            add_msg( _( "%s are now %s." ),
-                     get_options().get_option( "AUTO_FEATURES" ).getMenuText(),
-                     get_option<bool>( "AUTO_FEATURES" ) ? _( "ON" ) : _( "OFF" ) );
+            // Set Auto Features to x
+            set_next_option( "AUTO_FEATURES" );
             break;
 
         case ACTION_TOGGLE_AUTO_PULP_BUTCHER:
-            //~ Auto Pulp/Pulp Adjacent/Butcher is now set to x
-            auto_features_next( "AUTO_PULP_BUTCHER" );
+            // Set Auto pulp or butcher to x
+            set_next_option( "AUTO_PULP_BUTCHER" );
             auto_features_warn();
             break;
 
         case ACTION_TOGGLE_AUTO_MINING:
-            //~ Auto Mining is now set to x
-            auto_features_next( "AUTO_MINING" );
+            // Set Auto Mining to x
+            set_next_option( "AUTO_MINING" );
             auto_features_warn();
             break;
 
@@ -2886,14 +2880,14 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             break;
 
         case ACTION_TOGGLE_AUTO_FORAGING:
-            //~ Auto Foraging is now set to x
-            auto_features_next( "AUTO_FORAGING" );
+            // Set Auto Foraging to x
+            set_next_option( "AUTO_FORAGING" );
             auto_features_warn();
             break;
 
         case ACTION_TOGGLE_AUTO_PICKUP:
-            //~ Auto pickup is now set to x
-            auto_features_next( "AUTO_PICKUP" );
+            // Set Auto pickup enabled to x
+            set_next_option( "AUTO_PICKUP" );
             break;
 
         case ACTION_DISPLAY_SCENT:
@@ -2956,8 +2950,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             break;
 
         case ACTION_TOGGLE_PREVENT_OCCLUSION:
-            get_options().get_option( "PREVENT_OCCLUSION" ).setNext();
-            get_options().save();
+            set_next_option( "PREVENT_OCCLUSION" );
             break;
 
         case ACTION_ZOOM_IN:

--- a/src/options.h
+++ b/src/options.h
@@ -367,6 +367,9 @@ class options_manager
         /** Add empty line to page. */
         void add_empty_line( const std::string &sPageIn );
 
+        /** Find page by id. */
+        Page &find_page( const std::string &id );
+
         /** Find group by id. */
         const Group &find_group( const std::string &id ) const;
 };

--- a/src/options.h
+++ b/src/options.h
@@ -320,7 +320,7 @@ class options_manager
                 PageItem( ItemType type, const std::string &data, const std::string &group )
                     : type( type ), data( data ), group( group ) { }
 
-                std::string fmt_tooltip( const Group &group, const options_container &cont ) const;
+                std::string fmt_tooltip( const std::string &group_id, const options_container &cont ) const;
         };
 
         /**


### PR DESCRIPTION
#### Summary
Bugfixes "Make options fail faster, fix silent errors"

#### Purpose of change

Build on previous PR to make (renamed) `auto_features_next` -> `set_next_option` more general and use it more.
 - #74324

Implement `options_manager::find_page`. I found some errors along the way, so I fixed them.

#### Describe the solution

1. First commit da3035a
   - Implement and use `options_manager::find_page`.
2. Second commit 0e521d9
    - Added some `debugmsg` to catch more errors.
    - Fix silent errors
      - `EXTRA_OPTIONS` tried to add every entry to an invalid `Page`, but now it adds it to no `Page` since it shouldn't be displayed.
      - When `Page` had only 1 line, it would crash on display.
      - Postponed `find_group` call to `fmt_tooltip` and only call it when needed. This is to prevent calling `find_group` with empty `group_id`.
3. Third commit 88034ed
   - Rename `auto_features_next` -> `set_next_option`, change `%s is now set to %s.` -> `Set %s to %s.` to be singular/plural agnostic and use it more.
   - Fix clang errors https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/9376288841/job/25815978767?pr=74324#step:9:889
   - On toggling `PREVENT_OCCLUSION`, say the current state (previously it was completely silent).

I Changed `Auto reactivate safe mode` message from blue to white. I think SAFE MODE is the important one, but maybe I will get push back on my change too:

Before:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/45b549fa-3fe4-46d9-a551-71486d02fc01)

After:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/7c7a3d11-2c0e-431c-a53a-38705ecffa13)


#### Describe alternatives you've considered


#### Testing

Toggling features work: Toggled, checked in settings.

#### Additional context

Reminder for myself: Should have set #74324 to draft even if it had clang errors and shouldn't be merged, since I haven't finished it.