### PR TITLE
Auto path

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -3574,6 +3574,18 @@
   },
   {
     "type": "keybinding",
+    "id": "RENAME_START",
+    "category": "PATH_MANAGER",
+    "name": "Rename start"
+  },
+  {
+    "type": "keybinding",
+    "id": "RENAME_END",
+    "category": "PATH_MANAGER",
+    "name": "Rename end"
+  },
+  {
+    "type": "keybinding",
     "id": "ADD_ZONE",
     "category": "ZONES_MANAGER",
     "name": "Add zone",

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -3550,6 +3550,12 @@
   },
   {
     "type": "keybinding",
+    "id": "CONTINUE_RECORDING",
+    "category": "PATH_MANAGER",
+    "name": "Continue recording"
+  },
+  {
+    "type": "keybinding",
     "id": "STOP_RECORDING",
     "category": "PATH_MANAGER",
     "name": "Stop recording"

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -3538,6 +3538,42 @@
   },
   {
     "type": "keybinding",
+    "id": "WALK_PATH",
+    "category": "PATH_MANAGER",
+    "name": "Walk path"
+  },
+  {
+    "type": "keybinding",
+    "id": "START_RECORDING",
+    "category": "PATH_MANAGER",
+    "name": "Start recording"
+  },
+  {
+    "type": "keybinding",
+    "id": "STOP_RECORDING",
+    "category": "PATH_MANAGER",
+    "name": "Stop recording"
+  },
+  {
+    "type": "keybinding",
+    "id": "DELETE_PATH",
+    "category": "PATH_MANAGER",
+    "name": "Delete"
+  },
+  {
+    "type": "keybinding",
+    "id": "MOVE_PATH_UP",
+    "category": "PATH_MANAGER",
+    "name": "Move up"
+  },
+  {
+    "type": "keybinding",
+    "id": "MOVE_PATH_DOWN",
+    "category": "PATH_MANAGER",
+    "name": "Move down"
+  },
+  {
+    "type": "keybinding",
     "id": "ADD_ZONE",
     "category": "ZONES_MANAGER",
     "name": "Add zone",

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -3296,6 +3296,12 @@
   },
   {
     "type": "keybinding",
+    "id": "open_path_manager",
+    "name": "Path manager",
+    "category": "DEFAULTMODE"
+  },
+  {
+    "type": "keybinding",
     "id": "SCROLL_ITEM_INFO_UP",
     "category": "LIST_ITEMS",
     "name": "Scroll item info up",

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -3544,6 +3544,12 @@
   },
   {
     "type": "keybinding",
+    "id": "WALK_PATH_FROM_MIDDLE",
+    "category": "PATH_MANAGER",
+    "name": "Walk path from middle"
+  },
+  {
+    "type": "keybinding",
     "id": "START_RECORDING",
     "category": "PATH_MANAGER",
     "name": "Start recording"

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -3586,6 +3586,12 @@
   },
   {
     "type": "keybinding",
+    "id": "SWAP_START_END",
+    "category": "PATH_MANAGER",
+    "name": "Swap start with end"
+  },
+  {
+    "type": "keybinding",
     "id": "ADD_ZONE",
     "category": "ZONES_MANAGER",
     "name": "Add zone",

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -400,6 +400,8 @@ std::string action_ident( action_id act )
             return "main_menu";
         case ACTION_DIARY:
             return "diary";
+        case ACTION_PATH_MANAGER:
+            return "open_path_manager";
         case ACTION_KEYBINDINGS:
             return "HELP_KEYBINDINGS";
         case ACTION_OPTIONS:

--- a/src/action.h
+++ b/src/action.h
@@ -274,6 +274,8 @@ enum action_id : int {
     ACTION_HELP,
     /** Display Diary window*/
     ACTION_DIARY,
+    /** Open Path manager*/
+    ACTION_PATH_MANAGER,
     /** Open body status menu **/
     ACTION_BODYSTATUS,
     /** Display main menu */

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -61,6 +61,7 @@
 #include "overmap.h"
 #include "overmapbuffer.h"
 #include "pathfinding.h"
+#include "path_manager.h"
 #include "pimpl.h"
 #include "profession.h"
 #include "ranged.h"
@@ -412,6 +413,14 @@ diary *avatar::get_avatar_diary()
         a_diary = std::make_unique<diary>();
     }
     return a_diary.get();
+}
+
+path_manager *avatar::get_path_manager()
+{
+    if( a_path_manager == nullptr ) {
+        a_path_manager = std::make_unique<path_manager>();
+    }
+    return a_path_manager.get();
 }
 
 bool avatar::read( item_location &book, item_location ereader )

--- a/src/avatar.h
+++ b/src/avatar.h
@@ -42,6 +42,7 @@ class mission;
 class monster;
 class nc_color;
 class npc;
+class path_manager;
 class talker;
 struct bionic;
 struct mtype;
@@ -196,6 +197,7 @@ class avatar : public Character
 
         //return avatar diary
         diary *get_avatar_diary();
