### PR TITLE
Fix incorrect grabbed vehicle falling logic

### DIFF
--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -198,7 +198,7 @@ bool game::grabbed_veh_move( const tripoint &dp )
         if( grabbed_vehicle->is_falling ) {
             add_msg( _( "You let go of the %1$s as it starts to fall." ), grabbed_vehicle->disp_name() );
             u.grab( object_type::NONE );
-            m.drop_vehicle( final_dp_veh );
+            m.set_seen_cache_dirty( grabbed_vehicle->pos_bub().raw() );
             return true;
         }
     } else {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Change faulty logic in falling grabbed vehicle handling.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Perform the only action provided by the called operation and not already performed directly with a correct coordinate.

The previous code fed an untyped tripoint into the removed operation. Inside the operation the relative coordinate fed in was treated as a bub coordinate, not a grab reference, and thus failed to find the vehicle's part and thus quit without doing anything (this was confirmed following the progress with the debugger).
Trying to fix it by adding the grab offset to the character's position still failed, because the offset was off by one. I think that's caused by the character's position not having been updated yet (i.e. the vehicle moves first and the character moves into the freed up space), but found the code to be too complex to be worth trying to figure out how to take the character's future movement into consideration and instead opted for providing the results of a successful call by performing the remaining action.
I don't see any visible difference between the original faulty "do nothing" call and the result of marking the cache as dirty, however.
I did test hacking the correct coordinates into the call by adding (0, 1, 0) to the character's position and the grab offset (relying on me knowing I'd push the test generator straight south), and that did indeed find a part of the generator and did call the cache dirty code (but with no visible difference).

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Figure out how to determine the character's future movement and add that to the current position and the grab offset in the call.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
- Teleport up to an evac shelter roof.
- Smash the gutter at one point (or the vehicle will collide with it).
- Debug spawn a generator vehicle.
- Grab the vehicle, push it, release it, grab the wheel part (the generator turns around when pushed from the north after spawning), and push it off the roof.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Saw the type inconsistency when performing an aborted typifying session and decided to investigate it on a clean slate.

Refrained from any typification efforts in order not to get slapped with "conflicts" with the currently outstanding typification PR.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
