### PR TITLE
Modification of recipes related to iodine

### DIFF
--- a/data/json/recipes/recipe_medsandchemicals.json
+++ b/data/json/recipes/recipe_medsandchemicals.json
@@ -574,7 +574,7 @@
     "skills_required": [ "firstaid", 1 ],
     "difficulty": 4,
     "time": "24 m",
-    "charges": 996,
+    "charges": 3,
     "book_learn": [ [ "adv_chemistry", 4 ], [ "textbook_chemistry", 4 ], [ "recipe_labchem", 4 ], [ "atomic_survival", 5 ] ],
     "proficiencies": [
       { "proficiency": "prof_intro_chemistry" },
@@ -585,9 +585,37 @@
     "qualities": [ { "id": "CHEM", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 25, "LIST" ] ] ],
     "components": [
-      [ [ "iodine_crystal", 218 ] ],
-      [ [ "chem_potassium_hydroxide", 600 ], [ "lye_potassium", 15 ] ],
-      [ [ "ammonia_hydroxide", 1 ] ]
+      [ [ "iodine_crystal", 1 ] ],
+      [ [ "chem_potassium_hydroxide", 2 ] ],
+      [ [ "formic_acid", 1 ] ],
+      [ [ "water", 1 ], [ "water_clean", 1 ] ]
+    ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "result": "iodine_crystal",
+    "category": "CC_CHEM",
+    "subcategory": "CSC_CHEM_DRUGS",
+    "skill_used": "chemistry",
+    "difficulty": 3,
+    "time": "60 m",
+    "book_learn": [ [ "adv_chemistry", 3 ], [ "textbook_chemistry", 3 ], [ "recipe_labchem", 3 ], [ "atomic_survival", 4 ] ],
+    "proficiencies": [
+      { "proficiency": "prof_intro_chemistry" },
+      { "proficiency": "prof_inorganic_chemistry" },
+      { "proficiency": "prof_intro_chem_synth" },
+      { "proficiency": "prof_pharmaceutical" }
+    ],
+    "qualities": [ { "id": "CHEM", "level": 2 } ],
+    "tools": [ [ [ "surface_heat", 25, "LIST" ] ] ],
+    "components": [
+      [ [ "kombu", 150 ] ],
+      [ [ "ether", 80 ] ],
+      [ [ "chem_washing_soda", 30 ] ],
+      [ [ "chem_muriatic_acid", 1 ] ],
+      [ [ "chem_hydrogen_peroxide", 1 ] ],
+      [ [ "water", 1 ], [ "water_clean", 1 ] ]
     ]
   },
   {


### PR DESCRIPTION
#### Summary

Content "Modification of recipes related to iodine"

#### Purpose of change

For a recipe for adding extracted iodine from kombucha, I've described in a previous issue. (https://github.com/CleverRaven/Cataclysm-DDA/issues/74391)
In addition, the current in-game recipe for potassium iodide doesn't make sense. First, it requires too many raw materials and produces too many products, and second, ammonia does not have enough reducing properties to allow it to reduce potassium iodate to potassium iodide. A more reasonable way is to use formic acid for reduction.

#### Describe the solution

Modify the recipe for potassium iodide and add a recipe for extracting iodine from kombu.

#### Describe alternatives you've considered

None.

#### Testing

Go into the game, check the recipe, and all is well.

#### Additional context

None.