### PR TITLE
[RDY] Correct MOVEMENT_EXERTION_MODIFIER values for exoskeletons, expand descriptions for player clarity

### DIFF
--- a/data/json/enchantments.json
+++ b/data/json/enchantments.json
@@ -198,7 +198,7 @@
     "has": "WORN",
     "condition": "ACTIVE",
     "values": [
-      { "value": "MOVEMENT_EXERTION_MODIFIER", "multiply": -0.2 }
+      { "value": "MOVEMENT_EXERTION_MODIFIER", "multiply": -0.2 },
       { "value": "CARRY_WEIGHT", "multiply": 0.8 },
       { "value": "CLIMATE_CONTROL_CHILL", "add": 50 }
     ]

--- a/data/json/enchantments.json
+++ b/data/json/enchantments.json
@@ -198,7 +198,7 @@
     "has": "WORN",
     "condition": "ACTIVE",
     "values": [
-      { "value": "MOVEMENT_EXERTION_MODIFIER", "multiply": -0.2 },
+      { "value": "MOVEMENT_EXERTION_MODIFIER", "multiply": -0.2 }
       { "value": "CARRY_WEIGHT", "multiply": 0.8 },
       { "value": "CLIMATE_CONTROL_CHILL", "add": 50 }
     ]

--- a/data/json/enchantments.json
+++ b/data/json/enchantments.json
@@ -207,7 +207,7 @@
     "id": "combat_exoskeleton_medium_active",
     "type": "enchantment",
     "name": { "str": "Active combat exoskeleton mk.2" },
