### PR TITLE
Fix NPC crafting message

### DIFF
--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1529,7 +1529,7 @@ void Character::complete_craft( item &craft, const std::optional<tripoint> &loc 
                 add_msg( _( "%1s crafts %2s from memory." ), get_name(), making.result_name() );
             }
         } else {
-            if( is_avatar() ){
+            if( is_avatar() ) {
                 add_msg( _( "You craft %s using a reference." ), making.result_name() );
             } else {
                 add_msg( _( "%1s crafts %2s using a reference." ), get_name(), making.result_name() );

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1523,7 +1523,7 @@ void Character::complete_craft( item &craft, const std::optional<tripoint> &loc 
     if( !making.is_practice() && ( !newits.empty() || !making.result_eocs.empty() ) ) {
         // TODO: reconsider recipe memorization
         if( knows_recipe( &making ) ) {
-            if( is_avatar() ){
+            if( is_avatar() ) {
                 add_msg( _( "You craft %s from memory." ), making.result_name() );
             } else {
                 add_msg( _( "%1s crafts %2s from memory." ), get_name(), making.result_name() );

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1523,9 +1523,17 @@ void Character::complete_craft( item &craft, const std::optional<tripoint> &loc 
     if( !making.is_practice() && ( !newits.empty() || !making.result_eocs.empty() ) ) {
         // TODO: reconsider recipe memorization
         if( knows_recipe( &making ) ) {
-            add_msg( _( "You craft %s from memory." ), making.result_name() );
+            if( is_avatar() ){
+                add_msg( _( "You craft %s from memory." ), making.result_name() );
+            } else {
+                add_msg( _( "%1s crafts %2s from memory." ), get_name(), making.result_name() );
+            }
         } else {
-            add_msg( _( "You craft %s using a reference." ), making.result_name() );
+            if( is_avatar() ){
+                add_msg( _( "You craft %s using a reference." ), making.result_name() );
+            } else {
+                add_msg( _( "%1s crafts %2s using a reference." ), get_name(), making.result_name() );
+            }
             // If we made it, but we don't know it, we're using a book, device or NPC
             // as a reference and have a chance to learn it.
             // Base expected time to learn is 1000*(difficulty^4)/skill/int moves.


### PR DESCRIPTION
#### Summary
Interface "Adds message for NPCs completing crafting so it doesn't reference the player incorrectly."

#### Purpose of change
Resolves #74242

#### Describe the solution
Added conditional to crafting.cpp to check if action was from avatar, then added appropriate messages for when crafting is not from avatar.

#### Testing
Compiled, ran, and ordered NPC to craft. Message displayed correctly.