### PR TITLE
Fix loading of inline EoCs, enchantments, and allow recipe_categories to extend

### DIFF
--- a/build-scripts/get_all_mods.py
+++ b/build-scripts/get_all_mods.py
@@ -11,8 +11,7 @@ import json
 mods_this_time = []
 
 exclusions = [
-    # #74443 - incompatibility between mindovermatter and aftershock due to bug
-    ('mindovermatter', 'aftershock')
+    # Tuple of (mod_id, mod_id) - these two mods will be incompatible
 ]
 
 

--- a/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
@@ -1120,7 +1120,7 @@
           "case": 7,
           "effect": {
             "run_eocs": [
-              { "id": "EOC_PORTAL_DUNGEON_REWARD_ITEM" },
+              "EOC_PORTAL_DUNGEON_REWARD_ITEM",
               {
                 "id": "EOC_PORTAL_DEPENDENT_DUNGEON_FINAL",
                 "condition": { "u_has_trait": "PORTAL_DEPENDENT" },

--- a/data/json/npcs/missiondef.json
+++ b/data/json/npcs/missiondef.json
@@ -330,9 +330,7 @@
     "end": {
       "effect": [
         "stop_following",
-        {
-          "weighted_list_eocs": [ [ { "id": "get_katana" }, 5 ], [ { "id": "get_deagle_44" }, 10 ], [ { "id": "get_m4_carbine" }, 6 ] ]
-        }
+        { "weighted_list_eocs": [ [ "get_katana", 5 ], [ "get_deagle_44", 10 ], [ "get_m4_carbine", 6 ] ] }
       ]
     },
     "origins": [ "ORIGIN_SECONDARY" ],

--- a/data/json/recipes/recipes.json
+++ b/data/json/recipes/recipes.json
@@ -3,6 +3,7 @@
     "type": "recipe_category",
     "id": "CC_*",
     "//": "This is just a dummy category. No recipes should be added in here.",
+    "is_wildcard": true,
     "recipe_subcategories": [ "CSC_*_FAVORITE", "CSC_*_RECENT", "CSC_*_HIDDEN", "CSC_*_NESTED" ]
   },
   {
@@ -125,11 +126,13 @@
     "type": "recipe_category",
     "id": "CC_BUILDING",
     "recipe_subcategories": [ "CSC_ALL", "CSC_BUILDING_BASES", "CSC_BUILDING_EXPANSIONS" ],
+    "is_building": true,
     "is_hidden": true
   },
   {
     "type": "recipe_category",
     "id": "CC_PRACTICE",
+    "is_practice": true,
     "recipe_subcategories": [
       "CSC_ALL",
       "CSC_PRACTICE_SCIENCE",

--- a/data/mods/Aftershock/effects_on_condition.json
+++ b/data/mods/Aftershock/effects_on_condition.json
@@ -73,11 +73,6 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_AFS_ESCAPE_POD_CARGO_TP",
-    "effect": [ { "u_teleport": { "global_val": "new_map" }, "force": true } ]
-  },
-  {
-    "type": "effect_on_condition",
     "id": "EOC_CRASHING_SHIP_SETUP",
     "eoc_type": "SCENARIO_SPECIFIC",
     "effect": [

--- a/data/mods/Aftershock/recipes/recipes_categories.json
+++ b/data/mods/Aftershock/recipes/recipes_categories.json
@@ -2,36 +2,13 @@
   {
     "type": "recipe_category",
     "id": "CC_ELECTRONIC",
-    "recipe_subcategories": [
-      "CSC_ALL",
-      "CSC_ELECTRONIC_CBMS",
-      "CSC_ELECTRONIC_TOOLS",
-      "CSC_ELECTRONIC_PARTS",
-      "CSC_ELECTRONIC_LIGHTING",
-      "CSC_ELECTRONIC_COMPONENTS",
-      "CSC_ELECTRONIC_OTHER"
-    ]
+    "copy-from": "CC_ELECTRONIC",
+    "extend": { "recipe_subcategories": [ "CSC_ELECTRONIC_CBMS" ] }
   },
   {
     "type": "recipe_category",
     "id": "CC_PRACTICE",
-    "recipe_subcategories": [
-      "CSC_ALL",
-      "CSC_PRACTICE_SCIENCE",
-      "CSC_PRACTICE_ELECTRONICS",
-      "CSC_PRACTICE_FABRICATION",
-      "CSC_PRACTICE_FOOD",
-      "CSC_PRACTICE_SURVIVAL",
-      "CSC_PRACTICE_TAILORING",
-      "CSC_PRACTICE_ATHLETICS",
-      "CSC_PRACTICE_COMPUTERS",
-      "CSC_PRACTICE_DEVICES",
-      "CSC_PRACTICE_HEALTH",
-      "CSC_PRACTICE_MECHANICS",
-      "CSC_PRACTICE_SOCIAL",
-      "CSC_PRACTICE_MELEE",
-      "CSC_PRACTICE_RANGED",
-      "CSC_PRACTICE_PSI"
-    ]
+    "copy-from": "CC_PRACTICE",
+    "extend": { "recipe_subcategories": [ "CSC_PRACTICE_PSI" ] }
   }
 ]

--- a/data/mods/DinoMod/recipes/recipes.json
+++ b/data/mods/DinoMod/recipes/recipes.json
@@ -2,15 +2,7 @@
   {
     "type": "recipe_category",
     "id": "CC_ANIMALS",
-    "recipe_subcategories": [
-      "CSC_ALL",
-      "CSC_ANIMALS_BOVINE ARMOR",
-      "CSC_ANIMALS_CANINE ARMOR",
-      "CSC_ANIMALS_EQUINE ARMOR",
-      "CSC_ANIMALS_ELEPHANT ARMOR",
-      "CSC_ANIMALS_OSTRICH ARMOR",
-      "CSC_ANIMALS_BEAR ARMOR",
-      "CSC_ANIMALS_EQUINE STORAGE"
-    ]
+    "copy-from": "CC_ANIMALS",
+    "extend": { "recipe_subcategories": [ "CSC_ANIMALS_ELEPHANT ARMOR", "CSC_ANIMALS_OSTRICH ARMOR", "CSC_ANIMALS_BEAR ARMOR" ] }
   }
 ]

--- a/data/mods/MindOverMatter/recipes/psionics_practice.json
+++ b/data/mods/MindOverMatter/recipes/psionics_practice.json
@@ -2,24 +2,8 @@
   {
     "type": "recipe_category",
     "id": "CC_PRACTICE",
-    "recipe_subcategories": [
-      "CSC_ALL",
-      "CSC_PRACTICE_SCIENCE",
-      "CSC_PRACTICE_ELECTRONICS",
-      "CSC_PRACTICE_FABRICATION",
-      "CSC_PRACTICE_FOOD",
-      "CSC_PRACTICE_SURVIVAL",
-      "CSC_PRACTICE_TAILORING",
-      "CSC_PRACTICE_ATHLETICS",
-      "CSC_PRACTICE_COMPUTERS",
-      "CSC_PRACTICE_DEVICES",
-      "CSC_PRACTICE_HEALTH",
-      "CSC_PRACTICE_MECHANICS",
-      "CSC_PRACTICE_SOCIAL",
-      "CSC_PRACTICE_MELEE",
-      "CSC_PRACTICE_RANGED",
-      "CSC_PRACTICE_METAPHYSICS"
-    ]
+    "copy-from": "CC_PRACTICE",
+    "extend": { "recipe_subcategories": [ "CSC_PRACTICE_METAPHYSICS" ] }
   },
   {
     "id": "prac_psionics_begin",

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -36,6 +36,7 @@
 #include "contents_change_handler.h"
 #include "coordinates.h"
 #include "craft_command.h"
+#include "crafting_gui.h"
 #include "creature.h"
 #include "creature_tracker.h"
 #include "debug.h"
@@ -3768,7 +3769,7 @@ void craft_activity_actor::canceled( player_activity &/*act*/, Character &/*who*
     }
     const recipe item_recipe = craft->get_making();
     // practice recipe items with no components can be safely removed
-    if( item_recipe.category == "CC_PRACTICE" && craft->components.empty() ) {
+    if( item_recipe.category->is_practice && craft->components.empty() ) {
         craft_item.remove_item();
     }
 }

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -157,7 +157,7 @@ static bool crafting_allowed( const Character &p, const recipe &rec )
         return false;
     }
 
-    if( rec.category == "CC_BUILDING" ) {
+    if( rec.category->is_building ) {
         add_msg( m_info, _( "Overmap terrain building recipes are not implemented yet!" ) );
         return false;
     }

--- a/src/crafting_gui.h
+++ b/src/crafting_gui.h
@@ -23,11 +23,24 @@ class recipe;
 std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &batch_size_out,
         const recipe_id &goto_recipe, Character *crafter, std::string filterstring = "" );
 
-void load_recipe_category( const JsonObject &jsobj );
+void load_recipe_category( const JsonObject &jsobj, const std::string &src );
 void reset_recipe_categories();
 
 // Returns nullptr if the category does not exist, or a pointer to its vector
 // of subcategories it the category does exist
 const std::vector<std::string> *subcategories_for_category( const std::string &category );
+
+struct crafting_category {
+    crafting_category_id id;
+    bool was_loaded = false;
+
+    bool is_hidden;
+    bool is_practice;
+    bool is_building;
+    bool is_wildcard;
+    std::vector<std::string> subcategories;
+
+    void load( const JsonObject &jo, std::string_view src );
+};
 
 #endif // CATA_SRC_CRAFTING_GUI_H

--- a/src/damage.cpp
+++ b/src/damage.cpp
@@ -112,7 +112,7 @@ static damage_info_order::info_disp read_info_disp( const std::string &s )
     }
 }
 
-void damage_type::load( const JsonObject &jo, std::string_view )
+void damage_type::load( const JsonObject &jo, std::string_view src )
 {
     mandatory( jo, was_loaded, "name", name );
     optional( jo, was_loaded, "skill", skill, skill_id::NULL_ID() );
@@ -151,11 +151,11 @@ void damage_type::load( const JsonObject &jo, std::string_view )
     }
 
     for( JsonValue jv : jo.get_array( "onhit_eocs" ) ) {
-        onhit_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, "" ) );
+        onhit_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, std::string( src ) ) );
     }
 
     for( JsonValue jv : jo.get_array( "ondamage_eocs" ) ) {
-        ondamage_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, "" ) );
+        ondamage_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, std::string( src ) ) );
     }
 }
 

--- a/src/dialogue.h
+++ b/src/dialogue.h
@@ -129,12 +129,14 @@ struct talk_effect_t {
         void set_effect_consequence( const talk_effect_fun_t &fun, dialogue_consequence con );
         void set_effect_consequence( const std::function<void( npc &p )> &ptr, dialogue_consequence con );
 
-        void load_effect( const JsonObject &jo, const std::string &member_name );
-        void parse_sub_effect( const JsonObject &jo );
-        void parse_string_effect( const std::string &effect_id, const JsonObject &jo );
+        void load_effect( const JsonObject &jo, const std::string &member_name,
+                          std::string_view src );
+        void parse_sub_effect( const JsonObject &jo, std::string_view src );
+        void parse_string_effect( const std::string &effect_id, const JsonObject &jo,
+                                  std::string_view src );
 
         talk_effect_t() = default;
-        explicit talk_effect_t( const JsonObject &, const std::string & );
+        explicit talk_effect_t( const JsonObject &, const std::string &, std::string_view src );
 
         /**
          * Functions that are called when the response is chosen.
@@ -178,7 +180,7 @@ struct talk_response {
     std::set<dialogue_consequence> get_consequences( dialogue &d ) const;
 
     talk_response();
-    explicit talk_response( const JsonObject & );
+    explicit talk_response( const JsonObject &, std::string_view );
 };
 
 struct dialogue {
@@ -368,12 +370,12 @@ class json_talk_response
         // the topic to move to on failure
         std::string failure_topic;
 
-        void load_condition( const JsonObject &jo );
+        void load_condition( const JsonObject &jo, std::string_view src );
         bool test_condition( dialogue &d ) const;
 
     public:
         json_talk_response() = default;
-        explicit json_talk_response( const JsonObject &jo );
+        explicit json_talk_response( const JsonObject &jo, std::string_view src );
 
         const talk_response &get_actual_response() const;
         bool has_condition() const {
@@ -394,7 +396,7 @@ class json_talk_repeat_response
 {
     public:
         json_talk_repeat_response() = default;
-        explicit json_talk_repeat_response( const JsonObject &jo );
+        explicit json_talk_repeat_response( const JsonObject &jo, std::string_view src );
         bool is_npc = false;
         bool include_containers = false;
         std::vector<itype_id> for_item;
@@ -408,7 +410,7 @@ class json_dynamic_line_effect
         std::function<bool( dialogue & )> condition;
         talk_effect_t effect;
     public:
-        json_dynamic_line_effect( const JsonObject &jo, const std::string &id );
+        json_dynamic_line_effect( const JsonObject &jo, const std::string &id, std::string_view src );
         bool test_condition( dialogue &d ) const;
         void apply( dialogue &d ) const;
 };
@@ -433,7 +435,7 @@ class json_talk_topic
          * It will override dynamic_line and replace_built_in_responses if those entries
          * exist in the input, otherwise they will not be changed at all.
          */
-        void load( const JsonObject &jo );
+        void load( const JsonObject &jo, std::string_view src );
 
         std::string get_dynamic_line( dialogue &d ) const;
         std::vector<json_dynamic_line_effect> get_speaker_effects() const;
@@ -452,6 +454,6 @@ class json_talk_topic
 };
 
 void unload_talk_topics();
-void load_talk_topic( const JsonObject &jo );
+void load_talk_topic( const JsonObject &jo, std::string_view src );
 
 #endif // CATA_SRC_DIALOGUE_H

--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -1503,7 +1503,7 @@ static const std::unordered_set<efftype_id> hardcoded_movement_impairing = {{
     }
 };
 
-void load_effect_type( const JsonObject &jo )
+void load_effect_type( const JsonObject &jo, const std::string_view src )
 {
     effect_type new_etype;
     new_etype.id = efftype_id( jo.get_string( "id" ) );
@@ -1605,7 +1605,7 @@ void load_effect_type( const JsonObject &jo )
     for( JsonValue jv : jo.get_array( "enchantments" ) ) {
         std::string enchant_name = "INLINE_ENCH_" + new_etype.id.str() + "_" + std::to_string(
                                        enchant_num++ );
-        new_etype.enchantments.push_back( enchantment::load_inline_enchantment( jv, "", enchant_name ) );
+        new_etype.enchantments.push_back( enchantment::load_inline_enchantment( jv, src, enchant_name ) );
     }
     effect_types[new_etype.id] = new_etype;
 }

--- a/src/effect.h
+++ b/src/effect.h
@@ -103,7 +103,7 @@ struct effect_dur_mod {
 
 class effect_type
 {
-        friend void load_effect_type( const JsonObject &jo );
+        friend void load_effect_type( const JsonObject &jo, std::string_view src );
         friend class effect;
     public:
         enum class memorial_gender : int {
@@ -444,7 +444,7 @@ class effect
 
 };
 
-void load_effect_type( const JsonObject &jo );
+void load_effect_type( const JsonObject &jo, std::string_view src );
 void reset_effect_types();
 const std::map<efftype_id, effect_type> &get_effect_types();
 

--- a/src/effect_on_condition.cpp
+++ b/src/effect_on_condition.cpp
@@ -75,7 +75,7 @@ void effect_on_conditions::check_consistency()
 {
 }
 
-void effect_on_condition::load( const JsonObject &jo, const std::string_view )
+void effect_on_condition::load( const JsonObject &jo, const std::string_view src )
 {
     mandatory( jo, was_loaded, "id", id );
     optional( jo, was_loaded, "eoc_type", type, eoc_type::NUM_EOC_TYPES );
@@ -98,10 +98,10 @@ void effect_on_condition::load( const JsonObject &jo, const std::string_view )
         read_condition( jo, "condition", condition, false );
         has_condition = true;
     }
-    true_effect.load_effect( jo, "effect" );
+    true_effect.load_effect( jo, "effect", std::string( src ) );
 
     if( jo.has_member( "false_effect" ) ) {
-        false_effect.load_effect( jo, "false_effect" );
+        false_effect.load_effect( jo, "false_effect", std::string( src ) );
         has_false_effect = true;
     }
 
@@ -117,7 +117,7 @@ void effect_on_condition::load( const JsonObject &jo, const std::string_view )
 }
 
 effect_on_condition_id effect_on_conditions::load_inline_eoc( const JsonValue &jv,
-        std::string_view src )
+        const std::string_view src )
 {
     if( jv.test_string() ) {
         return effect_on_condition_id( jv.get_string() );

--- a/src/iexamine.h
+++ b/src/iexamine.h
@@ -29,7 +29,7 @@ struct iexamine_actor {
 
     explicit iexamine_actor( const std::string &type ) : type( type ) {}
 
-    virtual void load( const JsonObject & ) = 0;
+    virtual void load( const JsonObject &, const std::string & ) = 0;
     virtual void call( Character &, const tripoint & ) const = 0;
     virtual void finalize() const = 0;
 

--- a/src/iexamine_actors.cpp
+++ b/src/iexamine_actors.cpp
@@ -16,7 +16,7 @@
 static const ter_str_id ter_t_door_metal_c( "t_door_metal_c" );
 static const ter_str_id ter_t_door_metal_locked( "t_door_metal_locked" );
 
-void appliance_convert_examine_actor::load( const JsonObject &jo )
+void appliance_convert_examine_actor::load( const JsonObject &jo, const std::string & )
 {
     optional( jo, false, "furn_set", furn_set );
     optional( jo, false, "ter_set", ter_set );
@@ -193,7 +193,7 @@ void cardreader_examine_actor::call( Character &you, const tripoint &examp ) con
     }
 }
 
-void cardreader_examine_actor::load( const JsonObject &jo )
+void cardreader_examine_actor::load( const JsonObject &jo, const std::string & )
 {
     mandatory( jo, false, "flags", allowed_flags );
     optional( jo, false, "consume_card", consume, true );
@@ -257,10 +257,10 @@ void eoc_examine_actor::call( Character &you, const tripoint &examp ) const
     }
 }
 
-void eoc_examine_actor::load( const JsonObject &jo )
+void eoc_examine_actor::load( const JsonObject &jo, const std::string &src )
 {
     for( JsonValue jv : jo.get_array( "effect_on_conditions" ) ) {
-        eocs.emplace_back( effect_on_conditions::load_inline_eoc( jv, "" ) );
+        eocs.emplace_back( effect_on_conditions::load_inline_eoc( jv, src ) );
     }
 }
 

--- a/src/iexamine_actors.h
+++ b/src/iexamine_actors.h
@@ -20,7 +20,7 @@ class appliance_convert_examine_actor : public iexamine_actor
         explicit appliance_convert_examine_actor( const std::string &type = "appliance_convert" )
             : iexamine_actor( type ) {}
 
-        void load( const JsonObject &jo ) override;
+        void load( const JsonObject &jo, const std::string & ) override;
         void call( Character &you, const tripoint &examp ) const override;
         void finalize() const override;
 
@@ -60,7 +60,7 @@ class cardreader_examine_actor : public iexamine_actor
         explicit cardreader_examine_actor( const std::string &type = "cardreader" )
             : iexamine_actor( type ) {}
 
-        void load( const JsonObject &jo ) override;
+        void load( const JsonObject &jo, const std::string & ) override;
         void call( Character &you, const tripoint &examp ) const override;
         void finalize() const override;
 
@@ -75,7 +75,7 @@ class eoc_examine_actor : public iexamine_actor
         explicit eoc_examine_actor( const std::string &type = "effect_on_condition" )
             : iexamine_actor( type ) {}
 
-        void load( const JsonObject &jo ) override;
+        void load( const JsonObject &jo, const std::string &src ) override;
         void call( Character &you, const tripoint &examp ) const override;
         void finalize() const override;
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -301,8 +301,8 @@ void DynamicDataLoader::initialize()
 
     // json/colors.json would be listed here, but it's loaded before the others (see init_colors())
     // Non Static Function Access
-    add( "snippet", []( const JsonObject & jo ) {
-        SNIPPET.load_snippet( jo );
+    add( "snippet", []( const JsonObject & jo, const std::string & src ) {
+        SNIPPET.load_snippet( jo, src );
     } );
     add( "item_group", []( const JsonObject & jo ) {
         item_controller->load_item_group( jo );

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -66,6 +66,8 @@ static const ammo_effect_str_id ammo_effect_SPECIAL_COOKOFF( "SPECIAL_COOKOFF" )
 
 static const ammotype ammo_NULL( "NULL" );
 
+static const crafting_category_id crafting_category_CC_FOOD( "CC_FOOD" );
+
 static const damage_type_id damage_bash( "bash" );
 static const damage_type_id damage_bullet( "bullet" );
 
@@ -2666,7 +2668,7 @@ static void load_memory_card_data( memory_card_info &mcd, const JsonObject &jo )
             mcd.recipes_categories.emplace( cat );
         }
     } else {
-        mcd.recipes_categories = { "CC_FOOD" };
+        mcd.recipes_categories = { crafting_category_CC_FOOD };
     }
     if( jo.has_member( "secret_recipes" ) ) {
         mcd.secret_recipes = jo.get_bool( "secret_recipes" );

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -4492,7 +4492,7 @@ void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std:
         // auto-create a category that is unlikely to already be used and put the
         // snippets in it.
         def.snippet_category = "auto:" + def.id.str();
-        SNIPPET.add_snippets_from_json( def.snippet_category, jo.get_array( "snippet_category" ) );
+        SNIPPET.add_snippets_from_json( def.snippet_category, jo.get_array( "snippet_category" ), src );
     } else {
         def.snippet_category = jo.get_string( "snippet_category", "" );
     }

--- a/src/item_factory.h
+++ b/src/item_factory.h
@@ -329,12 +329,14 @@ class Item_factory
         void emplace_usage( std::map<std::string, use_function> &container,
                             const std::string &iuse_id );
 
-        void set_use_methods_from_json( const JsonObject &jo, const std::string &member,
-                                        std::map<std::string, use_function> &use_methods, std::map<std::string, int> &ammo_scale );
+        void set_use_methods_from_json( const JsonObject &jo, const std::string &src,
+                                        const std::string &member, std::map<std::string, use_function> &use_methods,
+                                        std::map<std::string, int> &ammo_scale );
 
         use_function usage_from_string( const std::string &type ) const;
 
-        std::pair<std::string, use_function> usage_from_object( const JsonObject &obj );
+        std::pair<std::string, use_function> usage_from_object( const JsonObject &obj,
+                const std::string & );
 
         /**
          * Helper function for Item_group loading

--- a/src/itype.h
+++ b/src/itype.h
@@ -1182,7 +1182,7 @@ struct memory_card_info {
     int recipes_amount;
     int recipes_level_min;
     int recipes_level_max;
-    std::set<std::string> recipes_categories;
+    std::set<crafting_category_id> recipes_categories;
     bool secret_recipes;
 };
 

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -146,6 +146,8 @@ static const construction_str_id construction_constr_pit( "constr_pit" );
 static const construction_str_id construction_constr_pit_shallow( "constr_pit_shallow" );
 static const construction_str_id construction_constr_water_channel( "constr_water_channel" );
 
+static const crafting_category_id crafting_category_CC_FOOD( "CC_FOOD" );
+
 static const efftype_id effect_adrenaline( "adrenaline" );
 static const efftype_id effect_antibiotic( "antibiotic" );
 static const efftype_id effect_antibiotic_visible( "antibiotic_visible" );
@@ -7569,7 +7571,8 @@ std::optional<int> iuse::multicooker( Character *p, item *it, const tripoint &po
         int counter = 0;
         static const std::set<std::string> multicooked_subcats = { "CSC_FOOD_MEAT", "CSC_FOOD_VEGGI", "CSC_FOOD_PASTA" };
 
-        for( const recipe * const &r : get_avatar().get_learned_recipes().in_category( "CC_FOOD" ) ) {
+        for( const recipe * const &r : get_avatar().get_learned_recipes().in_category(
+                 crafting_category_CC_FOOD ) ) {
             if( multicooked_subcats.count( r->subcategory ) > 0 ) {
                 dishes.push_back( r );
                 const bool can_make = r->deduped_requirements().can_make_with_inventory(

--- a/src/iuse.h
+++ b/src/iuse.h
@@ -285,7 +285,7 @@ class iuse_actor
         int cost;
 
         virtual ~iuse_actor() = default;
-        virtual void load( const JsonObject &jo ) = 0;
+        virtual void load( const JsonObject &jo, const std::string &src ) = 0;
         virtual std::optional<int> use( Character *, item &, const tripoint & ) const = 0;
         virtual ret_val<void> can_use( const Character &, const item &, const tripoint & ) const;
         virtual void info( const item &, std::vector<iteminfo> & ) const {}

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -168,7 +168,7 @@ std::unique_ptr<iuse_actor> iuse_transform::clone() const
     return std::make_unique<iuse_transform>( *this );
 }
 
-void iuse_transform::load( const JsonObject &obj )
+void iuse_transform::load( const JsonObject &obj, const std::string & )
 {
     obj.read( "target", target, true );
 
@@ -484,7 +484,7 @@ std::unique_ptr<iuse_actor> unpack_actor::clone() const
     return std::make_unique<unpack_actor>( *this );
 }
 
-void unpack_actor::load( const JsonObject &obj )
+void unpack_actor::load( const JsonObject &obj, const std::string & )
 {
     obj.read( "group", unpack_group );
     obj.read( "items_fit", items_fit );
@@ -537,7 +537,7 @@ std::unique_ptr<iuse_actor> message_iuse::clone() const
     return std::make_unique<message_iuse>( *this );
 }
 
-void message_iuse::load( const JsonObject &obj )
+void message_iuse::load( const JsonObject &obj, const std::string & )
 {
     obj.read( "name", name );
     obj.read( "message", message );
@@ -570,7 +570,7 @@ std::unique_ptr<iuse_actor> sound_iuse::clone() const
     return std::make_unique<sound_iuse>( *this );
 }
 
-void sound_iuse::load( const JsonObject &obj )
+void sound_iuse::load( const JsonObject &obj, const std::string & )
 {
     obj.read( "name", name );
     obj.read( "sound_message", sound_message );
@@ -625,7 +625,7 @@ static std::vector<tripoint> points_for_gas_cloud( const tripoint &center, int r
     return result;
 }
 
-void explosion_iuse::load( const JsonObject &obj )
+void explosion_iuse::load( const JsonObject &obj, const std::string & )
 {
     if( obj.has_object( "explosion" ) ) {
         JsonObject expl = obj.get_object( "explosion" );
@@ -717,7 +717,7 @@ static effect_data load_effect_data( const JsonObject &e )
                         bodypart_id( e.get_string( "bp", "bp_null" ) ), e.get_bool( "permanent", false ) );
 }
 
-void consume_drug_iuse::load( const JsonObject &obj )
+void consume_drug_iuse::load( const JsonObject &obj, const std::string & )
 {
     obj.read( "activation_message", activation_message );
     obj.read( "charges_needed", charges_needed );
@@ -855,9 +855,9 @@ std::unique_ptr<iuse_actor> delayed_transform_iuse::clone() const
     return std::make_unique<delayed_transform_iuse>( *this );
 }
 
-void delayed_transform_iuse::load( const JsonObject &obj )
+void delayed_transform_iuse::load( const JsonObject &obj, const std::string &src )
 {
-    iuse_transform::load( obj );
+    iuse_transform::load( obj, src );
     obj.get_member( "not_ready_msg" ).read( not_ready_msg );
     transform_age = obj.get_int( "transform_age" );
 }
@@ -883,7 +883,7 @@ std::unique_ptr<iuse_actor> place_monster_iuse::clone() const
     return std::make_unique<place_monster_iuse>( *this );
 }
 
-void place_monster_iuse::load( const JsonObject &obj )
+void place_monster_iuse::load( const JsonObject &obj, const std::string & )
 {
     mtypeid = mtype_id( obj.get_string( "monster_id" ) );
     obj.read( "friendly_msg", friendly_msg );
@@ -989,7 +989,7 @@ std::unique_ptr<iuse_actor> place_npc_iuse::clone() const
     return std::make_unique<place_npc_iuse>( *this );
 }
 
-void place_npc_iuse::load( const JsonObject &obj )
+void place_npc_iuse::load( const JsonObject &obj, const std::string & )
 {
     npc_class_id = string_id<npc_template>( obj.get_string( "npc_class_id" ) );
     obj.read( "summon_msg", summon_msg );
@@ -1069,7 +1069,7 @@ void deploy_furn_actor::info( const item &, std::vector<iteminfo> &dump ) const
     }
 }
 
-void deploy_furn_actor::load( const JsonObject &obj )
+void deploy_furn_actor::load( const JsonObject &obj, const std::string & )
 {
     furn_type = furn_str_id( obj.get_string( "furn_type" ) );
 }
@@ -1170,7 +1170,7 @@ void deploy_appliance_actor::info( const item &, std::vector<iteminfo> &dump ) c
                                       vpart_appliance_from_item( appliance_base )->name() ) );
 }
 
-void deploy_appliance_actor::load( const JsonObject &obj )
+void deploy_appliance_actor::load( const JsonObject &obj, const std::string & )
 {
     mandatory( obj, false, "base", appliance_base );
 }
@@ -1194,7 +1194,7 @@ std::unique_ptr<iuse_actor> reveal_map_actor::clone() const
     return std::make_unique<reveal_map_actor>( *this );
 }
 
-void reveal_map_actor::load( const JsonObject &obj )
+void reveal_map_actor::load( const JsonObject &obj, const std::string & )
 {
     radius = obj.get_int( "radius" );
     obj.get_member( "message" ).read( message );
@@ -1257,7 +1257,7 @@ std::optional<int> reveal_map_actor::use( Character *p, item &it, const tripoint
     return 0;
 }
 
-void firestarter_actor::load( const JsonObject &obj )
+void firestarter_actor::load( const JsonObject &obj, const std::string & )
 {
     moves_cost_fast = obj.get_int( "moves", moves_cost_fast );
     moves_cost_slow = obj.get_int( "moves_slow", moves_cost_fast * 10 );
@@ -1457,7 +1457,7 @@ std::optional<int> firestarter_actor::use( Character *p, item &it,
     return 0;
 }
 
-void salvage_actor::load( const JsonObject &obj )
+void salvage_actor::load( const JsonObject &obj, const std::string & )
 {
     assign( obj, "cost", cost );
     assign( obj, "moves_per_part", moves_per_part );
@@ -1785,7 +1785,7 @@ void salvage_actor::cut_up( Character &p, item_location &cut ) const
     }
 }
 
-void inscribe_actor::load( const JsonObject &obj )
+void inscribe_actor::load( const JsonObject &obj, const std::string & )
 {
     assign( obj, "cost", cost );
     assign( obj, "on_items", on_items );
@@ -1935,7 +1935,7 @@ std::optional<int> inscribe_actor::use( Character *p, item &it, const tripoint &
     return std::nullopt;
 }
 
-void fireweapon_off_actor::load( const JsonObject &obj )
+void fireweapon_off_actor::load( const JsonObject &obj, const std::string & )
 {
     obj.read( "target_id", target_id, true );
     obj.read( "success_message", success_message );
@@ -1991,7 +1991,7 @@ ret_val<void> fireweapon_off_actor::can_use( const Character &p, const item &it,
     return ret_val<void>::make_success();
 }
 
-void fireweapon_on_actor::load( const JsonObject &obj )
+void fireweapon_on_actor::load( const JsonObject &obj, const std::string & )
 {
     obj.read( "noise_message", noise_message );
     obj.get_member( "charges_extinguish_message" ).read( charges_extinguish_message );
@@ -2039,7 +2039,7 @@ std::optional<int> fireweapon_on_actor::use( Character *p, item &it,
     return 1;
 }
 
-void manualnoise_actor::load( const JsonObject &obj )
+void manualnoise_actor::load( const JsonObject &obj, const std::string & )
 {
     obj.get_member( "use_message" ).read( use_message );
     obj.read( "noise_message", noise_message );
@@ -2076,7 +2076,7 @@ ret_val<void> manualnoise_actor::can_use( const Character &p, const item &it,
     return ret_val<void>::make_success();
 }
 
-void play_instrument_iuse::load( const JsonObject & )
+void play_instrument_iuse::load( const JsonObject &, const std::string & )
 {
 }
 
@@ -2113,7 +2113,7 @@ std::unique_ptr<iuse_actor> musical_instrument_actor::clone() const
     return std::make_unique<musical_instrument_actor>( *this );
 }
 
-void musical_instrument_actor::load( const JsonObject &obj )
+void musical_instrument_actor::load( const JsonObject &obj, const std::string & )
 {
     speed_penalty = obj.get_int( "speed_penalty", 10 );
     volume = obj.get_int( "volume" );
@@ -2261,7 +2261,7 @@ std::unique_ptr<iuse_actor> learn_spell_actor::clone() const
     return std::make_unique<learn_spell_actor>( *this );
 }
 
-void learn_spell_actor::load( const JsonObject &obj )
+void learn_spell_actor::load( const JsonObject &obj, const std::string & )
 {
     spells = obj.get_string_array( "spells" );
 }
@@ -2404,7 +2404,7 @@ std::unique_ptr<iuse_actor> cast_spell_actor::clone() const
     return std::make_unique<cast_spell_actor>( *this );
 }
 
-void cast_spell_actor::load( const JsonObject &obj )
+void cast_spell_actor::load( const JsonObject &obj, const std::string & )
 {
     no_fail = obj.get_bool( "no_fail" );
     item_spell = spell_id( obj.get_string( "spell_id" ) );
@@ -2478,7 +2478,7 @@ std::unique_ptr<iuse_actor> holster_actor::clone() const
     return std::make_unique<holster_actor>( *this );
 }
 
-void holster_actor::load( const JsonObject &obj )
+void holster_actor::load( const JsonObject &obj, const std::string & )
 {
     obj.read( "holster_prompt", holster_prompt );
     obj.read( "holster_msg", holster_msg );
@@ -2633,7 +2633,7 @@ std::unique_ptr<iuse_actor> ammobelt_actor::clone() const
     return std::make_unique<ammobelt_actor>( *this );
 }
 
-void ammobelt_actor::load( const JsonObject &obj )
+void ammobelt_actor::load( const JsonObject &obj, const std::string & )
 {
     belt = itype_id( obj.get_string( "belt" ) );
 }
@@ -2665,7 +2665,7 @@ std::optional<int> ammobelt_actor::use( Character *p, item &, const tripoint & )
     return 0;
 }
 
-void repair_item_actor::load( const JsonObject &obj )
+void repair_item_actor::load( const JsonObject &obj, const std::string & )
 {
     // Mandatory:
     for( const std::string line : obj.get_array( "materials" ) ) {
@@ -3259,7 +3259,7 @@ std::string repair_item_actor::get_description() const
     return string_format( _( "Repair %s" ), mats );
 }
 
-void heal_actor::load( const JsonObject &obj )
+void heal_actor::load( const JsonObject &obj, const std::string & )
 {
     // Mandatory
     move_cost = obj.get_int( "move_cost" );
@@ -3770,7 +3770,7 @@ void place_trap_actor::data::load( const JsonObject &obj )
     assign( obj, "moves", moves );
 }
 
-void place_trap_actor::load( const JsonObject &obj )
+void place_trap_actor::load( const JsonObject &obj, const std::string & )
 {
     assign( obj, "allow_underwater", allow_underwater );
     assign( obj, "allow_under_player", allow_under_player );
@@ -3937,7 +3937,7 @@ std::optional<int> place_trap_actor::use( Character *p, item &it, const tripoint
     return 1;
 }
 
-void emit_actor::load( const JsonObject &obj )
+void emit_actor::load( const JsonObject &obj, const std::string & )
 {
     assign( obj, "emits", emits );
     assign( obj, "scale_qty", scale_qty );
@@ -3977,7 +3977,7 @@ void emit_actor::finalize( const itype_id &my_item_type )
     }
 }
 
-void saw_barrel_actor::load( const JsonObject &jo )
+void saw_barrel_actor::load( const JsonObject &jo, const std::string & )
 {
     assign( jo, "cost", cost );
 }
@@ -4038,7 +4038,7 @@ std::unique_ptr<iuse_actor> saw_barrel_actor::clone() const
     return std::make_unique<saw_barrel_actor>( *this );
 }
 
-void saw_stock_actor::load( const JsonObject &jo )
+void saw_stock_actor::load( const JsonObject &jo, const std::string & )
 {
     assign( jo, "cost", cost );
 }
@@ -4113,7 +4113,7 @@ std::unique_ptr<iuse_actor> saw_stock_actor::clone() const
     return std::make_unique<saw_stock_actor>( *this );
 }
 
-void molle_attach_actor::load( const JsonObject &jo )
+void molle_attach_actor::load( const JsonObject &jo, const std::string & )
 {
     assign( jo, "size", size );
     assign( jo, "moves", moves );
@@ -4180,7 +4180,7 @@ std::unique_ptr<iuse_actor> molle_detach_actor::clone() const
     return std::make_unique<molle_detach_actor>( *this );
 }
 
-void molle_detach_actor::load( const JsonObject &jo )
+void molle_detach_actor::load( const JsonObject &jo, const std::string & )
 {
     assign( jo, "moves", moves );
 }
@@ -4423,7 +4423,7 @@ void modify_gunmods_actor::finalize( const itype_id &my_item_type )
     }
 }
 
-void link_up_actor::load( const JsonObject &jo )
+void link_up_actor::load( const JsonObject &jo, const std::string & )
 {
     jo.read( "cable_length", cable_length );
     jo.read( "charge_rate", charge_rate );
@@ -5148,7 +5148,7 @@ std::unique_ptr<iuse_actor> deploy_tent_actor::clone() const
     return std::make_unique<deploy_tent_actor>( *this );
 }
 
-void deploy_tent_actor::load( const JsonObject &obj )
+void deploy_tent_actor::load( const JsonObject &obj, const std::string & )
 {
     assign( obj, "radius", radius );
     assign( obj, "wall", wall );
@@ -5253,7 +5253,7 @@ std::optional<int> weigh_self_actor::use( Character *p, item &, const tripoint &
     return 0;
 }
 
-void weigh_self_actor::load( const JsonObject &jo )
+void weigh_self_actor::load( const JsonObject &jo, const std::string & )
 {
     assign( jo, "max_weight", max_weight );
 }
@@ -5263,7 +5263,7 @@ std::unique_ptr<iuse_actor> weigh_self_actor::clone() const
     return std::make_unique<weigh_self_actor>( *this );
 }
 
-void sew_advanced_actor::load( const JsonObject &obj )
+void sew_advanced_actor::load( const JsonObject &obj, const std::string & )
 {
     // Mandatory:
     for( const std::string line : obj.get_array( "materials" ) ) {
@@ -5505,7 +5505,7 @@ std::unique_ptr<iuse_actor> sew_advanced_actor::clone() const
     return std::make_unique<sew_advanced_actor>( *this );
 }
 
-void change_scent_iuse::load( const JsonObject &obj )
+void change_scent_iuse::load( const JsonObject &obj, const std::string & )
 {
     scenttypeid = scenttype_id( obj.get_string( "scent_typeid" ) );
     if( !scenttypeid.is_valid() ) {
@@ -5551,12 +5551,12 @@ std::unique_ptr<iuse_actor> effect_on_conditons_actor::clone() const
     return std::make_unique<effect_on_conditons_actor>( *this );
 }
 
-void effect_on_conditons_actor::load( const JsonObject &obj )
+void effect_on_conditons_actor::load( const JsonObject &obj, const std::string &src )
 {
     obj.read( "description", description );
     obj.read( "menu_text", menu_text );
     for( JsonValue jv : obj.get_array( "effect_on_conditions" ) ) {
-        eocs.emplace_back( effect_on_conditions::load_inline_eoc( jv, "" ) );
+        eocs.emplace_back( effect_on_conditions::load_inline_eoc( jv, src ) );
     }
 }
 

--- a/src/iuse_actor.h
+++ b/src/iuse_actor.h
@@ -109,7 +109,7 @@ class iuse_transform : public iuse_actor
         explicit iuse_transform( const std::string &type = "transform" ) : iuse_actor( type ) {}
 
         ~iuse_transform() override = default;
-        void load( const JsonObject &obj ) override;
+        void load( const JsonObject &obj, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         ret_val<void> can_use( const Character &, const item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
@@ -138,7 +138,7 @@ class unpack_actor : public iuse_actor
         explicit unpack_actor( const std::string &type = "unpack" ) : iuse_actor( type ) {}
 
         ~unpack_actor() override = default;
-        void load( const JsonObject &obj ) override;
+        void load( const JsonObject &obj, const std::string & ) override;
         std::optional<int> use( Character *p, item &it, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> &dump ) const override;
@@ -156,7 +156,7 @@ class message_iuse : public iuse_actor
         translation message;
 
         ~message_iuse() override = default;
-        void load( const JsonObject &obj ) override;
+        void load( const JsonObject &obj, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         std::string get_name() const override;
@@ -178,7 +178,7 @@ class sound_iuse : public iuse_actor
         std::string sound_variant = "default";
 
         ~sound_iuse() override = default;
-        void load( const JsonObject &obj ) override;
+        void load( const JsonObject &obj, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         std::string get_name() const override;
@@ -216,7 +216,7 @@ class explosion_iuse : public iuse_actor
         explicit explosion_iuse( const std::string &type = "explosion" ) : iuse_actor( type ) {}
 
         ~explosion_iuse() override = default;
-        void load( const JsonObject &obj ) override;
+        void load( const JsonObject &obj, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
@@ -264,7 +264,7 @@ class consume_drug_iuse : public iuse_actor
         explicit consume_drug_iuse( const std::string &type = "consume_drug" ) : iuse_actor( type ) {}
 
         ~consume_drug_iuse() override = default;
-        void load( const JsonObject &obj ) override;
+        void load( const JsonObject &obj, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
@@ -299,7 +299,7 @@ class delayed_transform_iuse : public iuse_transform
                 type ) {}
 
         ~delayed_transform_iuse() override = default;
-        void load( const JsonObject &obj ) override;
+        void load( const JsonObject &obj, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
@@ -332,7 +332,7 @@ class place_monster_iuse : public iuse_actor
 
         place_monster_iuse() : iuse_actor( "place_monster" ) { }
         ~place_monster_iuse() override = default;
-        void load( const JsonObject &obj ) override;
+        void load( const JsonObject &obj, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
@@ -360,7 +360,7 @@ class change_scent_iuse : public iuse_actor
 
         change_scent_iuse() : iuse_actor( "change_scent" ) { }
         ~change_scent_iuse() override = default;
-        void load( const JsonObject &obj ) override;
+        void load( const JsonObject &obj, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
@@ -379,7 +379,7 @@ class place_npc_iuse : public iuse_actor
 
         place_npc_iuse() : iuse_actor( "place_npc" ) { }
         ~place_npc_iuse() override = default;
-        void load( const JsonObject &obj ) override;
+        void load( const JsonObject &obj, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
@@ -398,7 +398,7 @@ class deploy_furn_actor : public iuse_actor
         deploy_furn_actor() : iuse_actor( "deploy_furn" ) {}
 
         ~deploy_furn_actor() override = default;
-        void load( const JsonObject &obj ) override;
+        void load( const JsonObject &obj, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
@@ -415,7 +415,7 @@ class deploy_appliance_actor : public iuse_actor
         deploy_appliance_actor() : iuse_actor( "deploy_appliance" ) {}
         ~deploy_appliance_actor() override = default;
 
-        void load( const JsonObject &obj ) override;
+        void load( const JsonObject &obj, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
@@ -451,7 +451,7 @@ class reveal_map_actor : public iuse_actor
         explicit reveal_map_actor( const std::string &type = "reveal_map" ) : iuse_actor( type ) {}
 
         ~reveal_map_actor() override = default;
-        void load( const JsonObject &obj ) override;
+        void load( const JsonObject &obj, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
@@ -488,7 +488,7 @@ class firestarter_actor : public iuse_actor
         explicit firestarter_actor( const std::string &type = "firestarter" ) : iuse_actor( type ) {}
 
         ~firestarter_actor() override = default;
-        void load( const JsonObject &obj ) override;
+        void load( const JsonObject &obj, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         ret_val<void> can_use( const Character &, const item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
@@ -510,7 +510,7 @@ class salvage_actor : public iuse_actor
         explicit salvage_actor( const std::string &type = "salvage" ) : iuse_actor( type ) {}
 
         ~salvage_actor() override = default;
-        void load( const JsonObject &obj ) override;
+        void load( const JsonObject &obj, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
     private:
@@ -553,7 +553,7 @@ class inscribe_actor : public iuse_actor
         explicit inscribe_actor( const std::string &type = "inscribe" ) : iuse_actor( type ) {}
 
         ~inscribe_actor() override = default;
-        void load( const JsonObject &obj ) override;
+        void load( const JsonObject &obj, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
@@ -576,7 +576,7 @@ class fireweapon_off_actor : public iuse_actor
         fireweapon_off_actor() : iuse_actor( "fireweapon_off" ) {}
 
         ~fireweapon_off_actor() override = default;
-        void load( const JsonObject &obj ) override;
+        void load( const JsonObject &obj, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         ret_val<void> can_use( const Character &, const item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
@@ -597,7 +597,7 @@ class fireweapon_on_actor : public iuse_actor
         explicit fireweapon_on_actor( const std::string &type = "fireweapon_on" ) : iuse_actor( type ) {}
 
         ~fireweapon_on_actor() override = default;
-        void load( const JsonObject &obj ) override;
+        void load( const JsonObject &obj, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
@@ -618,7 +618,7 @@ class manualnoise_actor : public iuse_actor
         explicit manualnoise_actor( const std::string &type = "manualnoise" ) : iuse_actor( type ) {}
 
         ~manualnoise_actor() override = default;
-        void load( const JsonObject &obj ) override;
+        void load( const JsonObject &obj, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         ret_val<void> can_use( const Character &, const item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
@@ -630,7 +630,7 @@ class play_instrument_iuse : public iuse_actor
         explicit play_instrument_iuse( const std::string &type = "play_instrument" ) : iuse_actor( type ) {}
 
         ~play_instrument_iuse() override = default;
-        void load( const JsonObject &obj ) override;
+        void load( const JsonObject &obj, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         ret_val<void> can_use( const Character &, const item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
@@ -675,7 +675,7 @@ class musical_instrument_actor : public iuse_actor
                 type ) {}
 
         ~musical_instrument_actor() override = default;
-        void load( const JsonObject &obj ) override;
+        void load( const JsonObject &obj, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         ret_val<void> can_use( const Character &, const item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
@@ -693,7 +693,7 @@ class learn_spell_actor : public iuse_actor
         explicit learn_spell_actor( const std::string &type = "learn_spell" ) : iuse_actor( type ) {}
 
         ~learn_spell_actor() override = default;
-        void load( const JsonObject &obj ) override;
+        void load( const JsonObject &obj, const std::string & ) override;
         std::optional<int> use( Character *p, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
@@ -720,7 +720,7 @@ class cast_spell_actor : public iuse_actor
         explicit cast_spell_actor( const std::string &type = "cast_spell" ) : iuse_actor( type ) {}
 
         ~cast_spell_actor() override = default;
-        void load( const JsonObject &obj ) override;
+        void load( const JsonObject &obj, const std::string & ) override;
         std::optional<int> use( Character *p, item &it, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
@@ -747,7 +747,7 @@ class holster_actor : public iuse_actor
         explicit holster_actor( const std::string &type = "holster" ) : iuse_actor( type ) {}
 
         ~holster_actor() override = default;
-        void load( const JsonObject &obj ) override;
+        void load( const JsonObject &obj, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
@@ -761,7 +761,7 @@ class ammobelt_actor : public iuse_actor
         ammobelt_actor() : iuse_actor( "ammobelt" ) {}
 
         ~ammobelt_actor() override = default;
-        void load( const JsonObject &obj ) override;
+        void load( const JsonObject &obj, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
@@ -852,7 +852,7 @@ class repair_item_actor : public iuse_actor
         explicit repair_item_actor( const std::string &type = "repair_item" ) : iuse_actor( type ) {}
 
         ~repair_item_actor() override = default;
-        void load( const JsonObject &obj ) override;
+        void load( const JsonObject &obj, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 
@@ -919,7 +919,7 @@ class heal_actor : public iuse_actor
         explicit heal_actor( const std::string &type = "heal" ) : iuse_actor( type ) {}
 
         ~heal_actor() override = default;
-        void load( const JsonObject &obj ) override;
+        void load( const JsonObject &obj, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
@@ -966,7 +966,7 @@ class place_trap_actor : public iuse_actor
 
         explicit place_trap_actor( const std::string &type = "place_trap" );
         ~place_trap_actor() override = default;
-        void load( const JsonObject &obj ) override;
+        void load( const JsonObject &obj, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
@@ -980,7 +980,7 @@ class emit_actor : public iuse_actor
 
         explicit emit_actor( const std::string &type = "emit_actor" ) : iuse_actor( type ) {}
         ~emit_actor() override = default;
-        void load( const JsonObject &obj ) override;
+        void load( const JsonObject &obj, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void finalize( const itype_id &my_item_type ) override;
@@ -991,7 +991,7 @@ class saw_barrel_actor : public iuse_actor
     public:
         explicit saw_barrel_actor( const std::string &type = "saw_barrel" ) : iuse_actor( type ) {}
 
-        void load( const JsonObject &jo ) override;
+        void load( const JsonObject &jo, const std::string & ) override;
         std::optional<int> use( Character *p, item &it, const tripoint &pnt ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 
@@ -1003,7 +1003,7 @@ class saw_stock_actor : public iuse_actor
     public:
         explicit saw_stock_actor( const std::string &type = "saw_stock" ) : iuse_actor( type ) {}
 
-        void load( const JsonObject &jo ) override;
+        void load( const JsonObject &jo, const std::string & ) override;
         std::optional<int> use( Character *p, item &it, const tripoint &pnt ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 
@@ -1019,7 +1019,7 @@ class molle_attach_actor : public iuse_actor
         int size;
         int moves;
 
-        void load( const JsonObject &jo ) override;
+        void load( const JsonObject &jo, const std::string & ) override;
         std::optional<int> use( Character *p, item &it, const tripoint &pnt ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
@@ -1032,7 +1032,7 @@ class molle_detach_actor : public iuse_actor
 
         int moves;
 
-        void load( const JsonObject &jo ) override;
+        void load( const JsonObject &jo, const std::string & ) override;
         std::optional<int> use( Character *p, item &it, const tripoint &pnt ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
@@ -1042,7 +1042,7 @@ class install_bionic_actor : public iuse_actor
     public:
         explicit install_bionic_actor( const std::string &type = "install_bionic" ) : iuse_actor( type ) {}
 
-        void load( const JsonObject & ) override {}
+        void load( const JsonObject &, const std::string & ) override {}
         std::optional<int> use( Character *p, item &it, const tripoint &pnt ) const override;
         ret_val<void> can_use( const Character &, const item &it, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
@@ -1054,7 +1054,7 @@ class detach_gunmods_actor : public iuse_actor
     public:
         explicit detach_gunmods_actor( const std::string &type = "detach_gunmods" ) : iuse_actor( type ) {}
 
-        void load( const JsonObject & ) override {}
+        void load( const JsonObject &, const std::string & ) override {}
         std::optional<int> use( Character *p, item &it, const tripoint &pnt ) const override;
         ret_val<void> can_use( const Character &, const item &it, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
@@ -1066,7 +1066,7 @@ class modify_gunmods_actor : public iuse_actor
     public:
         explicit modify_gunmods_actor( const std::string &type = "modify_gunmods" ) : iuse_actor( type ) {}
 
-        void load( const JsonObject & ) override {}
+        void load( const JsonObject &, const std::string & ) override {}
         std::optional<int> use( Character *p, item &it, const tripoint &pnt ) const override;
         ret_val<void> can_use( const Character &, const item &it, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
@@ -1098,7 +1098,7 @@ class link_up_actor : public iuse_actor
         link_up_actor() : iuse_actor( "link_up" ) {}
 
         ~link_up_actor() override = default;
-        void load( const JsonObject &jo ) override;
+        void load( const JsonObject &jo, const std::string & ) override;
         std::unique_ptr<iuse_actor> clone() const override;
         std::string get_name() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
@@ -1119,7 +1119,7 @@ class deploy_tent_actor : public iuse_actor
         deploy_tent_actor() : iuse_actor( "deploy_tent" ) {}
 
         ~deploy_tent_actor() override = default;
-        void load( const JsonObject &obj ) override;
+        void load( const JsonObject &obj, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 
@@ -1138,7 +1138,7 @@ class weigh_self_actor : public iuse_actor
         explicit weigh_self_actor( const std::string &type = "weigh_self" ) : iuse_actor( type ) {}
 
         ~weigh_self_actor() override = default;
-        void load( const JsonObject &jo ) override;
+        void load( const JsonObject &jo, const std::string & ) override;
         std::optional<int> use( Character *p, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         void info( const item &, std::vector<iteminfo> & ) const override;
@@ -1160,7 +1160,7 @@ class sew_advanced_actor : public iuse_actor
         explicit sew_advanced_actor( const std::string &type = "sew_advanced" ) : iuse_actor( type ) {}
 
         ~sew_advanced_actor() override = default;
-        void load( const JsonObject &obj ) override;
+        void load( const JsonObject &obj, const std::string & ) override;
         std::optional<int> use( Character *, item &, const tripoint & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
 };
@@ -1178,7 +1178,7 @@ class effect_on_conditons_actor : public iuse_actor
                 type ) {}
 
         ~effect_on_conditons_actor() override = default;
-        void load( const JsonObject &obj ) override;
+        void load( const JsonObject &obj, const std::string &src ) override;
         std::optional<int> use( Character *p, item &it, const tripoint &point ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         std::string get_name() const override;

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -240,13 +240,10 @@ enchantment_id enchantment::load_inline_enchantment( const JsonValue &jv,
         if( inline_id.empty() ) {
             jv.throw_error( "Inline enchantment cannot be created without an id." );
         }
-        if( spell_factory.is_valid( enchantment_id( inline_id ) ) ) {
-            jv.throw_error( "Inline enchantment " + inline_id +
-                            " cannot be created as an enchantment already has this id." );
-        }
 
         enchantment inline_enchant;
         inline_enchant.load( jv.get_object(), src, inline_id );
+        mod_tracker::assign_src( inline_enchant, src );
         spell_factory.insert( inline_enchant );
         return enchantment_id( inline_id );
     } else {

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -822,7 +822,7 @@ void init_mapdata()
     add_actor( std::make_unique<eoc_examine_actor>() );
 }
 
-void map_data_common_t::load( const JsonObject &jo, const std::string & )
+void map_data_common_t::load( const JsonObject &jo, const std::string &src )
 {
     if( jo.has_string( "examine_action" ) ) {
         examine_actor = nullptr;
@@ -830,7 +830,7 @@ void map_data_common_t::load( const JsonObject &jo, const std::string & )
     } else if( jo.has_object( "examine_action" ) ) {
         JsonObject data = jo.get_object( "examine_action" );
         examine_actor = iexamine_actor_from_jsobj( data );
-        examine_actor->load( data );
+        examine_actor->load( data, src );
         examine_func = iexamine_functions_from_string( "invalid" );
     } else if( !was_loaded ) {
         examine_actor = nullptr;

--- a/src/mission.h
+++ b/src/mission.h
@@ -260,7 +260,8 @@ struct mission_type {
         static void finalize();
         static void check_consistency();
 
-        bool parse_funcs( const JsonObject &jo, std::function<void( mission * )> &phase_func );
+        bool parse_funcs( const JsonObject &jo, std::string_view src,
+                          std::function<void( mission * )> &phase_func );
         void load( const JsonObject &jo, const std::string &src );
 
         /**

--- a/src/mission_util.cpp
+++ b/src/mission_util.cpp
@@ -526,7 +526,8 @@ bool mission_util::load_funcs( const JsonObject &jo,
     return true;
 }
 
-bool mission_type::parse_funcs( const JsonObject &jo, std::function<void( mission * )> &phase_func )
+bool mission_type::parse_funcs( const JsonObject &jo, const std::string_view src,
+                                std::function<void( mission * )> &phase_func )
 {
     std::vector<std::function<void( mission *miss )>> funcs;
     if( !mission_util::load_funcs( jo, funcs ) ) {
@@ -537,7 +538,7 @@ bool mission_type::parse_funcs( const JsonObject &jo, std::function<void( missio
      * write that code in two places so here it goes.
      */
     talk_effect_t talk_effects;
-    talk_effects.load_effect( jo, "effect" );
+    talk_effects.load_effect( jo, "effect", src );
     phase_func = [ funcs, talk_effects ]( mission * miss ) {
         npc *beta_npc = g->find_npc( miss->get_npc_id() );
         ::dialogue d( get_talker_for( get_avatar() ),

--- a/src/missiondef.cpp
+++ b/src/missiondef.cpp
@@ -365,7 +365,7 @@ void mission_type::load( const JsonObject &jo, const std::string &src )
             assign_function( jo, phase, phase_func, mission_function_map );
         } else if( jo.has_member( phase ) ) {
             JsonObject j_start = jo.get_object( phase );
-            if( !parse_funcs( j_start, phase_func ) ) {
+            if( !parse_funcs( j_start, src, phase_func ) ) {
                 deferred.emplace_back( jo, src );
                 jo.allow_omitted_members();
                 j_start.allow_omitted_members();

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -296,7 +296,7 @@ npc &npc::operator=( npc && ) noexcept( list_is_noexcept ) = default;
 
 static std::map<string_id<npc_template>, npc_template> npc_templates;
 
-void npc_template::load( const JsonObject &jsobj )
+void npc_template::load( const JsonObject &jsobj, const std::string_view src )
 {
     npc_template tem;
     npc &guy = tem.guy;
@@ -450,7 +450,7 @@ void npc_template::load( const JsonObject &jsobj )
         tem.personality->altruism = personality.get_int( "altruism" );
     }
     for( JsonValue jv : jsobj.get_array( "death_eocs" ) ) {
-        guy.death_eocs.emplace_back( effect_on_conditions::load_inline_eoc( jv, "" ) );
+        guy.death_eocs.emplace_back( effect_on_conditions::load_inline_eoc( jv, src ) );
     }
 
     npc_templates.emplace( guy.idz, std::move( tem ) );

--- a/src/npc.h
+++ b/src/npc.h
@@ -1513,7 +1513,7 @@ class npc_template
         std::optional<int> per;
         std::optional<npc_personality> personality;
 
-        static void load( const JsonObject &jsobj );
+        static void load( const JsonObject &jsobj, std::string_view src );
         static void reset();
         static void check_consistency();
 };

--- a/src/output.h
+++ b/src/output.h
@@ -1221,9 +1221,9 @@ class tab_list
 {
     private:
         size_t _index = 0;
-        std::vector<std::string> *_list;
+        const std::vector<std::string> *_list;
     public:
-        explicit tab_list( std::vector<std::string> &_list ) : _list( &_list ) {
+        explicit tab_list( const std::vector<std::string> &_list ) : _list( &_list ) {
         }
 
         void last() {

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -15,6 +15,7 @@
 #include "cata_utility.h"
 #include "character.h"
 #include "color.h"
+#include "crafting_gui.h"
 #include "debug.h"
 #include "enum_traits.h"
 #include "effect_on_condition.h"
@@ -662,7 +663,7 @@ void recipe::add_requirements( const std::vector<std::pair<requirement_id, int>>
 
 std::string recipe::get_consistency_error() const
 {
-    if( category == "CC_BUILDING" ) {
+    if( category.is_valid() && category->is_building ) {
         if( is_blueprint() || oter_str_id( result_.c_str() ).is_valid() ) {
             return std::string();
         }

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -123,7 +123,7 @@ class recipe
         bool was_loaded = false;
         bool obsolete = false;
 
-        std::string category;
+        crafting_category_id category;
         std::string subcategory;
 
         translation description;

--- a/src/recipe_dictionary.cpp
+++ b/src/recipe_dictionary.cpp
@@ -341,7 +341,8 @@ std::vector<const recipe *> recipe_subset::recipes_that_produce( const itype_id 
     return res;
 }
 
-bool recipe_subset::empty_category( const std::string &cat, const std::string &subcat ) const
+bool recipe_subset::empty_category( const crafting_category_id &cat,
+                                    const std::string &subcat ) const
 {
     if( subcat == "CSC_*_FAVORITE" ) {
         return uistate.favorite_recipes.empty();
@@ -349,7 +350,7 @@ bool recipe_subset::empty_category( const std::string &cat, const std::string &s
         return uistate.recent_recipes.empty();
     } else if( subcat == "CSC_*_HIDDEN" ) {
         return uistate.hidden_recipes.empty();
-    } else if( cat == "CC_*" ) {
+    } else if( cat->is_wildcard ) {
         //any other category in CC_* is populated
         return false;
     }
@@ -369,7 +370,7 @@ bool recipe_subset::empty_category( const std::string &cat, const std::string &s
     return true;
 }
 
-std::vector<const recipe *> recipe_subset::in_category( const std::string &cat,
+std::vector<const recipe *> recipe_subset::in_category( const crafting_category_id &cat,
         const std::string &subcat ) const
 {
     std::vector<const recipe *> res;
@@ -676,7 +677,7 @@ void recipe_dictionary::check_consistency()
     for( const auto &e : recipe_dict.recipes ) {
         const recipe &r = e.second;
 
-        if( r.category.empty() ) {
+        if( r.category.str().empty() ) {
             if( !r.subcategory.empty() ) {
                 debugmsg( "recipe %s has subcategory but no category", r.ident().str() );
             }
@@ -684,18 +685,19 @@ void recipe_dictionary::check_consistency()
             continue;
         }
 
-        const std::vector<std::string> *subcategories = subcategories_for_category( r.category );
-        if( !subcategories ) {
-            debugmsg( "recipe %s has invalid category %s", r.ident().str(), r.category );
+        if( !r.category.is_valid() ) {
+            debugmsg( "recipe %s has invalid category %s", r.ident().str(), r.category.str() );
             continue;
         }
 
+        const std::vector<std::string> &subcategories = r.category->subcategories;
+
         if( !r.subcategory.empty() ) {
-            auto it = std::find( subcategories->begin(), subcategories->end(), r.subcategory );
-            if( it == subcategories->end() ) {
+            auto it = std::find( subcategories.begin(), subcategories.end(), r.subcategory );
+            if( it == subcategories.end() ) {
                 debugmsg(
                     "recipe %s has subcategory %s which is invalid or doesn't match category %s",
-                    r.ident().str(), r.subcategory, r.category );
+                    r.ident().str(), r.subcategory, r.category.str() );
             }
         }
     }

--- a/src/recipe_dictionary.h
+++ b/src/recipe_dictionary.h
@@ -128,11 +128,12 @@ class recipe_subset
         int get_custom_difficulty( const recipe *r ) const;
 
         /** Check if there is any recipes in given category (optionally restricted to subcategory), index which is for nested categories */
-        bool empty_category( const std::string &cat, const std::string &subcat = std::string() ) const;
+        bool empty_category( const crafting_category_id &cat,
+                             const std::string &subcat = std::string() ) const;
 
         /** Get all recipes in given category (optionally restricted to subcategory) */
         std::vector<const recipe *> in_category(
-            const std::string &cat,
+            const crafting_category_id &cat,
             const std::string &subcat = std::string() ) const;
 
         /** Returns all recipes which could use component */
@@ -202,7 +203,7 @@ class recipe_subset
     private:
         std::set<const recipe *> recipes;
         std::map<const recipe *, int> difficulties;
-        std::map<std::string, std::set<const recipe *>> category;
+        std::map<crafting_category_id, std::set<const recipe *>> category;
         std::map<itype_id, std::set<const recipe *>> component;
 };
 

--- a/src/text_snippets.cpp
+++ b/src/text_snippets.cpp
@@ -74,7 +74,7 @@ void snippet_library::add_snippet_from_json( const std::string &category, const 
         ids.emplace_back( weighted_id{ weight_acc, id } );
         snippets_by_id[id] = text;
         if( jo.has_member( "effect_on_examine" ) ) {
-            EOC_by_id[id] = talk_effect_t( jo, "effect_on_examine" );
+            EOC_by_id[id] = talk_effect_t( jo, "effect_on_examine", "" );
         }
         translation name;
         optional( jo, false, "name", name );

--- a/src/text_snippets.cpp
+++ b/src/text_snippets.cpp
@@ -14,7 +14,7 @@
 
 snippet_library SNIPPET;
 
-void snippet_library::load_snippet( const JsonObject &jsobj )
+void snippet_library::load_snippet( const JsonObject &jsobj, const std::string &src )
 {
     if( hash_to_id_migration.has_value() ) {
         debugmsg( "snippet_library::load_snippet called after snippet_library::migrate_hash_to_id." );
@@ -22,13 +22,14 @@ void snippet_library::load_snippet( const JsonObject &jsobj )
     hash_to_id_migration = std::nullopt;
     const std::string category = jsobj.get_string( "category" );
     if( jsobj.has_array( "text" ) ) {
-        add_snippets_from_json( category, jsobj.get_array( "text" ) );
+        add_snippets_from_json( category, jsobj.get_array( "text" ), src );
     } else {
-        add_snippet_from_json( category, jsobj );
+        add_snippet_from_json( category, jsobj, src );
     }
 }
 
-void snippet_library::add_snippets_from_json( const std::string &category, const JsonArray &jarr )
+void snippet_library::add_snippets_from_json( const std::string &category, const JsonArray &jarr,
+        const std::string &src )
 {
     if( hash_to_id_migration.has_value() ) {
         debugmsg( "snippet_library::add_snippets_from_json called after snippet_library::migrate_hash_to_id." );
@@ -45,12 +46,13 @@ void snippet_library::add_snippets_from_json( const std::string &category, const
             no_id.emplace_back( weighted_translation{ weight_acc, text } );
         } else {
             JsonObject jo = entry.get_object();
-            add_snippet_from_json( category, jo );
+            add_snippet_from_json( category, jo, src );
         }
     }
 }
 
-void snippet_library::add_snippet_from_json( const std::string &category, const JsonObject &jo )
+void snippet_library::add_snippet_from_json( const std::string &category, const JsonObject &jo,
+        const std::string &src )
 {
     if( hash_to_id_migration.has_value() ) {
         debugmsg( "snippet_library::add_snippet_from_json called after snippet_library::migrate_hash_to_id." );
@@ -74,7 +76,7 @@ void snippet_library::add_snippet_from_json( const std::string &category, const 
         ids.emplace_back( weighted_id{ weight_acc, id } );
         snippets_by_id[id] = text;
         if( jo.has_member( "effect_on_examine" ) ) {
-            EOC_by_id[id] = talk_effect_t( jo, "effect_on_examine", "" );
+            EOC_by_id[id] = talk_effect_t( jo, "effect_on_examine", src );
         }
         translation name;
         optional( jo, false, "name", name );

--- a/src/text_snippets.h
+++ b/src/text_snippets.h
@@ -23,20 +23,22 @@ class snippet_library
         /**
          * Load snippet from the standalone entry, used by the @ref DynamicDataLoader.
          */
-        void load_snippet( const JsonObject &jsobj );
+        void load_snippet( const JsonObject &jsobj, const std::string &src );
         /**
          * Load all snippet definitions in the json array into given category.
          * Entries in the array can be simple strings, or json objects (for the
          * later see add_snippet_from_json).
          */
-        void add_snippets_from_json( const std::string &category, const JsonArray &jarr );
+        void add_snippets_from_json( const std::string &category, const JsonArray &jarr,
+                                     const std::string &src );
         /**
          * Load a single snippet text from the json object. The object should have
          * a "text" member with the text of the snippet.
          * A "id" member is optional and if present gives the snippet text a id,
          * stored in snippets_by_id.
          */
-        void add_snippet_from_json( const std::string &category, const JsonObject &jo );
+        void add_snippet_from_json( const std::string &category, const JsonObject &jo,
+                                    const std::string &src );
         /**
          * Load name list from name.h/cpp
          */

--- a/src/type_id.h
+++ b/src/type_id.h
@@ -58,6 +58,9 @@ using construction_group_str_id = string_id<construction_group>;
 struct clothing_mod;
 using clothing_mod_id = string_id<clothing_mod>;
 
+struct crafting_category;
+using crafting_category_id = string_id<crafting_category>;
+
 struct effect_on_condition;
 using effect_on_condition_id = string_id<effect_on_condition>;
 

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -44,6 +44,8 @@
 
 static const activity_id ACT_CRAFT( "ACT_CRAFT" );
 
+static const crafting_category_id crafting_category_CC_FOOD( "CC_FOOD" );
+
 static const flag_id json_flag_ITEM_BROKEN( "ITEM_BROKEN" );
 static const flag_id json_flag_USE_UPS( "USE_UPS" );
 
@@ -142,7 +144,7 @@ TEST_CASE( "recipe_subset" )
                 CHECK( subset.get_custom_difficulty( r ) == r->difficulty );
             }
             THEN( "it's in the right category" ) {
-                const auto cat_recipes( subset.in_category( "CC_FOOD" ) );
+                const auto cat_recipes( subset.in_category( crafting_category_CC_FOOD ) );
 
                 CHECK( cat_recipes.size() == 1 );
                 CHECK( std::find( cat_recipes.begin(), cat_recipes.end(), r ) != cat_recipes.end() );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/74443

#### Describe the solution
Sorry for scope, I hope reasonable commits and that it's all in service of fixing the one issue (Mind Over Matter and Aftershock are incompatible) makes it acceptable.

Please read the commits for more details.

This does a few things:

1. Fix the loading of `src` data (where the item was loaded from) for inline effect_on_conditions. This requires passing this `src` data down in a bunch of places, and so requires a bunch of changes.  https://github.com/CleverRaven/Cataclysm-DDA/pull/74514/commits/4814801813253b5277356e0e9eef61ed5e69e295 https://github.com/CleverRaven/Cataclysm-DDA/pull/74514/commits/37bc60b951c8f3a1f74f5032fd54901c57464281 https://github.com/CleverRaven/Cataclysm-DDA/pull/74514/commits/2ecaa134315aaeb498a0cb3fc4fe279c0cae76bb https://github.com/CleverRaven/Cataclysm-DDA/pull/74514/commits/220517fa7e88f0385a38b64adc3089b55bb2e76d https://github.com/CleverRaven/Cataclysm-DDA/pull/74514/commits/0a73730545e1870dce7f4b7e651f4c3b1905e436

2. Do the same thing, but for magic_enchantments, and replace the homebrew duplicate checking with the duplicate checking used by everything else.  https://github.com/CleverRaven/Cataclysm-DDA/pull/74514/commits/15d5ca870ed6504799c4a69ac6ad75e8982b43f3

3. Allow extending recipe categories, so two mods can add to the same recipe category. Commit https://github.com/CleverRaven/Cataclysm-DDA/pull/74514/commits/a7fe7ec6ad4595a9b4df13cd47a7859d9044ea6f

4. Allow running the all mods test with both mindovermatter and aftershock again: https://github.com/CleverRaven/Cataclysm-DDA/pull/74514/commits/9ccf992eaa2c671ad5522248c945afd499b74a92

#### Describe alternatives you've considered
Doing this a simpler way.

#### Testing
`tests/cata_test --mods=dda,mindovermatter,aftershock 'force_load_game'` - no errors!
`builds-scripts/get_all_mods.py | xargs -I{} tests/cata_test --mods={} 'force_load_game'` - no errors!

Pull up the game and scroll through the crafting menu - looks the same.

#### Additional context