### PR TITLE
Revert conflicting fix that caused #74158

### DIFF
--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -5048,7 +5048,7 @@ void submap::load( const JsonValue &jv, const std::string &member_name, int vers
             if( spawn_entry.has_more() ) {
                 spawn_entry.throw_error( "Too many values for spawn" );
             }
-            spawn_point tmp( type, count, p, faction_id, mission_id, friendly, *name );
+            spawn_point tmp( type, count, p, faction_id, mission_id, friendly, name );
             spawns.push_back( tmp );
         }
     } else if( member_name == "vehicles" ) {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fixes #74158 
Fixes #74203
When backporting #71860 in #73684 I applied a fix that was subsequently conflicted with by a more complete fix in #71861 backported in #73921.  This caused inability to deserialize (by crashing) some valid monster spawn entries.

#### Describe the solution
Revert the commit https://github.com/CleverRaven/Cataclysm-DDA/commit/456277ac1af08110e2058271378c356f0dae6e16
With std::optional handling in place this breaks the code instead of fixing it.

#### Testing
I created a failing save as per the instructions in #74158 and reproduced the crash. More notes on what is going wrong there.
After reverting this commit the save successfully loads.