### PR TITLE
Added Tacoma roofs

### DIFF
--- a/data/json/npcs/tacoma_ranch/NPC_ranch_foreman.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_foreman.json
@@ -607,7 +607,7 @@
     "followup": "MISSION_RANCH_FOREMAN_10_1",
     "dialogue": {
       "describe": "We need help…",
-      "offer": "Disease and infection remains a persistent problem among the refugees.  Without dedicated medical personnel and facilities, I doubt everyone will be willing to stick around when the next outbreak happens.  Until we can get a former medic or nurse, I'm just going to have to improvise.  Sterilization would be the first step I imagine.  Bring me 5 gallon jugs of bleach so we can get started.",
+      "offer": "Disease and infection remains a persistent problem among the refugees.  Without dedicated medical personnel and facilities, I doubt everyone will be willing to stick around when the next outbreak happens.  Until we can get a former medic or nurse, I'm just going to have to improvise.  Sterilization would be the first step I imagine.  Bring me 150 units of bleach so we can get started.",
       "accepted": "I'm sure you can find bleach in most homes…",
       "rejected": "Come back when you get a chance.  We need skilled survivors.",
       "advice": "If you can't find a large supply I'd recommend checking hospitals or research labs.",
@@ -657,7 +657,7 @@
     },
     "end": {
       "update_mapgen": [
-        { "om_terrain": "ranch_camp_59", "place_nested": [ { "chunks": [ "tacoma_commune_clinic_10_1" ], "x": 3, "y": 0 } ] }
+        { "om_terrain": "ranch_camp_59", "place_nested": [ { "chunks": [ "tacoma_commune_clinic_10_1" ], "x": 2, "y": 0 } ] }
       ]
     }
   },

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_nurse.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_nurse.json
@@ -122,7 +122,7 @@
     "followup": "MISSION_RANCH_NURSE_2",
     "dialogue": {
       "describe": "We need help…",
-      "offer": "I've got a handful of bandages and a few first aid kits to work with at the moment… in other words I'm completely unable to treat most serious medical emergencies.  I'm supposed to have priority on any medical supplies that the scavengers bring in, but I imagine the black market for the stuff will prevent me from ever seeing it.  I could use your help getting a few bottles of aspirin to start with.",
+      "offer": "I've got a handful of bandages and a few first aid kits to work with at the moment… in other words I'm completely unable to treat most serious medical emergencies.  I'm supposed to have priority on any medical supplies that the scavengers bring in, but I imagine the black market for the stuff will prevent me from ever seeing it.  I could use your help getting me 100 aspirin pills to start with.",
       "accepted": "I'm counting on you.",
       "rejected": "Come back when you get a chance.  We need skilled survivors.",
       "advice": "Aspirin is pretty common in homes and convenience stores.",
@@ -342,7 +342,8 @@
             { "square": "terrain", "id": "t_dirtfloor", "x": 3, "y": 17, "x2": 8, "y2": 22 },
             { "square": "terrain", "id": "t_dirtfloor", "x": 14, "y": 17, "x2": 19, "y2": 22 },
             { "square": "terrain", "id": "t_dirtfloor", "x": 10, "y": 18, "x2": 12, "y2": 23 }
-          ]
+          ],
+          "place_nested": [ { "chunks": [ "tacoma_commune_clinic_12a_roof" ], "x": 2, "y": 5, "z": 1 } ]
         },
         {
           "om_terrain": "ranch_camp_59",
@@ -352,6 +353,7 @@
             { "square": "terrain", "id": "t_dirtfloor", "x": 10, "y": 0, "x2": 12, "y2": 4 },
             { "square": "terrain", "id": "t_dirtfloor", "x": 14, "y": 0, "x2": 17, "y2": 2 }
           ],
+          "place_nested": [ { "chunks": [ "tacoma_commune_clinic_12b_roof" ], "x": 3, "y": 0, "z": 1 } ],
           "place_item": [ { "item": "mask_filter", "x": 15, "y": 4, "amount": [ 2, 6 ], "faction": "tacoma_commune" } ]
         }
       ]

--- a/data/json/npcs/tacoma_ranch/mission_mapgen_tacoma_commune.json
+++ b/data/json/npcs/tacoma_ranch/mission_mapgen_tacoma_commune.json
@@ -66,7 +66,8 @@
         "q+",
         "  "
       ],
-      "terrain": { "q": "t_wall_wood", "+": "t_door_c" }
+      "terrain": { "q": "t_wall_wood", "+": "t_door_c" },
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -79,7 +80,8 @@
         "+q",
         "  "
       ],
-      "terrain": { "q": "t_wall_wood", "+": "t_door_c" }
+      "terrain": { "q": "t_wall_wood", "+": "t_door_c" },
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -125,7 +127,8 @@
         "   ..........       ",
         "   ..........       "
       ],