+        path_manager *get_path_manager();
 
         // Dialogue and bartering--see npctalk.cpp
         void talk_to( std::unique_ptr<talker> talk_with, bool radio_contact = false,
@@ -415,6 +417,10 @@ class avatar : public Character
         * diary to track player progression and to write the players stroy
         */
         std::unique_ptr <diary> a_diary;
+        /**
+         * Manager of paths the avatar created.
+         */
+        std::unique_ptr <path_manager> a_path_manager;
         /**
          * The amount of calories spent and gained per day for the last 30 days.
          * the back is popped off and a new one added to the front at midnight each day

--- a/src/game.h
+++ b/src/game.h
@@ -1319,7 +1319,7 @@ namespace cata_event_dispatch
 // @param p The point the avatar moved from in absolute coordinates
 // @param u The avatar (should have already moved to the new pos)
 // @param m The map the avatar is moving on
-void avatar_moves( const tripoint_abs_ms &old_abs_pos, const avatar &u, const map &m );
+void avatar_moves( const tripoint_abs_ms &old_abs_pos, avatar &u, const map &m );
 } // namespace cata_event_dispatch
 
 #endif // CATA_SRC_GAME_H

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -75,6 +75,7 @@
 #include "output.h"
 #include "overmap_ui.h"
 #include "panels.h"
+#include "path_manager.h"
 #include "player_activity.h"
 #include "popup.h"
 #include "ranged.h"
@@ -2920,6 +2921,10 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
 
         case ACTION_DISTRACTION_MANAGER:
             get_distraction_manager().show();
+            break;
+
+        case ACTION_PATH_MANAGER:
+            u.get_path_manager()->show();
             break;
 
         case ACTION_COLOR:

--- a/src/line.cpp
+++ b/src/line.cpp
@@ -3,12 +3,15 @@
 #include <algorithm>
 #include <array>
 #include <cstdlib>
+#include <memory>
 #include <tuple>
 #include <utility>
 
 #include "cata_assert.h"
+#include "debug.h"
 #include "enums.h"
 #include "math_defines.h"
+#include "map.h"
 #include "output.h"
 #include "string_formatter.h"
 #include "translations.h"
@@ -680,6 +683,15 @@ std::string direction_suffix( const tripoint_bub_ms &p, const tripoint_bub_ms &q
         return std::string();
     }
     return string_format( "%d%s", dist, trim( direction_name_short( direction_from( p, q ) ) ) );
+}
+
+std::string direction_suffix( const tripoint_abs_ms &p, const tripoint_abs_ms &q )
+{
+    int dist = square_dist( p, q );
+    if( dist <= 0 ) {
+        return std::string();
+    }
+    return string_format( "%d %s", dist, trim( direction_name_short( direction_from( p, q ) ) ) );
 }
 
 // Cardinals are cardinals. Result is cardinal and adjacent sub-cardinals.

--- a/src/line.h
+++ b/src/line.h
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <functional>
 #include <iosfwd>
+#include <string>
 #include <vector>
 
 #include "coords_fwd.h"
@@ -137,6 +138,7 @@ std::string direction_arrow( direction dir );
 
 /* Get suffix describing vector from p to q (e.g. 1NW, 2SE) or empty string if p == q */
 std::string direction_suffix( const tripoint_bub_ms &p, const tripoint_bub_ms &q );
+std::string direction_suffix( const tripoint_abs_ms &p, const tripoint_abs_ms &q );
 
 /**
  * The actual Bresenham algorithm in 2D and 3D, everything else should call these

--- a/src/path_manager.cpp
+++ b/src/path_manager.cpp
@@ -1,0 +1,195 @@
+#include "path_manager.h"
+
+#include <stddef.h>
+#include <iterator>
+#include <vector>
+
+#include "avatar.h"
+#include "cata_assert.h"
+#include "coordinates.h"
+#include "coords_fwd.h"
+#include "debug.h"
+#include "enums.h"
+#include "map.h"
+#include "messages.h"
+#include "translations.h"
+
+class path
+{
+        friend path_manager;
+        friend path_manager_impl;
+    public:
+        /**
+         * Record a single step of path.
+         * If this step makes a loop, remove the whole loop.
+         */
+        void record_step( const tripoint_abs_ms &new_pos );
+        /**
+         * Set avatar to auto route to this paths other end.
+         * Avatar must be at one of the ends of the path.
+         */
+        void set_avatar_path();
+    private:
+        std::vector<tripoint_abs_ms> recorded_path;
+};
+
+class path_manager_impl
+{
+        friend path_manager;
+    public:
+        /**
+         * Try to find a path then walk on it.
+         * Start new path if player doesn't stand at start or end of any path.
+         */
+        void auto_route_from_path();
+        /**
+         * Start recording a new path.
+         */
+        void start_recording();
+        /**
+         * Stop recording path.
+         */
+        void stop_recording();
+    private:
+        bool recording_path = false;
+        /// Set recording to true/false on current path, current path must be valid
+        void set_recording_path( bool set_to );
+        /// Set current path to p_index and recording_path to true
+        void set_recording_path( int p_index );
+        int current_path_index = -1;
+        std::vector<path> paths;
+};
+
+
+void path::record_step( const tripoint_abs_ms &new_pos )
+{
+    // if a loop exists find it and remove it
+    for( auto it = recorded_path.begin(); it != recorded_path.end(); ++it ) {
+        if( *it == new_pos ) {
+            const size_t old_path_len = recorded_path.size();
+            recorded_path.erase( it + 1, recorded_path.end() );
+            add_msg( m_info, _( "Auto path: Made a loop!  Old path len: %s, new path len: %s." ),
+                     old_path_len,
+                     recorded_path.size() );
+            return;
+        }
+    }
+    recorded_path.emplace_back( new_pos );
+}
+
+void path::set_avatar_path()
+{
+    avatar &player_character = get_avatar();
+    std::vector<tripoint_bub_ms> route;
+    if( player_character.pos_bub() == get_map().bub_from_abs( recorded_path.front() ) ) {
+        add_msg( m_info, _( "Auto path: Go from start." ) );
+        for( auto it = std::next( recorded_path.begin() ); it != recorded_path.end(); ++it ) {
+            route.emplace_back( get_map().bub_from_abs( *it ) );
+        }
+    } else if( player_character.pos_bub() == get_map().bub_from_abs( recorded_path.back() ) ) {
+        add_msg( m_info, _( "Auto path: Go from end." ) );
+        for( auto it = std::next( recorded_path.rbegin() ); it != recorded_path.rend(); ++it ) {
+            route.emplace_back( get_map().bub_from_abs( *it ) );
+        }
+    } else {
+        debugmsg( "Tried to set auto route but the player character isn't standing at path start or end." );
+        return;
+    }
+    player_character.set_destination( route );
+}
+
+void path_manager_impl::start_recording()
+{
+    current_path_index = paths.size();  // future_size - 1
+    paths.emplace_back( path() );
+    set_recording_path( current_path_index );
+    paths.back().record_step( get_avatar().get_location() );
+}
+
+void path_manager_impl::stop_recording()
+{
+    set_recording_path( false );
+
+    const path &current_path = paths[current_path_index];
+    const std::vector<tripoint_abs_ms> &curr_path = current_path.recorded_path;
+    if( curr_path.size() <= 1 ) {
+        add_msg( m_info, _( "Auto path: Recorded path has no lenght.  Path erased." ) );
+        paths.erase( paths.begin() + current_path_index );
+    } else {
+        add_msg( m_info, _( "Auto path: Path saved." ) );
+    }
+    current_path_index = -1;
+}
+
+void path_manager_impl::auto_route_from_path()
+{
+    avatar &player_character = get_avatar();
+    for( int path_index = 0; path_index < static_cast<int>( paths.size() ); ++path_index ) {
+        const std::vector<tripoint_abs_ms> &p = paths[path_index].recorded_path;
+        if( player_character.pos_bub() == get_map().bub_from_abs( p.front() )
+            || player_character.pos_bub() == get_map().bub_from_abs( p.back() )
+          ) {
+            current_path_index = path_index;
+            paths[path_index].set_avatar_path();
+            return;
+        }
+    }
+    // Didn't find any, set index to invalid.
+    current_path_index = -1;
+    add_msg( m_info,
+             _( "Auto path: Player doesn't stand at start or end of existing path.  Recording new path." ) );
+    start_recording();
+}
+
+
+void path_manager_impl::set_recording_path( bool set_to )
+{
+    if( set_to ) {
+        cata_assert( 0 <= current_path_index && current_path_index < static_cast<int>( paths.size() ) );
+    }
+    recording_path = set_to;
+}
+
+void path_manager_impl::set_recording_path( int p_index )
+{
+    cata_assert( 0 <= p_index && p_index < static_cast<int>( paths.size() ) );
+    current_path_index = p_index;
+    recording_path = true;
+}
+
+// These need to be here so that pimpl works with unique ptr
+path_manager::path_manager() = default;
+path_manager::~path_manager() = default;
+
+void path_manager::record_step( const tripoint_abs_ms &new_pos )
+{
+    if( !pimpl->recording_path ) {
+        return;
+    }
+    pimpl->paths[pimpl->current_path_index].record_step( new_pos );
+}
+
+bool path_manager::store()
+{
+    const std::string name = base64_encode( get_avatar().get_save_id() + "_path_manager" );
+    cata_path path = PATH_INFO::world_base_save_path() +  "/" + name + ".json";
+    const bool iswriten = write_to_file( path, [&]( std::ostream & fout ) {
+        serialize( fout );
+    }, _( "path_manager data" ) );
+    return iswriten;
+}
+
+void path_manager::load()
+{
+    pimpl = std::make_unique<path_manager_impl>();
+}
+
+void path_manager::show()
+{
+    if( pimpl->recording_path ) {
+        pimpl->stop_recording();
+        return;
+    }
+
+    pimpl->auto_route_from_path();
+}

--- a/src/path_manager.cpp
+++ b/src/path_manager.cpp
@@ -396,6 +396,17 @@ void path_manager_ui::enabled_active_button( const std::string action, bool enab
     ImGui::EndDisabled();
 }
 
