### PR TITLE
[Xedra Evolved] Vampires can just drink blood

### DIFF
--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -369,7 +369,8 @@
     "//": "Each stage is intended to last 5.3 days.  I'm not sure if I've got the decay ticks correct on this.",
     "blood_analysis_description": "Unknown RNA virus is rewriting sampled blood cells.",
     "base_mods": { "speed_mod": [ -5 ] },
-    "scaling_mods": { "speed_mod": [ 15 ], "str_mod": [ 1.5 ], "dodge_mod": [ 1.5 ] }
+    "scaling_mods": { "speed_mod": [ 15 ], "str_mod": [ 1.5 ], "dodge_mod": [ 1.5 ] },
+    "flags": [ "HEMOVORE" ]
   },
   {
     "type": "effect_type",

--- a/data/mods/Xedra_Evolved/mutations/mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/mutations.json
@@ -134,8 +134,7 @@
     "purifiable": false,
     "valid": false,
     "vitamin_rates": [ [ "human_blood_vitamin", 180 ] ],
-    "spells_learned": [ [ "consume_human_blood", 1 ] ],
-    "flags": [ "CANNIBAL" ]
+    "flags": [ "CANNIBAL", "HEMOVORE" ]
   },
   {
     "type": "mutation",

--- a/data/mods/Xedra_Evolved/mutations/spells.json
+++ b/data/mods/Xedra_Evolved/mutations/spells.json
@@ -66,23 +66,6 @@
     "effect": "attack"
   },
   {
-    "id": "consume_human_blood",
-    "type": "SPELL",
-    "name": "Consume human blood",
-    "description": "You consume human blood to keep the thirst at bay.",
-    "valid_targets": [ "self" ],
-    "effect": "effect_on_condition",
-    "effect_str": "consume_human_blood",
-    "shape": "blast",
-    "energy_source": "NONE",
-    "skill": "deduction",
-    "base_casting_time": 500,
-    "base_energy_cost": 0,
-    "components": "spell_components_human_blood",
-    "flags": [ "SILENT", "NO_LEGS", "NO_FAIL" ],
-    "difficulty": 0
-  },
-  {
     "id": "vampire_map_real",
     "type": "SPELL",
     "name": "Commune with children of the night Real Spell",

--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
@@ -6,7 +6,13 @@
     "required_event": "character_eats_item",
     "condition": {
       "and": [
-        { "compare_string": [ "blood", { "context_val": "itype" } ] },
+        {
+          "or": [
+            { "compare_string": [ "blood", { "context_val": "itype" } ] },
+            { "compare_string": [ "demihuman_blood", { "context_val": "itype" } ] },
+            { "compare_string": [ "mutant_human_blood", { "context_val": "itype" } ] }
+          ]
+        },
         { "or": [ { "u_has_trait": "VAMPIRE" }, { "u_has_effect": "vampire_virus" } ] }
       ]
     },

--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
@@ -1,6 +1,19 @@
 [
   {
     "type": "effect_on_condition",
+    "id": "EOC_VAMPIRE_BLOOD_DRINKING_DIRECTLY",
+    "eoc_type": "EVENT",
+    "required_event": "character_eats_item",
+    "condition": {
+      "and": [
+        { "compare_string": [ "blood", { "context_val": "itype" } ] },
+        { "or": [ { "u_has_trait": "VAMPIRE" }, { "u_has_effect": "vampire_virus" } ] }
+      ]
+    },
+    "effect": [ { "math": [ "u_vitamin('human_blood_vitamin')", "+=", "400 + rand(100)" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_EYEGLEAM_activated",
     "condition": { "math": [ "u_vitamin('human_blood_vitamin')", ">=", "-500" ] },
     "effect": [

--- a/data/mods/Xedra_Evolved/obsoletion_and_migration/components.json
+++ b/data/mods/Xedra_Evolved/obsoletion_and_migration/components.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": "spell_components_human_blood",
+    "type": "requirement",
+    "components": [ [ [ "demihuman_blood", 1 ], [ "mutant_human_blood", 1 ], [ "blood", 1 ] ] ]
+  }
+]

--- a/data/mods/Xedra_Evolved/obsoletion_and_migration/spells.json
+++ b/data/mods/Xedra_Evolved/obsoletion_and_migration/spells.json
@@ -352,5 +352,22 @@
     "max_level": { "math": [ "per_to_level(1)" ] },
     "effect": "translocate",
     "shape": "blast"
+  },
+  {
+    "id": "consume_human_blood",
+    "type": "SPELL",
+    "name": "Consume human blood",
+    "description": "You consume human blood to keep the thirst at bay.",
+    "valid_targets": [ "self" ],
+    "effect": "effect_on_condition",
+    "effect_str": "consume_human_blood",
+    "shape": "blast",
+    "energy_source": "NONE",
+    "skill": "deduction",
+    "base_casting_time": 500,
+    "base_energy_cost": 0,
+    "components": "spell_components_human_blood",
+    "flags": [ "SILENT", "NO_LEGS", "NO_FAIL" ],
+    "difficulty": 0
   }
 ]

--- a/data/mods/Xedra_Evolved/requirements/spell_components.json
+++ b/data/mods/Xedra_Evolved/requirements/spell_components.json
@@ -20,11 +20,6 @@
     "components": [ [ [ "drawing_tool", 2, "LIST" ] ], [ [ "paper", 8 ] ] ]
   },
   {
-    "id": "spell_components_human_blood",
-    "type": "requirement",
-    "components": [ [ [ "demihuman_blood", 1 ], [ "mutant_human_blood", 1 ], [ "blood", 1 ] ] ]
-  },
-  {
     "id": "spell_components_dreamer_coin",
     "type": "requirement",
     "components": [


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Xedra Evolved] Vampires can just drink blood.  They can just drink it"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

For technical reasons, XE's vampires were required to use an ability from their Supernatural Powers menu to drink blood. But that's not necessary anymore.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Obsolete the Consume human blood power and remove learning it from the `VAMPIRE` trait. Add an EoC that checks when a vampire drinks blood (human, demihuman, or mutant) and adds the hidden blood vitamin if so, allowing vampires to drink blood from the consume menu., 

Add the `HEMOVORE` flag to vampires so they're immune to the negative effects of drinking blood.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Drank human and demihuman blood and waited 20 hours. Gained the hidden blood vitamin, did not get brainworms. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
