### PR TITLE
[MoM] Extend mood stabilization to others outside of dialogue

### DIFF
--- a/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
+++ b/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
@@ -909,7 +909,7 @@ Powers causing telepathic damage have a 5% chance to down the target, a 33% chan
 
 ## Mood Stabilization (C)
 *Difficulty*: 3<br />
-*Target*: Self or one within 2 squares plus 1.1 squares per power level<br />
+*Target*: Self or one within 3 squares plus 1.1 squares per power level<br />
 *Duration*: 16 minutes and 21 seconds to 42 minutes, plus 6 minutes and 21 seconds to 14 minutes and 59 seconds per power level when used on self, indefinite when used on others<br />
 *Stamina Cost*: 5000, minus 125 per level to a minimum of 2000<br />
 *Channeling Time*: 300 moves, minus 9.5 moves per level to a minimum of 150<br />

--- a/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
+++ b/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
@@ -913,7 +913,7 @@ Powers causing telepathic damage have a 5% chance to down the target, a 33% chan
 *Duration*: 16 minutes and 21 seconds to 42 minutes, plus 6 minutes and 21 seconds to 14 minutes and 59 seconds per power level when used on self, indefinite when used on others<br />
 *Stamina Cost*: 5000, minus 125 per level to a minimum of 2000<br />
 *Channeling Time*: 300 moves, minus 9.5 moves per level to a minimum of 150<br />
-*Effects*: When used on oneself, edit the psion's mind, removing negative thoughts and improving mood. Adds a morale bonus of +10 (building up to a maximum of 25). When used on others, increases a target NPC's trust by 0.25 per power level and reduces both fear and anger by 0.5 per power level (usable a maximum of once per 12 hours) or reduces a target monster's aggression by power level times 5 (usable once per minute). It may also be used in dialogue to calm down angry NPCs.<br />
+*Effects*: When used on oneself, edit the psion's mind, removing negative thoughts and improving mood. Adds a morale bonus of +10 (building up to a maximum of 25). When used on others, increases a target NPC's trust by 0.25 per power level and reduces both fear and anger by 0.5 per power level (usable a maximum of once per 12 hours) or reduces a target monster's aggression by power level times 5 (usable once per 5 minutes). It may also be used in dialogue to calm down angry NPCs.<br />
 *Prerequisites*: Concentration Trance 6, Sense Minds 5<br />
 
 ## Synaptic Blast

--- a/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
+++ b/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
@@ -909,11 +909,11 @@ Powers causing telepathic damage have a 5% chance to down the target, a 33% chan
 
 ## Mood Stabilization (C)
 *Difficulty*: 3<br />
-*Target*: Self (or dialogue)<br />
-*Duration*: 16 minutes and 21 seconds to 42 minutes, plus 6 minutes and 21 seconds to 14 minutes and 59 seconds per power level<br />
+*Target*: Self or one within 2 squares plus 1.1 squares per power level<br />
+*Duration*: 16 minutes and 21 seconds to 42 minutes, plus 6 minutes and 21 seconds to 14 minutes and 59 seconds per power level when used on self, indefinite when used on others<br />
 *Stamina Cost*: 5000, minus 125 per level to a minimum of 2000<br />
 *Channeling Time*: 300 moves, minus 9.5 moves per level to a minimum of 150<br />
-*Effects*: Further edit the psion's mind, removing negative thoughts and improving mood. Adds a morale bonus of +10 (building up to a maximum of 25). It may also be used in dialogue to calm down angry NPCs.<br />
+*Effects*: When used on oneself, edit the psion's mind, removing negative thoughts and improving mood. Adds a morale bonus of +10 (building up to a maximum of 25). When used on others, increases a target NPC's trust by 0.25 per power level and reduces both fear and anger by 0.5 per power level (usable a maximum of once per 12 hours) or reduces a target monster's aggression by power level times 5 (usable once per minute). It may also be used in dialogue to calm down angry NPCs.<br />
 *Prerequisites*: Concentration Trance 6, Sense Minds 5<br />
 
 ## Synaptic Blast

