### PR TITLE
Rescale recovery chance to match previous probabilities

### DIFF
--- a/data/json/items/ammo.json
+++ b/data/json/items/ammo.json
@@ -539,7 +539,7 @@
     "dispersion": 14,
     "loudness": 0,
     "to_hit": -2,
-    "recovery_chance": 80,
+    "recovery_chance": 99,
     "effects": [ "NEVER_MISFIRES", "NON_FOULING" ],
     "melee_damage": { "cut": 9 }
   },
@@ -561,7 +561,7 @@
     "dispersion": 14,
     "loudness": 0,
     "to_hit": -1,
-    "recovery_chance": 80,
+    "recovery_chance": 99,
     "effects": [ "NEVER_MISFIRES", "NON_FOULING", "ALLOWS_BODY_BLOCK" ],
     "qualities": [ [ "HAMMER", 1 ] ],
     "melee_damage": { "bash": 7 }

--- a/data/json/items/generic/toys_and_sports.json
+++ b/data/json/items/generic/toys_and_sports.json
@@ -122,7 +122,7 @@
     "dispersion": 14,
     "loudness": 0,
     "to_hit": -3,
-    "recovery_chance": 60,
+    "recovery_chance": 98,
     "effects": [ "NEVER_MISFIRES", "NON_FOULING" ],
     "melee_damage": { "bash": 8 }
   },
@@ -164,7 +164,7 @@
     "dispersion": 12,
     "loudness": 0,
     "to_hit": 3,
-    "recovery_chance": 80,
+    "recovery_chance": 99,
     "effects": [ "NEVER_MISFIRES", "NON_FOULING" ],
     "melee_damage": { "bash": 6 }
   },

--- a/data/json/items/ranged/archery.json
+++ b/data/json/items/ranged/archery.json
@@ -12,7 +12,7 @@
     "description": "A crude pointed wooden shaft with a notch at the back.",
     "material": [ "wood" ],
     "damage": { "damage_type": "stab", "constant_damage_multiplier": 0.75 },
