### PR TITLE
Appease clang

### DIFF
--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -187,13 +187,13 @@ static const material_id material_water( "water" );
 
 static const morale_type morale_support( "morale_support" );
 
+static const mtype_id mon_amalgamation_breather( "mon_amalgamation_breather" );
+static const mtype_id mon_amalgamation_breather_hub( "mon_amalgamation_breather_hub" );
 static const mtype_id mon_biollante( "mon_biollante" );
 static const mtype_id mon_blob( "mon_blob" );
 static const mtype_id mon_blob_brain( "mon_blob_brain" );
 static const mtype_id mon_blob_large( "mon_blob_large" );
 static const mtype_id mon_blob_small( "mon_blob_small" );
-static const mtype_id mon_amalgamation_breather( "mon_amalgamation_breather" );
-static const mtype_id mon_amalgamation_breather_hub( "mon_amalgamation_breather_hub" );
 static const mtype_id mon_breather( "mon_breather" );
 static const mtype_id mon_breather_hub( "mon_breather_hub" );
 static const mtype_id mon_creeper_hub( "mon_creeper_hub" );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/9620109376/job/26537639091?pr=74700#step:9:995
```
/home/runner/work/Cataclysm-DDA/Cataclysm-DDA/src/monattack.cpp:94:1: error: string_id declarations should be sorted.
 /home/runner/work/Cataclysm-DDA/Cataclysm-DDA/src/monattack.cpp:195:1: note: 'mon_amalgamation_breather' should be before 'mon_blob_small'.
  195 | static const mtype_id mon_amalgamation_breather( "mon_amalgamation_breather" );
      | ^
```

#### Describe the solution
Sort static variables

#### Testing
Code compiles locally, but I don't have clang-tidy running, so watch the job here to ensure it passes.