### PR TITLE
Regenerating zombie evolutions

### DIFF
--- a/data/json/monsters/zed-medical.json
+++ b/data/json/monsters/zed-medical.json
@@ -25,7 +25,7 @@
     "description": "The zombified remains of a practitioner of medicine, you aren't certain what field - your focus is instead drawn to the way that its pink flesh snakes all over it, weaving its way over wounds and injuries.",
     "copy-from": "mon_zombie_regenerating",
     "death_drops": "mon_zombie_medical_death_drops",
-    "upgrades": { "half_life": 30, "into_group": "GROUP_MEDICAL_CRAWLER_UPGRADE" }
+    "upgrades": { "half_life": 30, "into": "mon_zombie_regenerating_hunter" }
   },
   {
     "id": "mon_skeleton_medical",

--- a/data/json/monsters/zed_misc.json
+++ b/data/json/monsters/zed_misc.json
@@ -1225,11 +1225,41 @@
     "id": "mon_zombie_regenerating_hunter",
     "type": "MONSTER",
     "name": { "str": "fleshy hunter" },
-    "description": "A zombie with the top layers of its skin either transluscent or gone entirely.  Its exposed tissue churns as muscles unravel, snake over and restitch themselves - almost as if it's endlessly reconstructing its body, becoming less humanoid with each iteration.",
+    "description": "A zombie prowling around on all fours; its exposed muscles churn and snake, unraveling before restitching themselves elsewhere along its red-raw figure.",
     "copy-from": "mon_zombie_hunter",
     "regenerates": 12,
     "color": "red_cyan",
-    "extend": { "flags": [ "SMELLS", "REVIVES_HEALTHY", "NO_NECRO" ] }
+    "upgrades": { "half_life": 35, "into": "mon_zombie_regenerating_final" },
+    "extend": { "flags": [ "SMELLS", "CLIMBS", "REVIVES_HEALTHY", "NO_NECRO" ] }
+  },
+  {
+    "id": "mon_zombie_regenerating_final",
+    "type": "MONSTER",
+    "name": { "str": "regenerating abomination" },
+    "description": "This zombie hardly resembles a human anymore - Its skeleton has been repeatedly dismantled and reassembled into a horrid quadrapedal shape, like some sort of mismatched action figure.  Slick, bloodied flesh writhes on its frame with an almost viscous quality, digesting and reconstituting itself in an endless ouroborous of undead flesh.",
+    "copy-from": "mon_zombie_predator",
+    "hp": 100,
+    "regenerates": 12,
+    "color": "red_cyan",
+    "special_attacks": [
+      {
+        "type": "bite",
+        "cooldown": 10,
+        "damage_max_instance": [ { "damage_type": "stab", "amount": 6, "armor_multiplier": 0.2 } ]
+      },
+      {
+        "id": "stretch_attack",
+        "cooldown": 5,
+        "move_cost": 50,
+        "range": 2,
+        "damage_max_instance": [ { "damage_type": "bash", "amount": 7 } ]
+      },
+      { "id": "ranged_pull", "cooldown": 30, "grab_data": { "pull_weight_ratio": 1 } },
+      { "id": "grab_drag", "cooldown": 5 },
+      { "id": "drag_followup" },
+      { "id": "longswipe" }
+    ],
+    "armor": { "electric": 1 }
   },
   {
     "id": "mon_zombie_predator",

--- a/data/json/monsters/zed_misc.json
+++ b/data/json/monsters/zed_misc.json
@@ -1224,7 +1224,7 @@
   {
     "id": "mon_zombie_regenerating_hunter",
     "type": "MONSTER",
-    "name": { "str": "fleshy hunter", },
+    "name": { "str": "fleshy hunter" },
     "description": "A zombie with the top layers of its skin either transluscent or gone entirely.  Its exposed tissue churns as muscles unravel, snake over and restitch themselves - almost as if it's endlessly reconstructing its body, becoming less humanoid with each iteration.",
     "copy-from": "mon_zombie_hunter",
     "regenerates": 12,

--- a/data/json/monsters/zed_misc.json
+++ b/data/json/monsters/zed_misc.json
@@ -1260,6 +1260,7 @@
       { "id": "longswipe", "cooldown": 15 }
     ],
     "armor": { "electric": 1 },
+    "bleed_rate": 0,
     "extend": { "flags": [ "SMELLS", "REVIVES_HEALTHY", "NO_NECRO" ] }
   },
   {

--- a/data/json/monsters/zed_misc.json
+++ b/data/json/monsters/zed_misc.json
@@ -1236,7 +1236,7 @@
     "id": "mon_zombie_regenerating_final",
     "type": "MONSTER",
     "name": { "str": "regenerating abomination" },
-    "description": "This zombie hardly resembles a human anymore - Its skeleton has been repeatedly dismantled and reassembled into a horrid quadrapedal shape, like some sort of mismatched action figure.  Slick, bloodied flesh writhes on its frame with an almost viscous quality, digesting and reconstituting itself in an endless ouroborous of undead flesh.",
+    "description": "This zombie hardly resembles a human anymore - Its skeleton has been repeatedly dismantled and reassembled into a horrid quadrupedal shape, like some sort of mismatched action figure.  Slick, bloodied flesh writhes on its frame with an almost viscous quality, digesting and reconstituting itself in an endless ouroboros of undead flesh.",
     "copy-from": "mon_zombie_predator",
     "hp": 100,
     "regenerates": 12,

--- a/data/json/monsters/zed_misc.json
+++ b/data/json/monsters/zed_misc.json
@@ -1249,7 +1249,7 @@
       },
       {
         "id": "stretch_attack",
-        "cooldown": 5,
+        "cooldown": 10,
         "move_cost": 50,
         "range": 2,
         "damage_max_instance": [ { "damage_type": "bash", "amount": 7 } ]
@@ -1257,7 +1257,7 @@
       { "id": "ranged_pull", "cooldown": 30, "grab_data": { "pull_weight_ratio": 1 } },
       { "id": "grab_drag", "cooldown": 5 },
       { "id": "drag_followup" },
-      { "id": "longswipe" }
+      { "id": "longswipe", "cooldown": 15 }
     ],
     "armor": { "electric": 1 },
     "extend": { "flags": [ "SMELLS", "REVIVES_HEALTHY", "NO_NECRO" ] }

