### PR TITLE
NPC @ menu: Show morale, medical; Change name, gender, armor sprite

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -4446,7 +4446,7 @@
     "type": "keybinding",
     "id": "CHANGE_ARMOR_SPRITE",
     "category": "PLAYER_INFO",
-    "name": "Change sprite of armor.",
+    "name": "Change armor sprite",
     "bindings": [ { "input_method": "keyboard_char", "key": "W" }, { "input_method": "keyboard_code", "key": "w", "mod": [ "shift" ] } ]
   },
   {

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -54,7 +54,6 @@
 #include "martialarts.h"
 #include "messages.h"
 #include "mission.h"
-#include "morale.h"
 #include "move_mode.h"
 #include "mutation.h"
 #include "npc.h"
@@ -84,8 +83,6 @@
 #include "veh_type.h"
 #include "vehicle.h"
 #include "vpart_position.h"
-
-class monfaction;
 
 static const bionic_id bio_cloak( "bio_cloak" );
 static const bionic_id bio_soporific( "bio_soporific" );
@@ -137,7 +134,6 @@ static const ter_str_id ter_t_pit_shallow( "t_pit_shallow" );
 
 static const trait_id trait_ARACHNID_ARMS( "ARACHNID_ARMS" );
 static const trait_id trait_ARACHNID_ARMS_OK( "ARACHNID_ARMS_OK" );
-static const trait_id trait_CENOBITE( "CENOBITE" );
 static const trait_id trait_CHITIN2( "CHITIN2" );
 static const trait_id trait_CHITIN3( "CHITIN3" );
 static const trait_id trait_CHITIN_FUR3( "CHITIN_FUR3" );
@@ -942,26 +938,6 @@ int avatar::print_info( const catacurses::window &w, int vStart, int, int column
 mfaction_id avatar::get_monster_faction() const
 {
     return monfaction_player.id();
-}
-
-void avatar::disp_morale()
-{
-    int equilibrium = calc_focus_equilibrium();
-
-    int sleepiness_penalty = 0;
-    const int sleepiness_cap = focus_equilibrium_sleepiness_cap( equilibrium );
-
-    if( sleepiness_cap < equilibrium ) {
-        sleepiness_penalty = equilibrium - sleepiness_cap;
-        equilibrium = sleepiness_cap;
-    }
-
-    int pain_penalty = 0;
-    if( get_perceived_pain() && !has_trait( trait_CENOBITE ) ) {
-        pain_penalty = calc_focus_equilibrium( true ) - equilibrium - sleepiness_penalty;
-    }
-
-    morale->display( equilibrium, pain_penalty, sleepiness_penalty );
 }
 
 void avatar::reset_stats()

--- a/src/avatar.h
+++ b/src/avatar.h
@@ -161,8 +161,6 @@ class avatar : public Character
 
         /** Provides the window and detailed morale data */
         void disp_morale();
-        /** Opens the medical window */
-        void disp_medical();
         /** Resets stats, and applies effects in an idempotent manner */
         void reset_stats() override;
         /** Resets all missions before saving character to template */

--- a/src/avatar.h
+++ b/src/avatar.h
@@ -159,8 +159,6 @@ class avatar : public Character
         nc_color basic_symbol_color() const override;
         int print_info( const catacurses::window &w, int vStart, int vLines, int column ) const override;
 
-        /** Provides the window and detailed morale data */
-        void disp_morale();
         /** Resets stats, and applies effects in an idempotent manner */
         void reset_stats() override;
         /** Resets all missions before saving character to template */

--- a/src/character.h
+++ b/src/character.h
@@ -1895,6 +1895,8 @@ class Character : public Creature, public visitable
         bool enough_power_for( const bionic_id &bid ) const;
         /** Handles and displays detailed character info for the '@' screen */
         void disp_info( bool customize_character = false );
+        /** Provides the window and detailed morale data */
+        void disp_morale();
         /** Opens the medical window */
         void disp_medical();
         void conduct_blood_analysis();

--- a/src/character.h
+++ b/src/character.h
@@ -1895,6 +1895,8 @@ class Character : public Creature, public visitable
         bool enough_power_for( const bionic_id &bid ) const;
         /** Handles and displays detailed character info for the '@' screen */
         void disp_info( bool customize_character = false );
+        /** Opens the medical window */
+        void disp_medical();
         void conduct_blood_analysis();
         // --------------- Generic Item Stuff ---------------
 

--- a/src/character_morale.cpp
+++ b/src/character_morale.cpp
@@ -35,6 +35,7 @@ static const morale_type morale_perm_hoarder( "morale_perm_hoarder" );
 static const morale_type morale_perm_noface( "morale_perm_noface" );
 static const morale_type morale_perm_nomad( "morale_perm_nomad" );
 
+static const trait_id trait_CENOBITE( "CENOBITE" );
 static const trait_id trait_HOARDER( "HOARDER" );
 static const trait_id trait_NOMAD( "NOMAD" );
 static const trait_id trait_NOMAD2( "NOMAD2" );
@@ -210,3 +211,22 @@ void Character::check_and_recover_morale()
     }
 }
 
