### PR TITLE
Add Mossberg 590M

### DIFF
--- a/data/json/itemgroups/Weapons_Mods_Ammo/guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/guns.json
@@ -554,6 +554,7 @@
       { "item": "benelli_sa", "variant": "sbe", "prob": 37 },
       { "item": "benelli_tsa", "variant": "m2_tac", "contents-item": [ "rail_mount" ], "prob": 12 },
       { "item": "mossberg_590", "variant": "slp", "contents-item": [ "rail_mount" ], "prob": 6 },
+      { "item": "mossberg_590m", "prob": 1 },
       { "item": "remington_870", "variant": "ithaca37", "prob": 6 },
       { "item": "remington_870", "variant": "remington_1100", "prob": 17 },
       { "item": "mossberg_930", "prob": 15 },
@@ -573,7 +574,8 @@
       { "group": "nested_ksg-25", "prob": 8 },
       { "group": "nested_tavor_12", "prob": 5 },
       { "group": "nested_m1014", "prob": 10 },
-      { "group": "nested_slp", "prob": 10 }
+      { "group": "nested_slp", "prob": 10 },
+      { "group": "nested_mossberg_590m", "prob": 2 }
     ]
   },
   {
@@ -587,7 +589,8 @@
       { "item": "ksg-25", "prob": 8, "charges": [ 0, 12 ] },
       { "item": "tavor_12", "prob": 5, "charges": [ 0, 5 ] },
       { "item": "mossberg_930", "variant": "m1014", "prob": 10, "charges": [ 0, 8 ] },
-      { "item": "mossberg_590", "variant": "slp", "contents-item": [ "rail_mount" ], "prob": 10, "charges": [ 0, 9 ] }
+      { "item": "mossberg_590", "variant": "slp", "contents-item": [ "rail_mount" ], "prob": 10, "charges": [ 0, 9 ] },
+      { "item": "mossberg_590m", "prob": 2, "charges": [ 0, 5 ] }
     ]
   },
   {
@@ -599,7 +602,8 @@
       { "item": "ksg", "prob": 25 },
       { "item": "tavor_12", "prob": 5 },
       { "item": "mossberg_930", "variant": "m1014", "prob": 10 },
-      { "item": "mossberg_590", "variant": "slp", "contents-item": [ "rail_mount" ], "prob": 10 }
+      { "item": "mossberg_590", "variant": "slp", "contents-item": [ "rail_mount" ], "prob": 10 },
+      { "item": "mossberg_590m", "prob": 2 }
     ]
   },
   {

--- a/data/json/itemgroups/Weapons_Mods_Ammo/magazines.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/magazines.json
@@ -478,7 +478,14 @@
     "type": "item_group",
     "id": "mags_shotgun_common",
     "//": "Factory specification shotgun magazines commonly owned by citizens.",
-    "items": [ [ "shot_speedloader6", 15 ], [ "shot_speedloader8", 15 ] ]
+    "items": [
+      [ "shot_speedloader6", 15 ],
+      [ "shot_speedloader8", 15 ],
+      { "item": "mossberg_590m_mag_5", "prob": 3, "charges": 0 },
+      { "item": "mossberg_590m_mag_10", "prob": 2, "charges": 0 },
+      { "item": "mossberg_590m_mag_15", "prob": 1, "charges": 0 },
+      { "item": "mossberg_590m_mag_20", "prob": 1, "charges": 0 }
+    ]
   },
   {
     "type": "item_group",

--- a/data/json/itemgroups/Weapons_Mods_Ammo/magazines.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/magazines.json
@@ -478,14 +478,7 @@
     "type": "item_group",
     "id": "mags_shotgun_common",
     "//": "Factory specification shotgun magazines commonly owned by citizens.",
-    "items": [
-      [ "shot_speedloader6", 15 ],
-      [ "shot_speedloader8", 15 ],
-      { "item": "mossberg_590m_mag_5", "prob": 3, "charges": 0 },
-      { "item": "mossberg_590m_mag_10", "prob": 2, "charges": 0 },
-      { "item": "mossberg_590m_mag_15", "prob": 1, "charges": 0 },
-      { "item": "mossberg_590m_mag_20", "prob": 1, "charges": 0 }
-    ]
+    "items": [ [ "shot_speedloader6", 15 ], [ "shot_speedloader8", 15 ] ]
   },
   {
     "type": "item_group",
@@ -501,7 +494,11 @@
       { "item": "saiga10mag", "prob": 50 },
       { "item": "saiga30mag", "prob": 10 },
       { "item": "saiga410mag_10rd", "prob": 30 },
-      { "item": "saiga410mag_30rd", "prob": 10 }
+      { "item": "saiga410mag_30rd", "prob": 10 },
+      { "item": "mossberg_590m_mag_5", "prob": 3, "charges": 0 },
+      { "item": "mossberg_590m_mag_10", "prob": 2, "charges": 0 },
+      { "item": "mossberg_590m_mag_15", "prob": 1, "charges": 0 },
+      { "item": "mossberg_590m_mag_20", "prob": 1, "charges": 0 }
     ]
   },
   {

--- a/data/json/itemgroups/Weapons_Mods_Ammo/nested_guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/nested_guns.json
@@ -2260,6 +2260,36 @@
     "entries": [ { "item": "mossberg_590", "charges": [ 0, 9 ] }, { "group": "on_hand_shot" } ]
   },
   {
+    "id": "nested_mossberg_590m",
+    "type": "item_group",
+    "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
+    "subtype": "collection",
+    "ammo": 100,
+    "entries": [
+      { "item": "mossberg_590", "charges": [ 0, 5 ] },
+      { "item": "mossberg_590m_mag_10" },
+      { "item": "mossberg_590m_mag_10", "prob": 50 },
+      {
+        "distribution": [
+          { "collection": [ { "item": "mossberg_590m_mag_5" }, { "item": "mossberg_590m_mag_5", "prob": 50 } ], "prob": 3 },
+          {
+            "collection": [ { "item": "mossberg_590m_mag_10" }, { "item": "mossberg_590m_mag_10", "prob": 50 } ],
+            "prob": 2
+          },
+          {
+            "collection": [ { "item": "mossberg_590m_mag_15" }, { "item": "mossberg_590m_mag_15", "prob": 50 } ],
+            "prob": 1
+          },
+          {
+            "collection": [ { "item": "mossberg_590m_mag_20" }, { "item": "mossberg_590m_mag_20", "prob": 50 } ],
+            "prob": 1
+          }
+        ]
+      },
+      { "group": "on_hand_shot" }
+    ]
+  },
+  {
     "id": "nested_remington_870_breacher",
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",

--- a/data/json/items/gun/shot.json
+++ b/data/json/items/gun/shot.json
@@ -230,6 +230,48 @@
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "shot": 9 } } ]
   },
   {
+    "id": "mossberg_590m",
+    "copy-from": "mossberg_590",
+    "looks_like": "mossberg_590",
+    "type": "GUN",
+    "name": { "str": "magazine-fed pump shotgun" },
+    "description": "Classic pump-action shotgun, where manufacturer modified the gun in order to use box magazines instead of tube.",
+    "variant_type": "gun",
+    "variants": [
+      {
+        "id": "mossberg_590",
+        "name": { "str": "Mossberg 590M shotgun" },
+        "description": "Classic Mossberg 590, modified by manufacturer to be able to utilize box magazines."
+      }
+    ],
+    "weight": "3628 g",
+    "volume": "2548 ml",
+    "longest_side": "1033 mm",
+    "barrel_length": "469 mm",
+    "price": "770 USD",
+    "price_postapoc": "19 USD",
+    "valid_mod_locations": [
+      [ "barrel", 1 ],
+      [ "bayonet lug", 1 ],
+      [ "brass catcher", 1 ],
+      [ "grip mount", 1 ],
+      [ "mechanism", 2 ],
+      [ "muzzle", 1 ],
+      [ "rail mount", 1 ],
+      [ "sights mount", 1 ],
+      [ "sling", 1 ],
+      [ "stock mount", 1 ],
+      [ "stock accessory", 2 ],
+      [ "underbarrel mount", 1 ]
+    ],
+    "pocket_data": [
+      {
+        "pocket_type": "MAGAZINE_WELL",
+        "item_restriction": [ "mossberg_590m_mag_5", "mossberg_590m_mag_10", "mossberg_590m_mag_15", "mossberg_590m_mag_20" ]
+      }
+    ]
+  },
+  {
     "id": "mossberg_930",
     "copy-from": "shotgun_base",
     "type": "GUN",

--- a/data/json/items/gun/shot.json
+++ b/data/json/items/gun/shot.json
@@ -235,13 +235,13 @@
     "looks_like": "mossberg_590",
     "type": "GUN",
     "name": { "str": "magazine-fed pump shotgun" },
-    "description": "Classic pump-action shotgun, where manufacturer modified the gun in order to use box magazines instead of tube.",
+    "description": "A classic pump-action shotgun, all save for the fact that the manufacturer has modified it to use detachable box magazines instead of a standard shotgun tube.",
     "variant_type": "gun",
     "variants": [
       {
         "id": "mossberg_590",
         "name": { "str": "Mossberg 590M shotgun" },
-        "description": "Classic Mossberg 590, modified by manufacturer to be able to utilize box magazines."
+        "description": "A classic Mossberg 590 pump-action shotgun, modified by the manufacturer to utilise box magazines."
       }
     ],
     "weight": "3628 g",

--- a/data/json/items/gun/shot.json
+++ b/data/json/items/gun/shot.json
@@ -241,7 +241,7 @@
       {
         "id": "mossberg_590",
         "name": { "str": "Mossberg 590M shotgun" },
-        "description": "A classic Mossberg 590 pump-action shotgun, modified by the manufacturer to utilise box magazines."
+        "description": "A classic Mossberg 590 pump-action shotgun, modified by the manufacturer to utilize box magazines."
       }
     ],
     "weight": "3628 g",

