### PR TITLE
[MoM] Write single variable-based EoC for power contemplation, make it more like other meditation activities

### DIFF
--- a/data/mods/MindOverMatter/activity_types.json
+++ b/data/mods/MindOverMatter/activity_types.json
@@ -12,6 +12,16 @@
     "type": "activity_type",
     "activity_level": "LIGHT_EXERCISE",
     "verb": "meditating",
+    "rooted": true,
     "based_on": "time"
+  },
+  {
+    "id": "ACT_PSI_STUDYING_POWER",
+    "type": "activity_type",
+    "activity_level": "LIGHT_EXERCISE",
+    "verb": "meditating",
+    "based_on": "time",
+    "rooted": true,
+    "do_turn_eoc": "EOC_PSI_STUDYING_POWER"
   }
 ]

--- a/data/mods/MindOverMatter/effects/effects_other.json
+++ b/data/mods/MindOverMatter/effects/effects_other.json
@@ -9,6 +9,14 @@
   },
   {
     "type": "effect_type",
+    "id": "effect_psi_studying_power",
+    "//": "Hidden effect, used as a tracker",
+    "name": [ "" ],
+    "desc": [ "" ],
+    "rating": "good"
+  },
+  {
+    "type": "effect_type",
     "id": "effect_vitakin_wakeful_resting",
     "//": "Hidden effect, used as a tracker",
     "name": [ "" ],

--- a/data/mods/MindOverMatter/jmath.json
+++ b/data/mods/MindOverMatter/jmath.json
@@ -57,7 +57,8 @@
     "type": "jmath_function",
     "id": "contemplation_factor",
     "num_args": 1,
-    "return": "(u_val('focus') * 0.001) * (_0)"
+    "//": "This equates to about 500 XP per hour of contemplation when at minimum focus",
+    "return": "(u_val('focus') * 0.005) * (_0)"
   },
   {
     "type": "jmath_function",

--- a/data/mods/MindOverMatter/jmath.json
+++ b/data/mods/MindOverMatter/jmath.json
@@ -33,7 +33,7 @@
     "type": "jmath_function",
     "id": "psionics_contemplation_kcal_cost",
     "num_args": 1,
-    "return": "( (25 * _0) * rng( 0.3, 1.7) )"
+    "return": "( (2.5 * _0) * rng( 0.3, 1.7) )"
   },
   {
     "type": "jmath_function",
@@ -57,7 +57,7 @@
     "type": "jmath_function",
     "id": "contemplation_factor",
     "num_args": 1,
-    "return": "(u_val('focus') * 0.0001) * (_0)"
+    "return": "(u_val('focus') * 0.001) * (_0)"
   },
   {
     "type": "jmath_function",

--- a/data/mods/MindOverMatter/jmath.json
+++ b/data/mods/MindOverMatter/jmath.json
@@ -57,7 +57,7 @@
     "type": "jmath_function",
     "id": "contemplation_factor",
     "num_args": 1,
-    "return": "(u_val('focus') * 18) * (_0)"
+    "return": "(u_val('focus') * 0.0001) * (_0)"
   },
   {
     "type": "jmath_function",

--- a/data/mods/MindOverMatter/jmath.json
+++ b/data/mods/MindOverMatter/jmath.json
@@ -33,7 +33,7 @@
     "type": "jmath_function",
     "id": "psionics_contemplation_kcal_cost",
     "num_args": 1,
-    "return": "( (2.5 * _0) * rng( 0.3, 1.7) )"
+    "return": "( (1.5 * _0) * rng( 0.3, 1.7) )"
   },
   {
     "type": "jmath_function",

--- a/data/mods/MindOverMatter/powers/learning_eocs/overall.json
+++ b/data/mods/MindOverMatter/powers/learning_eocs/overall.json
@@ -46,7 +46,7 @@
         "run_eocs": [
           {
             "id": "EOC_PSI_STUDYING_POWER_FOCUS_REDUCTION_2",
-            "condition": { "math": [ "u_val('focus')", ">=", "30" ] },
+            "condition": { "math": [ "u_val('focus')", ">=", "25" ] },
             "effect": [ { "math": [ "u_val('focus')", "-=", "rand(1)" ] } ]
           }
         ]

--- a/data/mods/MindOverMatter/powers/learning_eocs/overall.json
+++ b/data/mods/MindOverMatter/powers/learning_eocs/overall.json
@@ -59,7 +59,7 @@
     "id": "EOC_PSI_STUDYING_POWER_ADD_PROFICIENCY",
     "condition": { "u_has_effect": "effect_psi_studying_power" },
     "effect": [
-      { "math": [ "u_proficiency(u_latest_studied_power_proficiency, 'format': 'percent')", "+=", "(rand(4) / 50) * (u_val('focus') / 100)" ] }
+      { "math": [ "u_proficiency(u_latest_studied_power_proficiency, 'format': 'percent')", "+=", "(rand(4) / 50)" ] },
       { "queue_eocs": "EOC_PSI_STUDYING_POWER_ADD_PROFICIENCY", "time_in_future": [ "1 minutes", "1 minutes" ] }
     ]
   },