--- a/data/mods/MindOverMatter/effects/effects_psionic.json
+++ b/data/mods/MindOverMatter/effects/effects_psionic.json
@@ -1641,6 +1641,13 @@
   },
   {
     "type": "effect_type",
+    "id": "effect_telepath_mood_stabilization_attitude_modified",
+    "//": "A tracker effect to prevent the target's morale or fear from being modified more than once in a period of time",
+    "name": [ "" ],
+    "desc": [ "" ]
+  },
+  {
+    "type": "effect_type",
     "id": "telepathic_ignorance",
     "name": [ "Ignorance" ],
     "desc": [ "You're positive that no one is there." ],

--- a/data/mods/MindOverMatter/monsters/species_overrides.json
+++ b/data/mods/MindOverMatter/monsters/species_overrides.json
@@ -40,6 +40,13 @@
   },
   {
     "type": "SPECIES",
+    "id": "ROBOT_FLYING",
+    "description": "a flying robot",
+    "footsteps": "WHIRR",
+    "flags": [ "LOUDMOVES", "TEEP_IMMUNE" ]
+  },
+  {
+    "type": "SPECIES",
     "id": "FUNGUS",
     "description": "a fungus",
     "fear_triggers": [ "HURT", "FIRE" ],

--- a/data/mods/MindOverMatter/powers/telepathy.json
+++ b/data/mods/MindOverMatter/powers/telepathy.json
@@ -248,7 +248,18 @@
     "final_casting_time": 75,
     "casting_time_increment": -3.5,
     "targeted_monster_species": [ "MAMMAL", "BIRD", "AMPHIBIAN", "REPTILE", "FISH" ],
-    "ignored_monster_species": [ "ZOMBIE", "ROBOT", "NETHER", "NETHER_EMANATION", "LEECH_PLANT", "WORM", "FUNGUS", "SLIME", "PSI_NULL" ]
+    "ignored_monster_species": [
+      "ZOMBIE",
+      "ROBOT",
+      "ROBOT_FLYING",
+      "NETHER",
+      "NETHER_EMANATION",
+      "LEECH_PLANT",
+      "WORM",
+      "FUNGUS",
+      "SLIME",
+      "PSI_NULL"
+    ]
   },
   {
     "id": "telepathic_confusion",
@@ -290,7 +301,7 @@
     "base_casting_time": 90,
     "final_casting_time": 40,
     "casting_time_increment": -3.5,
-    "ignored_monster_species": [ "ROBOT", "NETHER_EMANATION", "LEECH_PLANT", "WORM", "FUNGUS", "SLIME", "PSI_NULL" ]
+    "ignored_monster_species": [ "ROBOT", "ROBOT_FLYING", "NETHER_EMANATION", "LEECH_PLANT", "WORM", "FUNGUS", "SLIME", "PSI_NULL" ]
   },
   {
     "id": "telepathic_confusion_blind",
@@ -320,7 +331,7 @@
         "( (u_spell_level('telepathic_confusion') * 2) + 3) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
       ]
     },
