### PR TITLE
More vampire additions

### DIFF
--- a/data/mods/Xedra_Evolved/effects/vampvirus.json
+++ b/data/mods/Xedra_Evolved/effects/vampvirus.json
@@ -119,8 +119,8 @@
     "type": "effect_on_condition",
     "id": "EOC_COMPLETED_VAMPIRE3",
     "condition": { "not": { "u_has_trait": "VAMPIRE4" } },
-    "effect": [ "EOC_COMPLETED_VAMPIRE3_REAL" ],
-    "false_effect": [ "EOC_VAMPVIRUS3" ]
+    "effect": { "run_eocs": "EOC_COMPLETED_VAMPIRE3_REAL" },
+    "false_effect": [ { "run_eocs": "EOC_VAMPVIRUS3" } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/Xedra_Evolved/effects/vampvirus.json
+++ b/data/mods/Xedra_Evolved/effects/vampvirus.json
@@ -125,12 +125,16 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_COMPLETED_VAMPIRE3_REAL",
-    "effect": { "u_message": "You can advance no further without access to a mentor.  Maybe you could find one where you've found the other vampires?" }
+    "effect": {
+      "u_message": "You can advance no further without access to a mentor.  Maybe you could find one where you've found the other vampires?"
+    }
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_COMPLETED_VAMPIRE4",
-    "effect": { "u_message": "You can advance no further without more guidance from your mentor [fourth wall tier 5 and its content do not exist yet]" }
+    "effect": {
+      "u_message": "You can advance no further without more guidance from your mentor [fourth wall tier 5 and its content do not exist yet]"
+    }
   },
   {
     "type": "effect_on_condition",
@@ -302,7 +306,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_VAMPVIRUS3",
-    "condition":  { "u_has_effect": "vampire_virus_ascendant", "intensity": 1 },
+    "condition": { "u_has_effect": "vampire_virus_ascendant", "intensity": 1 },
     "effect": {
       "run_eocs": {
         "id": "eoc_vampvirus_4_math_checker",
@@ -319,12 +323,12 @@
                 "false_eocs": [ "EOC_COMPLETED_VAMPIRE4" ]
               }
             ],
-        "false_effect": [ { "run_eocs": "EOC_COMPLETED_VAMPIRE4" } ]
+            "false_effect": [ { "run_eocs": "EOC_COMPLETED_VAMPIRE4" } ]
+          }
+        }
       }
     }
-  }
-   }
-    },
+  },
   {
     "type": "effect_on_condition",
     "id": "EOC_vampire_virus_blood_needs",

--- a/data/mods/Xedra_Evolved/effects/vampvirus.json
+++ b/data/mods/Xedra_Evolved/effects/vampvirus.json
@@ -22,7 +22,6 @@
               { "u_lose_trait": "EYEGLEAM" },
               { "u_lose_trait": "BLOOD_FUN" },
               { "u_lose_trait": "STAMINAFORBLOOD" },
-              { "u_lose_trait": "BLOODBANK" },
               { "u_lose_trait": "COMMUNE_NIGHT" },
               { "u_lose_trait": "VAMPIRIC_STRENGTH" },
               { "u_lose_trait": "VAMPIRIC_RESILIENCE" },
@@ -119,9 +118,9 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_COMPLETED_VAMPIRE3",
-    "condition":{ "not":{ "u_has_trait": "VAMPIRE4" } },
-    "true_eocs": [ "EOC_COMPLETED_VAMPIRE3_REAL" ],
-    "false_eocs": [ "EOC_VAMPVIRUS3" ]
+    "condition": { "not": { "u_has_trait": "VAMPIRE4" } },
+    "effect": [ "EOC_COMPLETED_VAMPIRE3_REAL" ],
+    "false_effect": [ "EOC_VAMPVIRUS3" ]
   },
   {
     "type": "effect_on_condition",
@@ -301,6 +300,7 @@
     }
   },
   {
+    "type": "effect_on_condition",
     "id": "EOC_VAMPVIRUS3",
     "condition":  { "u_has_effect": "vampire_virus_ascendant", "intensity": 1 },
     "effect": {

--- a/data/mods/Xedra_Evolved/effects/vampvirus.json
+++ b/data/mods/Xedra_Evolved/effects/vampvirus.json
@@ -116,9 +116,19 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_COMPLETED_VAMPIRE3",
-    "effect": {
-      "u_message": "You can advance no further without access to a mentor.  Maybe you could find one where you've found the other vampires?"
-    }
+    "condition":{ "not":{ "u_has_trait": "VAMPIRE4" } },
+    "true_eocs": [ "EOC_COMPLETED_VAMPIRE3_REAL" ],
+    "false_eocs": [ "EOC_VAMPVIRUS3" ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_COMPLETED_VAMPIRE3_REAL",
+    "effect": { "u_message": "You can advance no further without access to a mentor.  Maybe you could find one where you've found the other vampires?" }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_COMPLETED_VAMPIRE4",
+    "effect": { "u_message": "You can advance no further without more guidance from your mentor [fourth wall tier 5 and its content do not exist yet]" }
   },
   {
     "type": "effect_on_condition",
@@ -178,6 +188,7 @@
                       {
                         "u_roll_remainder": [
                           "EYEGLEAM",
+                          "BLOOD_FUN",
                           "STAMINAFORBLOOD",
                           "COMMUNE_NIGHT",
                           "VAMPIRIC_STRENGTH",
@@ -286,6 +297,31 @@
       ]
     }
   },
+  {
+    "id": "EOC_VAMPVIRUS3",
+    "condition":  { "u_has_effect": "vampire_virus_ascendant", "intensity": 1 },
+    "effect": {
+      "run_eocs": {
+        "id": "eoc_vampvirus_4_math_checker",
+        "condition": { "math": [ "vampire_total_tier_four_traits()", "<", "4" ] },
+        "effect": {
+          "run_eocs": {
+            "id": "eoc_vampvirus_4_trait",
+            "condition": { "u_has_trait": "VAMPIRE4" },
+            "effect": [
+              {
+                "u_roll_remainder": [  ],
+                "type": "mutation",
+                "true_eocs": [ "EOC_SUCCESFUL_ROLL_REMAINDER" ],
+                "false_eocs": [ "EOC_COMPLETED_VAMPIRE4" ]
+              }
+            ],
+        "false_effect": [ { "run_eocs": "EOC_COMPLETED_VAMPIRE4" } ]
+      }
+    }
+  }
+   }
+    },
   {
     "type": "effect_on_condition",
     "id": "EOC_vampire_virus_blood_needs",

--- a/data/mods/Xedra_Evolved/effects/vampvirus.json
+++ b/data/mods/Xedra_Evolved/effects/vampvirus.json
@@ -313,7 +313,7 @@
             "condition": { "u_has_trait": "VAMPIRE4" },
             "effect": [
               {
-                "u_roll_remainder": [ "TRUE_VAMPIRE_POWER", "VAMPIRE_TORPOR" ],
+                "u_roll_remainder": [ "TRUE_VAMPIRE_POWER", "VAMPIRE_TORPOR", "VAMPIRE_DOMINATE", "VAMPIRE_NO_BREATHE", "VAMPIRE_NO_ILLNESS" ],
                 "type": "mutation",
                 "true_eocs": [ "EOC_SUCCESFUL_ROLL_REMAINDER" ],
                 "false_eocs": [ "EOC_COMPLETED_VAMPIRE4" ]

--- a/data/mods/Xedra_Evolved/effects/vampvirus.json
+++ b/data/mods/Xedra_Evolved/effects/vampvirus.json
@@ -20,6 +20,7 @@
               { "u_lose_effect": "vampire_virus" },
               { "u_lose_trait": "VAMPIRE" },
               { "u_lose_trait": "EYEGLEAM" },
+              { "u_lose_trait": "BLOOD_FUN" },
               { "u_lose_trait": "STAMINAFORBLOOD" },
               { "u_lose_trait": "BLOODBANK" },
               { "u_lose_trait": "COMMUNE_NIGHT" },
@@ -62,8 +63,10 @@
               { "u_lose_trait": "BLOODBANK" },
               { "u_lose_trait": "HYPNOTIC_GAZE" },
               { "u_lose_trait": "BLOODHASTE" },
+              { "u_lose_trait": "MAGICFORBLOOD" },
               { "u_lose_trait": "VAMPIRE_COMMAND_BEAST" },
               { "u_lose_trait": "VAMPIRE_EARTH_SLUMBER" },
+              { "math": [ "u_spell_level('vampire_magic_for_blood_spell')", "=", "-1" ] },
               { "math": [ "u_spell_level('spell_hypnotic_gaze')", "=", "-1" ] },
               { "math": [ "u_spell_level('vampire_command_beast_spell')", "=", "-1" ] },
               {
@@ -276,7 +279,7 @@
                   "condition": { "u_has_trait": "VAMPIRE3" },
                   "effect": [
                     {
-                      "u_roll_remainder": [ "BLOODHASTE", "HYPNOTIC_GAZE", "BLOODBANK", "VAMPIRE_COMMAND_BEAST", "VAMPIRE_EARTH_SLUMBER" ],
+                      "u_roll_remainder": [ "BLOODHASTE", "MAGICFORBLOOD", "HYPNOTIC_GAZE", "BLOODBANK", "VAMPIRE_COMMAND_BEAST", "VAMPIRE_EARTH_SLUMBER" ],
                       "type": "mutation",
                       "true_eocs": [ "EOC_SUCCESFUL_ROLL_REMAINDER" ],
                       "false_eocs": [ "EOC_COMPLETED_VAMPIRE3" ]
@@ -310,7 +313,7 @@
             "condition": { "u_has_trait": "VAMPIRE4" },
             "effect": [
               {
-                "u_roll_remainder": [  ],
+                "u_roll_remainder": [ "TRUE_VAMPIRE_POWER", "VAMPIRE_TORPOR" ],
                 "type": "mutation",
                 "true_eocs": [ "EOC_SUCCESFUL_ROLL_REMAINDER" ],
                 "false_eocs": [ "EOC_COMPLETED_VAMPIRE4" ]

--- a/data/mods/Xedra_Evolved/effects/vampvirus.json
+++ b/data/mods/Xedra_Evolved/effects/vampvirus.json
@@ -310,7 +310,7 @@
     "effect": {
       "run_eocs": {
         "id": "eoc_vampvirus_4_math_checker",
-        "condition": { "math": [ "vampire_total_tier_four_traits()", "<", "4" ] },
+        "condition": { "math": [ "vampire_total_tier_four_traits()", "<", "10" ] },
         "effect": {
           "run_eocs": {
             "id": "eoc_vampvirus_4_trait",

--- a/data/mods/Xedra_Evolved/items/armor/integrated.json
+++ b/data/mods/Xedra_Evolved/items/armor/integrated.json
@@ -793,5 +793,27 @@
       }
     ],
     "armor": [ { "covers": [ "torso" ], "coverage": 0, "encumbrance": 0 } ]
+  },
+  {
+    "id": "integrated_nobreathe",
+    "type": "ARMOR",
+    "category": "armor",
+    "name": { "str_sp": "vestigial lungs" },
+    "description": "Breathing is now something you decide to do, rather than a biological necessity.",
+    "volume": "1 ml",
+    "price": "0 cent",
+    "price_postapoc": "0 cent",
+    "material": [ "flesh" ],
+    "symbol": "o",
+    "color": "magenta",
+    "flags": [ "INTEGRATED", "UNBREAKABLE", "PERSONAL", "NO_SALVAGE", "TRADER_AVOID" ],
+    "environmental_protection": 15,
+    "armor": [
+      {
+        "encumbrance": 0,
+        "coverage": 100,
+        "covers": [ "mouth" ]
+      }
+    ]
   }
 ]

--- a/data/mods/Xedra_Evolved/items/armor/integrated.json
+++ b/data/mods/Xedra_Evolved/items/armor/integrated.json
@@ -806,7 +806,7 @@
     "material": [ "flesh" ],
     "symbol": "o",
     "color": "magenta",
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "PERSONAL", "NO_SALVAGE", "TRADER_AVOID" ],
+    "flags": [ "INTEGRATED", "REBREATHER", "UNBREAKABLE", "PERSONAL", "NO_SALVAGE", "TRADER_AVOID" ],
     "environmental_protection": 15,
     "armor": [ { "encumbrance": 0, "coverage": 100, "covers": [ "mouth" ] } ]
   }

--- a/data/mods/Xedra_Evolved/items/armor/integrated.json
+++ b/data/mods/Xedra_Evolved/items/armor/integrated.json
@@ -808,12 +808,6 @@
     "color": "magenta",
     "flags": [ "INTEGRATED", "UNBREAKABLE", "PERSONAL", "NO_SALVAGE", "TRADER_AVOID" ],
     "environmental_protection": 15,
-    "armor": [
-      {
-        "encumbrance": 0,
-        "coverage": 100,
-        "covers": [ "mouth" ]
-      }
-    ]
+    "armor": [ { "encumbrance": 0, "coverage": 100, "covers": [ "mouth" ] } ]
   }
 ]

--- a/data/mods/Xedra_Evolved/items/comestibles/med.json
+++ b/data/mods/Xedra_Evolved/items/comestibles/med.json
@@ -95,15 +95,8 @@
     ],
     "false_effect": [
       { "u_message": "You imbibed the concoction and you feel your veins flex in a warm glow.", "type": "good" },
-      { "u_add_trait": "BLOOD_OF_SAINTS" }
+      { "u_add_trait": "BLOOD_OF_SAINTS" },
+      { "u_add_effect": "blood_treatment", "duration": "PERMANENT" }
     ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_BLOOD_OF_SAINTS_REVERSE_VAMPIRISM",
-    "recurrence": [ "6 hours", "6 hours" ],
-    "global": true,
-    "condition": { "u_has_trait": "BLOOD_OF_SAINTS" },
-    "effect": [ { "u_add_effect": "blood_treatment", "duration": "6 hours" } ]
   }
 ]

--- a/data/mods/Xedra_Evolved/items/comestibles/med.json
+++ b/data/mods/Xedra_Evolved/items/comestibles/med.json
@@ -84,6 +84,7 @@
     }
   },
   {
+    "type": "effect_on_condition",
     "id": "learn_blood_of_saints_2",
     "condition": { "u_has_effect": "vampire_virus_ascendant", "intensity": 1 },
     "effect": [
@@ -98,5 +99,13 @@
       { "u_add_trait": "BLOOD_OF_SAINTS" },
       { "u_add_effect": "blood_treatment", "duration": "PERMANENT" }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_BLOOD_OF_SAINTS_AGAINST_VAMPIRISM",
+    "recurrence": [ "16 hours", "16 hours" ],
+    "condition": { "u_has_trait": "BLOOD_OF_SAINTS" },
+    "global": true,
+    "effect": [ { "run_eocs": "EOC_REDUCE_VAMPVIRUS" }, { "run_eocs": "EOC_REDUCE_VAMPVIRUS1" }, { "run_eocs": "EOC_REDUCE_VAMPVIRUS2" }, { "run_eocs": "EOC_REDUCE_VAMPVIRUS3" } ]
   }
 ]

--- a/data/mods/Xedra_Evolved/items/comestibles/med.json
+++ b/data/mods/Xedra_Evolved/items/comestibles/med.json
@@ -73,12 +73,37 @@
       "effect_on_conditions": [
         {
           "id": "learn_blood_of_saints",
+          "condition": { "u_has_effect": "vampire_virus_post_mortal" },
           "effect": [
-            { "u_message": "You imbibed the concoction and you feel your veins flex in a warm glow." },
-            { "u_add_trait": "BLOOD_OF_SAINTS" }
-          ]
+            { "u_add_effect": "poisoned_blood2", "duration": "2 hours" },
+            { "u_message": "Your veins burn and ache.  What were you thinking trying this?  You are already one of the damned!", "type": "bad" }
+          ],
+          "false_effect": [ { "run_eocs": "learn_blood_of_saints_2" } ]
         }
       ]
     }
