### PR TITLE
[Mods] Aftershock/MoM compatibility fix

### DIFF
--- a/data/mods/Aftershock/EOC/esper_eoc.json
+++ b/data/mods/Aftershock/EOC/esper_eoc.json
@@ -104,7 +104,7 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_CONCENTRATION_SUCCESS_PROFICIENCY",
+    "id": "EOC_AFS_CONCENTRATION_SUCCESS_PROFICIENCY",
     "condition": {
       "and": [
         { "not": { "u_has_proficiency": "prof_concentration_basic" } },
@@ -116,7 +116,7 @@
     "false_effect": {
       "run_eocs": [
         {
-          "id": "EOC_CONCENTRATION_SUCCESS_PROFICIENCY_INT",
+          "id": "EOC_AFS_CONCENTRATION_SUCCESS_PROFICIENCY_INT",
           "condition": {
             "and": [
               { "not": { "u_has_proficiency": "prof_concentration_intermediate" } },
@@ -127,7 +127,7 @@
           "false_effect": {
             "run_eocs": [
               {
-                "id": "EOC_CONCENTRATION_SUCCESS_PROFICIENCY_MASTER",
+                "id": "EOC_AFS_CONCENTRATION_SUCCESS_PROFICIENCY_MASTER",
                 "condition": {
                   "and": [
                     { "not": { "u_has_proficiency": "prof_concentration_master" } },

--- a/data/mods/Aftershock/damage_types.json
+++ b/data/mods/Aftershock/damage_types.json
@@ -99,18 +99,18 @@
     "ablative_info": { "order": 301, "show_type": false }
   },
   {
-    "id": "psi_telepathic_damage",
+    "id": "afs_telepathic_damage",
     "type": "damage_type",
     "physical": false,
     "magic_color": "white",
     "name": "telepathic",
     "skill": "metaphysics",
     "immune_flags": { "character": [ "TEEPSHIELD", "PSYSHIELD_PROTECT" ], "monster": [ "TEEP_IMMUNE" ] },
-    "ondamage_eocs": [ "EOC_TELEPATHIC_DAMAGE_PSYSHIELD_CHECK", "EOC_TELEPATHIC_DAMAGE_STUN_HIVE_CHANCE" ]
+    "ondamage_eocs": [ "EOC_AFS_TELEPATHIC_DAMAGE_PSYSHIELD_CHECK", "EOC_AFS_TELEPATHIC_DAMAGE_STUN_HIVE_CHANCE" ]
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_TELEPATHIC_DAMAGE_PSYSHIELD_CHECK",
+    "id": "EOC_AFS_TELEPATHIC_DAMAGE_PSYSHIELD_CHECK",
     "condition": {
       "and": [
         { "npc_has_worn_with_flag": "PSYSHIELD_PARTIAL" },
@@ -125,7 +125,7 @@
       {
         "run_eocs": [
           {
-            "id": "EOC_TELEPATHIC_DAMAGE_PSYSHIELD_CHECK_2",
+            "id": "EOC_AFS_TELEPATHIC_DAMAGE_PSYSHIELD_CHECK_2",
             "condition": { "x_in_y_chance": { "x": 1, "y": 2 } },
             "effect": [
               {
@@ -145,13 +145,17 @@
     ],
     "false_effect": [
       {
-        "run_eocs": [ "EOC_TELEPATHIC_DAMAGE_STUN_CHANCE", "EOC_TELEPATHIC_DAMAGE_DAZED_CHANCE", "EOC_TELEPATHIC_DAMAGE_KNOCKDOWN_CHANCE" ]
+        "run_eocs": [
+          "EOC_AFS_TELEPATHIC_DAMAGE_STUN_CHANCE",
+          "EOC_AFS_TELEPATHIC_DAMAGE_DAZED_CHANCE",
+          "EOC_AFS_TELEPATHIC_DAMAGE_KNOCKDOWN_CHANCE"
+        ]
       }
     ]
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_TELEPATHIC_DAMAGE_KNOCKDOWN_CHANCE",
+    "id": "EOC_AFS_TELEPATHIC_DAMAGE_KNOCKDOWN_CHANCE",
     "condition": {
       "and": [
         { "x_in_y_chance": { "x": 1, "y": 20 } },
@@ -165,7 +169,7 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_TELEPATHIC_DAMAGE_STUN_CHANCE",
+    "id": "EOC_AFS_TELEPATHIC_DAMAGE_STUN_CHANCE",
     "condition": {
       "and": [
         { "x_in_y_chance": { "x": 1, "y": 3 } },
@@ -179,7 +183,7 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_TELEPATHIC_DAMAGE_DAZED_CHANCE",
+    "id": "EOC_AFS_TELEPATHIC_DAMAGE_DAZED_CHANCE",
     "condition": {
       "and": [
         { "x_in_y_chance": { "x": 2, "y": 3 } },
@@ -193,14 +197,14 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_TELEPATHIC_DAMAGE_STUN_HIVE_CHANCE",
+    "id": "EOC_AFS_TELEPATHIC_DAMAGE_STUN_HIVE_CHANCE",
     "condition": {
       "and": [ { "x_in_y_chance": { "x": 1, "y": 6 } }, { "math": [ "_damage_taken", ">", "0" ] }, { "npc_has_flag": "HIVE_MIND" } ]
     },
     "effect": [ { "npc_add_effect": "psi_stunned", "duration": "5 s" } ]
   },
   {
-    "id": "psi_telepathic_damage",
+    "id": "afs_telepathic_damage",
     "type": "damage_info_order",
     "info_display": "detailed",
     "verb": "mindblasting",

--- a/data/mods/Aftershock/effects_esper.json
+++ b/data/mods/Aftershock/effects_esper.json
@@ -87,14 +87,17 @@
     "rating": "good",
     "max_duration": "7 days",
     "max_intensity": 50,
-    "enchantments": [
+    "enchantments": [ "ench_afs_telepath_sense_minds" ]
+  },
+  {
+    "type": "enchantment",
+    "id": "ench_afs_telepath_sense_minds",
+    "condition": "ALWAYS",
+    "has": "HELD",
+    "values": [
       {
-        "values": [
-          {
-            "value": "SIGHT_RANGE_MINDS",
-            "add": { "math": [ "( ( u_spell_level('afs_telepathic_mind_sense') * 2) * (scaling_factor(u_val('intelligence') ) ) )" ] }
-          }
-        ]
+        "value": "SIGHT_RANGE_MINDS",
+        "add": { "math": [ "( ( u_spell_level('afs_telepathic_mind_sense') * 2) * (scaling_factor(u_val('intelligence') ) ) )" ] }
       }
     ]
   },

--- a/data/mods/Aftershock/spells/psionics/telepathy.json
+++ b/data/mods/Aftershock/spells/psionics/telepathy.json
@@ -142,7 +142,7 @@
     "max_level": { "math": [ "int_to_level(1)" ] },
     "effect": "attack",
     "effect_str": "blind",
-    "damage_type": "psi_telepathic_damage",
+    "damage_type": "afs_telepathic_damage",
     "shape": "blast",
     "min_duration": {
       "math": [ "( (u_spell_level('afs_telepathic_confusion') * 100) + 400) * (scaling_factor(u_val('intelligence') ) ) " ]
@@ -178,7 +178,7 @@
     "max_level": { "math": [ "int_to_level(1)" ] },
     "effect": "attack",
     "shape": "blast",
-    "damage_type": "psi_telepathic_damage",
+    "damage_type": "afs_telepathic_damage",
     "min_damage": { "math": [ "( (u_spell_level('afs_telepathic_blast') * 1.5) + 5) * (scaling_factor(u_val('intelligence') ) ) " ] },
     "max_damage": { "math": [ "( (u_spell_level('afs_telepathic_blast') * 3) + 5) * (scaling_factor(u_val('intelligence') ) ) " ] },
     "min_range": {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "[Mods] Aftershock/MoM compatibility"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I didn't realize that when two mods are loaded on the same level (i.e. when neither is dependent on the other), EoCs don't overwrite, they clash and cause an error, making it impossible to even load a game that has both MoM and Aftershock enabled.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Change some EoC IDs and set some effects to draw on non-inline enchants to allow both mods to load, as well as differentiate Aftershock's telepathic damage.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Game now loads.

PR now clean.

This should fix broken Clang building.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Obviously there's going to be a lot of thematic clash, but at least people can load their saves now.

Only the last-loaded mods' psi practice recipes work since both mods add a practice category. Not sure how to solve that one. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
