### PR TITLE
[Magiclysm] Add Hy-Brasilean ambassadorial honor guard profession

### DIFF
--- a/data/mods/Magiclysm/professions.json
+++ b/data/mods/Magiclysm/professions.json
@@ -12,6 +12,12 @@
     "entries": [ { "item": "arrow_heavy_fire_hardened_fletched", "charges": 20 } ]
   },
   {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "quiver_elven_ceremonial_guard",
+    "entries": [ { "item": "arrow_cf", "count": 40 } ]
+  },
+  {
     "type": "profession",
     "id": "wizard_novice",
     "name": "Would-be Wizard",
@@ -1255,6 +1261,58 @@
       },
       "male": { "entries": [ { "item": "under_armor_shorts" } ] },
       "female": { "entries": [ { "item": "sports_bra" }, { "item": "panties" } ] }
+    }
+  },
+  {
+    "type": "profession",
+    "id": "elven_ceremonial_guard",
+    "name": "Hy-Brasil ambassadorial honor guard",
+    "description": "You were a ceremonial guard for the Hy-Brasilean ambassador to the United States, equipped to bring to mind the elven forest warriors of old.  You were trained in archery, since you had to use your bow to impress foreign dignitaries, but you never expected you'd actually have to take it into a real battle.  Then the Cataclysm hit.  The ambassador and most of your fellow guards are dead, and you'll probably never see home again, but hopefully your skills will keep you alive.",
+    "points": 12,
+    "skills": [
+      { "level": 8, "name": "gun" },
+      { "level": 7, "name": "archery" },
+      { "level": 4, "name": "rifle" },
+      { "level": 2, "name": "pistol" },
+      { "level": 6, "name": "survival" },
+      { "level": 5, "name": "speech" }
+    ],
+    "proficiencies": [ "prof_bow_basic", "prof_bow_expert", "prof_spotting" ],
+    "traits": [
+      "THRESH_SPECIES_ELF",
+      "ANIMALEMPATH2",
+      "ELVEN_BUILD",
+      "ELFA_NV",
+      "ELVEN_BEAUTY",
+      "ELVEN_SLEEP",
+      "ELFA_EARS",
+      "ELVEN_HEARING",
+      "LIGHTSTEP",
+      "WILDWALKER",
+      "ANTIJUNK",
+      "WEAKSTOMACH",
+      "DISIMMUNE",
+      "PICKYEATER"
+    ],
+    "items": {
+      "both": {
+        "entries": [
+          { "item": "officer_uniform" },
+          { "item": "gloves_black" },
+          { "item": "socks" },
+          { "item": "wristwatch" },
+          { "item": "cloak_of_elvenkind" },
+          { "item": "boots_of_elvenkind" },
+          { "item": "tank_top", "variant": "tank_top_camo" },
+          { "item": "bow_sling", "contents-item": [ "bow_of_elvenkind" ] },
+          { "item": "quiver_of_holding_plus_one", "contents-group": [ "quiver_elven_ceremonial_guard" ] },
+          { "item": "m18", "ammo-item": "9mmfmj", "charges": 10, "container-item": "holster" },
+          { "item": "sheath", "contents-item": [ "knife_hunting_plus_one" ] },
+          { "item": "water_clean", "charges": 6, "container-item": "canteen" }
+        ]
+      },
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     }
   }
 ]

--- a/data/mods/Magiclysm/professions.json
+++ b/data/mods/Magiclysm/professions.json
@@ -1266,7 +1266,7 @@
   {
     "type": "profession",
     "id": "elven_ceremonial_guard",
-    "name": "Hy-Brasil ambassadorial honor guard",
+    "name": "Hy-Brasilean ambassadorial honor guard",
     "description": "You were a ceremonial guard for the Hy-Brasilean ambassador to the United States, equipped to bring to mind the elven forest warriors of old.  You were trained in archery, since you had to use your bow to impress foreign dignitaries, but you never expected you'd actually have to take it into a real battle.  Then the Cataclysm hit.  The ambassador and most of your fellow guards are dead, and you'll probably never see home again, but hopefully your skills will keep you alive.",
     "points": 12,
     "skills": [

--- a/data/mods/Magiclysm/scenarios.json
+++ b/data/mods/Magiclysm/scenarios.json
@@ -119,7 +119,7 @@
   {
     "copy-from": "heli_crash",
     "type": "scenario",
-    "extend": { "professions": [ "whitedeath_expy" ] },
+    "extend": { "professions": [ "whitedeath_expy", "elven_ceremonial_guard" ] },
     "id": "heli_crash"
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Magiclysm] Add Hy-Brasilean ambassadorial honor guard profession"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I wanted to add an "elven ranger"-style profession, but in a way that fits the Magiclysm lore.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the Hy-Brasilean ambassadorial honor guard profession. They start with traditional elven equipment (cloak of elvenkind, boots of elvenkind, bow of elvenkind), archery skills, and social (since they had to deal with dignitaries at least tangentially).  They were in America when the Cataclysm hit and now have to use their training to survive actual combat.

While they start with magical items, they don't have any magic, since they aren't actually elven forest ninjas, they're just supposed to make foreigners _think_ they are. They also don't start with magical arrows, since cool archery demonstrations  are riskier if your arrows explode or leave a cloud of poison gas behind. They do have one actual firearm since the months leading up to the Cataclysm were much more dangerous than previously.

I also added them to the helicopter crash scenario. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Profession appears and is selectable and starts with appropriate equipment.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Learned today that Hy-Brasil and Brazil are totally unrelated words.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
