### PR TITLE
Make tree communion full function not depend on playing the game in English

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -3789,7 +3789,8 @@ void activity_handlers::tree_communion_do_turn( player_activity *act, Character 
     q.push( loc );
     seen.insert( loc );
     const std::function<bool( const oter_id & )> filter = []( const oter_id & ter ) {
-        return ter.obj().is_wooded() || ter.obj().get_name() == "field";
+        // FIXME: this is terrible and should be a property instead of a name check...
+        return ter.obj().is_wooded() || ter.obj().get_name() == _( "field" );
     };
     while( !q.empty() ) {
         tripoint_abs_omt tpt = q.front();


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Tree communion can reveal fields, but only if the game's language is English.

#### Describe the solution
Translate the name it checks for.

#### Describe alternatives you've considered
Making this not do a name check, but that's more complex than I want to do right now

#### Testing
I haven't tested this. I don't know how to trigger tree communion, but it's a straightforward change.