-    "recovery_chance": 2
+    "recovery_chance": 50
   },
   {
     "type": "AMMO",
@@ -33,7 +33,7 @@
     "dispersion": 150,
     "loudness": 0,
     "critical_multiplier": 10,
-    "recovery_chance": 30,
+    "recovery_chance": 97,
     "melee_damage": { "bash": 3 }
   },
   {
@@ -50,7 +50,7 @@
     "material": [ { "type": "wood", "portion": 81 }, { "type": "rubber", "portion": 19 } ],
     "damage": { "damage_type": "stab", "constant_damage_multiplier": 0.2 },
     "critical_multiplier": 1,
-    "recovery_chance": 35,
+    "recovery_chance": 97,
     "effects": [ "BEANBAG" ]
   },
   {
@@ -64,7 +64,7 @@
     "copy-from": "arrow_field_point_fletched",
     "price_postapoc": "15 cent",
     "damage": { "damage_type": "stab", "constant_damage_multiplier": 0.5 },
-    "recovery_chance": 10,
+    "recovery_chance": 90,
     "effects": [ "NOGIB" ]
   },
   {
@@ -78,7 +78,7 @@
     "relative": { "dispersion": -40 },
     "price": "20 USD",
     "damage": { "damage_type": "stab", "armor_penetration": 1, "constant_damage_multiplier": 1.5 },
-    "recovery_chance": 25,
+    "recovery_chance": 96,
     "melee_damage": { "bash": 2, "cut": 1 }
   },
   {
@@ -92,7 +92,7 @@
     "material": [ "wood" ],
     "copy-from": "arrow_field_point_fletched",
     "damage": { "damage_type": "stab", "constant_damage_multiplier": 0.75 },
-    "recovery_chance": 6
+    "recovery_chance": 83
   },
   {
     "type": "AMMO",
@@ -105,7 +105,7 @@
     "copy-from": "arrow_field_point_fletched",
     "price_postapoc": "25 cent",
     "damage": { "damage_type": "stab", "constant_damage_multiplier": 0.5 },
-    "recovery_chance": 35,
+    "recovery_chance": 97,
     "effects": [ "NOGIB" ]
   },
   {
@@ -121,7 +121,7 @@
     "price_postapoc": "15 cent",
     "damage": { "damage_type": "stab", "constant_damage_multiplier": 1.25 },
     "show_stats": true,
-    "recovery_chance": 8
+    "recovery_chance": 87
   },
   {
     "type": "AMMO",
@@ -135,7 +135,7 @@
     "price_postapoc": "20 cent",
     "damage": { "damage_type": "stab", "armor_penetration": 1 },
     "show_stats": true,
-    "recovery_chance": 20,
+    "recovery_chance": 95,
     "melee_damage": { "bash": 2 }
   },
   {
@@ -151,7 +151,7 @@
     "price_postapoc": "40 cent",
     "damage": { "damage_type": "stab", "armor_penetration": 1, "constant_damage_multiplier": 1.5 },
     "range": 2,
-    "recovery_chance": 35,
+    "recovery_chance": 97,
     "melee_damage": { "bash": 3, "cut": 2 }
   },
   {
@@ -167,7 +167,7 @@
     "price_postapoc": "40 cent",
     "damage": { "damage_type": "stab", "armor_penetration": 3 },
     "range": 2,
-    "recovery_chance": 40,
+    "recovery_chance": 97,
     "melee_damage": { "bash": 3, "cut": 2 }
   },
   {
@@ -184,7 +184,7 @@
     "relative": { "dispersion": -75 },
     "damage": { "damage_type": "stab", "constant_damage_multiplier": 0.5 },
     "range": 2,
-    "recovery_chance": 45,
+    "recovery_chance": 98,
     "effects": [ "NOGIB" ]
   },
   {
@@ -201,7 +201,7 @@
     "price_postapoc": "50 cent",
     "damage": { "damage_type": "stab", "constant_damage_multiplier": 1.75 },
     "range": 4,
-    "recovery_chance": 30,
+    "recovery_chance": 97,
     "melee_damage": { "bash": 1 }
   },
   {
@@ -249,7 +249,7 @@
     "count": 1,
     "stack_size": 1,
     "critical_multiplier": 10,
-    "recovery_chance": 35,
+    "recovery_chance": 97,
     "use_action": {
       "target": "arrow_flamming",
       "target_timer": "20 seconds",
@@ -270,7 +270,7 @@
     "symbol": "=",
     "color": "brown",
     "revert_to": "arrow_field_point_fletched",
-    "recovery_chance": 35,
+    "recovery_chance": 97,
     "effects": [ "IGNITE" ],
     "flags": [ "TRADER_AVOID" ]
   },

--- a/data/json/items/ranged/atlatl.json
+++ b/data/json/items/ranged/atlatl.json
@@ -53,7 +53,7 @@
     "dispersion": 35,
     "loudness": 0,
     "critical_multiplier": 15,
-    "recovery_chance": 30,
+    "recovery_chance": 97,
     "melee_damage": { "stab": 10 }
   },
   {
@@ -74,7 +74,7 @@
     "dispersion": 35,
     "loudness": 0,
     "critical_multiplier": 15,
-    "recovery_chance": 25,
+    "recovery_chance": 96,
     "melee_damage": { "stab": 8 }
   },
   {
@@ -95,7 +95,7 @@
     "dispersion": 50,
     "loudness": 0,
     "critical_multiplier": 8,
-    "recovery_chance": 6,
+    "recovery_chance": 83,
     "melee_damage": { "stab": 5 }
   }
 ]

--- a/data/json/items/ranged/ballista.json
+++ b/data/json/items/ranged/ballista.json
@@ -48,7 +48,7 @@
     "dispersion": 35,
     "loudness": 5,
     "critical_multiplier": 2,
-    "recovery_chance": 50,
+    "recovery_chance": 98,
     "melee_damage": { "stab": 12 }
   }
 ]

--- a/data/json/items/ranged/crossbows.json
+++ b/data/json/items/ranged/crossbows.json
@@ -11,7 +11,7 @@
     "price": "0 cent",
     "price_postapoc": "20 cent",
     "damage": { "damage_type": "stab", "constant_damage_multiplier": 0.75 },
