### PR TITLE
Palette of surface+roof chunks

### DIFF
--- a/data/json/mapgen/cave.json
+++ b/data/json/mapgen/cave.json
@@ -2,6 +2,91 @@
   {
     "type": "mapgen",
     "method": "json",
+    "nested_mapgen_id": "nest_rock_roof",
+    "object": {
+      "mapgensize": [ 1, 1 ],
+      "rows": [ "%" ],
+      "terrain": { "%": "t_rock_floor_no_roof" },
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "nest_region_groundcover_forest",
+    "object": {
+      "mapgensize": [ 1, 1 ],
+      "rows": [ "%" ],
+      "terrain": { "%": "t_region_groundcover_forest" },
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "nest_rock_wall_roof",
+    "object": {
+      "mapgensize": [ 1, 1 ],
+      "rows": [ "%" ],
+      "terrain": { "%": "t_rock" },
+      "place_nested": [ { "chunks": [ "nest_rock_roof" ], "x": 0, "y": 0, "z": 1 } ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "nest_rock_floor_roof",
+    "object": {
+      "mapgensize": [ 1, 1 ],
+      "rows": [ "%" ],
+      "terrain": { "%": "t_rock_floor" },
+      "place_nested": [ { "chunks": [ "nest_rock_roof" ], "x": 0, "y": 0, "z": 1 } ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "nest_region_soil_rock_roof",
+    "object": {
+      "mapgensize": [ 1, 1 ],
+      "rows": [ "%" ],
+      "terrain": { "%": "t_region_soil" },
+      "place_nested": [ { "chunks": [ "nest_rock_roof" ], "x": 0, "y": 0, "z": 1 } ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "nest_slope_down_rock_roof",
+    "object": {
+      "mapgensize": [ 1, 1 ],
+      "rows": [ "%" ],
+      "terrain": { "%": "t_slope_down" },
+      "place_nested": [ { "chunks": [ "nest_rock_roof" ], "x": 0, "y": 0, "z": 1 } ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
+    }
+  },
+  {
+    "type": "palette",
+    "id": "cave_surface_palette",
+    "nested": {
+      "%": { "chunks": [ "nest_rock_wall_roof", "nest_region_groundcover_forest" ] },
+      "|": { "chunks": [ "nest_rock_wall_roof" ] },
+      ",": { "chunks": [ "nest_rock_floor_roof" ] },
+      ";": { "chunks": [ "nest_region_soil_rock_roof" ] },
+      "<": { "chunks": [ "nest_slope_down_rock_roof" ] },
+      "B": { "chunks": [ "nest_rock_floor_roof" ] },
+      "F": { "chunks": [ "nest_rock_floor_roof" ] },
+      "W": { "chunks": [ "nest_rock_floor_roof" ] }
+    },
+    "fields": { "W": { "field": "fd_web", "intensity": 2, "age": 10 } }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
     "om_terrain": [ "cave" ],
     "weight": 1000,
     "object": {
@@ -34,14 +119,7 @@
         "                        "
       ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
-      "terrain": {
-        "|": "t_rock",
-        ",": "t_rock_floor",
-        "%": [ "t_rock", "t_region_groundcover_forest" ],
-        ";": "t_region_soil",
-        "<": "t_slope_down"
-      },
-      "furniture": {  }
+      "palettes": [ "cave_surface_palette" ]
     }
   },
   {
@@ -79,14 +157,7 @@
         "                        "
       ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
-      "terrain": {
-        "|": "t_rock",
-        "%": [ "t_rock", "t_region_groundcover_forest" ],
-        ";": "t_region_soil",
-        ",": "t_rock_floor",
-        "<": "t_slope_down"
-      },
-      "furniture": {  }
+      "palettes": [ "cave_surface_palette" ]
     }
   },
   {
@@ -124,16 +195,7 @@
         "                        "
       ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
-      "terrain": {
-        "|": "t_rock",
-        "%": [ "t_rock", "t_region_groundcover_forest" ],
-        ";": "t_region_soil",
-        ",": "t_rock_floor",
-        "W": "t_rock_floor",
-        "<": "t_slope_down"
-      },
-      "furniture": {  },
-      "fields": { "W": { "field": "fd_web", "intensity": 2, "age": 10 } },
+      "palettes": [ "cave_surface_palette" ],
       "monsters": { "W": { "monster": "GROUP_SPIDER", "chance": 2, "density": 0.01 } }
     }
   },
@@ -172,16 +234,7 @@
         "                        "
       ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
-      "terrain": {
-        "|": "t_rock",
-        "%": [ "t_rock", "t_region_groundcover_forest" ],
-        ";": "t_region_soil",
-        ",": "t_rock_floor",
-        "W": "t_rock_floor",
-        "<": "t_slope_down"
-      },
-      "fields": { "W": { "field": "fd_web", "intensity": 1, "age": 10 } },
-      "furniture": {  }
+      "palettes": [ "cave_surface_palette" ]
     }
   },
   {
@@ -219,15 +272,7 @@
         "                        "
       ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
-      "terrain": {
-        "|": "t_rock",
-        "%": [ "t_rock", "t_region_groundcover_forest" ],
-        ";": "t_region_soil",
-        ",": "t_rock_floor",
-        "B": "t_rock_floor",
-        "<": "t_slope_down"
-      },
-      "furniture": {  },
+      "palettes": [ "cave_surface_palette" ],
       "monster": { "B": { "monster": "mon_bat" } }
     }
   },
@@ -266,16 +311,7 @@
         "                        "
       ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
-      "terrain": {
-        "|": "t_rock",
-        "%": [ "t_rock", "t_region_groundcover_forest" ],
-        ";": "t_region_soil",
-        ",": "t_rock_floor",
-        "B": "t_rock_floor",
-        "W": "t_rock_floor",
-        "<": "t_slope_down"
-      },
-      "furniture": {  },
+      "palettes": [ "cave_surface_palette" ],
       "fields": { "W": { "field": "fd_web", "intensity": 1, "age": 10 } },
       "monster": { "B": { "monster": "mon_bear" } }
     }
@@ -315,15 +351,7 @@
         "                        "
       ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
-      "terrain": {
-        "|": "t_rock",
-        "%": [ "t_rock", "t_region_groundcover_forest" ],
-        ";": "t_region_soil",
-        ",": "t_rock_floor",
-        "F": "t_rock_floor",
-        "<": "t_slope_down"
-      },
-      "furniture": {  },
+      "palettes": [ "cave_surface_palette" ],
       "monster": { "F": { "monster": "mon_pickerel_frog" } }
     }
   },
@@ -362,17 +390,8 @@
         "                        "
       ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
-      "terrain": {
-        "|": "t_rock",
-        "%": [ "t_rock", "t_region_groundcover_forest" ],
-        ";": "t_region_soil",
-        ",": "t_rock_floor",
-        "B": "t_rock_floor",
-        "W": "t_rock_floor",
-        "<": "t_slope_down"
-      },
-      "fields": { "W": { "field": "fd_web", "intensity": 1, "age": 10 } },
-      "furniture": {  }
+      "palettes": [ "cave_surface_palette" ],
+      "fields": { "W": { "field": "fd_web", "intensity": 1, "age": 10 } }
     }
   },
   {
@@ -410,16 +429,7 @@
         "                        "
       ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
-      "terrain": {
-        "|": "t_rock",
-        "%": [ "t_rock", "t_region_groundcover_forest" ],
-        ";": "t_region_soil",
-        ",": "t_rock_floor",
-        "B": "t_rock_floor",
-        "W": "t_rock_floor",
-        "<": "t_slope_down"
-      },
-      "furniture": {  },
+      "palettes": [ "cave_surface_palette" ],
       "fields": { "W": { "field": "fd_web", "intensity": 1, "age": 10 } },
       "monster": { "B": { "monster": "mon_cougar" } }
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Provide caves with roofs where they should be present and remove reliance of add_roofs magic.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Define a common palette consisting of ground level + roof chunks and use if for all caves.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Define roof chunks for each of the caves covering the static bits and only have a rock+roof chunk/ground chunk for the part that can be either wall or ground cover.
- Leaving the areas with ground cover exposed to the sky.
- Leaving the outer areas with ground cover exposed to the sky. Can change to either of these if advised to do so.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Debug spawn 9 caves, teleport to them, and examine the results.
![Screenshot (602)](https://github.com/CleverRaven/Cataclysm-DDA/assets/22739822/ebfd9428-9221-4758-b85c-aa132678e33f)
![Screenshot (603)](https://github.com/CleverRaven/Cataclysm-DDA/assets/22739822/20186ce6-a1d2-44d6-a64a-1dc9393ca248)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
The caves depending on add_roofs magic left holes over the region soil and slope down parts. This, in combination with the slope down location not being synchronized with the slope up on the level below (which still is the case) is probably the reason for why there were a bright patch in every cave (sunlight shining through slope down on level above). That suspicion has not been verified by checking if the light patch and the slope on the level above are aligned, though.

The tree tops are missing because the changes are tested with an exe that has add_roofs magic disabled, in order to see which roofs are actually generated directly.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
