### PR TITLE
burglar profession has the safecracking proficiency

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -4387,7 +4387,7 @@
     "name": "Burglar",
     "description": "This could be your lucky break.  Plenty of loot to be pilfered, and no cops to be seen.  Does it count as breaking and entering if everyone in town is undead?",
     "points": 2,
-    "proficiencies": [ "prof_lockpicking" ],
+    "proficiencies": [ "prof_lockpicking", "prof_safecracking" ],
     "skills": [ { "level": 6, "name": "traps" }, { "level": 2, "name": "dodge" } ],
     "items": {
       "both": {


### PR DESCRIPTION
#### Summary
Content "burglar profession has the safecracking proficiency"


#### Purpose of change

The burglar starts with a stethoscope so I thought it'd make sense to start with this proficiency. It's niche enough to where I doubt it'd be gamebreaking.

#### Describe the solution

Added `prof_safecracking` to the burglar's proficiency line in professions.json

#### Describe alternatives you've considered

N/A

#### Testing

N/A