--- a/data/json/items/magazine/shot.json
+++ b/data/json/items/magazine/shot.json
@@ -160,5 +160,100 @@
     "ammo_type": [ "shot" ],
     "flags": [ "MAG_COMPACT" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "shot": 5 } } ]
+  },
+  {
+    "id": "mossberg_590m_mag_5",
+    "copy-from": "mossberg_590m_mag_10",
+    "type": "MAGAZINE",
+    "name": { "str": "magazine-fed pump shotgun 5-round magazine" },
+    "description": "A small 5-round box magazine for the magazine-fed pump shotgun.",
+    "variant_type": "gun",
+    "variants": [
+      {
+        "id": "mossberg_590m_mag_5",
+        "name": { "str": "Mossberg 590M 5-round magazine" },
+        "description": "A small 5-round box magazine for the Mossberg 590M shotgun."
+      }
+    ],
+    "weight": "445 g",
+    "volume": "770 ml",
+    "longest_side": "136 mm",
+    "price": "88 USD",
+    "price_postapoc": "4 USD",
+    "symbol": "#",
+    "color": "dark_gray",
+    "flags": [ "MAG_COMPACT" ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "shot": 5 } } ]
+  },
+  {
+    "id": "mossberg_590m_mag_10",
+    "type": "MAGAZINE",
+    "name": { "str": "magazine-fed pump shotgun 10-round magazine" },
+    "description": "A 10-round box magazine for the magazine-fed pump shotgun.",
+    "variant_type": "gun",
+    "variants": [
+      {
+        "id": "mossberg_590m_mag_10",
+        "name": { "str": "Mossberg 590M 10-round magazine" },
+        "description": "A 10-round box magazine for the Mossberg 590M shotgun."
+      }
+    ],
+    "weight": "607 g",
+    "volume": "1147 ml",
+    "longest_side": "203 mm",
+    "price": "99 USD",
+    "price_postapoc": "6 USD",
+    "material": [ "lc_steel" ],
+    "symbol": "#",
+    "color": "dark_gray",
+    "ammo_type": [ "shot" ],
+    "flags": [ "MAG_BULKY" ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "shot": 10 } } ]
+  },
+  {
+    "id": "mossberg_590m_mag_15",
+    "copy-from": "mossberg_590m_mag_10",
+    "type": "MAGAZINE",
+    "name": { "str": "magazine-fed pump shotgun 15-round magazine" },
+    "description": "A 15-round box magazine for the magazine-fed pump shotgun.",
+    "variant_type": "gun",
+    "variants": [
+      {
+        "id": "mossberg_590m_mag_15",
+        "name": { "str": "Mossberg 590M 15-round magazine" },
+        "description": "A 15-round box magazine for the Mossberg 590M shotgun."
+      }
+    ],
+    "weight": "740 g",
+    "volume": "1487 ml",
+    "longest_side": "263 mm",
+    "price": "116 USD",
+    "price_postapoc": "4 USD",
+    "symbol": "#",
+    "color": "dark_gray",
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "shot": 15 } } ]
+  },
+  {
+    "id": "mossberg_590m_mag_20",
+    "copy-from": "mossberg_590m_mag_10",
+    "type": "MAGAZINE",
+    "name": { "str": "magazine-fed pump shotgun 20-round magazine" },
+    "description": "A 20-round box magazine for the magazine-fed pump shotgun.",
+    "variant_type": "gun",
+    "variants": [
+      {
+        "id": "mossberg_590m_mag_20",
+        "name": { "str": "Mossberg 590M 20-round magazine" },
+        "description": "A 20-round box magazine for the Mossberg 590M shotgun."
+      }
+    ],
+    "weight": "817 g",
+    "volume": "1810 ml",
+    "longest_side": "320 mm",
+    "price": "126 USD",
+    "price_postapoc": "3 USD",
+    "symbol": "#",
+    "color": "dark_gray",
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "shot": 20 } } ]
   }
 ]

