### PR TITLE
Typify a couple of activity actions

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -34,6 +34,7 @@
 #include "character_id.h"
 #include "clzones.h"
 #include "contents_change_handler.h"
+#include "coordinate_constants.h"
 #include "coordinates.h"
 #include "craft_command.h"
 #include "crafting_gui.h"
@@ -2403,7 +2404,7 @@ void move_items_activity_actor::serialize( JsonOut &jsout ) const
 
 std::unique_ptr<activity_actor> move_items_activity_actor::deserialize( JsonValue &jsin )
 {
-    move_items_activity_actor actor( {}, {}, false, tripoint_zero );
+    move_items_activity_actor actor( {}, {}, false, tripoint_rel_ms_zero );
 
     JsonObject data = jsin.get_object();
 

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -497,12 +497,12 @@ class move_items_activity_actor : public activity_actor
         std::vector<item_location> target_items;
         std::vector<int> quantities;
         bool to_vehicle;
-        tripoint relative_destination;
+        tripoint_rel_ms relative_destination;
         bool hauling_mode;
 
     public:
         move_items_activity_actor( std::vector<item_location> target_items, std::vector<int> quantities,
-                                   bool to_vehicle, tripoint relative_destination, bool hauling_mode = false ) :
+                                   bool to_vehicle, tripoint_rel_ms relative_destination, bool hauling_mode = false ) :
             target_items( std::move( target_items ) ), quantities( std::move( quantities ) ),
             to_vehicle( to_vehicle ),
             relative_destination( relative_destination ),
@@ -1049,7 +1049,7 @@ class drop_activity_actor : public activity_actor
     public:
         drop_activity_actor() = default;
         drop_activity_actor( const std::vector<drop_or_stash_item_info> &items,
-                             const tripoint &placement, const bool force_ground )
+                             const tripoint_rel_ms &placement, const bool force_ground )
             : items( items ), placement( placement ), force_ground( force_ground ) {}
 
         activity_id get_type() const override {
@@ -1075,7 +1075,7 @@ class drop_activity_actor : public activity_actor
     private:
         std::vector<drop_or_stash_item_info> items;
         contents_change_handler handler;
-        tripoint placement;
+        tripoint_rel_ms placement;
         bool force_ground = false;
         bool current_bulk_unload = false;
 };
