### PR TITLE
KA-BAR now looks like National Guard Bayonet

### DIFF
--- a/data/json/items/melee/swords_and_blades.json
+++ b/data/json/items/melee/swords_and_blades.json
@@ -523,6 +523,7 @@
     "to_hit": { "grip": "weapon", "length": "hand", "surface": "point", "balance": "good" },
     "material": [ "hc_steel", "leather" ],
     "repairs_with": [ "steel" ],
+    "looks_like": "knife_combat",
     "symbol": "/",
     "color": "dark_gray",
     "qualities": [ [ "CUT", 2 ], [ "CUT_FINE", 1 ], [ "BUTCHER", 27 ] ],


### PR DESCRIPTION
#### Summary
Features "Made KA-BAR knife look like National Guard Bayonet"

#### Purpose of change
Gave knife_KABAR the tag "looks_like": "knife_combat", making it share a wielded and ground sprite with the National Guard Bayonet. Previously it had an ASCII character for a tile sprite and no wielded sprite.

#### Describe the solution

This change makes the KA-BAR have a sprite and wielded sprite.

#### Describe alternatives you've considered

Creating unique sprites for the KA-BAR. I'm not great at pixel art so I don't know how well I'd be able to make a unique sprite.

#### Testing
I didn't think such a small change warranted any testing.