### PR TITLE
Fixed rotation and spawning issues

### DIFF
--- a/src/map_selector.cpp
+++ b/src/map_selector.cpp
@@ -37,6 +37,13 @@ tripoint_range<tripoint_bub_ms> points_in_range_bub( const map &m )
                tripoint_bub_ms( SEEX * m.getmapsize() - 1, SEEY * m.getmapsize() - 1, OVERMAP_HEIGHT ) );
 }
 
+tripoint_range<tripoint_bub_ms> points_in_level_range( const map &m, const int z )
+{
+    return tripoint_range<tripoint_bub_ms>(
+               tripoint_bub_ms( 0, 0, z ),
+               tripoint_bub_ms( SEEX * m.getmapsize() - 1, SEEY * m.getmapsize() - 1, z ) );
+}
+
 std::optional<tripoint> random_point( const map &m,
                                       const std::function<bool( const tripoint & )> &predicate )
 {
@@ -47,6 +54,12 @@ std::optional<tripoint_bub_ms> random_point( const map &m,
         const std::function<bool( const tripoint_bub_ms & )> &predicate )
 {
     return random_point( points_in_range_bub( m ), predicate );
+}
+
+std::optional<tripoint_bub_ms> random_point_on_level( const map &m, const int z,
+        const std::function<bool( const tripoint_bub_ms & )> &predicate )
+{
+    return random_point( points_in_level_range( m, z ), predicate );
 }
 
 std::optional<tripoint> random_point( const tripoint_range<tripoint> &range,

--- a/src/mapgen_functions.cpp
+++ b/src/mapgen_functions.cpp
@@ -328,6 +328,9 @@ void mapgen_subway( mapgendata &dat )
             break;
     }
 
+    // Rotate the map backwards so things can can be placed in their 'normal' orientation.
+    m->rotate( 4 - rot );
+
     // rotate the arrays left by rot steps
     nesw_array_rotate( subway_nesw, rot );
     nesw_array_rotate( curvedir_nesw, rot );
@@ -554,7 +557,7 @@ void mapgen_subway( mapgendata &dat )
             break;
     }
 
-    // finally, unrotate the map
+    // finally, unrotate the map back to its normal orientation, resulting in the new addition being rotated.
     m->rotate( rot );
 }
 
@@ -566,6 +569,19 @@ void mapgen_river_center( mapgendata &dat )
 void mapgen_river_curved_not( mapgendata &dat )
 {
     map *const m = &dat.m;
+    int rot = 0;
+
+    if( dat.terrain_type() == oter_river_c_not_se ) {
+        rot = 1;
+    } else if( dat.terrain_type() == oter_river_c_not_sw ) {
+        rot = 2;
+    } else if( dat.terrain_type() == oter_river_c_not_nw ) {
+        rot = 3;
+    }
+
+    // Rotate the map backwards so things can can be placed in their 'normal' orientation.
+    m->rotate( 4 - rot );
+
     fill_background( m, ter_t_water_moving_dp );
     // this is not_ne, so deep on all sides except ne corner, which is shallow
     // shallow is 20,0, 23,4
@@ -586,20 +602,26 @@ void mapgen_river_curved_not( mapgendata &dat )
         }
     }
 