@@ -1085,7 +1085,7 @@ class stash_activity_actor: public activity_actor
     public:
         stash_activity_actor() = default;
         stash_activity_actor( const std::vector<drop_or_stash_item_info> &items,
-                              const tripoint &placement )
+                              const tripoint_rel_ms &placement )
             : items( items ), placement( placement ) {}
 
         activity_id get_type() const override {
@@ -1111,7 +1111,7 @@ class stash_activity_actor: public activity_actor
     private:
         std::vector<drop_or_stash_item_info> items;
         contents_change_handler handler;
-        tripoint placement;
+        tripoint_rel_ms placement;
         bool current_bulk_unload = false;
 };
 

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -540,7 +540,7 @@ int activity_handlers::move_cost( const item &it, const tripoint_bub_ms &src,
 {
     avatar &player_character = get_avatar();
     if( player_character.get_grab_type() == object_type::VEHICLE ) {
-        const tripoint cart_position = player_character.pos() + player_character.grab_point;
+        const tripoint_bub_ms cart_position = player_character.pos_bub() + player_character.grab_point;
         if( const std::optional<vpart_reference> ovp = get_map().veh_at( cart_position ).cargo() ) {
             return move_cost_cart( it, src, dest, ovp->items().free_volume() );
         }

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -1163,7 +1163,7 @@ bool advanced_inventory::move_all_items()
             player_character.assign_activity( act );
         }
     } else if( spane.get_area() == AIM_INVENTORY || spane.get_area() == AIM_WORN ) {
-        const tripoint placement = darea.off;
+        const tripoint_rel_ms placement = darea.off;
         // in case there is vehicle cargo space at dest but the player wants to drop to ground
         const bool force_ground = !dpane.in_vehicle();
 
@@ -1188,7 +1188,7 @@ bool advanced_inventory::move_all_items()
         // Vehicle and map destinations are handled the same.
 
         // Stash the destination
-        const tripoint relative_destination = darea.off;
+        const tripoint_rel_ms relative_destination = darea.off;
 
         std::vector<item_location> target_items;
         std::vector<int> quantities;
@@ -1479,7 +1479,7 @@ void advanced_inventory::start_activity(
             player_character.assign_activity( act );
         } else {
             // Stash the destination
-            const tripoint relative_destination = squares[destarea].off;
+            const tripoint_rel_ms relative_destination = squares[destarea].off;
 
             const move_items_activity_actor act( target_items, quantities, to_vehicle, relative_destination );
             player_character.assign_activity( act );
@@ -1667,7 +1667,7 @@ bool advanced_inventory::action_move_item( advanced_inv_listitem *sitem,
                     do_return_entry();
                     start_activity( destarea, srcarea, sitem, amount_to_move, from_vehicle, to_vehicle );
                 } else {
-                    const tripoint placement = squares[destarea].off;
+                    const tripoint_rel_ms placement = squares[destarea].off;
                     // incase there is vehicle cargo space at dest but the player wants to drop to ground
                     const bool force_ground = !to_vehicle;
                     std::vector<drop_or_stash_item_info> to_drop;
@@ -2286,7 +2286,7 @@ void advanced_inventory::draw_minimap()
             continue;
         }
         advanced_inv_area sq = squares[panes[s].get_area()];
-        tripoint pt = pc + sq.off;
+        tripoint pt = pc + sq.off.raw();
         // invert the color if pointing to the player's position
         nc_color cl = sq.id == AIM_INVENTORY || sq.id == AIM_WORN ?
                       invert_color( c_light_cyan ) : c_light_cyan.blink();

--- a/src/advanced_inv_area.cpp
+++ b/src/advanced_inv_area.cpp
@@ -9,6 +9,7 @@
 #include "avatar.h"
 #include "character.h"
 #include "character_attire.h"
+#include "coordinate_constants.h"
 #include "debug.h"
 #include "enums.h"
 #include "field.h"
@@ -60,7 +61,7 @@ advanced_inv_area::advanced_inv_area( aim_location id, const point &h, tripoint 
 void advanced_inv_area::init()
 {
     avatar &player_character = get_avatar();
-    pos = player_character.pos() + off;
+    pos = player_character.pos_bub() + off;
     veh = nullptr;
     vstor = -1;
     // must update in main function
@@ -84,7 +85,7 @@ void advanced_inv_area::init()
             // offset for dragged vehicles is not statically initialized, so get it
             off = player_character.grab_point;
             // Reset position because offset changed
-            pos = player_character.pos() + off;
+            pos = player_character.pos_bub() + off;
             if( const std::optional<vpart_reference> vp = here.veh_at( pos ).cargo() ) {
                 veh = &vp->vehicle();
                 vstor = vp->part_index();
@@ -193,27 +194,27 @@ bool advanced_inv_area::canputitems( const item_location &container ) const
     return id != AIM_CONTAINER ? canputitemsloc : container && container.get_item()->is_container();
 }
 
-static tripoint aim_vector( aim_location id )
+static tripoint_rel_ms aim_vector( aim_location id )
 {
     switch( id ) {
         case AIM_SOUTHWEST:
-            return tripoint_south_west;
+            return tripoint_rel_ms_south_west;
         case AIM_SOUTH:
-            return tripoint_south;
+            return tripoint_rel_ms_south;
         case AIM_SOUTHEAST:
-            return tripoint_south_east;
+            return tripoint_rel_ms_south_east;
         case AIM_WEST:
-            return tripoint_west;
+            return tripoint_rel_ms_west;
         case AIM_EAST:
-            return tripoint_east;
+            return tripoint_rel_ms_east;
         case AIM_NORTHWEST:
-            return tripoint_north_west;
+            return tripoint_rel_ms_north_west;
         case AIM_NORTH:
-            return tripoint_north;
+            return tripoint_rel_ms_north;
         case AIM_NORTHEAST:
-            return tripoint_north_east;
+            return tripoint_rel_ms_north_east;
         default:
-            return tripoint_zero;
+            return tripoint_rel_ms_zero;
     }
 }
 
@@ -227,7 +228,7 @@ void advanced_inv_area::set_container_position()
         off = aim_vector( static_cast<aim_location>( uistate.adv_inv_container_location ) );
     }
     // update the absolute position
-    pos = player_character.pos() + off;
+    pos = player_character.pos_bub() + off;
     // update vehicle information
     if( const std::optional<vpart_reference> vp = get_map().veh_at( pos ).cargo() ) {
         veh = &vp->vehicle();
@@ -240,12 +241,12 @@ void advanced_inv_area::set_container_position()
 
 aim_location advanced_inv_area::offset_to_location() const
 {
-    static constexpr cata::mdarray<aim_location, point, 3, 3> loc_array = {
+    static constexpr cata::mdarray<aim_location, point_rel_ms, 3, 3> loc_array = {
         {AIM_NORTHWEST,     AIM_NORTH,      AIM_NORTHEAST},
         {AIM_WEST,          AIM_CENTER,     AIM_EAST},
         {AIM_SOUTHWEST,     AIM_SOUTH,      AIM_SOUTHEAST}
     };
-    return loc_array[off.xy() + point_south_east];
+    return loc_array[off.xy() + point_rel_ms_south_east];
 }
 
 bool advanced_inv_area::can_store_in_vehicle() const

--- a/src/advanced_inv_area.h
+++ b/src/advanced_inv_area.h
@@ -51,14 +51,14 @@ class advanced_inv_area
         // Used for the small overview 3x3 grid
         point hscreen = point_zero;
         // relative (to the player) position of the map point
-        tripoint off;
+        tripoint_rel_ms off;
         /** Long name, displayed, translated */
         const std::string name = "fake";
         /** Shorter name (2 letters) */
         // FK in my coffee
         const std::string shortname = "FK";
         // absolute position of the map point.
-        tripoint pos;
+        tripoint_bub_ms pos;
         /** Can we put items there? Only checks if location is valid, not if
             selected container in pane is. For full check use canputitems() **/
         bool canputitemsloc = false;

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -696,13 +696,13 @@ bool avatar::read( item_location &book, item_location ereader )
     return true;
 }
 
-void avatar::grab( object_type grab_type_new, const tripoint &grab_point_new )
+void avatar::grab( object_type grab_type_new, const tripoint_rel_ms &grab_point_new )
 {
     const auto update_memory =
-    [this]( const object_type gtype, const tripoint & gpoint, const bool erase ) {
+    [this]( const object_type gtype, const tripoint_rel_ms & gpoint, const bool erase ) {
         map &m = get_map();
         if( gtype == object_type::VEHICLE ) {
-            if( const optional_vpart_position ovp = m.veh_at( pos() + gpoint ) ) {
+            if( const optional_vpart_position ovp = m.veh_at( pos_bub() + gpoint ) ) {
                 for( const tripoint &target : ovp->vehicle().get_points() ) {
                     if( erase ) {
                         memorize_clear_decoration( m.getglobal( target ), /* prefix = */ "vp_" );
@@ -712,9 +712,9 @@ void avatar::grab( object_type grab_type_new, const tripoint &grab_point_new )
             }
         } else if( gtype != object_type::NONE ) {
             if( erase ) {
-                memorize_clear_decoration( m.getglobal( pos() + gpoint ) );
+                memorize_clear_decoration( m.getglobal( pos_bub() + gpoint ) );
             }
-            m.memory_cache_dec_set_dirty( pos() + gpoint, true );
+            m.memory_cache_dec_set_dirty( ( pos_bub() + gpoint ).raw(), true );
         }
     };
     // Mark the area covered by the previous vehicle/furniture/etc for re-memorizing.

--- a/src/avatar.h
+++ b/src/avatar.h
@@ -17,6 +17,7 @@
 #include "calendar.h"
 #include "character.h"
 #include "character_id.h"
+#include "coordinate_constants.h"
 #include "coords_fwd.h"
 #include "enums.h"
 #include "game_constants.h"
@@ -241,7 +242,7 @@ class avatar : public Character
 
         void wake_up() override;
         // Grab furniture / vehicle
-        void grab( object_type grab_type, const tripoint &grab_point = tripoint_zero );
+        void grab( object_type grab_type, const tripoint_rel_ms &grab_point = tripoint_rel_ms_zero );
         object_type get_grab_type() const;
         /** Handles player vomiting effects */
         void vomit();

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -3358,7 +3358,7 @@ bool cata_tiles::draw_furniture( const tripoint &p, const lit_level ll, int &hei
         }
         const std::string &fname = f.id().str();
         if( !( you.get_grab_type() == object_type::FURNITURE
-               && p == you.pos() + you.grab_point )
+               && tripoint_bub_ms( p ) == you.pos_bub() + you.grab_point )
             && here.memory_cache_dec_is_dirty( p ) ) {
             you.memorize_decoration( here.getglobal( p ), fname, subtile, rotation );
         }
@@ -3903,7 +3903,7 @@ bool cata_tiles::draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
             avatar &you = get_avatar();
             if( !veh.forward_velocity() && !veh.player_in_control( you )
                 && !( you.get_grab_type() == object_type::VEHICLE
-                      && veh.get_points().count( you.pos() + you.grab_point ) )
+                      && veh.get_points().count( ( you.pos_bub() + you.grab_point ).raw() ) )
                 && here.memory_cache_dec_is_dirty( p ) ) {
                 you.memorize_decoration( here.getglobal( p ), vd.get_tileset_id(), subtile, rotation );
             }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -34,6 +34,7 @@
 #include "color.h"
 #include "construction.h"
 #include "coordinates.h"
+#include "coordinates.h"
 #include "creature_tracker.h"
 #include "cursesdef.h"
 #include "debug.h"
@@ -613,7 +614,7 @@ Character::Character() :
     oxygen = 0;
     in_vehicle = false;
     controlling_vehicle = false;
-    grab_point = tripoint_zero;
+    grab_point = tripoint_rel_ms_zero;
     hauling = false;
     set_focus( 100 );
     last_item = itype_null;

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -34,7 +34,6 @@
 #include "color.h"
 #include "construction.h"
 #include "coordinates.h"
-#include "coordinates.h"
 #include "creature_tracker.h"
 #include "cursesdef.h"
 #include "debug.h"

--- a/src/character.h
+++ b/src/character.h
@@ -596,7 +596,7 @@ class Character : public Creature, public visitable
         std::set<const profession *> hobbies;
 
         // Relative direction of a grab, add to posx, posy to get the coordinates of the grabbed thing.
-        tripoint grab_point;
+        tripoint_rel_ms grab_point;
 
         std::optional<city> starting_city;
         std::optional<point_abs_om> world_origin;

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -595,7 +595,7 @@ void Character::drop( const drop_locations &what, const tripoint &target,
         return;
     }
 
-    const tripoint placement = target - pos();
+    const tripoint_rel_ms placement = tripoint_rel_ms( target - pos() );
     std::vector<drop_or_stash_item_info> items;
     for( drop_location item_pair : what ) {
         if( is_avatar() && vp.has_value() && item_pair.first->is_bucket_nonempty() &&

--- a/src/game.h
+++ b/src/game.h
@@ -919,7 +919,7 @@ class game
         not to step there */
         // Handle pushing during move, returns true if it handled the move
         bool grabbed_move( const tripoint &dp, bool via_ramp );
-        bool grabbed_veh_move( const tripoint &dp );
+        bool grabbed_veh_move( const tripoint_rel_ms &dp );
 
         void control_vehicle(); // Use vehicle controls  '^'
         // Examine nearby terrain 'e', with or without picking up items

--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -4,6 +4,7 @@
 #include <cstdlib>
 
 #include "avatar.h"
+#include "coordinate_constants.h"
 #include "debug.h"
 #include "map.h"
 #include "messages.h"
@@ -16,9 +17,9 @@
 #include "vpart_position.h"
 #include "vpart_range.h"
 
-bool game::grabbed_veh_move( const tripoint &dp )
+bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
 {
-    const optional_vpart_position grabbed_vehicle_vp = m.veh_at( u.pos() + u.grab_point );
+    const optional_vpart_position grabbed_vehicle_vp = m.veh_at( u.pos_bub() + u.grab_point );
     if( !grabbed_vehicle_vp ) {
         add_msg( m_info, _( "No vehicle at grabbed point." ) );
         u.grab( object_type::NONE );
@@ -38,35 +39,40 @@ bool game::grabbed_veh_move( const tripoint &dp )
     }
     const vehicle *veh_under_player = veh_pointer_or_null( m.veh_at( u.pos() ) );
     if( grabbed_vehicle == veh_under_player ) {
-        u.grab_point = -dp;
+        // TODO: Fix when unary operation available
+        u.grab_point = tripoint_rel_ms_zero - dp;
         return false;
     }
 
-    tripoint dp_veh = -u.grab_point;
-    const tripoint prev_grab = u.grab_point;
-    tripoint next_grab = u.grab_point;
+    // TODO: Fix when unary operation available
+    tripoint_rel_ms dp_veh = tripoint_rel_ms_zero - u.grab_point;
+    const tripoint_rel_ms prev_grab = u.grab_point;
+    tripoint_rel_ms next_grab = u.grab_point;
 
     bool zigzag = false;
 
     if( dp == prev_grab ) {
         // We are pushing in the direction of vehicle
         dp_veh = dp;
-    } else if( std::abs( dp.x + dp_veh.x ) != 2 && std::abs( dp.y + dp_veh.y ) != 2 ) {
+    } else if( std::abs( dp.x() + dp_veh.x() ) != 2 && std::abs( dp.y() + dp_veh.y() ) != 2 ) {
         // Not actually moving the vehicle, don't do the checks
-        u.grab_point = -( dp + dp_veh );
+        // TODO: Fix when unary operation available
+        u.grab_point = tripoint_rel_ms_zero - ( dp + dp_veh );
         return false;
-    } else if( ( dp.x == prev_grab.x || dp.y == prev_grab.y ) &&
-               next_grab.x != 0 && next_grab.y != 0 ) {
+    } else if( ( dp.x() == prev_grab.x() || dp.y() == prev_grab.y() ) &&
+               next_grab.x() != 0 && next_grab.y() != 0 ) {
         // Zig-zag (or semi-zig-zag) pull: player is diagonal to vehicle
         // and moves away from it, but not directly away
-        dp_veh.x = dp.x == -dp_veh.x ? 0 : dp_veh.x;
-        dp_veh.y = dp.y == -dp_veh.y ? 0 : dp_veh.y;
+        dp_veh.x() = dp.x() == -dp_veh.x() ? 0 : dp_veh.x();
+        dp_veh.y() = dp.y() == -dp_veh.y() ? 0 : dp_veh.y();
 
-        next_grab = -dp_veh;
+        // TODO: Fix when unary operation available
+        next_grab = tripoint_rel_ms_zero - dp_veh;
         zigzag = true;
     } else {
         // We are pulling the vehicle
-        next_grab = -dp;
+        // TODO: Fix when unary operation available
+        next_grab = tripoint_rel_ms_zero - dp;
     }
 
     // Make sure the mass and pivot point are correct
@@ -139,14 +145,14 @@ bool game::grabbed_veh_move( const tripoint &dp )
     }
 
     std::string blocker_name = _( "errors in movement code" );
-    const auto get_move_dir = [&]( const tripoint & dir, const tripoint & from ) {
+    const auto get_move_dir = [&]( const tripoint_rel_ms & dir, const tripoint_rel_ms & from ) {
         tileray mdir;
 
-        mdir.init( dir.xy() );
+        mdir.init( dir.xy().raw() );
         units::angle turn = normalize( mdir.dir() - grabbed_vehicle->face.dir() );
         if( grabbed_vehicle->is_on_ramp && turn == 180_degrees ) {
             add_msg( m_bad, _( "The %s can't be turned around while on a ramp." ), grabbed_vehicle->name );
-            return tripoint_zero;
+            return tripoint_rel_ms_zero;
         }
         grabbed_vehicle->turn( turn );
         grabbed_vehicle->face = tileray( grabbed_vehicle->turn_dir );
@@ -155,33 +161,35 @@ bool game::grabbed_veh_move( const tripoint &dp )
 
         // Grabbed part has to stay at distance 1 to the player
         // and in roughly the same direction.
-        const tripoint new_part_pos = grabbed_vehicle->global_pos3() +
-                                      grabbed_vehicle->part( grabbed_part ).precalc[ 1 ];
-        const tripoint expected_pos = u.pos() + dp + from;
-        const tripoint actual_dir = tripoint( ( expected_pos - new_part_pos ).xy(), 0 );
+        const tripoint_bub_ms new_part_pos = grabbed_vehicle->pos_bub() +
+                                             grabbed_vehicle->part( grabbed_part ).precalc[ 1 ];
+        const tripoint_bub_ms expected_pos = u.pos_bub() + dp + from;
+        const tripoint_rel_ms actual_dir = tripoint_rel_ms( ( expected_pos - new_part_pos ).xy(), 0 );
 
         // Set player location to illegal value so it can't collide with vehicle.
         const tripoint player_prev = u.pos();
         u.setpos( tripoint_zero );
         std::vector<veh_collision> colls;
-        const bool failed = grabbed_vehicle->collision( colls, actual_dir, true );
+        const bool failed = grabbed_vehicle->collision( colls, actual_dir.raw(), true );
         u.setpos( player_prev );
         if( !colls.empty() ) {
             blocker_name = colls.front().target_name;
         }
-        return failed ? tripoint_zero : actual_dir;
+        return failed ? tripoint_rel_ms_zero : actual_dir;
     };
 
     // First try the move as intended
     // But if that fails and the move is a zig-zag, try to recover:
     // Try to place the vehicle in the position player just left rather than "flattening" the zig-zag
-    tripoint final_dp_veh = get_move_dir( dp_veh, next_grab );
-    if( final_dp_veh == tripoint_zero && zigzag ) {
-        final_dp_veh = get_move_dir( -prev_grab, -dp );
-        next_grab = -dp;
+    tripoint_rel_ms final_dp_veh = get_move_dir( dp_veh, next_grab );
+    if( final_dp_veh == tripoint_rel_ms_zero && zigzag ) {
+        // TODO: Fix when unary operation available
+        final_dp_veh = get_move_dir( tripoint_rel_ms_zero - prev_grab, tripoint_rel_ms_zero - dp );
+        // TODO: Fix when unary operation available
+        next_grab = tripoint_rel_ms_zero - dp;
     }
 
-    if( final_dp_veh == tripoint_zero ) {
+    if( final_dp_veh == tripoint_rel_ms_zero ) {
         add_msg( _( "The %s collides with %s." ), grabbed_vehicle->name, blocker_name );
         u.grab_point = prev_grab;
         return true;
@@ -189,7 +197,7 @@ bool game::grabbed_veh_move( const tripoint &dp )
 
     u.grab_point = next_grab;
 
-    m.displace_vehicle( *grabbed_vehicle, final_dp_veh );
+    m.displace_vehicle( *grabbed_vehicle, final_dp_veh.raw() );
     m.rebuild_vehicle_level_caches();
 
     if( grabbed_vehicle ) {

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -697,10 +697,10 @@ static void grab()
     map &here = get_map();
 
     if( you.get_grab_type() != object_type::NONE ) {
-        if( const optional_vpart_position vp = here.veh_at( you.pos() + you.grab_point ) ) {
+        if( const optional_vpart_position vp = here.veh_at( you.pos_bub() + you.grab_point ) ) {
             add_msg( _( "You release the %s." ), vp->vehicle().name );
-        } else if( here.has_furn( you.pos() + you.grab_point ) ) {
-            add_msg( _( "You release the %s." ), here.furnname( you.pos() + you.grab_point ) );
+        } else if( here.has_furn( you.pos_bub() + you.grab_point ) ) {
+            add_msg( _( "You release the %s." ), here.furnname( you.pos_bub() + you.grab_point ) );
         }
 
         you.grab( object_type::NONE );
@@ -712,9 +712,9 @@ static void grab()
         add_msg( _( "Never mind." ) );
         return;
     }
-    tripoint grabp = *grabp_;
+    tripoint_bub_ms grabp = tripoint_bub_ms( *grabp_ );
 
-    if( grabp == you.pos() ) {
+    if( grabp == you.pos_bub() ) {
         add_msg( _( "You get a hold of yourself." ) );
         you.grab( object_type::NONE );
         return;
@@ -724,10 +724,10 @@ static void grab()
     if( !( here.veh_at( grabp ) || here.has_furn( grabp ) ) ) {
         if( here.has_flag( ter_furn_flag::TFLAG_RAMP_UP, grabp ) ||
             here.has_flag( ter_furn_flag::TFLAG_RAMP_UP, you.pos() ) ) {
-            grabp.z += 1;
+            grabp.z() += 1;
         } else if( here.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, grabp ) ||
                    here.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, you.pos() ) ) {
-            grabp.z -= 1;
+            grabp.z() -= 1;
         }
     }
 
@@ -756,14 +756,14 @@ static void grab()
                 return;
             }
         }
-        you.grab( object_type::VEHICLE, grabp - you.pos() );
+        you.grab( object_type::VEHICLE, grabp - you.pos_bub() );
         add_msg( _( "You grab the %s." ), veh_name );
     } else if( here.has_furn( grabp ) ) { // If not, grab furniture if present
         if( !here.furn( grabp ).obj().is_movable() ) {
             add_msg( _( "You can not grab the %s." ), here.furnname( grabp ) );
             return;
         }
-        you.grab( object_type::FURNITURE, grabp - you.pos() );
+        you.grab( object_type::FURNITURE, grabp - you.pos_bub() );
         if( !here.can_move_furniture( grabp, &you ) ) {
             add_msg( _( "You grab the %s. It feels really heavy." ), here.furnname( grabp ) );
         } else {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1379,7 +1379,7 @@ void map::board_vehicle( const tripoint &pos, Character *p )
     if( !vp ) {
         avatar *player_character = p->as_avatar();
         if( player_character != nullptr &&
-            player_character->grab_point.x == 0 && player_character->grab_point.y == 0 ) {
+            player_character->grab_point.x() == 0 && player_character->grab_point.y() == 0 ) {
             debugmsg( "map::board_vehicle: vehicle with unbroken and BOARDABLE part not found" );
         }
         return;
@@ -1757,6 +1757,12 @@ furn_id map::furn( const tripoint_bub_ms &p ) const
 bool map::furn_set( const tripoint &p, const furn_id &new_furniture, const bool furn_reset,
                     bool avoid_creatures )
 {
+    return furn_set( tripoint_bub_ms( p ), new_furniture, furn_reset, avoid_creatures );
+}
+
+bool map::furn_set( const tripoint_bub_ms &p, const furn_id &new_furniture, const bool furn_reset,
+                    bool avoid_creatures )
+{
     if( !inbounds( p ) ) {
         debugmsg( "map::furn_set %s out of bounds", p.to_string() );
         return false;
@@ -1768,7 +1774,7 @@ bool map::furn_set( const tripoint &p, const furn_id &new_furniture, const bool 
         }
     }
     point l;
-    submap *const current_submap = unsafe_get_submap_at( p, l );
+    submap *const current_submap = unsafe_get_submap_at( p.raw(), l );
     if( current_submap == nullptr ) {
         debugmsg( "Tried to set furniture at (%d,%d) but the submap is not loaded", l.x, l.y );
         return false;
@@ -1811,7 +1817,7 @@ bool map::furn_set( const tripoint &p, const furn_id &new_furniture, const bool 
     // If player has grabbed this furniture and it's no longer grabbable, release the grab.
     if( player_character.get_grab_type() == object_type::FURNITURE &&
         !furn_reset &&
-        player_character.pos() + player_character.grab_point == p && !new_f.is_movable() ) {
+        player_character.pos_bub() + player_character.grab_point == p && !new_f.is_movable() ) {
         add_msg( _( "The %s you were grabbing is destroyed!" ), old_f.name() );
         player_character.grab( object_type::NONE );
     }
@@ -1823,33 +1829,33 @@ bool map::furn_set( const tripoint &p, const furn_id &new_furniture, const bool 
         }
     }
     if( !new_f.emissions.empty() ) {
-        field_furn_locs.push_back( p );
+        field_furn_locs.push_back( p.raw() );
     }
     if( old_f.transparent != new_f.transparent ) {
-        set_transparency_cache_dirty( p );
-        set_seen_cache_dirty( p );
+        set_transparency_cache_dirty( p.raw() );
+        set_seen_cache_dirty( p.raw() );
     }
 
     if( old_f.has_flag( ter_furn_flag::TFLAG_INDOORS ) != new_f.has_flag(
             ter_furn_flag::TFLAG_INDOORS ) ) {
-        set_outside_cache_dirty( p.z );
+        set_outside_cache_dirty( p.z() );
     }
 
     if( old_f.has_flag( ter_furn_flag::TFLAG_NO_FLOOR ) != new_f.has_flag(
             ter_furn_flag::TFLAG_NO_FLOOR ) ) {
-        set_floor_cache_dirty( p.z );
-        set_seen_cache_dirty( p );
+        set_floor_cache_dirty( p.z() );
+        set_seen_cache_dirty( p.raw() );
         get_creature_tracker().invalidate_reachability_cache();
     }
 
     if( old_f.has_flag( ter_furn_flag::TFLAG_SUN_ROOF_ABOVE ) != new_f.has_flag(
             ter_furn_flag::TFLAG_SUN_ROOF_ABOVE ) ) {
-        set_floor_cache_dirty( p.z + 1 );
+        set_floor_cache_dirty( p.z() + 1 );
     }
 
-    invalidate_max_populated_zlev( p.z );
+    invalidate_max_populated_zlev( p.z() );
 
-    memory_cache_dec_set_dirty( p, true );
+    memory_cache_dec_set_dirty( p.raw(), true );
     if( player_character.sees( p ) ) {
         player_character.memorize_clear_decoration( getglobal( p ), "f_" );
     }
@@ -1858,24 +1864,18 @@ bool map::furn_set( const tripoint &p, const furn_id &new_furniture, const bool 
         get_creature_tracker().invalidate_reachability_cache();
     }
     // TODO: Limit to changes that affect move cost, traps and stairs
-    set_pathfinding_cache_dirty( p );
+    set_pathfinding_cache_dirty( p.raw() );
 
     // Make sure the furniture falls if it needs to
-    support_dirty( p );
-    tripoint above( p.xy(), p.z + 1 );
+    support_dirty( p.raw() );
+    tripoint_bub_ms above( p.xy(), p.z() + 1 );
     // Make sure that if we supported something and no longer do so, it falls down
-    support_dirty( above );
+    support_dirty( above.raw() );
 
     return result;
 }
 
-bool map::furn_set( const tripoint_bub_ms &p, const furn_id &new_furniture, const bool furn_reset,
-                    bool avoid_creatures )
-{
-    return furn_set( p.raw(), new_furniture, furn_reset, avoid_creatures );
-}
-
-bool map::can_move_furniture( const tripoint &pos, Character *you ) const
+bool map::can_move_furniture( const tripoint_bub_ms &pos, Character *you ) const
 {
     if( !you ) {
         return false;
@@ -5197,7 +5197,7 @@ void map::spawn_item( const tripoint_bub_ms &p, const itype_id &type_id, const u
     map::spawn_item( p.raw(), type_id, quantity, charges, birthday, damlevel, flags, variant, faction );
 }
 
-units::volume map::max_volume( const tripoint &p )
+units::volume map::max_volume( const tripoint_bub_ms &p )
 {
     return i_at( p ).max_volume();
 }
@@ -7195,7 +7195,7 @@ bool map::draw_maptile( const catacurses::window &w, const tripoint &p,
         sym = curr_furn.symbol();
         tercol = curr_furn.color();
         if( !( player_character.get_grab_type() == object_type::FURNITURE
-               && p == player_character.pos() + player_character.grab_point ) ) {
+               && tripoint_bub_ms( p ) == player_character.pos_bub() + player_character.grab_point ) ) {
             memory_sym = sym;
         }
     }
@@ -7317,7 +7317,8 @@ bool map::draw_maptile( const catacurses::window &w, const tripoint &p,
 
         if( !veh->forward_velocity() && !veh->player_in_control( player_character )
             && !( player_character.get_grab_type() == object_type::VEHICLE
-                  && veh->get_points().count( player_character.pos() + player_character.grab_point ) ) ) {
+                  && veh->get_points().count( ( player_character.pos_bub() +
+                                                player_character.grab_point ).raw() ) ) ) {
             memory_sym = sym;
         }
     }

--- a/src/map.h
+++ b/src/map.h
@@ -902,7 +902,7 @@ class map
         std::string furnname( const point &p ) {
             return furnname( tripoint( p, abs_sub.z() ) );
         }
-        bool can_move_furniture( const tripoint &pos, Character *you = nullptr ) const;
+        bool can_move_furniture( const tripoint_bub_ms &pos, Character *you = nullptr ) const;
 
         // Terrain
         // TODO: fix point types (remove the first overload)
@@ -1426,7 +1426,7 @@ class map
             spawn_item( tripoint( p, abs_sub.z() ), type_id, quantity, charges, birthday, damlevel, flags,
                         variant, faction );
         }
-        units::volume max_volume( const tripoint &p );
+        units::volume max_volume( const tripoint_bub_ms &p );
         // TODO: fix point types (remove the first overload)
         units::volume free_volume( const tripoint &p );
         units::volume free_volume( const tripoint_bub_ms &p );

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -24,6 +24,7 @@
 #include "character.h"
 #include "character_id.h"
 #include "character_martial_arts.h"
+#include "coordinate_constants.h"
 #include "coordinates.h"
 #include "creature.h"
 #include "debug.h"
@@ -868,7 +869,7 @@ void talk_function::drop_items_in_place( npc &p )
     }
     if( !to_drop.empty() ) {
         // spawn a activity for the npc to drop the specified items
-        p.assign_activity( drop_activity_actor( to_drop, tripoint_zero, false ) );
+        p.assign_activity( drop_activity_actor( to_drop, tripoint_rel_ms_zero, false ) );
         p.say( "<acknowledged>" );
     } else {
         p.say( _( "I don't have anything to drop off." ) );

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -1629,7 +1629,7 @@ void avatar::load( const JsonObject &data )
 
     data.read( "grab_point", grab_point );
     std::string grab_typestr = "OBJECT_NONE";
-    if( grab_point.x != 0 || grab_point.y != 0 ) {
+    if( grab_point.x() != 0 || grab_point.y() != 0 ) {
         grab_typestr = "OBJECT_VEHICLE";
         data.read( "grab_type", grab_typestr );
     } else {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -149,7 +149,7 @@ void DefaultRemovePartHandler::removed( vehicle &veh, const int part )
 {
     avatar &player_character = get_avatar();
     const vehicle_part &vp = veh.part( part );
-    const tripoint part_pos = veh.global_part_pos3( vp );
+    const tripoint_bub_ms part_pos = veh.bub_part_pos( vp );
 
     // If the player is currently working on the removed part, stop them as it's futile now.
     const player_activity &act = player_character.activity;
@@ -165,7 +165,7 @@ void DefaultRemovePartHandler::removed( vehicle &veh, const int part )
     }
     // TODO: maybe do this for all the nearby NPCs as well?
     if( player_character.get_grab_type() == object_type::VEHICLE &&
-        player_character.pos() + player_character.grab_point == part_pos ) {
+        player_character.pos_bub() + player_character.grab_point == part_pos ) {
         if( veh.parts_at_relative( vp.mount, false ).empty() ) {
             add_msg( m_info, _( "The vehicle part you were holding has been destroyed!" ) );
             player_character.grab( object_type::NONE );
@@ -173,9 +173,9 @@ void DefaultRemovePartHandler::removed( vehicle &veh, const int part )
     }
 
     here.dirty_vehicle_list.insert( &veh );
-    here.clear_vehicle_point_from_cache( &veh, part_pos );
+    here.clear_vehicle_point_from_cache( &veh, part_pos.raw() );
     here.add_vehicle_to_cache( &veh );
-    here.memory_cache_dec_set_dirty( part_pos, true );
+    here.memory_cache_dec_set_dirty( part_pos.raw(), true );
     player_character.memorize_clear_decoration(
         here.getglobal( part_pos ), "vp_" + vp.info().id.str() );
 }
@@ -1862,7 +1862,7 @@ bool vehicle::merge_appliance_into_grid( vehicle &veh_target )
     }
     // Release grab if player is dragging either appliance
     if( get_avatar().get_grab_type() == object_type::VEHICLE ) {
-        const tripoint grab_point = get_avatar().pos() + get_avatar().grab_point;
+        const tripoint_bub_ms grab_point = get_avatar().pos_bub() + get_avatar().grab_point;
         const optional_vpart_position grabbed_veh = get_map().veh_at( grab_point );
         if( grabbed_veh && ( &grabbed_veh->vehicle() == this || &grabbed_veh->vehicle() == &veh_target ) ) {
             add_msg( _( "You release the %s." ), grabbed_veh->vehicle().name );

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "avatar.h"
+#include "coordinate_constants.h"
 #include "coordinates.h"
 #include "enums.h"
 #include "itype.h"
@@ -78,13 +79,13 @@ TEST_CASE( "destroy_grabbed_furniture" )
         player_character.setpos( test_origin );
         const tripoint grab_point = test_origin + tripoint_east;
         here.furn_set( grab_point, furn_id( "f_chair" ) );
-        player_character.grab( object_type::FURNITURE, tripoint_east );
+        player_character.grab( object_type::FURNITURE, tripoint_rel_ms_east );
         REQUIRE( player_character.get_grab_type() == object_type::FURNITURE );
         WHEN( "The furniture grabbed by the player is destroyed" ) {
             here.destroy( grab_point );
             THEN( "The player's grab is released" ) {
                 CHECK( player_character.get_grab_type() == object_type::NONE );
-                CHECK( player_character.grab_point == tripoint_zero );
+                CHECK( player_character.grab_point == tripoint_rel_ms_zero );
             }
         }
     }

--- a/tests/player_activities_test.cpp
+++ b/tests/player_activities_test.cpp
@@ -8,6 +8,7 @@
 #include "avatar.h"
 #include "calendar.h"
 #include "character.h"
+#include "coordinate_constants.h"
 #include "flag.h"
 #include "game.h"
 #include "itype.h"
@@ -1710,7 +1711,7 @@ static const std::vector<std::function<player_activity()>> test_activities {
     [] { return player_activity( milk_activity_actor( 1, {get_avatar().pos()}, {std::string()} ) ); },
     [] { return player_activity( mop_activity_actor( 1 ) ); },
     //player_activity( move_furniture_activity_actor( p, false ) ),
-    [] { return player_activity( move_items_activity_actor( {}, {}, false, get_avatar().pos() + tripoint_north ) ); },
+    [] { return player_activity( move_items_activity_actor( {}, {}, false, tripoint_rel_ms_north ) ); },
     [] { return player_activity( open_gate_activity_actor( 1, get_avatar().pos_bub() ) ); },
     //player_activity( oxytorch_activity_actor( p, loc ) ),
     [] { return player_activity( pickup_activity_actor( {}, {}, std::nullopt, false ) ); },

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -4,6 +4,7 @@
 #include "avatar.h"
 #include "cata_catch.h"
 #include "character.h"
+#include "coordinate_constants.h"
 #include "damage.h"
 #include "enums.h"
 #include "item.h"
@@ -64,15 +65,15 @@ TEST_CASE( "destroy_grabbed_vehicle_section", "[vehicle]" )
                                              0, 0 );
         REQUIRE( veh_ptr != nullptr );
         tripoint grab_point = test_origin + tripoint_east;
-        player_character.grab( object_type::VEHICLE, tripoint_east );
+        player_character.grab( object_type::VEHICLE, tripoint_rel_ms_east );
         REQUIRE( player_character.get_grab_type() == object_type::VEHICLE );
-        REQUIRE( player_character.grab_point == tripoint_east );
+        REQUIRE( player_character.grab_point == tripoint_rel_ms_east );
         WHEN( "The vehicle section grabbed by the player is destroyed" ) {
             here.destroy( grab_point );
             REQUIRE( veh_ptr->get_parts_at( grab_point, "", part_status_flag::available ).empty() );
             THEN( "The player's grab is released" ) {
                 CHECK( player_character.get_grab_type() == object_type::NONE );
-                CHECK( player_character.grab_point == tripoint_zero );
+                CHECK( player_character.grab_point == tripoint_rel_ms_zero );
             }
         }
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Change code to use typed coordinates for a couple of additional activity actions.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Typed coordinates for a couple of actions and dealt with the fallout.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Do more.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Load a save, enter a car, drive a little. Since there should be no functional change there is no particular test focus to look at.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
The player_activities_test.cpp change is a functional change, as it changes the parameter from a bub to a relative coordinate. This indicates the test was actually incorrect, but I wouldn't be surprised if we won't see any difference...

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
