### PR TITLE
clean water goes bad if left in open container

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -2474,6 +2474,6 @@
   {
     "id": "DECAYS_IN_AIR",
     "type": "json_flag",
-    "info": "This will eventually <bad>go bad</bad> if left in open air too long."
+    "info": "This will eventually <bad>go bad</bad> if left in the open air too long."
   }
 ]

--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -2470,5 +2470,9 @@
     "id": "PREFIX_XS",
     "type": "json_flag",
     "item_prefix": "XS "
+  },
+  {
+    "id": "DECAYS_IN_AIR",
+    "type": "json_flag"
   }
 ]

--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -2473,6 +2473,7 @@
   },
   {
     "id": "DECAYS_IN_AIR",
-    "type": "json_flag"
+    "type": "json_flag",
+    "info": "This will eventually <bad>go bad</bad> if left in open air too long."
   }
 ]

--- a/data/json/items/comestibles/drink.json
+++ b/data/json/items/comestibles/drink.json
@@ -1491,6 +1491,7 @@
     "color": "light_blue",
     "container": "bottle_plastic",
     "sealed": false,
+    "delete": { "flags": [ "DECAYS_IN_AIR" ] },
     "contamination": [ { "disease": "highly_contaminated_food", "probability": 0.1 }, { "disease": "bad_food", "probability": 1 } ]
   },
   {
@@ -1518,11 +1519,13 @@
     "phase": "liquid",
     "quench": 50,
     "ammo_data": { "ammo_type": "water" },
-    "flags": [ "EATEN_COLD", "NUTRIENT_OVERRIDE" ],
+    "flags": [ "EATEN_COLD", "NUTRIENT_OVERRIDE", "DECAYS_IN_AIR" ],
     "name": { "str_sp": "clean water" },
     "description": "Fresh, clean water.  Truly the best thing to quench your thirst.",
     "container": "bottle_plastic",
     "sealed": true,
+    "revert_to": "water",
+    "properties": { "max_air_exposure_hours": "720" },
     "color": "light_cyan"
   },
   {

--- a/data/json/items/comestibles/drink.json
+++ b/data/json/items/comestibles/drink.json
@@ -1524,9 +1524,10 @@
     "description": "Fresh, clean water.  Truly the best thing to quench your thirst.",
     "container": "bottle_plastic",
     "sealed": true,
-    "revert_to": "water",
+    "color": "light_cyan",
+    "//": "Clean water becomes regular water in about 4 weeks if exposed to air (1 week if outdoors).",
     "properties": { "max_air_exposure_hours": "720" },
-    "color": "light_cyan"
+    "revert_to": "water"
   },
   {
     "id": "water_spring",

--- a/src/active_item_cache.cpp
+++ b/src/active_item_cache.cpp
@@ -17,6 +17,15 @@ float item_reference::spoil_multiplier()
     } );
 }
 
