### PR TITLE
Synchronized bashing to roof and ground level

### DIFF
--- a/data/json/mapgen/derelict_property.json
+++ b/data/json/mapgen/derelict_property.json
@@ -99,10 +99,10 @@
       "W": { "param": "trash_type", "fallback": "f_null" }
     },
     "nested": {
-      "|": { "chunks": [ [ "1x1_bash", 7 ], [ "general_graffiti", 20 ], [ "null", 90 ] ] },
-      "w": { "chunks": [ [ "1x1_bash", 1 ], [ "null", 6 ] ] },
-      ".": { "chunks": [ [ "1x1_bash", 1 ], [ "null", 10 ] ] },
-      "4": { "chunks": [ [ "1x1_bash", 1 ], [ "null", 4 ] ] }
+      "|": { "chunks": [ [ "1x1_2z_bash", 7 ], [ "general_graffiti", 20 ], [ "null", 90 ] ] },
+      "w": { "chunks": [ [ "1x1_2z_bash", 1 ], [ "null", 6 ] ] },
+      ".": { "chunks": [ [ "1x1_2z_bash", 1 ], [ "null", 10 ] ] },
+      "4": { "chunks": [ [ "1x1_2z_bash", 1 ], [ "null", 4 ] ] }
     },
     "items": {
       "{": { "item": "homebooks", "chance": 20, "repeat": [ 1, 2 ] },
@@ -146,9 +146,9 @@
     "id": "derelict_roof_palette",
     "palettes": [ "roof_palette" ],
     "nested": {
-      ".": { "chunks": [ [ "1x1_bash", 1 ], [ "null", 9 ] ] },
-      "-": { "chunks": [ [ "1x1_bash", 1 ], [ "null", 4 ] ] },
-      "5": { "chunks": [ [ "1x1_bash", 1 ], [ "null", 4 ] ] }
+      ".": { "chunks": [ [ "1x1_2z_bash", 1 ], [ "null", 9 ] ] },
+      "-": { "chunks": [ [ "1x1_2z_bash", 1 ], [ "null", 4 ] ] },
+      "5": { "chunks": [ [ "1x1_2z_bash", 1 ], [ "null", 4 ] ] }
     }
   },
   {

--- a/data/json/mapgen/nested/aux_nested.json
+++ b/data/json/mapgen/nested/aux_nested.json
@@ -379,6 +379,16 @@
   {
     "type": "mapgen",
     "method": "json",
+    "//": "A nested map bash damage.",
+    "nested_mapgen_id": "1x1_2z_bash",
+    "object": {
+      "mapgensize": [ 1, 1 ],
+      "set": [ { "point": "bash", "x": 0, "y": 0, "z": 0 }, { "point": "bash", "x": 0, "y": 0, "z": 1 } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
     "nested_mapgen_id": "destroyed_small_tent",
     "object": {
       "mapgensize": [ 3, 3 ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Synchronize bash destruction between ground level and roof for derelict property.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add a new bashing chunk that bashes both the ground and roof level at the same time.
Use this chunk instead of the single level one on the derelict property.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Investigate and apply to other usages of the single tile bash chunk as well. That's left for interested parties.
Modify the existing bashing chunk and only check the derelict property. That's considered slightly unsafe.
The above but check all usages. That's considered too much work.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Debug spawn a bunch of derelict properties and teleport to them. Examine them to see that the results look reasonable.
![Screenshot (596)](https://github.com/CleverRaven/Cataclysm-DDA/assets/22739822/be793991-3764-492b-9b6d-3426fff84c44)
It can be noted that some gutters have been smashed. The black tiles I've investigated are defined as gutters both by direct look and by using debug edit. I have no idea why they're not rendered properly, but don't think that's caused by this PR (damaged tiles somehow given a different rendering not supported by the tile set?).
![Screenshot (597)](https://github.com/CleverRaven/Cataclysm-DDA/assets/22739822/e18776e5-a421-40df-87ea-971e6b4496dd)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
