### PR TITLE
Update power_leech.json

### DIFF
--- a/data/json/monsters/power_leech.json
+++ b/data/json/monsters/power_leech.json
@@ -21,15 +21,6 @@
     "vision_night": 12,
     "luminance": 200,
     "special_attacks": [
-      {
-        "type": "gun",
-        "cooldown": 5,
-        "gun_type": "emp_frond",
-        "fake_skills": [ [ "gun", 3 ], [ "pistol", 3 ] ],
-        "ranges": [ [ 0, 12, "DEFAULT" ] ],
-        "targeting_sound": "a faint buzz",
-        "description": "Lightning arcs from the leech blossom!"
-      },
       [ "LEECH_SPAWNER", 75 ],
       [ "MON_LEECH_EVOLUTION", 40 ],
       [ "PARROT", 40 ]
@@ -64,15 +55,6 @@
     "vision_night": 8,
     "luminance": 200,
     "special_attacks": [
-      {
-        "type": "gun",
-        "cooldown": 15,
-        "gun_type": "emp_frond",
-        "fake_skills": [ [ "gun", 2 ], [ "pistol", 2 ] ],
-        "ranges": [ [ 0, 12, "DEFAULT" ] ],
-        "targeting_sound": "a faint buzz",
-        "description": "Lightning arcs from the leech stalk!"
-      },
       [ "MON_LEECH_EVOLUTION", 30 ]
     ],
     "special_when_hit": [ "ZAPBACK", 100 ],
@@ -131,14 +113,6 @@
     "morale": 100,
     "luminance": 60,
     "special_attacks": [
-      {
-        "type": "gun",
-        "cooldown": 15,
-        "gun_type": "emp_frond",
-        "ranges": [ [ 0, 1, "DEFAULT" ] ],
-        "targeting_sound": "a faint buzz",
-        "description": "Lightning arcs from the pod cluster!"
-      },
       [ "LEECH_SPAWNER", 120 ]
     ],
     "weakpoint_sets": [ "wps_power_leech" ],
@@ -174,15 +148,6 @@
     "melee_damage": [ { "damage_type": "electric", "amount": 4 } ],
     "upgrades": { "half_life": 9999, "into": "mon_leech_stalk" },
     "special_attacks": [
-      {
-        "type": "gun",
-        "cooldown": 15,
-        "gun_type": "emp_frond",
-        "fake_skills": [ [ "gun", 1 ], [ "pistol", 1 ] ],
-        "ranges": [ [ 0, 2, "DEFAULT" ] ],
-        "targeting_sound": "a faint buzz",
-        "description": "Sparks fly from the root runner!"
-      },
       [ "EVOLVE_KILL_STRIKE", 3 ]
     ],
     "special_when_hit": [ "ZAPBACK", 100 ],
@@ -218,15 +183,6 @@
     "melee_damage": [ { "damage_type": "electric", "amount": 3 } ],
     "upgrades": { "half_life": 999, "into": "mon_leech_pod_cluster" },
     "special_attacks": [
-      {
-        "type": "gun",
-        "cooldown": 15,
-        "gun_type": "emp_frond",
-        "fake_skills": [ [ "gun", 1 ], [ "pistol", 1 ] ],
-        "ranges": [ [ 0, 2, "DEFAULT" ] ],
-        "targeting_sound": "a faint buzz",
-        "description": "Lightning arcs from the root pod!"
-      },
       [ "EVOLVE_KILL_STRIKE", 6 ]
     ],
     "weakpoint_sets": [ "wps_power_leech" ],


### PR DESCRIPTION

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Remove leech plants' lightning arc attacks"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Same reasoning as the removal from skeletal creatures. Their status as extradimensional creatures did not create exception, apparently.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
I removed the "gun" special attacks from their json files.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Leaving it in or changing it to be more palatable, but I'm not sure what will satisfy palette in this case.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I removed the attacks in my own game, then started Cranberry's leech mission: went as expected, no lightning balls and no error messages.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Feel absolutely free to comment and criticize.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
