### PR TITLE
Display distance to mission objective as a real distance

### DIFF
--- a/src/mission_ui.cpp
+++ b/src/mission_ui.cpp
@@ -17,6 +17,7 @@
 #include "translations.h"
 #include "ui.h"
 #include "ui_manager.h"
+#include "units_utility.h"
 #include "cata_imgui.h"
 #include "imgui/imgui.h"
 
@@ -306,6 +307,14 @@ void mission_ui_impl::draw_selected_description( std::vector<mission *> missions
         // Below is done instead of a table for the benefit of right-to-left languages
         //~Extra padding spaces in the English text are so that the replaced string vertically aligns with the one above
         draw_colored_text( string_format( _( "You:    %s" ), pos.to_string() ), c_white );
+        int omt_distance = rl_dist( pos, miss->get_target() );
+        if( omt_distance > 0 ) {
+            // One OMT is 24 tiles across, at 1x1 meters each, so we can simply do number of OMTs * 24
+            units::length actual_distance = omt_distance * 24_meter;
+            //~Paranthesis is a real-world value for distance. Example string: "Distance: 223 tiles (5352 m)"
+            draw_colored_text( string_format( _( "Distance: %1$s tiles (%2$s)" ),
+                                              omt_distance, length_to_string( actual_distance ) ), c_white );
+        }
     }
 }
 

--- a/src/mission_ui.cpp
+++ b/src/mission_ui.cpp
@@ -313,7 +313,7 @@ void mission_ui_impl::draw_selected_description( std::vector<mission *> missions
             units::length actual_distance = omt_distance * 24_meter;
             //~Paranthesis is a real-world value for distance. Example string: "Distance: 223 tiles (5352 m)"
             draw_colored_text( string_format( _( "Distance: %1$s tiles (%2$s)" ),
-                                              omt_distance, length_to_string( actual_distance ) ), c_white );
+                                              omt_distance, length_to_string_approx( actual_distance ) ), c_white );
         }
     }
 }

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -65,6 +65,7 @@
 #include "ui_manager.h"
 #include "uistate.h"
 #include "units.h"
+#include "units_utility.h"
 #include "vehicle.h"
 #include "vpart_position.h"
 #include "weather_gen.h"
@@ -1170,6 +1171,8 @@ static void draw_om_sidebar(
         const int distance = rl_dist( center, target );
         mvwprintz( wbar, point( 1, ++lines ), c_white, _( "Distance to current objective:" ) );
         mvwprintz( wbar, point( 1, ++lines ), c_white, _( "%d tiles" ), distance );
+        // One OMT is 24 tiles across, at 1x1 meters each, so we can simply do number of OMTs * 24
+        mvwprintz( wbar, point( 1, ++lines ), c_white, _( "%s" ), length_to_string( distance * 24_meter ) );
 
         const int above_below = target.z() - orig.z();
         std::string msg;

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1172,7 +1172,8 @@ static void draw_om_sidebar(
         mvwprintz( wbar, point( 1, ++lines ), c_white, _( "Distance to current objective:" ) );
         mvwprintz( wbar, point( 1, ++lines ), c_white, _( "%d tiles" ), distance );
         // One OMT is 24 tiles across, at 1x1 meters each, so we can simply do number of OMTs * 24
-        mvwprintz( wbar, point( 1, ++lines ), c_white, _( "%s" ), length_to_string( distance * 24_meter ) );
+        mvwprintz( wbar, point( 1, ++lines ), c_white, _( "%s" ),
+                   length_to_string_approx( distance * 24_meter ) );
 
         const int above_below = target.z() - orig.z();
         std::string msg;

--- a/src/units_utility.cpp
+++ b/src/units_utility.cpp
@@ -246,6 +246,72 @@ std::string length_to_string( const units::length &length, const bool compact )
                           length_units( length ) );
 }
 