+static void draw_distance_from_tile( const tripoint_abs_ms &tile )
+{
+    const tripoint_abs_ms player_pos = get_map().getglobal( get_avatar().pos_bub() );
+    if( player_pos == tile ) {
+        cataimgui::draw_colored_text( _( "It's under your feet." ), c_light_green );
+    } else {
+        const std::string dist = direction_suffix( player_pos, tile );
+        cataimgui::draw_colored_text( dist, c_white );
+    }
+}
+
 void path_manager_ui::draw_controls()
 {
     // general buttons
@@ -451,23 +462,13 @@ void path_manager_ui::draw_controls()
             cataimgui::draw_colored_text( curr_path.name_start, c_white );
 
             ImGui::TableNextColumn();
-            if( curr_path.player_at_start() ) {
-                cataimgui::draw_colored_text( _( "It's under your feet." ), c_light_green );
-            } else {
-                std::string dist = direction_suffix( get_avatar().get_location(), curr_path.recorded_path.front() );
-                cataimgui::draw_colored_text( dist, c_white );
-            }
+            draw_distance_from_tile( curr_path.recorded_path.front() );
 
             ImGui::TableNextColumn();
             cataimgui::draw_colored_text( curr_path.name_end, c_white );
 
             ImGui::TableNextColumn();
-            if( curr_path.player_at_end() ) {
-                cataimgui::draw_colored_text( _( "It's under your feet." ), c_light_green );
-            } else {
-                std::string dist = direction_suffix( get_avatar().get_location(), curr_path.recorded_path.back() );
-                cataimgui::draw_colored_text( dist, c_white );
-            }
+            draw_distance_from_tile( curr_path.recorded_path.back() );
 
             ImGui::TableNextColumn();
             ImGui::Text( "%zu", curr_path.recorded_path.size() );

--- a/src/path_manager.cpp
+++ b/src/path_manager.cpp
@@ -24,6 +24,7 @@
 #include "flexbuffer_json.h"
 #include "imgui/imgui.h"
 #include "input_context.h"
+#include "input_popup.h"
 #include "json.h"
 #include "json_error.h"
 #include "line.h"
@@ -33,7 +34,6 @@
 #include "path_info.h"
 #include "point.h"
 #include "string_formatter.h"
-#include "string_input_popup.h"
 #include "translations.h"
 #include "ui_manager.h"
 
@@ -89,7 +89,6 @@ class path
         void serialize( JsonOut &jsout );
         void deserialize( const JsonObject &jsin );
     private:
-        std::string set_name_popup( std::string old_name, const std::string &label ) const;
         std::vector<tripoint_abs_ms> recorded_path;
         std::string name_start;
         std::string name_end;
@@ -268,26 +267,12 @@ void path::set_avatar_path( bool towards_end ) const
 
 void path::set_name_start()
 {
-    name_start = set_name_popup( name_start, _( "Name path start:" ) );
+    name_start = string_input_popup_imgui( 34, name_start, _( "Name path start:" ) ).query();
 }
 
 void path::set_name_end()
 {
-    name_end = set_name_popup( name_end, _( "Name path end:" ) );
-}
-
-std::string path::set_name_popup( std::string old_name, const std::string &label ) const
-{
-    std::string new_name = old_name;
-    string_input_popup popup;
-    popup
-    .title( label )
-    .width( 85 )
-    .edit( new_name );
-    if( popup.confirmed() ) {
-        return new_name;
-    }
-    return old_name;
+    name_end = string_input_popup_imgui( 34, name_end, _( "Name path end:" ) ).query();
 }
 
 void path::swap_start_end()

--- a/src/path_manager.cpp
+++ b/src/path_manager.cpp
@@ -546,7 +546,8 @@ void path_manager_ui::draw_controls()
     enabled_active_button( "SWAP_START_END", pimpl->selected_id != -1 );
     ImGui::PopItemFlag();  // ImGuiItemFlags_NoNav
 
-    if( ! ImGui::BeginTable( "PATH_MANAGER", 6, ImGuiTableFlags_Resizable | ImGuiTableFlags_ScrollY ) ) {
+    ImGui::BeginChild( "table", ImVec2( 0, 0 ), ImGuiChildFlags_NavFlattened );
+    if( ! ImGui::BeginTable( "PATH_MANAGER", 6, ImGuiTableFlags_Resizable ) ) {
         return;
     }
     // TODO invlet
@@ -593,6 +594,7 @@ void path_manager_ui::draw_controls()
         }
     }
     ImGui::EndTable();
+    ImGui::EndChild();
 }
 
 void path_manager_ui::run()

--- a/src/path_manager.cpp
+++ b/src/path_manager.cpp
@@ -147,8 +147,7 @@ void path::record_step( const tripoint_abs_ms &new_pos )
         }
     }
     // if a loop exists find it and remove it
-    // todo optimize, probably with unordered set
-    for( auto it = recorded_path.begin(); it != recorded_path.end(); ++it ) {
+    for( auto it = recorded_path.begin(); it != recorded_path.end(); ) {
         if( *it == new_pos ) {
             const size_t old_path_len = recorded_path.size();
             recorded_path.erase( it + 1, recorded_path.end() );
@@ -157,6 +156,12 @@ void path::record_step( const tripoint_abs_ms &new_pos )
                      recorded_path.size() );
             return;
         }
+        // Asuming the path tiles are at most (1, 1, 1) apart,
+        // we can skip as many tiles, as the curent tile is far from the `new_pos`.
+        tripoint point_diff = ( *it - new_pos ).raw().abs();
+        int diff = std::max( { point_diff.x, point_diff.y, point_diff.z } );
+        // Move 1 less than that for the corner optimization. Move at least 1.
+        it += std::max( 1, diff - 1 );
     }
     recorded_path.emplace_back( new_pos );
 }

--- a/src/path_manager.cpp
+++ b/src/path_manager.cpp
@@ -1,6 +1,6 @@
 #include "path_manager.h"
 
-#include <stddef.h>
+#include <cstddef>
 #include <iterator>
 #include <memory>
 #include <string>
@@ -39,7 +39,7 @@ class path
     public:
         path() = default;
         path( const path &other ) = default;
-        path( std::vector<tripoint_abs_ms> &&recorded_path_in )
+        explicit path( std::vector<tripoint_abs_ms> &&recorded_path_in )
             : recorded_path( std::move( recorded_path_in ) ) {}
         path &operator=( const path &other ) = default;
         path &operator=( path &&other ) = default;
@@ -96,7 +96,7 @@ class path_manager_impl
 class path_manager_ui : public cataimgui::window
 {
     public:
-        path_manager_ui( path_manager_impl *pimpl_in );
+        explicit path_manager_ui( path_manager_impl *pimpl_in );
         void run();
 
     protected:
@@ -149,7 +149,7 @@ void path::set_avatar_path()
 void path_manager_impl::start_recording()
 {
     current_path_index = paths.size();  // future_size - 1
-    paths.emplace_back( path() );
+    paths.emplace_back();
     set_recording_path( current_path_index );
     paths.back().record_step( get_avatar().get_location() );
 }
@@ -334,7 +334,7 @@ void path_manager::deserialize( const JsonValue &jsin )
         std::vector<std::vector<tripoint_abs_ms>> recorded_paths;
         data.read( "recorded_paths", recorded_paths );
         for( std::vector<tripoint_abs_ms> &p : recorded_paths ) {
-            pimpl->paths.emplace_back( path( std::move( p ) ) );
+            pimpl->paths.emplace_back( std::move( p ) );
         }
     } catch( const JsonError &e ) {
     }

--- a/src/path_manager.cpp
+++ b/src/path_manager.cpp
@@ -179,6 +179,16 @@ class path_manager_ui : public cataimgui::window
         path_manager_impl *pimpl;
 };
 
+static std::string avatar_distance_from_tile( const tripoint_abs_ms &tile )
+{
+    const tripoint_abs_ms &avatar_pos = get_map().getglobal( get_avatar().pos_bub() );
+    if( avatar_pos == tile ) {
+        return colorize( _( "It's here." ), c_light_green );
+    } else {
+        return direction_suffix( avatar_pos, tile );
+    }
+}
+
 void path::record_step( const tripoint_abs_ms &new_pos )
 {
     // early return on a huge step, like an elevator teleport
@@ -459,14 +469,16 @@ bool path_manager_impl::auto_route_from_path_middle() const
         const path &curr_path = paths[i];
         const std::string from_to = string_format( "from %s (%s) to %s (%s)",
                                     curr_path.name_start,
-                                    direction_suffix( avatar_pos, curr_path.recorded_path.front() ),
+                                    avatar_distance_from_tile( curr_path.recorded_path.front() ),
                                     curr_path.name_end,
-                                    direction_suffix( avatar_pos, curr_path.recorded_path.back() ) );
+                                    avatar_distance_from_tile( curr_path.recorded_path.back() ) );
         const int avatar_at_i = curr_path.avatar_closest_i_approximate();
         const int start_steps = avatar_at_i;
         const int end_steps = curr_path.recorded_path.size() - avatar_at_i - 1;
-        const std::string start = string_format( "%s (%d steps)", curr_path.name_start, avatar_at_i );
-        const std::string end = string_format( "%s (%d steps)", curr_path.name_end, end_steps );
+        const std::string start = string_format( _( "%s%s (%d steps)" ), start_steps == 0 ? "    " : "",
+                                  curr_path.name_start, avatar_at_i );
+        const std::string end = string_format( _( "%s%s (%d steps)" ), end_steps == 0 ? "    " : "",
+                                               curr_path.name_end, end_steps );
         path_selection.addentry( -1, false, MENU_AUTOASSIGN, from_to );
         path_selection.addentry( i << 1, start_steps > 0, MENU_AUTOASSIGN, start );
         path_selection.addentry( ( i << 1 ) + 1, end_steps > 0, MENU_AUTOASSIGN, end );
