### PR TITLE
Offspring inherit friendly

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -604,7 +604,7 @@ void monster::try_reproduce()
         if( season_match && female && one_in( chance ) ) {
             int spawn_cnt = rng( 1, type->baby_count );
             if( type->baby_monster ) {
-                here.add_spawn( type->baby_monster, spawn_cnt, pos_bub() );
+                here.add_spawn( type->baby_monster, spawn_cnt, pos_bub(), friendly );
             } else {
                 const item egg( type->baby_egg, *baby_timer );
                 for( int i = 0; i < spawn_cnt; i++ ) {


### PR DESCRIPTION
#### Summary
Bugfixes "Offspring inherit friendly value from parents to prevent conflict with tamed parents"

#### Purpose of change
Fixes #74317

#### Describe the solution
Added argument to add_spawn call in try_reproduce in monster.cpp to pass parent's friendly value to offspring.

#### Describe alternatives you've considered
Aggro functions and monster objects could be modified to detect if monster is parent or offspring and act accordingly, but this seems unnecessarily complicated and above my current familiarity with the source

#### Testing
Verified bug behavior with current version. Made change and compiled with temporary changes to mammals.json so some animals would breed and mature quickly. Spawned and tamed animals in the basement bathrooms of the starting evac shelter. Verified that animals would pass their tamed status to their offspring and that it would prevent conflicts. Tested several ingame days with parents locked in the cramped bathroom with myself and their offspring which was easily enough time to see the hostile behavior in current version. Also made sure that untamed animals would still spawn untamed offspring.

#### Additional context
Behavior of tamed animals attacking untamed offspring and untamed offspring attacking tamed parents was somewhat erratic, but after seeing the behavior in the current version, I am confident that my testing was exhaustive enough to show that the undesired behavior stopped after the change.