+double convert_length_approx( const units::length &length, bool &display_as_integer )
+{
+    double ret = static_cast<double>( to_millimeter( length ) );
+    const bool metric = get_option<std::string>( "DISTANCE_UNITS" ) == "metric";
+    if( metric ) {
+        if( ret > 500'000 ) {
+            // kilometers
+            ret /= 1'000'000.0;
+        } else {
+            // meters
+            ret /= 1'000.0;
+            display_as_integer = true;
+        }
+    } else {
+        double inches_value = ret / 25.4;
+        if( inches_value > 31680 ) {
+            // Miles
+            inches_value /= 63360.0;
+        } else {
+            // Yards
+            inches_value /= 36.0;
+            display_as_integer = true;
+        }
+        ret = inches_value;
+    }
+    return ret;
+}
+
+std::string length_units_approx( const units::length &length )
+{
+    int length_mm = to_millimeter( length );
+    const bool metric = get_option<std::string>( "DISTANCE_UNITS" ) == "metric";
+    if( metric ) {
+        if( length_mm > 500'000 ) {
+            //~ kilometers
+            return _( "km" );
+        } else {
+            //~ meters
+            return _( "m" );
+        }
+    } else {
+        int length_inches = length_mm / 25.4;
+        if( length_inches > 31680 ) {
+            //~ miles
+            return _( "mi" );
+        } else {
+            //~ yards (length)
+            return _( "yd" );
+        }
+    }
+}
+
+std::string length_to_string_approx( const units::length &length )
+{
+    bool display_as_integer = false;
+    double approx_length = convert_length_approx( length, display_as_integer );
+    std::string string_to_format = "%.2f%s";
+    if( display_as_integer ) {
+        string_to_format = "%u%s";
+        int approx_length_as_integer = static_cast<int>( approx_length );
+        return string_format( string_to_format, approx_length_as_integer, length_units_approx( length ) );
+    } else {
+        return string_format( string_to_format, approx_length, length_units_approx( length ) );
+    }
+}
+
 std::string weight_to_string( const units::mass &weight, const bool compact,
                               const bool remove_trailing_zeroes )
 {

--- a/src/units_utility.h
+++ b/src/units_utility.h
@@ -98,6 +98,16 @@ int convert_length( const units::length &length );
 std::string length_units( const units::length &length );
 std::string length_to_string( const units::length &length, bool compact = false );
 
+/**
+* Rounds length so that reasonably large units can be used (kilometers/meters or miles/yards).
+* If value is >0.5km or >0.5mi then uses km/mi respectively, otherwise uses meters/yards.
+* Outputs to two decimal places (km/mi) or as integer (meters/yards).
+* Should always be accessed through length_to_string_approx()
+*/
+double convert_length_approx( const units::length &length, bool &display_as_integer );
+std::string length_units_approx( const units::length &length );
+std::string length_to_string_approx( const units::length &length );
+
 /** Convert length to inches or cm. Used in pickup UI */
 double convert_length_cm_in( const units::length &length );
 


### PR DESCRIPTION
#### Summary
Interface "Show actual real-world distance to mission objective"

#### Purpose of change
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/85edf786-3eb8-43e5-b10a-cf9719a31c32)


#### Describe the solution
Just do that

#### Describe alternatives you've considered

#### Testing
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/bd0cf3ec-078b-4465-943d-03d64eeb3e47)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/700ae7d4-ff68-4230-a234-f69680cebbf8)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/948e7766-356f-4446-aa53-57081135c2d0)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/d826be18-edf8-4d09-b59d-a8e731dd7d97)



#### Additional context
~~due to how `length_units` converts we always get a meters/yards value unless it is **perfectly** divisible into kilometers. I wasn't going to risk touching that when the meters-->kilometers conversion is perfectly easy to do in your head just by looking at it.
(Yes, this IS much more difficult with imperial! Too bad, use a real measurement system! -Signed, American who uses metric)~~

IMPERIAL WINS AGAIN! GOD BLESS AMERICA!
-Signed, **American** (who uses metric 😢 )