+bool item_reference::has_watertight_container()
+{
+    return std::any_of(
+               pocket_chain.begin(), pocket_chain.end(),
+    []( item_pocket const * pk ) {
+        return pk->can_contain_liquid( false );
+    } );
+}
+
 bool active_item_cache::add( item &it, point location, item *parent,
                              std::vector<item_pocket const *> const &pocket_chain )
 {

--- a/src/active_item_cache.h
+++ b/src/active_item_cache.h
@@ -22,6 +22,7 @@ struct item_reference {
     std::vector<item_pocket const *> pocket_chain;
 
     float spoil_multiplier();
+    bool has_watertight_container();
 };
 
 enum class special_item_type : int {

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -86,6 +86,7 @@ const flag_id flag_CUT_HARVEST( "CUT_HARVEST" );
 const flag_id flag_CUT_IMMUNE( "CUT_IMMUNE" );
 const flag_id flag_DANGEROUS( "DANGEROUS" );
 const flag_id flag_DEAF( "DEAF" );
+const flag_id flag_DECAYS_IN_AIR( "DECAYS_IN_AIR" );
 const flag_id flag_DIAMOND( "DIAMOND" );
 const flag_id flag_DIG_TOOL( "DIG_TOOL" );
 const flag_id flag_DIMENSIONAL_ANCHOR( "DIMENSIONAL_ANCHOR" );

--- a/src/flag.h
+++ b/src/flag.h
@@ -94,6 +94,7 @@ extern const flag_id flag_CUT_HARVEST;
 extern const flag_id flag_CUT_IMMUNE;
 extern const flag_id flag_DANGEROUS;
 extern const flag_id flag_DEAF;
+extern const flag_id flag_DECAYS_IN_AIR;
 extern const flag_id flag_DIAMOND;
 extern const flag_id flag_DIG_TOOL;
 extern const flag_id flag_DIMENSIONAL_ANCHOR;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1416,6 +1416,10 @@ bool item::combine( const item &rhs )
             set_item_specific_energy( units::from_joule_per_gram( combined_specific_energy ) );
         }
 
+        if( item_counter > 0 || rhs.item_counter > 0 ) {
+            item_counter = ( static_cast<double>( item_counter ) * charges + static_cast<double>
+                             ( rhs.item_counter ) * rhs.charges ) / ( charges + rhs.charges );
+        }
     }
     charges += rhs.charges;
     if( !rhs.has_flag( flag_NO_PARASITES ) ) {
@@ -2542,6 +2546,8 @@ void item::debug_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
                                active );
             info.emplace_back( "BASE", _( "burn: " ), "", iteminfo::lower_is_better,
                                burnt );
+            info.emplace_back( "BASE", _( "counter: " ), "", iteminfo::lower_is_better,
+                               item_counter );
             if( countdown_point != calendar::turn_max ) {
                 info.emplace_back( "BASE", _( "countdown: " ), "", iteminfo::lower_is_better,
                                    to_seconds<int>( countdown_point - calendar::turn ) );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8025,11 +8025,12 @@ void item::calc_rot_while_processing( time_duration processing_duration )
     last_temp_check += processing_duration;
 }
 
