### PR TITLE
Not to shatter already shattered armor.

### DIFF
--- a/data/json/monster_weakpoints/humanoid_weakpoints.json
+++ b/data/json/monster_weakpoints/humanoid_weakpoints.json
@@ -284,8 +284,9 @@
         "id": "armour_plate_bullet",
         "name": "the body armor",
         "armor_mult": { "cut": 1.5, "stab": 1.5, "bash": 1.5 },
-        "coverage_mult": { "melee": 0 },
+        "coverage_mult": { "ranged": 0.8, "melee": 0 },
         "//": "Note that most bullet hits on an armour plate probably shatter it, but not all of them shatter it enough to matter for future attacks.",
+        "disabled_by": [ "shattered" ],
         "effects": [
           {
             "effect": "shattered",
@@ -309,14 +310,15 @@
             "permanent": true
           }
         ],
-        "coverage": 40
+        "coverage": 50
       },
       {
         "id": "armour_plate_melee",
         "name": "the body armor",
         "armor_mult": { "cut": 1.3, "stab": 1.15, "bash": 1.15 },
-        "coverage_mult": { "ranged": 0 },
+        "coverage_mult": { "ranged": 0, "melee": 0.8 },
         "//": "Note that most bullet hits on an armour plate probably shatter it, but not all of them shatter it enough to matter for future attacks.",
+        "disabled_by": [ "shattered" ],
         "effects": [
           {
             "effect": "shattered",
@@ -340,7 +342,7 @@
             "permanent": true
           }
         ],
-        "coverage": 40
+        "coverage": 50
       },
       {
         "id": "armour_shattered",

--- a/doc/MONSTERS.md
+++ b/doc/MONSTERS.md
@@ -353,6 +353,7 @@ Field              | Description
 `damage_mult`      | object mapping damage types to multipliers on the post-armor damage, when hitting the weakpoint.
 `crit_mult`        | object mapping damage types to multipliers on the post-armor damage, when critically hitting the weakpoint. Defaults to `damage_mult`, if not specified.
 `required_effects` | list of effect names applied to the monster required to hit the weakpoint.
+`disabled_by`      | list of effect names applied to the monster which prevent you to hit the weakpoint.
 `effects`          | list of effects objects that may be applied to the monster by hitting the weakpoint.
 
 The `effects` field is a list of objects with the following subfields:

--- a/src/weakpoint.cpp
+++ b/src/weakpoint.cpp
@@ -420,6 +420,9 @@ void weakpoint::load( const JsonObject &jo )
     if( jo.has_array( "required_effects" ) ) {
         assign( jo, "required_effects", required_effects );
     }
+    if( jo.has_array( "disabled_by" ) ) {
+        assign( jo, "disabled_by", disabled_by );
+    }
     if( jo.has_array( "effects" ) ) {
         for( const JsonObject effect_jo : jo.get_array( "effects" ) ) {
             weakpoint_effect effect;
@@ -513,6 +516,12 @@ float weakpoint::hit_chance( const weakpoint_attack &attack ) const
             return 0.0f;
         }
     }
+    // Effects that disable this weakpoint
+    for( const auto &effect : disabled_by ) {
+        if( attack.target->has_effect( effect ) ) {
+            return 0.0f;
+        }
+    }
     // Retrieve multipliers.
     float constant_mult = coverage_mult.of( attack );
     // Probability of a sample from a normal distribution centered on `skill` with `SD = 2`
@@ -551,6 +560,12 @@ const weakpoint *weakpoints::select_weakpoint( const weakpoint_attack &attack ) 
     float reweighed = 0.0f;
     float idx = rng_float( 0.0f, 100.0f );
     for( const weakpoint &weakpoint : weakpoint_list ) {
+        if( weakpoint.hit_chance( attack ) == 0.0f ) {
+            add_msg_debug( debugmode::DF_MONSTER,
+                           "Weakpoint Selection: weakpoint %s, conditions not match",
+                           weakpoint.id  );
+            continue;
+        }
         float new_base = base + weakpoint.hit_chance( attack );
         float new_reweighed = 100.0f * reweigh( new_base / 100.0f, rolls );
         float hit_chance = new_reweighed - reweighed;

--- a/src/weakpoint.cpp
+++ b/src/weakpoint.cpp
@@ -563,7 +563,7 @@ const weakpoint *weakpoints::select_weakpoint( const weakpoint_attack &attack ) 
         if( weakpoint.hit_chance( attack ) == 0.0f ) {
             add_msg_debug( debugmode::DF_MONSTER,
                            "Weakpoint Selection: weakpoint %s, conditions not match",
-                           weakpoint.id  );
+                           weakpoint.id );
             continue;
         }
         float new_base = base + weakpoint.hit_chance( attack );

--- a/src/weakpoint.h
+++ b/src/weakpoint.h
@@ -134,6 +134,8 @@ struct weakpoint {
     std::unordered_map<damage_type_id, float> crit_mult;
     // A list of required effects.
     std::vector<efftype_id> required_effects;
+    // A list of effects that will disable this weakpoint.
+    std::vector<efftype_id> disabled_by;
     // A list of effects that may trigger by hitting this weak point.
     std::vector<weakpoint_effect> effects;
     // Constant coverage multipliers, depending on the attack type.


### PR DESCRIPTION
#### Summary
Bugfixes "Not to shatter already shattered armor."
#### Purpose of change
Fix #73351 
#### Describe the solution
Added `disabled_by` to stop certain weakpoint from working.
Also changed the coverage and coverage_mult of armour_plate to correctly sort the weakpoints.
Changed the debug msg.
#### Describe alternatives you've considered
Making weakpoints support conditions
#### Testing
![2024-06-15 010000](https://github.com/CleverRaven/Cataclysm-DDA/assets/78858975/311b4993-1ec9-4ded-bff2-65c6798fcbba)
The only thing is the hit_chance of shattered armor being too high (the actual chance is 46%).
Maybe the coverage and coverage_mult of shattered armor should be lower.
#### Additional context
https://github.com/CleverRaven/Cataclysm-DDA/issues/73351#issuecomment-2167885553
There is still weirdness in the weakpoint system.