### PR TITLE
Backport #74053 Hordes don't wander to 0,0

### DIFF
--- a/src/mongroup.h
+++ b/src/mongroup.h
@@ -136,7 +136,8 @@ struct mongroup {
               unsigned int ppop )
         : type( ptype )
         , abs_pos( ppos )
-        , population( ppop ) {
+        , population( ppop )
+        , target( abs_pos.xy() ) {
     }
     mongroup( const std::string &ptype, const tripoint_abs_sm &ppos,
               unsigned int ppop, point_abs_sm ptarget, int pint, bool pdie, bool phorde ) :


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
This was the commit that fixed #73725 for newly created hordes

#### Describe the solution
Backport JUST the fix for newly created hordes

Saves from 0.G do not need the save migration, since re-adding pre-seeded hordes without having wandering hordes enabled was post 0.G (#69980, Dec 2023)

#### Describe alternatives you've considered
Backport the save migration too? just in case people are going from earlier 0.H release candidates

#### Testing


#### Additional context
This PR has always been here. I did not accidentally commit directly to the 0.H branch /waves hand