### PR TITLE
Adding Doctor and Pharmacist Professions

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -9080,7 +9080,7 @@
     "name": { "str": "MD" },
     "points": 0,
     "//": "In the US, a medical 'residency' is essentially an extended post-graduate, on-the-job medical training.  The idea here is that hospital computer systems would recognize the PC as a valid user and grant access.",
-    "description": "You were just through with the administrative formalities for your residency when the Cataclysm struck.  \"Your\" hospital was overrun and evacuated, but there's always work for a good doctor.",
+    "description": "You trained as a medical professional in a clinic or hospital.  You can put \"Dr.\" in front of your name and everything.",
     "valid": false,
     "purifiable": false,
     "profession": true

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -2042,13 +2042,7 @@
     "description": "You were a pharmacist working in a community pharmacy.  No simple pill-pusher, you have a plethora of knowledge of drug preparation, biochemistry, and biology.  With your trusty mortar and pestle, you hope to grind the undead to a pulp.",
     "points": 5,
     "skills": [ { "level": 6, "name": "firstaid" }, { "level": 1, "name": "speech" } ],
-    "proficiencies": [
-      "prof_intro_biology",
-      "prof_intro_chemistry",
-      "prof_organic_chemistry",
-      "prof_biochemistry",
-      "prof_physiology"
-    ],
+    "proficiencies": [ "prof_intro_biology", "prof_intro_chemistry", "prof_organic_chemistry", "prof_biochemistry", "prof_physiology" ],
     "traits": [ "PROF_MED" ],
     "items": {
       "both": {
@@ -2068,12 +2062,42 @@
           "disinfectant",
           "pepto",
           "flu_shot",
-          { "item": "tramadol", "count": 30, "container-item": "null", "entry-wrapper": "bottle_plastic_pill_prescription" },
-          { "item": "ibuprofen", "count": 30, "container-item": "null", "entry-wrapper": "bottle_plastic_pill_prescription" },
-          { "item": "aspirin", "count": 30, "container-item": "null", "entry-wrapper": "bottle_plastic_pill_prescription" },
-          { "item": "antibiotics", "count": 10, "container-item": "null", "entry-wrapper": "bottle_plastic_pill_prescription" },
-          { "item": "antifungal", "count": 10, "container-item": "null", "entry-wrapper": "bottle_plastic_pill_prescription" },
-          { "item": "antiparasitic", "count": 10, "container-item": "null", "entry-wrapper": "bottle_plastic_pill_prescription" }
+          {
+            "item": "tramadol",
+            "count": 30,
+            "container-item": "null",
+            "entry-wrapper": "bottle_plastic_pill_prescription"
+          },
+          {
+            "item": "ibuprofen",
+            "count": 30,
+            "container-item": "null",
+            "entry-wrapper": "bottle_plastic_pill_prescription"
+          },
+          {
+            "item": "aspirin",
+            "count": 30,
+            "container-item": "null",
+            "entry-wrapper": "bottle_plastic_pill_prescription"
+          },
+          {
+            "item": "antibiotics",
+            "count": 10,
+            "container-item": "null",
+            "entry-wrapper": "bottle_plastic_pill_prescription"
+          },
+          {
+            "item": "antifungal",
+            "count": 10,
+            "container-item": "null",
+            "entry-wrapper": "bottle_plastic_pill_prescription"
+          },
+          {
+            "item": "antiparasitic",
+            "count": 10,
+            "container-item": "null",
+            "entry-wrapper": "bottle_plastic_pill_prescription"
+          }
         ],
         "entries": [ { "item": "pants", "variant": "pants_blue" }, { "group": "charged_smart_phone" }, { "group": "full_1st_aid" } ]
       },

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -1979,7 +1979,6 @@
           { "item": "water_clean" },
           { "item": "bandages", "count": 3 },
           { "item": "adhesive_bandages", "count": 10 },
