### PR TITLE
Remove the shooting lightning ability from monsters

### DIFF
--- a/data/json/monsters/zed-winged.json
+++ b/data/json/monsters/zed-winged.json
@@ -168,10 +168,7 @@
     "melee_damage": [ { "damage_type": "electric", "amount": 8 } ],
     "luminance": 8,
     "families": [ "prof_intro_biology", "prof_physiology", "prof_wp_zombie", "prof_electromagnetics" ],
-    "special_attacks": [
-      [ "SHOCKSTORM", 25 ],
-      { "id": "impale", "damage_max_instance": [ { "damage_type": "stab", "amount": 15, "armor_multiplier": 0.6 } ] }
-    ],
+    "special_attacks": [ { "id": "impale", "damage_max_instance": [ { "damage_type": "stab", "amount": 15, "armor_multiplier": 0.6 } ] } ],
     "special_when_hit": [ "ZAPBACK", 100 ],
     "upgrades": false,
     "extend": { "flags": [ "ELECTRIC" ] }

--- a/data/json/monsters/zed_electric.json
+++ b/data/json/monsters/zed_electric.json
@@ -19,7 +19,7 @@
     "special_attacks": [ [ "PARROT", 8 ], { "id": "smash", "throw_strength": 36, "cooldown": 30 } ],
     "special_when_hit": [ "ZAPBACK", 75 ],
     "upgrades": false,