+  },
+  {
+    "id": "learn_blood_of_saints_2",
+    "condition": { "u_has_effect": "vampire_virus_ascendant", "intensity": 1 },
+    "effect": [
+      { "u_add_effect": "poisoned_blood", "intensity": 1, "duration": "8 hours" },
+      {
+        "u_message": "Your veins burn and ache.  What were you thinking trying this?  You are already one of the damned!",
+        "type": "bad"
+      }
+    ],
+    "false_effect": [
+      { "u_message": "You imbibed the concoction and you feel your veins flex in a warm glow.", "type": "good" },
+      { "u_add_trait": "BLOOD_OF_SAINTS" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_BLOOD_OF_SAINTS_REVERSE_VAMPIRISM",
+    "recurrence": [ "6 hours", "6 hours" ],
+    "global": true,
+    "condition": { "u_has_trait": "BLOOD_OF_SAINTS" },
+    "effect": [ { "u_add_effect": "blood_treatment", "duration": "6 hours" } ]
   }
 ]

--- a/data/mods/Xedra_Evolved/items/comestibles/med.json
+++ b/data/mods/Xedra_Evolved/items/comestibles/med.json
@@ -76,7 +76,10 @@
           "condition": { "u_has_effect": "vampire_virus_post_mortal" },
           "effect": [
             { "u_add_effect": "poisoned_blood2", "duration": "2 hours" },
-            { "u_message": "Your veins burn and ache.  What were you thinking trying this?  You are already one of the damned!", "type": "bad" }
+            {
+              "u_message": "Your veins burn and ache.  What were you thinking trying this?  You are already one of the damned!",
+              "type": "bad"
+            }
           ],
           "false_effect": [ { "run_eocs": "learn_blood_of_saints_2" } ]
         }
@@ -106,6 +109,11 @@
     "recurrence": [ "16 hours", "16 hours" ],
     "condition": { "u_has_trait": "BLOOD_OF_SAINTS" },
     "global": true,
-    "effect": [ { "run_eocs": "EOC_REDUCE_VAMPVIRUS" }, { "run_eocs": "EOC_REDUCE_VAMPVIRUS1" }, { "run_eocs": "EOC_REDUCE_VAMPVIRUS2" }, { "run_eocs": "EOC_REDUCE_VAMPVIRUS3" } ]
+    "effect": [
+      { "run_eocs": "EOC_REDUCE_VAMPVIRUS" },
+      { "run_eocs": "EOC_REDUCE_VAMPVIRUS1" },
+      { "run_eocs": "EOC_REDUCE_VAMPVIRUS2" },
+      { "run_eocs": "EOC_REDUCE_VAMPVIRUS3" }
+    ]
   }
 ]

--- a/data/mods/Xedra_Evolved/jmath.json
+++ b/data/mods/Xedra_Evolved/jmath.json
@@ -114,6 +114,6 @@
     "type": "jmath_function",
     "id": "vampire_total_tier_four_traits",
     "num_args": 0,
-    "return": "(u_has_trait('TRUE_VAMPIRE_POWER') * 6)+ u_has_trait('VAMPIRE_TORPOR') + u_has_trait('VAMPIRE_DOMINATE') + u_has_trait('VAMPIRE_NO_BREATHE') + u_has_trait('VAMPIRE_NO_ILLNESS')"
+    "return": "(u_has_trait('TRUE_VAMPIRE_POWER') * 6) + u_has_trait('VAMPIRE_TORPOR') + u_has_trait('VAMPIRE_DOMINATE') + u_has_trait('VAMPIRE_NO_BREATHE') + u_has_trait('VAMPIRE_NO_ILLNESS')"
   }
 ]

--- a/data/mods/Xedra_Evolved/jmath.json
+++ b/data/mods/Xedra_Evolved/jmath.json
@@ -96,7 +96,7 @@
     "type": "jmath_function",
     "id": "vampire_total_tier_one_traits",
     "num_args": 0,
-    "return": "u_has_trait('EYEGLEAM') + u_has_trait('STAMINAFORBLOOD') + u_has_trait('COMMUNE_NIGHT') + u_has_trait('VAMPIRIC_STRENGTH') + u_has_trait('VAMPIRIC_RESILIENCE') + u_has_trait('VAMPIRE_HEIGHTENED_SENSES') + u_has_trait('VAMPIRE_SILENT_MOVE')"
+    "return": "u_has_trait('EYEGLEAM') + u_has_trait('BLOOD_FUN') + u_has_trait('STAMINAFORBLOOD') + u_has_trait('COMMUNE_NIGHT') + u_has_trait('VAMPIRIC_STRENGTH') + u_has_trait('VAMPIRIC_RESILIENCE') + u_has_trait('VAMPIRE_HEIGHTENED_SENSES') + u_has_trait('VAMPIRE_SILENT_MOVE')"
   },
   {
     "type": "jmath_function",

--- a/data/mods/Xedra_Evolved/jmath.json
+++ b/data/mods/Xedra_Evolved/jmath.json
@@ -114,7 +114,6 @@
     "type": "jmath_function",
     "id": "vampire_total_tier_four_traits",
     "num_args": 0,
-    "//": "Tier four is currently impossible to get and has no traits. Jmath is included so that durations don't all have to be scaled when it is implemented",
-    "return": "0"
+    "return": "(u_has_trait('TRUE_VAMPIRE_POWER') * 6)+ u_has_trait('VAMPIRE_TORPOR') + u_has_trait('VAMPIRE_DOMINATE') + u_has_trait('VAMPIRE_NO_BREATHE') + u_has_trait('VAMPIRE_NO_ILLNESS')"
   }
 ]

--- a/data/mods/Xedra_Evolved/jmath.json
+++ b/data/mods/Xedra_Evolved/jmath.json
@@ -108,7 +108,7 @@
     "type": "jmath_function",
     "id": "vampire_total_tier_three_traits",
     "num_args": 0,
-    "return": "u_has_trait('BLOODHASTE') + u_has_trait('HYPNOTIC_GAZE') + u_has_trait('BLOODBANK') + u_has_trait('VAMPIRE_COMMAND_BEAST') + u_has_trait('VAMPIRE_EARTH_SLUMBER')"
+    "return": "u_has_trait('BLOODHASTE') + u_has_trait('HYPNOTIC_GAZE') + u_has_trait('MAGICFORBLOOD') + u_has_trait('BLOODBANK') + u_has_trait('VAMPIRE_COMMAND_BEAST') + u_has_trait('VAMPIRE_EARTH_SLUMBER')"
   },
   {
     "type": "jmath_function",

--- a/data/mods/Xedra_Evolved/morale_types.json
+++ b/data/mods/Xedra_Evolved/morale_types.json
@@ -5,6 +5,11 @@
     "text": "Ate dreamdross"
   },
   {
+    "id": "morale_drank_blood",
+    "type": "morale_type",
+    "text": "Drank human blood"
+  },
+  {
     "id": "morale_craving_lotus_blossom",
     "type": "morale_type",
     "text": "A hum at the edge of your thoughts."

--- a/data/mods/Xedra_Evolved/mutations/mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/mutations.json
@@ -506,7 +506,7 @@
     "purifiable": false,
     "valid": false,
     "name": { "str": "Facultative Breathing" },
-    "description": "You do not need to breathe air to live anymore.  It prevents you from being drowed or suffocated and allows you to ignore inhaled gases.",
+    "description": "You do not need to breathe air to live anymore.  It prevents you from being drowned or suffocated and allows you to ignore inhaled gases.",
     "flags": [ "GILLS" ],
     "integrated_armor": [ "integrated_nobreathe" ]
   },

--- a/data/mods/Xedra_Evolved/mutations/mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/mutations.json
@@ -521,7 +521,7 @@
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
-    "name": { "str": "Falcultative Breathing" },
+    "name": { "str": "Facultative Breathing" },
     "description": "You do not need to breathe air to live anymore.  It prevents you from drowning and allows you to ignore inhaled gases.",
     "flags": [ "GILLS" ],
     "integrated_armor": [ "integrated_nobreathe" ]

