### PR TITLE
Remove flavored condom variants

### DIFF
--- a/data/json/ascii_art/containers/containers.json
+++ b/data/json/ascii_art/containers/containers.json
@@ -2110,60 +2110,6 @@
   },
   {
     "type": "ascii_art",
-    "id": "condom_flavored_cherry",
-    "picture": [
-      "<color_red>╔↔↔↔╗",
-      "║( )║",
-      "╚↔↔↔╝"
-    ]
-  },
-  {
-    "type": "ascii_art",
-    "id": "condom_flavored_banana",
-    "picture": [
-      "<color_yellow>╔↔↔↔╗",
-      "║( )║",
-      "╚↔↔↔╝"
-    ]
-  },
-  {
-    "type": "ascii_art",
-    "id": "condom_flavored_strawberry",
-    "picture": [
-      "<color_red>╔↔↔↔╗",
-      "║( )║",
-      "╚↔↔↔╝"
-    ]
-  },
-  {
-    "type": "ascii_art",
-    "id": "condom_flavored_orange",
-    "picture": [
-      "<color_yellow>╔↔↔↔╗",
-      "║( )║",
-      "╚↔↔↔╝"
-    ]
-  },
-  {
-    "type": "ascii_art",
-    "id": "condom_flavored_foodplace",
-    "picture": [
-      "<color_magenta>╔↔↔↔╗",
-      "║( )║",
-      "╚↔↔↔╝"
-    ]
-  },
-  {
-    "type": "ascii_art",
-    "id": "condom_flavored_jalapeno",
-    "picture": [
-      "<color_light_green>╔↔↔↔╗",
-      "║( )║",
-      "╚↔↔↔╝"
-    ]
-  },
-  {
-    "type": "ascii_art",
     "id": "condom_sealed",
     "picture": [
       "<color_dark_gray>╔↔↔↔╗",

--- a/data/json/items/containers/containers.json
+++ b/data/json/items/containers/containers.json
@@ -3743,53 +3743,6 @@
         "ascii_picture": "condom_ribbed",
         "weight": 100,
         "append": true
-      },
-      {
-        "id": "condom_flavored_cherry",
-        "name": { "str": "cherry flavored condom" },
-        "description": "A condom with cherry flavored lube, in red packaging to match.",
-        "ascii_picture": "condom_flavored_cherry",
-        "weight": 40,
-        "append": true
-      },
-      {
-        "id": "condom_flavored_banana",
-        "name": { "str": "banana flavored condom" },
-        "description": "A condom with banana flavored lube, in yellow packaging to match.",
-        "ascii_picture": "condom_flavored_banana",
-        "weight": 40,
-        "append": true
-      },
-      {
-        "id": "condom_flavored_strawberry",
-        "name": { "str": "strawberry flavored condom" },
-        "description": "A condom with strawberry flavored lube, in red packaging to match.",
-        "ascii_picture": "condom_flavored_strawberry",
-        "weight": 40,
-        "append": true
-      },
-      {
-        "id": "condom_flavored_orange",
-        "name": { "str": "orange flavored condom" },
-        "description": "A condom with orange flavored lube, in orange packaging to match.",
-        "ascii_picture": "condom_flavored_orange",
-        "weight": 40,
-        "append": true
-      },
-      {
-        "id": "condom_flavored_foodplace",
-        "name": { "str": "food™ flavored condom" },
-        "description": "A condom with Foodplace's delicious food™ flavored lube, in purple packaging to match.",
-        "ascii_picture": "condom_flavored_foodplace",
-        "weight": 2,
-        "append": true
-      },
-      {
-        "id": "condom_flavored_jalapeno",
-        "name": { "str": "jalapeno flavored condom" },
-        "description": "For those who need to spice up their sex life, are masochistic, or just hate themselves, this condom is flavored after jalapeños.",
-        "ascii_picture": "condom_flavored_jalapeno",
-        "append": true
       }
     ],
     "pocket_data": [


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
These have been admitted to be a joke and should never have been PR'd or merged

#### Describe the solution
Remove them. Also remove the ascii images for them as they are otherwise inaccessible.

#### Describe alternatives you've considered
I should have done this earlier.

#### Testing
Put 100 of each in my inventory before removing the variants and reloaded the game. No errors on load, items were correctly reassigned to other variants.

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/aa9aa8f0-b993-40f1-8be0-4136cb48dd90)


#### Additional context