-    "recovery_chance": 2
+    "recovery_chance": 50
   },
   {
     "type": "AMMO",
@@ -26,7 +26,7 @@
     "price": "5 USD",
     "price_postapoc": "25 cent",
     "damage": { "damage_type": "stab", "constant_damage_multiplier": 0.75 },
-    "recovery_chance": 6
+    "recovery_chance": 83
   },
   {
     "type": "AMMO",
@@ -41,7 +41,7 @@
     "price": "6 USD 50 cent",
     "price_postapoc": "25 cent",
     "damage": { "damage_type": "stab", "constant_damage_multiplier": 0.5 },
-    "recovery_chance": 10,
+    "recovery_chance": 90,
     "effects": [ "NOGIB" ]
   },
   {
@@ -58,7 +58,7 @@
     "price_postapoc": "30 cent",
     "damage": { "damage_type": "stab", "constant_damage_multiplier": 1.25 },
     "show_stats": true,
-    "recovery_chance": 8
+    "recovery_chance": 87
   },
   {
     "type": "AMMO",
@@ -70,7 +70,7 @@
     "copy-from": "bolt_wood_bodkin",
     "relative": { "dispersion": 10 },
     "damage": { "damage_type": "stab", "constant_damage_multiplier": 1.5, "armor_penetration": 1 },
-    "recovery_chance": 25
+    "recovery_chance": 96
   },
   {
     "type": "AMMO",
@@ -90,7 +90,7 @@
     "dispersion": 100,
     "loudness": 0,
     "critical_multiplier": 10,
-    "recovery_chance": 30,
+    "recovery_chance": 97,
     "melee_damage": { "bash": 3 }
   },
   {
@@ -103,7 +103,7 @@
     "copy-from": "bolt_wood_bodkin",
     "relative": { "dispersion": 30 },
     "damage": { "damage_type": "stab", "constant_damage_multiplier": 0.5 },
-    "recovery_chance": 35,
+    "recovery_chance": 97,
     "effects": [ "NOGIB" ]
   },
   {
@@ -117,7 +117,7 @@
     "relative": { "dispersion": 80 },
     "damage": { "damage_type": "stab", "constant_damage_multiplier": 1.25, "armor_penetration": 1 },
     "show_stats": true,
-    "recovery_chance": 20
+    "recovery_chance": 95
   },
   {
     "type": "AMMO",
@@ -133,7 +133,7 @@
     "price_postapoc": "50 cent",
     "damage": { "damage_type": "stab", "constant_damage_multiplier": 1.5, "armor_penetration": 2 },
     "range": 2,
-    "recovery_chance": 35
+    "recovery_chance": 97
   },
   {
     "type": "AMMO",
@@ -149,7 +149,7 @@
     "price_postapoc": "50 cent",
     "damage": { "damage_type": "stab", "armor_penetration": 4 },
     "range": 2,
-    "recovery_chance": 40
+    "recovery_chance": 97
   },
   {
     "type": "AMMO",
@@ -163,7 +163,7 @@
     "relative": { "dispersion": -30 },
     "damage": { "damage_type": "stab", "constant_damage_multiplier": 0.5 },
     "range": 2,
-    "recovery_chance": 45,
+    "recovery_chance": 98,
     "effects": [ "NOGIB" ]
   },
   {
@@ -180,7 +180,7 @@
     "price_postapoc": "60 cent",
     "damage": { "damage_type": "stab", "constant_damage_multiplier": 1.75 },
     "range": 4,
-    "recovery_chance": 30
+    "recovery_chance": 97
   },
   {
     "id": "bullet_crossbow",

--- a/data/json/items/ranged/spearguns.json
+++ b/data/json/items/ranged/spearguns.json
@@ -19,7 +19,7 @@
     "dispersion": 150,
     "loudness": 0,
     "count": 4,
-    "recovery_chance": 5,
+    "recovery_chance": 80,
     "melee_damage": { "bash": 1 }
   },
   {
@@ -42,7 +42,7 @@
     "dispersion": 90,
     "loudness": 0,
     "count": 4,
-    "recovery_chance": 3,
+    "recovery_chance": 66,
     "melee_damage": { "bash": 1 }
   },
   {
@@ -65,7 +65,7 @@
     "dispersion": 120,
     "loudness": 0,
     "count": 4,
-    "recovery_chance": 15,
+    "recovery_chance": 93,
     "melee_damage": { "bash": 1 }
   },
   {

--- a/data/json/items/resources/stone.json
+++ b/data/json/items/resources/stone.json
@@ -18,7 +18,7 @@
     "dispersion": 14,
     "loudness": 0,
     "to_hit": -1,
-    "recovery_chance": 60,
+    "recovery_chance": 98,
     "effects": [ "NEVER_MISFIRES", "NON_FOULING" ],
     "melee_damage": { "bash": 7 }
   },