-bool item::process_decay_in_air( map& here, Character *carrier, const tripoint& pos, int max_air_exposure_hours,
+bool item::process_decay_in_air( map &here, Character *carrier, const tripoint &pos,
+                                 int max_air_exposure_hours,
                                  time_duration time_delta )
 {
     if( !has_own_flag( flag_FROZEN ) ) {
-        double environment_multiplier = here.is_outside(pos) ? 2.0 : 1.0;
+        double environment_multiplier = here.is_outside( pos ) ? 2.0 : 1.0;
         time_duration new_air_exposure = time_duration::from_seconds( item_counter ) + time_delta *
                                          rng_normal( 0.9, 1.1 ) * environment_multiplier;
         if( new_air_exposure >= time_duration::from_hours( max_air_exposure_hours ) ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8025,12 +8025,13 @@ void item::calc_rot_while_processing( time_duration processing_duration )
     last_temp_check += processing_duration;
 }
 
-bool item::process_decay_in_air( Character *carrier, int max_air_exposure_hours,
+bool item::process_decay_in_air( map& here, Character *carrier, const tripoint& pos, int max_air_exposure_hours,
                                  time_duration time_delta )
 {
     if( !has_own_flag( flag_FROZEN ) ) {
+        double environment_multiplier = here.is_outside(pos) ? 2.0 : 1.0;
         time_duration new_air_exposure = time_duration::from_seconds( item_counter ) + time_delta *
-                                         rng_normal( 0.9, 1.1 );
+                                         rng_normal( 0.9, 1.1 ) * environment_multiplier;
         if( new_air_exposure >= time_duration::from_hours( max_air_exposure_hours ) ) {
             convert( *type->revert_to, carrier );
             return true;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -12833,7 +12833,8 @@ bool item::process_temperature_rot( float insulation, const tripoint &pos, map &
             }
             last_temp_check = time;
 
-            if( decays_in_air && process_decay_in_air( carrier, max_air_exposure_hours, time_delta ) ) {
+            if( decays_in_air &&
+                process_decay_in_air( here, carrier, pos, max_air_exposure_hours, time_delta ) ) {
                 return false;
             }
 
@@ -12855,7 +12856,8 @@ bool item::process_temperature_rot( float insulation, const tripoint &pos, map &
         calc_temp( temp, insulation, now - time );
         last_temp_check = now;
 
-        if( decays_in_air && process_decay_in_air( carrier, max_air_exposure_hours, now - time ) ) {
+        if( decays_in_air &&
+            process_decay_in_air( here, carrier, pos, max_air_exposure_hours, now - time ) ) {
             return false;
         }
 

--- a/src/item.h
+++ b/src/item.h
@@ -1040,6 +1040,9 @@ class item : public visitable
          */
         void calc_rot_while_processing( time_duration processing_duration );
 
+        bool calc_decay_in_air( Character *carrier, int max_air_exposure_hours,
+                                time_duration processing_duration );
+
         /**
          * Update temperature for things like food
          * Update rot for things that perish
@@ -1051,7 +1054,8 @@ class item : public visitable
          * @return true if the item is fully rotten and is ready to be removed
          */
         bool process_temperature_rot( float insulation, const tripoint &pos, map &here, Character *carrier,
-                                      temperature_flag flag = temperature_flag::NORMAL, float spoil_modifier = 1.0f );
+                                      temperature_flag flag = temperature_flag::NORMAL, float spoil_modifier = 1.0f,
+                                      bool watertight_container = false );
 
         /** Set the item to HOT and resets last_temp_check */
         void heat_up();
@@ -1448,7 +1452,7 @@ class item : public visitable
          */
         bool process( map &here, Character *carrier, const tripoint &pos, float insulation = 1,
                       temperature_flag flag = temperature_flag::NORMAL, float spoil_multiplier_parent = 1.0f,
-                      bool recursive = true );
+                      bool watertight_container = false, bool recursive = true );
 
         bool leak( map &here, Character *carrier, const tripoint &pos, item_pocket *pocke = nullptr );
 
@@ -3006,8 +3010,8 @@ class item : public visitable
         const use_function *get_use_internal( const std::string &use_name ) const;
         template<typename Item>
         static Item *get_usable_item_helper( Item &self, const std::string &use_name );
-        bool process_internal( map &here, Character *carrier, const tripoint &pos, float insulation = 1,
-                               temperature_flag flag = temperature_flag::NORMAL, float spoil_modifier = 1.0f );
+        bool process_internal( map &here, Character *carrier, const tripoint &pos, float insulation,
+                               temperature_flag flag, float spoil_modifier, bool watertight_container );
         void iterate_covered_body_parts_internal( side s,
                 const std::function<void( const bodypart_str_id & )> &cb ) const;
         void iterate_covered_sub_body_parts_internal( side s,

--- a/src/item.h
+++ b/src/item.h
@@ -1040,9 +1040,6 @@ class item : public visitable
          */
         void calc_rot_while_processing( time_duration processing_duration );
 
-        bool calc_decay_in_air( Character *carrier, int max_air_exposure_hours,
-                                time_duration processing_duration );
-
         /**
          * Update temperature for things like food
          * Update rot for things that perish
@@ -3077,6 +3074,9 @@ class item : public visitable
         bool process_blackpowder_fouling( Character *carrier );
         bool process_gun_cooling( Character *carrier );
         bool process_tool( Character *carrier, const tripoint &pos );
+        bool process_decay_in_air( Character *carrier, int max_air_exposure_hours,
+                                   time_duration time_delta );
+
 
     public:
         static const int INFINITE_CHARGES;

--- a/src/item.h
+++ b/src/item.h
@@ -3074,7 +3074,7 @@ class item : public visitable
         bool process_blackpowder_fouling( Character *carrier );
         bool process_gun_cooling( Character *carrier );
         bool process_tool( Character *carrier, const tripoint &pos );
-        bool process_decay_in_air( Character *carrier, int max_air_exposure_hours,
+        bool process_decay_in_air( map& here, Character *carrier, const tripoint& pos, int max_air_exposure_hours,
                                    time_duration time_delta );
 
 

--- a/src/item.h
+++ b/src/item.h
@@ -3074,7 +3074,8 @@ class item : public visitable
         bool process_blackpowder_fouling( Character *carrier );
         bool process_gun_cooling( Character *carrier );
         bool process_tool( Character *carrier, const tripoint &pos );
-        bool process_decay_in_air( map& here, Character *carrier, const tripoint& pos, int max_air_exposure_hours,
+        bool process_decay_in_air( map &here, Character *carrier, const tripoint &pos,
+                                   int max_air_exposure_hours,
                                    time_duration time_delta );
 
 

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -2494,11 +2494,12 @@ void item_contents::remove_internal( const std::function<bool( item & )> &filter
 }
 
 void item_contents::process( map &here, Character *carrier, const tripoint &pos, float insulation,
-                             temperature_flag flag, float spoil_multiplier_parent )
+                             temperature_flag flag, float spoil_multiplier_parent, bool watertight_container )
 {
     for( item_pocket &pocket : contents ) {
         if( pocket.is_type( pocket_type::CONTAINER ) ) {
-            pocket.process( here, carrier, pos, insulation, flag, spoil_multiplier_parent );
+            pocket.process( here, carrier, pos, insulation, flag, spoil_multiplier_parent,
+                            watertight_container );
         }
     }
 }

--- a/src/item_contents.h
+++ b/src/item_contents.h
@@ -352,7 +352,8 @@ class item_contents
          * NOTE: this destroys the items that get processed
          */
         void process( map &here, Character *carrier, const tripoint &pos, float insulation = 1,
-                      temperature_flag flag = temperature_flag::NORMAL, float spoil_multiplier_parent = 1.0f );
+                      temperature_flag flag = temperature_flag::NORMAL, float spoil_multiplier_parent = 1.0f,
+                      bool watertight_container = false );
 
         void leak( map &here, Character *carrier, const tripoint &pos, item_pocket *pocke = nullptr );
 

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -899,7 +899,7 @@ bool item_pocket::detonate( const tripoint &pos, std::vector<item> &drops )
 }
 
 bool item_pocket::process( const itype &type, map &here, Character *carrier, const tripoint &pos,
-                           float insulation, const temperature_flag flag )
+                           float insulation, temperature_flag flag, bool watertight_container )
 {
     bool processed = false;
     float spoil_multiplier = 1.0f;
@@ -908,7 +908,7 @@ bool item_pocket::process( const itype &type, map &here, Character *carrier, con
             spoil_multiplier = 0.0f;
         }
         if( it->process( here, carrier, pos, type.insulation_factor * insulation, flag,
-                         spoil_multiplier ) ) {
+                         spoil_multiplier, watertight_container ) ) {
             it->spill_contents( pos );
             it = contents.erase( it );
             processed = true;
@@ -1983,12 +1983,13 @@ void item_pocket::remove_items_if( const std::function<bool( item & )> &filter )
 }
 
 void item_pocket::process( map &here, Character *carrier, const tripoint &pos, float insulation,
-                           temperature_flag flag, float spoil_multiplier_parent )
+                           temperature_flag flag, float spoil_multiplier_parent, bool watertight_container )
 {
     for( auto iter = contents.begin(); iter != contents.end(); ) {
         if( iter->process( here, carrier, pos, insulation, flag,
                            // spoil multipliers on pockets are not additive or multiplicative, they choose the best
-                           std::min( spoil_multiplier_parent, spoil_multiplier() ) ) ) {
+                           std::min( spoil_multiplier_parent, spoil_multiplier() ),
+                           watertight_container || can_contain_liquid( false ) ) ) {
             iter->spill_contents( pos );
             iter = contents.erase( iter );
         } else {

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -279,7 +279,7 @@ class item_pocket
         std::string translated_sealed_prefix() const;
         bool detonate( const tripoint &p, std::vector<item> &drops );
         bool process( const itype &type, map &here, Character *carrier, const tripoint &pos,
-                      float insulation, temperature_flag flag );
+                      float insulation, temperature_flag flag, bool watertight_container );
         void remove_all_ammo( Character &guy );
         void remove_all_mods( Character &guy );
 
@@ -304,7 +304,8 @@ class item_pocket
          * NOTE: this destroys the items that get processed
          */
         void process( map &here, Character *carrier, const tripoint &pos, float insulation = 1,
-                      temperature_flag flag = temperature_flag::NORMAL, float spoil_multiplier_parent = 1.0f );
+                      temperature_flag flag = temperature_flag::NORMAL, float spoil_multiplier_parent = 1.0f,
+                      bool watertight_container = false );
 
         void leak( map &here, Character *carrier, const tripoint &pos, item_pocket *pocke = nullptr );
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5561,10 +5561,11 @@ void map::update_lum( item_location &loc, bool add )
 }
 
 static bool process_map_items( map &here, item_stack &items, safe_reference<item> &item_ref,
-                               item *parent, const tripoint &location, const float insulation,
-                               const temperature_flag flag, const float spoil_multiplier )
+                               item *parent, const tripoint &location, float insulation,
+                               temperature_flag flag, float spoil_multiplier, bool watertight_container )
 {
-    if( item_ref->process( here, nullptr, location, insulation, flag, spoil_multiplier, false ) ) {
+    if( item_ref->process( here, nullptr, location, insulation, flag, spoil_multiplier,
+                           watertight_container, false ) ) {
         // Item is to be destroyed so erase it from the map stack
         // unless it was already destroyed by processing.
         if( item_ref ) {
@@ -5760,7 +5761,8 @@ void map::process_items_in_submap( submap &current_submap, const tripoint &gridp
 
         process_map_items( *this, items, active_item_ref.item_ref, active_item_ref.parent,
                            map_location, 1, flag,
-                           spoil_multiplier * active_item_ref.spoil_multiplier() );
+                           spoil_multiplier * active_item_ref.spoil_multiplier(),
+                           active_item_ref.has_watertight_container() );
     }
 }
 
@@ -5841,7 +5843,7 @@ void map::process_items_in_vehicle( vehicle &cur_veh, submap &current_submap )
         }
         if( !process_map_items( *this, items, active_item_ref.item_ref, active_item_ref.parent,
                                 item_loc, it_insulation, flag,
-                                active_item_ref.spoil_multiplier() ) ) {
+                                active_item_ref.spoil_multiplier(), active_item_ref.has_watertight_container() ) ) {
             // If the item was NOT destroyed, we can skip the remainder,
             // which handles fallout from the vehicle being damaged.
             continue;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Clean water in open containers reverts to water after a while"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
Continuation from https://github.com/CleverRaven/Cataclysm-DDA/pull/72252#issuecomment-1993440272.
If in an open container, eventually clean water (or spring or mineral water) will accumulate some environmental bacteria and become slightly dangerous to drink.

Ref #72.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
This doesn't use the rot system because:
1. That makes "clean water" show up as a perishable, which is a bit weird, and
2. spoil_multiplier isn't quite the right system to model this—e.g. a 3L glass
   jar with a lid on will happily preserve clean water basically forever, but
   it has no spoil_multiplier unless sealed.

Instead, I've added a new DECAYS_IN_AIR flag that will use an item's
`revert_to` field to convert to a different item after it's been exposed to
atmosphere for long enough (defined by an item property
`max_air_exposure_hours`). This is calculated similarly to rot, but slightly
randomized to avoid all clean water decaying at the same moment.

"exposed to atmosphere" here is defined as not in a container that
`can_contain_liquid( false )`, i.e. a container that's watertight even if it's
in another container. (This excludes items like a drinking glass, which is
watertight but can't be packed and still hold its contents.)

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
Clean water could become a perishable (with a long shelf life) and use regular
spoil rules. This would be simpler and more visible to the player, but would be
a less realistic model.

Instead of using watertight to define "exposed to atmosphere", we could use the
airtight flag. However, a lot of totally fine watertight containers for
storing water aren't listed as airtight, e.g. 2lcanteen, 30gal_barrel,
bag_zipper, etc.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
I tested:
1. water_clean in a stock pot, after the max_air_exposure_hours, it turned into water.
2. water_clean in a glass jar, after the max_air_exposure_hours, it turned was still water_clean.

Not yet tested:
- water_clean in a water heater shouldn't decay
- water_clean in an open container in a fridge or vehicle fridge shouldn't decay
- frozen water_clean shouldn't decay
- putting partly decayed water_clean into a closed container should stop the decay. returning it to an open container should resume the decay.
- when outside the player's reality bubble, decay should still happen.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
