### PR TITLE
Remove weird DUKW spawns

### DIFF
--- a/data/json/vehicle_groups.json
+++ b/data/json/vehicle_groups.json
@@ -129,13 +129,7 @@
   {
     "type": "vehicle_group",
     "id": "boatrent",
-    "vehicles": [
-      [ "canoe", 2000 ],
-      [ "kayak", 1500 ],
-      [ "kayak_racing", 500 ],
-      [ "raft", 2000 ],
-      [ "wood_rowboat_double", 1500 ]
-    ]
+    "vehicles": [ [ "canoe", 2000 ], [ "kayak", 1500 ], [ "kayak_racing", 500 ], [ "raft", 2000 ], [ "wood_rowboat_double", 1500 ] ]
   },
   {
     "type": "vehicle_group",

--- a/data/json/vehicle_groups.json
+++ b/data/json/vehicle_groups.json
@@ -133,7 +133,6 @@
       [ "canoe", 2000 ],
       [ "kayak", 1500 ],
       [ "kayak_racing", 500 ],
-      [ "DUKW", 250 ],
       [ "raft", 2000 ],
       [ "wood_rowboat_double", 1500 ]
     ]
@@ -146,7 +145,7 @@
   {
     "type": "vehicle_group",
     "id": "lake",
-    "vehicles": [ [ "DUKW", 250 ], [ "cabin_cruiser_wood", 1500 ] ]
+    "vehicles": [ [ "cabin_cruiser_wood", 1500 ] ]
   },
   {
     "type": "vehicle_group",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
These are vanishingly rare, there is potential to have literally one or two spawning in the whole game as they are sometimes operated as tour vehicles, but having them spawn randomly in marinas or out in the water at any rate is nonsense.

#### Describe the solution
Remove the nonsense spawns.