-      "terrain": { ".": "t_dirt" }
+      "terrain": { ".": "t_dirt" },
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -141,22 +144,54 @@
         "                    ",
         "                    ",
         "                    ",
-        "       w..wwwww     ",
-        "       w..w...w     ",
-        "       w..w...w     ",
-        "wwwwwwww..ww.www..ww",
-        "w.............w....w",
-        "w..................w",
-        "w.............w....w",
-        "w.............wwwwww",
-        "w.............w     ",
-        "w.............w     ",
-        "wwww........www     ",
-        "   .........w       ",
-        "   .........w       ",
+        "       w  wwwww     ",
+        "       w  w   w     ",
+        "       w  w   w     ",
+        "wwwwwwww  ww www  ww",
+        "w             w    w",
+        "w                  w",
+        "w             w    w",
+        "w             wwwwww",
+        "w             w     ",
+        "w             w     ",
+        "wwww        www     ",
+        "            w       ",
+        "            w       ",
         "   wwwwwwwwww       "
       ],
-      "terrain": { "w": "t_wall_half", ".": "t_dirt" }
+      "terrain": { "w": "t_wall_half" },
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "tacoma_commune_bar_15_roof",
+    "object": {
+      "mapgensize": [ 20, 20 ],
+      "rows": [
+        "                    ",
+        "                    ",
+        "                    ",
+        "                    ",
+        "                    ",
+        "                    ",
+        "       rrrrrrrr     ",
+        "       rrrrrrrr     ",
+        "       rrrrrrrr     ",
+        "rrrrrrrrrrrrrrrrrrrr",
+        "rrrrrrrrrrrrrrrrrrrr",
+        "rrrrrrrrrrrrrrrrrrrr",
+        "rrrrrrrrrrrrrrrrrrrr",
+        "rrrrrrrrrrrrrrrrrrrr",
+        "rrrrrrrrrrrrrrr     ",
+        "rrrrrrrrrrrrrrr     ",
+        "rrrrrrrrrrrrrrr     ",
+        "   rrrrrrrrrr       ",
+        "   rrrrrrrrrr       ",
+        "   rrrrrrrrrr       "
+      ],
+      "terrain": { "r": "t_wood_roof" }
     }
   },
   {
@@ -187,7 +222,9 @@
         "   f........w       ",
         "   wwww00wwww       "
       ],
-      "terrain": { "w": "t_wall", ".": "t_dirtfloor", "0": "t_window_empty", "f": "t_door_frame" }
+      "terrain": { "w": "t_wall", ".": "t_dirtfloor", "0": "t_window_empty", "f": "t_door_frame" },
+      "place_nested": [ { "chunks": [ "tacoma_commune_bar_15_roof" ], "x": 0, "y": 0, "z": 1 } ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -269,7 +306,8 @@
         { "item": "cotton_patchwork", "x": 13, "y": 15, "faction": "tacoma_commune", "repeat": [ 2, 4 ] },
         { "item": "glass", "x": 13, "y": 14, "faction": "tacoma_commune", "repeat": [ 15, 30 ] },
         { "item": "shot_glass", "x": 13, "y": 14, "faction": "tacoma_commune", "repeat": [ 10, 20 ] }
-      ]
+      ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ]
     }
   },
   {
@@ -295,7 +333,8 @@
         "               ",
         "               "
       ],
-      "terrain": { "w": "t_wall", ".": "t_dirt", "q": "t_wall_half" }
+      "terrain": { ".": "t_dirt", "q": "t_wall_half" },
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -327,7 +366,39 @@
         "                    "
       ],
       "terrain": { "w": "t_wall", "f": "t_door_frame", ".": "t_dirt", "q": "t_wall_half", "0": "t_window_empty" },
-      "furniture": { "k": "f_wood_keg" }
+      "furniture": { "k": "f_wood_keg" },
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "tacoma_commune_bar_bartender_3_roof",
+    "object": {
+      "mapgensize": [ 20, 20 ],
+      "rows": [
+        "rrrrrrrrrrrrrrr     ",
+        "rrrrrrrrrrrrrrr     ",
+        "rrrrrrrrrrrrrrrrrrrr",
+        "rrrrrrrrrrrrrrrrrrrr",
+        "rrrrrrrrrrrrrrrrrrrr",
+        "rrrrrrrrrrrrrrrrrrrr",
+        "rrrrrrr        rrrrr",
+        "               rrrrr",
+        "               rrrrr",
+        "                    ",
+        "                    ",
+        "                    ",
+        "                    ",
+        "                    ",
+        "                    ",
+        "                    ",
+        "                    ",
+        "                    ",
+        "                    ",
+        "                    "
+      ],
+      "terrain": { "r": "t_wood_roof" }
     }
   },
   {
@@ -358,7 +429,9 @@
         "                    ",
         "                    "
       ],
