### PR TITLE
Fix character volume calculation

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3102,13 +3102,22 @@ units::volume Character::get_total_volume() const
 
 units::volume Character::get_base_volume() const
 {
-    const int your_height = height(); // avg 175cm
-    const double your_weight = units::to_gram<double>( bodyweight() ) * 1000;
+    // The formula used here to calculate base volume for a human body is
+    //     BV = W / BD
+    // Where:
+    // * BV is the body volume in liters
+    // * W  is the weight in kilograms
+    // * BD is the body density (kg/L), estimated using the Brozek formula:
+    //     BD = 1.097 – 0.00046971 * W + 0.00000056 * W^2 – 0.00012828 * H
+    // See
+    //   https://en.wikipedia.org/wiki/Body_fat_percentage
+    //   https://calculator.academy/body-volume-calculator/
+    const int your_height = height();
+    const double your_weight = units::to_kilogram( bodyweight() );
     const double your_density = 1.097 - 0.00046971 * your_weight
                                 + 0.00000056 * std::pow( your_weight, 2 )
                                 - 0.00012828 * your_height;
-    units::volume your_base_volume = units::from_liter( static_cast<double>
-                                     ( your_weight ) / your_density );
+    units::volume your_base_volume = units::from_liter( your_weight / your_density );
     return your_base_volume;
 }
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3103,14 +3103,13 @@ units::volume Character::get_total_volume() const
 units::volume Character::get_base_volume() const
 {
     const int your_height = height(); // avg 175cm
-    // Arbitrary number picked relative to aisle (100L), not necessarily accurate
-    const units::volume avg_human_volume = 70_liter;
-
-    // Very scientific video game size to metric human volume calculation. Avg height == avg_human_volume;
-    units::volume your_base_volume = units::from_liter( static_cast<double>( your_height ) / 2.5 );
-    double volume_proport = units::to_liter( your_base_volume ) / units::to_liter( avg_human_volume );
-
-    return std::pow( volume_proport, 3.0 ) * avg_human_volume;
+    const double your_weight = units::to_gram<double>( bodyweight() ) * 1000;
+    const double your_density = 1.097 - 0.00046971 * your_weight
+                                + 0.00000056 * std::pow( your_weight, 2 )
+                                - 0.00012828 * your_height;
+    units::volume your_base_volume = units::from_liter( static_cast<double>
+                                     ( your_weight ) / your_density );
+    return your_base_volume;
 }
 
 units::mass Character::weight_carried() const

--- a/tests/char_volume_test.cpp
+++ b/tests/char_volume_test.cpp
@@ -109,7 +109,7 @@ TEST_CASE( "character_at_volume_can_or_cannot_enter_vehicle", "[volume]" )
     cramped = false;
 
     // Try the cramped aisle with a rock again, but now we are tiny, so it is easy.
-    CHECK( your_volume_with_trait( trait_SMALL2 ) == 23326_ml );
+    CHECK( your_volume_with_trait( trait_SMALL2 ) < 30_liter );
     you.setpos( test_pos ); // set our position again, clear_avatar() moved us
     dest_loc = dest_loc + tripoint_north;
     CHECK( you.can_move_to_vehicle_tile( dest_loc, cramped ) );
@@ -117,7 +117,7 @@ TEST_CASE( "character_at_volume_can_or_cannot_enter_vehicle", "[volume]" )
     dest_loc = you.get_location(); //reset
 
     // Same aisle, but now we have HUGE GUTS. We will never fit.
-    CHECK( your_volume_with_trait( trait_HUGE ) == 156228_ml );
+    CHECK( your_volume_with_trait( trait_HUGE ) > 150_liter );
     you.setpos( test_pos ); // set our position again, clear_avatar() moved us
     dest_loc = dest_loc + tripoint_north;
     CHECK( !you.can_move_to_vehicle_tile( dest_loc ) );

--- a/tests/char_volume_test.cpp
+++ b/tests/char_volume_test.cpp
@@ -9,7 +9,6 @@
 #include "map_helpers.h"
 #include "mutation.h"
 #include "player_helpers.h"