-          { "item": "aspirin" },
           { "item": "stethoscope" },
           { "item": "pants", "variant": "pants_blue" },
           { "group": "charged_smart_phone" },
@@ -2022,12 +2021,9 @@
           "water_clean",
           { "item": "bandages", "count": 5 },
           { "item": "adhesive_bandages", "count": 10 },
-          { "item": "disinfectant", "count": 10 },
-          "aspirin",
+          "disinfectant",
           "thermometer",
           "pepto",
-          "syringe",
-          "morphine",
           "stethoscope",
           "scalpel"
         ],
@@ -2047,14 +2043,11 @@
     "points": 5,
     "skills": [ { "level": 6, "name": "firstaid" }, { "level": 1, "name": "speech" } ],
     "proficiencies": [
-      "prof_wound_care",
-      "prof_wound_care_expert",
       "prof_intro_biology",
       "prof_intro_chemistry",
       "prof_organic_chemistry",
       "prof_biochemistry",
-      "prof_physiology",
-      "prof_burn_care"
+      "prof_physiology"
     ],
     "traits": [ "PROF_MED" ],
     "items": {
@@ -2072,11 +2065,15 @@
           "water_clean",
           { "item": "bandages", "count": 5 },
           { "item": "adhesive_bandages", "count": 10 },
-          { "item": "disinfectant", "count": 10 },
-          "aspirin",
+          "disinfectant",
           "pepto",
-          "syringe",
-          "morphine"
+          "flu_shot",
+          { "item": "tramadol", "count": 30, "container-item": "null", "entry-wrapper": "bottle_plastic_pill_prescription" },
+          { "item": "ibuprofen", "count": 30, "container-item": "null", "entry-wrapper": "bottle_plastic_pill_prescription" },
+          { "item": "aspirin", "count": 30, "container-item": "null", "entry-wrapper": "bottle_plastic_pill_prescription" },
+          { "item": "antibiotics", "count": 10, "container-item": "null", "entry-wrapper": "bottle_plastic_pill_prescription" },
+          { "item": "antifungal", "count": 10, "container-item": "null", "entry-wrapper": "bottle_plastic_pill_prescription" },
+          { "item": "antiparasitic", "count": 10, "container-item": "null", "entry-wrapper": "bottle_plastic_pill_prescription" }
         ],
         "entries": [ { "item": "pants", "variant": "pants_blue" }, { "group": "charged_smart_phone" }, { "group": "full_1st_aid" } ]
       },

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -1959,6 +1959,7 @@
       "prof_wound_care",
       "prof_wound_care_expert",
       "prof_intro_biology",
+      "prof_intro_chemistry",
       "prof_physiology",
       "prof_burn_care",
       "prof_dissect_humans"
@@ -1988,6 +1989,107 @@
       "male": { "entries": [ { "item": "boxer_shorts" } ] },
       "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