+void Character::disp_morale()
+{
+    int equilibrium = calc_focus_equilibrium();
+
+    int sleepiness_penalty = 0;
+    const int sleepiness_cap = focus_equilibrium_sleepiness_cap( equilibrium );
+
+    if( sleepiness_cap < equilibrium ) {
+        sleepiness_penalty = equilibrium - sleepiness_cap;
+        equilibrium = sleepiness_cap;
+    }
+
+    int pain_penalty = 0;
+    if( get_perceived_pain() && !has_trait( trait_CENOBITE ) ) {
+        pain_penalty = calc_focus_equilibrium( true ) - equilibrium - sleepiness_penalty;
+    }
+
+    morale->display( equilibrium, pain_penalty, sleepiness_penalty );
+}

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1362,7 +1362,7 @@ std::string display::colorized_compass_legend_text( int width, int max_height, i
                     name = colorize( "@", c_pink );
                     break;
             }
-            name = string_format( "%s %s", name, n->name );
+            name = string_format( "%s %s", name, n->get_name() );
             names.emplace_back( name );
         }
     }

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -495,7 +495,7 @@ void talk_function::wake_up( npc &p )
 
 void talk_function::reveal_stats( npc &p )
 {
-    p.disp_info();
+    p.disp_info( true );
 }
 
 void talk_function::end_conversation( npc &p )

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -1152,7 +1152,7 @@ static void on_customize_character( Character &you )
     }
 }
 
-static void change_armor_sprite( avatar &you )
+static void change_armor_sprite( Character &you )
 {
     item_location target_loc;
     target_loc = game_menus::inv::change_sprite( you );
@@ -1168,17 +1168,14 @@ static void change_armor_sprite( avatar &you )
         menu.query();
         if( menu.ret == 0 ) {
             item_location sprite_loc;
-            avatar *you = get_player_character().as_avatar();
             auto armor_filter = [&]( const item & i ) {
                 return i.is_armor();
             };
-            if( you != nullptr ) {
-                sprite_loc = game_menus::inv::titled_filter_menu( armor_filter,
-                             *you,
-                             _( "Select appearance of this armor:" ),
-                             -1,
-                             _( "You have nothing to wear." ) );
-            }
+            sprite_loc = game_menus::inv::titled_filter_menu( armor_filter,
+                         you,
+                         _( "Select appearance of this armor:" ),
+                         -1,
+                         _( "You have nothing to wear." ) );
             if( sprite_loc && sprite_loc.get_item() ) {
                 const item *sprite_item = sprite_loc.get_item();
                 const std::string variant = sprite_item->has_itype_variant() ? sprite_item->itype_variant().id : "";
@@ -1494,9 +1491,7 @@ static bool handle_player_display_action( Character &you, unsigned int &line,
         info_line = 0;
         ui_info.invalidate_ui();
     } else if( action == "CHANGE_ARMOR_SPRITE" ) {
-        if( you.as_avatar() ) {
-            change_armor_sprite( *you.as_avatar() );
-        }
+        change_armor_sprite( you );
     }
     return done;
 }

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -1447,9 +1447,7 @@ static bool handle_player_display_action( Character &you, unsigned int &line,
         ++info_line;
         ui_info.invalidate_ui();
     } else if( action == "MEDICAL_MENU" ) {
-        if( you.is_avatar() ) {
-            you.as_avatar()->disp_medical();
-        }
+        you.disp_medical();
     } else if( action == "SELECT_STATS_TAB" ) {
         invalidate_tab( curtab );
         curtab = player_display_tab::stats;

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -1375,9 +1375,7 @@ static bool handle_player_display_action( Character &you, unsigned int &line,
                         }
                         break;
                     case 1:
-                        if( you.is_avatar() ) {
-                            you.as_avatar()->disp_morale();
-                        }
+                        you.disp_morale();
                         break;
                     case 2:
                         ctxt.display_menu();
@@ -1431,9 +1429,7 @@ static bool handle_player_display_action( Character &you, unsigned int &line,
         show_proficiencies_window( you );
 
     } else if( action == "morale" ) {
-        if( you.is_avatar() ) {
-            you.as_avatar()->disp_morale( );
-        }
+        you.disp_morale( );
     } else if( action == "VIEW_BODYSTAT" ) {
         display_bodygraph( you );
     } else if( customize_character && action == "SWITCH_GENDER" ) {


### PR DESCRIPTION
#### Summary
Features "NPC @ menu: Show morale, medical; Change name, gender, armor sprite"

#### Purpose of change

Resolve #74314 - my issue, all the info is there
Resolve #72138

#### Describe the solution

 - Move disp_morale, medical, from `avatar` to `Character`.
   - Medical menu `apply` uses some avatar use_action. Changed the behaviour so that: If called on avatar, use as before, if NPC, popup `Apply not implemented for NPCs.`
 - Allow calling all the things mentioned in summary from NPC @ menu.
 - Conversation topic "I'd like to know a bit more about your abilities." now does allow customization of name and gender.
 - Show the `display_name` in widgets in the side panel: https://github.com/CleverRaven/Cataclysm-DDA/pull/74406#issuecomment-2156253373

#### Describe alternatives you've considered

Train of thought:
1. "I'd like to know a bit more about your abilities." calls `reveal_stats`.
2. `reveal_stats` is called from allied NPCs, and unique NPCs under topics: `TALK_FRIEND_Liam_Abilities` and `TALK_FRIEND_Luo_Abilities`.
3. So we could split the calls to not be able to change these two unique NPCs but still change allied NPCs.

But I decided to keep it as is, I never met those guys and I assume it is not super important to forbid customizing these characters specifically. Should we forbid to do other actions (show morale, medical)?

Also, do IWYU. I would need to compile tests, so I didn't do it.

#### Testing

Compile, launch game try all the shortcuts. Try the popup in NPC @ menu > medical > apply.

Didn't test: medical: check that `.pos()` still works. - if it were called by an NPC. I believe it does still work.

#### Additional context

Ref:
 - #66931
 - #51142