### PR TITLE
adding tiny bottles and modifying nicotine liquid bottles

### DIFF
--- a/data/json/items/ammo.json
+++ b/data/json/items/ammo.json
@@ -1198,12 +1198,12 @@
     "symbol": "=",
     "color": "yellow",
     "description": "Liquid made up of propylene glycol, vegetable glycerin, flavorings, and nicotine.  Intended for use in an advanced electronic cigarette.",
-    "container": "bottle_plastic_small",
+    "container": "bottle_plastic_tiny",
     "phase": "liquid",
     "volume": "30 ml",
-    "weight": "2 g",
+    "weight": "1 g",
     "ammo_type": "components",
-    "count": 50
+    "count": 30
   },
   {
     "id": "fish_bait",

--- a/data/json/items/ammo.json
+++ b/data/json/items/ammo.json
@@ -1200,7 +1200,7 @@
     "description": "Liquid made up of propylene glycol, vegetable glycerin, flavorings, and nicotine.  Intended for use in an advanced electronic cigarette.",
     "container": "bottle_plastic_small",
     "phase": "liquid",
-    "volume": "250 ml",
+    "volume": "30 ml",
     "weight": "2 g",
     "ammo_type": "components",
     "count": 50

--- a/data/json/items/containers/containers.json
+++ b/data/json/items/containers/containers.json
@@ -637,6 +637,37 @@
     "flags": [ "COLLAPSE_CONTENTS" ]
   },
   {
+    "id": "bottle_plastic_tiny",
+    "type": "GENERIC",
+    "category": "container",
+    "name": { "str": "tiny plastic bottle" },
+    "looks_like": "bottle_plastic",
+    "description": "A watertight plastic bottle, holds 30 mL of liquid.",
+    "ascii_picture": "bottle_plastic_small",
+    "weight": "2 g",
+    "volume": "35 ml",
+    "longest_side": "4 cm",
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "watertight": true,
+        "rigid": true,
+        "transparent": true,
+        "max_contains_volume": "30 ml",
+        "max_item_volume": "1 ml",
+        "max_contains_weight": "1 kg",
+        "moves": 400
+      }
+    ],
+    "price": "0 cent",
+    "price_postapoc": "0 cent",
+    "to_hit": 1,
+    "material": [ "plastic" ],
+    "symbol": ")",
+    "color": "white",
+    "flags": [ "COLLAPSE_CONTENTS" ]
+  },
+  {
     "id": "bottle_plastic_pill_prescription",
     "type": "GENERIC",
     "category": "container",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.
-->

#### Summary
Content "nicotine liquid alteration"


#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

I had noticed that nicotine bottles were 250ml and also held that much liquid. this is a colossal amount of fluid for this particular task. in life, they tend to use a standardized 30ml eyedropper style bottle, and so i've added that bottle, and i've adjusted the count such that it's now 1 charge per smoke sesh. i've also changed the weight of it, because previously it was about twice as dense as water, now it's as dense as, which also matches with the specific gravity of propylene glycol.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

it simply adds an item, calls to that item, and also changes the nicotine liquid values themselves to reflect the changes

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

the only possibly considerations i had were bottle sizes. i looked for eye dropper bottles but didn't find any which i found a little surprising, so i figured making my own would be good.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

rolled a random character, spawned in an advanced e-cig, spawned in an ultra-light battery, spawned in some nicotine liquid bottles. i examined everything and tried smoking to make sure the charge count was correct. everything looks okay.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