--- a/data/mods/Xedra_Evolved/mutations/mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/mutations.json
@@ -488,22 +488,6 @@
     "spells_learned": [ [ "vampire_torpor", 1 ] ]
   },
   {
-    "id": "vampire_torpor",
-    "type": "SPELL",
-    "name": "Torpor",
-    "description": "Enter a deathlike slumber and recover from your wounds and fatigue.",
-    "message": "You enter a torpor.",
-    "teachable": false,
-    "valid_targets": [ "self" ],
-    "skill": "deduction",
-    "spell_class": "VAMPIRE",
-    "flags": [ "SILENT", "NO_HANDS", "NO_LEGS", "NO_FAIL" ],
-    "effect": "effect_on_condition",
-    "effect_str": "EOC_VAMPIRE_TORPOR_activated",
-    "shape": "blast",
-    "energy_source": "NONE"
-  },
-  {
     "type": "mutation",
     "id": "VAMPIRE_DOMINATE",
     "points": 0,

--- a/data/mods/Xedra_Evolved/mutations/mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/mutations.json
@@ -474,69 +474,7 @@
     "purifiable": false,
     "valid": false,
     "name": { "str": "True Vampire's Potence" },
-    "description": "Your new status as a true vampire has empowered your other abilities.",
-    "enchantments": [ "true_vampire_power_real" ]
-  },
-  {
-    "type": "enchantment",
-    "id": "true_vampire_power_real",
-    "condition": "ALWAYS",
-    "mutations": [ "TRUE_VAMPIRE_POWER_1", "TRUE_VAMPIRE_POWER_2", "TRUE_VAMPIRE_POWER_3", "TRUE_VAMPIRE_POWER_4", "TRUE_VAMPIRE_POWER_5" ]
-  },
-  {
-    "type": "mutation",
-    "id": "TRUE_VAMPIRE_POWER_1",
-    "points": 0,
-    "player_display": false,
-    "starting_trait": false,
-    "purifiable": false,
-    "valid": false,
-    "name": { "str": "True Vampire's Potence 1" },
-    "description": "Fake mutation to boost vampiric abilities."
-  },
-  {
-    "type": "mutation",
-    "id": "TRUE_VAMPIRE_POWER_2",
-    "points": 0,
-    "player_display": false,
-    "starting_trait": false,
-    "purifiable": false,
-    "valid": false,
-    "name": { "str": "True Vampire's Potence 2" },
-    "description": "Fake mutation to boost vampiric abilities."
-  },
-  {
-    "type": "mutation",
-    "id": "TRUE_VAMPIRE_POWER_3",
-    "points": 0,
-    "player_display": false,
-    "starting_trait": false,
-    "purifiable": false,
-    "valid": false,
-    "name": { "str": "True Vampire's Potence 3" },
-    "description": "Fake mutation to boost vampiric abilities."
-  },
-  {
-    "type": "mutation",
-    "id": "TRUE_VAMPIRE_POWER_4",
-    "points": 0,
-    "player_display": false,
-    "starting_trait": false,
-    "purifiable": false,
-    "valid": false,
-    "name": { "str": "True Vampire's Potence 4" },
-    "description": "Fake mutation to boost vampiric abilities."
-  },
-  {
-    "type": "mutation",
-    "id": "TRUE_VAMPIRE_POWER_5",
-    "points": 0,
-    "player_display": false,
-    "starting_trait": false,
-    "purifiable": false,
-    "valid": false,
-    "name": { "str": "True Vampire's Potence 5" },
-    "description": "Fake mutation to boost vampiric abilities."
+    "description": "Your new status as a true vampire has empowered your other abilities."
   },
   {
     "type": "mutation",
@@ -565,13 +503,40 @@
     "shape": "blast",
     "energy_source": "NONE"
   },
-
-
-
-
-
-
-
+  {
+    "type": "mutation",
+    "id": "VAMPIRE_DOMINATE",
+    "points": 0,
+    "starting_trait": false,
+    "purifiable": false,
+    "valid": false,
+    "name": { "str": "Dominating Gaze" },
+    "description": "You can focus your gaze and take control of your target.  Only works against targets that have a mind.",
+    "spells_learned": [ [ "vampire_dominate", 1 ] ]
+  },
+  {
+    "type": "mutation",
+    "id": "VAMPIRE_NO_BREATHE",
+    "points": 0,
+    "starting_trait": false,
+    "purifiable": false,
+    "valid": false,
+    "name": { "str": "Falcultative Breathing" },
+    "description": "You do not need to breathe air to live anymore.  It prevents you from drowning and allows you to ignore inhaled gases.",
+    "flags": [ "GILLS" ],
+    "integrated_armor": [ "integrated_nobreathe" ]
+  },
+  {
+    "type": "mutation",
+    "id": "VAMPIRE_NO_ILLNESS",
+    "points": 0,
+    "starting_trait": false,
+    "purifiable": false,
+    "valid": false,
+    "name": { "str": "Corpse-like Flesh" },
+    "description": "Your undead body is now much more dead than alive.  It prevents mundane illnesses and parasites from affecting you, while granting you a total immunity against radiation.",
+    "flags": [ "PARAIMMUNE", "NO_DISEASE", "NO_RADIATION", "INFECTION_IMMUNE" ]
+  },
   {
     "type": "mutation",
     "id": "BLOOD_DRINKER",

--- a/data/mods/Xedra_Evolved/mutations/mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/mutations.json
@@ -157,7 +157,7 @@
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
-    "name": { "str": "Sanguine Extasy" },
+    "name": { "str": "Sanguine Ecstasy" },
     "description": "Your palate adapted to your new condition.  Drinking human blood will make you feel great."
   },
   {
@@ -422,6 +422,17 @@
   },
   {
     "type": "mutation",
+    "id": "MAGICFORBLOOD",
+    "points": 0,
+    "starting_trait": false,
+    "purifiable": false,
+    "valid": false,
+    "name": { "str": "Blood-Fueled Magic" },
+    "description": "Your exhaust some of the blood in your veins to recover some of your spent mana.",
+    "spells_learned": [ [ "vampire_magic_for_blood_spell", 1 ] ]
+  },
+  {
+    "type": "mutation",
     "id": "VAMPIRE_COMMAND_BEAST",
     "points": 0,
     "starting_trait": false,
@@ -455,15 +466,105 @@
     "anger_relations": [ [ "VAMPIRE", -95 ], [ "RENFIELD", -95 ] ],
     "enchantments": [ { "values": [ { "value": "STAMINA_REGEN_MOD", "add": 0.1 }, { "value": "METABOLISM", "multiply": 0.5 } ] } ]
   },
-
-
-
-
-
-
-
-
-
+  {
+    "type": "mutation",
+    "id": "TRUE_VAMPIRE_POWER",
+    "points": 0,
+    "starting_trait": false,
+    "purifiable": false,
+    "valid": false,
+    "name": { "str": "True Vampire's Potence" },
+    "description": "Your new status as a true vampire has empowered your other abilities.",
+    "enchantments": [ "true_vampire_power_real" ]
+  },
+  {
+    "type": "enchantment",
+    "id": "true_vampire_power_real",
+    "condition": "ALWAYS",
+    "mutations": [ "TRUE_VAMPIRE_POWER_1", "TRUE_VAMPIRE_POWER_2", "TRUE_VAMPIRE_POWER_3", "TRUE_VAMPIRE_POWER_4", "TRUE_VAMPIRE_POWER_5" ]
+  },
+  {
+    "type": "mutation",
+    "id": "TRUE_VAMPIRE_POWER_1",
+    "points": 0,
+    "player_display": false,
+    "starting_trait": false,
+    "purifiable": false,
+    "valid": false,
+    "name": { "str": "True Vampire's Potence 1" },
+    "description": "Fake mutation to boost vampiric abilities."
+  },
+  {
+    "type": "mutation",
+    "id": "TRUE_VAMPIRE_POWER_2",
+    "points": 0,
+    "player_display": false,
+    "starting_trait": false,
+    "purifiable": false,
+    "valid": false,
+    "name": { "str": "True Vampire's Potence 2" },
+    "description": "Fake mutation to boost vampiric abilities."
+  },
+  {
+    "type": "mutation",
+    "id": "TRUE_VAMPIRE_POWER_3",
+    "points": 0,
+    "player_display": false,
+    "starting_trait": false,
+    "purifiable": false,
+    "valid": false,
+    "name": { "str": "True Vampire's Potence 3" },
+    "description": "Fake mutation to boost vampiric abilities."
+  },
+  {
+    "type": "mutation",
+    "id": "TRUE_VAMPIRE_POWER_4",
+    "points": 0,
+    "player_display": false,
+    "starting_trait": false,
+    "purifiable": false,
+    "valid": false,
+    "name": { "str": "True Vampire's Potence 4" },
+    "description": "Fake mutation to boost vampiric abilities."
+  },
+  {
+    "type": "mutation",
+    "id": "TRUE_VAMPIRE_POWER_5",
+    "points": 0,
+    "player_display": false,
+    "starting_trait": false,
+    "purifiable": false,
+    "valid": false,
+    "name": { "str": "True Vampire's Potence 5" },
+    "description": "Fake mutation to boost vampiric abilities."
+  },
+  {
+    "type": "mutation",
+    "id": "VAMPIRE_TORPOR",
+    "points": 0,
+    "starting_trait": false,
+    "purifiable": false,
+    "valid": false,
+    "name": { "str": "Torpor" },
+    "description": "You can enter a deathlike stake known as torpor, in which your wounds will close faster, your fatigue will recover and your blood thirst will be less intense.  You can wake up from torpor as you want.",
+    "spells_learned": [ [ "vampire_torpor", 1 ] ]
+  },
+  {
+    "id": "vampire_torpor",
+    "type": "SPELL",
+    "name": "Torpor",
+    "description": "Enter a deathlike slumber and recover from your wounds and fatigue.",
+    "message": "You enter a torpor.",
+    "teachable": false,
+    "valid_targets": [ "self" ],
+    "skill": "deduction",
+    "spell_class": "VAMPIRE",
+    "flags": [ "SILENT", "NO_HANDS", "NO_LEGS", "NO_FAIL" ],
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_VAMPIRE_TORPOR_activated",
+    "shape": "blast",
+    "energy_source": "NONE"
+  },
 
 
 

--- a/data/mods/Xedra_Evolved/mutations/mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/mutations.json
@@ -152,6 +152,16 @@
   },
   {
     "type": "mutation",
+    "id": "BLOOD_FUN",
+    "points": 0,
+    "starting_trait": false,
+    "purifiable": false,
+    "valid": false,
+    "name": { "str": "Sanguine Extasy" },
+    "description": "Your palate adapted to your new condition.  Drinking human blood will make you feel great."
+  },
+  {
+    "type": "mutation",
     "id": "VAMPIRIC_STRENGTH",
     "points": 0,
     "starting_trait": false,
@@ -445,6 +455,22 @@
     "anger_relations": [ [ "VAMPIRE", -95 ], [ "RENFIELD", -95 ] ],
     "enchantments": [ { "values": [ { "value": "STAMINA_REGEN_MOD", "add": 0.1 }, { "value": "METABOLISM", "multiply": 0.5 } ] } ]
   },
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
   {
     "type": "mutation",
     "id": "BLOOD_DRINKER",

--- a/data/mods/Xedra_Evolved/mutations/mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/mutations.json
@@ -506,7 +506,7 @@
     "purifiable": false,
     "valid": false,
     "name": { "str": "Facultative Breathing" },
-    "description": "You do not need to breathe air to live anymore.  It prevents you from drowning and allows you to ignore inhaled gases.",
+    "description": "You do not need to breathe air to live anymore.  It prevents you from being drowed or suffocated and allows you to ignore inhaled gases.",
     "flags": [ "GILLS" ],
     "integrated_armor": [ "integrated_nobreathe" ]
   },

--- a/data/mods/Xedra_Evolved/mutations/mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/mutations.json
@@ -484,7 +484,7 @@
     "purifiable": false,
     "valid": false,
     "name": { "str": "Torpor" },