-    if( dat.terrain_type() == oter_river_c_not_se ) {
-        m->rotate( 1 );
-    }
-    if( dat.terrain_type() == oter_river_c_not_sw ) {
-        m->rotate( 2 );
-    }
-    if( dat.terrain_type() == oter_river_c_not_nw ) {
-        m->rotate( 3 );
-    }
+    // finally, unrotate the map back to its normal orientation, resulting in the new addition being rotated.
+    m->rotate( rot );
 }
 
 void mapgen_river_straight( mapgendata &dat )
 {
     map *const m = &dat.m;
+    int rot = 0;
+
+    if( dat.terrain_type() == oter_river_east ) {
+        rot = 1;
+    } else if( dat.terrain_type() == oter_river_south ) {
+        rot = 2;
+    } else if( dat.terrain_type() == oter_river_west ) {
+        rot = 3;
+    }
+
+    // Rotate the map backwards so things can can be placed in their 'normal' orientation.
+    m->rotate( 4 - rot );
+
     fill_background( m, ter_t_water_moving_dp );
 
     for( int x = 0; x < SEEX * 2; x++ ) {
@@ -612,20 +634,26 @@ void mapgen_river_straight( mapgendata &dat )
         line( m, ter_t_water_moving_sh, point( x, ++ground_edge ), point( x, shallow_edge ), dat.zlevel() );
     }
 
-    if( dat.terrain_type() == oter_river_east ) {
-        m->rotate( 1 );
-    }
-    if( dat.terrain_type() == oter_river_south ) {
-        m->rotate( 2 );
-    }
-    if( dat.terrain_type() == oter_river_west ) {
-        m->rotate( 3 );
-    }
+    // finally, unrotate the map back to its normal orientation, resulting in the new addition being rotated.
+    m->rotate( rot );
 }
 
 void mapgen_river_curved( mapgendata &dat )
 {
     map *const m = &dat.m;
+    int rot = 0;
+
+    if( dat.terrain_type() == oter_river_se ) {
+        rot = 1;
+    } else if( dat.terrain_type() == oter_river_sw ) {
+        rot = 2;
+    } else if( dat.terrain_type() == oter_river_nw ) {
+        rot = 3;
+    }
+
+    // Rotate the map backwards so things can can be placed in their 'normal' orientation.
+    m->rotate( 4 - rot );
+
     fill_background( m, ter_t_water_moving_dp );
     // NE corner deep, other corners are shallow.  do 2 passes: one x, one y
     for( int x = 0; x < SEEX * 2; x++ ) {
@@ -647,15 +675,8 @@ void mapgen_river_curved( mapgendata &dat )
         line( m, ter_t_water_moving_sh, point( shallow_edge, y ), point( --ground_edge, y ), dat.zlevel() );
     }
 
-    if( dat.terrain_type() == oter_river_se ) {
-        m->rotate( 1 );
-    }
-    if( dat.terrain_type() == oter_river_sw ) {
-        m->rotate( 2 );
-    }
-    if( dat.terrain_type() == oter_river_nw ) {
-        m->rotate( 3 );
-    }
+    // finally, unrotate the map back to its normal orientation, resulting in the new addition being rotated.
+    m->rotate( rot );
 }
 
 void mapgen_rock_partial( mapgendata &dat )
@@ -2111,47 +2132,81 @@ void mapgen_ravine_edge( mapgendata &dat )
 
     //With that done, we generate the maps.
     if( straight ) {
+        int rot = 0;
+
+        if( w_ravine ) {
+            rot += 1;
+        }
+        if( n_ravine ) {
+            rot += 2;
+        }
+        if( e_ravine ) {
+            rot += 3;
+        }
+
+        rot %= 4;
+
+        // Rotate the map 'backwards' to allow the new addition to be placed at its normal orientation.
+        m->rotate( 4 - rot );
+
         for( int x = 0; x < SEEX * 2; x++ ) {
             int ground_edge = 12 + rng( 1, 3 );
             line( m, ter_str_id::NULL_ID(), point( x, ++ground_edge ), point( x, SEEY * 2 ), dat.zlevel() );
         }
-        if( w_ravine ) {
-            m->rotate( 1 );
-        }
-        if( n_ravine ) {
-            m->rotate( 2 );
-        }
-        if( e_ravine ) {
-            m->rotate( 3 );
-        }
+
+        // Rotate the map back to its normal rotation, resulting in the new contents becoming rotated.
+        m->rotate( rot );
+
     } else if( interior_corner ) {
+        int rot = 0;
+
+        if( nw_ravine ) {
+            rot += 1;
+        }
+        if( ne_ravine ) {
+            rot += 2;
+        }
+        if( se_ravine ) {
+            rot += 3;
+        }
+
+        rot %= 4;
+
+        // Rotate the map 'backwards' to allow the new addition to be placed at its normal orientation.
+        m->rotate( 4 - rot );
+
         for( int x = 0; x < SEEX * 2; x++ ) {
             int ground_edge = 12 + rng( 1, 3 ) + x;
             line( m, ter_str_id::NULL_ID(), point( x, ++ground_edge ), point( x, SEEY * 2 ), dat.zlevel() );
         }
-        if( nw_ravine ) {
-            m->rotate( 1 );
-        }
-        if( ne_ravine ) {
-            m->rotate( 2 );
-        }
-        if( se_ravine ) {
-            m->rotate( 3 );
-        }
+
+        // Rotate the map back to its normal rotation, resulting in the new contents becoming rotated.
+        m->rotate( rot );
+
     } else if( exterior_corner ) {
+        int rot = 0;
+
+        if( w_ravine && s_ravine ) {
+            rot += 1;
+        }
+        if( w_ravine && n_ravine ) {
+            rot += 2;
+        }
+        if( e_ravine && n_ravine ) {
+            rot += 3;
+        }
+
+        rot %= 4;
+
+        // Rotate the map 'backwards' to allow the new addition to be placed at its normal orientation.
+        m->rotate( 4 - rot );
+
         for( int x = 0; x < SEEX * 2; x++ ) {
             int ground_edge =  12  + rng( 1, 3 ) - x;
             line( m, ter_str_id::NULL_ID(), point( x, --ground_edge ), point( x, SEEY * 2 - 1 ), dat.zlevel() );
         }
-        if( w_ravine && s_ravine ) {
-            m->rotate( 1 );
-        }
-        if( w_ravine && n_ravine ) {
-            m->rotate( 2 );
-        }
-        if( e_ravine && n_ravine ) {
-            m->rotate( 3 );
-        }
+        // Rotate the map back to its normal rotation, resulting in the new contents becoming rotated.
+        m->rotate( rot );
     }
     // The placed t_null terrains are converted into the regional groundcover in the ravine's bottom level,
     // in the other levels they are converted into open air to generate the cliffside.

