### PR TITLE
Add white phosphorus and related recipes

### DIFF
--- a/data/json/itemgroups/science_and_tech.json
+++ b/data/json/itemgroups/science_and_tech.json
@@ -227,6 +227,7 @@
       { "item": "denat_alcohol", "prob": 6, "charges": [ 250, -1 ] },
       { "item": "methed_alcohol", "prob": 4, "charges": [ 250, -1 ] },
       { "item": "red_phosphorous", "prob": 10, "charges": [ 100, 1200 ] },
+      { "item": "white_phosphorous", "prob": 10, "charges": [ 100, 1200 ] },
       { "item": "acetic_anhydride", "prob": 8 },
       { "item": "iodine_crystal", "prob": 12 }
     ]

--- a/data/json/itemgroups/supplies.json
+++ b/data/json/itemgroups/supplies.json
@@ -459,6 +459,7 @@
       [ "chem_aluminium_sulphate", 10 ],
       [ "chem_saltpetre", 10 ],
       { "item": "red_phosphorous", "prob": 5, "charges": [ 100, -1 ] },
+      { "item": "white_phosphorous", "prob": 5, "charges": [ 100, -1 ] },
       { "item": "bismuth", "prob": 5, "charges": [ 1, -1 ] },
       { "item": "chem_benzene", "prob": 10, "charges": [ 1, -1 ] },
       { "item": "chem_toluene", "prob": 10, "charges": [ 1, -1 ] },

--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -1935,7 +1935,7 @@
     "category": "chems",
     "name": { "str_sp": "red phosphorous" },
     "description": "An allotrope of the element phosphorous.  It's what you use to light matches, but can also be used in the synthesis of methamphetamine.  You could use it to make bombs, and if you were truly desperate you might even be able to use it as a propellant for bullets.",
-    "weight": "100 mg",
+    "weight": "10 g",
     "volume": "5 ml",
     "//": "Density around 2.2g/cm3, but since it's a powder, it's a bit lower, around 1.8-2.0 g/cm3",
     "container": "bottle_plastic_small",
@@ -1943,7 +1943,23 @@
     "color": "red",
     "price": "50 cent",
     "price_postapoc": "2 cent",