-    "description": "Now powered, the exoskeleton shields you against harmful gas, cools you down, and has reduced encumbrance. Designed for medium loadouts, this model also provides moderate improvements to your movement exertion cost and carry weight.",
+    "description": "Now powered, the exoskeleton provides <color_white>moderate</color> improvements to your carry weight and movement exertion while the life support system shields you against harmful gas, cools you down, and dampens harmful sounds.",
     "has": "WORN",
     "condition": "ACTIVE",
     "values": [

--- a/data/json/enchantments.json
+++ b/data/json/enchantments.json
@@ -220,7 +220,7 @@
     "id": "combat_exoskeleton_light_active",
     "type": "enchantment",
     "name": { "str": "Active combat exoskeleton mk.3" },
-    "description": "Now powered, the exoskeleton shields you against harmful gas, cools you down, and has reduced encumbrance. Designed for light loadouts, this model also provides slight improvements to your movement exertion cost and carry weight.",
+    "description": "Now powered, the exoskeleton provides <color_white>slight</color> improvements to your carry weight and movement exertion while the life support system shields you against harmful gas, cools you down, and dampens harmful sounds.",
     "has": "WORN",
     "condition": "ACTIVE",
     "values": [

--- a/data/json/enchantments.json
+++ b/data/json/enchantments.json
@@ -198,7 +198,7 @@
     "has": "WORN",
     "condition": "ACTIVE",
     "values": [
-      { "value": "MOVEMENT_EXERTION_MODIFIER", "multiply": -0.4 },
+      { "value": "MOVEMENT_EXERTION_MODIFIER", "multiply": -0.2 },
       { "value": "CARRY_WEIGHT", "multiply": 0.8 },
       { "value": "CLIMATE_CONTROL_CHILL", "add": 50 }
     ]

--- a/data/json/enchantments.json
+++ b/data/json/enchantments.json
@@ -194,7 +194,7 @@
     "id": "combat_exoskeleton_heavy_active",
     "type": "enchantment",
     "name": { "str": "Active combat exoskeleton mk.1" },
-    "description": "Now powered, the exoskeleton shields you against harmful gas, cools you down, and has reduced encumbrance. Designed for heavy loadouts, this model also provides significant improvements to your movement exertion cost and carry weight.",
+    "description": "Now powered, the exoskeleton provides <color_white>significant</color> improvements to your carry weight and movement exertion while the life support system shields you against harmful gas, cools you down, and dampens harmful sounds.",
     "has": "WORN",
     "condition": "ACTIVE",
     "values": [

--- a/data/json/enchantments.json
+++ b/data/json/enchantments.json
@@ -224,7 +224,7 @@
     "has": "WORN",
     "condition": "ACTIVE",
     "values": [
-      { "value": "MOVEMENT_EXERTION_MODIFIER", "multiply": -0.2 },
+      { "value": "MOVEMENT_EXERTION_MODIFIER", "multiply": -0.4 },
       { "value": "CARRY_WEIGHT", "multiply": 0.4 },
       { "value": "CLIMATE_CONTROL_CHILL", "add": 50 }
     ]

--- a/data/json/enchantments.json
+++ b/data/json/enchantments.json
@@ -188,7 +188,7 @@
     "description": "The exoskeleton is inactive and makes moving in it difficult and exhausting.",
     "has": "WORN",
     "condition": "INACTIVE",
-    "values": [ { "value": "MOVEMENT_EXERTION_MODIFIER", "multiply": 0.8 } ]
+    "values": [ { "value": "MOVEMENT_EXERTION_MODIFIER", "multiply": 0.5 } ]
   },
   {
     "id": "combat_exoskeleton_heavy_active",
@@ -198,7 +198,7 @@
     "has": "WORN",
     "condition": "ACTIVE",
     "values": [
-      { "value": "MOVEMENT_EXERTION_MODIFIER", "multiply": 0.4 },
+      { "value": "MOVEMENT_EXERTION_MODIFIER", "multiply": -0.4 },
       { "value": "CARRY_WEIGHT", "multiply": 0.8 },
       { "value": "CLIMATE_CONTROL_CHILL", "add": 50 }
     ]
@@ -211,7 +211,7 @@
     "has": "WORN",
     "condition": "ACTIVE",
     "values": [
-      { "value": "MOVEMENT_EXERTION_MODIFIER", "multiply": 0.3 },
+      { "value": "MOVEMENT_EXERTION_MODIFIER", "multiply": -0.3 },
       { "value": "CARRY_WEIGHT", "multiply": 0.6 },
       { "value": "CLIMATE_CONTROL_CHILL", "add": 50 }
     ]
@@ -224,7 +224,7 @@
     "has": "WORN",
     "condition": "ACTIVE",
     "values": [
-      { "value": "MOVEMENT_EXERTION_MODIFIER", "multiply": 0.2 },
+      { "value": "MOVEMENT_EXERTION_MODIFIER", "multiply": -0.2 },
       { "value": "CARRY_WEIGHT", "multiply": 0.4 },
       { "value": "CLIMATE_CONTROL_CHILL", "add": 50 }
     ]

--- a/data/json/enchantments.json
+++ b/data/json/enchantments.json
@@ -194,7 +194,7 @@
     "id": "combat_exoskeleton_heavy_active",
     "type": "enchantment",
     "name": { "str": "Active combat exoskeleton mk.1" },
-    "description": "The exoskeleton helps you carry more weight, protects you against harmful gas, cools you down, and has reduced encumbrance.",
+    "description": "Now powered, the exoskeleton shields you against harmful gas, cools you down, and has reduced encumbrance. Designed for heavy loadouts, this model also provides significant improvements to your movement exertion cost and carry weight.",
     "has": "WORN",
     "condition": "ACTIVE",
     "values": [
@@ -207,7 +207,7 @@
     "id": "combat_exoskeleton_medium_active",
     "type": "enchantment",
     "name": { "str": "Active combat exoskeleton mk.2" },
-    "description": "The exoskeleton helps you carry more weight, protects you against harmful gas, cools you down, and has reduced encumbrance.",
+    "description": "Now powered, the exoskeleton shields you against harmful gas, cools you down, and has reduced encumbrance. Designed for medium loadouts, this model also provides moderate improvements to your movement exertion cost and carry weight.",
     "has": "WORN",
     "condition": "ACTIVE",
     "values": [
@@ -220,7 +220,7 @@
     "id": "combat_exoskeleton_light_active",
     "type": "enchantment",
     "name": { "str": "Active combat exoskeleton mk.3" },
-    "description": "The exoskeleton helps you carry more weight, protects you against harmful gas, cools you down, and has reduced encumbrance.",
+    "description": "Now powered, the exoskeleton shields you against harmful gas, cools you down, and has reduced encumbrance. Designed for light loadouts, this model also provides slight improvements to your movement exertion cost and carry weight.",
     "has": "WORN",
     "condition": "ACTIVE",
     "values": [

--- a/data/json/enchantments.json
+++ b/data/json/enchantments.json
@@ -188,7 +188,7 @@
     "description": "The exoskeleton is inactive and makes moving in it difficult and exhausting.",
     "has": "WORN",
     "condition": "INACTIVE",
-    "values": [ { "value": "MOVEMENT_EXERTION_MODIFIER", "multiply": 0.5 } ]
+    "values": [ { "value": "MOVEMENT_EXERTION_MODIFIER", "multiply": 0.8 } ]
   },
   {
     "id": "combat_exoskeleton_heavy_active",
@@ -211,7 +211,7 @@
     "has": "WORN",
     "condition": "ACTIVE",
     "values": [
-      { "value": "MOVEMENT_EXERTION_MODIFIER", "multiply": 0.6 },
+      { "value": "MOVEMENT_EXERTION_MODIFIER", "multiply": 0.3 },
       { "value": "CARRY_WEIGHT", "multiply": 0.6 },
       { "value": "CLIMATE_CONTROL_CHILL", "add": 50 }
     ]
@@ -224,7 +224,7 @@
     "has": "WORN",
     "condition": "ACTIVE",
     "values": [
-      { "value": "MOVEMENT_EXERTION_MODIFIER", "multiply": 0.8 },
+      { "value": "MOVEMENT_EXERTION_MODIFIER", "multiply": 0.2 },
       { "value": "CARRY_WEIGHT", "multiply": 0.4 },
       { "value": "CLIMATE_CONTROL_CHILL", "add": 50 }
     ]


### PR DESCRIPTION
#### Summary

Bugfixes "Powered exoskeletons are now less exerting to operate than unpowered ones, correct powered states to reduce exertion rather than increase it"

#### Purpose of change

Fixes #74785 

Powered exoskeletons currently make it harder for the player to move. According to the author of the revised exoskeletons, this was an oversight during initial implementation, as:

> Due to a quirk somewhere in the code `"multiply": x` actually means `"multiply": 1+x` and to reduce a value you need to input `"multiply": -x.`
> 
> So basically my error was not putting minuses in front of the active exos multiply values.

The current values are:

Unpowered: `1.5`
Active mk1 (heavy): `1.4`
Active mk2 (medium): `1.6`
Active mk3 (light): `1.8`

Values above 1.0 increase movement exertion, values below decrease it. The correct implementation should have been Active values between 0 and 1.0, as per the original author.

Currently, Active mk2 and mk3 exoskeletons cause more exertion to the player than their inactive states, which is nonsensical.

#### Describe the solution

Changed values to be negative, made lighter suits have greater effect, as both I and the original author agreed that later generation exoskeletons should have greater advantages in mobility than the older tank suits.

Unpowered: `1.5`
Active mk1 (heavy): `0.8`
Active mk2 (medium): `0.7`
Active mk3 (light): `0.6`

Expand the descriptions to tell players that there are differences in these values between the suits, without them having to dig into the code to find out (as I had to).

#### Describe alternatives you've considered

Creating inactive states for each version of exoskeleton, and providing unique values to each's exertion cost. Considering each suit weighs the same and the original author did not do this, just having a big exertion cost across the board seems sufficient.

#### Testing

With the current values I now propose (heavy -0.2, medium -0.3, light -0.4), walking becomes a `Light` activity for all three suits (an improvement over the `Moderate` of walking without the suit), while running becomes a `Moderate` activity for the mk3 and mk2, and `Brisk` for the mk1.

#### Additional context

It's been a while since I've used git and contributed to this project, apologies in advance if I messed anything up.


