### PR TITLE
Nerf to-hit of lucern hammer

### DIFF
--- a/data/json/items/melee/bludgeons.json
+++ b/data/json/items/melee/bludgeons.json
@@ -1150,12 +1150,12 @@
     "weight": "3200 g",
     "volume": "3750 ml",
     "longest_side": "200 cm",
-    "to_hit": { "grip": "weapon", "length": "long", "surface": "any", "balance": "uneven" },
+    "to_hit": { "grip": "weapon", "length": "long", "surface": "point", "balance": "uneven" },
     "price_postapoc": "100 USD",
     "qualities": [ [ "COOK", 1 ] ],
     "use_action": [ "HEAT_SOLID_ITEMS" ],
     "category": "weapons",
-    "melee_damage": { "bash": 44, "stab": 33 }
+    "melee_damage": { "bash": 44, "stab": 39 }
   },
   {
     "id": "lucern_hammerfake",

--- a/data/mods/TEST_DATA/expected_dps_data/polearms_dps.json
+++ b/data/mods/TEST_DATA/expected_dps_data/polearms_dps.json
@@ -5,11 +5,11 @@
     "expected_dps": {
       "naginata_fake": 5.38,
       "pike_fake": 7.55,
+      "lucern_hammerfake": 10.0,
       "pike_wood": 10.08,
       "pike_pole": 12.51,
       "halberd_fake": 12.77,
       "long_pole": 13.0,
-      "lucern_hammerfake": 13.0,
       "pike_copper": 13.96,
       "spear_homemade_halfpike": 15.41,
       "pike_inferior": 16.0,
@@ -22,12 +22,12 @@
       "brush_axe": 27.67,
       "spear_dory": 28.0,
       "qiang": 30.68,
+      "lucern_hammer": 31.5,
       "glaive": 33.87,
       "naginata": 33.97,
       "poleaxe": 34.5,
       "scythe_war": 34.59,
       "ji": 35.82,
-      "lucern_hammer": 36.0,
       "halberd": 36.28
     }
   }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Hitting with the spike or head of the hammer requires a bit of effort, and is not deserving of an "any" rating.

#### Describe the solution
Change the to-hit, and increase the stab to be similar to other polearms to adjust the DPS back up a bit from the change.

#### Describe alternatives you've considered

#### Testing
`tests/cata_test 'expected_weapon_dps'

#### Additional context
Came up in https://github.com/CleverRaven/Cataclysm-DDA/pull/74786
[This](https://en.wikipedia.org/wiki/Lucerne_hammer), on top of a ~2 meter pole.
![image of lucern hammer](https://upload.wikimedia.org/wikipedia/commons/thumb/5/54/Lucerne_Hammer_MET_14.25.222_002dec2014.jpg/220px-Lucerne_Hammer_MET_14.25.222_002dec2014.jpg)