### PR TITLE
`Pour into` instead of `Container for`

### DIFF
--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -502,9 +502,9 @@ item_location game_menus::inv::container_for( Character &you, const item &liquid
         const item *const avoid )
 {
     return inv_internal( you, liquid_inventory_selector_preset( liquid, avoid ),
-                         string_format( _( "Container for %s | %s %s" ), liquid.display_name( liquid.charges ),
+                         string_format( _( "Pour %s | %s %s into" ), liquid.display_name( liquid.charges ),
                                         format_volume( liquid.volume() ), volume_units_abbr() ), radius,
-                         string_format( _( "You don't have a suitable container for carrying %s." ),
+                         string_format( _( "You don't have a suitable container to pour %s into." ),
                                         liquid.tname() ) );
 }
 

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1831,27 +1831,15 @@ void game_menus::inv::insert_items( avatar &you, item_location &holster )
 
 static bool valid_unload_container( const item_location &container )
 {
-    // Item must be a container.
-    if( !container->is_container() ) {
-        return false;
-    }
-
-    // Item must be able to be unloaded
-    if( container->has_flag( flag_NO_UNLOAD ) ) {
-        return false;
-    }
-
-    // Container must contain at least one item
-    if( container->empty_container() ) {
-        return false;
-    }
-
-    // Not all contents should not be liquid, gas or plasma
-    if( container->contains_no_solids() ) {
-        return false;
-    }
-
-    return true;
+    return
+        // Item must be a container.
+        container->is_container()
+        // Item must be able to be unloaded
+        && !container->has_flag( flag_NO_UNLOAD )
+        // Container must contain at least one item
+        && !container->empty_container()
+        // Not all contents should not be liquid, gas or plasma
+        && !container->contains_no_solids();
 }
 
 drop_locations game_menus::inv::unload_container( avatar &you )

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -2696,7 +2696,8 @@ int inventory_selector::query_count( char init, bool end_with_toggle )
         try {
             ret = std::stoi( query.second );
         } catch( const std::invalid_argument &e ) {
-            // TODO Tell User they did a bad
+            // Tell User they did a bad
+            popup( _( "That is not an integer." ) );
             ret = -1;
         } catch( const std::out_of_range &e ) {
             ret = INT_MAX;

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -4441,7 +4441,7 @@ std::string unload_selector::hint_string()
 {
     std::string mode = uistate.unload_auto_contain ? _( "Auto" ) : _( "Manual" );
     return string_format(
-               _( "[<color_yellow>%s</color>] Confirm [<color_yellow>%s</color>] Cancel [<color_yellow>%s</color>] Contain mode(<color_yellow>%s</color>)" ),
+               _( "[<color_yellow>%s</color>] Confirm [<color_yellow>%s</color>] Cancel [<color_yellow>%s</color>] Select destination(<color_yellow>%s</color>)" ),
                ctxt.get_desc( "CONFIRM" ), ctxt.get_desc( "QUIT" ), ctxt.get_desc( "CONTAIN_MODE" ), mode );
 }
 

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -3934,9 +3934,9 @@ void inventory_multiselector::on_input( const inventory_input &input )
         if( entry.is_selectable() ) {
             size_t const count = entry.chosen_count;
             size_t const max = entry.get_available_count();
-            size_t const newcount = input.action == "INCREASE_COUNT"
-                                    ? count < max ? count + 1 : max
-                                    : count > 1 ? count - 1 : 0;
+            size_t const newcount = std::clamp<size_t>( 0,
+                                    count + ( input.action == "INCREASE_COUNT" ? +1 : -1 ),
+                                    max );
             toggle_entry( entry, newcount );
         }
     } else if( input.action == "VIEW_CATEGORY_MODE" ) {


### PR DESCRIPTION
#### Summary
Interface "Change: Container for X -> Pour X into"

#### Purpose of change

The interface wants to say _Choose a container to pour X into_ and _Container for X_ was previously chosen. This evokes _Guess what is the container for X?_ or something. It was confusing when viewed alone out of context.

#### Describe the solution

_Pour X into_ is much more descriptive. It says what the action is.

Same story for _Contain mode_ (auto/manual) changed to _Select destination_ (auto/manual).

Also some refactoring.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Compiles, shows in the menu:

0. Unload a container with liquid.
   - ![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/1e2eb762-9978-4cd7-b0a8-041544e49d66)
2. ![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/b4b2b00e-3be9-4f61-86cc-f0975a0bf375)
3. ![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/8daad6dd-091d-4381-a06a-3dbd3d1bc8c9)



#### Additional context