--- a/data/mods/Magiclysm/items/archery.json
+++ b/data/mods/Magiclysm/items/archery.json
@@ -74,7 +74,7 @@
     "count": 15,
     "stack_size": 15,
     "critical_multiplier": 10,
-    "recovery_chance": 65,
+    "recovery_chance": 98,
     "melee_damage": { "bash": 12 }
   },
   {
@@ -98,7 +98,7 @@
     "loudness": 0,
     "show_stats": true,
     "critical_multiplier": 10,
-    "recovery_chance": 7,
+    "recovery_chance": 86,
     "effects": [ "TANGLE" ]
   },
   {
@@ -107,7 +107,7 @@
     "copy-from": "arrow_druid_crafted",
     "name": { "str": "thunderclap arrow" },
     "color": "magenta",
-    "recovery_chance": 7,
+    "recovery_chance": 86,
     "description": "An arrow with a fragment of a stormshaper rune in the arrowhead.  It trails lightning and explodes with a crash of thunder.",
     "effects": [ "LIGHTNING", "FLASHBANG" ]
   },
@@ -126,7 +126,7 @@
     "copy-from": "arrow_druid_crafted",
     "name": { "str": "fireball arrow" },
     "color": "red",
-    "recovery_chance": 7,
+    "recovery_chance": 86,
     "description": "An arrow with a fragment of a kelvinist rune in the arrowhead.  It explodes into a firestorm.",
     "effects": [ "NAPALM" ]
   },
@@ -137,7 +137,7 @@
     "name": { "str": "visceral arrow" },
     "color": "green",
     "material": [ "bone" ],
-    "recovery_chance": 7,
+    "recovery_chance": 86,
     "description": "A disturbing bone arrow with a fragment of a biomancer rune in the arrowhead.  It showers its target in acid.",
     "effects": [ "ACIDBOMB" ]
   },
@@ -147,7 +147,7 @@
     "copy-from": "arrow_druid_crafted",
     "name": { "str": "sparking arrow" },
     "color": "white",
-    "recovery_chance": 7,
+    "recovery_chance": 86,
     "description": "A metallic arrow with a fragment of a technomancer rune in the arrowhead.  It destroys electronic targets.",
     "effects": [ "EMP", "DRAW_LASER_BEAM" ]
   },
@@ -158,7 +158,7 @@
     "//": "I'd like this to cause massive knockback but I'm limited by the available ammo flags.",
     "name": { "str": "gravity arrow" },
     "color": "black",
-    "recovery_chance": 7,
+    "recovery_chance": 86,
     "description": "An arrow with a fragment of a magus rune in the arrowhead.  It reverses flight briefly after striking its target and then hits another one.",
     "effects": [ "BOUNCE" ]
   },
@@ -169,7 +169,7 @@
     "//": "I'd like this to drain life but see above.",
     "name": { "str": "enervating arrow" },
     "color": "cyan",
-    "recovery_chance": 7,
+    "recovery_chance": 86,
     "description": "An arrow with a fragment of an animist rune in the arrowhead.  It unleashes a cloud of enervating gas.",
     "effects": [ "PARALYZEPOISON", "TOXICGAS" ]
   },

--- a/data/mods/Magiclysm/items/ethereal_items.json
+++ b/data/mods/Magiclysm/items/ethereal_items.json
@@ -446,7 +446,7 @@
     "description": "A magically conjured arrow made of twisted wood.",
     "damage": { "damage_type": "stab", "armor_penetration": 3 },
     "count": 1,
