### PR TITLE
Allow mod exclusions in get_all_mods.py

### DIFF
--- a/build-scripts/get_all_mods.py
+++ b/build-scripts/get_all_mods.py
@@ -23,11 +23,14 @@ def add_mods(mods):
             # Either an invalid mod id, or blacklisted.
             return False
     for mod in mods:
-        if mod not in mods_this_time and compatible_with(mod, mods_this_time):
-            if add_mods(all_mod_dependencies[mod]):
-                mods_this_time.append(mod)
-            else:
-                return False
+        if mod in mods_this_time:
+            continue
+        if not compatible_with(mod, mods_this_time):
+            return False
+        if add_mods(all_mod_dependencies[mod]):
+            mods_this_time.append(mod)
+        else:
+            return False
     return True
 
 

--- a/build-scripts/get_all_mods.py
+++ b/build-scripts/get_all_mods.py
@@ -10,10 +10,20 @@ import json
 
 mods_this_time = []
 
+exclusions = [
+    # #74443 - incompatibility between mindovermatter and aftershock due to bug
+    ('mindovermatter', 'aftershock')
+]
+
 
 def compatible_with(mod, existing_mods):
     if mod in total_conversions and total_conversions & set(existing_mods):
         return False
+    for entry in exclusions:
+        if entry[0] == mod and entry[1] in existing_mods:
+            return False
+        if entry[1] == mod and entry[0] in existing_mods:
+            return False
     return True
 
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
https://github.com/CleverRaven/Cataclysm-DDA/issues/74443 is causing CI flakiness and has a quite involved fix. While I work towards that fix, keep the CI stable.

AFAIK, the purpose of the all mods test is to test individual mods for errors, instead of checking inter-mod compatibility. As such, it shouldn't need to start triggering errors  because of a between-mod compatibility error that is tracked.

#### Describe the solution
Mark Aftershock & Mind Over Matter as incompatible when generating lists of mods to test, preventing them from being selected together.

Also, reorganize the mod-adding conditions to fix a bug where if a dependency of a mod was incompatible, the mod could still be added.

#### Describe alternatives you've considered
Leaving CI broken for a while as I plug the holes that https://github.com/CleverRaven/Cataclysm-DDA/issues/74443 exposed.

#### Testing
`for i in {1..1000}; do ./build-scripts/get_all_mods.py | grep aftershock | grep mindovermatter; done`
If output is empty (it is), it hasn't generated a pairing with aftershock (or aftershock_exoplanet) and mindovermatter in 1000 runs.

#### Additional context
I don't like the hack instead of fixing the bugs, but I think it's acceptable here.