### PR TITLE
Allow EOCs to check and modify battery charge in items

### DIFF
--- a/data/json/effects_on_condition/example_eocs.json
+++ b/data/json/effects_on_condition/example_eocs.json
@@ -511,5 +511,16 @@
       { "u_set_talker": { "global_val": "u_character_id" } },
       { "u_message": "Your character id is <global_val:u_character_id>" }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_print_item_charge",
+    "condition": { "math": [ "n_val('power_max')", ">", "0" ] },
+    "effect": [
+      { "math": [ "ITEM_POWER", "=", "n_val('power')" ] },
+      { "math": [ "ITEM_POWER_MAX", "=", "n_val('power_max')" ] },
+      { "math": [ "ITEM_POWER_PERC", "=", "n_val('power_percentage')" ] },
+      { "u_message": "<global_val:ITEM_POWER> / <global_val:ITEM_POWER_MAX> (<global_val:ITEM_POWER_PERC>%)" }
+    ]
   }
 ]

--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -2048,7 +2048,7 @@ Run EOCs on items in your or NPC's inventory
 | Syntax | Optionality | Value  | Info |
 | --- | --- | --- | --- | 
 | "u_run_inv_eocs" / "npc_run_inv_eocs" | **mandatory** | string or [variable object](#variable-object) | way the item would be picked; <br/>values can be:<br/>`all` - all items that match the conditions are picked;<br/> `random` - from all items that match the conditions, one picked;<br/>`manual` - menu is open with all items that can be picked, and you can choose one;<br/>`manual_mult` - same as `manual`, but multiple items can be picked |
-| "search_data" | optional | `search_data` | sets the condition for the target item; lack of search_data means any item can be picked; conditions can be:<br/>`id` - id of a specific item;<br/>`category` - category of an item (case sensitive, should always be in lower case);<br/>`flags`- flag or flags the item has<br/>`excluded_flags`- flag or flags the item doesn't have<br/>`material` - material of an item;<br/>`worn_only` - if true, return only items, that are worn;<br/>`wielded_only` - if true, return only wielded items;<br/>`calories` - minimum amount of kcal of an item | 
+| "search_data" | optional | `search_data` | sets the condition(s) for the target item; lack of search_data means any item can be picked; conditions can be:<br/>`id` - id of a specific item;<br/>`category` - category of an item (case sensitive, should always be in lower case);<br/>`flags`- flag or flags the item has<br/>`excluded_flags`- flag or flags the item doesn't have<br/>`material` - material of an item;<br/>`worn_only` - if true, return only items, that are worn;<br/>`wielded_only` - if true, return only wielded items;<br/>`calories` - minimum amount of kcal of an item | 
 | "title" | optional | string or [variable object](#variable-object) | name of the menu, that would be shown, if `manual` or `manual_mult` is used | 
 | "true_eocs" / "false_eocs" | optional | string, [variable object](##variable-object), inline EoC, or range of all of them | if item was picked successfully, all EoCs from `true_eocs` are run, otherwise all EoCs from `false_eocs` are run; picked item is returned as npc; for example, `n_hp()` return hp of an item | 
 
@@ -2088,7 +2088,20 @@ Pick a wooden item with `DURABLE_MELEE` and `ALWAYS_TWOHAND` flags, and run `EOC
   ]
 }
 ```
-
+Pick all items with `RECHARGE` _or_ `ELECTRONIC` flags, and run `EOC_PRINT_ITEM_CHARGE` on them.
+```json
+{
+  "type": "effect_on_condition",
+  "id": "eoc_print_inv_power",
+  "effect": [
+    {
+      "u_run_inv_eocs": "all",
+      "search_data": [ { "flags": [ "RECHARGE" ] }, { "flags": [ "ELECTRONIC" ] } ],
+      "true_eocs": [ "EOC_PRINT_ITEM_CHARGE" ]
+    }
+  ]
+}
+```
 
 #### `u_map_run_item_eocs`, `npc_map_run_item_eocs`
 Search items around you on the map, and run EoC on them
@@ -2099,7 +2112,7 @@ Search items around you on the map, and run EoC on them
 | "loc" | optional | location variable | location, where items would be scanned; lack of it would scan only tile the talker stands on | 
 | "min_radius", "max_radius" | optional | int or [variable object](#variable-object) | radius around the location/talker that would be searched | 
 | "title" | optional | string or [variable object](#variable-object) | name of the menu that would be shown, if `manual` or `manual_mult` values are used | 
-| "search_data" | optional | `search_data` | sets the condition for the target item; lack of search_data means any item can be picked; conditions can be:<br/>`id` - id of a specific item;<br/>`category` - category of an item (case sensitive, should always be in lower case);<br/>`flags`- flag or flags the item has<br/>`excluded_flags`- flag or flags the item doesn't have<br/>`material` - material of an item;<br/>`worn_only` - if true, return only items, that are worn;<br/>`wielded_only` - if true, return only wielded items | 
+| "search_data" | optional | `search_data` | sets the condition(s) for the target item; lack of search_data means any item can be picked; conditions can be:<br/>`id` - id of a specific item;<br/>`category` - category of an item (case sensitive, should always be in lower case);<br/>`flags`- flag or flags the item has<br/>`excluded_flags`- flag or flags the item doesn't have<br/>`material` - material of an item;<br/>`worn_only` - if true, return only items, that are worn;<br/>`wielded_only` - if true, return only wielded items | 
 | "true_eocs", "false_eocs" | optional | string, [variable object](##variable-object), inline EoC, or range of all of them | if item was picked successfully, all EoCs from `true_eocs` are run, otherwise all EoCs from `false_eocs` are run; picked item is returned as npc | 
 
 ##### Valid talkers:

--- a/doc/NPCs.md
+++ b/doc/NPCs.md
@@ -1417,9 +1417,9 @@ These can be read or written to with `val()`.
 | `owed` | ✅ | Amount of money the Character owes the avatar. |
 | `pkill` | ✅ | Current painkiller level. |
 | `pos_x`<br/>`pos_y`<br/>`pos_z` | ✅ | Coordinate in the reality bubble |
-| `power` | ✅ | Bionic power in millijoule. |
-| `power_percentage` | ✅ | Percentage of max bionic power |
-| `power_max` | ❌ | Max bionic power in millijoule. |
+| `power` | ✅ | Bionic or item power in millijoule. |
+| `power_percentage` | ✅ | Percentage of max bionic or item power |
+| `power_max` | ❌ | Max bionic or item power in millijoule. |
 | `rad` | ✅ | Current radiation level. |
 | `size` | ❌ | Size category from 1 (tiny) to 5 (huge). |
 | `sleep_deprivation` | ✅ | Current sleep deprivation level. |

--- a/src/talker_item.cpp
+++ b/src/talker_item.cpp
@@ -136,6 +136,12 @@ void talker_item::remove_value( const std::string &var_name )
     me_it->get_item()->erase_var( var_name );
 }
 
+void talker_item::set_power_cur( units::energy value )
+{
+    me_it->get_item()->ammo_set( itype_battery, clamp( ( int )value.value(), 0,
+                                 me_it_const->get_item()->ammo_capacity( ammo_battery ) ) );
+}
+
 void talker_item::set_all_parts_hp_cur( int set ) const
 {
     me_it->get_item()->set_damage( me_it->get_item()->max_damage() - set );

--- a/src/talker_item.cpp
+++ b/src/talker_item.cpp
@@ -10,6 +10,10 @@
 #include "talker_item.h"
 #include "vehicle.h"
 
+static const ammotype ammo_battery( "battery" );
+
+static const itype_id itype_battery( "battery" );
+
 talker_item::talker_item( item_location *new_me )
 {
     me_it = new_me;

--- a/src/talker_item.cpp
+++ b/src/talker_item.cpp
@@ -142,7 +142,7 @@ void talker_item::remove_value( const std::string &var_name )
 
 void talker_item::set_power_cur( units::energy value )
 {
-    me_it->get_item()->ammo_set( itype_battery, clamp( ( int )value.value(), 0,
+    me_it->get_item()->ammo_set( itype_battery, clamp( static_cast<int>( value.value() ), 0,
                                  me_it_const->get_item()->ammo_capacity( ammo_battery ) ) );
 }
 

--- a/src/talker_item.cpp
+++ b/src/talker_item.cpp
@@ -89,6 +89,16 @@ int talker_item_const::get_hp_max( const bodypart_id & ) const
     return me_it_const->get_item()->max_damage();
 }
 
+units::energy talker_item_const::power_cur() const
+{
+    return 1_mJ * me_it_const->get_item()->ammo_remaining();
+}
+
+units::energy talker_item_const::power_max() const
+{
+    return 1_mJ * me_it_const->get_item()->ammo_capacity( ammo_battery );
+}
+
 int talker_item_const::get_count() const
 {
     return me_it_const->get_item()->count();

--- a/src/talker_item.h
+++ b/src/talker_item.h
@@ -45,6 +45,8 @@ class talker_item_const: public talker_cloner<talker_item_const>
 
         int get_cur_hp( const bodypart_id & ) const override;
         int get_hp_max( const bodypart_id & ) const override;
+        units::energy power_cur() const override;
+        units::energy power_max() const override;
 
         int get_count() const override;
         int coverage_at( bodypart_id & ) const override;

--- a/src/talker_item.h
+++ b/src/talker_item.h
@@ -75,6 +75,7 @@ class talker_item: public talker_cloner<talker_item, talker_item_const>
         void set_value( const std::string &var_name, const std::string &value ) override;
         void remove_value( const std::string & ) override;
 
+        void set_power_cur( units::energy value ) override;
         void set_all_parts_hp_cur( int ) const override;
         void die() override;
 


### PR DESCRIPTION
#### Summary

Infrastructure "Allow EOCs to check and modify battery charge in items"

#### Purpose of change

Fixes #74657 

#### Describe the solution

Override the `power_cur`, `power_max`, and `set_power_cur` functions for `talker_item`, to make those functions work intuitively with items.

#### Describe alternatives you've considered

Make completely new functions.

#### Testing

```json
[
  {
    "type": "effect_on_condition",
    "id": "eoc_print_inv_power",
    "effect": [
      {
        "u_run_inv_eocs": "all",
        "search_data": [ { "flags": [ "RECHARGE" ] }, { "flags": [ "ELECTRONIC" ] } ],
        "true_eocs": [ "eoc_print_item_charge" ]
      }
    ]
  },
  {
    "type": "effect_on_condition",
    "id": "eoc_charge_inv_power",
    "effect": [
      {
        "u_run_inv_eocs": "all",
        "search_data": [ { "flags": [ "RECHARGE" ] }, { "flags": [ "ELECTRONIC" ] } ],
        "true_eocs": [ "eoc_charge_item" ]
      }
    ]
  },
  {
    "type": "effect_on_condition",
    "id": "eoc_charge_item",
    "condition": { "math": [ "n_val('power')", "<", "n_val('power_max')" ] },
    "effect": [ { "math": [ "n_val('power')", "++" ] } ]
  }
]

```

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/30245333/e74df98a-ade7-4074-850d-e1db38d09de9)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/30245333/32c42f86-ba58-4b02-8aa6-7da9538b2b6e)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/30245333/35046dee-8e4e-45fa-81c5-a87ec6870743)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/30245333/e383e3b5-6263-45dc-87b6-9b59eb1bb1b6)

#### Additional context

None.