### PR TITLE
Fixing raw copper wire weight consistency with copper

### DIFF
--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -434,9 +434,9 @@
     "reversible": true,
     "autolearn": false,
     "qualities": [ { "id": "HAMMER", "level": 1 } ],
-    "charges": 15,
+    "charges": 19,
     "tools": [ [ [ "surface_heat", 10, "LIST" ] ] ],
-    "//": "There is a loss of approximately 24.6 grams, for the math check <PR number>",
+    "//": "There is a loss of approximately 4687 milligrams, for the math check #74702",
     "components": [ [ [ "copper_wire", 21 ] ] ]
   },
   {

--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -425,6 +425,22 @@
   },
   {
     "type": "recipe",
+    "activity_level": "MODERATE_EXERCISE",
+    "result": "copper",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_MATERIALS",
+    "skill_used": "fabrication",
+    "time": "1 h",
+    "reversible": true,
+    "autolearn": false,
+    "qualities": [ { "id": "HAMMER", "level": 1 } ],
+    "charges": "15",
+    "tools": [ [ [ "surface_heat", 10, "LIST" ] ] ],
+    "//": "There is a loss of approximately 24.6 grams, for the math check <PR number>",
+    "components": [ [ [ "copper_wire", 21 ] ] ]
+  },
+  {
+    "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
     "result": "plastic_chunk",
     "id_suffix": "from_plastic_bags",

--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -434,7 +434,7 @@
     "reversible": true,
     "autolearn": false,
     "qualities": [ { "id": "HAMMER", "level": 1 } ],
-    "charges": "15",
+    "charges": 15,
     "tools": [ [ [ "surface_heat", 10, "LIST" ] ] ],
     "//": "There is a loss of approximately 24.6 grams, for the math check <PR number>",
     "components": [ [ [ "copper_wire", 21 ] ] ]

--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -435,7 +435,7 @@
     "qualities": [ { "id": "HAMMER", "level": 1 } ],
     "charges": 19,
     "tools": [ [ [ "surface_heat", 10, "LIST" ] ] ],
-    "//": "There is a loss of approximately 24.6 grams, for the math check <PR number>",
+    "//": "There is a loss of approximately 4.687 grams, for the math check #74702.",
     "components": [ [ [ "copper_wire", 21 ] ] ]
   },
   {

--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -431,12 +431,11 @@
     "subcategory": "CSC_OTHER_MATERIALS",
     "skill_used": "fabrication",
     "time": "1 h",
-    "reversible": true,
     "autolearn": false,
     "qualities": [ { "id": "HAMMER", "level": 1 } ],
     "charges": 19,
     "tools": [ [ [ "surface_heat", 10, "LIST" ] ] ],
-    "//": "There is a loss of approximately 4687 milligrams, for the math check #74702",
+    "//": "There is a loss of approximately 24.6 grams, for the math check <PR number>",
     "components": [ [ [ "copper_wire", 21 ] ] ]
   },
   {

--- a/data/json/recipes/recipe_deconstruction.json
+++ b/data/json/recipes/recipe_deconstruction.json
@@ -2023,14 +2023,6 @@
     "components": [ [ [ "copper_wire", 1 ] ] ]
   },
   {
-    "result": "copper_wire",
-    "type": "uncraft",
-    "time": "1 s",
-    "//": "I made this a near instant conversion.  Raw copper wire is essentially just copper and imo should be freely converted without a huge time investment or tool requirement, they are effectively identical items.",
-    "activity_level": "LIGHT_EXERCISE",
-    "components": [ [ [ "copper", 1 ] ] ]
-  },
-  {
     "result": "camera",
     "type": "uncraft",
     "activity_level": "LIGHT_EXERCISE",


### PR DESCRIPTION
#### Summary
Bugfixes "Raw copper wire (weighing 4.747 g) can no longer be disassembled into copper (5 g). New recipe to turn raw copper wire into copper."

#### Purpose of change

Partial continuation of #74296. Raw copper wire could be converted into copper for 1 to 1 ratio, despite raw copper wire being lighter. We respect the law of conversion of energy. 

#### Describe the solution

I have removed the raw copper wire disassembly recipe and added a new recipe to turn raw copper wire into copper.

#### Describe alternatives you've considered

- Make raw copper be used as a substitute for copper (I'm not doing that).
- Change the recipe itself slightly. I know next to nothing about smithing, so I just reduced the time by half compared to the chunk of copper recipe.
- Make no changes, continue violating laws of physics.

#### Testing

1008 raw copper wires can be crafted into 912 coppers, for a mass loss of approximately .22 kilograms, which is very close to my guess you can read in Additional context. No more matter is being created out of thin air, yippie.

#### Additional context

Naturally this needs some math, and I'm willing to provide the proof.

4.747g * x = 100g
x = ~21.0659 units (closest I could get to a whole number)
5g * x = 100g
x = 20 units`

There is .0659 units of raw copper wire unaccounted for, to fix this I just decided to make 1 less copper from the recipe. A simple fix that's still pretty efficient, for a loss of 4.687 grams of copper.

21.0659 - 21 = 0.0659
0.0659 * 4.747 = 0.313g of mass created out of nowhere (bad)
0.313 - 5.0 = -4.687g of mass consumed by entropy (good)