### PR TITLE
Break fake parts when main part breaks

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -7523,6 +7523,10 @@ int vehicle::damage_direct( map &here, vehicle_part &vp, int dmg, const damage_t
         invalidate_mass();
         coeff_air_changed = true;
 
+        // update the fake part
+        if( vp.has_fake ) {
+            parts[vp.fake_part_at].base = vp.base;
+        }
         // refresh cache in case the broken part has changed the status
         // do not remove fakes parts in case external vehicle part references get invalidated
         refresh( false );


### PR DESCRIPTION
#### Summary
Bugfixes "Break fake vehicle parts when the real part breaks"

#### Purpose of change
When a fake part is bashed, it bashes the main part. However, this doesn't update the fake part, and so when the main part breaks, it can result in a still functional fake part.

Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/74307

#### Describe the solution
Break the fake part when the main part breaks.

#### Describe alternatives you've considered

#### Testing
Turn a car 45 degrees, bash the fake doors. See they break when the real door breaks.

#### Additional context
