### PR TITLE
Try to appease clang

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5245,6 +5245,9 @@ item &map::add_item_or_charges( const tripoint &pos, item obj, int &copies_remai
     return *_add_item_or_charges( pos, std::move( obj ), copies_remaining, overflow ).first;
 }
 
+// clang-tidy is confused and thinks obj can be made into a const reference, but it can't
+// on_drop is not a const function
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
 std::pair<item *, tripoint> map::_add_item_or_charges( const tripoint &pos, item obj,
         int &copies_remaining, bool overflow )
 {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Clang-tidy keeps making this suggestion in my PR: https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/9634796206/job/26570985402?pr=74700#step:9:913
```
Error: /home/runner/work/Cataclysm-DDA/Cataclysm-DDA/src/map.cpp:5248:82: error: the parameter 'obj' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param,-warnings-as-errors]
 5248 | std::pair<item *, tripoint> map::_add_item_or_charges( const tripoint &pos, item obj,
      |                                                                                  ^
      |                                                                             const  &
```
This doesn't compile.

#### Describe the solution
Silence the clang-tidy check.

#### Testing
Watch the clang-tidy run on this PR.