-      "terrain": { "w": "t_wall", ".": "t_floor", "]": "t_window_boarded_noglass", "+": "t_door_c", "2": "t_floor_olight" }
+      "terrain": { "w": "t_wall", ".": "t_floor", "]": "t_window_boarded_noglass", "+": "t_door_c", "2": "t_floor_olight" },
+      "place_nested": [ { "chunks": [ "tacoma_commune_bar_bartender_3_roof" ], "x": 0, "y": 0, "z": 1 } ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -385,7 +458,8 @@
         "                ",
         "                "
       ],
-      "furniture": { "C": "f_chair", "t": "f_table", "k": "f_wood_keg", "v": "f_fvat_empty", "s": "f_standing_tank" }
+      "furniture": { "C": "f_chair", "t": "f_table", "k": "f_wood_keg", "v": "f_fvat_empty", "s": "f_standing_tank" },
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -416,7 +490,8 @@
         "                    ",
         "                    "
       ],
-      "terrain": { "w": "t_wall_half", ".": "t_dirt" }
+      "terrain": { "w": "t_wall_half", ".": "t_dirt" },
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -431,23 +506,55 @@
         "                    ",
         "                    ",
         "wwwwwwwwwwwwwwwwwwww",
-        "w..................w",
-        "....................",
-        "....................",
-        "....................",
-        "....................",
-        "....................",
-        "....................",
-        "w..................w",
+        "w                  w",
+        "                    ",
+        "                    ",
+        "                    ",
+        "                    ",
+        "                    ",
+        "                    ",
+        "w                  w",
         "wwwwwww+www+wwwwwwww",
-        "     w...w...w      ",
-        "     w...w...w      ",
+        "     w   w   w      ",
+        "     w   w   w      ",
         "     wwwwww+ww      ",
         "                    ",
         "                    ",
         "                    "
       ],
-      "terrain": { "w": "t_wall", ".": "t_dirt", "+": "t_door_c" }
+      "terrain": { "w": "t_wall", "+": "t_door_c" },
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "tacoma_commune_chopshop_12_roof",
+    "object": {
+      "mapgensize": [ 20, 20 ],
+      "rows": [
+        "                    ",
+        "                    ",
+        "                    ",
+        "                    ",
+        "rrrrrrrrrrrrrrrrrrrr",
+        "rrrrrrrrrrrrrrrrrrrr",
+        "rrrrrrrrrrrrrrrrrrrr",
+        "rrrrrrrrrrrrrrrrrrrr",
+        "rrrrrrrrrrrrrrrrrrrr",
+        "rrrrrrrrrrrrrrrrrrrr",
+        "rrrrrrrrrrrrrrrrrrrr",
+        "rrrrrrrrrrrrrrrrrrrr",
+        "rrrrrrrrrrrrrrrrrrrr",
+        "rrrrrrrrrrrrrrrrrrrr",
+        "     rrrrrrrrr      ",
+        "     rrrrrrrrr      ",
+        "     rrrrrrrrr      ",
+        "                    ",
+        "                    ",
+        "                    "
+      ],
+      "terrain": { "r": "t_wood_roof" }
     }
   },
   {
@@ -481,7 +588,9 @@
       "terrain": { "w": "t_wall", ".": "t_dirtfloor", "+": "t_door_c", "r": "t_dirtfloor", "c": "t_dirtfloor", "b": "t_dirtfloor" },
       "furniture": { "r": "f_rack", "c": "f_counter", "b": "f_makeshift_bed" },
       "place_vehicles": [ { "vehicle": "armored_car", "chance": 100, "rotation": 0, "x": 15, "y": 7, "faction": "tacoma_commune" } ],
-      "place_npcs": [ { "class": "ranch_scrapper_1", "x": 13, "y": 12 } ]
+      "place_npcs": [ { "class": "ranch_scrapper_1", "x": 13, "y": 12 } ],
+      "place_nested": [ { "chunks": [ "tacoma_commune_chopshop_12_roof" ], "x": 0, "y": 0, "z": 1 } ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -511,7 +620,8 @@
         "                   ",
         "                   "
       ],
-      "terrain": { ".": "t_dirt" }
+      "terrain": { ".": "t_dirt" },
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -542,41 +652,14 @@
         "                   "
       ],
       "terrain": { "w": "t_wall_half" },
