### PR TITLE
Connect Group for LIXA

### DIFF
--- a/data/json/connect_groups.json
+++ b/data/json/connect_groups.json
@@ -47,6 +47,10 @@
   },
   {
     "type": "connect_group",
+    "id": "LIXATUBE"
+  },
+  {
+    "type": "connect_group",
     "id": "CANVAS_WALL"
   },
   {

--- a/data/json/furniture_and_terrain/LIXA_furniture_and_terrain.json
+++ b/data/json/furniture_and_terrain/LIXA_furniture_and_terrain.json
@@ -33,7 +33,8 @@
     "color": "light_gray",
     "move_cost": 3,
     "coverage": 50,
-    "connect_groups": "INDOORFLOOR",
+    "connect_groups": [ "INDOORFLOOR", "LIXATUBE" ],
+    "connects_to": "LIXATUBE",
     "flags": [ "TRANSPARENT", "MOUNTABLE", "PERMEABLE", "THIN_OBSTACLE", "MINEABLE", "UNSTABLE", "INDOORS" ],
     "bash": {
       "str_min": 30,
@@ -106,7 +107,8 @@
     "color": "light_gray",
     "move_cost": 3,
     "coverage": 50,
-    "connect_groups": "INDOORFLOOR",
+    "connect_groups": [ "INDOORFLOOR", "LIXATUBE" ],
+    "connects_to": "LIXATUBE",
     "flags": [ "TRANSPARENT", "MOUNTABLE", "PERMEABLE", "INDOORS", "THIN_OBSTACLE", "UNSTABLE", "MINEABLE" ],
     "bash": {
       "str_min": 7,
@@ -128,7 +130,8 @@
     "light_emitted": 120,
     "move_cost": 2,
     "coverage": 50,
-    "connect_groups": "INDOORFLOOR",
+    "connect_groups": [ "INDOORFLOOR", "LIXATUBE" ],
+    "connects_to": "LIXATUBE",
     "flags": [ "TRANSPARENT", "MOUNTABLE", "PERMEABLE", "INDOORS", "THIN_OBSTACLE", "UNSTABLE", "MINEABLE" ],
     "emissions": [ "emit_congealed_light" ]
   },
@@ -304,6 +307,8 @@
     "move_cost": 3,
     "roof": "t_metal_roof",
     "flags": [ "TRANSPARENT", "FLAMMABLE", "FLAT" ],
+    "connect_groups": [ "INDOORFLOOR", "LIXATUBE" ],
+    "connects_to": "LIXATUBE",
     "deconstruct": {
       "ter_set": "t_metal_floor",
       "items": [

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -33,7 +33,7 @@ struct itype;
 struct tripoint;
 
 // size of connect groups bitset; increase if needed
-const int NUM_TERCONN = 32;
+const int NUM_TERCONN = 256;
 connect_group get_connect_group( const std::string &name );
 
 template <typename E> struct enum_traits;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "LIXA connect_group"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Both pairs of terrain tiles
"t_LIXA_tube" / "t_LIXA_laser" 
and 
"t_LIXA_tube_unfolded" / "t_LIXA_unfolded_tube_broken" 
need to connect to each other to draw correctly, whether my new tiles get approved or not.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Adds a new connect_group for LIXA-related multitiles and updates the relevant terrain.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Verified correct drawing in multiple LIXA orientations:

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/65314588/4892dbea-3efe-43cb-8e45-6388405a672c)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/65314588/0ba710aa-1714-4b09-b1c9-3e41201d7448)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/65314588/1401a08e-a1f4-4a4e-9933-1ef91c190ef9)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/65314588/0cf7847f-bb20-4b03-8945-23ad05cb9b40)


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
