### PR TITLE
Add flag for immunity to skin irritants

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -589,7 +589,7 @@
       [ "hand_r", 1 ],
       [ "mouth", 1 ]
     ],
-    "flags": [ "BIONIC_NPC_USABLE", "BIONIC_SHOCKPROOF", "IRRITATION_IMMUNE" ],
+    "flags": [ "BIONIC_NPC_USABLE", "BIONIC_SHOCKPROOF", "IRRITANT_IMMUNE" ],
     "protec": [
       [ "torso", { "cut": 4, "bullet": 4, "stab": 4 } ],
       [ "head", { "cut": 4, "bullet": 4, "stab": 4 } ],

--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -589,7 +589,7 @@
       [ "hand_r", 1 ],
       [ "mouth", 1 ]
     ],
-    "flags": [ "BIONIC_NPC_USABLE", "BIONIC_SHOCKPROOF", "IRRITANT_IMMUNE" ],
+    "flags": [ "BIONIC_NPC_USABLE", "BIONIC_SHOCKPROOF" ],
     "protec": [
       [ "torso", { "cut": 4, "bullet": 4, "stab": 4 } ],
       [ "head", { "cut": 4, "bullet": 4, "stab": 4 } ],

--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -589,7 +589,7 @@
       [ "hand_r", 1 ],
       [ "mouth", 1 ]
     ],
-    "flags": [ "BIONIC_NPC_USABLE", "BIONIC_SHOCKPROOF" ],
+    "flags": [ "BIONIC_NPC_USABLE", "BIONIC_SHOCKPROOF", "IRRITATION_IMMUNE" ],
     "protec": [
       [ "torso", { "cut": 4, "bullet": 4, "stab": 4 } ],
       [ "head", { "cut": 4, "bullet": 4, "stab": 4 } ],

--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -2498,8 +2498,8 @@
     "info": "This will eventually <bad>go bad</bad> if left in the open air too long."
   },
   {
-    "id": "BILE_PROOF",
+    "id": "IRRITANT_IMMUNE",
     "type": "json_flag",
-    "info": "The character's skin is <good>completely protected</good> from <info>boomer bile</info>."
+    "info": "This gear <good>completely protects</good> you from <info>skin irritants</info>."
   }
 ]

--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -2496,5 +2496,10 @@
     "id": "DECAYS_IN_AIR",
     "type": "json_flag",
     "info": "This will eventually <bad>go bad</bad> if left in the open air too long."
+  },
+  {
+    "id": "BILE_PROOF",
+    "type": "json_flag",
+    "info": "The character's skin is <good>completely protected</good> from <info>boomer bile</info>."
   }
 ]

--- a/data/json/items/armor/integrated.json
+++ b/data/json/items/armor/integrated.json
@@ -43,7 +43,16 @@
     "color": "brown",
     "warmth": 1,
     "environmental_protection": 3,