-      "place_item": [ { "item": "hammer_sledge", "x": 12, "y": 18, "faction": "tacoma_commune" } ]
+      "place_item": [ { "item": "hammer_sledge", "x": 12, "y": 18, "faction": "tacoma_commune" } ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
     "type": "mapgen",
     "method": "json",
     "nested_mapgen_id": "tacoma_commune_clinic_10_1",
-    "object": {
-      "mapgensize": [ 17, 17 ],
-      "rows": [
-        "                 ",
-        "                 ",
-        "                 ",
-        "                 ",
-        "......     ......",
-        "......  .  ......",
-        "...... ... ......",
-        ".................",
-        "...... ... ......",
-        "......     ......",
-        "  ..             ",
-        "                 ",
-        "                 ",
-        "                 ",
-        "                 ",
-        "                 ",
-        "                 "
-      ],
-      "terrain": { ".": "t_dirtfloor" }
-    }
-  },
-  {
-    "type": "mapgen",
-    "method": "json",
-    "nested_mapgen_id": "tacoma_commune_clinic_10",
     "object": {
       "mapgensize": [ 19, 19 ],
       "rows": [
@@ -600,8 +683,70 @@
         "                   ",
         "                   "
       ],
-      "terrain": { "w": "t_wall", "[": "t_window_boarded_noglass", "f": "t_door_frame" },
-      "place_item": [ { "item": "ax", "x": 13, "y": 18, "faction": "tacoma_commune" } ]
+      "terrain": { "w": "t_wall", "[": "t_window_boarded_noglass", "f": "t_door_frame" }
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "tacoma_commune_clinic_10_roof",
+    "object": {
+      "mapgensize": [ 19, 19 ],
+      "rows": [
+        "                   ",
+        "                   ",
+        "                   ",
+        "rrrrrrrr   rrrrrrrr",
+        "rrrrrrrr   rrrrrrrr",
+        "rrrrrrrrrrrrrrrrrrr",
+        "rrrrrrrrrrrrrrrrrrr",
+        "rrrrrrrrrrrrrrrrrrr",
+        "rrrrrrrrrrrrrrrrrrr",
+        "rrrrrrrrrrrrrrrrrrr",
+        "rrrrrrrr   rrrrrrrr",
+        "                   ",
+        "                   ",
+        "                   ",
+        "                   ",
+        "                   ",
+        "                   ",
+        "                   ",
+        "                   "
+      ],
+      "terrain": { "r": "t_wood_roof" }
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "tacoma_commune_clinic_10",
+    "object": {
+      "mapgensize": [ 19, 19 ],
+      "rows": [
+        "                   ",
+        "                   ",
+        "                   ",
+        "                   ",
+        " ......     ...... ",
+        " ......  .  ...... ",
+        " ...... ... ...... ",
+        " ................. ",
+        " ...... ... ...... ",
+        " ......     ...... ",
+        "   ..              ",
+        "                   ",
+        "                   ",
+        "                   ",
+        "                   ",
+        "                   ",
+        "                   ",
+        "                   ",
+        "                   "
+      ],
+      "terrain": { ".": "t_dirtfloor" },
+      "place_item": [ { "item": "ax", "x": 13, "y": 18, "faction": "tacoma_commune" } ],
+      "place_nested": [ { "chunks": [ "tacoma_commune_clinic_10_roof" ], "x": 0, "y": 0, "z": 1 } ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -633,7 +778,8 @@
       "furniture": { "c": "f_cupboard", "t": "f_table", "s": "f_stool" },
       "place_signs": [ { "signage": "Clinic", "x": 1, "y": 10 } ],
       "place_npcs": [ { "class": "ranch_nurse_1", "x": 4, "y": 6 } ],
-      "place_item": [ { "item": "hoe", "x": 14, "y": 18, "faction": "tacoma_commune" } ]
+      "place_item": [ { "item": "hoe", "x": 14, "y": 18, "faction": "tacoma_commune" } ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -655,15 +801,16 @@
         "                   ",
         "                   ",
         "wwwwwwww   wwwwwwww",
-        "w      wwwww      w",
-        "w      w   w      w",
-        "w      f   f      w",
-        "w      w   w      w",
-        "w      w   w      w",
-        "w      w   w      w",
-        "wwwwwwww   wwwwwwww"
+        "w......wwwww......w",
+        "w......w...w......w",
+        "w......f...f......w",
+        "w......w...w......w",
+        "w......w...w......w",
+        "w......w...w......w",
+        "wwwwwwww...wwwwwwww"
       ],
-      "terrain": { "w": "t_wall_half", "f": "t_door_frame" }
+      "terrain": { ".": "t_dirt", "w": "t_wall_half", "f": "t_door_frame" },
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -673,9 +820,9 @@
     "object": {
       "mapgensize": [ 16, 16 ],
       "rows": [
-        " w    w   w    w",
-        " w    f   f    w",
-        " w    w   w    w",
+        " w....w...w....w",
+        " w....f...f....w",
+        " w....w...w....w",
         "                ",
         "                ",
         "                ",
@@ -690,8 +837,66 @@
         "                ",
         "                "
       ],
-      "terrain": { "w": "t_wall_half", "f": "t_door_frame" },
-      "furniture": { "c": "f_chair", "t": "f_table" }
+      "terrain": { ".": "t_dirt", "w": "t_wall_half", "f": "t_door_frame" },
+      "furniture": { "c": "f_chair", "t": "f_table" },
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "tacoma_commune_clinic_12a_roof",
+    "object": {
+      "mapgensize": [ 19, 19 ],
+      "rows": [
+        "                   ",
+        "                   ",
+        "                   ",
+        "                   ",
+        "                   ",
+        "                   ",
+        "                   ",
+        "                   ",
+        "                   ",
+        "                   ",
+        "                   ",
+        "rrrrrrrr   rrrrrrrr",
+        "rrrrrrrrrrrrrrrrrrr",
+        "rrrrrrrrrrrrrrrrrrr",
+        "rrrrrrrrrrrrrrrrrrr",
+        "rrrrrrrrrrrrrrrrrrr",
+        "rrrrrrrrrrrrrrrrrrr",
+        "rrrrrrrrrrrrrrrrrrr",
+        "rrrrrrrrrrrrrrrrrrr"
+      ],
+      "terrain": { "r": "t_wood_roof" }
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "tacoma_commune_clinic_12b_roof",
+    "object": {
+      "mapgensize": [ 16, 16 ],
+      "rows": [
+        " rrrrrrrrrrrrrrr",
+        " rrrrrrrrrrrrrrr",
+        " rrrrrrrrrrrrrrr",
+        "       rrr      ",
+        "       rrr      ",
+        "                ",
+        "                ",
+        "                ",
+        "                ",
+        "                ",
+        "                ",
+        "                ",
+        "                ",
+        "                ",
+        "                ",
+        "                "
+      ],
+      "terrain": { "r": "t_wood_roof" }
     }
   },
   {
@@ -729,7 +934,32 @@
         "w.........w  ",
         "wwwww.wwwww  "
       ],
-      "terrain": { "w": "t_wall_half", ".": "t_dirt" }
+      "terrain": { "w": "t_wall_half", ".": "t_dirt" },
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "tacoma_commune_greenhouse_17_roof",
+    "object": {
+      "mapgensize": [ 13, 13 ],
+      "rows": [
+        "rrrrrrrrrrr  ",
+        "rrrrrrrrrrr  ",
+        "rrrrrrrrrrr  ",
+        "rrrrrrrrrrr  ",
+        "rrrrrrrrrrr  ",
+        "rrrrrrrrrrr  ",
+        "rrrrrrrrrrr  ",
+        "rrrrrrrrrrr  ",
+        "rrrrrrrrrrr  ",
+        "rrrrrrrrrrr  ",
+        "rrrrrrrrrrr  ",
+        "rrrrrrrrrrr  ",
+        "rrrrrrrrrrr  "
+      ],
+      "terrain": { "r": "t_glass_roof" }
     }
   },
   {
@@ -740,20 +970,21 @@
       "mapgensize": [ 13, 13 ],
       "rows": [
         "wwwww+wwwww  ",
-        "w.........w  ",
-        "w.........w  ",
-        "w.........w  ",
-        "w.........w  ",
-        "w.........w  ",
-        "w.........w  ",
-        "w.........w  ",
-        "w.........w  ",
-        "w.........w  ",
-        "w.........w  ",
-        "w.........w  ",
+        "w         w  ",
+        "w         w  ",
+        "w         w  ",
+        "w         w  ",
+        "w         w  ",
+        "w         w  ",
+        "w         w  ",
+        "w         w  ",
+        "w         w  ",
+        "w         w  ",
+        "w         w  ",
         "wwwww+wwwww  "
       ],
-      "terrain": { "w": "t_window", ".": "t_dirt", "+": "t_door_c" }
+      "terrain": { "w": "t_window", "+": "t_door_c" },
+      "place_nested": [ { "chunks": [ "tacoma_commune_greenhouse_17_roof" ], "x": 0, "y": 0, "z": 1 } ]
     }
   },
   {
@@ -806,7 +1037,35 @@
         "       wwwwwww  ",
         "                "
       ],
-      "terrain": { "w": "t_wall_half", ".": "t_dirt" }
+      "terrain": { "w": "t_wall_half", ".": "t_dirt" },
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "tacoma_commune_junk_shop_13_roof",
+    "object": {
+      "mapgensize": [ 16, 16 ],
+      "rows": [
+        "rrrrrr          ",
+        "rrrrrrrrrrrrrrrr",
+        "rrrrrrrrrrrrrrrr",
+        "rrrrrrrrrrrrrrrr",
+        "rrrrrrrrrrrrrrrr",
+        "rrrrrrrrrrrrrrrr",
+        "     rrrrrrrrrrr",
+        "     rrrrrrrrrrr",
+        "     rrrrrrrrrrr",
+        "     rrrrrrrrrrr",
+        "       rrrrrrr  ",
+        "       rrrrrrr  ",
+        "       rrrrrrr  ",
+        "       rrrrrrr  ",
+        "       rrrrrrr  ",
+        "                "
+      ],
+      "terrain": { "r": "t_wood_roof" }
     }
   },
   {
@@ -833,7 +1092,9 @@
         "       wwwwwww  ",
         "                "
       ],
-      "terrain": { "w": "t_wall", ".": "t_dirtfloor", "0": "t_window_empty", "f": "t_door_frame" }
+      "terrain": { "w": "t_wall", ".": "t_dirtfloor", "0": "t_window_empty", "f": "t_door_frame" },
+      "place_nested": [ { "chunks": [ "tacoma_commune_junk_shop_13_roof" ], "x": 0, "y": 0, "z": 1 } ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -875,7 +1136,8 @@
         { "signage": "Extra Supplies.  Take what you need.", "x": 11, "y": 8 },
         { "signage": "Scavenger Storage.  Stay out!", "x": 5, "y": 4 }
       ],
-      "place_npcs": [ { "class": "ranch_scavenger_1", "x": 9, "y": 12 } ]
+      "place_npcs": [ { "class": "ranch_scavenger_1", "x": 9, "y": 12 } ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -890,7 +1152,8 @@
         "w  w",
         "wwww"
       ],
-      "terrain": { "w": "t_wall_half", "f": "t_door_frame" }
+      "terrain": { "w": "t_wall_half", "f": "t_door_frame" },
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -907,7 +1170,8 @@
       ],
       "terrain": { "w": "t_wall_wood", "d": "t_door_locked", ".": "t_dirtfloor", "s": "t_dirtfloor" },
       "furniture": { "s": "f_woodstove" },
-      "place_item": [ { "item": "log", "x": 2, "y": 1, "amount": [ 3, 5 ] } ]
+      "place_item": [ { "item": "log", "x": 2, "y": 1, "amount": [ 3, 5 ] } ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -930,7 +1194,31 @@
         "..........  ",
         "..........  "
       ],
-      "terrain": { "W": "t_wall_log_half", ".": "t_dirt" }
+      "terrain": { "W": "t_wall_log_half", ".": "t_dirt" },
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "tacoma_commune_lumbermill_5_roof",
+    "object": {
+      "mapgensize": [ 12, 12 ],
+      "rows": [
+        "            ",
+        "            ",
+        "rrrrrrrrrr  ",
+        "rrrrrrrrrr  ",
+        "rrrrrrrrrr  ",
+        "rrrrrrrrrr  ",
+        "rrrrrrrrrr  ",
+        "rrrrrrrrrr  ",
+        "rrrrrrrrrr  ",
+        "rrrrrrrrrr  ",
+        "rrrrrrrrrr  ",
+        "rrrrrrrrrr  "
+      ],
+      "terrain": { "r": "t_wood_roof" }
     }
   },
   {
@@ -954,7 +1242,8 @@
         "WWW....WWW  "
       ],
       "flags": [ "DISMANTLE_ALL_BEFORE_PLACING_TERRAIN" ],
-      "terrain": { "W": "t_wall_log", ".": "t_dirtfloor" }
+      "terrain": { "W": "t_wall_log", ".": "t_dirtfloor" },
+      "place_nested": [ { "chunks": [ "tacoma_commune_lumbermill_5_roof" ], "x": 0, "y": 0, "z": 1 } ]
     }
   },
   {
@@ -966,18 +1255,18 @@
       "rows": [
         "            ",
         "            ",
-        "WWW....WWW  ",
-        "W........W  ",
-        "W........W  ",
-        "W.........  ",
-        "W.........  ",
-        "W.........  ",
-        "W.........  ",
-        "W.......rW  ",
-        "W.......rW  ",
-        "WWW....WWW  "
+        "            ",
+        "            ",
+        "            ",
+        "            ",
+        "            ",
+        "            ",
+        "            ",
+        "        r   ",
+        "        r   ",
+        "            "
       ],
-      "terrain": { "r": "t_dirtfloor", "W": "t_wall_log", ".": "t_dirtfloor" },
+      "terrain": {  },
       "furniture": { "r": "f_rack" },
       "place_item": [
         { "item": "frame", "x": 3, "y": 6, "faction": "tacoma_commune" },
@@ -995,19 +1284,20 @@
       "rows": [
         "            ",
         "            ",
-        "WWWc...WWW  ",
-        "W..c....rW  ",
-        "W..c....rW  ",
-        "W..c......  ",
-        "W.........  ",
-        "W.........  ",
-        "W.........  ",
-        "W.......rW  ",
-        "W.......rW  ",
-        "WWW....WWW  "
+        "   c        ",
+        "   c    r   ",
+        "   c    r   ",
+        "   c        ",
+        "            ",
+        "            ",
+        "            ",
+        "            ",
+        "            ",
+        "            "
       ],
-      "terrain": { "r": "t_dirtfloor", "W": "t_wall_log", ".": "t_dirtfloor", "c": "t_conveyor" },
-      "furniture": { "r": "f_rack" }
+      "terrain": { "c": "t_conveyor" },
+      "furniture": { "r": "f_rack" },
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -1019,19 +1309,19 @@
       "rows": [
         "            ",
         "            ",
-        "WWWc...WWW  ",
-        "W..c....rW  ",
-        "W..c....rW  ",
-        "W..c......  ",
-        "W..m......  ",
-        "W..m......  ",
-        "W..M......  ",
-        "W.......rW  ",
-        "W.......rW  ",
-        "WWW....WWW  "
+        "            ",
+        "            ",
+        "            ",
+        "            ",
+        "   m        ",
+        "   m        ",
+        "   M        ",
+        "            ",
+        "            ",
+        "            "
       ],
-      "terrain": { "r": "t_dirtfloor", "W": "t_wall_log", ".": "t_dirtfloor", "m": "t_dirtfloor", "M": "t_dirtfloor", "c": "t_conveyor" },
-      "furniture": { "m": "f_machinery_old", "M": "f_machinery_heavy", "r": "f_rack" },
+      "terrain": {  },
+      "furniture": { "m": "f_machinery_old", "M": "f_machinery_heavy" },
       "place_item": [
         { "item": "log", "x": 3, "y": 0 },
         { "item": "log", "x": 3, "y": 1 },
@@ -1057,7 +1347,24 @@
         "..0w ",
         "wwww "
       ],
-      "terrain": { "w": "t_wall_half", "0": "t_pit", ".": "t_dirtfloor" }
+      "terrain": { "w": "t_wall_half", "0": "t_pit", ".": "t_dirt" },
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "tacoma_commune_outhouse_9_roof",
+    "object": {
+      "mapgensize": [ 5, 5 ],
+      "rows": [
+        "rrrr ",
+        "rrrr ",
+        "rrrr ",
+        "rrrr ",
+        "rrrr "
+      ],
+      "terrain": { "r": "t_wood_roof" }
     }
   },
   {
@@ -1074,7 +1381,9 @@
         "wwww "
       ],
       "terrain": { "w": "t_wall", "+": "t_door_c", ".": "t_dirtfloor", "0": "t_pit" },
-      "place_npcs": [ { "class": "ranch_ill_1", "x": 2, "y": 1 } ]
+      "place_npcs": [ { "class": "ranch_ill_1", "x": 2, "y": 1 } ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "place_nested": [ { "chunks": [ "tacoma_commune_outhouse_9_roof" ], "x": 0, "y": 0, "z": 1 } ]
     }
   },
   {
@@ -1091,7 +1400,25 @@
         "wwwwww",
         "      "
       ],
