### PR TITLE
[Bombastic Perks] Add blood-themed perks

### DIFF
--- a/data/mods/BombasticPerks/perkdata/blood_drinking_heal.json
+++ b/data/mods/BombasticPerks/perkdata/blood_drinking_heal.json
@@ -1,0 +1,91 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_perk_blood_drinking_heal",
+    "eoc_type": "EVENT",
+    "required_event": "character_eats_item",
+    "condition": {
+      "and": [
+        {
+          "or": [
+            { "compare_string": [ "blood", { "context_val": "itype" } ] },
+            { "compare_string": [ "animal_blood", { "context_val": "itype" } ] },
+            { "compare_string": [ "demihuman_blood", { "context_val": "itype" } ] },
+            { "compare_string": [ "mutant_human_blood", { "context_val": "itype" } ] }
+          ]
+        },
+        { "u_has_trait": "perk_blood_drinking_heal" }
+      ]
+    },
+    "effect": [ { "math": [ "u_pain()", "-=", "2" ] }, { "run_eocs": "EOC_perk_blood_drinking_heal_hp_check" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_perk_blood_drinking_heal_hp_check",
+    "condition": {
+      "or": [
+        { "math": [ "u_hp('arm_l')", "<", "u_hp_max('arm_l')" ] },
+        { "math": [ "u_hp('arm_r')", "<", "u_hp_max('arm_r')" ] },
+        { "math": [ "u_hp('leg_l')", "<", "u_hp_max('leg_l')" ] },
+        { "math": [ "u_hp('leg_r')", "<", "u_hp_max('leg_r')" ] },
+        { "math": [ "u_hp('torso')", "<", "u_hp_max('torso')" ] },
+        { "math": [ "u_hp('head')", "<", "u_hp_max('head')" ] }
+      ]
+    },
+    "effect": [
+      {
+        "switch": { "math": [ "rand(5)" ] },
+        "cases": [
+          { "case": 0, "effect": { "run_eocs": "EOC_perk_blood_drinking_heal_arm_l" } },
+          { "case": 1, "effect": { "run_eocs": "EOC_perk_blood_drinking_heal_arm_r" } },
+          { "case": 2, "effect": { "run_eocs": "EOC_perk_blood_drinking_heal_leg_l" } },
+          { "case": 3, "effect": { "run_eocs": "EOC_perk_blood_drinking_heal_leg_r" } },
+          { "case": 4, "effect": { "run_eocs": "EOC_perk_blood_drinking_heal_torso" } },
+          { "case": 5, "effect": { "run_eocs": "EOC_perk_blood_drinking_heal_head" } }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_perk_blood_drinking_heal_arm_l",
+    "condition": { "math": [ "u_hp('arm_l')", "<", "u_hp_max('arm_l')" ] },
+    "effect": [ { "math": [ "u_hp('arm_l')", "+=", "2" ] } ],
+    "false_effect": [ { "run_eocs": "EOC_perk_blood_drinking_heal_hp_check" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_perk_blood_drinking_heal_arm_r",
+    "condition": { "math": [ "u_hp('arm_r')", "<", "u_hp_max('arm_r')" ] },
+    "effect": [ { "math": [ "u_hp('arm_r')", "+=", "2" ] } ],
+    "false_effect": [ { "run_eocs": "EOC_perk_blood_drinking_heal_hp_check" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_perk_blood_drinking_heal_leg_l",
+    "condition": { "math": [ "u_hp('leg_l')", "<", "u_hp_max('leg_l')" ] },
+    "effect": [ { "math": [ "u_hp('leg_l')", "+=", "2" ] } ],
+    "false_effect": [ { "run_eocs": "EOC_perk_blood_drinking_heal_hp_check" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_perk_blood_drinking_heal_leg_r",
+    "condition": { "math": [ "u_hp('leg_r')", "<", "u_hp_max('leg_r')" ] },
+    "effect": [ { "math": [ "u_hp('leg_r')", "+=", "2" ] } ],
+    "false_effect": [ { "run_eocs": "EOC_perk_blood_drinking_heal_hp_check" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_perk_blood_drinking_heal_torso",
+    "condition": { "math": [ "u_hp('torso')", "<", "u_hp_max('torso')" ] },
+    "effect": [ { "math": [ "u_hp('torso')", "+=", "2" ] } ],
+    "false_effect": [ { "run_eocs": "EOC_perk_blood_drinking_heal_hp_check" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_perk_blood_drinking_heal_head",
+    "condition": { "math": [ "u_hp('head')", "<", "u_hp_max('head')" ] },
+    "effect": [ { "math": [ "u_hp('head')", "+=", "2" ] } ],
+    "false_effect": [ { "run_eocs": "EOC_perk_blood_drinking_heal_hp_check" } ]
+  }
+]

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -807,6 +807,47 @@
         "topic": "TALK_PERK_MENU_SELECT"
       },
       {
+        "condition": { "not": { "u_has_trait": "perk_blood_drinker" } },
+        "text": "Gain [<trait_name:perk_blood_drinker>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_blood_drinker>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:perk_blood_drinker>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "perk_blood_drinker", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Must not have the Squeamish, Meat Intolerance, Herbivore, or Vegan traits.",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          {
+            "set_condition": "perk_condition",
+            "condition": { "not": { "u_has_any_trait": [ "SQUEAMISH", "VEGETARIAN", "HERBIVORE", "VEGAN" ] } }
+          }
+        ],
+        "topic": "TALK_PERK_MENU_SELECT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "perk_blood_drinking_heal" } },
+        "text": "Gain [<trait_name:perk_blood_drinking_heal>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_blood_drinking_heal>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:perk_blood_drinking_heal>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "perk_blood_drinking_heal", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Must have <trait_name:perk_blood_drinker>.",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "u_has_trait": "perk_blood_drinker" } }
+        ],
+        "topic": "TALK_PERK_MENU_SELECT"
+      },
+      {
         "condition": { "not": { "u_has_trait": "perk_long_shot" } },
         "text": "Gain [<trait_name:perk_long_shot>]",
         "effect": [

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -497,6 +497,23 @@
   },
   {
     "type": "mutation",
+    "id": "perk_blood_drinker",
+    "name": { "str": "Hemophage" },
+    "points": 0,
+    "description": "You do not drink…wine.  You are immune to the negative consequences of drinking blood, such as parasitic infection.",
+    "category": [ "perk" ],
+    "flags": [ "HEMOVORE" ]
+  },
+  {
+    "type": "mutation",
+    "id": "perk_blood_drinking_heal",
+    "name": { "str": "The Blood is the Life" },
+    "points": 0,
+    "description": "Drinking blood makes you feel really good.  REALLY good.  So good that all your aches and pains just seem to fade away.  Every time you drink blood, you heal a bit of damage and lose a bit of pain.",
+    "category": [ "perk" ]
+  },
+  {
+    "type": "mutation",
     "id": "perk_popeye",
     "name": { "str": "Of sailors and spinach" },
     "points": 0,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Bombastic Perks] Add blood-themed perks"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The `HEMOVORE` flag gave me an idea.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add two perks:

- Hemophage: You do not drink…wine.  You can drink blood without gaining parasites and enjoy it. Adds the `HEMOVORE` flag to the character. Cannot be taken if you have the Squeamish trait or any trait that prevents eating meat (Herbivore, Vegan, etc). Leads to:
- The Blood is the Life: Drinking blood makes you feel good. _Really_ good. So good you actually heal from it. Each item of blood you drink restores 2 hp to a random body part and removes 1 pain. 

Balance here is that a character's stomach is only so big, so even if you're bringing a gallon jug full of fresh blood with you on raids, you'll only get so much healing from it before you're full.  It's mostly useful for recovering faster during downtime, and to do that you'll need to source and preserve the blood. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Both perks work. The Blood is the Life does not cause problems if the character has full health.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