-    "count": 1000,
+    "stack_size": 25
+  },
+  {
+    "id": "white_phosphorous",
+    "type": "AMMO",
+    "ammo_type": "components",
+    "category": "chems",
+    "name": { "str_sp": "white phosphorous" },
+    "description": "An allotrope of the element phosphorous.  Extremely flammable, produces toxic smoke, you can use it to make smoke bombs.",
+    "weight": "7500 mg",
+    "volume": "5 ml",
+    "//": "Density around 1.8g/cm3, but since it's a powder, it's a bit lower, around 1.5 g/cm3",
+    "container": "bottle_plastic_small",
+    "symbol": "=",
+    "color": "white",
+    "price": "50 cent",
+    "price_postapoc": "2 cent",
     "stack_size": 25
   },
   {

--- a/data/json/recipes/recipe_medsandchemicals.json
+++ b/data/json/recipes/recipe_medsandchemicals.json
@@ -1494,16 +1494,49 @@
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
     "result": "red_phosphorous",
-    "charges": 1,
-    "batch_time_factors": [ 60, 5 ],
+    "charges": 3,
+    "batch_time_factors": [ 95, 1 ],
     "category": "CC_CHEM",
-    "subcategory": "CSC_CHEM_OTHER",
-    "skill_used": "fabrication",
-    "time": "10 m",
-    "autolearn": true,
-    "qualities": [ { "id": "FINE_GRIND", "level": 1 }, { "id": "CUT", "level": 1 }, { "id": "SIEVE", "level": 1 } ],
-    "//": "calculation based on https://www.youtube.com/watch?v=5ZrfNAHDjWU; 1 matchbox contains 30 mg phosphorus and 1 unit of phosphor is 100 mg",
-    "components": [ [ [ "survival_match", 1 ], [ "ref_matches", 3 ], [ "matches", 5 ] ] ]
+    "subcategory": "CSC_CHEM_CHEMICALS",
+    "difficulty": 3,
+    "skill_used": "chemistry",
+    "time": "1 h",
+    "tools": [ [ [ "vac_oven_small" , 1000 ] ] ],
+    "book_learn": [
+      [ "textbook_gaswarfare", 2 ],
+      [ "textbook_chemistry", 3 ],
+      [ "adv_chemistry", 3 ],
+      [ "textbook_anarch", 3 ]
+    ],
+    "components": [ [ [ "white_phosphorous", 4 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "result": "white_phosphorous",
+    "charges": 1,
+    "batch_time_factors": [ 95, 1 ],
+    "category": "CC_CHEM",
+    "subcategory": "CSC_CHEM_CHEMICALS",
+    "difficulty": 3,
+    "skill_used": "chemistry",
+    "time": "30 m",
+    "qualities": [ { "id": "CHEM", "level": 2 } ],
+    "book_learn": [
+      [ "textbook_gaswarfare", 2 ],
+      [ "textbook_chemistry", 3 ],
+      [ "adv_chemistry", 3 ],
+      [ "textbook_anarch", 3 ]
+    ],
+    "tools": [
+      [ [ "surface_heat", 50, "LIST" ] ],
+      [ [ "water",  1 ], [ "water_clean", 1 ] ]
+    ],
+    "components": [
+      [ [ "bone_meal_any", 1, "LIST" ] ],
+      [ [ "material_sand", 3 ] ],
+      [ [ "charcoal", 7 ], [ "coal_lump", 7 ] ]
+    ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/weapon/explosive.json
+++ b/data/json/recipes/weapon/explosive.json
@@ -265,6 +265,32 @@
     ]
   },
   {
+    "result": "smokebomb",
+    "id_suffix": "with_white_phosphorous",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_EXPLOSIVE",
+    "skill_used": "chemistry",
+    "skills_required": [ "mechanics", 1 ],
+    "difficulty": 2,
+    "book_learn": [
+      [ "textbook_gaswarfare", 2 ],
+      [ "textbook_chemistry", 3 ],
+      [ "adv_chemistry", 3 ],
+      [ "textbook_anarch", 3 ]
+    ],
+    "proficiencies": [ { "proficiency": "prof_intro_chemistry" }, { "proficiency": "prof_inorganic_chemistry" } ],
+    "time": "7 m 30 s",
+    "qualities": [ { "id": "SCREW", "level": 1 } ],
+    "using": [ [ "small_gas_canister_case", 1 ] ],
+    "components": [
+      [ [ "water", 1 ], [ "water_clean", 1 ], [ "salt_water", 1 ], [ "saline", 5 ] ],
+      [ [ "white_phosphorous", 20 ] ],
+      [ [ "superglue", 1 ] ]
+    ]
+  },
+  {
     "result": "military_explosive_small_grenade",
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",


### PR DESCRIPTION
#### Summary

Content "Add white phosphorus and related recipes"

#### Purpose of change

Regarding adding recipes for extracting phosphorus from bones, I've covered this in a previous issue.(https://github.com/CleverRaven/Cataclysm-DDA/issues/73298)
In addition, the weight of red phosphorus is greatly underestimated based on the code's description of its density.

#### Describe the solution

Add white phosphorus.
Add recipes that use bones to extract white phosphorus.
Add recipes for using white phosphorus to make smoke bombs and red phosphorus.
Fixed the weight of red phosphorus.
Removed the previous recipe for making red phosphorus using matches due to the much higher weight of red phosphorus making it too costly (about 300+ matchboxes needed).

#### Describe alternatives you've considered

Maybe keep the recipe for making red phosphorus using matchboxes - it's not unfeasible after all, it just requires a lot of ingredients.

#### Testing

Go into the game, check the recipe and item, and all is well.

#### Additional context

None,