-#include "units.h"
 #include "vehicle.h"
 #include "veh_type.h"
 

--- a/tests/char_volume_test.cpp
+++ b/tests/char_volume_test.cpp
@@ -44,10 +44,9 @@ TEST_CASE( "character_baseline_volumes", "[volume]" )
     Character &you = get_player_character();
     REQUIRE( you.get_mutations().empty() );
     REQUIRE( you.height() == 175 );
-    CHECK( you.get_base_volume() == 70_liter );
 
     REQUIRE( your_height_with_trait( trait_SMALL2 ) == 70 );
-    CHECK( your_volume_with_trait( trait_SMALL2 ) == 4480_ml );
+    CHECK( your_volume_with_trait( trait_SMALL2 ) == 23326_ml );
 
     REQUIRE( your_height_with_trait( trait_SMALL ) == 122 );
     CHECK( your_volume_with_trait( trait_SMALL ) == 23717_ml );
@@ -56,7 +55,7 @@ TEST_CASE( "character_baseline_volumes", "[volume]" )
     CHECK( your_volume_with_trait( trait_LARGE ) == 152778_ml );
 
     REQUIRE( your_height_with_trait( trait_HUGE ) == 280 );
-    CHECK( your_volume_with_trait( trait_HUGE ) == 286720_ml );
+    CHECK( your_volume_with_trait( trait_HUGE ) == 156228_ml );
 }
 
 TEST_CASE( "character_at_volume_can_or_cannot_enter_vehicle", "[volume]" )
@@ -66,8 +65,6 @@ TEST_CASE( "character_at_volume_can_or_cannot_enter_vehicle", "[volume]" )
     map &here = get_map();
     Character &you = get_player_character();
     REQUIRE( you.get_mutations().empty() );
-    REQUIRE( you.get_base_volume() == 70_liter );
-    REQUIRE( you.get_total_volume() == 70_liter );
 
     tripoint test_pos = tripoint{10, 10, 0 };
 
@@ -107,7 +104,7 @@ TEST_CASE( "character_at_volume_can_or_cannot_enter_vehicle", "[volume]" )
     cramped = false;
 
     // Try the cramped aisle with a rock again, but now we are tiny, so it is easy.
-    CHECK( your_volume_with_trait( trait_SMALL2 ) == 4480_ml );
+    CHECK( your_volume_with_trait( trait_SMALL2 ) == 23326_ml );
     you.setpos( test_pos ); // set our position again, clear_avatar() moved us
     dest_loc = dest_loc + tripoint_north;
     CHECK( you.can_move_to_vehicle_tile( dest_loc, cramped ) );
@@ -115,7 +112,7 @@ TEST_CASE( "character_at_volume_can_or_cannot_enter_vehicle", "[volume]" )
     dest_loc = you.get_location(); //reset
 
     // Same aisle, but now we have HUGE GUTS. We will never fit.
-    CHECK( your_volume_with_trait( trait_HUGE ) == 286720_ml );
+    CHECK( your_volume_with_trait( trait_HUGE ) == 156228_ml );
     you.setpos( test_pos ); // set our position again, clear_avatar() moved us
     dest_loc = dest_loc + tripoint_north;
     CHECK( !you.can_move_to_vehicle_tile( dest_loc ) );

--- a/tests/char_volume_test.cpp
+++ b/tests/char_volume_test.cpp
@@ -9,6 +9,7 @@
 #include "map_helpers.h"
 #include "mutation.h"
 #include "player_helpers.h"
+#include "units.h"
 #include "vehicle.h"
 #include "veh_type.h"
 
