### PR TITLE
Remove extreme kcal cost for Pounce, decrease cost for Slime Spray and Bioluminescent Flare

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -405,7 +405,7 @@
     "threshreq": [ "THRESH_INSECT" ],
     "active": true,
     "kcal": true,
-    "cost": 400,
+    "cost": 40,
     "activated_eocs": [ "EOC_BIOLUM3_activated" ]
   },
   {
@@ -3897,7 +3897,7 @@
     "description": "You exude slime from your pores.  You can spread that slime on an opponent in melee range.",
     "active": true,
     "kcal": true,
-    "cost": 700,
+    "cost": 70,
     "activated_is_setup": false,
     "activated_eocs": [ "EOC_SLIME_SPRAY" ],
     "prereqs": [ "VISCOUS", "AMORPHOUS" ],
@@ -4440,8 +4440,6 @@
     "description": "You've gained a strong ability to leap a short distance from a standing position with little preparation time.",
     "//": "This is differentiated from the other two leaps by a shorter range yet a shorter prep time. Probably less useful than them since it will still exhaust you.",
     "active": true,
-    "kcal": true,
-    "cost": 400,
     "activated_is_setup": false,
     "activated_eocs": [ "EOC_FELINE_LEAP" ],
     "cancels": [ "LEAPING_LEGS", "LEAPING_LEGS2" ],


### PR DESCRIPTION
#### Summary
Balance "Removed kcal cost of Pounce, decreased kcal cost of Slime Spray and Bioluminescent Flare"

#### Purpose of change

Pounce/Feline Leap costs a whopping 400 kcal to use, in addition to its stamina cost. This extremely high, as a single long jump shouldn't burn as much energy as ~40 minutes of high-intensity cardio. Furthermore, the other mutation leap abilities have no kcal cost at all, making this seem like a mistake.

Two other mutations have similarly high kcal costs: Slime Spray (700 kcal) and Bioluminescent Flare (400 kcal). It makes sense for both of these abilities to have kcal costs, as they involve the player creating substances from their body, but the costs of these abilities are many times higher than other, similar abilities, like creating webs or firing quills.

#### Describe the solution

Removed the kcal cost of Feline Leap. Costing stamina like the other leap abilities is enough.

Divided the kcal cost of Slime Spray and Bioluminescent Flare by 10. This brings Slime Spray roughly in line with Web Weaver (69 kcal). There's no realism-based math behind this change, so if anyone thinks they should be higher, feel free to argue.

#### Describe alternatives you've considered

Leaving Slime Spray and Bioluminescent Flare alone.

Reducing Feline Leap's cost to a small amount rather than removing it entirely, and adding a comparable cost to the other leap abilities.

#### Testing

Created a character with the relevant mutations, saw that the costs were changed correctly, and made sure the mutations still worked.
