### PR TITLE
Make farm plots re-tillable in farming extension version 2

### DIFF
--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -443,6 +443,8 @@ class basecamp
         * @param op whether to plow, plant, or harvest
         */
         bool farm_return( const mission_id &miss_id, const tripoint_abs_omt &omt_tgt );
+        std::pair<size_t, std::string> farm_action( const tripoint_abs_omt &omt_tgt, farm_ops op,
+                                                    const npc_ptr &comp = nullptr );
         void fortifications_return( const mission_id &miss_id );
         bool salt_water_pipe_swamp_return( const mission_id &miss_id,
                                            const comp_list &npc_list );

--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -444,7 +444,7 @@ class basecamp
         */
         bool farm_return( const mission_id &miss_id, const point &dir );
         std::pair<size_t, std::string> farm_action( const point &dir, farm_ops op,
-                                                    const npc_ptr &comp = nullptr );
+                const npc_ptr &comp = nullptr );
         void fortifications_return( const mission_id &miss_id );
         bool salt_water_pipe_swamp_return( const mission_id &miss_id,
                                            const comp_list &npc_list );

--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -336,7 +336,7 @@ class basecamp
         std::string gathering_description();
         /// Returns a string for the number of plants that are harvestable, plots ready to plant,
         /// and ground that needs tilling
