### PR TITLE
[Xedra Evolved] More paraclesian powers

### DIFF
--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -994,6 +994,14 @@
   },
   {
     "type": "effect_type",
+    "id": "effect_salamander_fire_dot",
+    "name": [ "Fire in the Marrow" ],
+    "desc": [ "Your burning internal organs are making it more difficult to aim." ],
+    "rating": "bad",
+    "base_mods": { "hit_mod": [ -3 ] }
+  },
+  {
+    "type": "effect_type",
     "id": "effect_salamander_featherfall",
     "name": [ "" ],
     "desc": [ "" ],
@@ -1199,6 +1207,17 @@
     "remove_message": "Your feet touch the ground once again.",
     "rating": "good",
     "flags": [ "LEVITATION" ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_sylph_hindering_wind",
+    "name": [ "Hindering Winds" ],
+    "desc": [ "The winds are swirling around you and slowing you down!" ],
+    "apply_message": "A wind swirls up around you, slowing you.",
+    "remove_message": "The wind around you dies down.",
+    "rating": "bad",
+    "base_mods": { "dodge_mod": [ -2 ] },
+    "enchantments": [ { "values": [ { "value": "SPEED", "multiply": -0.1 } ] } ]
   },
   {
     "type": "effect_type",

--- a/data/mods/Xedra_Evolved/items/ethereal_items.json
+++ b/data/mods/Xedra_Evolved/items/ethereal_items.json
@@ -417,5 +417,137 @@
         }
       ]
     }
+  },
+  {
+    "id": "item_ierde_reveal_earth_map_01",
+    "copy-from": "abstractmap",
+    "type": "GENERIC",
+    "category": "maps",
+    "name": "ierde map",
+    "description": "This is a magical map that, if everything works correctly, you'll never actually see.",
+    "color": "brown",
+    "use_action": {
+      "type": "reveal_map",
+      "radius": 15,
+      "terrain": [
+        { "om_terrain": "field", "om_terrain_match_type": "PREFIX" },
+        { "om_terrain": "swamp", "om_terrain_match_type": "TYPE" },
+        { "om_terrain": "forest", "om_terrain_match_type": "PREFIX" },
+        { "om_terrain": "stream", "om_terrain_match_type": "PREFIX" },
+        "solid_earth",
+        "empty_rock"
+      ],
+      "message": "The earth reveals its secrets."
+    }
+  },
+  {
+    "id": "item_ierde_reveal_earth_map_02",
+    "copy-from": "abstractmap",
+    "type": "GENERIC",
+    "category": "maps",
+    "name": "ierde map",
+    "description": "This is a magical map that, if everything works correctly, you'll never actually see.",
+    "color": "brown",
+    "use_action": {
+      "type": "reveal_map",
+      "radius": 20,
+      "terrain": [
+        { "om_terrain": "field", "om_terrain_match_type": "PREFIX" },
+        { "om_terrain": "swamp", "om_terrain_match_type": "TYPE" },
+        { "om_terrain": "forest", "om_terrain_match_type": "PREFIX" },
+        { "om_terrain": "stream", "om_terrain_match_type": "PREFIX" },
+        "solid_earth",
+        "empty_rock"
+      ],
+      "message": "The earth reveals its secrets."
+    }
+  },
+  {
+    "id": "item_ierde_reveal_earth_map_03",
+    "copy-from": "abstractmap",
+    "type": "GENERIC",
+    "category": "maps",
+    "name": "ierde map",
+    "description": "This is a magical map that, if everything works correctly, you'll never actually see.",
+    "color": "brown",
+    "use_action": {
+      "type": "reveal_map",
+      "radius": 25,
+      "terrain": [
+        { "om_terrain": "field", "om_terrain_match_type": "PREFIX" },
+        { "om_terrain": "swamp", "om_terrain_match_type": "TYPE" },
+        { "om_terrain": "forest", "om_terrain_match_type": "PREFIX" },
+        { "om_terrain": "stream", "om_terrain_match_type": "PREFIX" },
+        "solid_earth",
+        "empty_rock"
+      ],
+      "message": "The earth reveals its secrets."
+    }
+  },
+  {
+    "id": "item_ierde_reveal_earth_map_04",
+    "copy-from": "abstractmap",
+    "type": "GENERIC",
+    "category": "maps",
+    "name": "ierde map",
+    "description": "This is a magical map that, if everything works correctly, you'll never actually see.",
+    "color": "brown",
+    "use_action": {
+      "type": "reveal_map",
+      "radius": 30,
+      "terrain": [
+        { "om_terrain": "field", "om_terrain_match_type": "PREFIX" },
+        { "om_terrain": "swamp", "om_terrain_match_type": "TYPE" },
+        { "om_terrain": "forest", "om_terrain_match_type": "PREFIX" },
+        { "om_terrain": "stream", "om_terrain_match_type": "PREFIX" },
+        "solid_earth",
+        "empty_rock"
+      ],
+      "message": "The earth reveals its secrets."
+    }
+  },
+  {
+    "id": "item_ierde_reveal_earth_map_05",
+    "copy-from": "abstractmap",
+    "type": "GENERIC",
+    "category": "maps",
+    "name": "ierde map",
+    "description": "This is a magical map that, if everything works correctly, you'll never actually see.",
+    "color": "brown",
+    "use_action": {
+      "type": "reveal_map",
+      "radius": 35,
+      "terrain": [
+        { "om_terrain": "field", "om_terrain_match_type": "PREFIX" },
+        { "om_terrain": "swamp", "om_terrain_match_type": "TYPE" },
+        { "om_terrain": "forest", "om_terrain_match_type": "PREFIX" },
+        { "om_terrain": "stream", "om_terrain_match_type": "PREFIX" },
+        "solid_earth",
+        "empty_rock"
+      ],
+      "message": "The earth reveals its secrets."
+    }
+  },
+  {
+    "id": "item_ierde_reveal_earth_map_06",
+    "copy-from": "abstractmap",
+    "type": "GENERIC",
+    "category": "maps",
+    "name": "ierde map",
+    "description": "This is a magical map that, if everything works correctly, you'll never actually see.",
+    "color": "brown",
+    "use_action": {
+      "type": "reveal_map",
+      "radius": 40,
+      "terrain": [
+        { "om_terrain": "field", "om_terrain_match_type": "PREFIX" },
+        { "om_terrain": "swamp", "om_terrain_match_type": "TYPE" },
+        { "om_terrain": "forest", "om_terrain_match_type": "PREFIX" },
+        { "om_terrain": "stream", "om_terrain_match_type": "PREFIX" },
+        "solid_earth",
+        "empty_rock"
+      ],
+      "message": "The earth reveals its secrets."
+    }
   }
 ]

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutation_spells.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutation_spells.json
@@ -568,8 +568,32 @@
     "base_casting_time": 6000,
     "final_casting_time": 1500,
     "casting_time_increment": -225,