-      "terrain": { "w": "t_wall_half", ".": "t_dirtfloor" }
+      "terrain": { "w": "t_wall_half", ".": "t_dirt" },
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "tacoma_commune_toolshed_9_roof",
+    "object": {
+      "mapgensize": [ 6, 6 ],
+      "rows": [
+        "rrrrrr",
+        "rrrrrr",
+        "rrrrrr",
+        "rrrrrr",
+        "rrrrrr",
+        "      "
+      ],
+      "terrain": { "r": "t_wood_roof" }
     }
   },
   {
@@ -1109,7 +1436,9 @@
         "      "
       ],
       "terrain": { "w": "t_wall", "+": "t_door_c", "W": "t_window_boarded_noglass", "c": "t_dirtfloor", ".": "t_dirtfloor" },
-      "furniture": { "c": "f_counter" }
+      "furniture": { "c": "f_counter" },
+      "place_nested": [ { "chunks": [ "tacoma_commune_toolshed_9_roof" ], "x": 0, "y": 0, "z": 1 } ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -1141,7 +1470,8 @@
         { "square": "terrain", "id": "t_dirtmound", "x": 15, "y": 3, "x2": 15, "y2": 20 },
         { "square": "terrain", "id": "t_dirtmound", "x": 17, "y": 2, "x2": 17, "y2": 21 }
       ],