-    "extend": { "families": [ "prof_electromagnetics" ], "flags": [ "ELECTRIC", "RANGED_ATTACKER" ] }
+    "extend": { "families": [ "prof_electromagnetics" ], "flags": [ "ELECTRIC" ] }
   },
   {
     "id": "mon_zombie_electric",
@@ -40,7 +40,7 @@
     "special_attacks": [ [ "PARROT", 8 ] ],
     "special_when_hit": [ "ZAPBACK", 100 ],
     "upgrades": { "half_life": 42, "into_group": "GROUP_ZOMBIE_ELECTRIC_UPGRADE" },
-    "extend": { "families": [ "prof_electromagnetics" ], "flags": [ "ELECTRIC", "RANGED_ATTACKER" ] }
+    "extend": { "families": [ "prof_electromagnetics" ], "flags": [ "ELECTRIC" ] }
   },
   {
     "id": "mon_zombie_nullfield",

--- a/data/json/monsters/zed_electric.json
+++ b/data/json/monsters/zed_electric.json
@@ -16,7 +16,7 @@
     "vision_night": 3,
     "luminance": 16,
     "harvest": "zombie_humanoid_electric",
-    "special_attacks": [ [ "PARROT", 8 ], [ "SHOCKSTORM", 15 ], { "id": "smash", "throw_strength": 36, "cooldown": 30 } ],
+    "special_attacks": [ [ "PARROT", 8 ], { "id": "smash", "throw_strength": 36, "cooldown": 30 } ],
     "special_when_hit": [ "ZAPBACK", 75 ],
     "upgrades": false,
     "extend": { "families": [ "prof_electromagnetics" ], "flags": [ "ELECTRIC", "RANGED_ATTACKER" ] }
@@ -37,7 +37,7 @@
     "bleed_rate": 50,
     "luminance": 8,
     "harvest": "zombie_humanoid_electric",
-    "special_attacks": [ [ "PARROT", 8 ], [ "SHOCKSTORM", 25 ] ],
+    "special_attacks": [ [ "PARROT", 8 ] ],
     "special_when_hit": [ "ZAPBACK", 100 ],
     "upgrades": { "half_life": 42, "into_group": "GROUP_ZOMBIE_ELECTRIC_UPGRADE" },
     "extend": { "families": [ "prof_electromagnetics" ], "flags": [ "ELECTRIC", "RANGED_ATTACKER" ] }

--- a/data/json/monsters/zed_skeletal.json
+++ b/data/json/monsters/zed_skeletal.json
@@ -53,6 +53,37 @@
     "extend": { "weakpoint_sets": [ "wps_bone_armor" ], "families": [ "prof_wp_skeleton" ] }
   },
   {
+    "id": "mon_skeleton_electric",
+    "type": "MONSTER",
+    "name": { "str": "skeletal shocker" },
+    "description": "Heavy, jagged bone plates have grown out of the surface of this zombie's skin.  Underneath, its flesh glows and crackles with the occasional jolt of electricity.",
+    "copy-from": "mon_zombie_base",
+    "diff": 15,
+    "hp": 105,
+    "speed": 60,
+    "material": [ "bone" ],
+    "color": "blue_white",
+    "melee_damage": [ { "damage_type": "electric", "amount": 12 }, { "damage_type": "cut", "amount": 3 } ],
+    "luminance": 8,
+    "bleed_rate": 0,
+    "harvest": "mr_bones",
+    "special_attacks": [
+      { "id": "grab", "cooldown": 21 },
+      { "id": "scratch_humanoid" },
+      { "id": "bite_humanoid", "cooldown": 5 },
+      [ "PARROT", 8 ],
+      [ "SHOCKSTORM", 25 ]
+    ],
+    "special_when_hit": [ "ZAPBACK", 100 ],
+    "fungalize_into": "mon_skeleton_fungus",
+    "armor": { "cut": 15, "stab": 30, "acid": 3, "bullet": 30 },
+    "extend": {
+      "weakpoint_sets": [ "wps_bone_armor" ],
+      "families": [ "prof_wp_skeleton", "prof_electromagnetics" ],
+      "flags": [ "ELECTRIC" ]
+    }
+  },
+  {
     "id": "mon_skeleton_hulk",
     "type": "MONSTER",
     "name": { "str": "skeletal juggernaut" },

--- a/data/json/monsters/zed_skeletal.json
+++ b/data/json/monsters/zed_skeletal.json
@@ -53,35 +53,6 @@
     "extend": { "weakpoint_sets": [ "wps_bone_armor" ], "families": [ "prof_wp_skeleton" ] }
   },
   {
-    "id": "mon_skeleton_electric",
-    "type": "MONSTER",
-    "name": { "str": "skeletal shocker" },
-    "description": "Heavy, jagged bone plates have grown out of the surface of this zombie's skin.  Underneath, its flesh glows and crackles with the occasional jolt of electricity.",
-    "copy-from": "mon_zombie_base",
-    "diff": 15,
-    "hp": 105,
-    "speed": 60,
-    "material": [ "bone" ],
-    "color": "blue_white",
-    "melee_damage": [ { "damage_type": "cut", "amount": 3 } ],
-    "luminance": 8,
-    "bleed_rate": 0,
-    "harvest": "mr_bones",
-    "special_attacks": [
-      { "id": "grab", "cooldown": 21 },
-      { "id": "scratch_humanoid" },
-      { "id": "bite_humanoid", "cooldown": 5 },
-      [ "PARROT", 8 ]
-    ],
-    "fungalize_into": "mon_skeleton_fungus",
-    "armor": { "cut": 15, "stab": 30, "acid": 3, "bullet": 30 },
-    "extend": {
-      "weakpoint_sets": [ "wps_bone_armor" ],
-      "families": [ "prof_wp_skeleton", "prof_electromagnetics" ],
-      "flags": [ "ELECTRIC" ]
-    }
-  },
-  {
     "id": "mon_skeleton_hulk",
     "type": "MONSTER",
     "name": { "str": "skeletal juggernaut" },

--- a/data/json/monsters/zed_skeletal.json
+++ b/data/json/monsters/zed_skeletal.json
@@ -71,8 +71,7 @@
       { "id": "grab", "cooldown": 21 },
       { "id": "scratch_humanoid" },
       { "id": "bite_humanoid", "cooldown": 5 },
-      [ "PARROT", 8 ],
-      [ "SHOCKSTORM", 25 ]
+      [ "PARROT", 8 ]
     ],
     "fungalize_into": "mon_skeleton_fungus",
     "armor": { "cut": 15, "stab": 30, "acid": 3, "bullet": 30 },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Remove the 'Shockstorm' attack from monsters that have it"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I dislike the "Shockstorm" ability for a few reasons but mainly because shooting arcs of electricity at this scale would require absurd amounts of energy. Now, I was told this isn't an issue in itself but I'm still putting the PR up for the sake of discussion and also because it turns out that this belonging in the game may be a "vibe"/"magic" issue that I can't have a say on (not that I'm complaining).
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Remove the Shockstorm attack from monsters that had it. The attack stays in the code as well as the monsters because they're probably getting updated in the future.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Severely reduce the range of the shockstorm but even a 1m arc would require too much energy for something as big as a hulk to produce, so even then it'd be very very magic.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
None, but there is no way this breaks anything (probably).
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