@@ -501,17 +513,6 @@ void path_manager_ui::enabled_active_button( const std::string action, bool enab
     ImGui::BeginDisabled( !enabled );
     action_button( action, ctxt.get_button_text( action ) );
     ImGui::EndDisabled();
-}
-
-static void draw_distance_from_tile( const tripoint_abs_ms &tile )
-{
-    const tripoint_abs_ms &avatar_pos = get_map().getglobal( get_avatar().pos_bub() );
-    if( avatar_pos == tile ) {
-        cataimgui::draw_colored_text( _( "It's under your feet." ), c_light_green );
-    } else {
-        const std::string dist = direction_suffix( avatar_pos, tile );
-        cataimgui::draw_colored_text( dist );
-    }
 }
 
 void path_manager_ui::draw_controls()
@@ -580,16 +581,17 @@ void path_manager_ui::draw_controls()
             cataimgui::draw_colored_text( curr_path.name_start );
 
             ImGui::TableNextColumn();
-            draw_distance_from_tile( curr_path.recorded_path.front() );
+            cataimgui::draw_colored_text( avatar_distance_from_tile( curr_path.recorded_path.front() ) );
 
             ImGui::TableNextColumn();
             cataimgui::draw_colored_text( curr_path.name_end );
 
             ImGui::TableNextColumn();
-            draw_distance_from_tile( curr_path.recorded_path.back() );
+            cataimgui::draw_colored_text( avatar_distance_from_tile( curr_path.recorded_path.back() ) );
 
             ImGui::TableNextColumn();
-            draw_distance_from_tile( curr_path.recorded_path[curr_path.avatar_closest_i_approximate()] );
+            cataimgui::draw_colored_text( avatar_distance_from_tile(
+                                              curr_path.recorded_path[curr_path.avatar_closest_i_approximate()] ) );
 
             ImGui::TableNextColumn();
             ImGui::Text( "%zu", curr_path.recorded_path.size() );

--- a/src/path_manager.cpp
+++ b/src/path_manager.cpp
@@ -135,6 +135,17 @@ class path_manager_ui : public cataimgui::window
 
 void path::record_step( const tripoint_abs_ms &new_pos )
 {
+    // early return on a huge step, like an elevator teleport
+    if( recorded_path.size() >= 1 ) {
+        tripoint diff = ( recorded_path.back() - new_pos ).raw().abs();
+        if( std::max( { diff.x, diff.y, diff.z } ) > 1 ) {
+            popup( _( string_format(
+                          "Character moved by %s, expected 1 in each at most.  Recording stopped.",
+                          diff.to_string_writable() ) ) );
+            get_avatar().get_path_manager()->pimpl->stop_recording();
+            return;
+        }
+    }
     // if a loop exists find it and remove it
     // todo optimize, probably with unordered set
     for( auto it = recorded_path.begin(); it != recorded_path.end(); ++it ) {

--- a/src/path_manager.cpp
+++ b/src/path_manager.cpp
@@ -104,7 +104,6 @@ class path_manager_ui : public cataimgui::window
         void draw_controls() override;
         cataimgui::bounds get_bounds() override;
     private:
-        std::string msg;
         path_manager_impl *pimpl;
 };
 

--- a/src/path_manager.cpp
+++ b/src/path_manager.cpp
@@ -91,6 +91,7 @@ class path_manager_impl
         /// Set current path to p_index and recording_path to true
         void set_recording_path( int p_index );
         int recording_path_index = -1;
+        int selected_id = -1;
         std::vector<path> paths;
 };
 
@@ -228,15 +229,14 @@ void path_manager_ui::draw_controls()
 
     ImGuiListClipper clipper;
     clipper.Begin( pimpl->paths.size() );
