### PR TITLE
Only get valid rotations for SDL overmaps

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2611,6 +2611,9 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEG
             const oter_type_str_id tmp( id );
             if( tmp.is_valid() ) {
                 if( !tmp->is_linear() ) {
+                    // if rota is for a omt with connections, it can be outside the bounds of
+                    // om_direction::type. We can't do anything about that now, so just stay inbounds
+                    rota %= om_direction::size;
                     sym = tmp->get_rotated( static_cast<om_direction::type>( rota ) )->get_uint32_symbol();
                 } else {
                     sym = tmp->symbol;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
In drawing the SDL overmap, the rotation is determined by this call:
https://github.com/CleverRaven/Cataclysm-DDA/blob/375c71223007066beb7b12d8688217b00ea04b7d/src/sdltiles.cpp#L820
If it goes down the branch to call this:
https://github.com/CleverRaven/Cataclysm-DDA/blob/375c71223007066beb7b12d8688217b00ea04b7d/src/sdltiles.cpp#L701
It can get a rotation that isn't one of the four rotations that the fallback expects:
https://github.com/CleverRaven/Cataclysm-DDA/blob/375c71223007066beb7b12d8688217b00ea04b7d/src/omdata.h#L57-L60
https://github.com/CleverRaven/Cataclysm-DDA/blob/375c71223007066beb7b12d8688217b00ea04b7d/src/overmap.cpp#L879-L880
Resulting in undefined behavior (e.g. dir=10, which is not one of the valid enum values, or inbounds) and the debugmsg reported in 
Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/72814
Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/71772


#### Describe the solution
To avoid breaking this for actual tiles, before the call that results in undefined behavior, modulus it inbounds. If it's valid there are no differences. If it isn't, it's a less severe bug.

#### Describe alternatives you've considered

#### Testing
Reproducible with this save (from 0.H, so there will be errors on load). Load in, use surveyor'smap for the overmap tileset, and open the overmap.
[hunting-lodge.zip](https://github.com/user-attachments/files/15860398/hunting-lodge.zip)

#### Additional context
