### PR TITLE
Add Variants/Variable Snippets for Tights

### DIFF
--- a/data/json/items/armor/undergarment.json
+++ b/data/json/items/armor/undergarment.json
@@ -1058,7 +1058,7 @@
   {
     "id": "tights",
     "type": "ARMOR",
-    "name": { "str_sp": "tights", "str_plural": "pairs of tights" },
+    "name": { "str_sp": "tights", "str_pl": "pairs of tights" },
     "description": "A snug cloth garment which clings tightly to the legs and feet to protect them from the cold.",
     "weight": "114 g",
     "volume": "250 ml",

--- a/data/json/items/armor/undergarment.json
+++ b/data/json/items/armor/undergarment.json
@@ -1058,7 +1058,7 @@
   {
     "id": "tights",
     "type": "ARMOR",
-    "name": { "str_sp": "tights" },
+    "name": { "str_sp": "tights", "str_plural": "pairs of tights" },
     "description": "A snug cloth garment which clings tightly to the legs and feet to protect them from the cold.",
     "weight": "114 g",
     "volume": "250 ml",
@@ -1071,7 +1071,38 @@
     "warmth": 10,
     "material_thickness": 0.1,
     "flags": [ "VARSIZE", "SKINTIGHT" ],
-    "armor": [ { "coverage": 100, "covers": [ "foot_l", "foot_r", "leg_r", "leg_l" ] } ]
+    "armor": [ { "coverage": 100, "covers": [ "foot_l", "foot_r", "leg_r", "leg_l" ] } ],
+    "variants": [
+      {
+        "id": "tights_basic",
+        "name": { "str": "tights", "str_pl": "pairs of tights" },
+        "description": "A snug cloth garment which clings tightly to the legs and feet to protect them from the cold.",
+        "expand_snippets": true,
+        "weight": 50
+      },
+      {
+        "id": "tights_polka_dot",
+        "name": { "str": "polka dot tights", "str_pl": "pairs of polka dot tights" },
+        "description": "These are adorned with dozens of <color> polka dots.",
+        "expand_snippets": true,
+        "append": true,
+        "weight": 50
+      },
+      {
+        "id": "tights_print",
+        "name": { "str": "animal print tights", "str_pl": "pairs of animal print tights" },
+        "description": "A pair of snug cotton tights, featuring a classic <animal_print> pattern.",
+        "expand_snippets": true,
+        "weight": 150
+      },
+      {
+        "id": "tights_solid",
+        "name": { "str": "solid color tights", "str_pl": "pairs of solid color tights" },
+        "description": "A pair of cotton tights, these are a solid <color> color.",
+        "expand_snippets": true,
+        "weight": 300
+      }
+    ]
   },
   {
     "id": "under_armor",

--- a/data/json/items/armor/undergarment.json
+++ b/data/json/items/armor/undergarment.json
@@ -1058,7 +1058,7 @@
   {
     "id": "tights",
     "type": "ARMOR",
-    "name": { "str_sp": "tights", "str_pl": "pairs of tights" },
+    "name": { "str": "tights", "str_pl": "pairs of tights" },
     "description": "A snug cloth garment which clings tightly to the legs and feet to protect them from the cold.",
     "weight": "114 g",
     "volume": "250 ml",

--- a/data/json/snippets/clothing.json
+++ b/data/json/snippets/clothing.json
@@ -26,5 +26,17 @@
       { "id": "mice", "text": "mice" },
       { "id": "puppies", "text": "puppies" }
     ]
+  },
+  {
+    "type": "snippet",
+    "category": "<animal_print>",
+    "//": "This category was originally made for tights, and should be appropriate prints you would find on such garments.",
+    "text": [
+      { "id": "cowprint", "text": "cow print" },
+      { "id": "leopardprint", "text": "leopard print" },
+      { "id": "snakeprint", "text": "snake print" },
+      { "id": "tigerprint", "text": "tiger print" },
+      { "id": "zebraprint", "text": "zebra print" }
+    ]
   }
 ]


### PR DESCRIPTION
#### Summary
Content "Add Variants/Variable Snippets for Tights"

#### Purpose of change
#74201 requested some variants for various undergarments.  In a previous PR (#74257 ) I added some variants/snippets for boxers and boxer briefs.  I wanted to do this for tights, because idk I wanted zebra print tights to exist.

#### Describe the solution
Added three variants for tights, animal print, polka dot, and solid color tights.  I maintained the original tights item to preserve its description/existence.  The three additions use snippets for variability, IE: the color for solid color tights are randomized, and the animal print is randomized for those tights.  I also created a snippet group for animal prints, to allow for them to be randomized.  I also made the plural of regular tights "pairs of X tights" just to keep consistency throughout.

#### Describe alternatives you've considered
Not doing this because people seem to get angry over variants, and because spriters don't seem to like the variability that comes from randomizing snippets.

#### Testing
Checked that they print correctly, no syntax errors, linted, blah blah etc.

#### Additional context
Examples with screenshots:
Animal Print = "A pair of snug cotton tights, featuring a classic <animal_print> pattern." 
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/41651793/3634f735-c135-49bf-9909-27feca5f2e22)
Polka dot = "These are adorned with dozens of \<color> polka dots."
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/41651793/dc48bc94-6a9a-42d6-916d-fc44af26a609)
Solid color = "A pair of cotton tights, these are a solid \<color> color."
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/41651793/75892d29-57d7-4096-8ca4-819f43fcd770)