--- a/src/rng.h
+++ b/src/rng.h
@@ -198,7 +198,7 @@ inline V random_entry_removed( C &container )
 tripoint_range<tripoint> points_in_range( const map &m );
 tripoint_range<tripoint_bub_ms> points_in_range_bub( const map &m );
 // Restricts the points to the specified Z level.
-tripoint_range<tripoint_bub_ms> points_in_level_range( const map &m, const int z );
+tripoint_range<tripoint_bub_ms> points_in_level_range( const map &m, int z );
 /// Returns a random point in the given range that satisfies the given predicate ( if any ).
 // TODO: Remove untyped overload
 std::optional<tripoint> random_point( const tripoint_range<tripoint> &range,
@@ -211,7 +211,7 @@ std::optional<tripoint> random_point( const map &m,
                                       const std::function<bool( const tripoint & )> &predicate );
 std::optional<tripoint_bub_ms> random_point( const map &m,
         const std::function<bool( const tripoint_bub_ms & )> &predicate );
-std::optional<tripoint_bub_ms> random_point_on_level( const map &m, const int z,
+std::optional<tripoint_bub_ms> random_point_on_level( const map &m, int z,
         const std::function<bool( const tripoint_bub_ms & )> &predicate );
 
 #endif // CATA_SRC_RNG_H

--- a/src/rng.h
+++ b/src/rng.h
@@ -197,6 +197,8 @@ inline V random_entry_removed( C &container )
 // TODO: Remove untyped overload
 tripoint_range<tripoint> points_in_range( const map &m );
 tripoint_range<tripoint_bub_ms> points_in_range_bub( const map &m );
+// Restricts the points to the specified Z level.
+tripoint_range<tripoint_bub_ms> points_in_level_range( const map &m, const int z );
 /// Returns a random point in the given range that satisfies the given predicate ( if any ).
 // TODO: Remove untyped overload
 std::optional<tripoint> random_point( const tripoint_range<tripoint> &range,
@@ -208,6 +210,8 @@ std::optional<tripoint_bub_ms> random_point( const tripoint_range<tripoint_bub_m
 std::optional<tripoint> random_point( const map &m,
                                       const std::function<bool( const tripoint & )> &predicate );
 std::optional<tripoint_bub_ms> random_point( const map &m,
+        const std::function<bool( const tripoint_bub_ms & )> &predicate );
+std::optional<tripoint_bub_ms> random_point_on_level( const map &m, const int z,
         const std::function<bool( const tripoint_bub_ms & )> &predicate );
 
 #endif // CATA_SRC_RNG_H


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #74725, i.e. random rotation of prison over lab.
Fix #74741, i.e. rain of zombie miners (again).

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Ensured hard coded mapgen pieces get rotated backwards, piece generated, and rotated back as the rest of the assets (That wasn't needed with tinymap, as the generated level was the only one in the map).
- Fixed the sneaky causing the primary issue, namely that the function providing the rotation can return a randomized value, and so can not be called separately on the two rotations. Call it once and use the returned value for both rotations instead.
- Addressed the issue of creatures spawning on the wrong level again, and properly this time by introducing a new function that only returns the points on the same Z level, rather than the whole map. For some reason the fix from the previous PR wasn't present, but this should take care of it finally.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Clean up the usage of the random point operations. As far as I could see it is only used by a test function, but I think typifying is out of scope for this PR.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Teleported to the same prison that's been misbehaving a few times (reloading in between), with no issues seen anymore (including the lab beneath). Also teleported to all hunting lodges to see they were sane, as well as spawning the church retreat (ignoring duplicate warning) rotated for good measure, and didn't find any issues. Also teleported around a little to see if anything else looked off.
Teleported along both sides of a river (one of the hard coded bits) to see if anything looked off, but found it looking as it usually does.
Teleported to a subway (another hard coded piece) and examined various stretches of it, including a lab connection, without finding anything odd.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
As mentioned, I did look for other usages of random_point to see if there might be any other victims of tinymap -> smallmap + random_point victims, but failed to find any. The test code uses it with map, so it presumably wants all Z levels.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
