### PR TITLE
Field type migration

### DIFF
--- a/data/mods/TEST_DATA/field_type_migrations.json
+++ b/data/mods/TEST_DATA/field_type_migrations.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "field_type_migration",
+    "from_field": "test_fd_migration_old_id",
+    "to_field": "test_fd_migration_new_id"
+  }
+]

--- a/data/mods/TEST_DATA/fields.json
+++ b/data/mods/TEST_DATA/fields.json
@@ -64,5 +64,10 @@
     "display_items": false,
     "display_field": true,
     "looks_like": "fd_fog"
+  },
+  {
+    "id": "test_fd_migration_new_id",
+    "type": "field_type",
+    "intensity_levels": [ { "name": "migrated" } ]
   }
 ]

--- a/doc/OBSOLETION_AND_MIGRATION.md
+++ b/doc/OBSOLETION_AND_MIGRATION.md
@@ -162,7 +162,7 @@ Move multiple ids that don't need to be unique any more to a single id
 
 # Field migration
 
-Field migration replaces the provided id as submaps are loaded. You can use `fd_null` with `to_field` to remove furniture entirely without creating errors.
+Field migration replaces the provided id as submaps are loaded. You can use `fd_null` with `to_field` to remove the field entirely without creating errors.
 
 ```json
 {
@@ -172,7 +172,7 @@ Field migration replaces the provided id as submaps are loaded. You can use `fd_
 },
 ```
 
-## Example
+## Examples
 
 Migrate an id
 

--- a/doc/OBSOLETION_AND_MIGRATION.md
+++ b/doc/OBSOLETION_AND_MIGRATION.md
@@ -160,6 +160,40 @@ Move multiple ids that don't need to be unique any more to a single id
   }
 ```
 
+# Field migration
+
+Field migration replaces the provided id as submaps are loaded. You can use `fd_null` with `to_field` to remove furniture entirely without creating errors.
+
+```json
+{
+    "type": "field_type_migration",   // Mandatory. String. Must be "field_type_migration"
+    "from_field": "t_old_field",        // Mandatory. String. Id of the field to replace.
+    "to_field": "f_new_field",      // Mandatory. String. Id of the new field to place.
+},
+```
+
+## Example
+
+Migrate an id
+
+```json
+  {
+    "type": "field_type_migration",
+    "from_field": "fd_being_migrated_id",
+    "to_field": "fd_new_id"
+  }
+```
+
+Errorlessly obsolete an id
+
+```json
+  {
+    "type": "field_type_migration",
+    "from_field": "fd_being_obsoleted_id",
+    "to_field": "fd_null"
+  }
+```
+
 # Overmap terrain migration
 
 Overmap terrain migration replaces the location, if it's not generated, and replaces the entry shown on your map even if it's already generated. If you need the map to be removed without alternative, use `omt_obsolete`

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -254,6 +254,7 @@ void DynamicDataLoader::initialize()
     add( "relic_procgen_data", &relic_procgen_data::load_relic_procgen_data );
     add( "effect_on_condition", &effect_on_conditions::load );
     add( "field_type", &field_types::load );
+    add( "field_type_migration", &field_type_migrations::load );
     add( "weather_type", &weather_types::load );
     add( "ammo_effect", &ammo_effects::load );
     add( "emit", &emit::load_emit );
@@ -582,6 +583,7 @@ void DynamicDataLoader::unload_data()
     faction_template::reset();
     faults::reset();
     field_types::reset();
+    field_type_migrations::reset();
     gates::reset();
     harvest_drop_type::reset();
     harvest_list::reset();
@@ -800,6 +802,7 @@ void DynamicDataLoader::check_consistency( loading_ui &ui )
             { _( "Weapon Categories" ), &weapon_category::verify_weapon_categories },
             { _( "Effect on conditions" ), &effect_on_conditions::check_consistency },
             { _( "Field types" ), &field_types::check_consistency },
+            { _( "Field type migrations" ), &field_type_migrations::check },
             { _( "Ammo effects" ), &ammo_effects::check_consistency },
             { _( "Emissions" ), &emit::check_consistency },
             { _( "Effect types" ), &effect_type::check_consistency },
@@ -825,6 +828,7 @@ void DynamicDataLoader::check_consistency( loading_ui &ui )
             },
             { _( "Monster groups" ), &MonsterGroupManager::check_group_definitions },
             { _( "Furniture and terrain" ), &check_furniture_and_terrain },
+            { _( "Furniture amd terrain migrations" ), &ter_furn_migrations::check },
             { _( "Constructions" ), &check_constructions },
             { _( "Crafting recipes" ), &recipe_dictionary::check_consistency },
             { _( "Professions" ), &profession::check_definitions },
@@ -834,7 +838,6 @@ void DynamicDataLoader::check_consistency( loading_ui &ui )
             { _( "Mutations" ), &mutation_branch::check_consistency },
             { _( "Mutation categories" ), &mutation_category_trait::check_consistency },
             { _( "Region settings" ), check_region_settings },
-            { _( "Terrain/Furniture migrations" ), &ter_furn_migrations::check },
             { _( "Overmap land use codes" ), &overmap_land_use_codes::check_consistency },
             { _( "Overmap connections" ), &overmap_connections::check_consistency },
             { _( "Overmap terrain" ), &overmap_terrains::check_consistency },

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -828,7 +828,7 @@ void DynamicDataLoader::check_consistency( loading_ui &ui )
             },
             { _( "Monster groups" ), &MonsterGroupManager::check_group_definitions },
             { _( "Furniture and terrain" ), &check_furniture_and_terrain },
-            { _( "Furniture amd terrain migrations" ), &ter_furn_migrations::check },
+            { _( "Furniture and terrain migrations" ), &ter_furn_migrations::check },
             { _( "Constructions" ), &check_constructions },
             { _( "Crafting recipes" ), &recipe_dictionary::check_consistency },
             { _( "Professions" ), &profession::check_definitions },

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -693,7 +693,20 @@ void verify_terrain();
 class ter_furn_migrations
 {
     public:
-        /** Handler for loading "ter_furn_migrations" type of json object */
+        /** Handler for loading "ter_furn_migration" type of json object */
+        static void load( const JsonObject &jo );
+
+        /** Clears migration list */
+        static void reset();
+
+        /** Checks migrations */
+        static void check();
+};
+
+class field_type_migrations
+{
+    public:
+        /** Handler for loading "field_type_migration" type of json object */
         static void load( const JsonObject &jo );
 
         /** Clears migration list */

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -5046,10 +5046,9 @@ void submap::load( const JsonValue &jv, const std::string &member_name, int vers
                                m->fld[i][j].add_field( ft.id(), intensity, time_duration::from_turns( age ) ) ) {
                         field_count++;
                     }
-                } else {
-                    field_json.throw_error( "field type relying on ancient legacy int method" );
-                    field_json.next_value(); // skip intensity
-                    field_json.next_value(); // skip age
+                } else { // Handle removed int enum method
+                    field_json.next_value(); // Skip intensity
+                    field_json.next_value(); // Skip age
                 }
             }
         }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Closes #73967
Migration good
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adds basic JSON field type migration
Adds a test to check it works
Adds it to the docs

Removes reading ancient legacy ints that corresponded to field types, if it tries to read a legacy int it silently skips that field types members and then continues normally. 
Doesn't remove the legacy functions etc, will clean up in a separate PR.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not letting Erk get away with renaming ids just because they don't like them
Nesting the ter/furn and field migration checks inside their respective non migration checks
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Compiles and loads, tests compile, existing field submap test and new migration one both pass
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
