### PR TITLE
clang-tidy: fix cata-unsequenced-calls

### DIFF
--- a/src/active_item_cache.cpp
+++ b/src/active_item_cache.cpp
@@ -8,7 +8,7 @@
 #include "item_pocket.h"
 #include "safe_reference.h"
 
-float item_reference::spoil_multiplier()
+float item_reference::spoil_multiplier() const
 {
     return std::accumulate(
                pocket_chain.begin(), pocket_chain.end(), 1.0F,
@@ -17,7 +17,7 @@ float item_reference::spoil_multiplier()
     } );
 }
 
-bool item_reference::has_watertight_container()
+bool item_reference::has_watertight_container() const
 {
     return std::any_of(
                pocket_chain.begin(), pocket_chain.end(),

--- a/src/active_item_cache.h
+++ b/src/active_item_cache.h
@@ -21,8 +21,8 @@ struct item_reference {
     item *parent = nullptr;
     std::vector<item_pocket const *> pocket_chain;
 
-    float spoil_multiplier();
-    bool has_watertight_container();
+    float spoil_multiplier() const;
+    bool has_watertight_container() const;
 };
 
 enum class special_item_type : int {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
The clang-tidy test is currently failing with a pretty cryptic error message:
https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/9459263520/job/26056592453?pr=74353#step:9:1081

#### Describe the solution
Attempt to address it by making the functions it's complaining about `const`.

#### Describe alternatives you've considered

#### Testing
Let the clang-tidy test run. Take the wheel, GitHub.

#### Additional context