-    "//": "Energy cost and lack of AoE so that Arvore can't just have infinite food through crop growth.  They need to go stand in the sun for that.",
-    "learn_spells": { "arvore_summon_preservation_container": 6, "arvore_tree_singing_spell": 10 }
+    "learn_spells": { "arvore_summon_preservation_container": 6, "arvore_tree_singing_spell": 10, "arvore_nurture_the_green_aoe": 14 }
+  },
+  {
+    "id": "arvore_nurture_the_green_aoe",
+    "type": "SPELL",
+    "name": "Spreading the Viridian Mantle",
+    "description": "Rather than fostering the growth of a single plant, you can cause a wave of growth all around you, affecting an entire field and bringing it towards ripeness.",
+    "flags": [ "SOMATIC", "VERBAL" ],
+    "spell_class": "ARVORE",
+    "teachable": false,
+    "valid_targets": [ "ground" ],
+    "skill": "deduction",
+    "max_level": { "math": [ "int_to_level(1)" ] },
+    "shape": "blast",
+    "difficulty": 9,
+    "effect": "ter_transform",
+    "effect_str": "ter_arvore_plant_growth",
+    "min_aoe": { "math": [ "(1 + (u_spell_level('arvore_nurture_the_green_aoe') * 1) * (scaling_factor(u_val('intelligence') ) ) )" ] },
+    "max_aoe": { "math": [ "(1 + (u_spell_level('arvore_nurture_the_green_aoe') * 1) * (scaling_factor(u_val('intelligence') ) ) )" ] },
+    "energy_source": "MANA",
+    "base_energy_cost": 4000,
+    "final_energy_cost": 2500,
+    "energy_increment": -50,
+    "base_casting_time": 720000,
+    "final_casting_time": 360000,
+    "casting_time_increment": -15000
   },
   {
     "id": "arvore_growing_wood_walls",
@@ -973,7 +997,7 @@
     "base_casting_time": 200,
     "casting_time_increment": -5,
     "final_casting_time": 100,
-    "ignored_monster_species": [ "NETHER_EMANATION", "ROBOT" ]
+    "ignored_monster_species": [ "NETHER_EMANATION", "ROBOT", "ROBOT_FLYING" ]
   },
   {
     "id": "arvore_turn_into_tree_banish",
@@ -991,7 +1015,7 @@
     "max_damage": { "math": [ "(100 + (u_arvore_turn_into_tree_spell_level * 15)) * u_arvore_turn_into_tree_intelligence" ] },
     "min_range": 0,
     "max_range": 0,
-    "ignored_monster_species": [ "NETHER_EMANATION", "ROBOT" ]
+    "ignored_monster_species": [ "NETHER_EMANATION", "ROBOT", "ROBOT_FLYING" ]
   },
   {
     "id": "arvore_reduce_thirst_spell",
@@ -1118,6 +1142,7 @@
       "ZOMBIE",
       "FERAL",
       "ROBOT",
+      "ROBOT_FLYING",
       "HORROR",
       "ABERRATION",
       "HALLUCINATION",

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_spell_learning_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_spell_learning_eocs.json
@@ -63,6 +63,7 @@
     "condition": {
       "or": [
         { "math": [ "u_spell_level('arvore_nurture_the_green')", "<", "int_to_level(1)" ] },
+        { "math": [ "u_spell_level('arvore_nurture_the_green_aoe')", "<", "int_to_level(1)" ] },
         { "math": [ "u_spell_level('arvore_growing_wood_walls')", "<", "int_to_level(1)" ] },
         { "math": [ "u_spell_level('arvore_commune_with_nature')", "<", "per_to_level(1)" ] },
         { "math": [ "u_spell_level('arvore_summon_briars')", "<", "int_to_level(1)" ] },
@@ -89,6 +90,7 @@
     "effect": {
       "weighted_list_eocs": [
         [ "EOC_LEVELER_ARVORE_NURTURING_THE_GREEN", 9 ],
+        [ "EOC_LEVELER_ARVORE_NURTURING_THE_GREEN_AOE", 2 ],
         [ "EOC_LEVELER_ARVORE_SUMMON_WOOD_WALL", 5 ],
         [ "EOC_LEVELER_ARVORE_COMMUNE_WITH_NATURE", 7 ],
         [ "EOC_LEVELER_ARVORE_SUMMON_BRIARS", 6 ],
@@ -128,6 +130,24 @@
         "type": "good"
       },
       { "math": [ "u_spell_exp('arvore_nurture_the_green')", "+=", "paraclesian_passive_spell_exp(1)" ] }
+    ],
+    "false_effect": [ { "run_eocs": "EOC_ARVORE_SPELL_EXPERIENCE_INCREASER_SELECTOR" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_LEVELER_ARVORE_NURTURING_THE_GREEN_AOE",
+    "condition": {
+      "and": [
+        { "math": [ "u_spell_level('arvore_nurture_the_green_aoe')", ">=", "0" ] },
+        { "math": [ "u_spell_level('arvore_nurture_the_green_aoe')", "<", "int_to_level(1)" ] }
+      ]
+    },
+    "effect": [
+      {
+        "u_message": "Your time spent under the shadows of the trees has increased your facility with your fae magicks.",
+        "type": "good"
+      },
+      { "math": [ "u_spell_exp('arvore_nurture_the_green_aoe')", "+=", "paraclesian_passive_spell_exp(1)" ] }
     ],
     "false_effect": [ { "run_eocs": "EOC_ARVORE_SPELL_EXPERIENCE_INCREASER_SELECTOR" } ]
   },

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/ierde_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/ierde_eocs.json
@@ -1,6 +1,28 @@
 [
   {
     "type": "effect_on_condition",
+    "id": "EOC_CONDITION_CHECK_IERDE_ON_NATURAL_EARTH_OR_UNDERGROUND",
+    "condition": {
+      "or": [
+        { "math": [ "u_val('pos_z')", "<=", "-1" ] },
+        {
+          "and": [
+            { "u_is_on_terrain_with_flag": "DIGGABLE" },
+            { "not": { "u_is_on_terrain": "t_vitrified_sand" } },
+            { "not": { "u_is_on_terrain": "t_pit_corpsed" } },
+            { "not": { "u_is_on_terrain": "t_fungus" } },
+            { "not": { "u_is_on_terrain": "t_glassed_sand" } },
+            { "not": { "u_is_on_terrain": "t_rubber_mulch" } },
+            { "not": { "u_is_on_terrain": "t_swater_surf" } },
+            { "not": { "u_is_on_terrain": "t_woodchips" } }
+          ]
+        }
+      ]
+    },
+    "effect": [  ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_IERDE_DETECT_NEARBY_MONSTERS_EARTH_ON",
     "condition": {
       "or": [
@@ -117,7 +139,26 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_IERDE_REVEAL_MAP",
-    "condition": XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX,
+    "condition": {
+      "and": [
+        {
+          "or": [
+            { "u_is_on_terrain_with_flag": "DIGGABLE" },
+            { "u_is_on_terrain": "t_rock_floor" },
+            { "u_is_on_terrain": "t_railroad_rubble" },
+            { "u_is_on_terrain": "t_dirt_underground" }
+          ]
+        },
+        { "not": { "u_is_on_terrain": "t_grass_alien" } },
+        { "not": { "u_is_on_terrain": "t_vitrified_sand" } },
+        { "not": { "u_is_on_terrain": "t_pit_corpsed" } },
+        { "not": { "u_is_on_terrain": "t_fungus" } },
+        { "not": { "u_is_on_terrain": "t_glassed_sand" } },
+        { "not": { "u_is_on_terrain": "t_rubber_mulch" } },
+        { "not": { "u_is_on_terrain": "t_swater_surf" } },
+        { "not": { "u_is_on_terrain": "t_woodchips" } }
+      ]
+    },
     "effect": {
       "switch": { "math": [ "u_spell_level('ierde_reveal_earth_map_spell')" ] },
       "cases": [

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/ierde_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/ierde_eocs.json
@@ -116,6 +116,131 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_IERDE_REVEAL_MAP",
+    "condition": XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX,
+    "effect": {
+      "switch": { "math": [ "u_spell_level('ierde_reveal_earth_map_spell')" ] },
+      "cases": [
+        {
+          "case": 0,
+          "effect": [
+            { "u_spawn_item": "item_ierde_reveal_earth_map_01", "suppress_message": true },
+            { "run_eocs": "EOC_IERDE_REVEAL_MAP_ITEM_01" },
+            { "u_remove_item_with": "item_ierde_reveal_earth_map_01" }
+          ]
+        },
+        {
+          "case": 3,
+          "effect": [
+            { "u_spawn_item": "item_ierde_reveal_earth_map_02", "suppress_message": true },
+            { "run_eocs": "EOC_IERDE_REVEAL_MAP_ITEM_02" },
+            { "u_remove_item_with": "item_ierde_reveal_earth_map_02" }
+          ]
+        },
+        {
+          "case": 6,
+          "effect": [
+            { "u_spawn_item": "item_ierde_reveal_earth_map_03", "suppress_message": true },
+            { "run_eocs": "EOC_IERDE_REVEAL_MAP_ITEM_03" },
+            { "u_remove_item_with": "item_ierde_reveal_earth_map_03" }
+          ]
+        },
+        {
+          "case": 9,
+          "effect": [
+            { "u_spawn_item": "item_ierde_reveal_earth_map_04", "suppress_message": true },
+            { "run_eocs": "EOC_IERDE_REVEAL_MAP_ITEM_04" },
+            { "u_remove_item_with": "item_ierde_reveal_earth_map_04" }
+          ]
+        },
+        {
+          "case": 12,
+          "effect": [
+            { "u_spawn_item": "item_ierde_reveal_earth_map_05", "suppress_message": true },
+            { "run_eocs": "EOC_IERDE_REVEAL_MAP_ITEM_05" },
+            { "u_remove_item_with": "item_ierde_reveal_earth_map_05" }
+          ]
+        },
+        {
+          "case": 15,
+          "effect": [
+            { "u_spawn_item": "item_ierde_reveal_earth_map_06", "suppress_message": true },
+            { "run_eocs": "EOC_IERDE_REVEAL_MAP_ITEM_06" },
+            { "u_remove_item_with": "item_ierde_reveal_earth_map_06" }
+          ]
+        }
+      ]
+    },
+    "false_effect": [ { "u_message": "Without a direct connection to the living earth, the spell fails." } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_IERDE_REVEAL_MAP_ITEM_01",
+    "effect": [
+      {
+        "u_run_inv_eocs": "random",
+        "search_data": [ { "id": "item_ierde_reveal_earth_map_01" } ],
+        "true_eocs": [ { "id": "EOC_IERDE_REVEAL_MAP_ITEM_01_ACTIVATE", "effect": { "u_activate": "reveal_map" } } ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_IERDE_REVEAL_MAP_ITEM_02",
+    "effect": [
+      {
+        "u_run_inv_eocs": "random",
+        "search_data": [ { "id": "item_ierde_reveal_earth_map_02" } ],
+        "true_eocs": [ { "id": "EOC_IERDE_REVEAL_MAP_ITEM_02_ACTIVATE", "effect": { "u_activate": "reveal_map" } } ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_IERDE_REVEAL_MAP_ITEM_03",
+    "effect": [
+      {
+        "u_run_inv_eocs": "random",
+        "search_data": [ { "id": "item_ierde_reveal_earth_map_03" } ],
+        "true_eocs": [ { "id": "EOC_IERDE_REVEAL_MAP_ITEM_03_ACTIVATE", "effect": { "u_activate": "reveal_map" } } ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_IERDE_REVEAL_MAP_ITEM_04",
+    "effect": [
+      {
+        "u_run_inv_eocs": "random",
+        "search_data": [ { "id": "item_ierde_reveal_earth_map_04" } ],
+        "true_eocs": [ { "id": "EOC_IERDE_REVEAL_MAP_ITEM_04_ACTIVATE", "effect": { "u_activate": "reveal_map" } } ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_IERDE_REVEAL_MAP_ITEM_05",
+    "effect": [
+      {
+        "u_run_inv_eocs": "random",
+        "search_data": [ { "id": "item_ierde_reveal_earth_map_05" } ],
+        "true_eocs": [ { "id": "EOC_IERDE_REVEAL_MAP_ITEM_05_ACTIVATE", "effect": { "u_activate": "reveal_map" } } ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_IERDE_REVEAL_MAP_ITEM_06",
+    "effect": [
+      {
+        "u_run_inv_eocs": "random",
+        "search_data": [ { "id": "item_ierde_reveal_earth_map_06" } ],
+        "true_eocs": [ { "id": "EOC_IERDE_REVEAL_MAP_ITEM_06_ACTIVATE", "effect": { "u_activate": "reveal_map" } } ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_IERDE_SMASHING_PUNCH_activated",
     "effect": [
       {

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/ierde_mutation_spells.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/ierde_mutation_spells.json
@@ -145,6 +145,27 @@
     "max_range": 1
   },
   {
+    "id": "ierde_see_earth_spell",
+    "type": "SPELL",
+    "name": "Knowing the Hills and Valleys",
+    "description": "Commune with the earth, whispering to it to reveal its secrets to you.  This spell will reveal natural features within a large radius around the Ierde.  The spell must be cast while standing on the living earth.",
+    "teachable": false,
+    "flags": [ "SOMATIC", "VERBAL" ],
+    "valid_targets": [ "self" ],
+    "skill": "deduction",
+    "max_level": { "math": [ "per_to_level(1)" ] },
+    "spell_class": "IERDE",
+    "difficulty": 7
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_IERDE_REVEAL_MAP",
+    "shape": "blast",
+    "energy_source": "MANA",
+    "base_energy_cost": 700,
+    "final_energy_cost": 450,
+    "energy_increment": -12,
+    "base_casting_time": 30000
+  },
+  {
     "id": "ierde_reshape_the_earth_spell",
     "type": "SPELL",
     "name": "Reshape the Living Earth",

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/ierde_mutation_spells.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/ierde_mutation_spells.json
@@ -145,7 +145,7 @@
     "max_range": 1
   },
   {
-    "id": "ierde_see_earth_spell",
+    "id": "ierde_reveal_earth_map_spell",
     "type": "SPELL",
     "name": "Knowing the Hills and Valleys",
     "description": "Commune with the earth, whispering to it to reveal its secrets to you.  This spell will reveal natural features within a large radius around the Ierde.  The spell must be cast while standing on the living earth.",

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/ierde_mutation_spells.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/ierde_mutation_spells.json
@@ -147,7 +147,7 @@
   {
     "id": "ierde_reveal_earth_map_spell",
     "type": "SPELL",
-    "name": "Knowing the Hills and Valleys",
+    "name": "Knowing Every Furrow",
     "description": "Commune with the earth, whispering to it to reveal its secrets to you.  This spell will reveal natural features within a large radius around the Ierde.  The spell must be cast while standing on the living earth.",
     "teachable": false,
     "flags": [ "SOMATIC", "VERBAL" ],
@@ -155,7 +155,7 @@
     "skill": "deduction",
     "max_level": { "math": [ "per_to_level(1)" ] },
     "spell_class": "IERDE",
-    "difficulty": 7
+    "difficulty": 7,
     "effect": "effect_on_condition",
     "effect_str": "EOC_IERDE_REVEAL_MAP",
     "shape": "blast",

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/ierde_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/ierde_mutations.json
@@ -97,11 +97,28 @@
     "points": 4,
     "visibility": 0,
     "ugliness": 0,
-    "description": "Your stony skin makes your fists hit like hammers.  Though your attacks are slower, you do more bashing damage with your punches and can use your hands to replace some simple tools.",
+    "description": "The Ierde's stony skin makes their fists hit like hammers.  Though their attacks are slower, the Ierde does more bashing damage with punches and can use their hands to replace some simple tools.",
     "types": [ "CLAWS" ],
     "prereqs": [ "IERDE_SKIN_2", "IERDE_SKIN_3" ],
     "category": [ "IERDE" ],
     "integrated_armor": [ "integrated_ierde_fists" ]
+  },
+  {
+    "type": "mutation",
+    "id": "IERDE_STRONG_EQUIPMENT",
+    "name": { "str": "Stone-Hardened Panoply" },
+    "points": 6,
+    "visibility": 0,
+    "ugliness": 0,
+    "description": "Just as their body is now one with the stone, the Ierde can infuse the strength of the earth into their equipment, rendering it more resilient.  While on natural earth or stone or underground, the Ierde's equipment is twice as difficult to damage.",
+    "prereqs": [ "IERDE_STONE_FISTS" ],
+    "category": [ "IERDE" ],
+    "enchantments": [
+      {
+        "condition": { "test_eoc": "EOC_CONDITION_CHECK_IERDE_ON_NATURAL_EARTH_OR_UNDERGROUND" },
+        "values": [ { "value": "EQUIPMENT_DAMAGE_CHANCE", "multiply": -0.5 } ]
+      }
+    ]
   },
   {
     "type": "mutation",
@@ -172,7 +189,7 @@
   {
     "type": "mutation",
     "id": "IERDE_REVEAL_EARTH_MAP",
-    "name": { "str": "Knowing the Hills and Valleys" },
+    "name": { "str": "Knowing Every Furrow" },
     "points": 6,
     "visibility": 0,
     "ugliness": 0,
@@ -261,7 +278,7 @@
     "ugliness": 0,
     "description": "When gaining this ability, the Ierde gains the ability to infuse the resilience of the earth into one of their allies.",
     "prereqs": [ "IERDE_IRON_ARMOR" ],
-    "prereqs2": [ "IERDE_SLOW_ENEMIES" ],
+    "prereqs2": [ "IERDE_STRONG_EQUIPMENT" ],
     "category": [ "IERDE" ],
     "spells_learned": [ [ "ierde_buff_armor_allies_spell", 1 ] ]
   },

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/ierde_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/ierde_mutations.json
@@ -171,6 +171,18 @@
   },
   {
     "type": "mutation",
+    "id": "IERDE_REVEAL_EARTH_MAP",
+    "name": { "str": "Knowing the Hills and Valleys" },
+    "points": 6,
+    "visibility": 0,
+    "ugliness": 0,
+    "description": "Upon gaining this ability the Ierde gains the ability to learn the terrain layout in a large area around themselves.",
+    "category": [ "IERDE" ],
+    "prereqs": [ "IERDE_PER_BONUS" ],
+    "spells_learned": [ [ "ierde_reveal_earth_map_spell", 1 ] ]
+  },
+  {
+    "type": "mutation",
     "id": "IERDE_CREATE_PITS",
     "name": { "str": "Earthen Grasp" },
     "points": 3,

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/ierde_spell_learning_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/ierde_spell_learning_eocs.json
@@ -11,6 +11,7 @@
           "u_has_any_trait": [
             "IERDE_STOMP_GROUND_SMASH",
             "IERDE_CREATE_PITS",
+            "IERDE_REVEAL_EARTH_MAP",
             "IERDE_KNOCKBACK_PUNCH",
             "IERDE_RESHAPE_THE_EARTH",
             "IERDE_SLOW_ENEMIES",
@@ -59,6 +60,7 @@
         { "math": [ "u_spell_level('ierde_create_pits_spell')", "<", "str_to_level(1)" ] },
         { "math": [ "u_spell_level('ierde_knockback_punch_spell')", "<", "str_to_level(1)" ] },
         { "math": [ "u_spell_level('ierde_iron_armor_spell')", "<", "per_to_level(1)" ] },
+        { "math": [ "u_spell_level('ierde_reveal_earth_map_spell')", "<", "per_to_level(1)" ] },
         { "math": [ "u_spell_level('ierde_reshape_the_earth_spell')", "<", "per_to_level(1)" ] },
         { "math": [ "u_spell_level('ierde_slow_enemies_spell')", "<", "str_to_level(1)" ] },
         { "math": [ "u_spell_level('ierde_entrap_target_in_stone')", "<", "per_to_level(1)" ] },
@@ -76,6 +78,7 @@
         [ "EOC_LEVELER_IERDE_CREATE_PITS", 7 ],
         [ "EOC_LEVELER_IERDE_KNOCKBACK_PUNCH", 9 ],
         [ "EOC_LEVELER_IERDE_IRON_ARMOR", 6 ],
+        [ "EOC_LEVELER_IERDE_REVEAL_EARTH_MAP", 4 ],
         [ "EOC_LEVELER_IERDE_RESHAPE_THE_EARTH", 7 ],
         [ "EOC_LEVELER_IERDE_SLOW_ENEMIES", 5 ],
         [ "EOC_LEVELER_IERDE_ENTRAP_TARGET_IN_STONE", 4 ],
@@ -157,6 +160,24 @@
         "type": "good"
       },
       { "math": [ "u_spell_exp('ierde_iron_armor_spell')", "+=", "paraclesian_passive_spell_exp(1)" ] }
+    ],
+    "false_effect": [ { "run_eocs": "EOC_IERDE_SPELL_EXPERIENCE_INCREASER_SELECTOR" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_LEVELER_IERDE_REVEAL_EARTH_MAP",
+    "condition": {
+      "and": [
+        { "math": [ "u_spell_level('ierde_reveal_earth_map_spell')", ">=", "0" ] },
+        { "math": [ "u_spell_level('ierde_reveal_earth_map_spell')", "<", "per_to_level(1)" ] }
+      ]
+    },
+    "effect": [
+      {
+        "u_message": "Your time spent surrounded by the living earth has increased your facility with your fae magicks.",
+        "type": "good"
+      },
+      { "math": [ "u_spell_exp('ierde_reveal_earth_map_spell')", "+=", "paraclesian_passive_spell_exp(1)" ] }
     ],
     "false_effect": [ { "run_eocs": "EOC_IERDE_SPELL_EXPERIENCE_INCREASER_SELECTOR" } ]
   },

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/salamander_mutation_spells.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/salamander_mutation_spells.json
@@ -107,7 +107,8 @@
     "max_field_intensity": 2,
     "field_chance": 1,
     "sound_type": "combat",
-    "sound_description": "a crackle!"
+    "sound_description": "a crackle!",
+    "learn_spells": { "salamander_fire_dot_spell": 12 }
   },
   {
     "id": "salamander_flame_punch_spell",
@@ -184,7 +185,8 @@
     "energy_increment": -6,
     "base_casting_time": 1000,
     "final_casting_time": 750,
-    "casting_time_increment": -10
+    "casting_time_increment": -10,
+    "learn_spells": { "salamander_fire_dot_spell": 6 }
   },
   {
     "id": "salamander_smoke_teleport_spell",
@@ -259,7 +261,38 @@
     "base_energy_cost": 800,
     "final_energy_cost": 550,
     "energy_increment": -6,
-    "base_casting_time": 3000
+    "base_casting_time": 3000,
+    "learn_spells": { "salamander_fire_dot_spell": 7 }
+  },
+  {
+    "id": "salamander_fire_dot_spell",
+    "type": "SPELL",
+    "name": "The Fire in the Marrow",
+    "description": "Kindle a flame within the target, slowly burning them from the inside.  This spell does damage only slowly, but there is little defense against being burned from the inside out.",
+    "valid_targets": [ "hostile" ],
+    "flags": [ "SOMATIC", "VERBAL", "RANDOM_DURATION", "NO_LEGS" ],
+    "skill": "deduction",
+    "teachable": false,
+    "spell_class": "SALAMANDER",
+    "difficulty": 5,
+    "max_level": { "math": [ "dex_to_level(1)" ] },
+    "effect": "attack",
+    "effect_str": "effect_salamander_fire_dot",
+    "damage_type": "heat",
+    "shape": "blast",
+    "min_dot": 1,
+    "max_dot": 1,
+    "min_duration": { "math": [ "(1500 + (u_spell_level('salamander_fire_dot_spell') * 50) * (scaling_factor(u_val('dexterity') ) ) )" ] },
+    "max_duration": { "math": [ "(3500 + (u_spell_level('salamander_fire_dot_spell') * 350) * (scaling_factor(u_val('dexterity') ) ) )" ] },
+    "min_range": { "math": [ "(3 + (u_spell_level('salamander_fire_dot_spell') * 1.1) * (scaling_factor(u_val('dexterity') ) ) )" ] },
+    "max_range": { "math": [ "(3 + (u_spell_level('salamander_fire_dot_spell') * 1.1) * (scaling_factor(u_val('dexterity') ) ) )" ] },
+    "energy_source": "MANA",
+    "base_energy_cost": 250,
+    "final_energy_cost": 100,
+    "energy_increment": -10,
+    "base_casting_time": 100,
+    "final_casting_time": 40,
+    "casting_time_increment": -6
   },
   {
     "id": "salamander_increase_speed_spell",
@@ -348,7 +381,7 @@
     "id": "salamander_summon_firebird_spell",
     "type": "SPELL",
     "name": "Flame of the Firebird",
-    "description": "Summon a delicate bird made of pure flame.  The bird will last only a few moments, but if it sees an enemy it will eager dive upon them and erupt into a fireball.",
+    "description": "Summon a delicate bird made of pure flame.  The bird will last only a few moments, but if it sees an enemy it will eagerly dive upon them and erupt into a fireball.",
     "flags": [ "SOMATIC", "VERBAL" ],
     "valid_targets": [ "ground", "hostile" ],
     "skill": "deduction",
@@ -435,6 +468,59 @@
     "base_casting_time": 200,
     "final_casting_time": 50,
     "casting_time_increment": -6
+  },
+  {
+    "id": "salamander_explosion_trap_spell",
+    "type": "SPELL",
+    "name": "Sigil of Detonation",
+    "description": "Place a magical rune on a the ground that will explode when stepped on.",
+    "valid_targets": [ "hostile", "ground", "ally" ],
+    "flags": [ "SOMATIC", "NO_LEGS" ],
+    "skill": "deduction",
+    "teachable": false,
+    "spell_class": "SALAMANDER",
+    "max_level": { "math": [ "per_to_level(1)" ] },
+    "difficulty": 5,
+    "effect": "add_trap",
+    "effect_str": "tr_salamander_bomb",
+    "shape": "blast",
+    "min_range": {
+      "math": [ "(3 + (u_spell_level('salamander_explosion_trap_spell') * 1) * (scaling_factor(u_val('perception') ) ) )" ]
+    },
+    "max_range": {
+      "math": [ "(3 + (u_spell_level('salamander_explosion_trap_spell') * 1) * (scaling_factor(u_val('perception') ) ) )" ]
+    },
+    "energy_source": "MANA",
+    "base_energy_cost": 200,
+    "final_energy_cost": 75,
+    "energy_increment": -6,
+    "base_casting_time": 125,
+    "final_casting_time": 75,
+    "casting_time_increment": -3
+  },
+  {
+    "id": "salamander_explosion_trap_spell_activated",
+    "type": "SPELL",
+    "name": "Salamander Trap Explosion",
+    "description": "This is the AoE used by Sigil of Detonation.  It's a bug if you have it directly.",
+    "message": "",
+    "valid_targets": [ "hostile", "ground", "ally" ],
+    "skill": "deduction",
+    "flags": [ "LOUD", "NO_PROJECTILE", "IGNITE_FLAMMABLE", "RANDOM_AOE", "RANDOM_DAMAGE", "NO_HANDS", "NO_LEGS" ],
+    "effect": "attack",
+    "shape": "blast",
+    "damage_type": "heat",
+    "min_damage": 20,
+    "max_damage": 70,
+    "min_aoe": 1,
+    "max_aoe": 2,
+    "aoe_increment": 1,
+    "field_id": "fd_fire",
+    "min_field_intensity": 1,
+    "max_field_intensity": 2,
+    "field_chance": 2,
+    "sound_type": "combat",
+    "sound_description": "a crackle!"
   },
   {
     "id": "salamander_cultivate_goblin_fruit",

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/salamander_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/salamander_mutations.json
@@ -69,6 +69,18 @@
   },
   {
     "type": "mutation",
+    "id": "SALAMANDER_EXPLOSION_TRAP",
+    "name": { "str": "Sigil of Detonation" },
+    "points": 4,
+    "visibility": 0,
+    "ugliness": 0,
+    "description": "Upon gaining this ability the Salamander gains the ability to lay a fiery trap which will burst into searing flames when stepped on.",
+    "prereqs": [ "SALAMANDER_DASH_BOOM" ],
+    "category": [ "SALAMANDER" ],
+    "spells_learned": [ [ "salamander_explosion_trap_spell", 1 ] ]
+  },
+  {
+    "type": "mutation",
     "id": "SALAMANDER_SMOKE_TELEPORT",
     "name": { "str": "In a Puff of Smoke" },
     "points": 6,

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/salamander_spell_learning_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/salamander_spell_learning_eocs.json
@@ -11,6 +11,7 @@
           "u_has_any_trait": [
             "SALAMANDER_MAKE_FIRE",
             "SALAMANDER_DASH_BOOM",
+            "SALAMANDER_EXPLOSION_TRAP",
             "SALAMANDER_SMOKE_TELEPORT",
             "SALAMANDER_FLAME_PUNCH",
             "SALAMANDER_SUMMON_FIRE_SPIRIT",
@@ -57,6 +58,7 @@
       "or": [
         { "math": [ "u_spell_level('salamander_make_fire')", "<", "str_to_level(1)" ] },
         { "math": [ "u_spell_level('salamander_dash_boom_spell')", "<", "str_to_level(1)" ] },
+        { "math": [ "u_spell_level('salamander_explosion_trap_spell')", "<", "per_to_level(1)" ] },
         { "math": [ "u_spell_level('salamander_smoke_teleport_spell')", "<", "per_to_level(1)" ] },
         { "math": [ "u_spell_level('salamander_flame_punch_spell')", "<", "str_to_level(1)" ] },
         { "math": [ "u_spell_level('salamander_summon_fire_spirit')", "<", "35" ] },
@@ -66,6 +68,7 @@
         { "math": [ "u_spell_level('salamander_flaming_whip_spell')", "<", "dex_to_level(1)" ] },
         { "math": [ "u_spell_level('salamander_emit_heat')", "<", "str_to_level(1)" ] },
         { "math": [ "u_spell_level('salamander_cure_conditions')", "<", "str_to_level(1)" ] },
+        { "math": [ "u_spell_level('salamander_fire_dot_spell')", "<", "dex_to_level(1)" ] },
         { "math": [ "u_spell_level('create_light_salamander')", "<", "20" ] },
         { "math": [ "u_spell_level('salamander_fire_fly')", "<", "str_to_level(1)" ] },
         { "math": [ "u_spell_level('salamander_ally_flame_immune_spell')", "<", "per_to_level(1)" ] },
@@ -78,6 +81,7 @@
       "weighted_list_eocs": [
         [ "EOC_LEVELER_SALAMANDER_MAKE_FIRE", 10 ],
         [ "EOC_LEVELER_SALAMANDER_DASH_BOOM", 7 ],
+        [ "EOC_LEVELER_SALAMANDER_EXPLOSION_TRAP", 6 ],
         [ "EOC_LEVELER_SALAMANDER_SMOKE_TELEPORT", 8 ],
         [ "EOC_LEVELER_SALAMANDER_FLAME_PUNCH", 8 ],
         [ "EOC_LEVELER_SALAMANDER_SUMMON_FIRE_SPIRIT", 8 ],
@@ -87,6 +91,7 @@
         [ "EOC_LEVELER_SALAMANDER_SUMMON_WHIP", 6 ],
         [ "EOC_LEVELER_SALAMANDER_EMIT_HEAT", 5 ],
         [ "EOC_LEVELER_SALAMANDER_CURE_CONDITIONS", 5 ],
+        [ "EOC_LEVELER_SALAMANDER_FIRE_DOT", 6 ],
         [ "EOC_LEVELER_SALAMANDER_CREATE_LIGHT", 9 ],
         [ "EOC_LEVELER_SALAMANDER_FLY_IN_FIRE_SPELL", 5 ],
         [ "EOC_LEVELER_SALAMANDER_FLAME_IMMUNITY_ALLY", 4 ],
@@ -129,6 +134,24 @@
         "type": "good"
       },
       { "math": [ "u_spell_exp('salamander_dash_boom_spell')", "+=", "paraclesian_passive_spell_exp(1)" ] }
+    ],
+    "false_effect": [ { "run_eocs": "EOC_SALAMANDER_SPELL_EXPERIENCE_INCREASER_SELECTOR" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_LEVELER_SALAMANDER_EXPLOSION_TRAP",
+    "condition": {
+      "and": [
+        { "math": [ "u_spell_level('salamander_explosion_trap_spell')", ">=", "0" ] },
+        { "math": [ "u_spell_level('salamander_explosion_trap_spell')", "<", "per_to_level(1)" ] }
+      ]
+    },
+    "effect": [
+      {
+        "u_message": "Your time spent among the heat and flames has increased your facility with your fae magicks.",
+        "type": "good"
+      },
+      { "math": [ "u_spell_exp('salamander_explosion_trap_spell')", "+=", "paraclesian_passive_spell_exp(1)" ] }
     ],
     "false_effect": [ { "run_eocs": "EOC_SALAMANDER_SPELL_EXPERIENCE_INCREASER_SELECTOR" } ]
   },
@@ -291,6 +314,24 @@
         "type": "good"
       },
       { "math": [ "u_spell_exp('salamander_cure_conditions')", "+=", "paraclesian_passive_spell_exp(1)" ] }
+    ],
+    "false_effect": [ { "run_eocs": "EOC_SALAMANDER_SPELL_EXPERIENCE_INCREASER_SELECTOR" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_LEVELER_SALAMANDER_FIRE_DOT",
+    "condition": {
+      "and": [
+        { "math": [ "u_spell_level('salamander_fire_dot_spell')", ">=", "0" ] },
+        { "math": [ "u_spell_level('salamander_fire_dot_spell')", "<", "dex_to_level(1)" ] }
+      ]
+    },
+    "effect": [
+      {
+        "u_message": "Your time spent among the heat and flames has increased your facility with your fae magicks.",
+        "type": "good"
+      },
+      { "math": [ "u_spell_exp('salamander_fire_dot_spell')", "+=", "paraclesian_passive_spell_exp(1)" ] }
     ],
     "false_effect": [ { "run_eocs": "EOC_SALAMANDER_SPELL_EXPERIENCE_INCREASER_SELECTOR" } ]
   },

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/sylph_mutation_spells.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/sylph_mutation_spells.json
@@ -1,6 +1,12 @@
 [
   {
     "type": "enchantment",
+    "id": "ench_sylph_louder_shouting",
+    "condition": "ACTIVE",
+    "values": [ { "value": "SHOUT_NOISE", "multiply": { "math": [ " 1 + (u_spell_level_sum('school': 'SYLPH') / 20)" ] } } ]
+  },
+  {
+    "type": "enchantment",
     "id": "sylph_extra_dodges",
     "condition": "ALWAYS",
     "values": [ { "value": "BONUS_DODGE", "add": { "math": [ "1 + u_has_trait('THRESH_SYLPH')" ] } } ]
@@ -416,9 +422,9 @@
     "difficulty": 2,
     "max_level": { "math": [ "int_to_level(1)" ] },
     "damage_type": "bashing",
-    "min_damage": { "math": [ "( (u_spell_level('pushing_wind') * 0.25) + 2) * (scaling_factor(u_val('dexterity') ) )" ] },
-    "max_damage": { "math": [ "( (u_spell_level('pushing_wind') * 0.25) + 6) * (scaling_factor(u_val('dexterity') ) )" ] },
-    "min_range": { "math": [ "( (u_spell_level('pushing_wind') * 1.2) + 1) * (scaling_factor(u_val('dexterity') ) )" ] },
+    "min_damage": { "math": [ "( (u_spell_level('pushing_wind') * 0.25) + 2) * (scaling_factor(u_val('intelligence') ) )" ] },
+    "max_damage": { "math": [ "( (u_spell_level('pushing_wind') * 0.25) + 6) * (scaling_factor(u_val('intelligence') ) )" ] },
+    "min_range": { "math": [ "( (u_spell_level('pushing_wind') * 1.2) + 1) * (scaling_factor(u_val('intelligence') ) )" ] },
     "max_range": 40,
     "energy_source": "MANA",
     "base_energy_cost": 100,
@@ -426,6 +432,31 @@
     "energy_increment": -5,
     "base_casting_time": 50,
     "final_casting_time": 10,
+    "casting_time_increment": -4
+  },
+  {
+    "id": "sylph_hindering_wind_spell",
+    "type": "SPELL",
+    "name": "Hindering Winds",
+    "description": "Surround a target with a blanket of buffeting winds, slowing them and hindering their freedom of movement.",
+    "valid_targets": [ "hostile" ],
+    "skill": "deduction",
+    "teachable": false,
+    "spell_class": "SYLPH",
+    "flags": [ "VERBAL", "SOMATIC", "NO_LEGS" ],
+    "difficulty": 4,
+    "max_level": { "math": [ "int_to_level(1)" ] },
+    "effect": "attack",
+    "effect_str": "effect_sylph_hindering_wind",
+    "shape": "blast",
+    "min_range": { "math": [ "( (u_spell_level('sylph_hindering_wind_spell') * 1.2) + 1) * (scaling_factor(u_val('intelligence') ) )" ] },
+    "max_range": 40,
+    "energy_source": "MANA",
+    "base_energy_cost": 250,
+    "final_energy_cost": 100,
+    "energy_increment": -5,
+    "base_casting_time": 75,
+    "final_casting_time": 15,
     "casting_time_increment": -4
   },
   {

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/sylph_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/sylph_mutations.json
@@ -100,6 +100,21 @@
   },
   {
     "type": "mutation",
+    "id": "SYLPH_LOUDER_SHOUTING",
+    "name": { "str": "Voice of Thunder" },
+    "points": 2,
+    "visibility": 0,
+    "ugliness": 0,
+    "description": "The Sylph can make their voice boom like a peal of thunder, shouting so loudly that they can be heard from hundreds of yards away.",
+    "prereqs": [ "CLAP_OF_THUNDER" ],
+    "prereqs2": [ "BREATHE_WO_AIR" ],
+    "category": [ "SYLPH" ],
+    "active": true,
+    "activated_is_setup": false,
+    "enchantments": [ "ench_sylph_louder_shouting" ]
+  },
+  {
+    "type": "mutation",
     "id": "CLAP_OF_THUNDER",
     "name": { "str": "Clap of Thunder" },
     "points": 1,
@@ -277,7 +292,7 @@
     "type": "mutation",
     "id": "SYLPH_SPEED_INCREASE2",
     "name": { "str": "Outrunning the Gale" },
-    "points": 4,
+    "points": 8,
     "visibility": 0,
     "ugliness": 0,
     "description": "When outdoors, the Sylph moves 10% faster and has +10% increased speed.",
@@ -324,6 +339,18 @@
     "description": "The Sylph learns how to use the wind to push their opponents.",
     "category": [ "SYLPH" ],
     "spells_learned": [ [ "pushing_wind", 1 ] ]
+  },
+  {
+    "type": "mutation",
+    "id": "SYLPH_HINDERING_WINDS",
+    "name": { "str": "Hindering Winds" },
+    "points": 3,
+    "visibility": 0,
+    "ugliness": 0,
+    "description": "The Sylph learns how to use surround a single target with buffeting winds, slowing their movements and knocking them off-balance.",
+    "prereqs": [ "PUSHING_WIND" ],
+    "category": [ "SYLPH" ],
+    "spells_learned": [ [ "sylph_hindering_wind_spell", 1 ] ]
   },
   {
     "type": "mutation",

--- a/data/mods/Xedra_Evolved/traps.json
+++ b/data/mods/Xedra_Evolved/traps.json
@@ -1,0 +1,19 @@
+[
+  {
+    "type": "trap",
+    "id": "tr_salamander_bomb",
+    "name": "sigil of detonation",
+    "color": "red",
+    "symbol": "#",
+    "always_invisible": false,
+    "memorial_male": { "ctxt": "memorial_male", "str": "Detonated by elemental magicks." },
+    "memorial_female": { "ctxt": "memorial_female", "str": "Detonated by elemental magicks." },
+    "visibility": 2,
+    "avoidance": 14,
+    "difficulty": 10,
+    "trap_radius": 0,
+    "action": "spell",
+    "flags": [ "UNDODGEABLE" ],
+    "spell_data": { "id": "salamander_explosion_trap_spell_activated" }
+  }
+]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Xedra Evolved] More paraclesian powers"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

It is once again time to add more fae magicks.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the following traits:

ARVORE

- Spreading the Viridian Mantle: An AoE version of Nurturing the Green, affecting whole fields at high level. However, it has a very high mana cost and casting time, so it will still take a few days to grow a full field to ripeness, and by the time the Arvore has enough mana to cast it, they will almost certainly be able to survive themselves on sunlight anyway. But it is an excellent way to feed others. (_Learned from Nurturing the Green level 14)_

IERDE

- Knowing Every Furrow: Speak to the earth and ask it to guide you. Reveals the layout of natural terrain (earth, forest, etc., not water or roads or towns) within a radius of the Ierde. Port of the Earthshaper spell Revealing the Earthbones (_Requires The Hills Overlook the Valleys_)
- Stone-Hardened Panoply: The Ierde infuses the resilience of the earth into their equipment, making it resistant to damage. While standing on the living earth or underground, their equipment is 50% less likely to be damaged. (_Requires Fists of Stone_)

SALAMANDER

- The Fire in the Marrow: Kindles a fire within a target, doing slow but inescapable damage (1 heat per second for a variable length). (_Learned from Enkindle level 12 or Burning Away Your Impurities level 7_ )
- Sigil of Detonation: Places a mystical sigil on the ground that explodes into a fireball when trespassed upon (_Requires Fiery Charge_)

SYLPH

- Hindering Winds: Teaches the Sylph a spell to wrap a single target in buffeting winds that slow their movements and knock them off balance (_Requires Pushing Wind_)
- Voice of Thunder: At will, the Sylph can make their voice as loud as a booming roll of thunder. Multiplies the Sylph's volume by 100% plus 5% per level in Sylph spells they have (_Requires Clap of Thunder and Breathe Without Air_)

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Everything works (as far as I can tell--difficult to test Stone-Hardened Panoply)
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