-      "place_signs": [ { "signage": "Your name is crudely scribbled on the sign with 'Not for commune use' below it.", "x": 0, "y": 9 } ]
+      "place_signs": [ { "signage": "Your name is crudely scribbled on the sign with 'Not for commune use' below it.", "x": 0, "y": 9 } ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -1157,7 +1487,8 @@
         { "point": "terrain", "id": "t_fencegate_c", "x": 10, "y": 1 },
         { "point": "terrain", "id": "t_fencegate_c", "x": 10, "y": 22 },
         { "square": "terrain", "id": "t_fencegate_c", "x": 2, "y": 11, "x2": 2, "y2": 12 }
-      ]
+      ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Provide Tacoma farm upgrades with roofs, without relying on add_roofs magic.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Add roof chunks and hooked them into the buildings they belong to.
- Also update a couple of misleading quests.
- Switched the build order of one building because building the floors and their magically added roof while the walls were only half built made no sense.
- Removed a number of multiply defined constructions (upgrade specifying the same things as the previous step had already provided when adding furniture).
- Had to increase the size of one chunk to fit the roof added on top of it (walls were defined previously, but not the roof on top of those).
- Add flags to stop issues with stuff getting in the way of placements.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Resize construction chunks shrunk because they no longer specified things again. Decided against it because of the extra work and because it's easier to map the upgrades on top of each other if their chunks actually overlap properly.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
- Debug spawn evac center.
- Go through quest chain to get Tacoma prospectus quest.
- Teleport to Tacoma.
- Go through Foreman quest chain and note when roofs where created (and that they were created correctly).
- Go through the Nurse and Bartender quest chains until their roof constructions were done.

