### PR TITLE
Added a portable makeshift brazier

### DIFF
--- a/data/json/furniture_and_terrain/furniture-fireplaces.json
+++ b/data/json/furniture_and_terrain/furniture-fireplaces.json
@@ -74,7 +74,7 @@
     "id": "f_makeshift_brazier",
     "name": "makeshift brazier",
     "looks_like": "bucket",
-    "description": "A metal bucket with holes in which to safely burn things.  It's too small to fit any fule larger than splintered wood.",
+    "description": "A metal bucket with holes, in which you can safely start a fire.  It's too small to fit any fuel item larger than some splintered wood.",
     "symbol": "#",
     "color": "red",
     "move_cost_mod": 2,

--- a/data/json/furniture_and_terrain/furniture-fireplaces.json
+++ b/data/json/furniture_and_terrain/furniture-fireplaces.json
@@ -71,6 +71,33 @@
   },
   {
     "type": "furniture",
+    "id": "f_makeshift_brazier",
+    "name": "makeshift brazier",
+    "looks_like": "bucket",
+    "description": "A metal bucket with holes in which to safely burn things.  It's too small to fit any fule larger than splintered wood.",
+    "symbol": "#",
+    "color": "red",
+    "move_cost_mod": 2,
+    "coverage": 35,
+    "required_str": 4,
+    "crafting_pseudo_item": "fake_fireplace",
+    "flags": [ "PLACE_ITEM", "TRANSPARENT", "FIRE_CONTAINER", "EASY_DECONSTRUCT" ],
+    "deployed_item": "makeshift_brazier",
+    "examine_action": "fireplace",
+    "bash": {
+      "str_min": 8,
+      "str_max": 30,
+      "sound": "metal screeching!",
+      "sound_fail": "clang!",
+      "items": [
+        { "item": "scrap", "count": [ 3, 6 ] },
+        { "item": "steel_chunk", "count": [ 1, 3 ] },
+        { "item": "sheet_metal_small", "count": [ 1, 3 ] }
+      ]
+    }
+  },
+  {
+    "type": "furniture",
     "id": "f_hobo_stove",
     "name": "hobo stove",
     "description": "A small improvised wood stove, made from a metal can.  It's too small to fit any fuel much larger than splintered wood.",

--- a/data/json/furniture_and_terrain/furniture-fireplaces.json
+++ b/data/json/furniture_and_terrain/furniture-fireplaces.json
@@ -80,6 +80,7 @@
     "move_cost_mod": 2,
     "coverage": 35,
     "required_str": 4,
+    "max_volume": "5 L",
     "crafting_pseudo_item": "fake_fireplace",
     "flags": [ "PLACE_ITEM", "TRANSPARENT", "FIRE_CONTAINER", "EASY_DECONSTRUCT" ],
     "deployed_item": "makeshift_brazier",

--- a/data/json/items/tool/deployable.json
+++ b/data/json/items/tool/deployable.json
@@ -20,6 +20,28 @@
     "//2": "Based on https://www.amazon.com/dp/B0BQ6JNS2H"
   },
   {
+    "id": "makeshift_brazier",
+    "type": "TOOL",
+    "name": { "str": "makeshift brazier" },
+    "description": "A protable brazier fashioned from a steel bucket by punching small holes on the sides to imrove air supply.  It is too small to fit anything much larger than splintered wood.  Fires set in the bucket will not spread to surrounding flammable objects",
+    "copy-from": "bucket",
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "rigid": true,
+        "watertight": false,
+        "open_container": true,
+        "max_contains_volume": "5000 ml",
+        "max_contains_weight": "20 kg"
+      }
+    ],
+    "use_action": {
+      "type": "deploy_furn",
+      "furn_type": "f_makeshift_brazier"
+    },
+    "qualities": [ [ "COOK", 1 ], [ "BOIL", 1 ], [ "CONTAIN", 1 ] ]
+  },
+  {
     "id": "hobo_stove",
     "type": "TOOL",
     "name": { "str": "hobo stove" },

--- a/data/json/items/tool/deployable.json
+++ b/data/json/items/tool/deployable.json
@@ -35,10 +35,7 @@
         "max_contains_weight": "20 kg"
       }
     ],
-    "use_action": {
-      "type": "deploy_furn",
-      "furn_type": "f_makeshift_brazier"
-    },
+    "use_action": { "type": "deploy_furn", "furn_type": "f_makeshift_brazier" },
     "qualities": [ [ "COOK", 1 ], [ "BOIL", 1 ], [ "CONTAIN", 1 ] ]
   },
   {

--- a/data/json/items/tool/deployable.json
+++ b/data/json/items/tool/deployable.json
@@ -23,7 +23,7 @@
     "id": "makeshift_brazier",
     "type": "TOOL",
     "name": { "str": "makeshift brazier" },
-    "description": "A protable brazier fashioned from a steel bucket by punching small holes on the sides to imrove air supply.  It is too small to fit anything much larger than splintered wood.  Fires set in the bucket will not spread to surrounding flammable objects",
+    "description": "A portable brazier fashioned from a steel bucket by punching small holes on the sides to improve the air supply.  It is too small to fit any fuel item larger than some splintered wood.  Fires set in this bucket will not spread to surrounding flammable objects",
     "copy-from": "bucket",
     "pocket_data": [
       {

--- a/data/json/recipes/recipe_others.json
+++ b/data/json/recipes/recipe_others.json
@@ -1040,6 +1040,20 @@
   },
   {
     "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "result": "makeshift_brazier",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_TOOLS",
+    "skill_used": "survival",
+    "difficulty": 1,
+    "time": "10 m",
+    "autolearn": true,
+    "qualities": [ { "id": "HAMMER", "level": 1 } ],
+    "tools": [ [ [ "spike", -1 ], [ "nail", -1 ], [ "sharp_rock", -1 ], [ "rebar", -1 ], [ "spear_rebar", -1 ] ] ],
+    "components": [ [ [ "bucket", 1 ] ] ]
+  },
+  {
+    "type": "recipe",
     "activity_level": "MODERATE_EXERCISE",
     "result": "55gal_firebarrel",
     "category": "CC_OTHER",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Added a portable makeshift brazier created from  a bucket."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Closes #73187 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Added the item, the corresponding furniture and the recipe.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Not to add it.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Crafted the brazier, deployed it and lit a fire then took it down.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

The sprite looks good
 
![brazier](https://github.com/CleverRaven/Cataclysm-DDA/assets/48031422/c0e18bb0-c763-4dcc-8d9d-1b29b44cc66d)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