@@ -42,25 +43,23 @@ TEST_CASE( "character_baseline_volumes", "[volume]" )
 {
     clear_avatar();
     Character &you = get_player_character();
+    you.set_stored_kcal( you.get_healthy_kcal() );
     REQUIRE( you.get_mutations().empty() );
     REQUIRE( you.height() == 175 );
-    CHECK( ( you.get_base_volume() > 55_liter && you.get_base_volume() < 80_liter ) );
+    REQUIRE( you.bodyweight() == 76562390_milligram );
+    CHECK( you.get_base_volume() == 73485_ml );
 
     REQUIRE( your_height_with_trait( trait_SMALL2 ) == 70 );
-    CHECK( ( your_volume_with_trait( trait_SMALL2 ) > 20_liter &&
-             your_volume_with_trait( trait_SMALL2 ) < 30_liter ) );
+    CHECK( your_volume_with_trait( trait_SMALL2 ) == 23326_ml );
 
     REQUIRE( your_height_with_trait( trait_SMALL ) == 122 );
-    CHECK( ( your_volume_with_trait( trait_SMALL ) > 40_liter &&
-             your_volume_with_trait( trait_SMALL ) < 50_liter ) );
+    CHECK( your_volume_with_trait( trait_SMALL ) == 42476_ml );
 
     REQUIRE( your_height_with_trait( trait_LARGE ) == 227 );
-    CHECK( ( your_volume_with_trait( trait_LARGE ) > 100_liter &&
-             your_volume_with_trait( trait_LARGE ) < 120_liter ) );
+    CHECK( your_volume_with_trait( trait_LARGE ) == 116034_ml );
 
     REQUIRE( your_height_with_trait( trait_HUGE ) == 280 );
-    CHECK( ( your_volume_with_trait( trait_HUGE ) > 150_liter &&
-             your_volume_with_trait( trait_HUGE ) < 200_liter ) );
+    CHECK( your_volume_with_trait( trait_HUGE ) == 156228_ml );
 }
 
 TEST_CASE( "character_at_volume_can_or_cannot_enter_vehicle", "[volume]" )
@@ -109,7 +108,7 @@ TEST_CASE( "character_at_volume_can_or_cannot_enter_vehicle", "[volume]" )
     cramped = false;
 
     // Try the cramped aisle with a rock again, but now we are tiny, so it is easy.
-    CHECK( your_volume_with_trait( trait_SMALL2 ) < 30_liter );
+    CHECK( your_volume_with_trait( trait_SMALL2 ) == 23326_ml );
     you.setpos( test_pos ); // set our position again, clear_avatar() moved us
     dest_loc = dest_loc + tripoint_north;
     CHECK( you.can_move_to_vehicle_tile( dest_loc, cramped ) );
@@ -117,7 +116,7 @@ TEST_CASE( "character_at_volume_can_or_cannot_enter_vehicle", "[volume]" )
     dest_loc = you.get_location(); //reset
 
     // Same aisle, but now we have HUGE GUTS. We will never fit.
-    CHECK( your_volume_with_trait( trait_HUGE ) > 150_liter );
+    CHECK( your_volume_with_trait( trait_HUGE ) == 156228_ml );
     you.setpos( test_pos ); // set our position again, clear_avatar() moved us
     dest_loc = dest_loc + tripoint_north;
     CHECK( !you.can_move_to_vehicle_tile( dest_loc ) );

--- a/tests/char_volume_test.cpp
+++ b/tests/char_volume_test.cpp
@@ -49,10 +49,10 @@ TEST_CASE( "character_baseline_volumes", "[volume]" )
     CHECK( your_volume_with_trait( trait_SMALL2 ) == 23326_ml );
 
     REQUIRE( your_height_with_trait( trait_SMALL ) == 122 );
-    CHECK( your_volume_with_trait( trait_SMALL ) == 23717_ml );
+    CHECK( your_volume_with_trait( trait_SMALL ) == 42476_ml );
 
     REQUIRE( your_height_with_trait( trait_LARGE ) == 227 );
-    CHECK( your_volume_with_trait( trait_LARGE ) == 152778_ml );
+    CHECK( your_volume_with_trait( trait_LARGE ) == 116034_ml );
 
     REQUIRE( your_height_with_trait( trait_HUGE ) == 280 );
     CHECK( your_volume_with_trait( trait_HUGE ) == 156228_ml );

