### PR TITLE
Backport 74617 "Only get valid rotations for SDL overmaps"

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2522,6 +2522,9 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEG
             const oter_type_str_id tmp( id );
             if( tmp.is_valid() ) {
                 if( !tmp->is_linear() ) {
+                    // if rota is for a omt with connections, it can be outside the bounds of
+                    // om_direction::type. We can't do anything about that now, so just stay inbounds
+                    rota %= om_direction::size;
                     sym = tmp->get_rotated( static_cast<om_direction::type>( rota ) )->get_uint32_symbol();
                 } else {
                     sym = tmp->symbol;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
https://github.com/CleverRaven/Cataclysm-DDA/issues/71772 is present in 0.H

#### Describe the solution
Backport https://github.com/CleverRaven/Cataclysm-DDA/pull/74617

#### Describe alternatives you've considered

#### Testing
See https://github.com/CleverRaven/Cataclysm-DDA/pull/74617

#### Additional context