-    "recovery_chance": 8
+    "recovery_chance": 87
   },
   {
     "id": "arrow_druid",
@@ -457,7 +457,7 @@
     "description": "A arrow that looks more like it was grown than carved.  Despite that, it flies straight and true.  It explodes into a mass of entangling vegetation when it hits its target.",
     "damage": { "damage_type": "stab", "armor_penetration": 2 },
     "count": 1,
-    "recovery_chance": 6,
+    "recovery_chance": 83,
     "effects": [ "TANGLE" ]
   },
   {

--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -82,7 +82,7 @@
     "dispersion": 14,
     "loudness": 0,
     "to_hit": -2,
-    "recovery_chance": 80,
+    "recovery_chance": 99,
     "effects": [ "NEVER_MISFIRES", "NON_FOULING" ],
     "qualities": [ [ "HAMMER", 1 ] ],
     "melee_damage": { "bash": 7 },
@@ -1748,7 +1748,7 @@
     "flags": [ "FREEZERBURN" ],
     "rot_spawn": "GROUP_EGG_BIRD_WILD",
     "vitamins": [ [ "calcium", 3 ], [ "iron", 4 ] ],
-    "rot_spawn_chance": 50
+    "rot_spawn_chance": 98
   },
   {
     "type": "COMESTIBLE",
@@ -2121,7 +2121,7 @@
     "loudness": 0,
     "count": 10,
     "critical_multiplier": 10,
-    "recovery_chance": 25,
+    "recovery_chance": 96,
     "melee_damage": { "bash": 2, "cut": 1 }
   },
   {

--- a/data/mods/Xedra_Evolved/items/ammo.json
+++ b/data/mods/Xedra_Evolved/items/ammo.json
@@ -18,7 +18,7 @@
     "range": 10,
     "dispersion": 14,
     "loudness": 0,
-    "recovery_chance": 80,
+    "recovery_chance": 99,
     "effects": [ "NEVER_MISFIRES", "NON_FOULING" ],
     "qualities": [ [ "CUT", 1 ] ],
     "melee_damage": { "bash": 1, "cut": 10 }

--- a/data/mods/Xedra_Evolved/items/range.json
+++ b/data/mods/Xedra_Evolved/items/range.json
@@ -69,7 +69,7 @@
     "loudness": 0,
     "show_stats": true,
     "critical_multiplier": 10,
-    "recovery_chance": 20,
+    "recovery_chance": 95,
     "melee_damage": { "bash": 2 }
   },
   {
@@ -129,7 +129,7 @@
     "dispersion": 60,
     "loudness": 0,
     "critical_multiplier": 10,
-    "recovery_chance": 30,
+    "recovery_chance": 97,
     "melee_damage": { "bash": 1 }
   }
 ]

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3079,13 +3079,13 @@ void item::ammo_info( std::vector<iteminfo> &info, const iteminfo_query *parts, 
         fx.emplace_back( _( "This ammo <good>never misfires</good>." ) );
     }
     if( parts->test( iteminfo_parts::AMMO_FX_RECOVER ) ) {
-        if( ammo.recovery_chance <= 5 ) {
+        if( ammo.recovery_chance <= 75 ) {
             fx.emplace_back( _( "Stands a <bad>very low</bad> chance of remaining intact once fired." ) );
-        } else if( ammo.recovery_chance <= 10 ) {
+        } else if( ammo.recovery_chance <= 80 ) {
             fx.emplace_back( _( "Stands a <bad>low</bad> chance of remaining intact once fired." ) );
-        } else if( ammo.recovery_chance <= 20 ) {
+        } else if( ammo.recovery_chance <= 90 ) {
             fx.emplace_back( _( "Stands a <bad>somewhat low</bad> chance of remaining intact once fired." ) );
-        } else if( ammo.recovery_chance <= 30 ) {
+        } else if( ammo.recovery_chance <= 95 ) {
             fx.emplace_back( _( "Stands a <good>decent</good> chance of remaining intact once fired." ) );
         } else {
             fx.emplace_back( _( "Stands a <good>good</good> chance of remaining intact once fired." ) );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fixes #74655 
As outlined in that issue, the meaning of recovery chance was changed in #73931 without rescaling the numbers.
They kinda sorta look like percents, but the vast majority of those numbers were working as intended in the previous system.

#### Describe the solution
Rescale all the numbers to match previous behavior.
Had to poke at the menus too because they expected the previous numbers.

#### Describe alternatives you've considered
These aren't golden and perfect numbers, and some authors may well have intended to have single-digit recovery chances for things, but the safest bet right now is restoring the recovery rate we've had for years.

#### Testing
Spawned a hunting bow and a debug monster and 100 simple wooden arrows.
Fired all hundred arrows.
Counted arrows with view window, 89, pretty close to the expected 83.
Examined some arrows and verified that it wasn't claiming every single arrow had a good chance of recovery.