--- a/data/json/monsters/zed_misc.json
+++ b/data/json/monsters/zed_misc.json
@@ -1218,7 +1218,17 @@
     "melee_damage": [ { "damage_type": "cut", "amount": 1 } ],
     "dodge": 1,
     "regenerates": 12,
-    "upgrades": false,
+    "upgrades": { "half_life": 35, "into": "mon_zombie_regenerating_hunter" },
+    "extend": { "flags": [ "SMELLS", "REVIVES_HEALTHY", "NO_NECRO" ] }
+  },
+  {
+    "id": "mon_zombie_regenerating_hunter",
+    "type": "MONSTER",
+    "name": { "str": "fleshy hunter", },
+    "description": "A zombie with the top layers of its skin either transluscent or gone entirely.  Its exposed tissue churns as muscles unravel, snake over and restitch themselves - almost as if it's endlessly reconstructing its body, becoming less humanoid with each iteration.",
+    "copy-from": "mon_zombie_hunter",
+    "regenerates": 12,
+    "color": "red_cyan",
     "extend": { "flags": [ "SMELLS", "REVIVES_HEALTHY", "NO_NECRO" ] }
   },
   {

--- a/data/json/monsters/zed_misc.json
+++ b/data/json/monsters/zed_misc.json
@@ -1259,7 +1259,8 @@
       { "id": "drag_followup" },
       { "id": "longswipe" }
     ],
-    "armor": { "electric": 1 }
+    "armor": { "electric": 1 },
+    "extend": { "flags": [ "SMELLS", "REVIVES_HEALTHY", "NO_NECRO" ] }
   },
   {
     "id": "mon_zombie_predator",


### PR DESCRIPTION
#### Summary
Content "Expands the regenerating zombie into it's own line"


#### Purpose of change

The regenerating zombie was one of my first contributions to the game, 4 years ago. Since then I've seen people encounter it on occasions and they've stated that it was somewhat of a pushover despite it's threatening appearance. Probably because it doesn't have anything it upgrades into.

#### Describe the solution

I set to make the regenerating zombie's line into something that conveys how unstable it's mutation is - It first transforms into a hunter analogue, a hunched and deformed humanoid capable of leaping and climbing, before its regenerative abilities degrade it into a misshapen creature that loses it's ability to leap, but gains several ranged melee attacks in its stead. I was initially going to go with a regular zombie > hunter > predator line, but I wasn't satisfied with it.

#### Describe alternatives you've considered

I could return the final evolution to it's original predator design, but I also had other, more out-there ideas. Initially I thought "wouldn't it be cool if the predator ejected it's skeleton on death, and became something similar to a hollow?" But I decided against it due to it being too silly. 

#### Testing

I fought the things a couple times with a couple different weapons, and even put it against some NPCs. They seem ready to me.

#### Additional context