--- a/data/mods/Generic_Guns/firearms/gg_firearms_migration.json
+++ b/data/mods/Generic_Guns/firearms/gg_firearms_migration.json
@@ -418,6 +418,7 @@
       "aa_12",
       "benelli_tsa",
       "bigun",
+      "mossberg_590m",
       "USAS_12"
     ],
     "type": "MIGRATION",

--- a/data/mods/Generic_Guns/magazines/gg_magazines_migration.json
+++ b/data/mods/Generic_Guns/magazines/gg_magazines_migration.json
@@ -401,6 +401,10 @@
       "aa12_box_mag",
       "aa12_drum_mag",
       "aa12_vehicle_drum",
+      "mossberg_590m_mag_5",
+      "mossberg_590m_mag_10",
+      "mossberg_590m_mag_15",
+      "mossberg_590m_mag_20",
       "m26_mass_mag_3",
       "m26_mass_mag_5"
     ],


### PR DESCRIPTION
#### Summary
Content "Added Mossberg 590M. Just look at this gun, it is ridiculous"
#### Purpose of change
Discussion about gun removing sparked me a bit, and i found the very existence of the gun to be fun
#### Describe the solution
Added ridiculous gun, it's mags, make itemgroup stuff
#### Testing
Walked around, shooted zeds with a gun, found mags 
#### Additional context
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/67688115/9eac62a8-88cd-455c-aede-f52b00228f5a)

Gunbroker as proof, but the gun was designed in 2018, and is still manufactured by Mossberg & Sons
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/67688115/405280c4-289d-4042-a645-ce542abb8339)

And, just, look at this thing! They even left the tube mag untouched to cheapen the manufacturing!
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/67688115/7cb0a809-9be1-42ee-8a34-ac1e47d6357c)