### PR TITLE
Lime, sulphur chunks, rhodonite, and zincite are now categorised as chemicals

### DIFF
--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -56,7 +56,7 @@
   {
     "type": "AMMO",
     "id": "chunk_sulfur",
-    "category": "spare_parts",
+    "category": "chems",
     "price": "50 cent",
     "price_postapoc": "1 USD",
     "name": { "str": "chunk of sulfur", "str_pl": "chunks of sulfur" },
@@ -123,7 +123,7 @@
   {
     "type": "AMMO",
     "id": "material_limestone",
-    "category": "spare_parts",
+    "category": "chems",
     "price": "50 cent",
     "price_postapoc": "10 cent",
     "name": { "str_sp": "limestone" },
@@ -140,7 +140,7 @@
   {
     "type": "AMMO",
     "id": "material_quicklime",
-    "category": "spare_parts",
+    "category": "chems",
     "price": "1 USD",
     "price_postapoc": "10 cent",
     "name": { "str_sp": "quicklime" },
@@ -207,7 +207,7 @@
     "symbol": ",",
     "color": "light_gray",
     "name": { "str": "limestone shard" },
-    "category": "spare_parts",
+    "category": "chems",
     "description": "A small shard of limestone.  Pretty flimsy and not much of a weapon, but its alkaline properties may yet find some use.",
     "price": "5 USD",
     "price_postapoc": "10 cent",
@@ -235,7 +235,7 @@
   {
     "type": "GENERIC",
     "id": "material_rhodonite",
-    "category": "spare_parts",
+    "category": "chems",
     "price": "2 USD 50 cent",
     "price_postapoc": "1 USD",
     "name": { "str_sp": "rhodonite" },
@@ -251,7 +251,7 @@
   {
     "type": "GENERIC",
     "id": "material_zincite",
-    "category": "spare_parts",
+    "category": "chems",
     "price": "2 USD 50 cent",
     "price_postapoc": "1 USD",
     "name": { "str_sp": "zincite" },


### PR DESCRIPTION
#### Summary

Bugfixes "Lime, sulphur chunks, rhodonite, and zincite are now categorised as chemicals"

#### Purpose of change

A number of results of mining (or looting a mine) were counted as 'spare parts', even though they are chemicals, and not really 'parts'.

This PR moves them into the chemicals category so they sort better, and so that 'spare parts' can be a little less cluttered.

#### Describe the solution

JSON edits.

#### Describe alternatives you've considered

None.

#### Testing

I've been using these changes in my current playthrough, but that was a few months ago.

I haven't tested these in anger with a current build, but they don't throw any errors on game load.

#### Additional context

- There may be other items that could be moved to chemicals. There is no promise this list is exhaustive.
- I'm trying to lower the amount of local patches I have applied by sending appropriate ones upstream. This one was low hanging fruit.