The above is a simplification. In practice saves were made when a roof had been verified, and as often as not the next one had some issue, so the game was exited, the issue fixed, and the game resumed from the last save.
Had to start the whole sequence from scratch with the Nurse quest chain, because I noticed too late that thistles were placed on the ground when it was transformed (by something, not an explicit chunk) to dirt. Those remained when the floor was built since it was assumed the dirt stage cleared the thistles.

![Screenshot (525)](https://github.com/CleverRaven/Cataclysm-DDA/assets/22739822/c82b395b-ba4f-4e4b-ac17-6ae7603c7a61)

![Screenshot (526)](https://github.com/CleverRaven/Cataclysm-DDA/assets/22739822/100ddfc6-c5ff-4667-8ac4-105950cddb8b)

![Screenshot (527)](https://github.com/CleverRaven/Cataclysm-DDA/assets/22739822/f4785a78-7a11-4b3d-bfd3-a60aef407e43)

![Screenshot (528)](https://github.com/CleverRaven/Cataclysm-DDA/assets/22739822/4c873094-338d-4865-8f6a-3879ec803bb2)

![Screenshot (529)](https://github.com/CleverRaven/Cataclysm-DDA/assets/22739822/f5fcc16c-157d-4a34-a61c-8b70ec5f683f)

![Screenshot (530)](https://github.com/CleverRaven/Cataclysm-DDA/assets/22739822/88473595-a905-44f2-8765-4668b3fe8d0f)

![Screenshot (531)](https://github.com/CleverRaven/Cataclysm-DDA/assets/22739822/99632eb0-b34c-4197-893c-937696515161)

![Screenshot (532)](https://github.com/CleverRaven/Cataclysm-DDA/assets/22739822/420758ef-f502-415b-87ca-5bc701b08a9a)

![Screenshot (533)](https://github.com/CleverRaven/Cataclysm-DDA/assets/22739822/08284c5a-5456-4855-9ba4-154f12b97b7a)

![Screenshot (534)](https://github.com/CleverRaven/Cataclysm-DDA/assets/22739822/cff81358-b557-4b66-8c1c-254cfdee76c6)
![Screenshot (535)](https://github.com/CleverRaven/Cataclysm-DDA/assets/22739822/0b1a8a6c-64af-4aa2-bb68-9f9b0a4e0827)

![Screenshot (536)](https://github.com/CleverRaven/Cataclysm-DDA/assets/22739822/c293bf08-54dd-455d-9c1e-65ffd47a2f8d)

![Screenshot (537)](https://github.com/CleverRaven/Cataclysm-DDA/assets/22739822/d3cc8a37-ab96-4f09-9c68-b86453480145)

![Screenshot (538)](https://github.com/CleverRaven/Cataclysm-DDA/assets/22739822/e3e65eae-d7aa-4184-a97e-e2524a22a46d)

![Screenshot (541)](https://github.com/CleverRaven/Cataclysm-DDA/assets/22739822/7eddc0e0-bfc8-4086-ab72-10d32a433c38)

![Screenshot (542)](https://github.com/CleverRaven/Cataclysm-DDA/assets/22739822/7be99e56-50ce-45ee-b7c7-a1b0c69dcc85)

![Screenshot (543)](https://github.com/CleverRaven/Cataclysm-DDA/assets/22739822/27e64d19-5ad8-41c0-971e-3f853e223071)

![Screenshot (544)](https://github.com/CleverRaven/Cataclysm-DDA/assets/22739822/8343093a-06ad-4a80-97e7-daa636eec0ed)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