-    int selected_id = -1;
     while( clipper.Step() ) {
         for( int i = clipper.DisplayStart; i < clipper.DisplayEnd; i++ ) {
             const path &curr_path = pimpl->paths[i];
             ImGui::TableNextColumn();
-            if( ImGui::Selectable( ( "##" + std::to_string( i ) ).c_str(), selected_id == i,
+            if( ImGui::Selectable( ( "##" + std::to_string( i ) ).c_str(), pimpl->selected_id == i,
                                    ImGuiSelectableFlags_SpanAllColumns )
               ) {
-                //set_selected_id( i );
+                pimpl->selected_id = i;
             }
             ImGui::SameLine();
             draw_colored_text( "start", c_white );

--- a/src/path_manager.cpp
+++ b/src/path_manager.cpp
@@ -507,6 +507,8 @@ void path_manager_ui::enabled_active_button( const std::string action, bool enab
 
 void path_manager_ui::draw_controls()
 {
+    // make buttons unselectable with arrows
+    ImGui::PushItemFlag( ImGuiItemFlags_NoNav, true );
     // walk buttons
     cataimgui::draw_colored_text( _( "Walk:" ) );
     ImGui::SameLine();
@@ -542,19 +544,23 @@ void path_manager_ui::draw_controls()
     enabled_active_button( "RENAME_END", pimpl->selected_id != -1 );
     ImGui::SameLine();
     enabled_active_button( "SWAP_START_END", pimpl->selected_id != -1 );
+    ImGui::PopItemFlag();  // ImGuiItemFlags_NoNav
 
     ImGui::BeginChild( "table" );
     if( ! ImGui::BeginTable( "PATH_MANAGER", 6, ImGuiTableFlags_Resizable ) ) {
         return;
     }
     // TODO invlet
+    ImGui::TableSetupScrollFreeze( 0, 1 );
     ImGui::TableSetupColumn( _( "start name" ) );
     ImGui::TableSetupColumn( _( "start distance" ) );
     ImGui::TableSetupColumn( _( "end name" ) );
     ImGui::TableSetupColumn( _( "end distance" ) );
     ImGui::TableSetupColumn( _( "closest tile" ) );
     ImGui::TableSetupColumn( _( "total length" ) );
+    ImGui::PushItemFlag( ImGuiItemFlags_NoNav, true );
     ImGui::TableHeadersRow();
+    ImGui::PopItemFlag();  // ImGuiItemFlags_NoNav
 
     ImGuiListClipper clipper;
     clipper.Begin( pimpl->paths.size() );

--- a/src/path_manager.cpp
+++ b/src/path_manager.cpp
@@ -479,7 +479,8 @@ path_manager::~path_manager() = default;
 
 void path_manager::record_step( const tripoint_abs_ms &new_pos )
 {
-    if( !pimpl->recording_path() ) {
+    // !pimpl for tests, they don't initialize avatar like game does
+    if( !pimpl || !pimpl->recording_path() ) {
         return;
     }
     pimpl->paths[pimpl->recording_path_index].record_step( new_pos );

--- a/src/path_manager.cpp
+++ b/src/path_manager.cpp
@@ -659,13 +659,12 @@ void path_manager_ui::run()
 }
 
 // These need to be here so that pimpl works with unique ptr
-path_manager::path_manager() = default;
+path_manager::path_manager() : pimpl( std::make_unique<path_manager_impl>() ) {}
 path_manager::~path_manager() = default;
 
 void path_manager::record_step( const tripoint_abs_ms &new_pos )
 {
-    // !pimpl for tests, they don't initialize avatar like game does
-    if( !pimpl || !pimpl->is_recording_path() ) {
+    if( !pimpl->is_recording_path() ) {
         return;
     }
     pimpl->paths[pimpl->recording_path_index].record_step( new_pos );
@@ -683,8 +682,6 @@ bool path_manager::store()
 
 void path_manager::load()
 {
-    pimpl = std::make_unique<path_manager_impl>();
-
     const std::string name = base64_encode( get_avatar().get_save_id() + "_path_manager" );
     cata_path path = PATH_INFO::world_base_save_path() / ( name + ".json" );
     if( file_exist( path ) ) {

--- a/src/path_manager.cpp
+++ b/src/path_manager.cpp
@@ -546,8 +546,11 @@ void path_manager_ui::draw_controls()
     enabled_active_button( "SWAP_START_END", pimpl->selected_id != -1 );
     ImGui::PopItemFlag();  // ImGuiItemFlags_NoNav
 
+    // Use NavFlattened to select the first entry in the table instead of the table itself.
     ImGui::BeginChild( "table", ImVec2( 0, 0 ), ImGuiChildFlags_NavFlattened );
-    if( ! ImGui::BeginTable( "PATH_MANAGER", 6, ImGuiTableFlags_Resizable ) ) {
+    if( ! ImGui::BeginTable( "PATH_MANAGER", 6,
+                             ImGuiTableFlags_Resizable | ImGuiTableFlags_ScrollY ) ) {
+        ImGui::EndChild();
         return;
     }
     // TODO invlet

--- a/src/path_manager.cpp
+++ b/src/path_manager.cpp
@@ -143,7 +143,7 @@ void path::record_step( const tripoint_abs_ms &new_pos )
         tripoint diff = ( recorded_path.back() - new_pos ).raw().abs();
         if( std::max( { diff.x, diff.y, diff.z } ) > 1 ) {
             popup( _( string_format(
-                          "Character moved by %s, expected 1 in each at most.  Recording stopped.",
+                          "Character moved by %s, expected 1 in each direction at most.  Recording stopped.",
                           diff.to_string_writable() ) ) );
             get_avatar().get_path_manager()->pimpl->stop_recording();
             return;
@@ -254,7 +254,7 @@ void path_manager_impl::stop_recording()
     path &current_path = paths[recording_path_index];
     if( current_path.recorded_path.size() <= 1 ) {
         paths.erase( paths.begin() + recording_path_index );
-        popup( _( "Recorded path has no lenght.  Path erased." ) );
+        popup( _( "Recorded path has no length.  Path erased." ) );
     } else {
         current_path.set_name_end();
         popup( _( "Path saved." ) );
@@ -373,11 +373,11 @@ void path_manager_ui::draw_controls()
         return;
     }
     // TODO invlet
-    ImGui::TableSetupColumn( "start name" );
-    ImGui::TableSetupColumn( "start distance" );
-    ImGui::TableSetupColumn( "end name" );
-    ImGui::TableSetupColumn( "end distance" );
-    ImGui::TableSetupColumn( "total lenght" );
+    ImGui::TableSetupColumn( _( "start name" ) );
+    ImGui::TableSetupColumn( _( "start distance" ) );
+    ImGui::TableSetupColumn( _( "end name" ) );
+    ImGui::TableSetupColumn( _( "end distance" ) );
+    ImGui::TableSetupColumn( _( "total length" ) );
     ImGui::TableHeadersRow();
 
     ImGuiListClipper clipper;
@@ -396,16 +396,18 @@ void path_manager_ui::draw_controls()
 
             ImGui::TableNextColumn();
             std::string dist = direction_suffix( get_avatar().get_location(), curr_path.recorded_path.front() );
+            nc_color color = dist == "" ? c_light_green : c_white;
             dist = dist == "" ? _( "It's under your feet." ) : dist;
-            draw_colored_text( dist, c_white );
+            draw_colored_text( dist, color );
 
             ImGui::TableNextColumn();
             draw_colored_text( curr_path.name_end, c_white );
 
             ImGui::TableNextColumn();
             dist = direction_suffix( get_avatar().get_location(), curr_path.recorded_path.back() );
+            color = dist == "" ? c_light_green : c_white;
             dist = dist == "" ? _( "It's under your feet." ) : dist;
-            draw_colored_text( dist, c_white );
+            draw_colored_text( dist, color );
 
             ImGui::TableNextColumn();
             ImGui::Text( "%zu", curr_path.recorded_path.size() );

--- a/src/path_manager.cpp
+++ b/src/path_manager.cpp
@@ -24,6 +24,7 @@
 #include "input_context.h"
 #include "json.h"
 #include "json_error.h"
+#include "line.h"
 #include "map.h"
 #include "messages.h"
 #include "output.h"
@@ -247,13 +248,15 @@ void path_manager_ui::draw_controls()
             ImGui::Text( "%s", "start" );
 
             ImGui::TableNextColumn();
-            ImGui::Text( "%d", rl_dist( get_avatar().get_location(), curr_path.recorded_path.front() ) );
+            std::string dist = direction_suffix( get_avatar().get_location(), curr_path.recorded_path.front() );
+            ImGui::Text( "%s", dist == "" ? _( "It's under your feet." ) : dist );
 
             ImGui::TableNextColumn();
             ImGui::Text( "%s", "end" );
 
             ImGui::TableNextColumn();
-            ImGui::Text( "%d", rl_dist( get_avatar().get_location(), curr_path.recorded_path.back() ) );
+            dist = direction_suffix( get_avatar().get_location(), curr_path.recorded_path.back() );
+            ImGui::Text( "%s", dist == "" ? _( "It's under your feet." ) : dist );
         }
     }
     ImGui::EndTable();

--- a/src/path_manager.cpp
+++ b/src/path_manager.cpp
@@ -546,8 +546,7 @@ void path_manager_ui::draw_controls()
     enabled_active_button( "SWAP_START_END", pimpl->selected_id != -1 );
     ImGui::PopItemFlag();  // ImGuiItemFlags_NoNav
 
-    ImGui::BeginChild( "table" );
-    if( ! ImGui::BeginTable( "PATH_MANAGER", 6, ImGuiTableFlags_Resizable ) ) {
+    if( ! ImGui::BeginTable( "PATH_MANAGER", 6, ImGuiTableFlags_Resizable | ImGuiTableFlags_ScrollY ) ) {
         return;
     }
     // TODO invlet
@@ -594,7 +593,6 @@ void path_manager_ui::draw_controls()
         }
     }
     ImGui::EndTable();
-    ImGui::EndChild();
 }
 
 void path_manager_ui::run()

--- a/src/path_manager.cpp
+++ b/src/path_manager.cpp
@@ -60,6 +60,10 @@ class path
         void set_avatar_path();
         void set_name_start();
         void set_name_end();
+        /**
+         * Reverse path and swap start, end names.
+         */
+        void swap_start_end();
 
         void serialize( JsonOut &jsout );
         void deserialize( const JsonObject &jsin );
@@ -215,6 +219,12 @@ std::string path::set_name_popup( std::string old_name, const std::string &label
     return old_name;
 }
 
+void path::swap_start_end()
+{
+    std::reverse( recorded_path.begin(), recorded_path.end() );
+    std::swap( name_start, name_end );
+}
+
 void path::serialize( JsonOut &jsout )
 {
     jsout.start_object();
@@ -355,6 +365,8 @@ void path_manager_ui::draw_controls()
     enabled_active_button( "RENAME_START", pimpl->selected_id != -1 );
     ImGui::SameLine();
     enabled_active_button( "RENAME_END", pimpl->selected_id != -1 );
+    ImGui::SameLine();
+    enabled_active_button( "SWAP_START_END", pimpl->selected_id != -1 );
 
     ImGui::BeginChild( "table" );
     if( ! ImGui::BeginTable( "PATH_MANAGER", 5, ImGuiTableFlags_Resizable ) ) {
@@ -419,6 +431,7 @@ void path_manager_ui::run()
     ctxt.register_action( "MOVE_PATH_DOWN" );
     ctxt.register_action( "RENAME_START" );
     ctxt.register_action( "RENAME_END" );
+    ctxt.register_action( "SWAP_START_END" );
     std::string action;
 
     ui_manager::redraw();
@@ -452,6 +465,8 @@ void path_manager_ui::run()
             pimpl->paths[pimpl->selected_id].set_name_start();
         } else if( action == "RENAME_END" && pimpl->selected_id != -1 ) {
             pimpl->paths[pimpl->selected_id].set_name_end();
+        } else if( action == "SWAP_START_END" && pimpl->selected_id != -1 ) {
+            pimpl->paths[pimpl->selected_id].swap_start_end();
         } else if( action == "QUIT" ) {
             break;
         }

--- a/src/path_manager.cpp
+++ b/src/path_manager.cpp
@@ -320,6 +320,7 @@ int path::avatar_closest_i_approximate() const
         // Asuming the path tiles are at most (1, 1, 1) apart,
         // we can skip as many tiles, as the curent tile is far from the `avatar_pos`.
         int diff = square_dist( *it, avatar_pos );
+        // TODO north is closer than northeast && north is closer than z-1
         if( diff < closest_dist ) {
             closest_i = it - recorded_path.begin();
             if( diff == 0 ) {
@@ -330,6 +331,11 @@ int path::avatar_closest_i_approximate() const
         it += diff;
     }
     return closest_i;
+    // TODO remove start and end distance?
+    /*
+    | name        | distance              | length |
+    | start | end | start | end | closest |        |
+    */
 }
 
 void path::serialize( JsonOut &jsout )

--- a/src/path_manager.cpp
+++ b/src/path_manager.cpp
@@ -409,7 +409,7 @@ void path_manager_ui::draw_controls()
     enabled_active_button( "STOP_RECORDING", pimpl->recording_path() );
 
     // buttons related to selected path
-    draw_colored_text( _( "Selected path:" ), c_white );
+    cataimgui::draw_colored_text( _( "Selected path:" ), c_white );
     ImGui::SameLine();
     enabled_active_button( "DELETE_PATH", pimpl->selected_id != -1 );
     ImGui::SameLine();
@@ -448,25 +448,25 @@ void path_manager_ui::draw_controls()
                 pimpl->selected_id = i;
             }
             ImGui::SameLine();
-            draw_colored_text( curr_path.name_start, c_white );
+            cataimgui::draw_colored_text( curr_path.name_start, c_white );
 
             ImGui::TableNextColumn();
             if( curr_path.player_at_start() ) {
-                draw_colored_text( _( "It's under your feet." ), c_light_green );
+                cataimgui::draw_colored_text( _( "It's under your feet." ), c_light_green );
             } else {
                 std::string dist = direction_suffix( get_avatar().get_location(), curr_path.recorded_path.front() );
-                draw_colored_text( dist, c_white );
+                cataimgui::draw_colored_text( dist, c_white );
             }
 
             ImGui::TableNextColumn();
-            draw_colored_text( curr_path.name_end, c_white );
+            cataimgui::draw_colored_text( curr_path.name_end, c_white );
 
             ImGui::TableNextColumn();
             if( curr_path.player_at_end() ) {
-                draw_colored_text( _( "It's under your feet." ), c_light_green );
+                cataimgui::draw_colored_text( _( "It's under your feet." ), c_light_green );
             } else {
                 std::string dist = direction_suffix( get_avatar().get_location(), curr_path.recorded_path.back() );
-                draw_colored_text( dist, c_white );
+                cataimgui::draw_colored_text( dist, c_white );
             }
 
             ImGui::TableNextColumn();

--- a/src/path_manager.cpp
+++ b/src/path_manager.cpp
@@ -245,19 +245,20 @@ void path_manager_ui::draw_controls()
                 //set_selected_id( i );
             }
             ImGui::SameLine();
-
-            ImGui::Text( "%s", "start" );
+            draw_colored_text( "start", c_white );
 
             ImGui::TableNextColumn();
             std::string dist = direction_suffix( get_avatar().get_location(), curr_path.recorded_path.front() );
-            ImGui::Text( "%s", dist == "" ? _( "It's under your feet." ) : dist );
+            dist = dist == "" ? _( "It's under your feet." ) : dist;
+            draw_colored_text( dist, c_white );
 
             ImGui::TableNextColumn();
-            ImGui::Text( "%s", "end" );
+            draw_colored_text( "end", c_white );
 
             ImGui::TableNextColumn();
             dist = direction_suffix( get_avatar().get_location(), curr_path.recorded_path.back() );
-            ImGui::Text( "%s", dist == "" ? _( "It's under your feet." ) : dist );
+            dist = dist == "" ? _( "It's under your feet." ) : dist;
+            draw_colored_text( dist, c_white );
 
             ImGui::TableNextColumn();
             ImGui::Text( "%zu", curr_path.recorded_path.size() );

--- a/src/path_manager.cpp
+++ b/src/path_manager.cpp
@@ -436,7 +436,7 @@ static void draw_distance_from_tile( const tripoint_abs_ms &tile )
         cataimgui::draw_colored_text( _( "It's under your feet." ), c_light_green );
     } else {
         const std::string dist = direction_suffix( avatar_pos, tile );
-        cataimgui::draw_colored_text( dist, c_white );
+        cataimgui::draw_colored_text( dist );
     }
 }
 
@@ -493,13 +493,13 @@ void path_manager_ui::draw_controls()
                 pimpl->selected_id = i;
             }
             ImGui::SameLine();
-            cataimgui::draw_colored_text( curr_path.name_start, c_white );
+            cataimgui::draw_colored_text( curr_path.name_start );
 
             ImGui::TableNextColumn();
             draw_distance_from_tile( curr_path.recorded_path.front() );
 
             ImGui::TableNextColumn();
-            cataimgui::draw_colored_text( curr_path.name_end, c_white );
+            cataimgui::draw_colored_text( curr_path.name_end );
 
             ImGui::TableNextColumn();
             draw_distance_from_tile( curr_path.recorded_path.back() );

--- a/src/path_manager.cpp
+++ b/src/path_manager.cpp
@@ -219,7 +219,7 @@ cataimgui::bounds path_manager_ui::get_bounds()
 
 void path_manager_ui::draw_controls()
 {
-    if( ! ImGui::BeginTable( "PATH_MANAGER", 4,
+    if( ! ImGui::BeginTable( "PATH_MANAGER", 5,
                              ImGuiTableFlags_ScrollY | ImGuiTableFlags_Resizable
                              | ImGuiTableFlags_BordersOuter ) ) {
         return;
@@ -229,6 +229,7 @@ void path_manager_ui::draw_controls()
     ImGui::TableSetupColumn( "start distance" );
     ImGui::TableSetupColumn( "end name" );
     ImGui::TableSetupColumn( "end distance" );
+    ImGui::TableSetupColumn( "total lenght" );
     ImGui::TableHeadersRow();
 
     ImGuiListClipper clipper;
@@ -257,6 +258,9 @@ void path_manager_ui::draw_controls()
             ImGui::TableNextColumn();
             dist = direction_suffix( get_avatar().get_location(), curr_path.recorded_path.back() );
             ImGui::Text( "%s", dist == "" ? _( "It's under your feet." ) : dist );
+
+            ImGui::TableNextColumn();
+            ImGui::Text( "%zu", curr_path.recorded_path.size() );
         }
     }
     ImGui::EndTable();

--- a/src/path_manager.cpp
+++ b/src/path_manager.cpp
@@ -182,13 +182,10 @@ void path_manager_impl::auto_route_from_path()
         if( player_character.pos_bub() == get_map().bub_from_abs( p.front() )
             || player_character.pos_bub() == get_map().bub_from_abs( p.back() )
           ) {
-            current_path_index = path_index;
             paths[path_index].set_avatar_path();
             return;
         }
     }
-    // Didn't find any, set index to invalid.
-    current_path_index = -1;
     add_msg( m_info,
              _( "Auto path: Player doesn't stand at start or end of existing path.  Recording new path." ) );
     start_recording();

--- a/src/path_manager.cpp
+++ b/src/path_manager.cpp
@@ -90,7 +90,7 @@ class path_manager_impl
         void set_recording_path( bool set_to );
         /// Set current path to p_index and recording_path to true
         void set_recording_path( int p_index );
-        int current_path_index = -1;
+        int recording_path_index = -1;
         std::vector<path> paths;
 };
 
@@ -149,9 +149,9 @@ void path::set_avatar_path()
 
 void path_manager_impl::start_recording()
 {
-    current_path_index = paths.size();  // future_size - 1
+    recording_path_index = paths.size();  // future_size - 1
     paths.emplace_back();
-    set_recording_path( current_path_index );
+    set_recording_path( recording_path_index );
     paths.back().record_step( get_avatar().get_location() );
 }
 
@@ -159,16 +159,16 @@ void path_manager_impl::stop_recording()
 {
     set_recording_path( false );
 
-    const path &current_path = paths[current_path_index];
+    const path &current_path = paths[recording_path_index];
     const std::vector<tripoint_abs_ms> &curr_path = current_path.recorded_path;
     if( curr_path.size() <= 1 ) {
         add_msg( m_info, _( "Auto path: Recorded path has no lenght.  Path erased." ) );
-        paths.erase( paths.begin() + current_path_index );
+        paths.erase( paths.begin() + recording_path_index );
     } else {
         add_msg( m_info, _( "Auto path: Path saved." ) );
     }
 
-    current_path_index = -1;
+    recording_path_index = -1;
     // TODO error when starts or stops at the same tile as another path ??
     // or just prefer the higher path - this allows
     // more flexibility, but it needs to be documented
@@ -194,7 +194,7 @@ void path_manager_impl::auto_route_from_path()
 void path_manager_impl::set_recording_path( bool set_to )
 {
     if( set_to ) {
-        cata_assert( 0 <= current_path_index && current_path_index < static_cast<int>( paths.size() ) );
+        cata_assert( 0 <= recording_path_index && recording_path_index < static_cast<int>( paths.size() ) );
     }
     recording_path = set_to;
 }
@@ -202,7 +202,7 @@ void path_manager_impl::set_recording_path( bool set_to )
 void path_manager_impl::set_recording_path( int p_index )
 {
     cata_assert( 0 <= p_index && p_index < static_cast<int>( paths.size() ) );
-    current_path_index = p_index;
+    recording_path_index = p_index;
     recording_path = true;
 }
 
@@ -292,7 +292,7 @@ void path_manager::record_step( const tripoint_abs_ms &new_pos )
     if( !pimpl->recording_path ) {
         return;
     }
-    pimpl->paths[pimpl->current_path_index].record_step( new_pos );
+    pimpl->paths[pimpl->recording_path_index].record_step( new_pos );
 }
 
 bool path_manager::store()
@@ -332,7 +332,7 @@ void path_manager::deserialize( const JsonValue &jsin )
         JsonObject data = jsin.get_object();
 
         data.read( "recording_path", pimpl->recording_path );
-        data.read( "current_path_index", pimpl->current_path_index );
+        data.read( "recording_path_index", pimpl->recording_path_index );
         // from `path` load only recorded_path
         std::vector<std::vector<tripoint_abs_ms>> recorded_paths;
         data.read( "recorded_paths", recorded_paths );
@@ -346,7 +346,7 @@ void path_manager::deserialize( const JsonValue &jsin )
 void path_manager::serialize( JsonOut &jsout )
 {
     jsout.member( "recording_path", pimpl->recording_path );
-    jsout.member( "current_path_index", pimpl->current_path_index );
+    jsout.member( "recording_path_index", pimpl->recording_path_index );
     // from `path` save only recorded_path
     std::vector<std::vector<tripoint_abs_ms>> recorded_paths;
     for( const path &p : pimpl->paths ) {

--- a/src/path_manager.cpp
+++ b/src/path_manager.cpp
@@ -31,6 +31,12 @@ class path
         void set_avatar_path();
     private:
         std::vector<tripoint_abs_ms> recorded_path;
+        // std::string name_start;
+        // std::string name_end;
+        /// There are no 2 same tiles on the path
+        // bool optimize_loops;
+        /// A Character walking this path could never go from i-th tile to i+k-th tile, where k > 1
+        // bool optimize_nearby;
 };
 
 class path_manager_impl
@@ -52,6 +58,7 @@ class path_manager_impl
         void stop_recording();
     private:
         bool recording_path = false;
+        // todo int or size_t?
         /// Set recording to true/false on current path, current path must be valid
         void set_recording_path( bool set_to );
         /// Set current path to p_index and recording_path to true
@@ -64,6 +71,7 @@ class path_manager_impl
 void path::record_step( const tripoint_abs_ms &new_pos )
 {
     // if a loop exists find it and remove it
+    // todo optimize, probably with unordered set
     for( auto it = recorded_path.begin(); it != recorded_path.end(); ++it ) {
         if( *it == new_pos ) {
             const size_t old_path_len = recorded_path.size();
@@ -118,7 +126,11 @@ void path_manager_impl::stop_recording()
     } else {
         add_msg( m_info, _( "Auto path: Path saved." ) );
     }
+
     current_path_index = -1;
+    // TODO error when starts or stops at the same tile as another path ??
+    // or just prefer the higher path - this allows
+    // more flexibility, but it needs to be documented
 }
 
 void path_manager_impl::auto_route_from_path()
@@ -192,4 +204,7 @@ void path_manager::show()
     }
 
     pimpl->auto_route_from_path();
+
+    // todo activity title and progress
+    // player_character.assign_activity( workout_activity_actor( player_character.pos() ) );
 }

--- a/src/path_manager.cpp
+++ b/src/path_manager.cpp
@@ -219,9 +219,7 @@ cataimgui::bounds path_manager_ui::get_bounds()
 
 void path_manager_ui::draw_controls()
 {
-    if( ! ImGui::BeginTable( "PATH_MANAGER", 5,
-                             ImGuiTableFlags_ScrollY | ImGuiTableFlags_Resizable
-                             | ImGuiTableFlags_BordersOuter ) ) {
+    if( ! ImGui::BeginTable( "PATH_MANAGER", 5, ImGuiTableFlags_Resizable )) {
         return;
     }
     // TODO invlet

--- a/src/path_manager.cpp
+++ b/src/path_manager.cpp
@@ -462,7 +462,6 @@ void path_manager_impl::auto_route_from_path() const
 
 bool path_manager_impl::auto_route_from_path_middle() const
 {
-    const tripoint_abs_ms &avatar_pos = get_map().getglobal( get_avatar().pos_bub() );
     uilist path_selection;
     path_selection.text = _( "Select path and direction to walk in." );
     for( int i : avatar_at_what_paths() ) {

--- a/src/path_manager.cpp
+++ b/src/path_manager.cpp
@@ -443,7 +443,7 @@ static void draw_distance_from_tile( const tripoint_abs_ms &tile )
 void path_manager_ui::draw_controls()
 {
     // general buttons
-    enabled_active_button( "WALK_PATH", true );
+    enabled_active_button( "WALK_PATH", pimpl->player_at_what_start_or_end() != -1 );
     ImGui::SameLine();
     enabled_active_button( "START_RECORDING", !pimpl->recording_path() );
     ImGui::SameLine();
@@ -545,7 +545,7 @@ void path_manager_ui::run()
             action = ctxt.handle_input( 17 );
         }
 
-        if( action == "WALK_PATH" ) {
+        if( action == "WALK_PATH" && pimpl->player_at_what_start_or_end() != -1 ) {
             pimpl->auto_route_from_path();
             break;
         } else if( action == "START_RECORDING" && !pimpl->recording_path() ) {

--- a/src/path_manager.cpp
+++ b/src/path_manager.cpp
@@ -180,7 +180,7 @@ class path_manager_ui : public cataimgui::window
 
 static std::string avatar_distance_from_tile( const tripoint_abs_ms &tile )
 {
-    const tripoint_abs_ms &avatar_pos = get_map().getglobal( get_avatar().pos_bub() );
+    const tripoint_abs_ms &avatar_pos = get_avatar().pos_abs();
     if( avatar_pos == tile ) {
         return colorize( _( "It's here." ), c_light_green );
     } else {
@@ -253,13 +253,13 @@ void path::set_avatar_path( bool towards_end ) const
     if( towards_end ) {
         add_msg( m_info, _( string_format( "Auto path: Go from %s to %s.", from, name_end ) ) );
         for( auto it = std::next( recorded_path.begin() + avatar_at ); it != recorded_path.end(); ++it ) {
-            route.emplace_back( get_map().bub_from_abs( *it ) );
+            route.emplace_back( get_map().get_bub( *it ) );
         }
     } else {
         add_msg( m_info, _( string_format( "Auto path: Go from %s to %s.", from, name_start ) ) );
         for( auto it = std::next( recorded_path.rbegin() + recorded_path.size() - avatar_at - 1 );
              it != recorded_path.rend(); ++it ) {
-            route.emplace_back( get_map().bub_from_abs( *it ) );
+            route.emplace_back( get_map().get_bub( *it ) );
         }
     }
     player_character.set_destination( route );
@@ -283,18 +283,18 @@ void path::swap_start_end()
 
 bool path::is_avatar_at_start() const
 {
-    return get_avatar().pos_bub() == get_map().bub_from_abs( recorded_path.front() );
+    return get_avatar().pos_bub() == get_map().get_bub( recorded_path.front() );
 }
 
 bool path::is_avatar_at_end() const
 {
-    return get_avatar().pos_bub() == get_map().bub_from_abs( recorded_path.back() );
+    return get_avatar().pos_bub() == get_map().get_bub( recorded_path.back() );
 }
 
 int path::avatar_closest_i_approximate() const
 {
     cata_assert( !recorded_path.empty() );
-    const tripoint_abs_ms &avatar_pos = get_map().getglobal( get_avatar().pos_bub() );
+    const tripoint_abs_ms &avatar_pos = get_avatar().pos_abs();
     // Check start and end so that the path is not further away than either of those.
     int closest_i = recorded_path.size() - 1;
     int closest_dist = square_dist( recorded_path.back(), avatar_pos );
@@ -343,7 +343,7 @@ void path_manager_impl::start_recording()
 {
     path &p = paths.emplace_back();
     set_recording_path( paths.size() - 1 );
-    p.record_step( get_avatar().get_location() );
+    p.record_step( get_avatar().pos_abs() );
     p.set_name_start();
 }
 
@@ -430,7 +430,7 @@ int path_manager_impl::avatar_at_what_start_or_end() const
 std::vector<int> path_manager_impl::avatar_at_what_paths() const
 {
     std::vector<int> ret;
-    const tripoint_abs_ms &avatar_pos = get_map().getglobal( get_avatar().pos_bub() );
+    const tripoint_abs_ms &avatar_pos = get_avatar().pos_abs();
     for( auto it = paths.begin(); it != paths.end(); ++it ) {
         if( avatar_pos == it->recorded_path[it->avatar_closest_i_approximate()] ) {
             ret.emplace_back( static_cast<int>( it - paths.begin() ) );

--- a/src/path_manager.h
+++ b/src/path_manager.h
@@ -1,0 +1,39 @@
+#pragma once
+#ifndef CATA_SRC_PATH_MANAGER_H
+#define CATA_SRC_PATH_MANAGER_H
+
+#include <iosfwd>
+#include <memory>
+
+#include "coords_fwd.h"
+
+class JsonOut;
+class JsonValue;
+class path;
+class path_manager_impl;
+
+class path_manager
+{
+        friend path_manager_impl;
+        friend path;
+    public:
+        path_manager();
+        ~path_manager();
+        /**
+         * Record a single step of path. Only if `path_manager_impl::recording_path` is true.
+         * If this step makes a loop, remove the whole loop.
+         */
+        void record_step( const tripoint_abs_ms &new_pos );
+        /*serialize and deserialize*/
+        bool store();
+        void load();
+        void serialize( std::ostream &fout );
+        void deserialize( const JsonValue &jsin );
+        void serialize( JsonOut &jsout );
+
+        void show();
+    private:
+        std::unique_ptr <path_manager_impl> pimpl;
+};
+
+#endif // CATA_SRC_PATH_MANAGER_H

--- a/src/text.cpp
+++ b/src/text.cpp
@@ -203,6 +203,14 @@ Paragraph *Paragraph::separated()
     return this;
 }
 
+/**
+ * Split @str to fit within @wrap_width.
+ *
+ * @wrap_width is the window width.
+ *
+ * Internaly figure out remaining width by reading the cursor position.
+ * Dedicate drawing of @str segments to TextUnformatted.
+ */
 static void TextEx( const std::string_view str, float wrap_width, uint32_t color )
 {
     if( str.empty() ) {
@@ -284,6 +292,11 @@ void TextParagraph( nc_color color, const std::string_view para, float wrap_widt
     TextEx( para, wrap_width, u32_from_color( color ) );
 }
 
+/**
+ * Draw text with color tags and newlines. Insert newline at end.
+ *
+ * Process color tags and dedicate text drawing to Text*Ex functions.
+ */
 void TextColoredParagraph( nc_color default_color, const std::string_view str,
                            std::optional<Segment> value, float wrap_width )
 {


### PR DESCRIPTION
#### Summary
Features "Player can record paths and automatically walk them again"

#### Purpose of change

Resolve #74433

#### Describe the solution

Listen with `u.get_path_manager()->record_step` to when the avatar moves in
```cpp
void avatar_moves( const tripoint &old_abs_pos, avatar &u, const map &m )
```
Add the new_pos to `std::vector<tripoint_abs_ms> recorded_path`. If a cycle is detected, remove it.

Add an interface, where the player can manage their paths:
![image](https://github.com/user-attachments/assets/f7c19a9a-7a2e-4df1-a134-e8f2f459adcc)

If they select `Walk path from middle`:
![image](https://github.com/user-attachments/assets/ef21b7bc-70f5-4940-9d1e-0bc6ff87e6ad)

#### Known issues to fix / features to implement:

- [x] Recording path across ramp doesn't work (stairs do work).
   - (Will be) fixed by #74762
- [x] When a problem occurs, it continues recording. I want to change this to fail fast.
   - Example of detectable unsolved problem: lift going more than 1 z-level.
   - ![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/119e6814-cac7-4ce4-93f2-e15b001e3f5a)
 - [x] The latest version crashed on me, so I need to fix at least one crash.
 - [ ] `(i)` hover next to `Walk the path` button: `Walk the first path from the list the player is standing on either end.`

#### ~Will not fix~ Depends on:
- [x] #74341 - this uses uilist and without its migration, the uilist shows under the Path Manager menu
- [x] When naming start/end the string_popup is under the window (barely visible) but it does work.
   - Will be solved by #77863
   - Will not fix, unless somebody tells me how to easily do it without migrating `string_input_popup` to ImGui.
      - Migrating `string_input_popup` to ImGui needs migrating `string_input_popup::*history` which uses `uilist` so it needs its migration which is being done in #74341

#### Further possible improvements

- [x] I have a nice optimizations in my back pocket, described in the issue #74433
   -  > Look at one point at index `i`, count the distance from the new point `dist = abs(z1-z2) + max(abs(x1-x2), abs(y1-y2))`. The new point cannot be at indexes `i-dist+1, ..., i+dist-1`. So skip those in-loop checking.

<details>

<summary>dist optimization results</summary>

---

For the optimization, I ended up doing `max( tripoint_diff.abs().xyz() )` . The results are pretty amazing: 4 checks instead of 800 on this test path:


https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/c6d2dc67-b2fd-40eb-9090-b5ccd76e660e


Works reasonably in a spiral. I especially like how the number of checks decreases despite the number of tiles increasing when the character walks away from the spiral at the end:


https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/7f44f12e-a91b-44aa-853c-497edd3e01f8

---

</details>

- [x] Also, add QoL optimization to cut corners:  going north and then west can be replaced by going north-west. In general: iterate over `recorded_path` from `begin()` to `end()` with `tile`, if the player is next to the `tile`, delete everything from `tile` to `recorded_path.end()`. This is similar to loop optimization but more aggressive.
- [ ] A checkbox to turn off cut-corner optimization.
- [x] New button: Take an already recorded path the player is standing at either end of. Start recording (again) to edit this path as if recorded for the first time.
   - [ ] `(i)` hover next to the button: `Continue recording the first path the player is standing at either end of.  Temporarily swaps start and end until the recording is finished.`
- [ ] New button: fix path. Something interrupted the walking (even if you did). You can snip the next tile of the path. This leaves two separate paths: from_start & till_end. Start recording until you reach any tile from till_end. Then glue them together (from_start ends at your feet, remove tiles from till_end from the snipped tile until the tile under your feet. Merge paths and that is your result.) - Not sure whether this works when the path has loops. 
   - [ ] "Abort fix path" button. It stops everything and restores the original path before snipping.
- [ ] ~~Remember the path and the direction the player was walking. The player can press "continue walking". They continue if they are on the same path (even at different tile of the path). Otherwise popup with info to the closest tile and the tile you left the path: `popup( "You are no longer standing on the path you were walking.  You left the path 3SW, closest tile is 1N." )`~~
   - This is close to a special case of the next one. So don't do this.
- [x] Walk from middle:
   1. Find paths under the player's feet (not start/end but any tile).
      - With the optimizations, this could be decently fast.
   3. The player selects a path.
   4. The player selects whether to go to the path start or the path end.
 - [ ] Edit paths without the need to walk them: Instead of walking, record the cursor position in `look around`. Such paths might need some fixing on first use.

UI improvements from https://github.com/CleverRaven/Cataclysm-DDA/pull/74644#issuecomment-2200467587:
 - [ ] I want `(i)` to show in detail what some buttons do. `(i)` doesn't show in ImGui demo ~with my version of ImGui. I should mark that regression separately~.
 - [x] I would like it if a TAB would always switch focus from buttons to paths list. I will see if I can make the buttons unselectable. Like in the keybindings menu.
    - Made buttons unselectable.
    - Making the table selected right away depends on https://github.com/ocornut/imgui/issues/8280. 
 - [ ] I dislike that when you browse paths with UP & DOWN, the bright blue is "hovered over" and light blue is "selected". This is confusing. I accidentally deleted the wrong path.
   - Maybe related: #76033
 - [ ] Add a popup on deleting a path. With all the path's info.
 - [ ] The keybindings are what I figured could work. The menu could be opened with `}` by default.

#### Describe alternatives you've considered

Record keystrokes https://github.com/CleverRaven/Cataclysm-DDA/issues/74433#issuecomment-2171117437

#### Testing

I tried whatever I could think of. Should work on flat ground, with stairs, and ladders. Doesn't work with ramps, I will look into Travel To code when I have the time.

#### Additional context

