### PR TITLE
[MoM] Fear hawks exist

### DIFF
--- a/data/mods/MindOverMatter/mapgen/map_extras/wilderness_extras.json
+++ b/data/mods/MindOverMatter/mapgen/map_extras/wilderness_extras.json
@@ -32,7 +32,7 @@
       ],
       "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ],
       "palettes": [ "fear_hawk_copse_trees_palette" ],
-      "place_monster": [ { "monster": "mon_fear_hawk", "x": [ 0, 23 ], "y": [ 0, 23 ], "repeat": [ 1, 5 ] } ]
+      "place_monsters": [ { "monster": "GROUP_FEAR_HAWKS", "x": [ 0, 23 ], "y": [ 0, 23 ], "density": 0.1 } ]
     }
   }
 ]

--- a/data/mods/MindOverMatter/mapgen/map_extras/wilderness_extras.json
+++ b/data/mods/MindOverMatter/mapgen/map_extras/wilderness_extras.json
@@ -32,7 +32,7 @@
       ],
       "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ],
       "palettes": [ "fear_hawk_copse_trees_palette" ],
-      "place_monsters": [ { "monster": "GROUP_FEAR_HAWKS", "x": [ 0, 23 ], "y": [ 0, 23 ], "density": 0.1 } ]
+      "place_monster": [ { "monster": "mon_fear_hawk", "x": [ 0, 23 ], "y": [ 0, 23 ], "repeat": [ 1, 5 ] } ]
     }
   }
 ]

--- a/data/mods/MindOverMatter/mapgen_palettes/wilderness.json
+++ b/data/mods/MindOverMatter/mapgen_palettes/wilderness.json
@@ -8,7 +8,7 @@
       ";": [
         [ "t_region_groundcover", 10 ],
         [ "t_region_groundcover_forest", 8 ],
-        [ "t_region_tree", 5 ],
+        [ "t_region_tree", 6 ],
         [ "t_tree_hawk_nest", 1 ],
         "t_region_shrub"
       ],

--- a/data/mods/MindOverMatter/mapgen_palettes/wilderness.json
+++ b/data/mods/MindOverMatter/mapgen_palettes/wilderness.json
@@ -5,7 +5,13 @@
     "terrain": {
       ".": [ [ "t_region_groundcover", 60 ], "t_region_tree", "t_region_shrub" ],
       ",": [ [ "t_region_groundcover", 30 ], [ "t_region_groundcover_forest", 8 ], [ "t_region_tree", 2 ], "t_region_shrub" ],
-      ";": [ [ "t_region_groundcover", 10 ], [ "t_region_groundcover_forest", 8 ], [ "t_tree_hawk_nest", 6 ], "t_region_shrub" ],
+      ";": [
+        [ "t_region_groundcover", 10 ],
+        [ "t_region_groundcover_forest", 8 ],
+        [ "t_region_tree", 5 ],
+        [ "t_tree_hawk_nest", 1 ],
+        "t_region_shrub"
+      ],
       "|": [ [ "t_region_groundcover_forest", 7 ], "t_puddle" ]
     },
     "furniture": {

--- a/data/mods/MindOverMatter/monstergroups/monstergroups_new.json
+++ b/data/mods/MindOverMatter/monstergroups/monstergroups_new.json
@@ -94,7 +94,7 @@
   {
     "name": "GROUP_FEAR_HAWKS",
     "type": "monstergroup",
-    "monsters": [ { "monster": "mon_fear_hawk", "weight": 8 }, { "monster": "mon_null", "weight": 25 } ]
+    "monsters": [ { "monster": "mon_fear_hawk", "weight": 1000 } ]
   },
   {
     "type": "monstergroup",

--- a/data/mods/MindOverMatter/monsters/animal_psychics.json
+++ b/data/mods/MindOverMatter/monsters/animal_psychics.json
@@ -79,6 +79,8 @@
         "cooldown": 5,
         "move_cost": 100,
         "range": 3,
+        "dodgeable": false,
+        "blockable": false,
         "condition": { "not": { "u_has_effect": "effect_psi_null" } },
         "damage_max_instance": [ { "damage_type": "psi_telepathic_damage", "amount": 10 } ],
         "hit_dmg_u": "%1$s shrieks at your %2$s!",

--- a/data/mods/MindOverMatter/monsters/animal_psychics.json
+++ b/data/mods/MindOverMatter/monsters/animal_psychics.json
@@ -83,7 +83,7 @@
         "blockable": false,
         "condition": { "not": { "u_has_effect": "effect_psi_null" } },
         "damage_max_instance": [ { "damage_type": "psi_telepathic_damage", "amount": 10 } ],
-        "hit_dmg_u": "%1$s shrieks at your %2$s!",
+        "hit_dmg_u": "%1$s shrieks at you!",
         "hit_dmg_npc": "%1$s shrieks at <npcname>!",
         "no_dmg_msg_u": "%1$s's shriek radiates out at you without doing any damage.",
         "no_dmg_msg_npc": "%1$s's shriek radiates out at <npcname> without doing any damage.",

--- a/data/mods/MindOverMatter/overmap/map_extras.json
+++ b/data/mods/MindOverMatter/overmap/map_extras.json
@@ -74,7 +74,7 @@
     "type": "map_extra",
     "name": { "str": "Suspicious stand of trees" },
     "description": "A suspicious copse of trees.",
-    "generator": { "generator_method": "update_mapgen", "generator_id": "mx_trees_map" },
+    "generator": { "generator_method": "update_mapgen", "generator_id": "mx_fear_hawk_copse" },
     "min_max_zlevel": [ 0, 0 ],
     "autonote": true
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Fear hawks exist"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Have received multiple reports that the suspicious stand of trees is empty and I checked it out to find it empty.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Fix the map special reference (it was referring to `mx_trees_map`, which is just a grove of trees, and not `mx_fear_hawk_copse` like it should have been)

Reduce the density of fear hawk nests compared to regular trees to prevent an 8 to 1 nest to bird ratio. 

Also, make the fear hawk shriek undodgeable and unblockable (it's a psychic shriek, not a physical attack), thus allowing them to still hit you even with their low melee skill. Telepathic shield protects from their attack as appropriate.

In combat, the fear hawks run in, blast you a few times with their attack, and then run away. Nice wild animal simulation even though they have awesome mind powers.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Copse spawns in, hawks exist, nesting trees exist. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I should make it so that you have a chance to drop your weapon or lose morale when they attack you, but that's best done in another PR. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
