### PR TITLE
Fix bug in gun variant validator script

### DIFF
--- a/tools/json_tools/gun_variant_validator.py
+++ b/tools/json_tools/gun_variant_validator.py
@@ -309,11 +309,10 @@ def simplify_object(jo):
         return False
 
     req_keys = {"weight", "volume", "ammo", "id"}
-    extra_keys = {"longest_side", "pocket_data", "ranged_damage", "modes",
-                  "recoil", "dispersion", "name"}
+    all_keys = req_keys | set(INHERITED_KEYS)
+
     # Drop all the other keys
-    removed = list(filter(lambda key: key not in req_keys | extra_keys,
-                          jo.keys()))
+    removed = list(filter(lambda key: key not in all_keys, jo.keys()))
     # Need to iterate over removed because we can't delete from dict in for
     for key in removed:
         del jo[key]


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
```
GuardianDll: ERROR: Guns colt_anaconda_8 and colt_anaconda_6 are too similar and should be combined
GuardianDll: doc: "the barrel lengths of the guns are within 2 cm"
GuardianDll: "barrel_length": "203 mm" vs "barrel_length": "153 mm"
GuardianDll: what lies? documentation, script, or common sense?
anothersimulacrum: { 'id': 'colt_anaconda_8', 'ranged_damage': -17, 'ammo': ['44'], 'volume': 1384, 'weight': 1672, 'longest_side': 350, 'dispersion': 280, 'modes': [1], 'magazines': [6], 'speedloaders': ['44_speedloader6']}
anothersimulacrum: { 'id': 'colt_anaconda_6', 'ranged_damage': -17, 'ammo': ['44'], 'volume': 1299, 'weight': 1499, 'longest_side': 300, 'dispersion': 280, 'modes': [1], 'magazines': [6], 'speedloaders': ['44_speedloader6']}
anothersimulacrum: barrel_length isn't in the scraped JSON for whatever reason
```
Oops.

#### Describe the solution
Ensure all keys are preserved for checks.

#### Testing
Fetch https://github.com/CleverRaven/Cataclysm-DDA/pull/74719 and `tools/json_tools/gun_variant_validator.py -v -cin data/json` exits with code 0.

#### Additional context