-    "ignored_monster_species": [ "ROBOT", "NETHER_EMANATION", "LEECH_PLANT", "WORM", "FUNGUS", "SLIME", "PSI_NULL" ]
+    "ignored_monster_species": [ "ROBOT", "ROBOT_FLYING", "NETHER_EMANATION", "LEECH_PLANT", "WORM", "FUNGUS", "SLIME", "PSI_NULL" ]
   },
   {
     "id": "telepathic_fear",
@@ -356,7 +367,18 @@
     "base_casting_time": 125,
     "final_casting_time": 50,
     "casting_time_increment": -5,
-    "ignored_monster_species": [ "ZOMBIE", "ROBOT", "NETHER", "NETHER_EMANATION", "LEECH_PLANT", "WORM", "FUNGUS", "SLIME", "PSI_NULL" ]
+    "ignored_monster_species": [
+      "ZOMBIE",
+      "ROBOT",
+      "ROBOT_FLYING",
+      "NETHER",
+      "NETHER_EMANATION",
+      "LEECH_PLANT",
+      "WORM",
+      "FUNGUS",
+      "SLIME",
+      "PSI_NULL"
+    ]
   },
   {
     "id": "telepathic_invisibility",
@@ -403,7 +425,7 @@
     "base_casting_time": 100,
     "final_casting_time": 25,
     "casting_time_increment": -6.5,
-    "ignored_monster_species": [ "ZOMBIE", "ROBOT", "NETHER_EMANATION", "LEECH_PLANT", "WORM", "FUNGUS", "SLIME", "PSI_NULL" ]
+    "ignored_monster_species": [ "ZOMBIE", "ROBOT", "ROBOT_FLYING", "NETHER_EMANATION", "LEECH_PLANT", "WORM", "FUNGUS", "SLIME", "PSI_NULL" ]
   },
   {
     "id": "telepathic_invisibility_self",
@@ -547,7 +569,18 @@
     "energy_increment": -185,
     "base_casting_time": 12000,
     "targeted_monster_species": [ "MAMMAL", "BIRD", "AMPHIBIAN", "REPTILE", "FISH" ],
-    "ignored_monster_species": [ "ZOMBIE", "ROBOT", "NETHER", "NETHER_EMANATION", "LEECH_PLANT", "WORM", "FUNGUS", "SLIME", "PSI_NULL" ]
+    "ignored_monster_species": [
+      "ZOMBIE",
+      "ROBOT",
+      "ROBOT_FLYING",
+      "NETHER",
+      "NETHER_EMANATION",
+      "LEECH_PLANT",
+      "WORM",
+      "FUNGUS",
+      "SLIME",
+      "PSI_NULL"
+    ]
   },
   {
     "id": "telepathic_beast_taming_pet",
@@ -579,7 +612,18 @@
     },
     "max_range": 70,
     "targeted_monster_species": [ "MAMMAL", "BIRD", "AMPHIBIAN", "REPTILE", "FISH" ],
-    "ignored_monster_species": [ "ZOMBIE", "ROBOT", "NETHER", "NETHER_EMANATION", "LEECH_PLANT", "WORM", "FUNGUS", "SLIME", "PSI_NULL" ]
+    "ignored_monster_species": [
+      "ZOMBIE",
+      "ROBOT",
+      "ROBOT_FLYING",
+      "NETHER",
+      "NETHER_EMANATION",
+      "LEECH_PLANT",
+      "WORM",
+      "FUNGUS",
+      "SLIME",
+      "PSI_NULL"
+    ]
   },
   {
     "id": "telepathic_mind_control",
@@ -630,7 +674,18 @@
     "base_casting_time": 120,
     "final_casting_time": 65,
     "casting_time_increment": -3.5,
-    "ignored_monster_species": [ "ZOMBIE", "ROBOT", "NETHER", "NETHER_EMANATION", "LEECH_PLANT", "WORM", "FUNGUS", "SLIME", "PSI_NULL" ]
+    "ignored_monster_species": [
+      "ZOMBIE",
+      "ROBOT",
+      "ROBOT_FLYING",
+      "NETHER",
+      "NETHER_EMANATION",
+      "LEECH_PLANT",
+      "WORM",
+      "FUNGUS",
+      "SLIME",
+      "PSI_NULL"
+    ]
   },
   {
     "id": "telepathic_network",

--- a/data/mods/MindOverMatter/powers/telepathy.json
+++ b/data/mods/MindOverMatter/powers/telepathy.json
@@ -113,10 +113,10 @@
     "id": "telepathic_morale",
     "type": "SPELL",
     "name": "[Ψ]Mood Stabilization (C)",
-    "description": "With the ability to edit others' thoughts comes the ability to edit your own, removing negative moods to a degree.\n\nThis power <color_yellow>is maintained by concentration</color> and <color_red>may fail</color> if <color_yellow>concentration is interrupted</color>.",
+    "description": "With the ability to edit others' thoughts comes the ability to edit your own, removing negative moods to a degree.  YOu have also learned to do this more subtly on others, calming their anger or assuaging their fears.\n\nWhen used on yourself, this power <color_yellow>is maintained by concentration</color> and <color_red>may fail</color> if <color_yellow>concentration is interrupted</color>.",
     "message": "",
     "teachable": false,
-    "valid_targets": [ "self" ],
+    "valid_targets": [ "self", "ally", "hostile" ],
     "spell_class": "TELEPATH",
     "skill": "metaphysics",
     "flags": [ "PSIONIC", "CONCENTRATE", "SILENT", "NO_HANDS", "NO_LEGS", "RANDOM_DURATION" ],
@@ -135,6 +135,12 @@
         "( (u_spell_level('telepathic_morale') * 89900) + 252000) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
       ]
     },