-    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "NORMAL", "WATERPROOF", "IRRITANT_IMMUNE", "PADDED", "ALLOWS_TALONS" ],
+    "flags": [
+      "INTEGRATED",
+      "ALLOWS_NATURAL_ATTACKS",
+      "UNBREAKABLE",
+      "NORMAL",
+      "WATERPROOF",
+      "IRRITANT_IMMUNE",
+      "PADDED",
+      "ALLOWS_TALONS"
+    ],
     "armor": [
       {
         "material": [ { "type": "wood", "covered_by_mat": 100, "thickness": 4 }, { "type": "wood", "covered_by_mat": 75, "thickness": 6 } ],

--- a/data/json/items/armor/integrated.json
+++ b/data/json/items/armor/integrated.json
@@ -43,7 +43,7 @@
     "color": "brown",
     "warmth": 1,
     "environmental_protection": 3,
-    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "NORMAL", "WATERPROOF", "PADDED", "ALLOWS_TALONS" ],
+    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "NORMAL", "WATERPROOF", "IRRITANT_IMMUNE", "PADDED", "ALLOWS_TALONS" ],
     "armor": [
       {
         "material": [ { "type": "wood", "covered_by_mat": 100, "thickness": 4 }, { "type": "wood", "covered_by_mat": 75, "thickness": 6 } ],
@@ -68,7 +68,7 @@
     "color": "brown",
     "warmth": 2,
     "environmental_protection": 4,
-    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "NORMAL", "WATERPROOF", "PADDED", "ALLOWS_TALONS" ],
+    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "NORMAL", "WATERPROOF", "IRRITANT_IMMUNE", "PADDED", "ALLOWS_TALONS" ],
     "armor": [
       {
         "material": [ { "type": "wood", "covered_by_mat": 100, "thickness": 6 }, { "type": "wood", "covered_by_mat": 75, "thickness": 7 } ],
@@ -93,7 +93,7 @@
     "color": "brown",
     "warmth": 2,
     "environmental_protection": 4,
-    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "NORMAL", "WATERPROOF", "PADDED", "ALLOWS_TALONS" ],
+    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "NORMAL", "WATERPROOF", "IRRITANT_IMMUNE", "PADDED", "ALLOWS_TALONS" ],
     "armor": [
       {
         "material": [ { "type": "wood", "covered_by_mat": 100, "thickness": 15 } ],
@@ -344,7 +344,7 @@
     "color": "dark_gray",
     "warmth": 25,
     "environmental_protection": 1,
-    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "SKINTIGHT", "RAINPROOF" ],
+    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "SKINTIGHT", "RAINPROOF", "IRRITANT_IMMUNE" ],
     "armor": [
       {
         "material": [ { "type": "mut_fur", "covered_by_mat": 100, "thickness": 8 } ],
@@ -381,7 +381,7 @@
     "color": "dark_gray",
     "warmth": 18,
     "environmental_protection": 1,
-    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "SKINTIGHT", "RAINPROOF" ],
+    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "SKINTIGHT", "RAINPROOF", "IRRITANT_IMMUNE" ],
     "armor": [
       {
         "material": [ { "type": "mut_fur", "covered_by_mat": 100, "thickness": 6 } ],
@@ -513,6 +513,7 @@
       "UNBREAKABLE",
       "SKINTIGHT",
       "WATER_FRIENDLY",
+      "IRRITANT_IMMUNE",
       "SOFT",
       "TOUGH_FEET",
       "NO_SALVAGE"
@@ -549,7 +550,7 @@
     "color": "light_red",
     "warmth": 15,
     "environmental_protection": 1,
-    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "NORMAL", "WATER_FRIENDLY", "PADDED", "NO_SALVAGE" ],
+    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "NORMAL", "WATER_FRIENDLY", "PADDED", "IRRITANT_IMMUNE", "NO_SALVAGE" ],
     "armor": [
       {
         "material": [
@@ -670,6 +671,7 @@
       "UNBREAKABLE",
       "NORMAL",
       "WATER_FRIENDLY",
+      "IRRITANT_IMMUNE",
       "NO_SALVAGE",
       "PADDED",
       "ALLOWS_TALONS"
@@ -824,7 +826,7 @@
     "color": "brown",
     "warmth": 5,
     "environmental_protection": 1,
-    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "BLOCK_WHILE_WORN", "UNBREAKABLE", "OUTER", "PADDED", "ALLOWS_TALONS" ],
+    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "BLOCK_WHILE_WORN", "UNBREAKABLE", "OUTER", "PADDED", "IRRITANT_IMMUNE", "ALLOWS_TALONS" ],
     "armor": [
       {
         "material": [ { "type": "sclerotin", "covered_by_mat": 100, "thickness": 4 } ],
@@ -983,7 +985,7 @@
     "color": "brown",
     "warmth": 20,
     "environmental_protection": 1,
-    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "BLOCK_WHILE_WORN", "UNBREAKABLE", "OUTER", "PADDED", "ALLOWS_TALONS" ],
+    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "BLOCK_WHILE_WORN", "UNBREAKABLE", "OUTER", "PADDED", "IRRITANT_IMMUNE", "ALLOWS_TALONS" ],
     "armor": [
       {
         "material": [ { "type": "sclerotin", "covered_by_mat": 100, "thickness": 4.5 } ],
@@ -1348,7 +1350,7 @@
     "color": "light_red",
     "warmth": 3,
     "environmental_protection": 4,
-    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "SKINTIGHT", "WATER_FRIENDLY", "TOUGH_FEET", "ALLOWS_TALONS" ],
+    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "SKINTIGHT", "WATER_FRIENDLY", "IRRITANT_IMMUNE", "TOUGH_FEET", "ALLOWS_TALONS" ],
     "armor": [
       {
         "material": [
@@ -1409,6 +1411,7 @@
       "UNBREAKABLE",
       "SKINTIGHT",
       "WATER_FRIENDLY",
+      "IRRITANT_IMMUNE",
       "PADDED",
       "TOUGH_FEET",
       "NO_SALVAGE"

--- a/data/json/items/armor/integrated.json
+++ b/data/json/items/armor/integrated.json
@@ -102,7 +102,16 @@
     "color": "brown",
     "warmth": 2,
     "environmental_protection": 4,
-    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "NORMAL", "WATERPROOF", "IRRITANT_IMMUNE", "PADDED", "ALLOWS_TALONS" ],
+    "flags": [
+      "INTEGRATED",
+      "ALLOWS_NATURAL_ATTACKS",
+      "UNBREAKABLE",
+      "NORMAL",
+      "WATERPROOF",
+      "IRRITANT_IMMUNE",
+      "PADDED",
+      "ALLOWS_TALONS"
+    ],
     "armor": [
       {
         "material": [ { "type": "wood", "covered_by_mat": 100, "thickness": 15 } ],

--- a/data/json/items/armor/integrated.json
+++ b/data/json/items/armor/integrated.json
@@ -77,7 +77,16 @@
     "color": "brown",
     "warmth": 2,
     "environmental_protection": 4,
-    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "NORMAL", "WATERPROOF", "IRRITANT_IMMUNE", "PADDED", "ALLOWS_TALONS" ],
+    "flags": [
+      "INTEGRATED",
+      "ALLOWS_NATURAL_ATTACKS",
+      "UNBREAKABLE",
+      "NORMAL",
+      "WATERPROOF",
+      "IRRITANT_IMMUNE",
+      "PADDED",
+      "ALLOWS_TALONS"
+    ],
     "armor": [
       {
         "material": [ { "type": "wood", "covered_by_mat": 100, "thickness": 6 }, { "type": "wood", "covered_by_mat": 75, "thickness": 7 } ],
@@ -568,7 +577,16 @@
     "color": "light_red",
     "warmth": 15,
     "environmental_protection": 1,
-    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "NORMAL", "WATER_FRIENDLY", "PADDED", "IRRITANT_IMMUNE", "NO_SALVAGE" ],
+    "flags": [
+      "INTEGRATED",
+      "ALLOWS_NATURAL_ATTACKS",
+      "UNBREAKABLE",
+      "NORMAL",
+      "WATER_FRIENDLY",
+      "PADDED",
+      "IRRITANT_IMMUNE",
+      "NO_SALVAGE"
+    ],
     "armor": [
       {
         "material": [
@@ -844,7 +862,16 @@
     "color": "brown",
     "warmth": 5,
     "environmental_protection": 1,
-    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "BLOCK_WHILE_WORN", "UNBREAKABLE", "OUTER", "PADDED", "IRRITANT_IMMUNE", "ALLOWS_TALONS" ],
+    "flags": [
+      "INTEGRATED",
+      "ALLOWS_NATURAL_ATTACKS",
+      "BLOCK_WHILE_WORN",
+      "UNBREAKABLE",
+      "OUTER",
+      "PADDED",
+      "IRRITANT_IMMUNE",
+      "ALLOWS_TALONS"
+    ],
     "armor": [
       {
         "material": [ { "type": "sclerotin", "covered_by_mat": 100, "thickness": 4 } ],
@@ -1003,7 +1030,16 @@
     "color": "brown",
     "warmth": 20,
     "environmental_protection": 1,
-    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "BLOCK_WHILE_WORN", "UNBREAKABLE", "OUTER", "PADDED", "IRRITANT_IMMUNE", "ALLOWS_TALONS" ],
+    "flags": [
+      "INTEGRATED",
+      "ALLOWS_NATURAL_ATTACKS",
+      "BLOCK_WHILE_WORN",
+      "UNBREAKABLE",
+      "OUTER",
+      "PADDED",
+      "IRRITANT_IMMUNE",
+      "ALLOWS_TALONS"
+    ],
     "armor": [
       {
         "material": [ { "type": "sclerotin", "covered_by_mat": 100, "thickness": 4.5 } ],
@@ -1368,7 +1404,16 @@
     "color": "light_red",
     "warmth": 3,
     "environmental_protection": 4,
-    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "SKINTIGHT", "WATER_FRIENDLY", "IRRITANT_IMMUNE", "TOUGH_FEET", "ALLOWS_TALONS" ],
+    "flags": [
+      "INTEGRATED",
+      "ALLOWS_NATURAL_ATTACKS",
+      "UNBREAKABLE",
+      "SKINTIGHT",
+      "WATER_FRIENDLY",
+      "IRRITANT_IMMUNE",
+      "TOUGH_FEET",
+      "ALLOWS_TALONS"
+    ],
     "armor": [
       {
         "material": [

--- a/data/json/items/armor/suits_protection.json
+++ b/data/json/items/armor/suits_protection.json
@@ -2751,7 +2751,17 @@
     "warmth": 40,
     "material_thickness": 2,
     "environmental_protection": 20,
-    "flags": [ "VARSIZE", "WATERPROOF", "IRRITANT_IMMUNE", "RAINPROOF", "GAS_PROOF", "RAD_PROOF", "ELECTRIC_IMMUNE", "OUTER", "SOFT" ],
+    "flags": [
+      "VARSIZE",
+      "WATERPROOF",
+      "IRRITANT_IMMUNE",
+      "RAINPROOF",
+      "GAS_PROOF",
+      "RAD_PROOF",
+      "ELECTRIC_IMMUNE",
+      "OUTER",
+      "SOFT"
+    ],
     "armor": [
       {
         "encumbrance": 37,

--- a/data/json/items/armor/suits_protection.json
+++ b/data/json/items/armor/suits_protection.json
@@ -2646,7 +2646,7 @@
     "longest_side": "30 cm",
     "material_thickness": 5,
     "environmental_protection": 20,
-    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "GAS_PROOF", "STURDY", "OUTER" ],
+    "flags": [ "VARSIZE", "WATERPROOF", "IRRITANT_IMMUNE", "RAINPROOF", "GAS_PROOF", "STURDY", "OUTER" ],
     "armor": [
       {
         "encumbrance": 50,
@@ -2751,7 +2751,7 @@
     "warmth": 40,
     "material_thickness": 2,
     "environmental_protection": 20,
-    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "GAS_PROOF", "RAD_PROOF", "ELECTRIC_IMMUNE", "OUTER", "SOFT" ],
+    "flags": [ "VARSIZE", "WATERPROOF", "IRRITANT_IMMUNE", "RAINPROOF", "GAS_PROOF", "RAD_PROOF", "ELECTRIC_IMMUNE", "OUTER", "SOFT" ],
     "armor": [
       {
         "encumbrance": 37,
@@ -2956,7 +2956,7 @@
       "msg": "You slip out of the top of the suit and tie the sleeves around your waist.",
       "target": "robofac_enviro_suit_casual"
     },
-    "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "GAS_PROOF", "RAD_PROOF", "ELECTRIC_IMMUNE", "STURDY" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "IRRITANT_IMMUNE", "RAINPROOF", "GAS_PROOF", "RAD_PROOF", "ELECTRIC_IMMUNE", "STURDY" ]
   },
   {
     "id": "robofac_enviro_suit_casual",
@@ -3046,7 +3046,7 @@
       "msg": "You untie the sleeves and put back on the top of the suit.",
       "target": "robofac_enviro_suit"
     },
-    "delete": { "flags": [ "RAINPROOF", "GAS_PROOF", "RAD_PROOF", "ELECTRIC_IMMUNE" ] }
+    "delete": { "flags": [ "RAINPROOF", "IRRITANT_IMMUNE", "GAS_PROOF", "RAD_PROOF", "ELECTRIC_IMMUNE" ] }
   },
   {
     "id": "xedra_enviro_suit",

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -8045,7 +8045,7 @@
     "category": [ "PLANT" ],
     "scent_type": "sc_flower",
     "encumbrance_covered": [ [ "foot_l", 10 ], [ "foot_r", 10 ] ],
-    "flags": [ "TOUGH_FEET", "ROOTS3", "IRRITANT_IMMUNE" ]
+    "flags": [ "TOUGH_FEET", "ROOTS3" ]
   },
   {
     "type": "mutation",
@@ -8954,7 +8954,6 @@
     "vitamin_cost": 60,
     "description": "Your flesh is highly poisonous, and creatures that bite you will receive a nasty surprise.",
     "category": [ "FISH", "GASTROPOD" ],
-    "flags": [ "IRRITANT_IMMUNE" ],
     "threshreq": [ "THRESH_FISH", "THRESH_GASTROPOD" ],
     "purifiable": false
   },

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -2675,6 +2675,7 @@
     "description": "We have begun adapting local physiology to Mycus physical structure, greatly reducing wet effects.",
     "purifiable": false,
     "category": [ "MYCUS" ],
+    "flags": [ "IRRITANT_IMMUNE" ],
     "prereqs": [ "M_IMMUNE" ],
     "threshreq": [ "THRESH_MYCUS" ],
     "leads_to": [ "M_DEFENDER" ],
@@ -2702,7 +2703,7 @@
     "ugliness": 8,
     "description": "We have spliced the dense, amphibole fibers from Mycus core towers with the resilient, adaptive flesh of local physiology.  This reduces our speed by a moderate amount, but provides powerful armor across our body, nullifies wet effects, and provides complete protection from fire.",
     "purifiable": false,
-    "flags": [ "HEAT_IMMUNE" ],
+    "flags": [ "HEAT_IMMUNE", "IRRITANT_IMMUNE" ],
     "category": [ "MYCUS" ],
     "prereqs": [ "M_SKIN" ],
     "prereqs2": [ "M_DEFENDER" ],
@@ -2732,7 +2733,7 @@
     "ugliness": 10,
     "description": "Local physiology has been fully incorporated with that of Mycus silicate fibers.  In addition to benefits conferred by previous developments, we may join with Mycus fibers beneath us - sleeping on top of fungal areas places us into a dormant state, which spreads spores around us as we sleep and revitalizes our body much more quickly than regular sleep.",
     "purifiable": false,
-    "flags": [ "HEAT_IMMUNE" ],
+    "flags": [ "HEAT_IMMUNE", "IRRITANT_IMMUNE" ],
     "category": [ "MYCUS" ],
     "prereqs": [ "M_SKIN2" ],
     "threshreq": [ "THRESH_MYCUS" ],
@@ -5660,7 +5661,8 @@
     "prereqs": [ "GASTROPOD_FOOT" ],
     "leads_to": [ "MUCUS_SECRETION2" ],
     "changes_to": [ "SNAIL_TRAIL" ],
-    "category": [ "GASTROPOD" ]
+    "category": [ "GASTROPOD" ],
+    "flags": [ "IRRITANT_IMMUNE" ]
   },
   {
     "type": "mutation",
@@ -5679,7 +5681,8 @@
       "base_damage": { "damage_type": "acid", "amount": 6 }
     },
     "prereqs": [ "MUCUS_SECRETION" ],
-    "category": [ "GASTROPOD" ]
+    "category": [ "GASTROPOD" ],
+    "flags": [ "IRRITANT_IMMUNE" ]
   },
   {
     "type": "mutation",
@@ -5692,6 +5695,7 @@
     "description": "You've developed some ability to control your slime emissions.  As a result of this you can leave trails of slime anywhere you walk.",
     "prereqs": [ "MUCUS_SECRETION" ],
     "category": [ "GASTROPOD" ],
+    "flags": [ "IRRITANT_IMMUNE" ],
     "active": true,
     "cost": 174,
     "time": "100 s",
@@ -7700,6 +7704,7 @@
     "leads_to": [ "SLIME_HANDS" ],
     "changes_to": [ "VISCOUS" ],
     "category": [ "FISH", "SLIME", "TROGLOBITE", "CEPHALOPOD", "GASTROPOD", "BATRACHIAN" ],
+    "flags": [ "IRRITANT_IMMUNE" ],
     "wet_protection": [
       { "part": "head", "neutral": 3, "good": 4 },
       { "part": "leg_l", "neutral": 7, "good": 14 },
@@ -7726,6 +7731,7 @@
     "prereqs": [ "SLIMY" ],
     "threshreq": [ "THRESH_SLIME", "THRESH_GASTROPOD" ],
     "category": [ "SLIME", "GASTROPOD" ],
+    "flags": [ "IRRITANT_IMMUNE" ],
     "wet_protection": [
       { "part": "head", "neutral": 4, "good": 5 },
       { "part": "leg_l", "neutral": 8, "good": 15 },
@@ -8039,7 +8045,7 @@
     "category": [ "PLANT" ],
     "scent_type": "sc_flower",
     "encumbrance_covered": [ [ "foot_l", 10 ], [ "foot_r", 10 ] ],
-    "flags": [ "TOUGH_FEET", "ROOTS3" ]
+    "flags": [ "TOUGH_FEET", "ROOTS3", "IRRITANT_IMMUNE" ]
   },
   {
     "type": "mutation",
@@ -8875,7 +8881,7 @@
     "name": { "str": "Acidproof" },
     "points": 3,
     "vitamin_cost": 160,
-    "flags": [ "ACID_IMMUNE" ],
+    "flags": [ "ACID_IMMUNE", "IRRITANT_IMMUNE" ],
     "description": "Your mutated flesh is immune to the damaging effects of acid.",
     "threshreq": [ "THRESH_INSECT", "THRESH_CHIMERA", "THRESH_MEDICAL", "THRESH_SLIME" ],
     "category": [ "INSECT", "CHIMERA", "MEDICAL", "SLIME" ]
@@ -8948,6 +8954,7 @@
     "vitamin_cost": 60,
     "description": "Your flesh is highly poisonous, and creatures that bite you will receive a nasty surprise.",
     "category": [ "FISH", "GASTROPOD" ],
+    "flags": [ "IRRITANT_IMMUNE" ],
     "threshreq": [ "THRESH_FISH", "THRESH_GASTROPOD" ],
     "purifiable": false
   },


### PR DESCRIPTION
#### Summary

Infrastructure "Add IRRITANT_IMMUNE flag for describing immunity to skin irritants"

#### Purpose of change

When setting up an effect condition, I noted a significant number of potential mutations and mutation armors, and a few different armor suits, that could all reasonably provide total protection of the skin from irritating substances. The list in the effect condition was getting really long.

#### Describe the solution

Create a new flag, `IRRITANT_IMMUNE`, and add it to anything that seems like it would either prevent irritating substances from making contact with the skin. or just remove the skin entirely. I based it on coverage, existing flags, and descriptions.

#### Describe alternatives you've considered

Use the `ACID_IMMUNE` flag instead. While a heavy coat of stiff fur would reasonably prevent a spray of itch powder from making contact with the skin, acid would burn straight through.

Use the `WATERPROOF` and/or `RAINPROOF` flags instead. While letting a few droplets of water slip between your glove and arm sleeves isn't worth fussing about (it will just evaporate), any amount of itching powder slipping through would _suck_, and it would find its way over a lot of the rest of your body as you're swinging weapons and ducking and weaving and such.

#### Testing

The JSON style checker will yell at me if something is goofed.

#### Additional context

This is just for "all-or-nothing" things that cover basically all the skin on the body. More nuanced calculations will presumably come in #72271.