### PR TITLE
Add test for shooting terrain and fix OP birdshot terrain smashing

### DIFF
--- a/data/mods/TEST_DATA/terrain.json
+++ b/data/mods/TEST_DATA/terrain.json
@@ -189,6 +189,26 @@
   },
   {
     "type": "terrain",
+    "id": "test_t_door_glass_opaque_c",
+    "name": "closed opaque glass door",
+    "description": "Copy of glass door for shooting tests that is opaque as a testing workaround",
+    "symbol": "+",
+    "color": "light_cyan",
+    "move_cost": 0,
+    "flags": [ "DOOR", "NOITEM", "BLOCK_WIND", "SUPPORTS_ROOF" ],
+    "bash": {
+      "str_min": 6,
+      "str_max": 20,
+      "sound": "glass breaking!",
+      "sound_fail": "whack!",
+      "sound_vol": 16,
+      "sound_fail_vol": 10,
+      "ter_set": "t_door_frame",
+      "items": [ { "item": "glass_shard", "count": [ 42, 84 ] } ]
+    }
+  },
+  {
+    "type": "terrain",
     "id": "test_t_window_no_curtains",
     "name": "window without curtains",
     "description": "barricadable window",

--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -486,8 +486,18 @@ dealt_projectile_attack projectile_attack( const projectile &proj_arg, const tri
         } else if( in_veh != nullptr && veh_pointer_or_null( here.veh_at( tp ) ) == in_veh ) {
             // Don't do anything, especially don't call map::shoot as this would damage the vehicle
         } else {
+            if( proj.count > 1 ) {
+                if( rl_dist( source, tp ) > 1 ) {
+                    proj.impact = proj.shot_impact;
+                }
+            }
             here.shoot( tp, proj, !no_item_damage && tp == target );
             has_momentum = proj.impact.total_damage() > 0;
+        }
+        if( !has_momentum && proj.count > 1 && rl_dist( source, tp ) <= 1 ) {
+            // Track that we hit an obstacle while wadded up,
+            // to cancel out of applying the other projectiles.
+            proj.count = 1;
         }
 
         if( ( !has_momentum || !is_bullet ) && here.impassable( tp ) ) {

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1018,7 +1018,7 @@ int Character::fire_gun( const tripoint &target, int shots, item &gun, item_loca
             if( shot.missed_by <= .1 ) {
                 headshot = true;
             }
-            if( proj.count > 1 && rl_dist( pos(), shot.end_point ) == 1 ) {
+            if( proj.count > 1 && shot.proj.count == 1 ) {
                 // Point-blank shots don't act like shot, everything hits the same target.
                 multishot = false;
                 break;

--- a/tests/map_bash_test.cpp
+++ b/tests/map_bash_test.cpp
@@ -173,3 +173,92 @@ TEST_CASE( "map_bash_ephemeral_persistence", "[map][bash]" )
         CHECK( here.get_map_damage( test_pt ) == 0 );
     }
 }
+
+static void shoot_at_terrain( npc &shooter, const std::string &ter_str, tripoint wall_pos,
+                              bool expected_to_break, tripoint aim_pos = tripoint_zero )
+{
+    map &here = get_map();
+    // Place a terrain
+    ter_str_id id{ ter_str };
+    if( aim_pos == tripoint_zero ) {
+        aim_pos = wall_pos;
+    }
+    here.ter_set( wall_pos, id );
+    REQUIRE( here.ter( wall_pos ) == id );
+    // This is a workaround for nonsense where you can't shoot terrain or furniture unless it
+    // obscures sight, specifically map::is_transparent() must return false.
+    here.build_map_cache( 0, true );
+
+    // Shoot it a bunch
+    for( int i = 0; i < 5; ++i ) {
+        shooter.recoil = 0;
+        shooter.set_moves( 100 );
+        shooter.fire_gun( aim_pos );
+    }
+    // is it gone?
+    INFO( here.ter( wall_pos ).id().str() );
+    CHECK( ( here.ter( wall_pos ) != id ) == expected_to_break );
+}
+
+TEST_CASE( "shooting_at_terrain", "[map][bash][ranged]" )
+{
+    clear_map();
+
+    // Make a shooter
+    standard_npc shooter( "Shooter", { 10, 10, 0 } );
+    shooter.set_body();
+    shooter.worn.wear_item( shooter, item( "backpack" ), false, false );
+    SECTION( "birdshot vs adobe wall point blank" ) {
+        arm_shooter( shooter, "remington_870", {}, "shot_bird" );
+        shoot_at_terrain( shooter, "t_adobe_brick_wall", shooter.pos() + point_east, false );
+    }
+    SECTION( "birdshot vs adobe wall near" ) {
+        arm_shooter( shooter, "remington_870", {}, "shot_bird" );
+        shoot_at_terrain( shooter, "t_adobe_brick_wall", shooter.pos() + point_east * 2, false );
+    }
+    SECTION( "birdshot vs opaque glass door point blank" ) {
+        arm_shooter( shooter, "remington_870", {}, "shot_bird" );
+        shoot_at_terrain( shooter, "test_t_door_glass_opaque_c", shooter.pos() + point_east, true );
+    }
+    SECTION( "birdshot vs opaque glass door near" ) {
+        arm_shooter( shooter, "remington_870", {}, "shot_bird" );
+        shoot_at_terrain( shooter, "test_t_door_glass_opaque_c", shooter.pos() + point_east * 2, false );
+    }
+    SECTION( "birdshot vs door near" ) {
+        arm_shooter( shooter, "remington_870", {}, "shot_bird" );
+        shoot_at_terrain( shooter, "t_door_c", shooter.pos() + point_east * 2, false );
+    }
+    // I thought I saw some failures based on whether an unseen monster was present,
+    // But I think it was just shooting at door wthout a 100% chance to break it and getting unlucky.
+    SECTION( "birdshot through door at nothing" ) {
+        arm_shooter( shooter, "remington_870", {}, "shot_bird" );
+        shoot_at_terrain( shooter, "t_door_c", shooter.pos() + point_east, true,
+                          shooter.pos() + point_east * 2 );
+    }
+    SECTION( "birdshot through door at monster" ) {
+        arm_shooter( shooter, "remington_870", {}, "shot_bird" );
+        spawn_test_monster( "mon_zombie", shooter.pos() + point_east * 2 );
+        shoot_at_terrain( shooter, "t_door_c", shooter.pos() + point_east, true,
+                          shooter.pos() + point_east * 2 );
+    }
+    // TODO: If we get a feature where damage accumulates a test for it would go here.
+    // These are failing because you can't shoot transparent terrain.
+    /*
+    SECTION( "birdshot vs glass door point blank" ) {
+        arm_shooter( shooter, "remington_870", {}, "shot_bird" );
+        shoot_at_terrain( shooter, "t_door_glass_c", shooter.pos() + point_east, true );
+    }
+    SECTION( "birdshot vs glass door near" ) {
+        arm_shooter( shooter, "remington_870", {}, "shot_bird" );
+        shoot_at_terrain( shooter, "t_door_glass_c", shooter.pos() + point_east * 2, false );
+    }
+    SECTION( "birdshot vs screen door point blank" ) {
+        arm_shooter( shooter, "remington_870", {}, "shot_bird" );
+        shoot_at_terrain( shooter, "t_door_screen_c", shooter.pos() + point_east, true );
+    }
+    SECTION( "birdshot vs screen door near" ) {
+        arm_shooter( shooter, "remington_870", {}, "shot_bird" );
+        shoot_at_terrain( shooter, "t_door_screen_c", shooter.pos() + point_east * 2, true );
+    }
+    */
+}


### PR DESCRIPTION
This reproduces an error where shot is way too good at destroying terrain

Then fix the error, which was that the shot code wasn't exiting when hitting at point blank range, so each pellet was hitting as hard as the whole wad


#### Summary
Bugfixes "Stop birdshot from firing 20 projectiles, each of which has the power of 100 projectiles"

#### Purpose of change
Fixes #55541 
As outlined there, shot fired at terrain or furniture in an adjacent tile would count as both one big projectile and many smaller projectiles simultaneously, so birdshot in particular did as much damage as firing 20 12ga slugs.
Also we don't have a test for whether shooting terrain or furniture has reasonable outcomes.

#### Describe the solution
Added a shooting at terrain test to reproduce the issue, then found a way to fix the actual error, which is that the code for cancelling out of the loop that handles the individual shot projectiles was inappropriately using a variable indicating "where should bullets or whatever land" instead of figuring out what the bullets hit.
Replaced that with a more explicit thing that adjusted down the count variable in the dealt_projectile_attack.proj struct returned by projectile_attack().

#### Describe alternatives you've considered
While I was looking into this I also discovered that the check for "is this terrain or furniture shootable" is kinda gross
`if( impassable( p ) && !is_transparent( p ) )`, it references not just "is the terrain or furniture transparent", which would be bad enough, but "is the tile itself transparent", so like you can shoot iron bars, but only if there is heavy fog in the tile or something?  At the end of the day this might require adding more data to terrain and furniture, so I'm kinda loath to do that in an otherwise self contained fix, but I added some notes about it.
There is also some breakage with respect to shooting through obstacles, I'll probably do a follow-up PR for that one once I figure out what's happening.

#### Testing
Added a test to reproduce the behavior, it passes after my changes.
Also replicated the bug and fix in-game by shooting an adobe wall.