### PR TITLE
Rice material unification + MRE pluralization normalization

### DIFF
--- a/data/json/items/comestibles/mre.json
+++ b/data/json/items/comestibles/mre.json
@@ -337,7 +337,7 @@
     "type": "COMESTIBLE",
     "id": "mre_potato",
     "copy-from": "mre_side",
-    "name": { "str": "potatoes, Au Gratin" },
+    "name": { "str_sp": "potatoes, Au Gratin" },
     "description": "Golden-fried potatoes.",
     "material": [ "veggy" ]
   },
@@ -345,15 +345,15 @@
     "type": "COMESTIBLE",
     "id": "mre_fried_rice",
     "copy-from": "mre_side",
-    "name": { "str_sp": "fried rice(small portion)" },
+    "name": { "str": "fried rice (small portion)", "str_pl": "fried rice (small portions)" },
     "description": "Fried rice, a simple dish made by stir-frying rice with other ingredients.",
-    "material": [ "wheat" ]
+    "material": [ "veggy" ]
   },
   {
     "type": "COMESTIBLE",
     "id": "mre_zapplesauce",
     "copy-from": "mre_side",
-    "name": { "str": "zapplesauce" },
+    "name": { "str_sp": "zapplesauce" },
     "description": "Golden, jelly-like food with the flavor of apples.",
     "material": [ "fruit" ],
     "fun": 5
@@ -362,7 +362,7 @@
     "type": "COMESTIBLE",
     "id": "mre_blackbeans",
     "copy-from": "mre_side",
-    "name": { "str": "black beans in sauce" },
+    "name": { "str_sp": "black beans in sauce" },
     "description": "A savory and flavorful combination of black beans and sauce.",
     "material": [ "bean" ],
     "calories": 130
@@ -388,7 +388,7 @@
   {
     "type": "COMESTIBLE",
     "id": "mre_carrot_cake",
-    "name": { "str_sp": "carrot pound cake" },
+    "name": { "str": "carrot pound cake" },
     "copy-from": "mre_dessert",
     "description": "Delicious cake with carrots blended seamlessly."
   },
@@ -396,7 +396,7 @@
     "type": "COMESTIBLE",
     "id": "mre_poppyseed_cake",
     "copy-from": "mre_carrot_cake",
-    "name": { "str_sp": "lemon poppy seed pound cake" },
+    "name": { "str": "lemon poppy seed pound cake" },
     "calories": 290,
     "description": "Cake filled with the goodness of lemon and poppy seeds."
   },
@@ -413,7 +413,7 @@
     "type": "COMESTIBLE",
     "id": "mre_chocolate_cake",
     "copy-from": "mre_dessert",
-    "name": { "str_sp": "chocolate chip toaster pastry" },
+    "name": { "str": "chocolate chip toaster pastry", "str_pl": "chocolate chip toaster pastries" },
     "calories": 210,
     "description": "Pastry with chocolate chips."
   },
@@ -421,7 +421,7 @@
     "type": "COMESTIBLE",
     "id": "mre_strawberry_cake",
     "copy-from": "mre_dessert",
-    "name": { "str_sp": "strawberry toaster pastry" },
+    "name": { "str": "strawberry toaster pastry", "str_pl": "strawberry toaster pastries" },
     "calories": 210,
     "description": "Strawberry-flavor pastry."
   }

--- a/data/json/items/comestibles/raw_grain.json
+++ b/data/json/items/comestibles/raw_grain.json
@@ -383,6 +383,7 @@
     "id": "wild_rice",
     "name": { "str_sp": "wild rice" },
     "copy-from": "oats",
+    "material": [ "veggy" ],
     "calories": 120,
     "description": "Raw wild rice, still in its fibrous shell.  It'll need to be milled before it's edible for humans.",
     "milling": { "into": "dry_wild_rice", "recipe": "dry_wild_rice_mill_1_5" },

--- a/data/json/materials.json
+++ b/data/json/materials.json
@@ -2436,7 +2436,7 @@
   {
     "type": "material",
     "id": "veggy",
-    "name": "Vegetable Matter",
+    "name": "Plant Matter",
     "density": 1.1,
     "specific_heat_liquid": 3.9,
     "specific_heat_solid": 1.9,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Devcord pointed out we had some rice dishes which were made of wheat, which made them unable to be eaten if you had wheat intolerance

Then devcord launched into a small confused argument about why rice would be vegetable matter when it's not a vegetable

Then I found out a lot of our MRE dishes are wrongly pluralized
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Change material for MRE fried rice and raw wild rice to be plant matter instead of wheat
- Renamed vegetable matter to plant matter so we don't have to have this argument ever again. We use it for all generic plant matter anyway
- Corrected the pluralization for all the MRE dishes I found that had it set wrong
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
