### PR TITLE
Provided roofs for exodii crash site + debug mx spawn support

### DIFF
--- a/data/json/mapgen/map_extras/exodii_crashes.json
+++ b/data/json/mapgen/map_extras/exodii_crashes.json
@@ -156,6 +156,23 @@
   {
     "type": "mapgen",
     "method": "json",
+    "nested_mapgen_id": "nest_exodii_crash_6x6_roof",
+    "object": {
+      "mapgensize": [ 6, 6 ],
+      "rows": [
+        "RRRRRR",
+        "RRRRRR",
+        "RRRRRR",
+        "RRRRRR",
+        "RRRRRR",
+        "RRRRRR"
+      ],
+      "terrain": { "R": "t_metal_roof" }
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
     "nested_mapgen_id": "nest_exodii_crash_building_big_1",
     "object": {
       "mapgensize": [ 6, 6 ],
@@ -169,7 +186,8 @@
       ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "palettes": [ "exodii_crash_palette" ],
-      "items": { "_": [ { "item": "SUS_exodii_storage_lowvalue", "chance": 100 } ] }
+      "items": { "_": [ { "item": "SUS_exodii_storage_lowvalue", "chance": 100 } ] },
+      "place_nested": [ { "chunks": [ "nest_exodii_crash_6x6_roof" ], "x": 0, "y": 0, "z": 1 } ]
     }
   },
   {
@@ -188,7 +206,25 @@
       ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "palettes": [ "exodii_crash_palette" ],
-      "items": { "_": [ { "item": "SUS_exodii_storage_medvalue", "chance": 100 } ] }
+      "items": { "_": [ { "item": "SUS_exodii_storage_medvalue", "chance": 100 } ] },
+      "place_nested": [ { "chunks": [ "nest_exodii_crash_6x6_roof" ], "x": 0, "y": 0, "z": 1 } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "nest_exodii_crash_oval_roof",
+    "object": {
+      "mapgensize": [ 6, 6 ],
+      "rows": [
+        " RRRR ",
+        "RRRRRR",
+        "RRRRRR",
+        "RRRRRR",
+        "RRRRRR",
+        " RRRR "
+      ],
+      "terrain": { "R": "t_metal_roof" }
     }
   },
   {
@@ -207,7 +243,8 @@
       ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "palettes": [ "exodii_crash_palette" ],
-      "items": { "_": [ { "item": "SUS_exodii_storage_medvalue", "chance": 100 } ] }
+      "items": { "_": [ { "item": "SUS_exodii_storage_medvalue", "chance": 100 } ] },
+      "place_nested": [ { "chunks": [ "nest_exodii_crash_oval_roof" ], "x": 0, "y": 0, "z": 1 } ]
     }
   },
   {
@@ -226,7 +263,8 @@
       ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "palettes": [ "exodii_crash_palette" ],
-      "items": { "_": [ { "item": "SUS_exodii_storage_medvalue", "chance": 100, "repeat": [ 1, 2 ] } ] }
+      "items": { "_": [ { "item": "SUS_exodii_storage_medvalue", "chance": 100, "repeat": [ 1, 2 ] } ] },
+      "place_nested": [ { "chunks": [ "nest_exodii_crash_6x6_roof" ], "x": 0, "y": 0, "z": 1 } ]
     }
   },
   {
@@ -244,7 +282,8 @@
       ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "palettes": [ "exodii_crash_palette" ],
-      "items": { "_": [ { "item": "SUS_exodii_storage_highvalue", "chance": 100 } ] }
+      "items": { "_": [ { "item": "SUS_exodii_storage_highvalue", "chance": 100 } ] },
+      "place_nested": [ { "chunks": [ "nest_exodii_crash_6x6_roof" ], "x": 0, "y": 0, "z": 1 } ]
     }
   },
   {
@@ -262,7 +301,8 @@
       ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "palettes": [ "exodii_crash_palette" ],
-      "items": { "_": [ { "item": "SUS_exodii_storage_highvalue", "chance": 100 } ] }
+      "items": { "_": [ { "item": "SUS_exodii_storage_highvalue", "chance": 100 } ] },
+      "place_nested": [ { "chunks": [ "nest_exodii_crash_6x6_roof" ], "x": 0, "y": 0, "z": 1 } ]
     }
   },
   {
@@ -280,7 +320,22 @@
       ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "palettes": [ "exodii_crash_palette" ],
-      "items": { "_": [ { "item": "SUS_exodii_storage_highvalue", "chance": 100 } ] }
+      "items": { "_": [ { "item": "SUS_exodii_storage_highvalue", "chance": 100 } ] },
+      "place_nested": [ { "chunks": [ "nest_exodii_crash_oval_roof" ], "x": 0, "y": 0, "z": 1 } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "nest_exodii_crash_3x3_roof",
+    "object": {
+      "mapgensize": [ 3, 3 ],
+      "rows": [
+        "RRR",
+        "RRR",
+        "RRR"
+      ],
+      "terrain": { "R": "t_metal_roof" }
     }
   },
   {
@@ -296,7 +351,8 @@
       ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "palettes": [ "exodii_crash_palette" ],
-      "items": { "_": [ { "item": "SUS_exodii_storage_lowvalue", "chance": 100 } ] }
+      "items": { "_": [ { "item": "SUS_exodii_storage_lowvalue", "chance": 100 } ] },
+      "place_nested": [ { "chunks": [ "nest_exodii_crash_3x3_roof" ], "x": 0, "y": 0, "z": 1 } ]
     }
   },
   {
@@ -312,7 +368,8 @@
       ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "palettes": [ "exodii_crash_palette" ],
-      "items": { "_": [ { "item": "SUS_exodii_storage_lowvalue", "chance": 100 } ] }
+      "items": { "_": [ { "item": "SUS_exodii_storage_lowvalue", "chance": 100 } ] },
+      "place_nested": [ { "chunks": [ "nest_exodii_crash_3x3_roof" ], "x": 0, "y": 0, "z": 1 } ]
     }
   },
   {

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -3351,7 +3351,7 @@ static void map_extra()
     if( mx_choice >= 0 && mx_choice < static_cast<int>( mx_str.size() ) ) {
         const tripoint_abs_omt where_omt( ui::omap::choose_point( true ) );
         if( where_omt != overmap::invalid_tripoint ) {
-            tinymap mx_map;
+            smallmap mx_map;
             mx_map.load( where_omt, false );
             MapExtras::apply_function( mx_str[mx_choice], mx_map, where_omt );
             g->load_npcs();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
- Provide roofs for the exodii crash buildings without relying on add_roofs magic.
- Provide debug spawn support for map extras spanning more than a single Z level (needed to test the above).

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Add roof chunks and nest them with their corresponding buildings.
- Ditch tinymap in favor of smallmap for debug spawning of map extras, as tinymap will write everything onto the single Z level, replacing older content with newer ones (and likely issue complaint about the roof being placed on top of spawned items).

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Debug spawn the two map extras (1 and 2) on order to try to capture as many variants as possible. Realized that map extras can be spawned within the reality bubble, so you can see several at once. Also realized you can spawn them on top of each other, seemingly replacing the previous version, which was tried 30(?) times to the east in order to get the oval shaped building. Unfortunately, the wiping is only partial, since there's nothing wiping the roof level clean, so what was eventually generated is the amalgamation of all the overloaded generations. Gave up the pursuit of the oval building after that defeat, but here's the result:
![Screenshot (584)](https://github.com/CleverRaven/Cataclysm-DDA/assets/22739822/2813e49b-f506-4b79-989e-203c7522e334)
As mentioned, the roof mess to the east doesn't show anything useful due to the overlaid map extra generations.
![Screenshot (585)](https://github.com/CleverRaven/Cataclysm-DDA/assets/22739822/81852d6e-d3e0-4679-8aa7-5dccaf715adb)


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Note that there's a (very small) code change as well as JSON changes in this PR.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