--- a/tests/char_volume_test.cpp
+++ b/tests/char_volume_test.cpp
@@ -44,18 +44,23 @@ TEST_CASE( "character_baseline_volumes", "[volume]" )
     Character &you = get_player_character();
     REQUIRE( you.get_mutations().empty() );
     REQUIRE( you.height() == 175 );
+    CHECK( ( you.get_base_volume() > 55_liter && you.get_base_volume() < 80_liter ) );
 
     REQUIRE( your_height_with_trait( trait_SMALL2 ) == 70 );
-    CHECK( your_volume_with_trait( trait_SMALL2 ) == 23326_ml );
+    CHECK( ( your_volume_with_trait( trait_SMALL2 ) > 20_liter &&
+             your_volume_with_trait( trait_SMALL2 ) < 30_liter ) );
 
     REQUIRE( your_height_with_trait( trait_SMALL ) == 122 );
-    CHECK( your_volume_with_trait( trait_SMALL ) == 42476_ml );
+    CHECK( ( your_volume_with_trait( trait_SMALL ) > 40_liter &&
+             your_volume_with_trait( trait_SMALL ) < 50_liter ) );
 
     REQUIRE( your_height_with_trait( trait_LARGE ) == 227 );
-    CHECK( your_volume_with_trait( trait_LARGE ) == 116034_ml );
+    CHECK( ( your_volume_with_trait( trait_LARGE ) > 100_liter &&
+             your_volume_with_trait( trait_LARGE ) < 120_liter ) );
 
     REQUIRE( your_height_with_trait( trait_HUGE ) == 280 );
-    CHECK( your_volume_with_trait( trait_HUGE ) == 156228_ml );
+    CHECK( ( your_volume_with_trait( trait_HUGE ) > 150_liter &&
+             your_volume_with_trait( trait_HUGE ) < 200_liter ) );
 }
 
 TEST_CASE( "character_at_volume_can_or_cannot_enter_vehicle", "[volume]" )


### PR DESCRIPTION
#### Summary
Balance "Bring volume calculations for player body more in line with realistic examples"

#### Purpose of change
After the addition of volume calculations in #74162, my current character could no longer use any vehicles. The change is well meaning and brings realism, which I like, but the values seemed off, so I set out to make reasonably sized characters (both height and weight wise) able to get into car seats again, while retaining the limits for huge characters.

#### Describe the solution
I looked up how to calculate volume in the real world, from body density, which itself is dependent on the body fat to muscle and bone ratio, and age (age is NOT included in these calculations currently).

I tried calculating the volume sizes for various heights and sizes to see if they seem reasonable, the results can be found here: #74263.

I changed the volume calculation method for the character, and adjusted the unit tests accordingly.

The previous tests now pass. I removed some assertions based on assumptions on a default character having exactly 70 000 ml volume at 175 cm height, but the functional tests for getting into a vehicle and being cramped now works.

I play tested with my current character too (200 cm tall, normal weight), and she can now get into a car seat, even though she gets the "cramped" debuff.

#### Describe alternatives you've considered
Another approach would be to change the way car seats and volume calculations are performed, but this seemed like a MUCH bigger task, which would bring little benefit to the game or the maintainability of vehicles and vehicle parts.

#### Testing
The tests for the volume calculations and getting into a vehicle works, and gives the same results as before.

I've play tested the change, and now my character has to take off her rucksack to be able to sit in the driver seat, but she can drive the car, even though it's cramped.

#### Additional context
![Tawnya Ivey _2024-06-06T13-10-24](https://github.com/CleverRaven/Cataclysm-DDA/assets/3132980/dcdd6ff2-b8d8-4582-936a-f97d4ca7cfeb)
With military rucksack on.

![Tawnya Ivey _2024-06-06T13-11-02](https://github.com/CleverRaven/Cataclysm-DDA/assets/3132980/330fd987-e790-4c3c-b501-0abad89e8f2b)
With military rucksack taken off.

![Tawnya Ivey _2024-06-06T13-08-47](https://github.com/CleverRaven/Cataclysm-DDA/assets/3132980/f7314cca-bc52-40e2-9d69-8643c6ce5354)
Driving nude, in the middle of summer.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