--- a/data/mods/MindOverMatter/powers/learning_eocs/overall.json
+++ b/data/mods/MindOverMatter/powers/learning_eocs/overall.json
@@ -20,6 +20,15 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS",
+    "condition": { "u_has_effect": "effect_psi_studying_power" },
+    "effect": [
+      { "queue_eocs": "EOC_PSI_STUDYING_POWER_FOCUS_REDUCTION", "time_in_future": [ "1 minutes", "1 minutes" ] },
+      { "queue_eocs": "EOC_PSI_STUDYING_POWER_NETHER_ATTUNEMENT", "time_in_future": [ "3 minutes", "3 minutes" ] }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_PSI_STUDYING_POWER_FOCUS_REDUCTION",
     "condition": { "u_has_effect": "effect_psi_studying_power" },
     "effect": [
@@ -37,7 +46,7 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS",
+    "id": "EOC_PSI_STUDYING_POWER_NETHER_ATTUNEMENT",
     "condition": { "u_has_effect": "effect_psi_studying_power" },
     "effect": [
       { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rand(3)" ] },

--- a/data/mods/MindOverMatter/powers/learning_eocs/overall.json
+++ b/data/mods/MindOverMatter/powers/learning_eocs/overall.json
@@ -10,7 +10,7 @@
             "id": "EOC_PSI_STUDYING_POWER_INTEGER_TICK_OVER",
             "condition": { "math": [ "u_psi_studying_tick_experience_counter", ">=", "1" ] },
             "effect": [
-              { "math": [ "u_spell_exp(studied_power_name)", "+=", "1" ] },
+              { "math": [ "u_spell_exp(u_latest_studied_power_name)", "+=", "1" ] },
               { "math": [ "u_psi_studying_tick_experience_counter", "=", "0" ] }
             ]
           }
@@ -27,7 +27,7 @@
         "run_eocs": [
           {
             "id": "EOC_PSI_STUDYING_POWER_FOCUS_REDUCTION_2",
-            "condition": { "math": [ "u_val('focus')", ">=", "20" ] },
+            "condition": { "math": [ "u_val('focus')", ">=", "30" ] },
             "effect": [ { "math": [ "u_val('focus')", "--" ] } ]
           }
         ]

--- a/data/mods/MindOverMatter/powers/learning_eocs/overall.json
+++ b/data/mods/MindOverMatter/powers/learning_eocs/overall.json
@@ -11,7 +11,7 @@
             "condition": { "math": [ "u_psi_studying_tick_experience_counter", ">=", "1" ] },
             "effect": [
               { "math": [ "u_spell_exp(u_latest_studied_power_name)", "+=", "1" ] },
-              { "math": [ "u_psi_studying_tick_experience_counter", "=", "0" ] }
+              { "math": [ "u_psi_studying_tick_experience_counter", "-=", "1" ] }
             ]
           }
         ]

--- a/data/mods/MindOverMatter/powers/learning_eocs/overall.json
+++ b/data/mods/MindOverMatter/powers/learning_eocs/overall.json
@@ -68,8 +68,9 @@
     "id": "EOC_PSI_STUDYING_POWER_NETHER_ATTUNEMENT",
     "condition": { "u_has_effect": "effect_psi_studying_power" },
     "effect": [
-      { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rand(3)" ] },
-      { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(u_latest_studied_power_difficulty)" ] }
+      { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rand(2)" ] },
+      { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(u_latest_studied_power_difficulty)" ] },
+      { "queue_eocs": "EOC_PSI_STUDYING_POWER_NETHER_ATTUNEMENT", "time_in_future": [ "3 minutes", "3 minutes" ] }
     ]
   },
   {

--- a/data/mods/MindOverMatter/powers/learning_eocs/overall.json
+++ b/data/mods/MindOverMatter/powers/learning_eocs/overall.json
@@ -20,8 +20,16 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_PSI_STUDYING_POWER_BEGIN",
+    "effect": [
+      { "u_message": "You spend some time meditating and contemplating your powers.", "type": "good" },
+      { "u_add_effect": "effect_psi_studying_power", "duration": "24 hours" },
+      { "u_assign_activity": "ACT_PSI_STUDYING_POWER", "duration": "24 hours" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS",
-    "condition": { "u_has_effect": "effect_psi_studying_power" },
     "effect": [
       { "queue_eocs": "EOC_PSI_STUDYING_POWER_FOCUS_REDUCTION", "time_in_future": [ "1 minutes", "1 minutes" ] },
       { "queue_eocs": "EOC_PSI_STUDYING_POWER_NETHER_ATTUNEMENT", "time_in_future": [ "3 minutes", "3 minutes" ] }

--- a/data/mods/MindOverMatter/powers/learning_eocs/overall.json
+++ b/data/mods/MindOverMatter/powers/learning_eocs/overall.json
@@ -59,7 +59,7 @@
     "id": "EOC_PSI_STUDYING_POWER_ADD_PROFICIENCY",
     "condition": { "u_has_effect": "effect_psi_studying_power" },
     "effect": [
-      { "math": [ "u_proficiency(u_latest_studied_power_proficiency, 'format': 'percent')", "+=", "(rand(4) / 50)" ] },
+      { "math": [ "u_proficiency(u_latest_studied_power_proficiency, 'format': 'percent')", "+=", "(rand(4) / 66)" ] },
       { "queue_eocs": "EOC_PSI_STUDYING_POWER_ADD_PROFICIENCY", "time_in_future": [ "1 minutes", "1 minutes" ] }
     ]
   },

--- a/data/mods/MindOverMatter/powers/learning_eocs/overall.json
+++ b/data/mods/MindOverMatter/powers/learning_eocs/overall.json
@@ -28,7 +28,7 @@
           {
             "id": "EOC_PSI_STUDYING_POWER_FOCUS_REDUCTION_2",
             "condition": { "math": [ "u_val('focus')", ">=", "30" ] },
-            "effect": [ { "math": [ "u_val('focus')", "--" ] } ]
+            "effect": [ { "math": [ "u_val('focus')", "-=", "rand(1)" ] } ]
           }
         ]
       },
@@ -40,7 +40,7 @@
     "id": "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS",
     "condition": { "u_has_effect": "effect_psi_studying_power" },
     "effect": [
-      { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
+      { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rand(3)" ] },
       { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(u_latest_studied_power_difficulty)" ] }
     ]
   },

--- a/data/mods/MindOverMatter/powers/learning_eocs/overall.json
+++ b/data/mods/MindOverMatter/powers/learning_eocs/overall.json
@@ -23,6 +23,7 @@
     "id": "EOC_PSI_STUDYING_POWER_BEGIN",
     "effect": [
       { "u_message": "You spend some time meditating and contemplating your powers.", "type": "good" },
+      { "math": [ "u_psi_studying_tick_experience_counter", "=", "0" ] },
       { "u_add_effect": "effect_psi_studying_power", "duration": "24 hours" },
       { "u_assign_activity": "ACT_PSI_STUDYING_POWER", "duration": "24 hours" }
     ]
@@ -32,6 +33,7 @@
     "id": "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS",
     "effect": [
       { "queue_eocs": "EOC_PSI_STUDYING_POWER_FOCUS_REDUCTION", "time_in_future": [ "1 minutes", "1 minutes" ] },
+      { "queue_eocs": "EOC_PSI_STUDYING_POWER_ADD_PROFICIENCY", "time_in_future": [ "1 minutes", "1 minutes" ] },
       { "queue_eocs": "EOC_PSI_STUDYING_POWER_NETHER_ATTUNEMENT", "time_in_future": [ "3 minutes", "3 minutes" ] }
     ]
   },
@@ -50,6 +52,15 @@
         ]
       },
       { "queue_eocs": "EOC_PSI_STUDYING_POWER_FOCUS_REDUCTION", "time_in_future": [ "1 minutes", "1 minutes" ] }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PSI_STUDYING_POWER_ADD_PROFICIENCY",
+    "condition": { "u_has_effect": "effect_psi_studying_power" },
+    "effect": [
+      { "math": [ "u_proficiency(u_latest_studied_power_proficiency, 'format': 'percent')", "+=", "(rand(4) / 96) * (u_val('focus') / 100)" ] }
+      { "queue_eocs": "EOC_PSI_STUDYING_POWER_ADD_PROFICIENCY", "time_in_future": [ "1 minutes", "1 minutes" ] }
     ]
   },
   {

--- a/data/mods/MindOverMatter/powers/learning_eocs/overall.json
+++ b/data/mods/MindOverMatter/powers/learning_eocs/overall.json
@@ -1,19 +1,64 @@
 [
   {
     "type": "effect_on_condition",
+    "id": "EOC_PSI_STUDYING_POWER",
+    "effect": [
+      { "math": [ "u_psi_studying_tick_experience_counter", "+=", "contemplation_factor(1)" ] },
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_PSI_STUDYING_POWER_INTEGER_TICK_OVER",
+            "condition": { "math": [ "u_psi_studying_tick_experience_counter", ">=", "1" ] },
+            "effect": [
+              { "math": [ "u_spell_exp(studied_power_name)", "+=", "1" ] },
+              { "math": [ "u_psi_studying_tick_experience_counter", "=", "0" ] }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PSI_STUDYING_POWER_FOCUS_REDUCTION",
+    "condition": { "u_has_effect": "effect_psi_studying_power" },
+    "effect": [
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_PSI_STUDYING_POWER_FOCUS_REDUCTION_2",
+            "condition": { "math": [ "u_val('focus')", ">=", "20" ] },
+            "effect": [ { "math": [ "u_val('focus')", "--" ] } ]
+          }
+        ]
+      },
+      { "queue_eocs": "EOC_PSI_STUDYING_POWER_FOCUS_REDUCTION", "time_in_future": [ "1 minutes", "1 minutes" ] }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS",
+    "condition": { "u_has_effect": "effect_psi_studying_power" },
+    "effect": [
+      { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
+      { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(u_latest_studied_power_difficulty)" ] }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_PSI_MOVING_CANCELS_RESEARCH",
     "eoc_type": "EVENT",
     "required_event": "avatar_moves",
-    "condition": { "u_has_effect": "effect_psi_learning_new_power" },
-    "effect": [ { "u_lose_effect": "effect_psi_learning_new_power" } ]
+    "condition": { "or": [ { "u_has_effect": "effect_psi_learning_new_power" }, { "u_has_effect": "effect_psi_studying_power" } ] },
+    "effect": [ { "u_lose_effect": "effect_psi_learning_new_power" }, { "u_lose_effect": "effect_psi_studying_power" } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_PSI_CHANNELING_CANCELS_RESEARCH",
     "eoc_type": "EVENT",
     "required_event": "spellcasting_finish",
-    "condition": { "u_has_effect": "effect_psi_learning_new_power" },
-    "effect": [ { "u_lose_effect": "effect_psi_learning_new_power" } ]
+    "condition": { "or": [ { "u_has_effect": "effect_psi_learning_new_power" }, { "u_has_effect": "effect_psi_studying_power" } ] },
+    "effect": [ { "u_lose_effect": "effect_psi_learning_new_power" }, { "u_lose_effect": "effect_psi_studying_power" } ]
   },
   {
     "type": "effect_on_condition",
@@ -22,11 +67,18 @@
     "required_event": "character_finished_activity",
     "condition": {
       "and": [
-        { "compare_string": [ "ACT_PSI_LEARNING_NEW_POWER", { "context_val": "activity" } ] },
-        { "u_has_effect": "effect_psi_learning_new_power" }
+        {
+          "or": [
+            { "compare_string": [ "ACT_PSI_LEARNING_NEW_POWER", { "context_val": "activity" } ] },
+            { "compare_string": [ "ACT_PSI_STUDYING_POWER", { "context_val": "activity" } ] }
+          ]
+        },
+        {
+          "or": [ { "u_has_effect": "effect_psi_learning_new_power" }, { "u_has_effect": "effect_psi_studying_power" } ]
+        }
       ]
     },
-    "effect": [ { "u_lose_effect": "effect_psi_learning_new_power" } ]
+    "effect": [ { "u_lose_effect": "effect_psi_learning_new_power" }, { "u_lose_effect": "effect_psi_studying_power" } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/MindOverMatter/powers/learning_eocs/overall.json
+++ b/data/mods/MindOverMatter/powers/learning_eocs/overall.json
@@ -59,7 +59,7 @@
     "id": "EOC_PSI_STUDYING_POWER_ADD_PROFICIENCY",
     "condition": { "u_has_effect": "effect_psi_studying_power" },
     "effect": [
-      { "math": [ "u_proficiency(u_latest_studied_power_proficiency, 'format': 'percent')", "+=", "(rand(4) / 96) * (u_val('focus') / 100)" ] }
+      { "math": [ "u_proficiency(u_latest_studied_power_proficiency, 'format': 'percent')", "+=", "(rand(4) / 50) * (u_val('focus') / 100)" ] }
       { "queue_eocs": "EOC_PSI_STUDYING_POWER_ADD_PROFICIENCY", "time_in_future": [ "1 minutes", "1 minutes" ] }
     ]
   },

--- a/data/mods/MindOverMatter/recipes/practice/biokinetic_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/biokinetic_practice.json
@@ -39,7 +39,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 0,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_biokinesis", "required": false } ],
     "tools": [
@@ -52,10 +52,10 @@
         "condition": { "and": [ { "math": [ "u_spell_level('biokin_overcome_pain')", ">=", "1" ] } ] },
         "effect": [
           { "u_message": "You spend some time meditating and contemplating your powers.", "type": "good" },
-          { "set_string_var": "biokin_overcome_pain", "target_var": { "context_val": "studied_power_name" } },
+          { "set_string_var": "biokin_overcome_pain", "target_var": { "u_val": "latest_studied_power_name" } },
           { "math": [ "u_latest_studied_power_difficulty", "=", "1" ] },
           { "queue_eocs": "EOC_PSI_STUDYING_POWER_FOCUS_REDUCTION", "time_in_future": [ "1 minutes", "1 minutes" ] },
-          { "queue_eocs": "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS", "time_in_future": [ "30 minutes", "30 minutes" ] },
+          { "queue_eocs": "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS", "time_in_future": [ "3 minutes", "3 minutes" ] },
           { "u_add_effect": "effect_psi_studying_power", "duration": "16 hours" },
           { "u_assign_activity": "ACT_PSI_STUDYING_POWER", "duration": "16 hours" }
         ]

--- a/data/mods/MindOverMatter/recipes/practice/biokinetic_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/biokinetic_practice.json
@@ -51,12 +51,10 @@
         "id": "EOC_PRACTICE_BIOKIN_OVERCOME_PAIN",
         "condition": { "and": [ { "math": [ "u_spell_level('biokin_overcome_pain')", ">=", "1" ] } ] },
         "effect": [
-          { "u_message": "You spend some time meditating and contemplating your powers.", "type": "good" },
-          { "set_string_var": "biokin_overcome_pain", "target_var": { "u_val": "latest_studied_power_name" } },
+          { "set_string_var": "biokin_overcome_pain", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_biokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
           { "math": [ "u_latest_studied_power_difficulty", "=", "1" ] },
-          { "run_eocs": "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" },
-          { "u_add_effect": "effect_psi_studying_power", "duration": "16 hours" },
-          { "u_assign_activity": "ACT_PSI_STUDYING_POWER", "duration": "16 hours" }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ]
       }
     ]
@@ -83,14 +81,10 @@
         "id": "EOC_PRACTICE_BIOKIN_PHYSICAL_ENHANCE",
         "condition": { "math": [ "u_spell_level('biokin_physical_enhance')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('biokin_physical_enhance')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(2)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "biokin_physical_enhance", "target_var": { "u_val": "latest_studied_power_name" } },  
+          { "set_string_var": "prof_contemplation_biokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "2" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ]
       }
     ]
@@ -117,14 +111,10 @@
         "id": "EOC_PRACTICE_BIOKIN_BREATHE_SKIN",
         "condition": { "and": [ { "math": [ "u_spell_level('biokin_breathe_skin')", ">=", "1" ] } ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('biokin_breathe_skin')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(2)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "biokin_breathe_skin", "target_var": { "u_val": "latest_studied_power_name" } },       
+          { "set_string_var": "prof_contemplation_biokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "2" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -202,14 +192,10 @@
         "id": "EOC_PRACTICE_BIOKIN_FLEXIBILITY",
         "condition": { "math": [ "u_spell_level('biokin_flexibility')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('biokin_flexibility')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(3)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "biokin_flexibility", "target_var": { "u_val": "latest_studied_power_name" } },     
+          { "set_string_var": "prof_contemplation_biokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "3" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -283,14 +269,10 @@
         "id": "EOC_PRACTICE_BIOKIN_DASH",
         "condition": { "math": [ "u_spell_level('biokin_dash')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('biokin_dash')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(3)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "biokin_dash", "target_var": { "u_val": "latest_studied_power_name" } },     
+          { "set_string_var": "prof_contemplation_biokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "3" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -365,14 +347,10 @@
         "id": "EOC_PRACTICE_BIOKIN_ARMOR_SKIN",
         "condition": { "math": [ "u_spell_level('biokin_armor_skin')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('biokin_armor_skin')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(4)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "biokin_armor_skin", "target_var": { "u_val": "latest_studied_power_name" } },    
+          { "set_string_var": "prof_contemplation_biokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "4" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -447,14 +425,10 @@
         "id": "EOC_PRACTICE_BIOKIN_CLIMATE_CONTROL",
         "condition": { "math": [ "u_spell_level('biokin_climate_control')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('biokin_climate_control')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(4)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "biokin_climate_control", "target_var": { "u_val": "latest_studied_power_name" } },      
+          { "set_string_var": "prof_contemplation_biokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "4" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -529,14 +503,10 @@
         "id": "EOC_PRACTICE_BIOKIN_ADRENALINE",
         "condition": { "math": [ "u_spell_level('biokin_adrenaline')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('biokin_adrenaline')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(4)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "biokin_adrenaline", "target_var": { "u_val": "latest_studied_power_name" } },    
+          { "set_string_var": "prof_contemplation_biokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "4" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -611,14 +581,10 @@
         "id": "EOC_PRACTICE_BIOKIN_ENHANCE_MOBILITY",
         "condition": { "math": [ "u_spell_level('biokin_enhance_mobility')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('biokin_enhance_mobility')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(5)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "biokin_enhance_mobility", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_biokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "5" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -693,14 +659,10 @@
         "id": "EOC_PRACTICE_BIOKIN_HAMMERHAND",
         "condition": { "math": [ "u_spell_level('biokin_hammerhand')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('biokin_hammerhand')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(5)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "biokin_hammerhand", "target_var": { "u_val": "latest_studied_power_name" } },  
+          { "set_string_var": "prof_contemplation_biokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "5" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -774,15 +736,11 @@
       {
         "id": "EOC_PRACTICE_BIOKIN_REFLEX_ENHANCE",
         "condition": { "math": [ "u_spell_level('biokin_reflex_enhance')", ">=", "1" ] },
-        "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('biokin_reflex_enhance')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(6)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+        "effect": [    
+          { "set_string_var": "biokin_reflex_enhance", "target_var": { "u_val": "latest_studied_power_name" } },     
+          { "set_string_var": "prof_contemplation_biokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "6" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -857,14 +815,10 @@
         "id": "EOC_PRACTICE_BIOKIN_SEALED_SYSTEM",
         "condition": { "math": [ "u_spell_level('biokin_sealed_system')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('biokin_sealed_system')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(7)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "biokin_sealed_system", "target_var": { "u_val": "latest_studied_power_name" } },  
+          { "set_string_var": "prof_contemplation_biokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "7" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -939,14 +893,10 @@
         "id": "EOC_PRACTICE_BIOKIN_METABOLISM_ENHANCE",
         "condition": { "math": [ "u_spell_level('biokin_metabolism_enhance')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('biokin_metabolism_enhance')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(7)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "biokin_metabolism_enhance", "target_var": { "u_val": "latest_studied_power_name" } },    
+          { "set_string_var": "prof_contemplation_biokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "7" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -1021,14 +971,10 @@
         "id": "EOC_PRACTICE_BIOKIN_COMBAT_DANCE",
         "condition": { "math": [ "u_spell_level('biokin_combat_dance')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('biokin_combat_dance')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(8)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "biokin_combat_dance", "target_var": { "u_val": "latest_studied_power_name" } },
+          { "set_string_var": "prof_contemplation_biokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "8" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -1103,14 +1049,10 @@
         "id": "EOC_PRACTICE_BIOKIN_PERFECTED_MOTION",
         "condition": { "math": [ "u_spell_level('biokin_perfected_motion')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('biokin_perfected_motion')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,5 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(9)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "biokin_perfected_motion", "target_var": { "u_val": "latest_studied_power_name" } },
+          { "set_string_var": "prof_contemplation_biokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "9" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -1171,10 +1113,13 @@
     "category": "CC_*",
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
-    "difficulty": 8,
+    "difficulty": 9,
     "time": "30 m",
     "autolearn": false,
-    "tools": [ [ [ "matrix_crystal_drained", -1 ] ] ],
+    "proficiencies": [ { "proficiency": "prof_contemplation_biokinesis", "required": false } ],
+    "tools": [
+      [ [ "matrix_crystal_drained", -1 ], [ "black_nether_crystal_pseudo_tool", -1 ], [ "matrix_crystal_biokinesis", -1 ] ]
+    ],
     "components": [ [ [ "matrix_crystal_biokin_dust", 1 ] ] ],
     "flags": [ "SECRET", "BLIND_EASY", "NO_MANIP", "AFFECTED_BY_PAIN", "NO_BENCH", "NO_ENCHANTMENT" ],
     "result_eocs": [
@@ -1182,14 +1127,10 @@
         "id": "EOC_PRACTICE_BIOKIN_HURRICANE_BLOWS",
         "condition": { "math": [ "u_spell_level('biokin_hurricane_blows')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('biokin_hurricane_blows')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 0,2 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(10)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "biokin_hurricane_blows", "target_var": { "u_val": "latest_studied_power_name" } },
+          { "set_string_var": "prof_contemplation_biokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "10" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },

--- a/data/mods/MindOverMatter/recipes/practice/biokinetic_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/biokinetic_practice.json
@@ -54,8 +54,7 @@
           { "u_message": "You spend some time meditating and contemplating your powers.", "type": "good" },
           { "set_string_var": "biokin_overcome_pain", "target_var": { "u_val": "latest_studied_power_name" } },
           { "math": [ "u_latest_studied_power_difficulty", "=", "1" ] },
-          { "queue_eocs": "EOC_PSI_STUDYING_POWER_FOCUS_REDUCTION", "time_in_future": [ "1 minutes", "1 minutes" ] },
-          { "queue_eocs": "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS", "time_in_future": [ "3 minutes", "3 minutes" ] },
+          { "run_eocs": "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" },
           { "u_add_effect": "effect_psi_studying_power", "duration": "16 hours" },
           { "u_assign_activity": "ACT_PSI_STUDYING_POWER", "duration": "16 hours" }
         ]

--- a/data/mods/MindOverMatter/recipes/practice/biokinetic_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/biokinetic_practice.json
@@ -51,14 +51,13 @@
         "id": "EOC_PRACTICE_BIOKIN_OVERCOME_PAIN",
         "condition": { "and": [ { "math": [ "u_spell_level('biokin_overcome_pain')", ">=", "1" ] } ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('biokin_overcome_pain')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(1)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "u_message": "You spend some time meditating and contemplating your powers.", "type": "good" },
+          { "set_string_var": "biokin_overcome_pain", "target_var": { "context_val": "studied_power_name" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "1" ] },
+          { "queue_eocs": "EOC_PSI_STUDYING_POWER_FOCUS_REDUCTION", "time_in_future": [ "1 minutes", "1 minutes" ] },
+          { "queue_eocs": "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS", "time_in_future": [ "30 minutes", "30 minutes" ] },
+          { "u_add_effect": "effect_psi_studying_power", "duration": "16 hours" },
+          { "u_assign_activity": "ACT_PSI_STUDYING_POWER", "duration": "16 hours" }
         ]
       }
     ]

--- a/data/mods/MindOverMatter/recipes/practice/biokinetic_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/biokinetic_practice.json
@@ -69,7 +69,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 1,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_biokinesis", "required": false } ],
     "tools": [
@@ -99,7 +99,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 1,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_biokinesis", "required": false } ],
     "tools": [
@@ -180,7 +180,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 2,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_biokinesis", "required": false } ],
     "tools": [
@@ -257,7 +257,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 2,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_biokinesis", "required": false } ],
     "tools": [
@@ -334,7 +334,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 3,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_biokinesis", "required": false } ],
     "tools": [
@@ -412,7 +412,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 3,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_biokinesis", "required": false } ],
     "tools": [
@@ -490,7 +490,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 3,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_biokinesis", "required": false } ],
     "tools": [
@@ -568,7 +568,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 4,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_biokinesis", "required": false } ],
     "tools": [
@@ -646,7 +646,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 4,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_biokinesis", "required": false } ],
     "tools": [
@@ -724,7 +724,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 5,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_biokinesis", "required": false } ],
     "tools": [
@@ -802,7 +802,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 6,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_biokinesis", "required": false } ],
     "tools": [
@@ -880,7 +880,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 6,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_biokinesis", "required": false } ],
     "tools": [
@@ -958,7 +958,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 7,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_biokinesis", "required": false } ],
     "tools": [
@@ -1036,7 +1036,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 8,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_biokinesis", "required": false } ],
     "tools": [
@@ -1114,7 +1114,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 9,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_biokinesis", "required": false } ],
     "tools": [

--- a/data/mods/MindOverMatter/recipes/practice/biokinetic_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/biokinetic_practice.json
@@ -51,10 +51,13 @@
         "id": "EOC_PRACTICE_BIOKIN_OVERCOME_PAIN",
         "condition": { "and": [ { "math": [ "u_spell_level('biokin_overcome_pain')", ">=", "1" ] } ] },
         "effect": [
-          { "set_string_var": "biokin_overcome_pain", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_biokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "biokin_overcome_pain", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_biokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "1" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ]
       }
     ]
@@ -81,10 +84,13 @@
         "id": "EOC_PRACTICE_BIOKIN_PHYSICAL_ENHANCE",
         "condition": { "math": [ "u_spell_level('biokin_physical_enhance')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "biokin_physical_enhance", "target_var": { "u_val": "latest_studied_power_name" } },  
-          { "set_string_var": "prof_contemplation_biokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "biokin_physical_enhance", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_biokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "2" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ]
       }
     ]
@@ -111,10 +117,13 @@
         "id": "EOC_PRACTICE_BIOKIN_BREATHE_SKIN",
         "condition": { "and": [ { "math": [ "u_spell_level('biokin_breathe_skin')", ">=", "1" ] } ] },
         "effect": [
-          { "set_string_var": "biokin_breathe_skin", "target_var": { "u_val": "latest_studied_power_name" } },       
-          { "set_string_var": "prof_contemplation_biokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "biokin_breathe_skin", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_biokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "2" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -192,10 +201,13 @@
         "id": "EOC_PRACTICE_BIOKIN_FLEXIBILITY",
         "condition": { "math": [ "u_spell_level('biokin_flexibility')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "biokin_flexibility", "target_var": { "u_val": "latest_studied_power_name" } },     
-          { "set_string_var": "prof_contemplation_biokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "biokin_flexibility", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_biokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "3" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -269,10 +281,13 @@
         "id": "EOC_PRACTICE_BIOKIN_DASH",
         "condition": { "math": [ "u_spell_level('biokin_dash')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "biokin_dash", "target_var": { "u_val": "latest_studied_power_name" } },     
-          { "set_string_var": "prof_contemplation_biokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "biokin_dash", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_biokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "3" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -347,10 +362,13 @@
         "id": "EOC_PRACTICE_BIOKIN_ARMOR_SKIN",
         "condition": { "math": [ "u_spell_level('biokin_armor_skin')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "biokin_armor_skin", "target_var": { "u_val": "latest_studied_power_name" } },    
-          { "set_string_var": "prof_contemplation_biokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "biokin_armor_skin", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_biokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "4" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -425,10 +443,13 @@
         "id": "EOC_PRACTICE_BIOKIN_CLIMATE_CONTROL",
         "condition": { "math": [ "u_spell_level('biokin_climate_control')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "biokin_climate_control", "target_var": { "u_val": "latest_studied_power_name" } },      
-          { "set_string_var": "prof_contemplation_biokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "biokin_climate_control", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_biokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "4" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -503,10 +524,13 @@
         "id": "EOC_PRACTICE_BIOKIN_ADRENALINE",
         "condition": { "math": [ "u_spell_level('biokin_adrenaline')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "biokin_adrenaline", "target_var": { "u_val": "latest_studied_power_name" } },    
-          { "set_string_var": "prof_contemplation_biokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "biokin_adrenaline", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_biokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "4" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -581,10 +605,13 @@
         "id": "EOC_PRACTICE_BIOKIN_ENHANCE_MOBILITY",
         "condition": { "math": [ "u_spell_level('biokin_enhance_mobility')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "biokin_enhance_mobility", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_biokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "biokin_enhance_mobility", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_biokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "5" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -659,10 +686,13 @@
         "id": "EOC_PRACTICE_BIOKIN_HAMMERHAND",
         "condition": { "math": [ "u_spell_level('biokin_hammerhand')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "biokin_hammerhand", "target_var": { "u_val": "latest_studied_power_name" } },  
-          { "set_string_var": "prof_contemplation_biokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "biokin_hammerhand", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_biokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "5" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -736,11 +766,14 @@
       {
         "id": "EOC_PRACTICE_BIOKIN_REFLEX_ENHANCE",
         "condition": { "math": [ "u_spell_level('biokin_reflex_enhance')", ">=", "1" ] },
-        "effect": [    
-          { "set_string_var": "biokin_reflex_enhance", "target_var": { "u_val": "latest_studied_power_name" } },     
-          { "set_string_var": "prof_contemplation_biokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+        "effect": [
+          { "set_string_var": "biokin_reflex_enhance", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_biokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "6" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -815,10 +848,13 @@
         "id": "EOC_PRACTICE_BIOKIN_SEALED_SYSTEM",
         "condition": { "math": [ "u_spell_level('biokin_sealed_system')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "biokin_sealed_system", "target_var": { "u_val": "latest_studied_power_name" } },  
-          { "set_string_var": "prof_contemplation_biokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "biokin_sealed_system", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_biokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "7" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -893,10 +929,13 @@
         "id": "EOC_PRACTICE_BIOKIN_METABOLISM_ENHANCE",
         "condition": { "math": [ "u_spell_level('biokin_metabolism_enhance')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "biokin_metabolism_enhance", "target_var": { "u_val": "latest_studied_power_name" } },    
-          { "set_string_var": "prof_contemplation_biokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "biokin_metabolism_enhance", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_biokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "7" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -972,9 +1011,12 @@
         "condition": { "math": [ "u_spell_level('biokin_combat_dance')", ">=", "1" ] },
         "effect": [
           { "set_string_var": "biokin_combat_dance", "target_var": { "u_val": "latest_studied_power_name" } },
-          { "set_string_var": "prof_contemplation_biokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          {
+            "set_string_var": "prof_contemplation_biokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "8" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -1050,9 +1092,12 @@
         "condition": { "math": [ "u_spell_level('biokin_perfected_motion')", ">=", "1" ] },
         "effect": [
           { "set_string_var": "biokin_perfected_motion", "target_var": { "u_val": "latest_studied_power_name" } },
-          { "set_string_var": "prof_contemplation_biokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          {
+            "set_string_var": "prof_contemplation_biokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "9" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -1128,9 +1173,12 @@
         "condition": { "math": [ "u_spell_level('biokin_hurricane_blows')", ">=", "1" ] },
         "effect": [
           { "set_string_var": "biokin_hurricane_blows", "target_var": { "u_val": "latest_studied_power_name" } },
-          { "set_string_var": "prof_contemplation_biokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          {
+            "set_string_var": "prof_contemplation_biokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "10" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },

--- a/data/mods/MindOverMatter/recipes/practice/clairsentient_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/clairsentient_practice.json
@@ -2,7 +2,6 @@
   {
     "id": "clairsentient_practice",
     "type": "nested_category",
-    "//": "XP for level 12 is 49417, for level 10 is 35279, for level 7 is 20514",
     "activity_level": "LIGHT_EXERCISE",
     "category": "CC_PRACTICE",
     "subcategory": "CSC_PRACTICE_METAPHYSICS",
@@ -55,10 +54,13 @@
         "id": "EOC_PRACTICE_CLAIR_NIGHT_VISION",
         "condition": { "math": [ "u_spell_level('clair_night_vision')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "clair_night_vision", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_clairsentience", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "clair_night_vision", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_clairsentience",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "1" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ]
       }
     ]
@@ -89,10 +91,13 @@
         "id": "EOC_PRACTICE_CLAIR_DANGER_SENSE",
         "condition": { "math": [ "u_spell_level('clair_danger_sense')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "clair_danger_sense", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_clairsentience", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "clair_danger_sense", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_clairsentience",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "2" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -174,10 +179,13 @@
         "id": "EOC_PRACTICE_CLAIR_SPEED_READING",
         "condition": { "math": [ "u_spell_level('clair_speed_reading')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "clair_speed_reading", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_clairsentience", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "clair_speed_reading", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_clairsentience",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "2" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ]
       }
     ]
@@ -208,10 +216,13 @@
         "id": "EOC_PRACTICE_CLAIR_SPOT_WEAKNESS",
         "condition": { "math": [ "u_spell_level('clair_spot_weakness')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "clair_spot_weakness", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_clairsentience", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "clair_spot_weakness", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_clairsentience",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "3" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -293,10 +304,13 @@
         "id": "EOC_PRACTICE_CLAIR_SENSE_RADS",
         "condition": { "math": [ "u_spell_level('clair_sense_rads')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "clair_sense_rads", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_clairsentience", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "clair_sense_rads", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_clairsentience",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "3" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ]
       }
     ]
@@ -327,10 +341,13 @@
         "id": "EOC_PRACTICE_CLAIR_SEE_AURAS",
         "condition": { "math": [ "u_spell_level('clair_see_auras')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "clair_see_auras", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_clairsentience", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "clair_see_auras", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_clairsentience",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "3" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -413,10 +430,13 @@
         "id": "EOC_PRACTICE_CLAIR_RANGED_ENHANCE",
         "condition": { "math": [ "u_spell_level('clair_ranged_enhance')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "clair_ranged_enhance", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_clairsentience", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "clair_ranged_enhance", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_clairsentience",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "4" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -499,10 +519,13 @@
         "id": "EOC_PRACTICE_CLAIR_VOYANCE",
         "condition": { "math": [ "u_spell_level('clair_voyance')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "clair_voyance", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_clairsentience", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "clair_voyance", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_clairsentience",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "5" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -585,10 +608,13 @@
         "id": "EOC_PRACTICE_CLAIR_COMBAT_SENSE",
         "condition": { "math": [ "u_spell_level('clair_dodge_power')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "clair_dodge_power", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_clairsentience", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "clair_dodge_power", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_clairsentience",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "6" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -671,10 +697,13 @@
         "id": "EOC_PRACTICE_CLAIR_CRAFT_BONUS",
         "condition": { "math": [ "u_spell_level('clair_craft_bonus')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "clair_craft_bonus", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_clairsentience", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "clair_craft_bonus", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_clairsentience",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "6" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -757,10 +786,13 @@
         "id": "EOC_PRACTICE_CLAIR_SEE_MAP",
         "condition": { "math": [ "u_spell_level('clair_see_map')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "clair_see_map", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_clairsentience", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "clair_see_map", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_clairsentience",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "7" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -843,10 +875,13 @@
         "id": "EOC_PRACTICE_CLAIR_PERFECT_SHOT",
         "condition": { "math": [ "u_spell_level('clair_perfect_shot')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "clair_perfect_shot", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_clairsentience", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "clair_perfect_shot", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_clairsentience",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "7" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -929,10 +964,13 @@
         "id": "EOC_PRACTICE_CLAIR_CLEAR_SIGHT",
         "condition": { "math": [ "u_spell_level('clair_clear_sight')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "clair_clear_sight", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_clairsentience", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "clair_clear_sight", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_clairsentience",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "8" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -1015,10 +1053,13 @@
         "id": "EOC_PRACTICE_CLAIR_ASTRAL_PROJECTION",
         "condition": { "math": [ "u_spell_level('clair_astral_projection')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "clair_astral_projection", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_clairsentience", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "clair_astral_projection", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_clairsentience",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "8" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -1101,10 +1142,13 @@
         "id": "EOC_PRACTICE_CLAIR_GROUP_TACTICS",
         "condition": { "math": [ "u_spell_level('clair_group_tactics')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "clair_group_tactics", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_clairsentience", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "clair_group_tactics", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_clairsentience",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "9" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -1187,10 +1231,13 @@
         "id": "EOC_PRACTICE_CLAIR_OMNISCENCE",
         "condition": { "math": [ "u_spell_level('clair_omniscience')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "clair_omniscience", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_clairsentience", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "clair_omniscience", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_clairsentience",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "10" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },

--- a/data/mods/MindOverMatter/recipes/practice/clairsentient_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/clairsentient_practice.json
@@ -39,7 +39,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 0,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_clairsentience", "required": false } ],
     "tools": [
@@ -55,14 +55,10 @@
         "id": "EOC_PRACTICE_CLAIR_NIGHT_VISION",
         "condition": { "math": [ "u_spell_level('clair_night_vision')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('clair_night_vision')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(1)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "clair_night_vision", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_clairsentience", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "1" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ]
       }
     ]
@@ -77,7 +73,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 1,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_clairsentience", "required": false } ],
     "tools": [
@@ -93,14 +89,10 @@
         "id": "EOC_PRACTICE_CLAIR_DANGER_SENSE",
         "condition": { "math": [ "u_spell_level('clair_danger_sense')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('clair_danger_sense')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(2)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "clair_danger_sense", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_clairsentience", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "2" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -166,7 +158,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 1,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_clairsentience", "required": false } ],
     "tools": [
@@ -182,14 +174,10 @@
         "id": "EOC_PRACTICE_CLAIR_SPEED_READING",
         "condition": { "math": [ "u_spell_level('clair_speed_reading')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('clair_speed_reading')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(2)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "clair_speed_reading", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_clairsentience", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "2" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ]
       }
     ]
@@ -204,7 +192,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 2,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_clairsentience", "required": false } ],
     "tools": [
@@ -220,14 +208,10 @@
         "id": "EOC_PRACTICE_CLAIR_SPOT_WEAKNESS",
         "condition": { "math": [ "u_spell_level('clair_spot_weakness')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('clair_spot_weakness')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(3)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "clair_spot_weakness", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_clairsentience", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "3" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -293,7 +277,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 2,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_clairsentience", "required": false } ],
     "tools": [
@@ -309,14 +293,10 @@
         "id": "EOC_PRACTICE_CLAIR_SENSE_RADS",
         "condition": { "math": [ "u_spell_level('clair_sense_rads')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('clair_sense_rads')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(3)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "clair_sense_rads", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_clairsentience", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "3" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ]
       }
     ]
@@ -331,7 +311,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 2,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_clairsentience", "required": false } ],
     "tools": [
@@ -347,14 +327,10 @@
         "id": "EOC_PRACTICE_CLAIR_SEE_AURAS",
         "condition": { "math": [ "u_spell_level('clair_see_auras')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('clair_see_auras')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(3)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "clair_see_auras", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_clairsentience", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "3" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -420,7 +396,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 3,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_clairsentience", "required": false } ],
     "tools": [
@@ -437,14 +413,10 @@
         "id": "EOC_PRACTICE_CLAIR_RANGED_ENHANCE",
         "condition": { "math": [ "u_spell_level('clair_ranged_enhance')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('clair_ranged_enhance')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(4)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "clair_ranged_enhance", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_clairsentience", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "4" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -510,7 +482,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 4,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_clairsentience", "required": false } ],
     "tools": [
@@ -527,14 +499,10 @@
         "id": "EOC_PRACTICE_CLAIR_VOYANCE",
         "condition": { "math": [ "u_spell_level('clair_voyance')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('clair_voyance')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(5)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "clair_voyance", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_clairsentience", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "5" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -600,7 +568,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 5,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_clairsentience", "required": false } ],
     "tools": [
@@ -617,14 +585,10 @@
         "id": "EOC_PRACTICE_CLAIR_COMBAT_SENSE",
         "condition": { "math": [ "u_spell_level('clair_dodge_power')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('clair_dodge_power')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(6)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "clair_dodge_power", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_clairsentience", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "6" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -690,7 +654,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 5,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_clairsentience", "required": false } ],
     "tools": [
@@ -707,14 +671,10 @@
         "id": "EOC_PRACTICE_CLAIR_CRAFT_BONUS",
         "condition": { "math": [ "u_spell_level('clair_craft_bonus')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('clair_craft_bonus')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(6)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "clair_craft_bonus", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_clairsentience", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "6" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -780,7 +740,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 6,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_clairsentience", "required": false } ],
     "tools": [
@@ -797,14 +757,10 @@
         "id": "EOC_PRACTICE_CLAIR_SEE_MAP",
         "condition": { "math": [ "u_spell_level('clair_see_map')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('clair_see_map')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(7)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "clair_see_map", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_clairsentience", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "7" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -870,7 +826,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 6,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_clairsentience", "required": false } ],
     "tools": [
@@ -887,14 +843,10 @@
         "id": "EOC_PRACTICE_CLAIR_PERFECT_SHOT",
         "condition": { "math": [ "u_spell_level('clair_perfect_shot')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('clair_perfect_shot')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(7)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "clair_perfect_shot", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_clairsentience", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "7" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -960,7 +912,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 7,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_clairsentience", "required": false } ],
     "tools": [
@@ -977,14 +929,10 @@
         "id": "EOC_PRACTICE_CLAIR_CLEAR_SIGHT",
         "condition": { "math": [ "u_spell_level('clair_clear_sight')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('clair_clear_sight')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(8)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "clair_clear_sight", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_clairsentience", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "8" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -1050,7 +998,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 7,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_clairsentience", "required": false } ],
     "tools": [
@@ -1067,11 +1015,10 @@
         "id": "EOC_PRACTICE_CLAIR_ASTRAL_PROJECTION",
         "condition": { "math": [ "u_spell_level('clair_astral_projection')", ">=", "1" ] },
         "effect": [
-          { "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge." },
-          { "math": [ "u_spell_exp('clair_astral_projection')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(8)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "clair_astral_projection", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_clairsentience", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "8" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -1137,7 +1084,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 8,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_clairsentience", "required": false } ],
     "tools": [
@@ -1154,14 +1101,10 @@
         "id": "EOC_PRACTICE_CLAIR_GROUP_TACTICS",
         "condition": { "math": [ "u_spell_level('clair_group_tactics')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('clair_group_tactics')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(9)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "clair_group_tactics", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_clairsentience", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "9" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -1227,7 +1170,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 9,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_clairsentience", "required": false } ],
     "tools": [
@@ -1244,14 +1187,10 @@
         "id": "EOC_PRACTICE_CLAIR_OMNISCENCE",
         "condition": { "math": [ "u_spell_level('clair_omniscience')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('clair_omniscience')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(10)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "clair_omniscience", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_clairsentience", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "10" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },

--- a/data/mods/MindOverMatter/recipes/practice/electrokinesis_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/electrokinesis_practice.json
@@ -2,7 +2,6 @@
   {
     "id": "electrokinesis_practice",
     "type": "nested_category",
-    "//": "XP for level 12 is 49417, for level 10 is 35279, for level 7 is 20514",
     "activity_level": "LIGHT_EXERCISE",
     "category": "CC_PRACTICE",
     "subcategory": "CSC_PRACTICE_METAPHYSICS",
@@ -40,7 +39,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 0,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_electrokinesis", "required": false } ],
     "tools": [
@@ -56,14 +55,10 @@
         "id": "EOC_PRACTICE_ELECTROKIN_SPARK_SIGHT",
         "condition": { "math": [ "u_spell_level('electrokinetic_see_electric')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('electrokinetic_see_electric')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(1)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "electrokinetic_see_electric", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_electrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "1" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ]
       }
     ]
@@ -78,7 +73,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 0,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_electrokinesis", "required": false } ],
     "tools": [
@@ -94,14 +89,10 @@
         "id": "EOC_PRACTICE_ELECTROKIN_SHOCK_TOUCH",
         "condition": { "math": [ "u_spell_level('electrokinetic_shock_touch')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('electrokinetic_shock_touch')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(1)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "electrokinetic_shock_touch", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_electrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "1" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ]
       }
     ]
@@ -116,7 +107,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 1,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_electrokinesis", "required": false } ],
     "tools": [
@@ -132,14 +123,10 @@
         "id": "EOC_PRACTICE_ELECTROKIN_ZAP_ENEMIES",
         "condition": { "math": [ "u_spell_level('electrokinetic_zap_enemies')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('electrokinetic_zap_enemies')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(2)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "electrokinetic_zap_enemies", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_electrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "2" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -205,7 +192,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 2,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_electrokinesis", "required": false } ],
     "tools": [
@@ -221,14 +208,10 @@
         "id": "EOC_PRACTICE_ELECTROKIN_MELEE_ATTACKS",
         "condition": { "math": [ "u_spell_level('electrokinetic_melee_attacks')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('electrokinetic_melee_attacks')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(3)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "electrokinetic_melee_attacks", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_electrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "3" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -294,7 +277,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 3,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_electrokinesis", "required": false } ],
     "tools": [
@@ -310,14 +293,10 @@
         "id": "EOC_PRACTICE_ELECTRO_HACKING_INTERFACE",
         "condition": { "math": [ "u_spell_level('electrokinetic_hacking_interface')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('electrokinetic_hacking_interface')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(4)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "electrokinetic_hacking_interface", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_electrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "3" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -383,7 +362,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 7,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_electrokinesis", "required": false } ],
     "tools": [
@@ -399,14 +378,10 @@
         "id": "EOC_PRACTICE_ELECTRO_ROBOT_INTERFACE",
         "condition": { "math": [ "u_spell_level('electrokinetic_robot_interface')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('electrokinetic_robot_interface')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(8)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "electrokinetic_robot_interface", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_electrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "6" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -472,7 +447,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 2,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_electrokinesis", "required": false } ],
     "tools": [
@@ -488,14 +463,10 @@
         "id": "EOC_PRACTICE_ELECTRO_PERSONAL_BATTERY",
         "condition": { "math": [ "u_spell_level('electrokinetic_personal_battery')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('electrokinetic_personal_battery')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(3)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "electrokinetic_personal_battery", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_electrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "3" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -561,7 +532,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 3,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_electrokinesis", "required": false } ],
     "tools": [
@@ -578,14 +549,10 @@
         "id": "EOC_PRACTICE_ELECTROKIN_PARALYSIS",
         "condition": { "math": [ "u_spell_level('electrokinetic_paralysis')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('electrokinetic_paralysis')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(4)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "electrokinetic_paralysis", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_electrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "4" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -651,7 +618,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 3,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_electrokinesis", "required": false } ],
     "tools": [
@@ -668,14 +635,10 @@
         "id": "EOC_PRACTICE_ELECTROKIN_REDUCE_PAIN",
         "condition": { "math": [ "u_spell_level('electrokinetic_reduce_pain')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('electrokinetic_reduce_pain')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(4)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "electrokinetic_reduce_pain", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_electrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "4" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -741,7 +704,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 4,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_electrokinesis", "required": false } ],
     "tools": [
@@ -758,14 +721,10 @@
         "id": "EOC_PRACTICE_ELECTROKIN_LIGHTNING_BOLT",
         "condition": { "math": [ "u_spell_level('electrokinetic_lightning_bolt')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('electrokinetic_lightning_bolt')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(5)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "electrokinetic_lightning_bolt", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_electrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "5" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -831,7 +790,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 4,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_electrokinesis", "required": false } ],
     "tools": [
@@ -848,14 +807,10 @@
         "id": "EOC_PRACTICE_ELECTROKIN_RECHARGE_VEHICLE",
         "condition": { "math": [ "u_spell_level('electrokinetic_recharge_vehicle')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('electrokinetic_recharge_vehicle')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(5)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "electrokinetic_recharge_vehicle", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_electrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "5" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -921,7 +876,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 5,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_electrokinesis", "required": false } ],
     "tools": [
@@ -938,14 +893,10 @@
         "id": "EOC_PRACTICE_ELECTROKIN_SPEED_BOOST",
         "condition": { "math": [ "u_spell_level('electrokinetic_speed_boost')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('electrokinetic_speed_boost')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(6)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "electrokinetic_speed_boost", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_electrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "6" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -1011,7 +962,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 5,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_electrokinesis", "required": false } ],
     "tools": [
@@ -1028,14 +979,10 @@
         "id": "EOC_PRACTICE_ELECTROKIN_PAIN_IMMUNE",
         "condition": { "math": [ "u_spell_level('electrokinetic_pain_immune')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('electrokinetic_pain_immune')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(6)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "electrokinetic_pain_immune", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_electrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "6" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -1101,7 +1048,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 6,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_electrokinesis", "required": false } ],
     "tools": [
@@ -1118,14 +1065,10 @@
         "id": "EOC_PRACTICE_ELECTROKIN_KILL_ROBOT",
         "condition": { "math": [ "u_spell_level('electrokinetic_kill_robot')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('electrokinetic_kill_robot')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(7)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "electrokinetic_kill_robot", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_electrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "7" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -1191,7 +1134,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 7,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_electrokinesis", "required": false } ],
     "tools": [
@@ -1208,14 +1151,10 @@
         "id": "EOC_PRACTICE_ELECTROKIN_LIGHTNING_AURA",
         "condition": { "math": [ "u_spell_level('electrokinetic_lightning_aura')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('electrokinetic_lightning_aura')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(8)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "electrokinetic_lightning_aura", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_electrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "8" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -1281,7 +1220,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 8,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_electrokinesis", "required": false } ],
     "tools": [
@@ -1298,14 +1237,10 @@
         "id": "EOC_PRACTICE_ELECTROKIN_LIGHTNING_BLAST",
         "condition": { "math": [ "u_spell_level('electrokinetic_lightning_blast')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('electrokinetic_lightning_blast')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(9)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "electrokinetic_lightning_blast", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_electrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "9" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -1371,7 +1306,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 9,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_electrokinesis", "required": false } ],
     "tools": [
@@ -1388,14 +1323,10 @@
         "id": "EOC_PRACTICE_ELECTROKIN_REVIVE",
         "condition": { "math": [ "u_spell_level('electrokinetic_revive')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('electrokinetic_revive')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(10)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "electrokinetic_revive", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_electrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "10" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },

--- a/data/mods/MindOverMatter/recipes/practice/electrokinesis_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/electrokinesis_practice.json
@@ -55,10 +55,13 @@
         "id": "EOC_PRACTICE_ELECTROKIN_SPARK_SIGHT",
         "condition": { "math": [ "u_spell_level('electrokinetic_see_electric')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "electrokinetic_see_electric", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_electrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "electrokinetic_see_electric", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_electrokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "1" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ]
       }
     ]
@@ -89,10 +92,13 @@
         "id": "EOC_PRACTICE_ELECTROKIN_SHOCK_TOUCH",
         "condition": { "math": [ "u_spell_level('electrokinetic_shock_touch')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "electrokinetic_shock_touch", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_electrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "electrokinetic_shock_touch", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_electrokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "1" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ]
       }
     ]
@@ -123,10 +129,13 @@
         "id": "EOC_PRACTICE_ELECTROKIN_ZAP_ENEMIES",
         "condition": { "math": [ "u_spell_level('electrokinetic_zap_enemies')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "electrokinetic_zap_enemies", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_electrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "electrokinetic_zap_enemies", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_electrokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "2" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -208,10 +217,13 @@
         "id": "EOC_PRACTICE_ELECTROKIN_MELEE_ATTACKS",
         "condition": { "math": [ "u_spell_level('electrokinetic_melee_attacks')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "electrokinetic_melee_attacks", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_electrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "electrokinetic_melee_attacks", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_electrokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "3" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -293,10 +305,13 @@
         "id": "EOC_PRACTICE_ELECTRO_HACKING_INTERFACE",
         "condition": { "math": [ "u_spell_level('electrokinetic_hacking_interface')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "electrokinetic_hacking_interface", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_electrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "electrokinetic_hacking_interface", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_electrokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "3" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -378,10 +393,13 @@
         "id": "EOC_PRACTICE_ELECTRO_ROBOT_INTERFACE",
         "condition": { "math": [ "u_spell_level('electrokinetic_robot_interface')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "electrokinetic_robot_interface", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_electrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "electrokinetic_robot_interface", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_electrokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "6" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -463,10 +481,13 @@
         "id": "EOC_PRACTICE_ELECTRO_PERSONAL_BATTERY",
         "condition": { "math": [ "u_spell_level('electrokinetic_personal_battery')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "electrokinetic_personal_battery", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_electrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "electrokinetic_personal_battery", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_electrokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "3" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -549,10 +570,13 @@
         "id": "EOC_PRACTICE_ELECTROKIN_PARALYSIS",
         "condition": { "math": [ "u_spell_level('electrokinetic_paralysis')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "electrokinetic_paralysis", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_electrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "electrokinetic_paralysis", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_electrokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "4" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -635,10 +659,13 @@
         "id": "EOC_PRACTICE_ELECTROKIN_REDUCE_PAIN",
         "condition": { "math": [ "u_spell_level('electrokinetic_reduce_pain')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "electrokinetic_reduce_pain", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_electrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "electrokinetic_reduce_pain", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_electrokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "4" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -721,10 +748,13 @@
         "id": "EOC_PRACTICE_ELECTROKIN_LIGHTNING_BOLT",
         "condition": { "math": [ "u_spell_level('electrokinetic_lightning_bolt')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "electrokinetic_lightning_bolt", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_electrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "electrokinetic_lightning_bolt", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_electrokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "5" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -807,10 +837,13 @@
         "id": "EOC_PRACTICE_ELECTROKIN_RECHARGE_VEHICLE",
         "condition": { "math": [ "u_spell_level('electrokinetic_recharge_vehicle')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "electrokinetic_recharge_vehicle", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_electrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "electrokinetic_recharge_vehicle", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_electrokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "5" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -893,10 +926,13 @@
         "id": "EOC_PRACTICE_ELECTROKIN_SPEED_BOOST",
         "condition": { "math": [ "u_spell_level('electrokinetic_speed_boost')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "electrokinetic_speed_boost", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_electrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "electrokinetic_speed_boost", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_electrokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "6" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -979,10 +1015,13 @@
         "id": "EOC_PRACTICE_ELECTROKIN_PAIN_IMMUNE",
         "condition": { "math": [ "u_spell_level('electrokinetic_pain_immune')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "electrokinetic_pain_immune", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_electrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "electrokinetic_pain_immune", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_electrokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "6" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -1065,10 +1104,13 @@
         "id": "EOC_PRACTICE_ELECTROKIN_KILL_ROBOT",
         "condition": { "math": [ "u_spell_level('electrokinetic_kill_robot')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "electrokinetic_kill_robot", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_electrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "electrokinetic_kill_robot", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_electrokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "7" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -1151,10 +1193,13 @@
         "id": "EOC_PRACTICE_ELECTROKIN_LIGHTNING_AURA",
         "condition": { "math": [ "u_spell_level('electrokinetic_lightning_aura')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "electrokinetic_lightning_aura", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_electrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "electrokinetic_lightning_aura", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_electrokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "8" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -1237,10 +1282,13 @@
         "id": "EOC_PRACTICE_ELECTROKIN_LIGHTNING_BLAST",
         "condition": { "math": [ "u_spell_level('electrokinetic_lightning_blast')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "electrokinetic_lightning_blast", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_electrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "electrokinetic_lightning_blast", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_electrokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "9" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -1323,10 +1371,13 @@
         "id": "EOC_PRACTICE_ELECTROKIN_REVIVE",
         "condition": { "math": [ "u_spell_level('electrokinetic_revive')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "electrokinetic_revive", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_electrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "electrokinetic_revive", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_electrokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "10" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },

--- a/data/mods/MindOverMatter/recipes/practice/photokinesis_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/photokinesis_practice.json
@@ -49,10 +49,13 @@
         "id": "EOC_PRACTICE_PHOTOKIN_LIGHT_LOCAL",
         "condition": { "math": [ "u_spell_level('photokinetic_light_local')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "photokinetic_light_local", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_photokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "photokinetic_light_local", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_photokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "1" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ]
       }
     ]
@@ -79,10 +82,13 @@
         "id": "EOC_PRACTICE_PHOTOKIN_CREATE_LIGHT",
         "condition": { "math": [ "u_spell_level('photokinetic_create_light')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "photokinetic_create_light", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_photokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "photokinetic_create_light", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_photokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "2" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ]
       }
     ]
@@ -109,10 +115,13 @@
         "id": "EOC_PRACTICE_PHOTOKIN_SNUFF_LIGHT",
         "condition": { "math": [ "u_spell_level('photokinetic_snuff_light')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "photokinetic_snuff_light", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_photokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "photokinetic_snuff_light", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_photokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "2" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -190,10 +199,13 @@
         "id": "EOC_PRACTICE_PHOTOKIN_LIGHT_DODGE",
         "condition": { "math": [ "u_spell_level('photokinetic_light_dodge')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "photokinetic_light_dodge", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_photokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "photokinetic_light_dodge", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_photokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "2" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -271,10 +283,13 @@
         "id": "EOC_PRACTICE_PHOTOKIN_LIGHT_BEAM",
         "condition": { "math": [ "u_spell_level('photokinetic_light_beam')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "photokinetic_light_beam", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_photokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "photokinetic_light_beam", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_photokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "3" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -352,10 +367,13 @@
         "id": "EOC_PRACTICE_PHOTOKIN_CAMOUFLAGE",
         "condition": { "math": [ "u_spell_level('photokinetic_camouflage')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "photokinetic_camouflage", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_photokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "photokinetic_camouflage", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_photokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "3" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -433,10 +451,13 @@
         "id": "EOC_PRACTICE_PHOTOKIN_RAD_IMMUNITY",
         "condition": { "math": [ "u_spell_level('photokinetic_rad_immunity')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "photokinetic_rad_immunity", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_photokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "photokinetic_rad_immunity", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_photokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "3" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -515,10 +536,13 @@
         "id": "EOC_PRACTICE_PHOTOKIN_LIGHT_ARMS",
         "condition": { "math": [ "u_spell_level('photokinetic_light_arms')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "photokinetic_light_arms", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_photokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "photokinetic_light_arms", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_photokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "4" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -597,10 +621,13 @@
         "id": "EOC_PRACTICE_PHOTOKIN_HIDE_UGLY",
         "condition": { "math": [ "u_spell_level('photokinetic_hide_ugly')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "photokinetic_hide_ugly", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_photokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "photokinetic_hide_ugly", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_photokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "4" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -679,10 +706,13 @@
         "id": "EOC_PRACTICE_PHOTOKIN_LIGHT_IMAGE",
         "condition": { "math": [ "u_spell_level('photokinetic_light_image')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "photokinetic_light_image", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_photokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "photokinetic_light_image", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_photokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "5" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -760,10 +790,13 @@
         "id": "EOC_PRACTICE_PHOTOKIN_RADIO",
         "condition": { "math": [ "u_spell_level('photokinetic_radio')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "photokinetic_radio", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_photokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "photokinetic_radio", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_photokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "5" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -842,10 +875,13 @@
         "id": "EOC_PRACTICE_PHOTOKIN_INVISIBILITY",
         "condition": { "math": [ "u_spell_level('photokinetic_invisibility')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "photokinetic_invisibility", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_photokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "photokinetic_invisibility", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_photokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "6" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -924,10 +960,13 @@
         "id": "EOC_PRACTICE_PHOTOKIN_LIGHT_FLASH",
         "condition": { "math": [ "u_spell_level('photokinetic_light_flash')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "photokinetic_light_flash", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_photokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "photokinetic_light_flash", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_photokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "6" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -1006,10 +1045,13 @@
         "id": "EOC_PRACTICE_PHOTOKIN_BLINDING_GLARE",
         "condition": { "math": [ "u_spell_level('photokinetic_blinding_glare')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "photokinetic_blinding_glare", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_photokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "photokinetic_blinding_glare", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_photokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "7" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -1088,10 +1130,13 @@
         "id": "EOC_PRACTICE_PHOTOKIN_LIGHT_DISINTEGRATE",
         "condition": { "math": [ "u_spell_level('photokinetic_light_disintegrate')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "photokinetic_light_disintegrate", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_photokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "photokinetic_light_disintegrate", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_photokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "8" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },

--- a/data/mods/MindOverMatter/recipes/practice/photokinesis_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/photokinesis_practice.json
@@ -2,7 +2,6 @@
   {
     "id": "photokinesis_practice",
     "type": "nested_category",
-    "//": "XP for level 12 is 49417, for level 10 is 35279, for level 7 is 20514",
     "activity_level": "LIGHT_EXERCISE",
     "category": "CC_PRACTICE",
     "subcategory": "CSC_PRACTICE_METAPHYSICS",
@@ -38,7 +37,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 0,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_photokinesis", "required": false } ],
     "tools": [
@@ -50,14 +49,10 @@
         "id": "EOC_PRACTICE_PHOTOKIN_LIGHT_LOCAL",
         "condition": { "math": [ "u_spell_level('photokinetic_light_local')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('photokinetic_light_local')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(1)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "photokinetic_light_local", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_photokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "1" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ]
       }
     ]
@@ -72,7 +67,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 1,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_photokinesis", "required": false } ],
     "tools": [
@@ -84,14 +79,10 @@
         "id": "EOC_PRACTICE_PHOTOKIN_CREATE_LIGHT",
         "condition": { "math": [ "u_spell_level('photokinetic_create_light')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('photokinetic_create_light')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(2)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "photokinetic_create_light", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_photokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "2" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ]
       }
     ]
@@ -106,7 +97,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 1,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_photokinesis", "required": false } ],
     "tools": [
@@ -118,14 +109,10 @@
         "id": "EOC_PRACTICE_PHOTOKIN_SNUFF_LIGHT",
         "condition": { "math": [ "u_spell_level('photokinetic_snuff_light')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('photokinetic_snuff_light')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(2)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "photokinetic_snuff_light", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_photokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "2" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -191,7 +178,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 1,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_photokinesis", "required": false } ],
     "tools": [
@@ -203,14 +190,10 @@
         "id": "EOC_PRACTICE_PHOTOKIN_LIGHT_DODGE",
         "condition": { "math": [ "u_spell_level('photokinetic_light_dodge')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('photokinetic_light_dodge')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(2)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "photokinetic_light_dodge", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_photokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "2" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -276,7 +259,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 2,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_photokinesis", "required": false } ],
     "tools": [
@@ -288,14 +271,10 @@
         "id": "EOC_PRACTICE_PHOTOKIN_LIGHT_BEAM",
         "condition": { "math": [ "u_spell_level('photokinetic_light_beam')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('photokinetic_light_beam')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(3)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "photokinetic_light_beam", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_photokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "3" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -361,7 +340,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 2,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_photokinesis", "required": false } ],
     "tools": [
@@ -373,14 +352,10 @@
         "id": "EOC_PRACTICE_PHOTOKIN_CAMOUFLAGE",
         "condition": { "math": [ "u_spell_level('photokinetic_camouflage')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('photokinetic_camouflage')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(3)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "photokinetic_camouflage", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_photokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "3" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -446,7 +421,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 2,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_photokinesis", "required": false } ],
     "tools": [
@@ -458,14 +433,10 @@
         "id": "EOC_PRACTICE_PHOTOKIN_RAD_IMMUNITY",
         "condition": { "math": [ "u_spell_level('photokinetic_rad_immunity')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('photokinetic_rad_immunity')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(3)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "photokinetic_rad_immunity", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_photokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "3" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -531,7 +502,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 3,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_photokinesis", "required": false } ],
     "tools": [
@@ -544,14 +515,10 @@
         "id": "EOC_PRACTICE_PHOTOKIN_LIGHT_ARMS",
         "condition": { "math": [ "u_spell_level('photokinetic_light_arms')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('photokinetic_light_arms')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(4)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "photokinetic_light_arms", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_photokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "4" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -617,7 +584,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 3,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_photokinesis", "required": false } ],
     "tools": [
@@ -630,14 +597,10 @@
         "id": "EOC_PRACTICE_PHOTOKIN_HIDE_UGLY",
         "condition": { "math": [ "u_spell_level('photokinetic_hide_ugly')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('photokinetic_hide_ugly')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(4)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "photokinetic_hide_ugly", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_photokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "4" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -703,7 +666,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 4,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_photokinesis", "required": false } ],
     "tools": [
@@ -716,14 +679,10 @@
         "id": "EOC_PRACTICE_PHOTOKIN_LIGHT_IMAGE",
         "condition": { "math": [ "u_spell_level('photokinetic_light_image')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('photokinetic_light_image')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(5)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "photokinetic_light_image", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_photokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "5" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -789,7 +748,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 4,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_photokinesis", "required": false } ],
     "tools": [
@@ -801,14 +760,10 @@
         "id": "EOC_PRACTICE_PHOTOKIN_RADIO",
         "condition": { "math": [ "u_spell_level('photokinetic_radio')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('photokinetic_radio')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(5)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "photokinetic_radio", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_photokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "5" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -874,7 +829,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 5,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_photokinesis", "required": false } ],
     "tools": [
@@ -887,14 +842,10 @@
         "id": "EOC_PRACTICE_PHOTOKIN_INVISIBILITY",
         "condition": { "math": [ "u_spell_level('photokinetic_invisibility')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('photokinetic_invisibility')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(6)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "photokinetic_invisibility", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_photokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "6" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -960,7 +911,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 5,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_photokinesis", "required": false } ],
     "tools": [
@@ -973,14 +924,10 @@
         "id": "EOC_PRACTICE_PHOTOKIN_LIGHT_FLASH",
         "condition": { "math": [ "u_spell_level('photokinetic_light_flash')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('photokinetic_light_flash')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(7)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "photokinetic_light_flash", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_photokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "6" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -1046,7 +993,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 6,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_photokinesis", "required": false } ],
     "tools": [
@@ -1059,14 +1006,10 @@
         "id": "EOC_PRACTICE_PHOTOKIN_BLINDING_GLARE",
         "condition": { "math": [ "u_spell_level('photokinetic_blinding_glare')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('photokinetic_blinding_glare')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(7)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "photokinetic_blinding_glare", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_photokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "7" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -1132,7 +1075,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 7,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_photokinesis", "required": false } ],
     "tools": [
@@ -1145,14 +1088,10 @@
         "id": "EOC_PRACTICE_PHOTOKIN_LIGHT_DISINTEGRATE",
         "condition": { "math": [ "u_spell_level('photokinetic_light_disintegrate')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('photokinetic_light_disintegrate')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(8)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "photokinetic_light_disintegrate", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_photokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "8" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },

--- a/data/mods/MindOverMatter/recipes/practice/pyrokinesis_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/pyrokinesis_practice.json
@@ -48,10 +48,13 @@
         "id": "EOC_PRACTICE_PYROKIN_FLASH",
         "condition": { "math": [ "u_spell_level('pyrokinetic_flash')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "pyrokinetic_flash", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_pyrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "pyrokinetic_flash", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_pyrokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "1" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ]
       }
     ]
@@ -78,10 +81,13 @@
         "id": "EOC_PRACTICE_PYROKIN_FLAMES",
         "condition": { "math": [ "u_spell_level('pyrokinetic_eruption')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "pyrokinetic_eruption", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_pyrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "pyrokinetic_eruption", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_pyrokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "2" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ]
       }
     ]
@@ -108,10 +114,13 @@
         "id": "EOC_PRACTICE_PYROKIN_CAUTERIZE",
         "condition": { "math": [ "u_spell_level('pyrokinetic_cauterize')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "pyrokinetic_cauterize", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_pyrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "pyrokinetic_cauterize", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_pyrokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "2" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -189,10 +198,13 @@
         "id": "EOC_PRACTICE_PYROKIN_QUELL_FIRE",
         "condition": { "math": [ "u_spell_level('pyrokinetic_quell_flames')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "pyrokinetic_quell_flames", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_pyrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "pyrokinetic_quell_flames", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_pyrokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "3" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -270,10 +282,13 @@
         "id": "EOC_PRACTICE_PYROKIN_CALL_FLAMES",
         "condition": { "math": [ "u_spell_level('pyrokinetic_call_flames')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "pyrokinetic_call_flames", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_pyrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "pyrokinetic_call_flames", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_pyrokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "3" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -352,10 +367,13 @@
         "id": "EOC_PRACTICE_PYROKIN_CLOAK",
         "condition": { "math": [ "u_spell_level('pyrokinetic_cloak')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "pyrokinetic_cloak", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_pyrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "pyrokinetic_cloak", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_pyrokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "4" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -434,10 +452,13 @@
         "id": "EOC_PRACTICE_PYROKIN_FLAMETHROWER",
         "condition": { "math": [ "u_spell_level('pyrokinetic_flamethrower')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "pyrokinetic_flamethrower", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_pyrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "pyrokinetic_flamethrower", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_pyrokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "5" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -516,10 +537,13 @@
         "id": "EOC_PRACTICE_PYROKIN_LANCE",
         "condition": { "math": [ "u_spell_level('pyrokinetic_lance')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "pyrokinetic_lance", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_pyrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "pyrokinetic_lance", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_pyrokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "5" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -598,10 +622,13 @@
         "id": "EOC_PRACTICE_PYROKIN_THERMOGENESIS",
         "condition": { "math": [ "u_spell_level('pyrokinetic_thermogenesis')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "pyrokinetic_thermogenesis", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_pyrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "pyrokinetic_thermogenesis", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_pyrokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "6" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -680,10 +707,13 @@
         "id": "EOC_PRACTICE_PYROKIN_AURA",
         "condition": { "math": [ "u_spell_level('pyrokinetic_aura')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "pyrokinetic_aura", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_pyrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "pyrokinetic_aura", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_pyrokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "6" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -762,10 +792,13 @@
         "id": "EOC_PRACTICE_PYROKIN_FLAME_IMMUNITY",
         "condition": { "math": [ "u_spell_level('pyrokinetic_flame_immunity')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "pyrokinetic_flame_immunity", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_pyrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "pyrokinetic_flame_immunity", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_pyrokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "7" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -844,10 +877,13 @@
         "id": "EOC_PRACTICE_PYROKIN_BLAST",
         "condition": { "math": [ "u_spell_level('pyrokinetic_blast')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "pyrokinetic_blast", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_pyrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "pyrokinetic_blast", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_pyrokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "7" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -926,10 +962,13 @@
         "id": "EOC_PRACTICE_PYROKIN_AOE_BLAST",
         "condition": { "math": [ "u_spell_level('pyrokinetic_aoe_blast')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "pyrokinetic_aoe_blast", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_pyrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "pyrokinetic_aoe_blast", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_pyrokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "9" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -1008,10 +1047,13 @@
         "id": "EOC_PRACTICE_PYROKIN_INCINERATION",
         "condition": { "math": [ "u_spell_level('pyrokinetic_incineration')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "pyrokinetic_incineration", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_pyrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "pyrokinetic_incineration", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_pyrokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "10" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },

--- a/data/mods/MindOverMatter/recipes/practice/pyrokinesis_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/pyrokinesis_practice.json
@@ -2,7 +2,6 @@
   {
     "id": "pyrokinesis_practice",
     "type": "nested_category",
-    "//": "XP for level 12 is 49417, for level 10 is 35279, for level 7 is 20514",
     "activity_level": "LIGHT_EXERCISE",
     "category": "CC_PRACTICE",
     "subcategory": "CSC_PRACTICE_METAPHYSICS",
@@ -37,7 +36,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 0,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_pyrokinesis", "required": false } ],
     "tools": [
@@ -49,14 +48,10 @@
         "id": "EOC_PRACTICE_PYROKIN_FLASH",
         "condition": { "math": [ "u_spell_level('pyrokinetic_flash')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('pyrokinetic_flash')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(1)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "pyrokinetic_flash", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_pyrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "1" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ]
       }
     ]
@@ -71,7 +66,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 1,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_pyrokinesis", "required": false } ],
     "tools": [
@@ -83,14 +78,10 @@
         "id": "EOC_PRACTICE_PYROKIN_FLAMES",
         "condition": { "math": [ "u_spell_level('pyrokinetic_eruption')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('pyrokinetic_eruption')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(2)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "pyrokinetic_eruption", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_pyrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "2" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ]
       }
     ]
@@ -105,7 +96,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 1,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_pyrokinesis", "required": false } ],
     "tools": [
@@ -117,14 +108,10 @@
         "id": "EOC_PRACTICE_PYROKIN_CAUTERIZE",
         "condition": { "math": [ "u_spell_level('pyrokinetic_cauterize')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('pyrokinetic_cauterize')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(2)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "pyrokinetic_cauterize", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_pyrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "2" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -190,7 +177,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 2,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_pyrokinesis", "required": false } ],
     "tools": [
@@ -202,14 +189,10 @@
         "id": "EOC_PRACTICE_PYROKIN_QUELL_FIRE",
         "condition": { "math": [ "u_spell_level('pyrokinetic_quell_flames')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('pyrokinetic_quell_flames')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(3)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "pyrokinetic_quell_flames", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_pyrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "3" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -275,7 +258,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 2,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_pyrokinesis", "required": false } ],
     "tools": [
@@ -287,14 +270,10 @@
         "id": "EOC_PRACTICE_PYROKIN_CALL_FLAMES",
         "condition": { "math": [ "u_spell_level('pyrokinetic_call_flames')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('pyrokinetic_call_flames')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(3)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "pyrokinetic_call_flames", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_pyrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "3" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -360,7 +339,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 3,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_pyrokinesis", "required": false } ],
     "tools": [
@@ -373,14 +352,10 @@
         "id": "EOC_PRACTICE_PYROKIN_CLOAK",
         "condition": { "math": [ "u_spell_level('pyrokinetic_cloak')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('pyrokinetic_cloak')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(4)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "pyrokinetic_cloak", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_pyrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "4" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -446,7 +421,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 4,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_pyrokinesis", "required": false } ],
     "tools": [
@@ -459,14 +434,10 @@
         "id": "EOC_PRACTICE_PYROKIN_FLAMETHROWER",
         "condition": { "math": [ "u_spell_level('pyrokinetic_flamethrower')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('pyrokinetic_flamethrower')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(5)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "pyrokinetic_flamethrower", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_pyrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "5" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -532,7 +503,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 4,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_pyrokinesis", "required": false } ],
     "tools": [
@@ -545,14 +516,10 @@
         "id": "EOC_PRACTICE_PYROKIN_LANCE",
         "condition": { "math": [ "u_spell_level('pyrokinetic_lance')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('pyrokinetic_lance')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(5)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "pyrokinetic_lance", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_pyrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "5" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -618,7 +585,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 5,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_pyrokinesis", "required": false } ],
     "tools": [
@@ -631,14 +598,10 @@
         "id": "EOC_PRACTICE_PYROKIN_THERMOGENESIS",
         "condition": { "math": [ "u_spell_level('pyrokinetic_thermogenesis')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('pyrokinetic_thermogenesis')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(6)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "pyrokinetic_thermogenesis", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_pyrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "6" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -704,7 +667,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 5,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_pyrokinesis", "required": false } ],
     "tools": [
@@ -717,14 +680,10 @@
         "id": "EOC_PRACTICE_PYROKIN_AURA",
         "condition": { "math": [ "u_spell_level('pyrokinetic_aura')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('pyrokinetic_aura')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(6)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "pyrokinetic_aura", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_pyrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "6" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -790,7 +749,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 6,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_pyrokinesis", "required": false } ],
     "tools": [
@@ -803,14 +762,10 @@
         "id": "EOC_PRACTICE_PYROKIN_FLAME_IMMUNITY",
         "condition": { "math": [ "u_spell_level('pyrokinetic_flame_immunity')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('pyrokinetic_flame_immunity')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(7)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "pyrokinetic_flame_immunity", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_pyrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "7" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -876,7 +831,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 6,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_pyrokinesis", "required": false } ],
     "tools": [
@@ -889,14 +844,10 @@
         "id": "EOC_PRACTICE_PYROKIN_BLAST",
         "condition": { "math": [ "u_spell_level('pyrokinetic_blast')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('pyrokinetic_blast')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(7)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "pyrokinetic_blast", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_pyrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "7" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -962,7 +913,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 8,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_pyrokinesis", "required": false } ],
     "tools": [
@@ -975,14 +926,10 @@
         "id": "EOC_PRACTICE_PYROKIN_AOE_BLAST",
         "condition": { "math": [ "u_spell_level('pyrokinetic_aoe_blast')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('pyrokinetic_aoe_blast')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(9)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "pyrokinetic_aoe_blast", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_pyrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "9" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -1048,7 +995,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 9,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_pyrokinesis", "required": false } ],
     "tools": [
@@ -1061,14 +1008,10 @@
         "id": "EOC_PRACTICE_PYROKIN_INCINERATION",
         "condition": { "math": [ "u_spell_level('pyrokinetic_incineration')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('pyrokinetic_incineration')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(10)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "pyrokinetic_incineration", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_pyrokinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "10" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },

--- a/data/mods/MindOverMatter/recipes/practice/telekinesis_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/telekinesis_practice.json
@@ -50,10 +50,13 @@
         "id": "EOC_PRACTICE_TELEKIN_PULL",
         "condition": { "math": [ "u_spell_level('telekinetic_pull')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "telekinetic_pull", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_telekinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "telekinetic_pull", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_telekinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "1" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ]
       }
     ]
@@ -80,10 +83,13 @@
         "id": "EOC_PRACTICE_TELEKIN_PUSH",
         "condition": { "math": [ "u_spell_level('telekinetic_push')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "telekinetic_push", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_telekinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "telekinetic_push", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_telekinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "2" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ]
       }
     ]
@@ -108,10 +114,13 @@
         "id": "EOC_PRACTICE_TELEKIN_NOISEMAKER",
         "condition": { "math": [ "u_spell_level('telekinetic_noise')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "telekinetic_noise", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_telekinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "telekinetic_noise", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_telekinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "2" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -185,10 +194,13 @@
         "id": "EOC_PRACTICE_TELEKIN_SLAM_DOWN",
         "condition": { "math": [ "u_spell_level('telekinetic_slam_down')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "telekinetic_slam_down", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_telekinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "telekinetic_slam_down", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_telekinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "2" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -262,10 +274,13 @@
         "id": "EOC_PRACTICE_TELEKIN_MOMENTUM",
         "condition": { "math": [ "u_spell_level('telekinetic_momentum')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "telekinetic_momentum", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_telekinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "telekinetic_momentum", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_telekinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "3" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -340,10 +355,13 @@
         "id": "EOC_PRACTICE_TELEKIN_SLOWFALL",
         "condition": { "math": [ "u_spell_level('telekinetic_slowfall')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "telekinetic_slowfall", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_telekinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "telekinetic_slowfall", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_telekinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "3" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -418,10 +436,13 @@
         "id": "EOC_PRACTICE_TELEKIN_FORCE_WAVE",
         "condition": { "math": [ "u_spell_level('telekinetic_wave')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "telekinetic_wave", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_telekinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "telekinetic_wave", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_telekinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "4" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -496,10 +517,13 @@
         "id": "EOC_PRACTICE_TELEKIN_ENHANCE_STRENGTH",
         "condition": { "math": [ "u_spell_level('telekinetic_strength')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "telekinetic_strength", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_telekinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "telekinetic_strength", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_telekinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "5" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -574,10 +598,13 @@
         "id": "EOC_PRACTICE_TELEKIN_MINDHAMMER",
         "condition": { "math": [ "u_spell_level('telekinetic_hammer')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "telekinetic_hammer", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_telekinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "telekinetic_hammer", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_telekinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "5" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -652,10 +679,13 @@
         "id": "EOC_PRACTICE_TELEKIN_VEHICLE_LIFT",
         "condition": { "math": [ "u_spell_level('telekinetic_vehicle_lift')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "telekinetic_vehicle_lift", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_telekinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "telekinetic_vehicle_lift", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_telekinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "6" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -730,10 +760,13 @@
         "id": "EOC_PRACTICE_TELEKIN_BARRIER",
         "condition": { "math": [ "u_spell_level('telekinetic_shield')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "telekinetic_shield", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_telekinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "telekinetic_shield", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_telekinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "6" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -808,10 +841,13 @@
         "id": "EOC_PRACTICE_TELEKIN_BLAST",
         "condition": { "math": [ "u_spell_level('telekinetic_explosion')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "telekinetic_explosion", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_telekinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "telekinetic_explosion", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_telekinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "7" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -886,10 +922,13 @@
         "id": "EOC_PRACTICE_LEVITATION",
         "condition": { "math": [ "u_spell_level('telekinetic_levitation')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "telekinetic_levitation", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_telekinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "telekinetic_levitation", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_telekinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "7" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -962,10 +1001,13 @@
         "id": "EOC_PRACTICE_MOVE_LARGE_WEIGHT",
         "condition": { "math": [ "u_spell_level('telekinetic_move_large_weight')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "telekinetic_move_large_weight", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_telekinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "telekinetic_move_large_weight", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_telekinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "8" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -1040,10 +1082,13 @@
         "id": "EOC_PRACTICE_TELEKIN_AEGIS",
         "condition": { "math": [ "u_spell_level('telekinetic_aegis')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "telekinetic_aegis", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_telekinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "telekinetic_aegis", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_telekinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "9" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -1118,10 +1163,13 @@
         "id": "EOC_PRACTICE_TELEKIN_EARTHSHAKER",
         "condition": { "math": [ "u_spell_level('telekinetic_earthshaker')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "telekinetic_earthshaker", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_telekinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "telekinetic_earthshaker", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_telekinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "10" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },

--- a/data/mods/MindOverMatter/recipes/practice/telekinesis_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/telekinesis_practice.json
@@ -2,7 +2,6 @@
   {
     "id": "telekinesis_practice",
     "type": "nested_category",
-    "//": "XP for level 12 is 49417, for level 10 is 35279, for level 7 is 20514",
     "activity_level": "LIGHT_EXERCISE",
     "category": "CC_PRACTICE",
     "subcategory": "CSC_PRACTICE_METAPHYSICS",
@@ -39,7 +38,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 0,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_telekinesis", "required": false } ],
     "tools": [
@@ -51,14 +50,10 @@
         "id": "EOC_PRACTICE_TELEKIN_PULL",
         "condition": { "math": [ "u_spell_level('telekinetic_pull')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('telekinetic_pull')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(1)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "telekinetic_pull", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_telekinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "1" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ]
       }
     ]
@@ -73,7 +68,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 1,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_telekinesis", "required": false } ],
     "tools": [
@@ -85,14 +80,10 @@
         "id": "EOC_PRACTICE_TELEKIN_PUSH",
         "condition": { "math": [ "u_spell_level('telekinetic_push')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('telekinetic_push')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(2)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "telekinetic_push", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_telekinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "2" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ]
       }
     ]
@@ -107,7 +98,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 1,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_telekinesis", "required": false } ],
     "tools": [ [ [ "matrix_crystal_drained", -1 ], [ "matrix_crystal_telekinesis", -1 ] ] ],
@@ -117,14 +108,10 @@
         "id": "EOC_PRACTICE_TELEKIN_NOISEMAKER",
         "condition": { "math": [ "u_spell_level('telekinetic_noise')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('telekinetic_noise')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(2)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "telekinetic_noise", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_telekinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "2" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -186,7 +173,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 1,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_telekinesis", "required": false } ],
     "tools": [
@@ -198,14 +185,10 @@
         "id": "EOC_PRACTICE_TELEKIN_SLAM_DOWN",
         "condition": { "math": [ "u_spell_level('telekinetic_slam_down')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('telekinetic_slam_down')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(2)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "telekinetic_slam_down", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_telekinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "2" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -267,7 +250,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 2,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_telekinesis", "required": false } ],
     "tools": [
@@ -279,14 +262,10 @@
         "id": "EOC_PRACTICE_TELEKIN_MOMENTUM",
         "condition": { "math": [ "u_spell_level('telekinetic_momentum')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('telekinetic_momentum')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(3)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "telekinetic_momentum", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_telekinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "3" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -348,7 +327,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 2,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_telekinesis", "required": false } ],
     "tools": [
@@ -361,14 +340,10 @@
         "id": "EOC_PRACTICE_TELEKIN_SLOWFALL",
         "condition": { "math": [ "u_spell_level('telekinetic_slowfall')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('telekinetic_slowfall')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(3)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "telekinetic_slowfall", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_telekinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "3" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -430,7 +405,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 3,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_telekinesis", "required": false } ],
     "tools": [
@@ -443,14 +418,10 @@
         "id": "EOC_PRACTICE_TELEKIN_FORCE_WAVE",
         "condition": { "math": [ "u_spell_level('telekinetic_wave')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('telekinetic_wave')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(4)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "telekinetic_wave", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_telekinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "4" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -512,7 +483,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 4,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_telekinesis", "required": false } ],
     "tools": [
@@ -525,14 +496,10 @@
         "id": "EOC_PRACTICE_TELEKIN_ENHANCE_STRENGTH",
         "condition": { "math": [ "u_spell_level('telekinetic_strength')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('telekinetic_strength')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(5)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "telekinetic_strength", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_telekinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "5" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -594,7 +561,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 4,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_telekinesis", "required": false } ],
     "tools": [
@@ -607,14 +574,10 @@
         "id": "EOC_PRACTICE_TELEKIN_MINDHAMMER",
         "condition": { "math": [ "u_spell_level('telekinetic_hammer')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('telekinetic_hammer')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(5)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "telekinetic_hammer", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_telekinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "5" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -676,7 +639,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 5,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_telekinesis", "required": false } ],
     "tools": [
@@ -689,14 +652,10 @@
         "id": "EOC_PRACTICE_TELEKIN_VEHICLE_LIFT",
         "condition": { "math": [ "u_spell_level('telekinetic_vehicle_lift')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('telekinetic_vehicle_lift')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(6)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "telekinetic_vehicle_lift", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_telekinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "6" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -758,7 +717,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 5,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_telekinesis", "required": false } ],
     "tools": [
@@ -771,14 +730,10 @@
         "id": "EOC_PRACTICE_TELEKIN_BARRIER",
         "condition": { "math": [ "u_spell_level('telekinetic_shield')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('telekinetic_shield')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(6)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "telekinetic_shield", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_telekinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "6" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -840,7 +795,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 6,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_telekinesis", "required": false } ],
     "tools": [
@@ -853,14 +808,10 @@
         "id": "EOC_PRACTICE_TELEKIN_BLAST",
         "condition": { "math": [ "u_spell_level('telekinetic_explosion')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('telekinetic_explosion')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(7)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "telekinetic_explosion", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_telekinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "7" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -922,7 +873,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 6,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_telekinesis", "required": false } ],
     "tools": [
@@ -935,14 +886,10 @@
         "id": "EOC_PRACTICE_LEVITATION",
         "condition": { "math": [ "u_spell_level('telekinetic_levitation')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('telekinetic_levitation')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(7)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "telekinetic_levitation", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_telekinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "7" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -1004,7 +951,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 7,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_telekinesis", "required": false } ],
     "tools": [ [ [ "matrix_crystal_drained", -1 ], [ "matrix_crystal_telekinesis", -1 ] ] ],
@@ -1015,14 +962,10 @@
         "id": "EOC_PRACTICE_MOVE_LARGE_WEIGHT",
         "condition": { "math": [ "u_spell_level('telekinetic_move_large_weight')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('telekinetic_move_large_weight')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(8)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "telekinetic_move_large_weight", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_telekinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "8" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -1084,7 +1027,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 8,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_telekinesis", "required": false } ],
     "tools": [
@@ -1097,14 +1040,10 @@
         "id": "EOC_PRACTICE_TELEKIN_AEGIS",
         "condition": { "math": [ "u_spell_level('telekinetic_aegis')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('telekinetic_aegis')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(9)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "telekinetic_aegis", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_telekinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "9" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -1166,7 +1105,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 9,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_telekinesis", "required": false } ],
     "tools": [
@@ -1179,14 +1118,10 @@
         "id": "EOC_PRACTICE_TELEKIN_EARTHSHAKER",
         "condition": { "math": [ "u_spell_level('telekinetic_earthshaker')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('telekinetic_earthshaker')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(10)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "telekinetic_earthshaker", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_telekinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "10" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },

--- a/data/mods/MindOverMatter/recipes/practice/telepathy_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/telepathy_practice.json
@@ -2,7 +2,6 @@
   {
     "id": "telepathy_practice",
     "type": "nested_category",
-    "//": "XP for level 12 is 49417, for level 10 is 35279, for level 7 is 20514",
     "activity_level": "LIGHT_EXERCISE",
     "category": "CC_PRACTICE",
     "subcategory": "CSC_PRACTICE_METAPHYSICS",
@@ -36,7 +35,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 0,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_telepathy", "required": false } ],
     "tools": [ [ [ "matrix_crystal_drained", -1 ], [ "black_nether_crystal_pseudo_tool", -1 ], [ "matrix_crystal_telepathy", -1 ] ] ],
@@ -46,14 +45,10 @@
         "id": "EOC_PRACTICE_TELEPATH_CONCENTRATION",
         "condition": { "math": [ "u_spell_level('telepathic_concentration')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('telepathic_concentration')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(1)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "telepathic_concentration", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_telepathy", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "1" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ]
       }
     ]
@@ -68,7 +63,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 1,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_telepathy", "required": false } ],
     "tools": [ [ [ "matrix_crystal_drained", -1 ], [ "black_nether_crystal_pseudo_tool", -1 ], [ "matrix_crystal_telepathy", -1 ] ] ],
@@ -78,14 +73,10 @@
         "id": "EOC_PRACTICE_TELEPATH_MIND_SENSE",
         "condition": { "math": [ "u_spell_level('telepathic_mind_sense')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('telepathic_mind_sense')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(2)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "telepathic_mind_sense", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_telepathy", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "2" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ]
       }
     ]
@@ -100,7 +91,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 1,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_telepathy", "required": false } ],
     "tools": [ [ [ "matrix_crystal_drained", -1 ], [ "black_nether_crystal_pseudo_tool", -1 ], [ "matrix_crystal_telepathy", -1 ] ] ],
@@ -110,14 +101,10 @@
         "id": "EOC_PRACTICE_TELEPATH_SHIELD",
         "condition": { "math": [ "u_spell_level('telepathic_shield')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('telepathic_shield')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(2)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "telepathic_shield", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_telepathy", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "2" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -179,7 +166,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 2,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_telepathy", "required": false } ],
     "tools": [ [ [ "matrix_crystal_drained", -1 ], [ "black_nether_crystal_pseudo_tool", -1 ], [ "matrix_crystal_telepathy", -1 ] ] ],
@@ -189,14 +176,10 @@
         "id": "EOC_PRACTICE_TELEPATH_MORALE",
         "condition": { "math": [ "u_spell_level('telepathic_morale')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('telepathic_morale')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(3)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "telepathic_morale", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_telepathy", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "3" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -258,7 +241,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 3,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_telepathy", "required": false } ],
     "tools": [ [ [ "matrix_crystal_drained", -1 ], [ "black_nether_crystal_pseudo_tool", -1 ], [ "matrix_crystal_telepathy", -1 ] ] ],
@@ -269,14 +252,10 @@
         "id": "EOC_PRACTICE_TELEPATHIC_BLAST",
         "condition": { "math": [ "u_spell_level('telepathic_blast')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('telepathic_blast')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(4)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "telepathic_blast", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_telepathy", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "4" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -338,7 +317,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 3,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_telepathy", "required": false } ],
     "tools": [ [ [ "matrix_crystal_drained", -1 ], [ "black_nether_crystal_pseudo_tool", -1 ], [ "matrix_crystal_telepathy", -1 ] ] ],
@@ -349,14 +328,10 @@
         "id": "EOC_PRACTICE_TELEPATHIC_ANIMAL_MIND_CONTROL",
         "condition": { "math": [ "u_spell_level('telepathic_animal_mind_control')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('telepathic_animal_mind_control')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(4)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "telepathic_animal_mind_control", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_telepathy", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "4" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -418,7 +393,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 4,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_telepathy", "required": false } ],
     "tools": [ [ [ "matrix_crystal_drained", -1 ], [ "black_nether_crystal_pseudo_tool", -1 ], [ "matrix_crystal_telepathy", -1 ] ] ],
@@ -429,14 +404,10 @@
         "id": "EOC_PRACTICE_TELEPATH_CONFUSION",
         "condition": { "math": [ "u_spell_level('telepathic_confusion')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('telepathic_confusion')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(5)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "telepathic_confusion", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_telepathy", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "5" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -498,7 +469,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 5,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_telepathy", "required": false } ],
     "tools": [ [ [ "matrix_crystal_drained", -1 ], [ "black_nether_crystal_pseudo_tool", -1 ], [ "matrix_crystal_telepathy", -1 ] ] ],
@@ -509,14 +480,10 @@
         "id": "EOC_PRACTICE_TELEPATH_OBSCURITY",
         "condition": { "math": [ "u_spell_level('telepathic_invisibility')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('telepathic_invisibility')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(6)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "telepathic_invisibility", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_telepathy", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "6" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -578,7 +545,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 5,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_telepathy", "required": false } ],
     "tools": [ [ [ "matrix_crystal_drained", -1 ], [ "black_nether_crystal_pseudo_tool", -1 ], [ "matrix_crystal_telepathy", -1 ] ] ],
@@ -589,14 +556,10 @@
         "id": "EOC_PRACTICE_TELEPATH_PRIMAL_FEAR",
         "condition": { "math": [ "u_spell_level('telepathic_fear')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('telepathic_fear')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(6)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "telepathic_fear", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_telepathy", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "6" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -658,7 +621,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 6,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_telepathy", "required": false } ],
     "tools": [ [ [ "matrix_crystal_drained", -1 ], [ "black_nether_crystal_pseudo_tool", -1 ], [ "matrix_crystal_telepathy", -1 ] ] ],
@@ -669,14 +632,10 @@
         "id": "EOC_PRACTICE_TELEPATH_SCREAM_RADIUS",
         "condition": { "math": [ "u_spell_level('telepathic_blast_radius')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('telepathic_blast_radius')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(7)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "telepathic_blast_radius", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_telepathy", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "7" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -738,7 +697,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 6,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_telepathy", "required": false } ],
     "tools": [ [ [ "matrix_crystal_drained", -1 ], [ "black_nether_crystal_pseudo_tool", -1 ], [ "matrix_crystal_telepathy", -1 ] ] ],
@@ -749,14 +708,10 @@
         "id": "EOC_PRACTICE_TELEPATH_BEAST_TAMING",
         "condition": { "math": [ "u_spell_level('telepathic_beast_taming')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('telepathic_beast_taming')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(7)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "telepathic_beast_taming", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_telepathy", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "7" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -818,7 +773,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 7,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_telepathy", "required": false } ],
     "tools": [ [ [ "matrix_crystal_drained", -1 ], [ "black_nether_crystal_pseudo_tool", -1 ], [ "matrix_crystal_telepathy", -1 ] ] ],
@@ -829,14 +784,10 @@
         "id": "EOC_PRACTICE_TELEPATH_MIND_CONTROL",
         "condition": { "math": [ "u_spell_level('telepathic_mind_control')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('telepathic_mind_control')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(8)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "telepathic_mind_control", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_telepathy", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "8" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -898,7 +849,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 8,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_telepathy", "required": false } ],
     "tools": [ [ [ "matrix_crystal_drained", -1 ], [ "black_nether_crystal_pseudo_tool", -1 ], [ "matrix_crystal_telepathy", -1 ] ] ],
@@ -909,14 +860,10 @@
         "id": "EOC_PRACTICE_TELEPATH_NETWORK_EFFECT",
         "condition": { "math": [ "u_spell_level('telepathic_network')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('telepathic_network')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(9)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "telepathic_network", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_telepathy", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "9" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },

--- a/data/mods/MindOverMatter/recipes/practice/telepathy_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/telepathy_practice.json
@@ -45,10 +45,13 @@
         "id": "EOC_PRACTICE_TELEPATH_CONCENTRATION",
         "condition": { "math": [ "u_spell_level('telepathic_concentration')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "telepathic_concentration", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_telepathy", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "telepathic_concentration", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_telepathy",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "1" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ]
       }
     ]
@@ -73,10 +76,13 @@
         "id": "EOC_PRACTICE_TELEPATH_MIND_SENSE",
         "condition": { "math": [ "u_spell_level('telepathic_mind_sense')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "telepathic_mind_sense", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_telepathy", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "telepathic_mind_sense", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_telepathy",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "2" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ]
       }
     ]
@@ -101,10 +107,13 @@
         "id": "EOC_PRACTICE_TELEPATH_SHIELD",
         "condition": { "math": [ "u_spell_level('telepathic_shield')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "telepathic_shield", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_telepathy", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "telepathic_shield", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_telepathy",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "2" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -176,10 +185,13 @@
         "id": "EOC_PRACTICE_TELEPATH_MORALE",
         "condition": { "math": [ "u_spell_level('telepathic_morale')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "telepathic_morale", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_telepathy", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "telepathic_morale", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_telepathy",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "3" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -252,10 +264,13 @@
         "id": "EOC_PRACTICE_TELEPATHIC_BLAST",
         "condition": { "math": [ "u_spell_level('telepathic_blast')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "telepathic_blast", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_telepathy", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "telepathic_blast", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_telepathy",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "4" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -328,10 +343,13 @@
         "id": "EOC_PRACTICE_TELEPATHIC_ANIMAL_MIND_CONTROL",
         "condition": { "math": [ "u_spell_level('telepathic_animal_mind_control')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "telepathic_animal_mind_control", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_telepathy", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "telepathic_animal_mind_control", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_telepathy",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "4" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -404,10 +422,13 @@
         "id": "EOC_PRACTICE_TELEPATH_CONFUSION",
         "condition": { "math": [ "u_spell_level('telepathic_confusion')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "telepathic_confusion", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_telepathy", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "telepathic_confusion", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_telepathy",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "5" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -480,10 +501,13 @@
         "id": "EOC_PRACTICE_TELEPATH_OBSCURITY",
         "condition": { "math": [ "u_spell_level('telepathic_invisibility')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "telepathic_invisibility", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_telepathy", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "telepathic_invisibility", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_telepathy",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "6" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -556,10 +580,13 @@
         "id": "EOC_PRACTICE_TELEPATH_PRIMAL_FEAR",
         "condition": { "math": [ "u_spell_level('telepathic_fear')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "telepathic_fear", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_telepathy", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "telepathic_fear", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_telepathy",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "6" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -632,10 +659,13 @@
         "id": "EOC_PRACTICE_TELEPATH_SCREAM_RADIUS",
         "condition": { "math": [ "u_spell_level('telepathic_blast_radius')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "telepathic_blast_radius", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_telepathy", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "telepathic_blast_radius", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_telepathy",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "7" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -708,10 +738,13 @@
         "id": "EOC_PRACTICE_TELEPATH_BEAST_TAMING",
         "condition": { "math": [ "u_spell_level('telepathic_beast_taming')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "telepathic_beast_taming", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_telepathy", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "telepathic_beast_taming", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_telepathy",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "7" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -784,10 +817,13 @@
         "id": "EOC_PRACTICE_TELEPATH_MIND_CONTROL",
         "condition": { "math": [ "u_spell_level('telepathic_mind_control')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "telepathic_mind_control", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_telepathy", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "telepathic_mind_control", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_telepathy",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "8" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -860,10 +896,13 @@
         "id": "EOC_PRACTICE_TELEPATH_NETWORK_EFFECT",
         "condition": { "math": [ "u_spell_level('telepathic_network')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "telepathic_network", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_telepathy", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "telepathic_network", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_telepathy",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "9" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },

--- a/data/mods/MindOverMatter/recipes/practice/teleportation_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/teleportation_practice.json
@@ -45,10 +45,13 @@
         "id": "EOC_PRACTICE_TELEPORT_BLINK",
         "condition": { "math": [ "u_spell_level('teleport_blink')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "teleport_blink", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_teleportation", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "teleport_blink", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_teleportation",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "1" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ]
       }
     ]
@@ -75,10 +78,13 @@
         "id": "EOC_PRACTICE_TELEPORT_SLOW",
         "condition": { "math": [ "u_spell_level('teleport_slow')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "teleport_slow", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_teleportation", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "teleport_slow", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_teleportation",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "2" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ]
       }
     ]
@@ -105,10 +111,13 @@
         "id": "EOC_PRACTICE_TELEPORT_PHASE",
         "condition": { "math": [ "u_spell_level('teleport_phase')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "teleport_phase", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_teleportation", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "teleport_phase", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_teleportation",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "2" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -186,10 +195,13 @@
         "id": "EOC_PRACTICE_TELEPORT_STRIDE",
         "condition": { "math": [ "u_spell_level('teleport_stride')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "teleport_stride", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_teleportation", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "teleport_stride", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_teleportation",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "3" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -267,10 +279,13 @@
         "id": "EOC_PRACTICE_TELEPORT_SWAP",
         "condition": { "math": [ "u_spell_level('teleport_transpose')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "teleport_transpose", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_teleportation", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "teleport_transpose", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_teleportation",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "4" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -349,10 +364,13 @@
         "id": "EOC_PRACTICE_TELEPORT_DISPLACEMENT",
         "condition": { "math": [ "u_spell_level('teleport_displacement')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "teleport_displacement", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_teleportation", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "teleport_displacement", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_teleportation",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "4" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -431,10 +449,13 @@
         "id": "EOC_PRACTICE_TELEPORT_COLLAPSE",
         "condition": { "math": [ "u_spell_level('teleport_collapse')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "teleport_collapse", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_teleportation", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "teleport_collapse", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_teleportation",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "5" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -513,10 +534,13 @@
         "id": "EOC_PRACTICE_TELEPORT_FARSTEP",
         "condition": { "math": [ "u_spell_level('teleport_farstep')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "teleport_farstep", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_teleportation", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "teleport_farstep", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_teleportation",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "6" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -595,10 +619,13 @@
         "id": "EOC_PRACTICE_TELEPORT_BANISH",
         "condition": { "math": [ "u_spell_level('teleport_banish')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "teleport_banish", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_teleportation", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "teleport_banish", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_teleportation",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "7" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -676,11 +703,14 @@
       {
         "id": "EOC_PRACTICE_TELEPORT_GATEWAY",
         "condition": { "math": [ "u_spell_level('teleport_gateway')", ">=", "1" ] },
-        "effect": [                   
-          { "set_string_var": "teleport_gateway", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_teleportation", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+        "effect": [
+          { "set_string_var": "teleport_gateway", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_teleportation",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "8" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -760,10 +790,13 @@
         "id": "EOC_PRACTICE_TELEPORT_BREACH",
         "condition": { "math": [ "u_spell_level('teleport_summon')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "teleport_summon", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_teleportation", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "teleport_summon", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_teleportation",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "9" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },

--- a/data/mods/MindOverMatter/recipes/practice/teleportation_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/teleportation_practice.json
@@ -2,7 +2,6 @@
   {
     "id": "teleportation_practice",
     "type": "nested_category",
-    "//": "XP for level 12 is 49417, for level 10 is 35279, for level 7 is 20514",
     "activity_level": "LIGHT_EXERCISE",
     "category": "CC_PRACTICE",
     "subcategory": "CSC_PRACTICE_METAPHYSICS",
@@ -34,7 +33,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 0,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_teleportation", "required": false } ],
     "tools": [
@@ -46,14 +45,10 @@
         "id": "EOC_PRACTICE_TELEPORT_BLINK",
         "condition": { "math": [ "u_spell_level('teleport_blink')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('teleport_blink')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(1)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "teleport_blink", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_teleportation", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "1" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ]
       }
     ]
@@ -68,7 +63,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 1,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_teleportation", "required": false } ],
     "tools": [
@@ -80,14 +75,10 @@
         "id": "EOC_PRACTICE_TELEPORT_SLOW",
         "condition": { "math": [ "u_spell_level('teleport_slow')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('teleport_slow')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 0,2 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(2)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "teleport_slow", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_teleportation", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "2" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ]
       }
     ]
@@ -102,7 +93,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 1,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_teleportation", "required": false } ],
     "tools": [
@@ -114,14 +105,10 @@
         "id": "EOC_PRACTICE_TELEPORT_PHASE",
         "condition": { "math": [ "u_spell_level('teleport_phase')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('teleport_phase')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(2)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "teleport_phase", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_teleportation", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "2" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -187,7 +174,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 2,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_teleportation", "required": false } ],
     "tools": [
@@ -199,14 +186,10 @@
         "id": "EOC_PRACTICE_TELEPORT_STRIDE",
         "condition": { "math": [ "u_spell_level('teleport_stride')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('teleport_stride')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(3)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "teleport_stride", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_teleportation", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "3" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -272,7 +255,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 3,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_teleportation", "required": false } ],
     "tools": [
@@ -284,14 +267,10 @@
         "id": "EOC_PRACTICE_TELEPORT_SWAP",
         "condition": { "math": [ "u_spell_level('teleport_transpose')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('teleport_transpose')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(4)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "teleport_transpose", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_teleportation", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "4" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -357,7 +336,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 3,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_teleportation", "required": false } ],
     "tools": [
@@ -370,14 +349,10 @@
         "id": "EOC_PRACTICE_TELEPORT_DISPLACEMENT",
         "condition": { "math": [ "u_spell_level('teleport_displacement')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('teleport_displacement')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(4)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "teleport_displacement", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_teleportation", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "4" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -443,7 +418,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 4,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_teleportation", "required": false } ],
     "tools": [
@@ -456,14 +431,10 @@
         "id": "EOC_PRACTICE_TELEPORT_COLLAPSE",
         "condition": { "math": [ "u_spell_level('teleport_collapse')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('teleport_collapse')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(5)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "teleport_collapse", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_teleportation", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "5" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -529,7 +500,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 5,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_teleportation", "required": false } ],
     "tools": [
@@ -542,14 +513,10 @@
         "id": "EOC_PRACTICE_TELEPORT_FARSTEP",
         "condition": { "math": [ "u_spell_level('teleport_farstep')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('teleport_farstep')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(6)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "teleport_farstep", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_teleportation", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "6" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -615,7 +582,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 6,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_teleportation", "required": false } ],
     "tools": [
@@ -628,14 +595,10 @@
         "id": "EOC_PRACTICE_TELEPORT_BANISH",
         "condition": { "math": [ "u_spell_level('teleport_banish')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('teleport_banish')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(7)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "teleport_banish", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_teleportation", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "7" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -701,7 +664,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 7,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_teleportation", "required": false } ],
     "tools": [
@@ -713,15 +676,11 @@
       {
         "id": "EOC_PRACTICE_TELEPORT_GATEWAY",
         "condition": { "math": [ "u_spell_level('teleport_gateway')", ">=", "1" ] },
-        "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('teleport_gateway')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(8)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+        "effect": [                   
+          { "set_string_var": "teleport_gateway", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_teleportation", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "8" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -788,7 +747,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 8,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_teleportation", "required": false } ],
     "tools": [
@@ -801,14 +760,10 @@
         "id": "EOC_PRACTICE_TELEPORT_BREACH",
         "condition": { "math": [ "u_spell_level('teleport_summon')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('teleport_summon')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(9)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "teleport_summon", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_teleportation", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "9" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },

--- a/data/mods/MindOverMatter/recipes/practice/vitakinesis_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/vitakinesis_practice.json
@@ -52,10 +52,13 @@
         "id": "EOC_PRACTICE_VITAKIN_HEALTH",
         "condition": { "math": [ "u_spell_level('vita_health_power')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "vita_health_power", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_vitakinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "vita_health_power", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_vitakinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "1" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ]
       }
     ]
@@ -82,10 +85,13 @@
         "id": "EOC_PRACTICE_VITAKIN_SLOW_BLEEDING",
         "condition": { "math": [ "u_spell_level('vita_slow_bleeding')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "vita_slow_bleeding", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_vitakinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "vita_slow_bleeding", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_vitakinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "1" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ]
       }
     ]
@@ -112,10 +118,13 @@
         "id": "EOC_PRACTICE_VITAKIN_STAUNCHING",
         "condition": { "math": [ "u_spell_level('vita_stop_bleeding')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "vita_stop_bleeding", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_vitakinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "vita_stop_bleeding", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_vitakinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "2" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -193,10 +202,13 @@
         "id": "EOC_PRACTICE_VITAKIN_HURT",
         "condition": { "math": [ "u_spell_level('vita_hurt_touch')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "vita_hurt_touch", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_vitakinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "vita_hurt_touch", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_vitakinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "3" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -274,10 +286,13 @@
         "id": "EOC_PRACTICE_VITAKIN_HEAL_TOUCH_ALLY",
         "condition": { "math": [ "u_spell_level('vita_health_power_ally')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "vita_health_power_ally", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_vitakinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "vita_health_power_ally", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_vitakinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "3" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -355,10 +370,13 @@
         "id": "EOC_PRACTICE_VITAKIN_REMOVE_POISON",
         "condition": { "math": [ "u_spell_level('vita_remove_poison')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "vita_remove_poison", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_vitakinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "vita_remove_poison", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_vitakinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "3" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -437,10 +455,13 @@
         "id": "EOC_PRACTICE_VITAKIN_SLEEP",
         "condition": { "math": [ "u_spell_level('vita_sleeping_trance')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "vita_sleeping_trance", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_vitakinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "vita_sleeping_trance", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_vitakinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "4" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -519,10 +540,13 @@
         "id": "EOC_PRACTICE_VITAKIN_CURE_DISEASE",
         "condition": { "math": [ "u_spell_level('vita_cure_disease')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "vita_cure_disease", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_vitakinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "vita_cure_disease", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_vitakinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "4" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -601,10 +625,13 @@
         "id": "EOC_PRACTICE_VITAKIN_DAMAGE_BALANCE",
         "condition": { "math": [ "u_spell_level('vita_pain_split')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "vita_pain_split", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_vitakinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "vita_pain_split", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_vitakinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "5" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -683,10 +710,13 @@
         "id": "EOC_PRACTICE_VITAKIN_STOP_INFECTION",
         "condition": { "math": [ "u_spell_level('vita_stop_infection')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "vita_stop_infection", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_vitakinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "vita_stop_infection", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_vitakinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "5" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -765,10 +795,13 @@
         "id": "EOC_PRACTICE_VITAKIN_HEALING_TRANCE",
         "condition": { "math": [ "u_spell_level('vita_healing_trance')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "vita_healing_trance", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_vitakinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "vita_healing_trance", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_vitakinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "6" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -847,10 +880,13 @@
         "id": "EOC_PRACTICE_VITAKIN_PURGE_RADS",
         "condition": { "math": [ "u_spell_level('vita_purge_rads')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "vita_purge_rads", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_vitakinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "vita_purge_rads", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_vitakinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "6" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ]
       }
     ]
@@ -877,10 +913,13 @@
         "id": "EOC_PRACTICE_VITAKIN_ATTACK_TOUCH",
         "condition": { "math": [ "u_spell_level('vita_attack_touch')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "vita_attack_touch", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_vitakinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "vita_attack_touch", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_vitakinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "6" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -959,10 +998,13 @@
         "id": "EOC_PRACTICE_VITAKIN_PURGE",
         "condition": { "math": [ "u_spell_level('vita_blood_purge')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "vita_blood_purge", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_vitakinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "vita_blood_purge", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_vitakinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "7" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -1041,10 +1083,13 @@
         "id": "EOC_PRACTICE_VITAKIN_BANISH_ILLNESS",
         "condition": { "math": [ "u_spell_level('vita_banish_illness')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "vita_banish_illness", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_vitakinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "vita_banish_illness", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_vitakinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "8" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -1123,10 +1168,13 @@
         "id": "EOC_PRACTICE_VITAKIN_SUPER_HEAL",
         "condition": { "math": [ "u_spell_level('vita_super_heal')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "vita_super_heal", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_vitakinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "vita_super_heal", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_vitakinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "9" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -1205,10 +1253,13 @@
         "id": "EOC_PRACTICE_VITAKIN_LIMB_RESTORE",
         "condition": { "math": [ "u_spell_level('vita_limb_restore')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "vita_limb_restore", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_vitakinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "vita_limb_restore", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_vitakinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "9" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ]
       }
     ]
@@ -1236,10 +1287,13 @@
         "id": "EOC_PRACTICE_VITAKIN_RETURN_FROM_DEATH",
         "condition": { "math": [ "u_spell_level('vita_return_from_death')", ">=", "1" ] },
         "effect": [
-          { "set_string_var": "vita_return_from_death", "target_var": { "u_val": "latest_studied_power_name" } },   
-          { "set_string_var": "prof_contemplation_vitakinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "set_string_var": "vita_return_from_death", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_vitakinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
           { "math": [ "u_latest_studied_power_difficulty", "=", "10" ] },
-          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },

--- a/data/mods/MindOverMatter/recipes/practice/vitakinesis_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/vitakinesis_practice.json
@@ -2,7 +2,6 @@
   {
     "id": "vitakinesis_practice",
     "type": "nested_category",
-    "//": "XP for level 12 is 49417, for level 10 is 35279, for level 7 is 20514",
     "activity_level": "LIGHT_EXERCISE",
     "category": "CC_PRACTICE",
     "subcategory": "CSC_PRACTICE_METAPHYSICS",
@@ -41,7 +40,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 0,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_vitakinesis", "required": false } ],
     "tools": [
@@ -53,14 +52,10 @@
         "id": "EOC_PRACTICE_VITAKIN_HEALTH",
         "condition": { "math": [ "u_spell_level('vita_health_power')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('vita_health_power')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(1)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "vita_health_power", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_vitakinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "1" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ]
       }
     ]
@@ -75,7 +70,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 0,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_vitakinesis", "required": false } ],
     "tools": [
@@ -87,14 +82,10 @@
         "id": "EOC_PRACTICE_VITAKIN_SLOW_BLEEDING",
         "condition": { "math": [ "u_spell_level('vita_slow_bleeding')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('vita_slow_bleeding')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(1)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "vita_slow_bleeding", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_vitakinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "1" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ]
       }
     ]
@@ -109,7 +100,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 1,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_vitakinesis", "required": false } ],
     "tools": [
@@ -121,14 +112,10 @@
         "id": "EOC_PRACTICE_VITAKIN_STAUNCHING",
         "condition": { "math": [ "u_spell_level('vita_stop_bleeding')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('vita_stop_bleeding')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(2)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "vita_stop_bleeding", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_vitakinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "2" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -194,7 +181,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 2,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_vitakinesis", "required": false } ],
     "tools": [
@@ -206,14 +193,10 @@
         "id": "EOC_PRACTICE_VITAKIN_HURT",
         "condition": { "math": [ "u_spell_level('vita_hurt_touch')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('vita_hurt_touch')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(3)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "vita_hurt_touch", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_vitakinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "3" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -279,7 +262,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 2,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_vitakinesis", "required": false } ],
     "tools": [
@@ -291,14 +274,10 @@
         "id": "EOC_PRACTICE_VITAKIN_HEAL_TOUCH_ALLY",
         "condition": { "math": [ "u_spell_level('vita_health_power_ally')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('vita_health_power_ally')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(3)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "vita_health_power_ally", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_vitakinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "3" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -364,7 +343,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 2,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_vitakinesis", "required": false } ],
     "tools": [
@@ -376,14 +355,10 @@
         "id": "EOC_PRACTICE_VITAKIN_REMOVE_POISON",
         "condition": { "math": [ "u_spell_level('vita_remove_poison')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('vita_remove_poison')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(3)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "vita_remove_poison", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_vitakinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "3" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -449,7 +424,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 3,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_vitakinesis", "required": false } ],
     "tools": [
@@ -462,14 +437,10 @@
         "id": "EOC_PRACTICE_VITAKIN_SLEEP",
         "condition": { "math": [ "u_spell_level('vita_sleeping_trance')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('vita_sleeping_trance')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(4)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "vita_sleeping_trance", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_vitakinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "4" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -535,7 +506,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 3,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_vitakinesis", "required": false } ],
     "tools": [
@@ -548,14 +519,10 @@
         "id": "EOC_PRACTICE_VITAKIN_CURE_DISEASE",
         "condition": { "math": [ "u_spell_level('vita_cure_disease')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('vita_cure_disease')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(4)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "vita_cure_disease", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_vitakinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "4" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -621,7 +588,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 4,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_vitakinesis", "required": false } ],
     "tools": [
@@ -634,14 +601,10 @@
         "id": "EOC_PRACTICE_VITAKIN_DAMAGE_BALANCE",
         "condition": { "math": [ "u_spell_level('vita_pain_split')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('vita_pain_split')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(5)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "vita_pain_split", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_vitakinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "5" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -707,7 +670,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 4,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_vitakinesis", "required": false } ],
     "tools": [
@@ -720,14 +683,10 @@
         "id": "EOC_PRACTICE_VITAKIN_STOP_INFECTION",
         "condition": { "math": [ "u_spell_level('vita_stop_infection')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('vita_stop_infection')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(5)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "vita_stop_infection", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_vitakinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "5" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -793,7 +752,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 5,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_vitakinesis", "required": false } ],
     "tools": [
@@ -806,14 +765,10 @@
         "id": "EOC_PRACTICE_VITAKIN_HEALING_TRANCE",
         "condition": { "math": [ "u_spell_level('vita_healing_trance')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('vita_healing_trance')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(6)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "vita_healing_trance", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_vitakinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "6" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -879,7 +834,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 5,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_vitakinesis", "required": false } ],
     "tools": [
@@ -892,14 +847,10 @@
         "id": "EOC_PRACTICE_VITAKIN_PURGE_RADS",
         "condition": { "math": [ "u_spell_level('vita_purge_rads')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('vita_purge_rads')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(6)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "vita_purge_rads", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_vitakinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "6" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ]
       }
     ]
@@ -914,7 +865,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 5,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_vitakinesis", "required": false } ],
     "tools": [
@@ -926,14 +877,10 @@
         "id": "EOC_PRACTICE_VITAKIN_ATTACK_TOUCH",
         "condition": { "math": [ "u_spell_level('vita_attack_touch')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('vita_attack_touch')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(6)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "vita_attack_touch", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_vitakinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "6" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -999,7 +946,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 6,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_vitakinesis", "required": false } ],
     "tools": [
@@ -1012,14 +959,10 @@
         "id": "EOC_PRACTICE_VITAKIN_PURGE",
         "condition": { "math": [ "u_spell_level('vita_blood_purge')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('vita_blood_purge')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(7)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "vita_blood_purge", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_vitakinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "7" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -1085,7 +1028,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 7,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_vitakinesis", "required": false } ],
     "tools": [
@@ -1098,14 +1041,10 @@
         "id": "EOC_PRACTICE_VITAKIN_BANISH_ILLNESS",
         "condition": { "math": [ "u_spell_level('vita_banish_illness')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('vita_banish_illness')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(8)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "vita_banish_illness", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_vitakinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "8" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -1171,7 +1110,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 8,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_vitakinesis", "required": false } ],
     "tools": [
@@ -1184,14 +1123,10 @@
         "id": "EOC_PRACTICE_VITAKIN_SUPER_HEAL",
         "condition": { "math": [ "u_spell_level('vita_super_heal')", ">=", "1" ] },
         "effect": [
-          {
-            "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge.",
-            "type": "good"
-          },
-          { "math": [ "u_spell_exp('vita_super_heal')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(9)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "vita_super_heal", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_vitakinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "9" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },
@@ -1257,24 +1192,23 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 9,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_vitakinesis", "required": false } ],
     "tools": [
       [ [ "matrix_crystal_drained", -1 ], [ "black_nether_crystal_pseudo_tool", -1 ], [ "matrix_crystal_vitakinesis", -1 ] ]
     ],
-    "components": [ [ [ "matrix_crystal_vitakin_dust", 2 ] ] ],
+    "components": [ [ [ "matrix_crystal_vitakin_dust", 1 ] ] ],
     "flags": [ "SECRET", "BLIND_EASY", "NO_MANIP", "AFFECTED_BY_PAIN", "NO_BENCH", "NO_ENCHANTMENT" ],
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_VITAKIN_LIMB_RESTORE",
         "condition": { "math": [ "u_spell_level('vita_limb_restore')", ">=", "1" ] },
         "effect": [
-          { "u_message": "You spend a lot of time meditating and contemplating your powers and emerge with new knowledge." },
-          { "math": [ "u_spell_exp('vita_limb_restore')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(10)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "vita_limb_restore", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_vitakinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "9" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ]
       }
     ]
@@ -1289,7 +1223,7 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
     "difficulty": 9,
-    "time": "30 m",
+    "time": "30 s",
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_contemplation_vitakinesis", "required": false } ],
     "tools": [
@@ -1302,11 +1236,10 @@
         "id": "EOC_PRACTICE_VITAKIN_RETURN_FROM_DEATH",
         "condition": { "math": [ "u_spell_level('vita_return_from_death')", ">=", "1" ] },
         "effect": [
-          { "u_message": "You spend a lot of time meditating and contemplating your powers and emerge with new knowledge." },
-          { "math": [ "u_spell_exp('vita_return_from_death')", "+=", "(contemplation_factor(1))" ] },
-          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 1,10 )" ] },
-          { "math": [ "u_calories()", "-=", "psionics_contemplation_kcal_cost(10)" ] },
-          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+          { "set_string_var": "vita_return_from_death", "target_var": { "u_val": "latest_studied_power_name" } },   
+          { "set_string_var": "prof_contemplation_vitakinesis", "target_var": { "u_val": "latest_studied_power_proficiency" } },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "10" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]  }
         ],
         "false_effect": [
           { "u_message": "You attempt to unlock new capabilities within your mind." },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Write single variable-based EoC for power contemplation, make it more like other meditation activities"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Crafting as a way to contemplate powers is currently necessary but it's a little weird. Though batch-crafting works now, it's back-loaded--you spend ten hours studying and then get a giant whack of Nether Attunement and calorie drain at the end, as well as all your XP, and if you're interrupted you get nothing. This was the problem with some of the powers like Wakeful Rest and I fixed them, and it's time to fix this too. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

The contemplation recipe now takes 30 seconds and then starts an activity with a `do_turn_eoc`. The activity EoC takes the power name and difficulty as variables and checks your focus, and then increments a hidden variable every second. This extra variable is necessary because power experience is an integer, but once the hidden variable hits 1, the power xp goes up by 1 and the variable is reset. Every minute you contemplate, you have a chance of losing 1 focus. Every three minutes you lose some calories (variable based on power difficulty) and have a chance of gaining Nether Attunement. And since you're no longer actually making the recipe most of the time, a separate EoC handles gaining the appropriate contemplation proficiency for whatever path you're contemplating. 

You can meditate as long as you want and cancel the activity at any time. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Generic EoCs work for both powers (appropriate power is passed through) and contemplation proficiency (appropriate path is leveled). It currently throws the "tried to learn negative without direct" error but #74641 should fix that.

Activity begins as appropriate and may be cancelled at any time. Contemplation gradually builds up Nether Attunement.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Going to have to switch the Aftershock Esper over to this too. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
