### PR TITLE
Moved zombie cage roofs to only generate when the cages are

### DIFF
--- a/data/json/mapgen/lake_buildings/lakeside_cabin.json
+++ b/data/json/mapgen/lake_buildings/lakeside_cabin.json
@@ -471,7 +471,7 @@
         { "chance": 5, "item": "clutter_bedroom", "x": 12, "y": 9 }
       ],
       "place_vehicles": [ { "chance": 75, "rotation": 90, "vehicle": "raft", "x": [ 1, 4 ], "y": [ 12, 16 ] } ],
-      "place_nested": [ { "chunks": [ [ "null", 1 ], [ "zombie_cages", 50 ] ], "x": 2, "y": 3 } ]
+      "place_nested": [ { "chunks": [ [ "null", 1000 ], [ "zombie_cages", 50 ] ], "x": 2, "y": 3 } ]
     }
   },
   {

--- a/data/json/mapgen/lake_buildings/lakeside_cabin.json
+++ b/data/json/mapgen/lake_buildings/lakeside_cabin.json
@@ -471,7 +471,7 @@
         { "chance": 5, "item": "clutter_bedroom", "x": 12, "y": 9 }
       ],
       "place_vehicles": [ { "chance": 75, "rotation": 90, "vehicle": "raft", "x": [ 1, 4 ], "y": [ 12, 16 ] } ],
-      "place_nested": [ { "chunks": [ [ "null", 1000 ], [ "zombie_cages", 50 ] ], "x": 2, "y": 3 } ]
+      "place_nested": [ { "chunks": [ [ "null", 1 ], [ "zombie_cages", 50 ] ], "x": 2, "y": 3 } ]
     }
   },
   {
@@ -501,14 +501,46 @@
         "         -........-     ",
         "         -........-     ",
         "         ----------     ",
-        "  ____                  ",
-        "  ____          ____    ",
-        "  ____          ____    ",
-        "  ____          ____    ",
-        "                ____    "
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        "
       ],
       "palettes": [ "roof_palette" ],
-      "terrain": { ".": "t_shingle_flat_roof", "_": "t_metal_flat_roof" }
+      "terrain": { ".": "t_shingle_flat_roof" }
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "zombie_cages_roof",
+    "object": {
+      "mapgensize": [ 21, 21 ],
+      "rows": [
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        "                     ",
+        " ____                ",
+        " ____          ____  ",
+        " ____          ____  ",
+        " ____          ____  ",
+        "               ____  "
+      ],
+      "terrain": { "_": "t_metal_flat_roof" }
     }
   },
   {
@@ -546,7 +578,8 @@
       "place_monsters": [
         { "monster": "GROUP_ZOMBIE", "x": [ 16, 17 ], "y": [ 19, 20 ] },
         { "monster": "GROUP_ZOMBIE", "x": [ 2, 3 ], "y": [ 18, 19 ] }
-      ]
+      ],
+      "place_nested": [ { "chunks": [ "zombie_cages_roof" ], "x": 0, "y": 0, "z": 1 } ]
     }
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Ensure zombie cage roof appearance is tied to the cages, not static for lakeside cabin 5.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Remove the static roofs and define roofs tied to the cages using nests.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Debug spawned site, teleported to it, verified no cage roofs appeared (as there are rarely any cages present, including in this case).
Hack the probability to get cages, redo the above, and verified cages showed up with roofs (properly aligned).
![Screenshot (577)](https://github.com/CleverRaven/Cataclysm-DDA/assets/22739822/82cf2913-e573-48b6-a98e-c2574163a5fd)
![Screenshot (578)](https://github.com/CleverRaven/Cataclysm-DDA/assets/22739822/404f68fd-91a5-4fd5-a205-14c6ada80d33)
![Screenshot (579)](https://github.com/CleverRaven/Cataclysm-DDA/assets/22739822/06d2d5c6-397a-4088-a4ac-fd9d741e1449)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