+  },
+  {
+    "type": "profession",
+    "id": "doctor",
+    "name": "Doctor",
+	"requirement": "achievement_reach_hospital",
+    "description": "You were a patient-facing doctor practicing general or specialized medicine.  While your bedside manner might not get you far in this new world, your medical skills will certainly help.",
+    "points": 5,
+    "skills": [
+	  { "level": 7, "name": "firstaid" },
+	  { "level": 3, "name": "speech" }
+	],
+    "proficiencies": [
+      "prof_wound_care",
+      "prof_wound_care_expert",
+      "prof_intro_biology",
+	  "prof_intro_chemistry",
+      "prof_physiology",
+      "prof_burn_care",
+      "prof_dissect_humans"
+    ],
+    "traits": [ "PROF_MED" ],
+    "items": {
+      "both": {
+        "items": [
+          "dress_shirt",
+          "gloves_medical",
+          "socks",
+          "dress_shoes",
+          "coat_lab",
+          "badge_doctor",
+          "glasses_safety",
+          "wristwatch",
+          "water_clean",
+          { "item": "bandages", "count": 5 },
+          { "item": "adhesive_bandages", "count": 10 },
+		  { "item": "disinfectant", "count": 10 },
+          "aspirin",
+		  "thermometer",
+		  "pepto",
+		  "syringe",
+		  "morphine",
+          "stethoscope",
+		  "scalpel"
+        ],
+        "entries": [ { "item": "pants", "variant": "pants_blue" }, { "group": "charged_smart_phone" }, { "group": "full_1st_aid" } ]
+      },
+      "male": [ "boxer_shorts" ],
+      "female": [ "bra", "panties" ]
+	},
+    "age_lower": 25
+  },
+  {
+    "type": "profession",
+    "id": "pharmacist",
+    "name": "Pharmacist",
+	"requirement": "achievement_reach_hospital",
+    "description": "You were a pharmacist working in a community pharmacy.  No simple pill-pusher, you have a plethora of knowledge of drug preparation, biochemistry, and biology.  With your trusty mortar and pestle, you hope to grind the undead to a pulp.",
+    "points": 5,
+    "skills": [ 
+	  { "level": 6, "name": "firstaid" },
+	  { "level": 1, "name": "speech" }
+	],
+    "proficiencies": [
+      "prof_wound_care",
+      "prof_wound_care_expert",
+      "prof_intro_biology",
+	  "prof_intro_chemistry",
+	  "prof_organic_chemistry",
+	  "prof_biochemistry",
+      "prof_physiology",
+      "prof_burn_care"
+    ],
+    "traits": [ "PROF_MED" ],
+    "items": {
+      "both": {
+        "items": [
+          "dress_shirt",
+          "gloves_medical",
+          "socks",
+          "dress_shoes",
+          "coat_lab",
+          "badge_doctor",
+          "glasses_safety",
+          "wristwatch",
+		  "mortar_pestle",
+          "water_clean",
+          { "item": "bandages", "count": 5 },
+          { "item": "adhesive_bandages", "count": 10 },
+		  { "item": "disinfectant", "count": 10 },
+          "aspirin",
+		  "pepto",
+		  "syringe",
+		  "morphine"
+        ],
+        "entries": [ { "item": "pants", "variant": "pants_blue" }, { "group": "charged_smart_phone" }, { "group": "full_1st_aid" } ]
+      },
+      "male": [ "boxer_shorts" ],
+      "female": [ "bra", "panties" ]
+	},
+    "age_lower": 25
   },
   {
     "type": "profession",

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -1994,18 +1994,15 @@
     "type": "profession",
     "id": "doctor",
     "name": "Doctor",
-	"requirement": "achievement_reach_hospital",
+    "requirement": "achievement_reach_hospital",
     "description": "You were a patient-facing doctor practicing general or specialized medicine.  While your bedside manner might not get you far in this new world, your medical skills will certainly help.",
     "points": 5,
-    "skills": [
-	  { "level": 7, "name": "firstaid" },
-	  { "level": 3, "name": "speech" }
-	],
+    "skills": [ { "level": 7, "name": "firstaid" }, { "level": 3, "name": "speech" } ],
     "proficiencies": [
       "prof_wound_care",
       "prof_wound_care_expert",
       "prof_intro_biology",
-	  "prof_intro_chemistry",
+      "prof_intro_chemistry",
       "prof_physiology",
       "prof_burn_care",
       "prof_dissect_humans"
@@ -2025,40 +2022,37 @@
           "water_clean",
           { "item": "bandages", "count": 5 },
           { "item": "adhesive_bandages", "count": 10 },
-		  { "item": "disinfectant", "count": 10 },
+          { "item": "disinfectant", "count": 10 },
           "aspirin",
-		  "thermometer",
-		  "pepto",
-		  "syringe",
-		  "morphine",
+          "thermometer",
+          "pepto",
+          "syringe",
+          "morphine",
           "stethoscope",
-		  "scalpel"
+          "scalpel"
         ],
         "entries": [ { "item": "pants", "variant": "pants_blue" }, { "group": "charged_smart_phone" }, { "group": "full_1st_aid" } ]
       },
       "male": [ "boxer_shorts" ],
       "female": [ "bra", "panties" ]
