### PR TITLE
Add some examples for rule #1 in gun naming

### DIFF
--- a/doc/GUN_NAMING_AND_INCLUSION.md
+++ b/doc/GUN_NAMING_AND_INCLUSION.md
@@ -139,14 +139,18 @@ There are two rules for the default names of guns. That is, the names of guns
 when the 'Gun Brand Names' option is not enabled. These rules are enforced by
 script.
 
-## Rule 1: What is this?
+## Rule 1 (Descriptive Names): What is this?
 
 This rule requires that the name of the gun clarifies what it is. This is meant
 to prevent gun names that are obscure strings of letters and numbers.
 
+Guns that follow this rule will have names like `Glock pistol`, `m4 carbine`,
+or `UMP submachine gun`. Guns that don't will have names like `FS2000`,
+`SIG P226`, `Ruger LCR .38`, or `Taurus Raging Bull`.
+
 As of writing, names are considered to be acceptable if the gun name contains
-any of these strings. As with the other rules, the most up-to-date info on what
-is acceptable is contained in the
+any of these strings that describe that it is a gun and it's role. As with the
+other rules, the most up-to-date info on what is acceptable is contained in the
 [verification script](../tools/json_tools/gun_variant_validator.py).
 
 |        String       |Reason|
@@ -179,7 +183,7 @@ is acceptable is contained in the
 |submachine gun       |describes a class of gun|
 |trenchgun            |describes a class of gun|
 
-## Rule 2: What goes with this?
+## Rule 2 (Identifier Check): What goes with this?
 
 This rule requires that there is a common "identifier" string shared between
 the gun and all the magazines or speedloaders it takes.


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Make it easier to figure out how to name guns that will comply with autotesting.

#### Describe the solution
Add examples, a little bit more clarity.

#### Testing
https://github.com/anothersimulacrum/Cataclysm-DDA/blob/clarify-gundoc/doc/GUN_NAMING_AND_INCLUSION.md#rule-1-what-is-this

#### Additional context