+    "min_range": {
+      "math": [
+        "min( (( (u_spell_level('telepathic_morale') * 1.1) + 3) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling), 80)"
+      ]
+    },
+    "max_range": 80,
     "energy_source": "STAMINA",
     "base_energy_cost": {
       "math": [
@@ -145,7 +151,19 @@
       "math": [
         "u_effect_intensity('effect_telepathic_morale') > -1 ? 10 : max((300 -(u_spell_level('telepathic_morale') * 9.5)), 150)"
       ]
-    }
+    },
+    "ignored_monster_species": [
+      "ZOMBIE",
+      "ROBOT",
+      "ROBOT_FLYING",
+      "NETHER",
+      "NETHER_EMANATION",
+      "LEECH_PLANT",
+      "WORM",
+      "FUNGUS",
+      "SLIME",
+      "PSI_NULL"
+    ]
   },
   {
     "id": "telepathic_blast",

--- a/data/mods/MindOverMatter/powers/telepathy.json
+++ b/data/mods/MindOverMatter/powers/telepathy.json
@@ -113,7 +113,7 @@
     "id": "telepathic_morale",
     "type": "SPELL",
     "name": "[Ψ]Mood Stabilization (C)",
-    "description": "With the ability to edit others' thoughts comes the ability to edit your own, removing negative moods to a degree.  YOu have also learned to do this more subtly on others, calming their anger or assuaging their fears.\n\nWhen used on yourself, this power <color_yellow>is maintained by concentration</color> and <color_red>may fail</color> if <color_yellow>concentration is interrupted</color>.",
+    "description": "With the ability to edit others' thoughts comes the ability to edit your own, removing negative moods to a degree.  You have also learned to do this more subtly on others, calming their anger or assuaging their fears.\n\nWhen used on yourself, this power <color_yellow>is maintained by concentration</color> and <color_red>may fail</color> if <color_yellow>concentration is interrupted</color>.",
     "message": "",
     "teachable": false,
     "valid_targets": [ "self", "ally", "hostile" ],

--- a/data/mods/MindOverMatter/powers/telepathy_concentration_eoc.json
+++ b/data/mods/MindOverMatter/powers/telepathy_concentration_eoc.json
@@ -182,7 +182,7 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_TELEPATH_MORALE_INITIATE",
+    "id": "EOC_TELEPATH_MORALE_INITIATE_SELF",
     "condition": { "not": { "u_has_effect": "effect_telepathic_morale" } },
     "effect": [
       { "u_message": "You begin to edit out your discouraging thoughts.", "type": "good" },

--- a/data/mods/MindOverMatter/powers/telepathy_eoc.json
+++ b/data/mods/MindOverMatter/powers/telepathy_eoc.json
@@ -52,9 +52,7 @@
             "id": "EOC_TELEPATH_MORALE_MODIFY_NPC_VALUES_2",
             "condition": { "not": { "u_has_effect": "effect_telepathic_psi_armor" } },
             "effect": [
-              {
-                "math": [ "u_val('npc_fear')", "=", "max(-10, (u_val('npc_fear') - (u_mood_stabilized_power_level / 2)))" ]
-              },
+              { "math": [ "u_val('npc_fear')", "=", "max(-10, (u_val('npc_fear') - (u_mood_stabilized_power_level / 2)))" ] },
               {
                 "math": [ "u_val('npc_anger')", "=", "max(-10, (u_val('npc_anger') - (u_mood_stabilized_power_level / 2)))" ]
               },

--- a/data/mods/MindOverMatter/powers/telepathy_eoc.json
+++ b/data/mods/MindOverMatter/powers/telepathy_eoc.json
@@ -52,17 +52,14 @@
             "id": "EOC_TELEPATH_MORALE_MODIFY_NPC_VALUES_2",
             "condition": { "not": { "u_has_effect": "effect_telepathic_psi_armor" } },
             "effect": [
-              { "math": [ "u_pre_power_fear", "=", "u_val('npc_fear')" ] },
-              { "math": [ "u_pre_power_anger", "=", "u_val('npc_anger')" ] },
-              { "math": [ "u_pre_power_trust", "=", "u_val('npc_trust')" ] },
               {
-                "math": [ "u_val('npc_fear')", "=", "max(-10, (u_pre_power_fear - (u_mood_stabilized_power_level / 2)))" ]
+                "math": [ "u_val('npc_fear')", "=", "max(-10, (u_val('npc_fear') - (u_mood_stabilized_power_level / 2)))" ]
               },
               {
-                "math": [ "u_val('npc_anger')", "=", "max(-10, (u_pre_power_anger - (u_mood_stabilized_power_level / 2)))" ]
+                "math": [ "u_val('npc_anger')", "=", "max(-10, (u_val('npc_anger') - (u_mood_stabilized_power_level / 2)))" ]
               },
               {
-                "math": [ "u_val('npc_trust')", "=", "min(20, (u_pre_power_trust + (u_mood_stabilized_power_level / 4)))" ]
+                "math": [ "u_val('npc_trust')", "=", "min(20, (u_val('npc_trust') + (u_mood_stabilized_power_level / 4)))" ]
               },
               {
                 "npc_message": "You reach in and, with a deft touch, sooth your target's negative emotions.",

--- a/data/mods/MindOverMatter/powers/telepathy_eoc.json
+++ b/data/mods/MindOverMatter/powers/telepathy_eoc.json
@@ -1,6 +1,67 @@
 [
   {
     "type": "effect_on_condition",
+    "id": "EOC_TELEPATH_MORALE_INITIATE",
+    "condition": "u_is_avatar",
+    "effect": [ { "run_eocs": "EOC_TELEPATH_MORALE_INITIATE_SELF" } ],
+    "false_effect": [
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_TELEPATH_MORALE_INITIATE_NPC_CHECK",
+            "condition": "u_is_npc",
+            "effect": [
+              { "math": [ "u_telepathy_intelligence", "=", "( ( n_val('intelligence') + 10) / 20 )" ] },
+              { "math": [ "u_telepathy_power_level", "=", "n_spell_level('telepathic_morale')" ] },
+              { "math": [ "u_nether_attunement_telepathy_scaling", "=", "n_nether_attunement_power_scaling" ] },
+              {
+                "math": [
+                  "u_mood_stabilized_power_level",
+                  "=",
+                  "u_telepathy_power_level * u_telepathy_intelligence * u_nether_attunement_telepathy_scaling"
+                ]
+              },
+              { "run_eocs": "EOC_TELEPATH_MORALE_MODIFY_NPC_VALUES" }
+            ],
+            "false_effect": [
+              { "math": [ "u_telepathy_intelligence", "=", "( ( n_val('intelligence') + 10) / 20 )" ] },
+              { "math": [ "u_telepathy_power_level", "=", "n_spell_level('telepathic_morale')" ] },
+              { "math": [ "u_nether_attunement_telepathy_scaling", "=", "n_nether_attunement_power_scaling" ] },
+              {
+                "math": [
+                  "u_mood_stabilized_power_level",
+                  "=",
+                  "u_telepathy_power_level * u_telepathy_intelligence * u_nether_attunement_telepathy_scaling"
+                ]
+              },
+              { "run_eocs": "EOC_TELEPATH_MORALE_MODIFY_MONSTER_VALUES" }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_TELEPATH_MORALE_MODIFY_NPC_VALUES",
+    "condition": { "not": { "u_has_effect": "effect_telepath_mood_stabilization_attitude_modified" } },
+    "effect": [
+      { "math": [ "u_val('npc_fear')", "-=", "u_mood_stabilized_power_level / 2" ] },
+      { "math": [ "u_val('npc_anger')", "-=", "u_mood_stabilized_power_level / 2" ] },
+      { "u_add_effect": "effect_telepath_mood_stabilization_attitude_modified", "duration": "12 hours" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_TELEPATH_MORALE_MODIFY_MONSTER_VALUES",
+    "condition": { "not": { "u_has_effect": "effect_telepath_mood_stabilization_attitude_modified" } },
+    "effect": [
+      { "math": [ "u_val('anger')", "-=", "u_mood_stabilized_power_level * 5" ] },
+      { "u_add_effect": "effect_telepath_mood_stabilization_attitude_modified", "duration": "12 hours" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_TELEPATH_PRIMAL_TERROR",
     "condition": {
       "and": [

--- a/data/mods/MindOverMatter/powers/telepathy_eoc.json
+++ b/data/mods/MindOverMatter/powers/telepathy_eoc.json
@@ -46,9 +46,26 @@
     "id": "EOC_TELEPATH_MORALE_MODIFY_NPC_VALUES",
     "condition": { "not": { "u_has_effect": "effect_telepath_mood_stabilization_attitude_modified" } },
     "effect": [
-      { "math": [ "u_val('npc_fear')", "-=", "u_mood_stabilized_power_level / 2" ] },
-      { "math": [ "u_val('npc_anger')", "-=", "u_mood_stabilized_power_level / 2" ] },
-      { "u_add_effect": "effect_telepath_mood_stabilization_attitude_modified", "duration": "12 hours" }
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_TELEPATH_MORALE_MODIFY_NPC_VALUES_2",
+            "condition": { "not": { "u_has_effect": "effect_telepathic_psi_armor" } },
+            "effect": [
+              { "math": [ "u_val('npc_fear')", "-=", "u_mood_stabilized_power_level / 2" ] },
+              { "math": [ "u_val('npc_anger')", "-=", "u_mood_stabilized_power_level / 2" ] },
+              { "math": [ "u_val('npc_trust')", "+=", "u_mood_stabilized_power_level / 3" ] },
+              { "u_add_effect": "effect_telepath_mood_stabilization_attitude_modified", "duration": "12 hours" }
+            ],
+            "false_effect": [
+              {
+                "npc_message": "You attempt to edit the target's mood, but your powers slam into a smooth, unyielding barrier and slide off.",
+                "type": "bad"
+              }
+            ]
+          }
+        ]
+      }
     ]
   },
   {
@@ -56,8 +73,24 @@
     "id": "EOC_TELEPATH_MORALE_MODIFY_MONSTER_VALUES",
     "condition": { "not": { "u_has_effect": "effect_telepath_mood_stabilization_attitude_modified" } },
     "effect": [
-      { "math": [ "u_val('anger')", "-=", "u_mood_stabilized_power_level * 5" ] },
-      { "u_add_effect": "effect_telepath_mood_stabilization_attitude_modified", "duration": "12 hours" }
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_TELEPATH_MORALE_MODIFY_MONSTER_VALUES_2",
+            "condition": { "not": { "u_has_effect": "effect_telepathic_psi_armor" } },
+            "effect": [
+              { "math": [ "u_val('anger')", "-=", "u_mood_stabilized_power_level * 5" ] },
+              { "u_add_effect": "effect_telepath_mood_stabilization_attitude_modified", "duration": "12 hours" }
+            ],
+            "false_effect": [
+              {
+                "npc_message": "You attempt to edit the target's mood, but your powers slam into a smooth, unyielding barrier and slide off.",
+                "type": "bad"
+              }
+            ]
+          }
+        ]
+      }
     ]
   },
   {

--- a/data/mods/MindOverMatter/powers/telepathy_eoc.json
+++ b/data/mods/MindOverMatter/powers/telepathy_eoc.json
@@ -52,9 +52,22 @@
             "id": "EOC_TELEPATH_MORALE_MODIFY_NPC_VALUES_2",
             "condition": { "not": { "u_has_effect": "effect_telepathic_psi_armor" } },
             "effect": [
-              { "math": [ "u_val('npc_fear')", "-=", "u_mood_stabilized_power_level / 2" ] },
-              { "math": [ "u_val('npc_anger')", "-=", "u_mood_stabilized_power_level / 2" ] },
-              { "math": [ "u_val('npc_trust')", "+=", "u_mood_stabilized_power_level / 3" ] },
+              { "math": [ "u_pre_power_fear", "=", "u_val('npc_fear')" ] },
+              { "math": [ "u_pre_power_anger", "=", "u_val('npc_anger')" ] },
+              { "math": [ "u_pre_power_trust", "=", "u_val('npc_trust')" ] },
+              {
+                "math": [ "u_val('npc_fear')", "=", "max(-10, (u_pre_power_fear - (u_mood_stabilized_power_level / 2)))" ]
+              },
+              {
+                "math": [ "u_val('npc_anger')", "=", "max(-10, (u_pre_power_anger - (u_mood_stabilized_power_level / 2)))" ]
+              },
+              {
+                "math": [ "u_val('npc_trust')", "=", "min(20, (u_pre_power_trust + (u_mood_stabilized_power_level / 4)))" ]
+              },
+              {
+                "npc_message": "You reach in and, with a deft touch, sooth your target's negative emotions.",
+                "type": "good"
+              },
               { "u_add_effect": "effect_telepath_mood_stabilization_attitude_modified", "duration": "12 hours" }
             ],
             "false_effect": [
@@ -66,6 +79,9 @@
           }
         ]
       }
+    ],
+    "false_effect": [
+      { "npc_message": "You don't want to risk affecting the target's mind too quickly, and withdraw.", "type": "neutral" }
     ]
   },
   {
@@ -80,7 +96,11 @@
             "condition": { "not": { "u_has_effect": "effect_telepathic_psi_armor" } },
             "effect": [
               { "math": [ "u_val('anger')", "-=", "u_mood_stabilized_power_level * 5" ] },
-              { "u_add_effect": "effect_telepath_mood_stabilization_attitude_modified", "duration": "12 hours" }
+              {
+                "npc_message": "You reach in and, with a deft touch, sooth your target's negative emotions.",
+                "type": "good"
+              },
+              { "u_add_effect": "effect_telepath_mood_stabilization_attitude_modified", "duration": "5 minutes" }
             ],
             "false_effect": [
               {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Extend mood stabilization to others outside of dialogue"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

You could use Mood Stabilization in dialogue to edit NPC moods, but not from the powers menu. This fixes that discrepancy. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Make Mood Stabilization targetable on monsters or allies and edit the EoCs. If used on yourself, it works like before. If used on a monster or an NPC, it reduces their anger (if a monster) or reduces their anger and fear and increases their trust (if an NPC). There's a rate limiter effect preventing you from using the power too often, and there is a limit to how much you can reduce fear and anger (or increase trust). 

This does not change anger triggers--if you stabilize a feral so it stops attacking you but just hang around, it's not going to remain docile for very long. 

It doesn't work at all on a target that has Telepathic Shield up.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Tested on both NPCs and monsters, it works. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Probable future addition--NPCs being able to realize you're editing their thoughts (some kind of periodic intelligence check that gets easier if you do it more) and mutinying. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