-    "description": "You can enter a deathlike stake known as torpor, in which your wounds will close faster, your fatigue will recover and your blood thirst will be less intense.  You can wake up from torpor as you want.",
+    "description": "You can enter a deathlike stake known as torpor, in which your wounds will close faster, your fatigue will fully recover and your blood thirst will be less intense.  Be careful, though, as nothing will be able to wake you up until eight hours have passed.",
     "spells_learned": [ [ "vampire_torpor", 1 ] ]
   },
   {

--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
@@ -917,8 +917,8 @@
     "type": "effect_on_condition",
     "id": "EOC_VAMPIRE_TORPOR_activated",
     "effect": [
-      { "u_assign_activity": "ACT_VAMPIRE_TORPOR", "duration": "2400 minutes" },
-      { "u_add_effect": "effect_vampire_torpor", "duration": "2400 minutes" }
+      { "u_assign_activity": "ACT_VAMPIRE_TORPOR", "duration": "8 hours" },
+      { "u_add_effect": "effect_vampire_torpor", "duration": "8 hours" }
     ]
   },
   {
@@ -928,42 +928,14 @@
     "verb": "slumbering",
     "based_on": "time",
     "can_resume": false,
-    "rooted": true,
-    "completion_eoc": "EOC_VAMPIRE_TORPOR_REMOVE",
+    "interruptable": false,
+    "interruptable_with_kb": false,
     "do_turn_eoc": "EOC_VAMPIRE_TORPOR_RECOVER"
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_VAMPIRE_TORPOR_REMOVE",
-    "effect": [ { "u_lose_effect": "effect_vampire_torpor" } ]
-  },
-  {
-    "type": "effect_on_condition",
     "id": "EOC_VAMPIRE_TORPOR_RECOVER",
-    "condition": { "math": [ "u_val('sleepiness') + u_val('sleep_deprivation')", ">=", "0" ] },
-    "effect": [ { "run_eocs": [ "EOC_VAMPIRE_TORPOR_SLEEPINESS", "EOC_VAMPIRE_TORPOR_DEPRIVATION" ] } ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_VAMPIRE_TORPOR_SLEEPINESS",
-    "condition": {
-      "and": [
-        { "math": [ "u_val('sleepiness')", ">=", "0" ] },
-        {
-          "x_in_y_chance": {
-            "x": 1,
-            "y": { "math": [ "max( (55 - ( (vampire_total_tier_one_traits() * 0.5) + (vampire_total_tier_two_traits() * 1) + (vampire_total_tier_three_traits() * 2)  +  (vampire_total_tier_four_traits() * 3)), 15 )" ] }
-          }
-        }
-      ]
-    },
-    "effect": [ { "math": [ "u_val('sleepiness')", "-=", "1" ] } ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_VAMPIRE_TORPOR_DEPRIVATION",
-    "condition": { "math": [ "u_val('sleep_deprivation')", ">=", "0" ] },
-    "effect": { "math": [ "u_val('sleep_deprivation')", "-=", "1" ] }
+    "effect": [ { "math": [ "u_val('sleepiness')", "=", "0" ] }, { "math": [ "u_val('sleep_deprivation')", "=", "0" ] } ]
   },
   {
     "type": "effect_type",
@@ -972,6 +944,7 @@
     "desc": [ "Thanks to your torpor you are healing and recovering quickly" ],
     "rating": "good",
     "vitamins": [ { "vitamin": "human_blood_vitamin", "rate": [ [ 1, 1 ] ], "tick": [ "3 m" ] } ],
+    "flags": [ "DEAF", "BLIND" ],
     "enchantments": [
       {
         "values": [
@@ -998,15 +971,19 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_DOMINATING_GAZE_activated",
+    "id": "EOC_VAMPIRE_DOMINATE_activated",
     "condition": { "math": [ "n_vitamin('human_blood_vitamin')", ">=", "-500" ] },
     "effect": [
-      { "math": [ "n_vitamin('human_blood_vitamin')", "-=", "300" ] },
+      { "math": [ "n_vitamin('human_blood_vitamin')", "-=", "700" ] },
+      { "u_location_variable": { "context_val": "loc" } },
       {
         "run_eocs": [
           {
-            "id": "EOC_DOMINATING_GAZE_activated_2",
-            "effect": [ { "u_cast_spell": "vampire_dominate_real" } ]
+            "id": "EOC_VAMPIRE_DOMINATE_activated2",
+            "effect": [
+              { "npc_cast_spell": { "id": "vampire_dominate_real", "min_level": 1 }, "loc": { "context_val": "loc" } },
+              { "npc_message": "You focus you gaze on your target's mind, attempting to take control of it.", "type": "good" }
+            ]
           }
         ]
       }

--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
@@ -20,6 +20,25 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_VAMPIRE_BLOOD_FUN",
+    "eoc_type": "EVENT",
+    "required_event": "character_eats_item",
+    "condition": {
+      "and": [
+        {
+          "or": [
+            { "compare_string": [ "blood", { "context_val": "itype" } ] },
+            { "compare_string": [ "demihuman_blood", { "context_val": "itype" } ] },
+            { "compare_string": [ "mutant_human_blood", { "context_val": "itype" } ] }
+          ]
+        },
+        { "u_has_trait": "BLOOD_FUN" }
+      ]
+    },
+    "effect": [ { "u_add_morale": "morale_drank_blood", "bonus": 20, "max_bonus": 60, "duration": "20 m", "decay_start": "10 m" } ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_SET_VAMPIRE_TRAIT_NUMBERS_FOR_NPC_USE",
     "//": "This is necessary for powers whose effect on NPCs is variable, since the jmath equations return the avatar's traits",
     "eoc_type": "EVENT",

--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
@@ -930,6 +930,7 @@
     "can_resume": false,
     "interruptable": false,
     "interruptable_with_kb": false,
+    "rooted": true,
     "do_turn_eoc": "EOC_VAMPIRE_TORPOR_RECOVER"
   },
   {
@@ -952,7 +953,7 @@
             "value": "REGEN_HP",
             "multiply": {
               "math": [
-                       "(n_vampire_total_tier_one_traits * 0.05) + (n_vampire_total_tier_two_traits * 0.075) + (n_vampire_total_tier_three_traits * 0.1) + (n_vampire_total_tier_four_traits * 0.2) "
+                       "(u_vampire_total_tier_one_traits * 0.05) + (u_vampire_total_tier_two_traits * 0.075) + (u_vampire_total_tier_three_traits * 0.1) + (u_vampire_total_tier_four_traits * 0.2) "
               ]
             }
           },
@@ -960,7 +961,7 @@
             "value": "MENDING_MODIFIER",
             "multiply": {
               "math": [
-                       "(n_vampire_total_tier_one_traits * 0.05) + (n_vampire_total_tier_two_traits * 0.075) + (n_vampire_total_tier_three_traits * 0.1) + (n_vampire_total_tier_four_traits * 0.2) "
+                       "(u_vampire_total_tier_one_traits * 0.05) + (u_vampire_total_tier_two_traits * 0.075) + (u_vampire_total_tier_three_traits * 0.1) + (u_vampire_total_tier_four_traits * 0.2) "
               ]
             }
           },
@@ -972,9 +973,9 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_VAMPIRE_DOMINATE_activated",
-    "condition": { "math": [ "n_vitamin('human_blood_vitamin')", ">=", "-500" ] },
+    "condition": { "math": [ "u_vitamin('human_blood_vitamin')", ">=", "-500" ] },
     "effect": [
-      { "math": [ "n_vitamin('human_blood_vitamin')", "-=", "700" ] },
+      { "math": [ "u_vitamin('human_blood_vitamin')", "-=", "700" ] },
       { "u_location_variable": { "context_val": "loc" } },
       {
         "run_eocs": [

--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
@@ -725,6 +725,27 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_MAGICFORBLOOD_activated",
+    "condition": { "math": [ "u_vitamin('human_blood_vitamin')", ">=", "-500" ] },
+    "effect": [
+      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": "1 seconds" },
+      { "math": [ "u_vitamin('human_blood_vitamin')", "-=", "100" ] },
+      {
+        "u_message": "Your veins pulse as your body pushes some of your blood reserves to exhaustion and early dissolution.",
+        "type": "good"
+      },
+      {
+        "math": [
+          "u_val('mana')",
+          "+=",
+          "min((150 + (vampire_total_tier_one_traits() * 20) + (vampire_total_tier_two_traits() * 45) + (vampire_total_tier_three_traits() * 90) + (vampire_total_tier_four_traits() * 150)), 1500)"
+        ]
+      }
+    ],
+    "false_effect": [ { "u_message": "You don't have enough blood to recover any mana.", "type": "bad" } ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_HYPNOTIC_GAZE_activated",
     "condition": { "math": [ "n_vitamin('human_blood_vitamin')", ">=", "-500" ] },
     "effect": [
@@ -890,6 +911,92 @@
     "false_effect": [
       { "u_teleport": { "u_val": "VAMPIRE_sleep_in_earth_starting_point" } },
       { "u_message": "You feel yourself rising until you stand in the clear air once again.", "type": "good" }
+    ]
+  },
+
+
+
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_VAMPIRE_TORPOR_activated",
+    "effect": [
+      { "u_assign_activity": "ACT_VAMPIRE_TORPOR", "duration": "2400 minutes" },
+      { "u_add_effect": "effect_vampire_torpor", "duration": "2400 minutes" }
+    ]
+  },
+  {
+    "id": "ACT_VAMPIRE_TORPOR",
+    "type": "activity_type",
+    "activity_level": "NO_EXERCISE",
+    "verb": "slumbering",
+    "based_on": "time",
+    "can_resume": false,
+    "rooted": true,
+    "completion_eoc": "EOC_VAMPIRE_TORPOR_REMOVE",
+    "do_turn_eoc": "EOC_VAMPIRE_TORPOR_RECOVER"
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_VAMPIRE_TORPOR_REMOVE",
+    "effect": [ { "u_lose_effect": "effect_vampire_torpor" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_VAMPIRE_TORPOR_RECOVER",
+    "condition": { "math": [ "u_val('sleepiness') + u_val('sleep_deprivation')", ">=", "0" ] },
+    "effect": [ { "run_eocs": [ "EOC_VAMPIRE_TORPOR_SLEEPINESS", "EOC_VAMPIRE_TORPOR_DEPRIVATION" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_VAMPIRE_TORPOR_SLEEPINESS",
+    "condition": {
+      "and": [
+        { "math": [ "u_val('sleepiness')", ">=", "0" ] },
+        {
+          "x_in_y_chance": {
+            "x": 1,
+            "y": { "math": [ "max( (55 - ( (vampire_total_tier_one_traits() * 0.5) + (vampire_total_tier_two_traits() * 1) + (vampire_total_tier_three_traits() * 2)  +  (vampire_total_tier_four_traits() * 3)), 15 )" ] }
+          }
+        }
+      ]
+    },
+    "effect": [ { "math": [ "u_val('sleepiness')", "-=", "1" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_VAMPIRE_TORPOR_DEPRIVATION",
+    "condition": { "math": [ "u_val('sleep_deprivation')", ">=", "0" ] },
+    "effect": { "math": [ "u_val('sleep_deprivation')", "-=", "1" ] }
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_vampire_torpor",
+    "name": [ "Torpor" ],
+    "desc": [ "Thanks to your torpor you are healing and recovering quickly" ],
+    "rating": "good",
+    "vitamins": [ { "vitamin": "human_blood_vitamin", "rate": [ [ 1, 1 ] ], "tick": [ "3 m" ] } ],
+    "enchantments": [
+      {
+        "values": [
+          {
+            "value": "REGEN_HP",
+            "multiply": {
+              "math": [
+                       "(n_vampire_total_tier_one_traits * 0.05) + (n_vampire_total_tier_two_traits * 0.075) + (n_vampire_total_tier_three_traits * 0.1) + (n_vampire_total_tier_four_traits * 0.2) "
+              ]
+            }
+          },
+          {
+            "value": "MENDING_MODIFIER",
+            "multiply": {
+              "math": [
+                       "(n_vampire_total_tier_one_traits * 0.05) + (n_vampire_total_tier_two_traits * 0.075) + (n_vampire_total_tier_three_traits * 0.1) + (n_vampire_total_tier_four_traits * 0.2) "
+              ]
+            }
+          },
+          { "value": "REGEN_HP_AWAKE", "multiply": 1 }
+        ]
+      }
     ]
   }
 ]

--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
@@ -953,7 +953,7 @@
             "value": "REGEN_HP",
             "multiply": {
               "math": [
-                       "(u_vampire_total_tier_one_traits * 0.05) + (u_vampire_total_tier_two_traits * 0.075) + (u_vampire_total_tier_three_traits * 0.1) + (u_vampire_total_tier_four_traits * 0.2) "
+                "(u_vampire_total_tier_one_traits * 0.05) + (u_vampire_total_tier_two_traits * 0.075) + (u_vampire_total_tier_three_traits * 0.1) + (u_vampire_total_tier_four_traits * 0.2) "
               ]
             }
           },
@@ -961,7 +961,7 @@
             "value": "MENDING_MODIFIER",
             "multiply": {
               "math": [
-                       "(u_vampire_total_tier_one_traits * 0.05) + (u_vampire_total_tier_two_traits * 0.075) + (u_vampire_total_tier_three_traits * 0.1) + (u_vampire_total_tier_four_traits * 0.2) "
+                "(u_vampire_total_tier_one_traits * 0.05) + (u_vampire_total_tier_two_traits * 0.075) + (u_vampire_total_tier_three_traits * 0.1) + (u_vampire_total_tier_four_traits * 0.2) "
               ]
             }
           },
@@ -983,7 +983,10 @@
             "id": "EOC_VAMPIRE_DOMINATE_activated2",
             "effect": [
               { "npc_cast_spell": { "id": "vampire_dominate_real", "min_level": 1 }, "loc": { "context_val": "loc" } },
-              { "npc_message": "You focus you gaze on your target's mind, attempting to take control of it.", "type": "good" }
+              {
+                "npc_message": "You focus you gaze on your target's mind, attempting to take control of it.",
+                "type": "good"
+              }
             ]
           }
         ]

--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
@@ -35,7 +35,7 @@
         { "u_has_trait": "BLOOD_FUN" }
       ]
     },
-    "effect": [ { "u_add_morale": "morale_drank_blood", "bonus": 20, "max_bonus": 60, "duration": "20 m", "decay_start": "10 m" } ]
+    "effect": [ { "u_add_morale": "morale_drank_blood", "bonus": 30, "max_bonus": 60, "duration": "20 m", "decay_start": "10 m" } ]
   },
   {
     "type": "effect_on_condition",
@@ -913,9 +913,6 @@
       { "u_message": "You feel yourself rising until you stand in the clear air once again.", "type": "good" }
     ]
   },
-
-
-
   {
     "type": "effect_on_condition",
     "id": "EOC_VAMPIRE_TORPOR_activated",
@@ -998,5 +995,30 @@
         ]
       }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_DOMINATING_GAZE_activated",
+    "condition": { "math": [ "n_vitamin('human_blood_vitamin')", ">=", "-500" ] },
+    "effect": [
+      {
+        "math": [
+          "u_vampire_hypnotic_gaze_power_level",
+          "=",
+          "2 + (n_vampire_total_tier_one_traits * 0.5) + (n_vampire_total_tier_two_traits * 0.75) + (n_vampire_total_tier_three_traits * 1.2) + (n_vampire_total_tier_four_traits * 2.5) "
+        ]
+      },
+      { "math": [ "n_vitamin('human_blood_vitamin')", "-=", "300" ] },
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_DOMINATING_GAZE_activated_2",
+            "effect": [ { "u_cast_spell": "vampire_dominate_real" } ]
+          }
+        ]
+      }
+    ],
+    "false_effect": [ { "npc_message": "You don't have enough blood to activate your dominating gaze.", "type": "bad" } ]
   }
+
 ]

--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
@@ -729,7 +729,7 @@
     "condition": { "math": [ "u_vitamin('human_blood_vitamin')", ">=", "-500" ] },
     "effect": [
       { "u_assign_activity": "ACT_GENERIC_EOC", "duration": "1 seconds" },
-      { "math": [ "u_vitamin('human_blood_vitamin')", "-=", "100" ] },
+      { "math": [ "u_vitamin('human_blood_vitamin')", "-=", "200" ] },
       {
         "u_message": "Your veins pulse as your body pushes some of your blood reserves to exhaustion and early dissolution.",
         "type": "good"
@@ -1001,13 +1001,6 @@
     "id": "EOC_DOMINATING_GAZE_activated",
     "condition": { "math": [ "n_vitamin('human_blood_vitamin')", ">=", "-500" ] },
     "effect": [
-      {
-        "math": [
-          "u_vampire_hypnotic_gaze_power_level",
-          "=",
-          "2 + (n_vampire_total_tier_one_traits * 0.5) + (n_vampire_total_tier_two_traits * 0.75) + (n_vampire_total_tier_three_traits * 1.2) + (n_vampire_total_tier_four_traits * 2.5) "
-        ]
-      },
       { "math": [ "n_vitamin('human_blood_vitamin')", "-=", "300" ] },
       {
         "run_eocs": [
@@ -1020,5 +1013,4 @@
     ],
     "false_effect": [ { "npc_message": "You don't have enough blood to activate your dominating gaze.", "type": "bad" } ]
   }
-
 ]

--- a/data/mods/Xedra_Evolved/npc/vampire_askblood.json
+++ b/data/mods/Xedra_Evolved/npc/vampire_askblood.json
@@ -8,12 +8,12 @@
         "topic": "TALK_FRIEND_FOLLOWER_BLOODFEED_YES",
         "condition": {
           "and": [
-            {"not": { "npc_has_flag": "BLEED_IMMUNE" } },
-            {"not": { "npc_has_trait": "ACIDBLOOD" } },
-            {"not": { "npc_has_trait": "THRESH_CRUSTACEAN" } },
-            {"not": { "npc_has_trait": "THRESH_INSECT" } },
-            {"not": { "npc_has_trait": "THRESH_CEPHALOPOD" } },
-            {"not": { "npc_has_trait": "THRESH_GASTROPOD" } },
+            { "not": { "npc_has_flag": "BLEED_IMMUNE" } },
+            { "not": { "npc_has_trait": "ACIDBLOOD" } },
+            { "not": { "npc_has_trait": "THRESH_CRUSTACEAN" } },
+            { "not": { "npc_has_trait": "THRESH_INSECT" } },
+            { "not": { "npc_has_trait": "THRESH_CEPHALOPOD" } },
+            { "not": { "npc_has_trait": "THRESH_GASTROPOD" } },
             { "math": [ "n_val('npc_trust')", ">=", "10" ] },
             { "math": [ "n_val('npc_value')", ">=", "10" ] },
             { "u_has_trait": "VAMPIRE" }
@@ -31,12 +31,12 @@
         "topic": "TALK_FRIEND_FOLLOWER_BLOODFEED_KINDA",
         "condition": {
           "and": [
-            {"not": { "npc_has_flag": "BLEED_IMMUNE" } },
-            {"not": { "npc_has_trait": "ACIDBLOOD" } },
-            {"not": { "npc_has_trait": "THRESH_CRUSTACEAN" } },
-            {"not": { "npc_has_trait": "THRESH_INSECT" } },
-            {"not": { "npc_has_trait": "THRESH_CEPHALOPOD" } },
-            {"not": { "npc_has_trait": "THRESH_GASTROPOD" } },
+            { "not": { "npc_has_flag": "BLEED_IMMUNE" } },
+            { "not": { "npc_has_trait": "ACIDBLOOD" } },
+            { "not": { "npc_has_trait": "THRESH_CRUSTACEAN" } },
+            { "not": { "npc_has_trait": "THRESH_INSECT" } },
+            { "not": { "npc_has_trait": "THRESH_CEPHALOPOD" } },
+            { "not": { "npc_has_trait": "THRESH_GASTROPOD" } },
             { "math": [ "n_val('npc_trust')", "<=", "9" ] },
             { "math": [ "n_val('npc_value')", "<=", "9" ] },
             { "math": [ "n_val('npc_trust')", ">=", "1" ] },
@@ -81,12 +81,12 @@
           "and": [
             { "math": [ "n_val('npc_trust')", ">=", "0" ] },
             { "math": [ "n_val('npc_value')", ">=", "0" ] },
-            {"not": { "npc_has_flag": "BLEED_IMMUNE" } },
-            {"not": { "npc_has_trait": "ACIDBLOOD" } },
-            {"not": { "npc_has_trait": "THRESH_CRUSTACEAN" } },
-            {"not": { "npc_has_trait": "THRESH_INSECT" } },
-            {"not": { "npc_has_trait": "THRESH_CEPHALOPOD" } },
-            {"not": { "npc_has_trait": "THRESH_GASTROPOD" } },
+            { "not": { "npc_has_flag": "BLEED_IMMUNE" } },
+            { "not": { "npc_has_trait": "ACIDBLOOD" } },
+            { "not": { "npc_has_trait": "THRESH_CRUSTACEAN" } },
+            { "not": { "npc_has_trait": "THRESH_INSECT" } },
+            { "not": { "npc_has_trait": "THRESH_CEPHALOPOD" } },
+            { "not": { "npc_has_trait": "THRESH_GASTROPOD" } },
             { "u_has_trait": "VAMPIRE" }
           ]
         }
@@ -211,14 +211,14 @@
     "int_decay_step": -2,
     "int_decay_tick": 1,
     "vitamins": [
-      { "vitamin": "blood", "rate": [ [ -250, -250 ] ], "tick": [ "1 s" ] },
-      { "vitamin": "redcells", "rate": [ [ -250, -250 ] ], "tick": [ "1 s" ] }
+      { "vitamin": "blood", "rate": [ [ -125, -125 ] ], "tick": [ "1 s" ] },
+      { "vitamin": "redcells", "rate": [ [ -125, -125 ] ], "tick": [ "1 s" ] }
     ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_VAMPIRE_DRINK_FROM_HUMAN",
-    "condition": {"u_has_trait": "BLOOD_FUN" },
+    "condition": { "u_has_trait": "BLOOD_FUN" },
     "effect": [ { "math": [ "u_vitamin('human_blood_vitamin')", "+=", "400 + rand(100)" ] }, { "u_add_morale": "morale_drank_blood", "bonus": 30, "max_bonus": 60, "duration": "20 m", "decay_start": "10 m" } ],
     "false_effect": [ { "math": [ "u_vitamin('human_blood_vitamin')", "+=", "400 + rand(100)" ] } ]
   },

--- a/data/mods/Xedra_Evolved/npc/vampire_askblood.json
+++ b/data/mods/Xedra_Evolved/npc/vampire_askblood.json
@@ -39,8 +39,8 @@
             { "not": { "npc_has_trait": "THRESH_GASTROPOD" } },
             { "math": [ "n_val('npc_trust')", "<=", "9" ] },
             { "math": [ "n_val('npc_value')", "<=", "9" ] },
-            { "math": [ "n_val('npc_trust')", ">=", "1" ] },
-            { "math": [ "n_val('npc_value')", ">=", "1" ] },
+            { "math": [ "n_val('npc_trust')", ">", "0" ] },
+            { "math": [ "n_val('npc_value')", ">", "0" ] },
             { "u_has_trait": "VAMPIRE" }
           ]
         }
@@ -79,8 +79,8 @@
         "topic": "TALK_FRIEND_FOLLOWER_BLOODFEED_NOPE",
         "condition": {
           "and": [
-            { "math": [ "n_val('npc_trust')", ">=", "0" ] },
-            { "math": [ "n_val('npc_value')", ">=", "0" ] },
+            { "math": [ "n_val('npc_trust')", "<=", "0" ] },
+            { "math": [ "n_val('npc_value')", "<=", "0" ] },
             { "not": { "npc_has_flag": "BLEED_IMMUNE" } },
             { "not": { "npc_has_trait": "ACIDBLOOD" } },
             { "not": { "npc_has_trait": "THRESH_CRUSTACEAN" } },
@@ -97,8 +97,7 @@
     "type": "talk_topic",
     "id": "TALK_FRIEND_FOLLOWER_BLOODFEED_YES",
     "dynamic_line": {
-      "npc_has_var": "feed_from_recently",
-      "value": "yes",
+      "npc_has_effect": "feed_from_recently",
       "yes": "It'll have to wait, unfortunately.  If I let you do that too often it'll be very bad for my health.",
       "no": "Sure!  Anything to help you feel better."
     },
@@ -107,13 +106,13 @@
         "text": "Thank you.  Can we talk about something else?", 
         "topic": "TALK_FRIEND", 
         "condition": { "not": { "npc_has_effect": "feed_from_recently" } },
-        "run_eocs": [ "EOC_VAMPIRE_DRINK_FROM_HUMAN", "EOC_NPC_GOT_DRANK_FROM_FRIEND" ]
+        "effect": [ { "run_eocs": "EOC_VAMPIRE_DRINK_FROM_HUMAN" }, { "run_eocs": "EOC_NPC_GOT_DRANK_FROM_FRIEND" } ]
     },
       { 
         "text": "Thank you.  See you later.", 
         "topic": "TALK_DONE",
         "condition": { "not": { "npc_has_effect": "feed_from_recently" } },
-        "run_eocs": [ "EOC_VAMPIRE_DRINK_FROM_HUMAN", "EOC_NPC_GOT_DRANK_FROM_FRIEND" ]
+        "effect": [ { "run_eocs": "EOC_VAMPIRE_DRINK_FROM_HUMAN" }, { "run_eocs": "EOC_NPC_GOT_DRANK_FROM_FRIEND" } ]
     },
     { 
       "text": "I changed my mind.  Keep your blood.", 
@@ -136,8 +135,7 @@
     "type": "talk_topic",
     "id": "TALK_FRIEND_FOLLOWER_BLOODFEED_KINDA",
     "dynamic_line": {
-      "npc_has_var": "feed_from_recently",
-      "value": "yes",
+      "npc_has_effect": "feed_from_recently",
       "yes": "I'm not letting you do that this soon after last time.  I need that blood too, you know?",
       "no": "If you really need to, then sure you can.  Don't make an habit out of it, however."
     },
@@ -146,14 +144,14 @@
         "text": "Thank you.  Can we talk about something else?", 
         "topic": "TALK_FRIEND", 
         "condition": { "not": { "npc_has_effect": "feed_from_recently" } },
-        "run_eocs": [ "EOC_VAMPIRE_DRINK_FROM_HUMAN", "EOC_NPC_GOT_DRANK_FROM_ALLY" ],
+        "effect": [ { "run_eocs": "EOC_VAMPIRE_DRINK_FROM_HUMAN" }, { "run_eocs": "EOC_NPC_GOT_DRANK_FROM_ALLY" } ],
         "opinion": { "trust": -1, "value": -1 } 
     },
       { 
         "text": "Thank you.  See you later.", 
         "topic": "TALK_DONE",
         "condition": { "not": { "npc_has_effect": "feed_from_recently" } },
-        "run_eocs": [ "EOC_VAMPIRE_DRINK_FROM_HUMAN", "EOC_NPC_GOT_DRANK_FROM_ALLY" ],
+        "effect": [ { "run_eocs": "EOC_VAMPIRE_DRINK_FROM_HUMAN" }, { "run_eocs": "EOC_NPC_GOT_DRANK_FROM_ALLY" } ],
         "opinion": { "trust": -1, "value": -1 } 
     },
     { 
@@ -196,7 +194,7 @@
     "id": "feed_from_recently",
     "name": [ "Gave you blood" ],
     "desc": [ "This person won't accept to let you drink more of their blood for a while." ],
-    "max_duration": "10 weeks"
+    "max_duration": "100 d"
   },
   {
     "id": "regular_vampire_blood_drink",

--- a/data/mods/Xedra_Evolved/npc/vampire_askblood.json
+++ b/data/mods/Xedra_Evolved/npc/vampire_askblood.json
@@ -105,13 +105,13 @@
     },
     "responses": [
       {
-        "text": "Thank you.  Can we talk about something else?",
+        "text": "[Drink from them] Thank you.  Can we talk about something else?",
         "topic": "TALK_FRIEND",
         "condition": { "not": { "npc_has_effect": "feed_from_recently" } },
         "effect": [ { "run_eocs": "EOC_VAMPIRE_DRINK_FROM_HUMAN" }, { "run_eocs": "EOC_NPC_GOT_DRANK_FROM_FRIEND" } ]
       },
       {
-        "text": "Thank you.  See you later.",
+        "text": "[Drink from them] Thank you.  See you later.",
         "topic": "TALK_DONE",
         "condition": { "not": { "npc_has_effect": "feed_from_recently" } },
         "effect": [ { "run_eocs": "EOC_VAMPIRE_DRINK_FROM_HUMAN" }, { "run_eocs": "EOC_NPC_GOT_DRANK_FROM_FRIEND" } ]
@@ -143,14 +143,14 @@
     },
     "responses": [
       {
-        "text": "Thank you.  Can we talk about something else?",
+        "text": "[Drink from them] Thank you.  Can we talk about something else?",
         "topic": "TALK_FRIEND",
         "condition": { "not": { "npc_has_effect": "feed_from_recently" } },
         "effect": [ { "run_eocs": "EOC_VAMPIRE_DRINK_FROM_HUMAN" }, { "run_eocs": "EOC_NPC_GOT_DRANK_FROM_ALLY" } ],
         "opinion": { "trust": -1, "value": -1 }
       },
       {
-        "text": "Thank you.  See you later.",
+        "text": "[Drink from them] Thank you.  See you later.",
         "topic": "TALK_DONE",
         "condition": { "not": { "npc_has_effect": "feed_from_recently" } },
         "effect": [ { "run_eocs": "EOC_VAMPIRE_DRINK_FROM_HUMAN" }, { "run_eocs": "EOC_NPC_GOT_DRANK_FROM_ALLY" } ],

--- a/data/mods/Xedra_Evolved/npc/vampire_askblood.json
+++ b/data/mods/Xedra_Evolved/npc/vampire_askblood.json
@@ -1,0 +1,243 @@
+[
+  {
+    "id": [ "TALK_FRIEND" ],
+    "type": "talk_topic",
+    "responses": [
+      {
+        "text": "Can I drink some of your blood?  I really need some of it.",
+        "topic": "TALK_FRIEND_FOLLOWER_BLOODFEED_YES",
+        "condition": {
+          "and": [
+            {"not": { "npc_has_flag": "BLEED_IMMUNE" } },
+            {"not": { "npc_has_trait": "ACIDBLOOD" } },
+            {"not": { "npc_has_trait": "THRESH_CRUSTACEAN" } },
+            {"not": { "npc_has_trait": "THRESH_INSECT" } },
+            {"not": { "npc_has_trait": "THRESH_CEPHALOPOD" } },
+            {"not": { "npc_has_trait": "THRESH_GASTROPOD" } },
+            { "math": [ "n_val('npc_trust')", ">=", "10" ] },
+            { "math": [ "n_val('npc_value')", ">=", "10" ] },
+            { "u_has_trait": "VAMPIRE" }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": [ "TALK_FRIEND" ],
+    "type": "talk_topic",
+    "responses": [
+      {
+        "text": "Can I drink some of your blood?  I really need some of it.",
+        "topic": "TALK_FRIEND_FOLLOWER_BLOODFEED_KINDA",
+        "condition": {
+          "and": [
+            {"not": { "npc_has_flag": "BLEED_IMMUNE" } },
+            {"not": { "npc_has_trait": "ACIDBLOOD" } },
+            {"not": { "npc_has_trait": "THRESH_CRUSTACEAN" } },
+            {"not": { "npc_has_trait": "THRESH_INSECT" } },
+            {"not": { "npc_has_trait": "THRESH_CEPHALOPOD" } },
+            {"not": { "npc_has_trait": "THRESH_GASTROPOD" } },
+            { "math": [ "n_val('npc_trust')", "<=", "9" ] },
+            { "math": [ "n_val('npc_value')", "<=", "9" ] },
+            { "math": [ "n_val('npc_trust')", ">=", "1" ] },
+            { "math": [ "n_val('npc_value')", ">=", "1" ] },
+            { "u_has_trait": "VAMPIRE" }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": [ "TALK_FRIEND" ],
+    "type": "talk_topic",
+    "responses": [
+      {
+        "text": "Can I drink some of your blood?  I really need some of it.",
+        "topic": "TALK_FRIEND_FOLLOWER_BLOODFEED_IMPOSSIBLE",
+        "condition": {
+          "and": [
+            { "u_has_trait": "VAMPIRE" },
+            { "or": [ 
+            { "npc_has_flag": "BLEED_IMMUNE" },
+            { "npc_has_trait": "ACIDBLOOD" },
+            { "npc_has_trait": "THRESH_CRUSTACEAN" },
+            { "npc_has_trait": "THRESH_INSECT" },
+            { "npc_has_trait": "THRESH_CEPHALOPOD" },
+            { "npc_has_trait": "THRESH_GASTROPOD" } ]
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "id": [ "TALK_FRIEND" ],
+    "type": "talk_topic",
+    "responses": [
+      {
+        "text": "Can I drink some of your blood?  I really need some of it.",
+        "topic": "TALK_FRIEND_FOLLOWER_BLOODFEED_NOPE",
+        "condition": {
+          "and": [
+            { "math": [ "n_val('npc_trust')", ">=", "0" ] },
+            { "math": [ "n_val('npc_value')", ">=", "0" ] },
+            {"not": { "npc_has_flag": "BLEED_IMMUNE" } },
+            {"not": { "npc_has_trait": "ACIDBLOOD" } },
+            {"not": { "npc_has_trait": "THRESH_CRUSTACEAN" } },
+            {"not": { "npc_has_trait": "THRESH_INSECT" } },
+            {"not": { "npc_has_trait": "THRESH_CEPHALOPOD" } },
+            {"not": { "npc_has_trait": "THRESH_GASTROPOD" } },
+            { "u_has_trait": "VAMPIRE" }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_FRIEND_FOLLOWER_BLOODFEED_YES",
+    "dynamic_line": {
+      "npc_has_var": "feed_from_recently",
+      "value": "yes",
+      "yes": "It'll have to wait, unfortunately.  If I let you do that too often it'll be very bad for my health.",
+      "no": "Sure!  Anything to help you feel better."
+    },
+    "responses": [
+      { 
+        "text": "Thank you.  Can we talk about something else?", 
+        "topic": "TALK_FRIEND", 
+        "condition": { "not": { "npc_has_effect": "feed_from_recently" } },
+        "run_eocs": [ "EOC_VAMPIRE_DRINK_FROM_HUMAN", "EOC_NPC_GOT_DRANK_FROM_FRIEND" ]
+    },
+      { 
+        "text": "Thank you.  See you later.", 
+        "topic": "TALK_DONE",
+        "condition": { "not": { "npc_has_effect": "feed_from_recently" } },
+        "run_eocs": [ "EOC_VAMPIRE_DRINK_FROM_HUMAN", "EOC_NPC_GOT_DRANK_FROM_FRIEND" ]
+    },
+    { 
+      "text": "I changed my mind.  Keep your blood.", 
+      "topic": "TALK_DONE",
+      "condition": { "not": { "npc_has_effect": "feed_from_recently" } }
+  },
+    { 
+      "text": "Got it.  Can we talk about something else?", 
+      "topic": "TALK_FRIEND", 
+      "condition": { "npc_has_effect": "feed_from_recently" }
+  },
+    { 
+      "text": "Got it.  See you later.", 
+      "topic": "TALK_DONE",
+      "condition": { "npc_has_effect": "feed_from_recently" }
+  }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_FRIEND_FOLLOWER_BLOODFEED_KINDA",
+    "dynamic_line": {
+      "npc_has_var": "feed_from_recently",
+      "value": "yes",
+      "yes": "I'm not letting you do that this soon after last time.  I need that blood too, you know?",
+      "no": "If you really need to, then sure you can.  Don't make an habit out of it, however."
+    },
+    "responses": [
+      { 
+        "text": "Thank you.  Can we talk about something else?", 
+        "topic": "TALK_FRIEND", 
+        "condition": { "not": { "npc_has_effect": "feed_from_recently" } },
+        "run_eocs": [ "EOC_VAMPIRE_DRINK_FROM_HUMAN", "EOC_NPC_GOT_DRANK_FROM_ALLY" ],
+        "opinion": { "trust": -1, "value": -1 } 
+    },
+      { 
+        "text": "Thank you.  See you later.", 
+        "topic": "TALK_DONE",
+        "condition": { "not": { "npc_has_effect": "feed_from_recently" } },
+        "run_eocs": [ "EOC_VAMPIRE_DRINK_FROM_HUMAN", "EOC_NPC_GOT_DRANK_FROM_ALLY" ],
+        "opinion": { "trust": -1, "value": -1 } 
+    },
+    { 
+      "text": "I changed my mind.  Keep your blood.", 
+      "topic": "TALK_DONE",
+      "condition": { "not": { "npc_has_effect": "feed_from_recently" } }
+  },
+    { 
+      "text": "Got it.  Can we talk about something else?", 
+      "topic": "TALK_FRIEND", 
+      "condition": { "npc_has_effect": "feed_from_recently" }
+  },
+    { 
+      "text": "Got it.  See you later.", 
+      "topic": "TALK_DONE",
+      "condition": { "npc_has_effect": "feed_from_recently" }
+  }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_FRIEND_FOLLOWER_BLOODFEED_NOPE",
+    "dynamic_line": "Nope.  I'm not going to be your blood bag.  Find someone else for that.",
+    "responses": [
+      { "text": "Got it.  Can we talk about something else?", "topic": "TALK_FRIEND" },
+      { "text": "Got it.  See you later.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_FRIEND_FOLLOWER_BLOODFEED_IMPOSSIBLE",
+    "dynamic_line": "(As you approach to ask about letting you drink their blood, your senses tell you that whatever blood they have in their veins wouldn't nourish you at all, so you decide to not ask your question)",
+    "responses": [
+      { "text": "(Ask them about something else)", "topic": "TALK_FRIEND" },
+      { "text": "(Go do something else)", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "effect_type",
+    "id": "feed_from_recently",
+    "name": [ "Gave you blood" ],
+    "desc": [ "This person won't accept to let you drink more of their blood for a while." ],
+    "max_duration": "10 weeks"
+  },
+  {
+    "id": "regular_vampire_blood_drink",
+    "type": "effect_type",
+    "name": [ "Bloodsucking" ],
+    "desc": [ "The monster is sucking up your blood!" ],
+    "rating": "bad",
+    "resist_traits": [ "BLEED_IMMUNE" ],
+    "show_in_info": true,
+    "max_intensity": 2,
+    "show_intensity": false,
+    "int_decay_step": -2,
+    "int_decay_tick": 1,
+    "vitamins": [
+      { "vitamin": "blood", "rate": [ [ -250, -250 ] ], "tick": [ "1 s" ] },
+      { "vitamin": "redcells", "rate": [ [ -250, -250 ] ], "tick": [ "1 s" ] }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_VAMPIRE_DRINK_FROM_HUMAN",
+    "condition": {"u_has_trait": "BLOOD_FUN" },
+    "effect": [ { "math": [ "u_vitamin('human_blood_vitamin')", "+=", "400 + rand(100)" ] }, { "u_add_morale": "morale_drank_blood", "bonus": 30, "max_bonus": 60, "duration": "20 m", "decay_start": "10 m" } ],
+    "false_effect": [ { "math": [ "u_vitamin('human_blood_vitamin')", "+=", "400 + rand(100)" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_NPC_GOT_DRANK_FROM_FRIEND",
+    "global": false,
+    "effect": [
+      { "npc_add_effect": "feed_from_recently", "duration": "5 d" },
+      { "npc_add_effect": "regular_vampire_blood_drink", "duration": "2 s" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_NPC_GOT_DRANK_FROM_ALLY",
+    "global": false,
+    "effect": [
+      { "npc_add_effect": "feed_from_recently", "duration": "10 d" },
+      { "npc_add_effect": "regular_vampire_blood_drink", "duration": "2 s" }
+    ]
+  }
+]

--- a/data/mods/Xedra_Evolved/npc/vampire_askblood.json
+++ b/data/mods/Xedra_Evolved/npc/vampire_askblood.json
@@ -57,13 +57,15 @@
         "condition": {
           "and": [
             { "u_has_trait": "VAMPIRE" },
-            { "or": [ 
-            { "npc_has_flag": "BLEED_IMMUNE" },
-            { "npc_has_trait": "ACIDBLOOD" },
-            { "npc_has_trait": "THRESH_CRUSTACEAN" },
-            { "npc_has_trait": "THRESH_INSECT" },
-            { "npc_has_trait": "THRESH_CEPHALOPOD" },
-            { "npc_has_trait": "THRESH_GASTROPOD" } ]
+            {
+              "or": [
+                { "npc_has_flag": "BLEED_IMMUNE" },
+                { "npc_has_trait": "ACIDBLOOD" },
+                { "npc_has_trait": "THRESH_CRUSTACEAN" },
+                { "npc_has_trait": "THRESH_INSECT" },
+                { "npc_has_trait": "THRESH_CEPHALOPOD" },
+                { "npc_has_trait": "THRESH_GASTROPOD" }
+              ]
             }
           ]
         }
@@ -102,33 +104,33 @@
       "no": "Sure!  Anything to help you feel better."
     },
     "responses": [
-      { 
-        "text": "Thank you.  Can we talk about something else?", 
-        "topic": "TALK_FRIEND", 
+      {
+        "text": "Thank you.  Can we talk about something else?",
+        "topic": "TALK_FRIEND",
         "condition": { "not": { "npc_has_effect": "feed_from_recently" } },
         "effect": [ { "run_eocs": "EOC_VAMPIRE_DRINK_FROM_HUMAN" }, { "run_eocs": "EOC_NPC_GOT_DRANK_FROM_FRIEND" } ]
-    },
-      { 
-        "text": "Thank you.  See you later.", 
+      },
+      {
+        "text": "Thank you.  See you later.",
         "topic": "TALK_DONE",
         "condition": { "not": { "npc_has_effect": "feed_from_recently" } },
         "effect": [ { "run_eocs": "EOC_VAMPIRE_DRINK_FROM_HUMAN" }, { "run_eocs": "EOC_NPC_GOT_DRANK_FROM_FRIEND" } ]
-    },
-    { 
-      "text": "I changed my mind.  Keep your blood.", 
-      "topic": "TALK_DONE",
-      "condition": { "not": { "npc_has_effect": "feed_from_recently" } }
-  },
-    { 
-      "text": "Got it.  Can we talk about something else?", 
-      "topic": "TALK_FRIEND", 
-      "condition": { "npc_has_effect": "feed_from_recently" }
-  },
-    { 
-      "text": "Got it.  See you later.", 
-      "topic": "TALK_DONE",
-      "condition": { "npc_has_effect": "feed_from_recently" }
-  }
+      },
+      {
+        "text": "I changed my mind.  Keep your blood.",
+        "topic": "TALK_DONE",
+        "condition": { "not": { "npc_has_effect": "feed_from_recently" } }
+      },
+      {
+        "text": "Got it.  Can we talk about something else?",
+        "topic": "TALK_FRIEND",
+        "condition": { "npc_has_effect": "feed_from_recently" }
+      },
+      {
+        "text": "Got it.  See you later.",
+        "topic": "TALK_DONE",
+        "condition": { "npc_has_effect": "feed_from_recently" }
+      }
     ]
   },
   {
@@ -140,35 +142,35 @@
       "no": "If you really need to, then sure you can.  Don't make an habit out of it, however."
     },
     "responses": [
-      { 
-        "text": "Thank you.  Can we talk about something else?", 
-        "topic": "TALK_FRIEND", 
+      {
+        "text": "Thank you.  Can we talk about something else?",
+        "topic": "TALK_FRIEND",
         "condition": { "not": { "npc_has_effect": "feed_from_recently" } },
         "effect": [ { "run_eocs": "EOC_VAMPIRE_DRINK_FROM_HUMAN" }, { "run_eocs": "EOC_NPC_GOT_DRANK_FROM_ALLY" } ],
-        "opinion": { "trust": -1, "value": -1 } 
-    },
-      { 
-        "text": "Thank you.  See you later.", 
+        "opinion": { "trust": -1, "value": -1 }
+      },
+      {
+        "text": "Thank you.  See you later.",
         "topic": "TALK_DONE",
         "condition": { "not": { "npc_has_effect": "feed_from_recently" } },
         "effect": [ { "run_eocs": "EOC_VAMPIRE_DRINK_FROM_HUMAN" }, { "run_eocs": "EOC_NPC_GOT_DRANK_FROM_ALLY" } ],
-        "opinion": { "trust": -1, "value": -1 } 
-    },
-    { 
-      "text": "I changed my mind.  Keep your blood.", 
-      "topic": "TALK_DONE",
-      "condition": { "not": { "npc_has_effect": "feed_from_recently" } }
-  },
-    { 
-      "text": "Got it.  Can we talk about something else?", 
-      "topic": "TALK_FRIEND", 
-      "condition": { "npc_has_effect": "feed_from_recently" }
-  },
-    { 
-      "text": "Got it.  See you later.", 
-      "topic": "TALK_DONE",
-      "condition": { "npc_has_effect": "feed_from_recently" }
-  }
+        "opinion": { "trust": -1, "value": -1 }
+      },
+      {
+        "text": "I changed my mind.  Keep your blood.",
+        "topic": "TALK_DONE",
+        "condition": { "not": { "npc_has_effect": "feed_from_recently" } }
+      },
+      {
+        "text": "Got it.  Can we talk about something else?",
+        "topic": "TALK_FRIEND",
+        "condition": { "npc_has_effect": "feed_from_recently" }
+      },
+      {
+        "text": "Got it.  See you later.",
+        "topic": "TALK_DONE",
+        "condition": { "npc_has_effect": "feed_from_recently" }
+      }
     ]
   },
   {
@@ -217,7 +219,16 @@
     "type": "effect_on_condition",
     "id": "EOC_VAMPIRE_DRINK_FROM_HUMAN",
     "condition": { "u_has_trait": "BLOOD_FUN" },
-    "effect": [ { "math": [ "u_vitamin('human_blood_vitamin')", "+=", "400 + rand(100)" ] }, { "u_add_morale": "morale_drank_blood", "bonus": 30, "max_bonus": 60, "duration": "20 m", "decay_start": "10 m" } ],
+    "effect": [
+      { "math": [ "u_vitamin('human_blood_vitamin')", "+=", "400 + rand(100)" ] },
+      {
+        "u_add_morale": "morale_drank_blood",
+        "bonus": 30,
+        "max_bonus": 60,
+        "duration": "20 m",
+        "decay_start": "10 m"
+      }
+    ],
     "false_effect": [ { "math": [ "u_vitamin('human_blood_vitamin')", "+=", "400 + rand(100)" ] } ]
   },
   {

--- a/data/mods/Xedra_Evolved/npc/vampire_mentor.json
+++ b/data/mods/Xedra_Evolved/npc/vampire_mentor.json
@@ -274,16 +274,18 @@
   {
     "id": [ "TALK_VAMPIRE_MENTOR_SACRIFICE_1" ],
     "type": "talk_topic",
+    "//": "Note: the part about the kill being in melee only is due to bug #72281.  Remove it when the bug gets fixed",
     "dynamic_line": {
-      "str": "They need to be completely trusting of you, someone that consider themselves your \"best friend forever\".  They also need to declare how much they love you right before you kill them, then you'll become a true vampire."
+      "str": "They need to be completely trusting of you, someone that consider themselves your \"best friend forever\".  They also need to declare how much they love you right before you kill them, then you'll become a true vampire.  And I almost forgot: you also need to kill them in melee combat or else it won't work."
     },
     "responses": [ { "text": "Got it.  See you.", "topic": "TALK_DONE" } ]
   },
   {
     "id": [ "TALK_VAMPIRE_MENTOR_SACRIFICE_2" ],
+    "//": "Note: the part about the kill being in melee only is due to bug #72281.  Remove it when the bug gets fixed",
     "type": "talk_topic",
     "dynamic_line": {
-      "str": "Do not worry about the pain, my friend.  It is always temporary, no matter how much it hurts.  After that, you won't ever be temporary again.  Keep in mind that they need to be completely trusting of you, someone that consider themselves your \"best friend forever\".  They also need to declare how much they love you right before you kill them, then you'll be freed from your limited time as you become a true vampire."
+      "str": "Do not worry about the pain, my friend.  It is always temporary, no matter how much it hurts.  After that, you won't ever be temporary again.  Keep in mind that they need to be completely trusting of you, someone that consider themselves your \"best friend forever\".  They also need to declare how much they love you right before you kill them, then you'll be freed from your limited time as you become a true vampire.  And I almost forgot: you also need to kill them in melee combat or else it won't work."
     },
     "responses": [ { "text": "Got it.  See you.", "topic": "TALK_DONE" } ]
   },

--- a/data/mods/Xedra_Evolved/spells/vampire_spells.json
+++ b/data/mods/Xedra_Evolved/spells/vampire_spells.json
@@ -249,8 +249,8 @@
     "id": "vampire_torpor",
     "type": "SPELL",
     "name": "Torpor",
-    "description": "Enter a deathlike slumber and recover from your wounds and fatigue.",
-    "message": "You enter a torpor.",
+    "description": "Enter a deathlike slumber and recover from your wounds and fatigue.  Preferably while somewhere nobody could attack you while you sleep.",
+    "message": "You enter torpor.",
     "teachable": false,
     "valid_targets": [ "self" ],
     "skill": "deduction",
@@ -259,40 +259,25 @@
     "effect": "effect_on_condition",
     "effect_str": "EOC_VAMPIRE_TORPOR_activated",
     "shape": "blast",
-    "energy_source": "NONE"
+    "base_casting_time": 100,
+    "difficulty": 2
   },
   {
     "id": "vampire_dominate",
     "type": "SPELL",
     "name": "Dominating Gaze",
-    "description": "Take control of a mind.  Only works on targets that have one.",
-    "message": "You attempt to take control of your target's mind.",
+    "description": "Take control of a mind.  Only works on targets that have weak minds.",
+    "message": "You look for a mind to control.",
     "teachable": false,
-    "valid_targets": [ "ally", "hostile" ],
+    "valid_targets": [ "hostile" ],
     "skill": "deduction",
     "spell_class": "VAMPIRE",
     "flags": [ "SILENT", "NO_HANDS", "NO_LEGS", "NO_FAIL" ],
     "effect": "effect_on_condition",
     "effect_str": "EOC_VAMPIRE_DOMINATE_activated",
     "shape": "blast",
-    "energy_source": "NONE"
-  },
-  {
-    "id": "spell_dominating_gaze",
-    "type": "SPELL",
-    "name": "Dominating Gaze",
-    "description": "Stare into the eyes of your victim and wills them to fight for you.  This power does not work on targets lacking a mind.",
-    "message": "",
-    "teachable": false,
-    "skill": "deduction",
-    "spell_class": "VAMPIRE",
-    "valid_targets": [ "ally", "hostile" ],
-    "effect": "effect_on_condition",
-    "effect_str": "EOC_DOMINATING_GAZE_activated",
-    "shape": "blast",
-    "flags": [ "NO_HANDS", "SILENT", "NO_FAIL", "NO_PROJECTILE" ],
-    "difficulty": 3,
     "base_casting_time": 100,
+    "difficulty": 8,
     "min_range": {
       "math": [
         "min((3 + (vampire_total_tier_one_traits() * 0.2) + (vampire_total_tier_two_traits() * 0.33) + (vampire_total_tier_three_traits() * 0.5) + (vampire_total_tier_four_traits() * 0.75)), 12)"
@@ -303,7 +288,7 @@
         "min((3 + (vampire_total_tier_one_traits() * 0.2) + (vampire_total_tier_two_traits() * 0.33) + (vampire_total_tier_three_traits() * 0.5) + (vampire_total_tier_four_traits() * 0.75)), 12)"
       ]
     },
-    "ignored_monster_species": [ "ZOMBIE", "ROBOT", "ROBOT_FLYING", "NETHER", "NETHER_EMANATION", "LEECH_PLANT", "WORM", "FUNGUS", "SLIME" ]
+    "targeted_monster_species": [ "HUMAN", "FERAL", "CYBORG" ]
   },
   {
     "id": "vampire_dominate_real",
@@ -323,24 +308,24 @@
     "max_range": 60,
     "min_damage": {
       "math": [
-        "rng (0.75,1.25) * (25 + (vampire_total_tier_one_traits()  * 5) + (vampire_total_tier_two_traits() * 12) + (vampire_total_tier_three_traits() * 20) + (vampire_total_tier_three_traits() * 35))"
+        "rng (0.75,1.25) * (20 + (vampire_total_tier_one_traits()  * 4) + (vampire_total_tier_two_traits() * 10) + (vampire_total_tier_three_traits() * 16) + (vampire_total_tier_four_traits() * 30))"
       ]
     },
     "max_damage": {
       "math": [
-        "rng (0.75,1.25) * (25 + (vampire_total_tier_one_traits()  * 5) + (vampire_total_tier_two_traits() * 12) + (vampire_total_tier_three_traits() * 20) + (vampire_total_tier_three_traits() * 35))"
+        "rng (0.75,1.25) * (20 + (vampire_total_tier_one_traits()  * 4) + (vampire_total_tier_two_traits() * 10) + (vampire_total_tier_three_traits() * 16) + (vampire_total_tier_four_traits() * 30))"
       ]
     },
     "min_duration": {
       "math": [
-        "rng (0.75,1.25) * (3000 + (vampire_total_tier_one_traits()  * 500) + (vampire_total_tier_two_traits() * 900) + (vampire_total_tier_three_traits() * 1350) + (vampire_total_tier_three_traits() * 2250))"
+        "rng (0.75,1.25) * (2500 + (vampire_total_tier_one_traits()  * 400) + (vampire_total_tier_two_traits() * 800) + (vampire_total_tier_three_traits() * 1150) + (vampire_total_tier_four_traits() * 2050))"
       ]
     },
     "max_duration": {
       "math": [
-        "rng (0.75,1.25) * (3000 + (vampire_total_tier_one_traits()  * 500) + (vampire_total_tier_two_traits() * 900) + (vampire_total_tier_three_traits() * 1350) + (vampire_total_tier_three_traits() * 2250))"
+        "rng (0.75,1.25) * (2500 + (vampire_total_tier_one_traits()  * 400) + (vampire_total_tier_two_traits() * 800) + (vampire_total_tier_three_traits() * 1150) + (vampire_total_tier_four_traits() * 2050))"
       ]
     },
-    "ignored_monster_species": [ "ZOMBIE", "ROBOT", "ROBOT_FLYING", "NETHER", "NETHER_EMANATION", "LEECH_PLANT", "WORM", "FUNGUS", "SLIME" ]
+    "targeted_monster_species": [ "HUMAN", "FERAL", "CYBORG" ]
   }
 ]

--- a/data/mods/Xedra_Evolved/spells/vampire_spells.json
+++ b/data/mods/Xedra_Evolved/spells/vampire_spells.json
@@ -246,6 +246,22 @@
     "difficulty": 2
   },
   {
+    "id": "vampire_torpor",
+    "type": "SPELL",
+    "name": "Torpor",
+    "description": "Enter a deathlike slumber and recover from your wounds and fatigue.",
+    "message": "You enter a torpor.",
+    "teachable": false,
+    "valid_targets": [ "self" ],
+    "skill": "deduction",
+    "spell_class": "VAMPIRE",
+    "flags": [ "SILENT", "NO_HANDS", "NO_LEGS", "NO_FAIL" ],
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_VAMPIRE_TORPOR_activated",
+    "shape": "blast",
+    "energy_source": "NONE"
+  },
+  {
     "id": "vampire_dominate",
     "type": "SPELL",
     "name": "Dominating Gaze",

--- a/data/mods/Xedra_Evolved/spells/vampire_spells.json
+++ b/data/mods/Xedra_Evolved/spells/vampire_spells.json
@@ -56,6 +56,23 @@
     "difficulty": 5
   },
   {
+    "id": "vampire_magic_for_blood_spell",
+    "type": "SPELL",
+    "name": "Blood-Fueled Magic",
+    "description": "You consume some of the blood in your veins, turning it into magical power.",
+    "message": "",
+    "teachable": false,
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_MAGICFORBLOOD_activated",
+    "shape": "blast",
+    "valid_targets": [ "self" ],
+    "flags": [ "NO_HANDS", "SILENT", "NO_FAIL" ],
+    "skill": "deduction",
+    "spell_class": "VAMPIRE",
+    "base_casting_time": 100,
+    "difficulty": 5
+  },
+  {
     "id": "spell_blood_heal",
     "type": "SPELL",
     "name": "Sanguine Restoration",

--- a/data/mods/Xedra_Evolved/spells/vampire_spells.json
+++ b/data/mods/Xedra_Evolved/spells/vampire_spells.json
@@ -244,5 +244,87 @@
     "skill": "deduction",
     "spell_class": "VAMPIRE",
     "difficulty": 2
+  },
+  {
+    "id": "vampire_dominate",
+    "type": "SPELL",
+    "name": "Dominating Gaze",
+    "description": "Take control of a mind.  Only works on targets that have one.",
+    "message": "You attempt to take control of your target's mind.",
+    "teachable": false,
+    "valid_targets": [ "ally", "hostile" ],
+    "skill": "deduction",
+    "spell_class": "VAMPIRE",
+    "flags": [ "SILENT", "NO_HANDS", "NO_LEGS", "NO_FAIL" ],
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_VAMPIRE_DOMINATE_activated",
+    "shape": "blast",
+    "energy_source": "NONE"
+  },
+  {
+    "id": "spell_dominating_gaze",
+    "type": "SPELL",
+    "name": "Dominating Gaze",
+    "description": "Stare into the eyes of your victim and wills them to fight for you.  This power does not work on targets lacking a mind.",
+    "message": "",
+    "teachable": false,
+    "skill": "deduction",
+    "spell_class": "VAMPIRE",
+    "valid_targets": [ "ally", "hostile" ],
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_DOMINATING_GAZE_activated",
+    "shape": "blast",
+    "flags": [ "NO_HANDS", "SILENT", "NO_FAIL", "NO_PROJECTILE" ],
+    "difficulty": 3,
+    "base_casting_time": 100,
+    "min_range": {
+      "math": [
+        "min((3 + (vampire_total_tier_one_traits() * 0.2) + (vampire_total_tier_two_traits() * 0.33) + (vampire_total_tier_three_traits() * 0.5) + (vampire_total_tier_four_traits() * 0.75)), 12)"
+      ]
+    },
+    "max_range": {
+      "math": [
+        "min((3 + (vampire_total_tier_one_traits() * 0.2) + (vampire_total_tier_two_traits() * 0.33) + (vampire_total_tier_three_traits() * 0.5) + (vampire_total_tier_four_traits() * 0.75)), 12)"
+      ]
+    },
+    "ignored_monster_species": [ "ZOMBIE", "ROBOT", "ROBOT_FLYING", "NETHER", "NETHER_EMANATION", "LEECH_PLANT", "WORM", "FUNGUS", "SLIME" ]
+  },
+  {
+    "id": "vampire_dominate_real",
+    "type": "SPELL",
+    "name": "Dominating Gaze real",
+    "description": "The actual power that lets you take over a mind.  If you see this, it's a bug.",
+    "message": "",
+    "teachable": false,
+    "valid_targets": [ "hostile" ],
+    "effect": "charm_monster",
+    "shape": "blast",
+    "flags": [ "NO_HANDS", "SILENT", "NO_FAIL" ],
+    "spell_class": "VAMPIRE",
+    "difficulty": 8,
+    "max_level": 1,
+    "min_range": 60,
+    "max_range": 60,
+    "min_damage": {
+      "math": [
+        "rng (0.75,1.25) * (25 + (vampire_total_tier_one_traits()  * 5) + (vampire_total_tier_two_traits() * 12) + (vampire_total_tier_three_traits() * 20) + (vampire_total_tier_three_traits() * 35))"
+      ]
+    },
+    "max_damage": {
+      "math": [
+        "rng (0.75,1.25) * (25 + (vampire_total_tier_one_traits()  * 5) + (vampire_total_tier_two_traits() * 12) + (vampire_total_tier_three_traits() * 20) + (vampire_total_tier_three_traits() * 35))"
+      ]
+    },
+    "min_duration": {
+      "math": [
+        "rng (0.75,1.25) * (3000 + (vampire_total_tier_one_traits()  * 500) + (vampire_total_tier_two_traits() * 900) + (vampire_total_tier_three_traits() * 1350) + (vampire_total_tier_three_traits() * 2250))"
+      ]
+    },
+    "max_duration": {
+      "math": [
+        "rng (0.75,1.25) * (3000 + (vampire_total_tier_one_traits()  * 500) + (vampire_total_tier_two_traits() * 900) + (vampire_total_tier_three_traits() * 1350) + (vampire_total_tier_three_traits() * 2250))"
+      ]
+    },
+    "ignored_monster_species": [ "ZOMBIE", "ROBOT", "ROBOT_FLYING", "NETHER", "NETHER_EMANATION", "LEECH_PLANT", "WORM", "FUNGUS", "SLIME" ]
   }
 ]


### PR DESCRIPTION
#### Summary
Mods "(XE) add more vampire traits, allow to drink from friends and make blood of saints actually block vampirism"

#### Purpose of change

Tier 4 needs more traits. I'm also adding more vampire-related stuff such as drinking from allies as killing and bleeding ferals all the time is impractical

#### Describe the solution

Add the following:

- [x] The ability to drink from allied NPCs. Kinda-friends won't like it, true friends won't mind it and others won't allow it. It takes some days before they allow you to do it again
- [x] Make blood of saints actually block vampirism

And these powers:
- [x] Sanguine Ecstasy (Tier 1: make drinking human blood make you feel great)
- [x] Blood-Fueled Magic (Tier 3: blood-to-mana conversion ability, scales with your vampiric power)
- [x] Torpor (Tier 4: can enter torpor, in which you heal faster, gain the benefits of sleep and pasively consume less blood. The drawback is that you are asleep during that time and nothing can wake you up)
- [x] True Vampire's Potence (Tier 4: counts as six tier 4 traits for the purpose of amplifying other traits)
- [x] Dominating Gaze (Tier 4: temporary mind control for targets with a mind, efficiency and duration scales with your vampiric power, doesn't work on NPCs)
- [x] Corpse-like Flesh (Tier 4: make you immune to disease, infection, parasites and radiation)
- [x] Facultative Breathing (Tier 4: makes you unable to drown and unaffected by inhaled gases as your lungs are mostly vestigial now)

#### Describe alternatives you've considered

Add other vampire traits

I've considered adding a way to drink from stunned humans or after succeeding at an intimidation check, which would both massively piss them off, but until I find how to make it work with ferals and non-npc civillans, it'll have to wait

#### Testing
drinking from a NPC grants you blood and gives them the effect that checks how long it has been since you last did
NPCs that like you enough won't mind
drinking from a NPC that doesn't like you enough lower their opinion of you
A low enough opinion of you make them refuse
NPCs with the effect will refuse to let you drink more until it goes away
The mutations and flags that prevent star vampires from drinking someone's blood also keep you from trying to do the same
only one drinking dialogue appears at once

Blood of saints makes you immune to vampvirus and will eventualy cure you if you're not too much of a vampire

Sanguine ecstasy grants a mood buff when drinking blood, whether by item or dialogue
Blood-fueled magic grant a spell that costs blood and gives mana
Torpor makes you sleep for eight hours, healing you faster, fully recovering your sleep and reducing your blood consumption. You cannot wake up before that time is up
True vampire's potence boosts other vampiric abilities
Dominating gaze made a feral become an ally
Corpse-like flesh protects against infections, diseases, parasites and radiation
Facultative breathing protects against drowing and inhaled gases and nothing else 

#### Additional context

Might decide to add more traits to this PR, if I can find more stuff that fits

Until NPCs can be made to be temporarily friendly, dominating gaze won't work on them