### PR TITLE
Phosphorus from Matchboxes and Potassium Chloride From Match-heads

### DIFF
--- a/data/json/recipes/recipe_medsandchemicals.json
+++ b/data/json/recipes/recipe_medsandchemicals.json
@@ -2612,7 +2612,7 @@
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "result": "chem_potassium_chloride",
-    "charges": 2,
+    "charges": 1,
     "batch_time_factors": [ 99, 1 ],
     "category": "CC_CHEM",
     "subcategory": "CSC_CHEM_OTHER",
@@ -2621,7 +2621,7 @@
     "autolearn": true,
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "tools": [ [ [ "water_boiling_heat", 1, "LIST" ] ] ],
-    "//": "basically burning potassium chlorate to form KCl",
-    "components": [ [ [ "survival_match", 1 ], [ "match", 60 ] ] ]
+    "//": "basically burning potassium chlorate to form KCl in the ratio 1.6:1, i.e 20 matches produce 71 mg of KCl.  A survial match burns for 15-20 seconds and have a thicker coating of Potassium Chlorate to make it windproof.",
+    "components": [ [ [ "survival_match", 1 ], [ "match", 28 ] ] ]
   }
 ]

--- a/data/json/recipes/recipe_medsandchemicals.json
+++ b/data/json/recipes/recipe_medsandchemicals.json
@@ -1494,7 +1494,7 @@
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
     "result": "red_phosphorous",
-    "charges": 5,
+    "charges": 1,
     "batch_time_factors": [ 60, 5 ],
     "category": "CC_CHEM",
     "subcategory": "CSC_CHEM_OTHER",
@@ -1502,7 +1502,8 @@
     "time": "10 m",
     "autolearn": true,
     "qualities": [ { "id": "FINE_GRIND", "level": 1 }, { "id": "CUT", "level": 1 }, { "id": "SIEVE", "level": 1 } ],
-    "components": [ [ [ "match", 85 ] ] ]
+    "//": "calculation based on https://www.youtube.com/watch?v=5ZrfNAHDjWU; 1 matchbox contains 30 mg phosphorus and 1 unit of phosphor is 100 mg",
+    "components": [ [ [ "survival_match", 1 ], [ "ref_matches", 3 ], ["matches", 5] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/recipe_medsandchemicals.json
+++ b/data/json/recipes/recipe_medsandchemicals.json
@@ -2607,5 +2607,21 @@
     "//4": "460kJ per mole @ 70% energy efficiency",
     "tools": [ [ [ "fake_arc_furnace", 650 ] ] ],
     "components": [ [ [ "cac2powder", 100 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "result": "chem_potassium_chloride",
+    "charges": 2,
+    "batch_time_factors": [ 99, 1 ],
+    "category": "CC_CHEM",
+    "subcategory": "CSC_CHEM_OTHER",
+    "skill_used": "fabrication",
+    "time": "2 m",
+    "autolearn": true,
+    "qualities": [{ "id": "CUT", "level": 1 }],
+    "tools": [ [ [ "water_boiling_heat", 1, "LIST" ] ] ],
+    "//" : "basically burning potassium chlorate to form KCl",
+    "components": [ [ [ "survival_match", 1 ], ["match", 60] ] ]
   }
 ]

--- a/data/json/recipes/recipe_medsandchemicals.json
+++ b/data/json/recipes/recipe_medsandchemicals.json
@@ -1503,7 +1503,7 @@
     "autolearn": true,
     "qualities": [ { "id": "FINE_GRIND", "level": 1 }, { "id": "CUT", "level": 1 }, { "id": "SIEVE", "level": 1 } ],
     "//": "calculation based on https://www.youtube.com/watch?v=5ZrfNAHDjWU; 1 matchbox contains 30 mg phosphorus and 1 unit of phosphor is 100 mg",
-    "components": [ [ [ "survival_match", 1 ], [ "ref_matches", 3 ], ["matches", 5] ] ]
+    "components": [ [ [ "survival_match", 1 ], [ "ref_matches", 3 ], [ "matches", 5 ] ] ]
   },
   {
     "type": "recipe",
@@ -2619,9 +2619,9 @@
     "skill_used": "fabrication",
     "time": "2 m",
     "autolearn": true,
-    "qualities": [{ "id": "CUT", "level": 1 }],
+    "qualities": [ { "id": "CUT", "level": 1 } ],
     "tools": [ [ [ "water_boiling_heat", 1, "LIST" ] ] ],
-    "//" : "basically burning potassium chlorate to form KCl",
-    "components": [ [ [ "survival_match", 1 ], ["match", 60] ] ]
+    "//": "basically burning potassium chlorate to form KCl",
+    "components": [ [ [ "survival_match", 1 ], [ "match", 60 ] ] ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Red Phosphorus Using Matchbox Strikers and Potassium Chloride Using Match-heads"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Closes #74459

Regular safety matches does not have any red phosphor in the match-heads only on the striker of the box, however it is a very small amount.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Added recipes to make minuscule quantities of  red phosphorus from survival matches, matchboxes and matchbooks. Gathering large amount red phosphorus from strikers is not a plausible solution for most recipes. 

Added a recipe to make Potassium Chloride from match heads.
 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

The quantity of Red Phosphorus obtained are too small for any worthwhile use, an alternative would be to gamify the recipes of obtain larger amounts of Red Phosphorus.

A single 9x19mm JHP round require 3 phosphorus charges, i.e 9 matchboxes to craft 3 red phosphorus, to gamify this would probably mean 1-2 matchboxes gives 9 phosphorus, enough to make a single 9mm round. 

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Crafted all the recipes.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

[NileRed](https://www.youtube.com/watch?v=5ZrfNAHDjWU) on extracting red phosphorus from matchbox strikers.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