-	},
+    },
     "age_lower": 25
   },
   {
     "type": "profession",
     "id": "pharmacist",
     "name": "Pharmacist",
-	"requirement": "achievement_reach_hospital",
+    "requirement": "achievement_reach_hospital",
     "description": "You were a pharmacist working in a community pharmacy.  No simple pill-pusher, you have a plethora of knowledge of drug preparation, biochemistry, and biology.  With your trusty mortar and pestle, you hope to grind the undead to a pulp.",
     "points": 5,
-    "skills": [ 
-	  { "level": 6, "name": "firstaid" },
-	  { "level": 1, "name": "speech" }
-	],
+    "skills": [ { "level": 6, "name": "firstaid" }, { "level": 1, "name": "speech" } ],
     "proficiencies": [
       "prof_wound_care",
       "prof_wound_care_expert",
       "prof_intro_biology",
-	  "prof_intro_chemistry",
-	  "prof_organic_chemistry",
-	  "prof_biochemistry",
+      "prof_intro_chemistry",
+      "prof_organic_chemistry",
+      "prof_biochemistry",
       "prof_physiology",
       "prof_burn_care"
     ],
@@ -2074,21 +2068,21 @@
           "badge_doctor",
           "glasses_safety",
           "wristwatch",
-		  "mortar_pestle",
+          "mortar_pestle",
           "water_clean",
           { "item": "bandages", "count": 5 },
           { "item": "adhesive_bandages", "count": 10 },
-		  { "item": "disinfectant", "count": 10 },
+          { "item": "disinfectant", "count": 10 },
           "aspirin",
-		  "pepto",
-		  "syringe",
-		  "morphine"
+          "pepto",
+          "syringe",
+          "morphine"
         ],
         "entries": [ { "item": "pants", "variant": "pants_blue" }, { "group": "charged_smart_phone" }, { "group": "full_1st_aid" } ]
       },
       "male": [ "boxer_shorts" ],
       "female": [ "bra", "panties" ]
-	},
+    },
     "age_lower": 25
   },
   {

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -1979,6 +1979,7 @@
           { "item": "water_clean" },
           { "item": "bandages", "count": 3 },
           { "item": "adhesive_bandages", "count": 10 },
+          { "group": "charged_aspirin" },
           { "item": "stethoscope" },
           { "item": "pants", "variant": "pants_blue" },
           { "group": "charged_smart_phone" },


### PR DESCRIPTION


<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "This adds a Doctor and Pharmacist profession. It also generalizes the "MD" trait description to include more medical professionals."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Previously, there was only the option to be a Medical Resident or Combat Medic, but not just a normal Doctor or Pharmacist. Both are fairly common professions, so this adds them to the game. The previous description of the medical degree trait, "MD" was very specific to the Medical Resident profession, so this generalizes it for use with more medical professions. Finally, I added Introduction to Chemistry to the Medical Resident as having a basic knowledge of chemistry is a typical requirement for medical school in the US.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
I added the Doctor and Pharmacist profession, edited the description for the MD trait, and added the Introduction to Chemistry proficiency to the Medical Resident. I achievement-gated the Doctor and Pharmacist behind the "Find a hospital" achievement, as that seemed fun and appropriate.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I considered adding Organic Chemistry as well for Medical Resident and Doctor as it's a common requirement, but I figured Physiology would cover the basics like the Krebs Cycle, etc. which is good enough. I considered Principles of Chemical Synthesis and Pharmaceutical Production for the Pharmacist, but Pharmacists don't really create drugs (outside of simple compounding), and I think those proficiencies are meant for actual Chemists.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I loaded up the Doctor, Pharmacist, and Medical Resident professions, walked around a bit, and saw that they had the right items and proficiencies. Doctor and Pharmacist are tied to an achievement, so I did unlock all achievements to make them.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