-        std::string farm_description( const tripoint_abs_omt &farm_pos, size_t &plots_count,
+        std::string farm_description( const point &dir, size_t &plots_count,
                                       farm_ops operation );
         /// Returns the description of a camp crafting options. converts fire charges to charcoal,
         /// allows dark crafting
@@ -392,7 +392,7 @@ class basecamp
         void start_salt_water_pipe( const mission_id &miss_id );
         void continue_salt_water_pipe( const mission_id &miss_id );
         void start_combat_mission( const mission_id &miss_id, float exertion_level );
-        void start_farm_op( const tripoint_abs_omt &omt_tgt, const mission_id &miss_id,
+        void start_farm_op( const point &dir, const mission_id &miss_id,
                             float exertion_level );
         ///Display items listed in @ref equipment to let the player pick what to give the departing
         ///NPC, loops until quit or empty.
@@ -442,8 +442,8 @@ class basecamp
         * @param omt_tgt the overmap pos3 of the farm_ops
         * @param op whether to plow, plant, or harvest
         */
-        bool farm_return( const mission_id &miss_id, const tripoint_abs_omt &omt_tgt );
-        std::pair<size_t, std::string> farm_action( const tripoint_abs_omt &omt_tgt, farm_ops op,
+        bool farm_return( const mission_id &miss_id, const point &dir );
+        std::pair<size_t, std::string> farm_action( const point &dir, farm_ops op,
                                                     const npc_ptr &comp = nullptr );
         void fortifications_return( const mission_id &miss_id );
         bool salt_water_pipe_swamp_return( const mission_id &miss_id,

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -3605,8 +3605,8 @@ std::pair<size_t, std::string> basecamp::farm_action( const point &dir, farm_ops
                                 mirror_horizontal,
                                 mirror_vertical,
                                 rotation,
-                                "farm_action failed to apply orientation flags to the %s upgrade",
-                                "" ) ) {
+                                "%s failed to apply orientation flags to the %s upgrade",
+                                "farm_action" ) ) {
                             continue;
                         }
                         farm_json->rotate( 4 - rotation );

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -1311,7 +1311,7 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, const p
                        "Skill used: fabrication\n"
                        "Difficulty: N/A\n"
                        "Effects:\n"
-                       "> Restores only the plots created in the last expansion upgrade.\n"
+                       "> Restores farm plots created in previous expansion upgrades.\n"
                        "> Does not damage existing crops.\n\n"
                        "Risk: None\n"
                        "Intensity: Moderate\n"

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -3589,12 +3589,12 @@ std::pair<size_t, std::string> basecamp::farm_action( const point &dir, farm_ops
                     }
                     // Add mapgen from expansion upgrades to fake_map
                     for( auto const &provide : e_data->second.provides ) {
-                        if ( !recipe_id( provide.first ).is_valid() ) {
+                        if( !recipe_id( provide.first ).is_valid() ) {
                             continue;
                         }
                         const recipe &making = *recipe_id( provide.first );
                         const update_mapgen_id update_id = making.get_blueprint();
-                        if ( !has_update_mapgen_for( update_id )) {
+                        if( !has_update_mapgen_for( update_id ) ) {
                             continue;
                         }
                         bool mirror_horizontal;
@@ -3611,7 +3611,7 @@ std::pair<size_t, std::string> basecamp::farm_action( const point &dir, farm_ops
                         }
                         farm_json->rotate( 4 - rotation );
                         farm_json->mirror( mirror_horizontal, mirror_vertical );
-                        if ( !run_mapgen_update_func( update_id, dat, false ) ) {
+                        if( !run_mapgen_update_func( update_id, dat, false ) ) {
                             debugmsg( "farm_action failed to apply the %s map update to %s",
                                       provide.first, omt_id );
                         }

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -3564,10 +3564,10 @@ std::pair<size_t, std::string> basecamp::farm_action( const point &dir, farm_ops
     }
 
     // farm_map is what the area actually looks like
-    tinymap farm_map;
+    smallmap farm_map;
     farm_map.load( omt_tgt, false );
     // farm_json is what the area should look like according to jsons (loaded on demand)
-    std::unique_ptr<fake_map> farm_json;
+    std::unique_ptr<small_fake_map> farm_json;
     tripoint mapmin = tripoint( 0, 0, omt_tgt.z() );
     tripoint mapmax = tripoint( 2 * SEEX - 1, 2 * SEEY - 1, omt_tgt.z() );
     bool done_planting = false;
@@ -3580,7 +3580,7 @@ std::pair<size_t, std::string> basecamp::farm_action( const point &dir, farm_ops
         switch( op ) {
             case farm_ops::plow: {
                 if( !farm_json ) {
-                    farm_json = std::make_unique<fake_map>();
+                    farm_json = std::make_unique<small_fake_map>();
                     mapgendata dat( omt_tgt, *farm_json->cast_to_map(), 0, calendar::turn, nullptr );
                     std::string omt_id = dat.terrain_type()->get_mapgen_id();
                     if( !run_mapgen_func( omt_id, dat ) ) {

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -3543,8 +3543,8 @@ static bool farm_valid_seed( const item &itm )
     return itm.is_seed() && itm.typeId() != itype_marloss_seed && itm.typeId() != itype_fungal_seeds;
 }
 
-static std::pair<size_t, std::string> farm_action( const tripoint_abs_omt &omt_tgt, farm_ops op,
-        const npc_ptr &comp = nullptr )
+std::pair<size_t, std::string> basecamp::farm_action( const tripoint_abs_omt &omt_tgt, farm_ops op,
+        const npc_ptr &comp )
 {
     size_t plots_cnt = 0;
     std::string crops;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Make farm plots re-tillable in farming extension version 2"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Farming plots in the basecamp farming extension version 2 that have changed terrain (due to plants being harvested / smashed, dirt mounds being tamped, ...) could not be re-tilled through the basecamp mission menu even though there's a mission "Plow fields" intended to do this (issue #73761).

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

This PR fixes this issue by making sure the field plots (dirt mounds) which have been built into the expansion are inserted correctly into the reference map which is used by the farming mission to check where tilling needs to be done (closes #73761).

The new code applies mapgen updates according to the upgrades which have been built into the expansion to the farming reference map. 
This farming reference map is used by existing code to decide how many / where dirt mounds need to be put.

Since the new code requires access to the expansion's upgrade list, the calling interface needed to be changed slightly (make `farm_action` a member of `basecamp` class, use relative coordinates instead of absolute ones).

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
Missions to build farm plots, and the mission to (re-)plow fields is in a way two times the same thing. More extensive changes could try to unify that. That would go beyond what should be a direct bugfix though.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

Made a field basecamp, created a farming extension version 1 in one tile, and three farming extensions version 2 (to test rotations and mirroring) in three other tiles. Built fields, planted a through seeds through the basecamp mission, went around and smashed plants / tamped dirt:

![Debug silvadomi _2024-06-06T11-19-35](https://github.com/CleverRaven/Cataclysm-DDA/assets/171120271/3ff7c123-49ae-4b9e-befd-bcdd499bcfbf)

Coming back to the bulletin board shows the correct number of spaces to plow:

<img width="1220" alt="Debug silvadomi _2024-06-06T11-23-10" src="https://github.com/CleverRaven/Cataclysm-DDA/assets/171120271/dcc38f27-76c1-4d92-8fde-b9b017d9343c">

Performing the "Plow fields" mission in all expansions restores the reference state with dirt mounds, leaving existing plants intact:

![Debug silvadomi _2024-06-06T11-25-12](https://github.com/CleverRaven/Cataclysm-DDA/assets/171120271/e9fb0658-eaff-4cb8-a3d3-2ecc877a1a10)


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
