### PR TITLE
Backport 71500 (Fix MOLLE pouches hiding stored items and showing incorrect movecosts)

### DIFF
--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -666,7 +666,7 @@ void outfit::holster_opts( std::vector<dispose_option> &opts, item_location obj,
                 }
                 opts.emplace_back( dispose_option{
                     string_format( "  >%s", it->tname() ), true, it->invlet,
-                    guy.item_store_cost( *obj, *it, false, it->insert_cost( *it ) ),
+                    guy.item_store_cost( *obj, *it, false, it->insert_cost( *obj ) ),
                     [&guy, it, con, obj] {
                         item &i = *item_location( obj );
                         guy.store( con, i, false, it->insert_cost( i ) );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1294,7 +1294,9 @@ void item::update_modified_pockets()
     // Prevent cleanup of added modular pockets
     for( const item *it : contents.get_added_pockets() ) {
         for( const pocket_data &pocket : it->type->pockets ) {
-            container_pockets.push_back( &pocket );
+            if( pocket.type == pocket_type::CONTAINER ) {
+                container_pockets.push_back( &pocket );
+            }
         }
     }
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
https://github.com/CleverRaven/Cataclysm-DDA/issues/71488 is present on 0.H.

#### Describe the solution
Cherry-pick https://github.com/CleverRaven/Cataclysm-DDA/pull/71500 to 0.H-branch

#### Describe alternatives you've considered

#### Testing
I've got a save where I can wield a knife stored in a sheath on a ballistic vest, wield anything else and in the dialog select to put the knife in the sheath on the vest, then it will fall to the ground the next turn. It also shows every pocket on the vest before this is applied, after it only shows the sheath.

#### Additional context
Maybe related to https://github.com/CleverRaven/Cataclysm-DDA/issues/74244?