### PR TITLE
Expanded seats so a character with some gear and a weapon can enter

### DIFF
--- a/data/json/vehicleparts/seats.json
+++ b/data/json/vehicleparts/seats.json
@@ -1,10 +1,10 @@
 [
   {
     "entries": [
-      { "count": [ 2, 8 ], "item": "nylon" },
-      { "count": [ 1, 3 ], "item": "pipe" },
-      { "count": [ 0, 2 ], "item": "spring" },
-      { "count": [ 3, 5 ], "item": "scrap" }
+      { "count": [2, 8], "item": "nylon" },
+      { "count": [1, 3], "item": "pipe" },
+      { "count": [0, 2], "item": "spring" },
+      { "count": [3, 5], "item": "scrap" }
     ],
     "id": "ig_vp_seat",
     "subtype": "collection",
@@ -12,11 +12,11 @@
   },
   {
     "entries": [
-      { "count": [ 1, 5 ], "item": "leather" },
-      { "count": [ 1, 3 ], "item": "nylon" },
-      { "count": [ 1, 3 ], "item": "pipe" },
-      { "count": [ 0, 2 ], "item": "spring" },
-      { "count": [ 3, 5 ], "item": "scrap" }
+      { "count": [1, 5], "item": "leather" },
+      { "count": [1, 3], "item": "nylon" },
+      { "count": [1, 3], "item": "pipe" },
+      { "count": [0, 2], "item": "spring" },
+      { "count": [3, 5], "item": "scrap" }
     ],
     "id": "ig_vp_seat_leather",
     "subtype": "collection",
@@ -26,14 +26,14 @@
     "id": "seat",
     "breaks_into": "ig_vp_seat",
     "broken_color": "red",
-    "categories": [ "operations", "passengers" ],
+    "categories": ["operations", "passengers"],
     "color": "red",
     "comfort": 2,
     "damage_modifier": 60,
     "damage_reduction": { "all": 2, "bash": 5 },
     "description": "A soft upholstered car seat, contoured to hold one person.",
     "durability": 300,
-    "flags": [ "SEAT", "BOARDABLE", "CARGO", "BELTABLE" ],
+    "flags": ["SEAT", "BOARDABLE", "CARGO", "BELTABLE"],
     "floor_bedding_warmth": 200,
     "item": "seat",
     "location": "center",
@@ -41,24 +41,63 @@
     "//": "weld repairs would mostly be the frame and springs of the seat, so low 6 cm cost per quadrant",
     "name": { "str": "bucket seat" },
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 1 ] ], "time": "30 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "15 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
-      "repair": {
-        "skills": [ [ "mechanics", 2 ] ],
+      "install": {
+        "skills": [["mechanics", 1]],
         "time": "30 m",
-        "using": [ [ "repair_welding_standard", 1 ], [ "sewing_standard", 8 ] ]
+        "using": [["vehicle_wrench_2", 1]]
+      },
+      "removal": {
+        "skills": [["mechanics", 2]],
+        "time": "15 m",
+        "using": [["vehicle_wrench_2", 1]]
+      },
+      "repair": {
+        "skills": [["mechanics", 2]],
+        "time": "30 m",
+        "using": [
+          ["repair_welding_standard", 1],
+          ["sewing_standard", 8]
+        ]
       }
     },
-    "size": "85 L",
+    "size": "125 L",
     "type": "vehicle_part",
-    "variants_bases": [ { "id": "windshield", "label": "Windshield" }, { "id": "swivel_chair", "label": "Swivel Chair" } ],
+    "variants_bases": [
+      { "id": "windshield", "label": "Windshield" },
+      { "id": "swivel_chair", "label": "Swivel Chair" }
+    ],
     "variants": [
-      { "id": "front", "label": "Front", "symbols": "#", "symbols_broken": "*" },
-      { "id": "vertical", "label": "Vertical", "symbols": "#", "symbols_broken": "*" },
-      { "id": "vertical_left", "label": "Left Vertical", "symbols": "#", "symbols_broken": "*" },
-      { "id": "vertical_right", "label": "Right Vertical", "symbols": "#", "symbols_broken": "*" },
+      {
+        "id": "front",
+        "label": "Front",
+        "symbols": "#",
+        "symbols_broken": "*"
+      },
+      {
+        "id": "vertical",
+        "label": "Vertical",
+        "symbols": "#",
+        "symbols_broken": "*"
+      },
+      {
+        "id": "vertical_left",
+        "label": "Left Vertical",
+        "symbols": "#",
+        "symbols_broken": "*"
+      },
+      {
+        "id": "vertical_right",
+        "label": "Right Vertical",
+        "symbols": "#",
+        "symbols_broken": "*"
+      },
       { "id": "left", "label": "Left", "symbols": "#", "symbols_broken": "*" },
-      { "id": "right", "label": "Right", "symbols": "#", "symbols_broken": "*" },
+      {
+        "id": "right",
+        "label": "Right",
+        "symbols": "#",
+        "symbols_broken": "*"
+      },
       { "id": "rear", "label": "Rear", "symbols": "#", "symbols_broken": "*" }
     ]
   },
@@ -70,7 +109,7 @@
     "name": { "str": "leather bucket seat" },
     "description": "A leather car seat for one.",
     "type": "vehicle_part",
-    "variants_bases": [ { "id": "windshield", "label": "Windshield" } ]
+    "variants_bases": [{ "id": "windshield", "label": "Windshield" }]
   },
   {
     "id": "reclining_seat",
@@ -79,12 +118,12 @@
     "//": "reclining and bench seats are roomier than standard and are able to fit Large characters, if not comfortably",
     "description": "A soft seat with an adjustable backrest, making it a reasonably comfortable place to sleep.",
     "durability": 100,
-    "size": "95 L",
+    "size": "115 L",
     "floor_bedding_warmth": 350,
     "name": { "str": "reclining bucket seat" },
-    "extend": { "flags": [ "BED" ] },
+    "extend": { "flags": ["BED"] },
     "type": "vehicle_part",
-    "variants_bases": [ { "id": "windshield", "label": "Windshield" } ]
+    "variants_bases": [{ "id": "windshield", "label": "Windshield" }]
   },
   {
     "id": "reclining_seat_leather",
@@ -94,7 +133,7 @@
     "looks_like": "seat_leather",
     "name": { "str": "reclining leather bucket seat" },
     "type": "vehicle_part",
-    "variants_bases": [ { "id": "windshield", "label": "Windshield" } ]
+    "variants_bases": [{ "id": "windshield", "label": "Windshield" }]
   },
   {
     "id": "seat_back",
@@ -103,9 +142,9 @@
     "description": "A soft, wide seat with a high back, the kind often used in back seats or older cars.  It might be a decent place to sleep.",
     "floor_bedding_warmth": 500,
     "item": "seat_bench",
-    "size": "95 L",
+    "size": "115 L",
     "name": { "str": "bench seat" },
-    "extend": { "flags": [ "BED" ] },
+    "extend": { "flags": ["BED"] },
     "type": "vehicle_part"
   },
   {
@@ -130,23 +169,52 @@
     "comfort": 1,
     "item": "saddle",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 1 ] ], "time": "200 s", "using": [ [ "vehicle_wrench_2", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "200 s", "using": [ [ "vehicle_wrench_2", 1 ] ] },
+      "install": {
+        "skills": [["mechanics", 1]],
+        "time": "200 s",
+        "using": [["vehicle_wrench_2", 1]]
+      },
+      "removal": {
+        "skills": [["mechanics", 1]],
+        "time": "200 s",
+        "using": [["vehicle_wrench_2", 1]]
+      },
       "repair": {
-        "skills": [ [ "mechanics", 2 ] ],
+        "skills": [["mechanics", 2]],
         "time": "20 m",
-        "using": [ [ "repair_welding_standard", 1 ], [ "sewing_standard", 4 ] ]
+        "using": [
+          ["repair_welding_standard", 1],
+          ["sewing_standard", 4]
+        ]
       }
     },
-    "breaks_into": [ { "item": "leather", "prob": 50 }, { "item": "scrap", "count": [ 1, 2 ] } ],
+    "breaks_into": [
+      { "item": "leather", "prob": 50 },
+      { "item": "scrap", "count": [1, 2] }
+    ],
     "size": "0 ml",
-    "extend": { "flags": [ "NONBELTABLE" ] },
-    "delete": { "flags": [ "BELTABLE", "CARGO" ] },
-    "variants_bases": [  ],
+    "extend": { "flags": ["NONBELTABLE"] },
+    "delete": { "flags": ["BELTABLE", "CARGO"] },
+    "variants_bases": [],
     "variants": [
-      { "id": "pedal", "label": "Pedals", "symbols": "#", "symbols_broken": "*" },
-      { "id": "motor", "label": "Motorcycle", "symbols": "#", "symbols_broken": "*" },
-      { "id": "scooter", "label": "Scooter", "symbols": "#", "symbols_broken": "*" }
+      {
+        "id": "pedal",
+        "label": "Pedals",
+        "symbols": "#",
+        "symbols_broken": "*"
+      },
+      {
+        "id": "motor",
+        "label": "Motorcycle",
+        "symbols": "#",
+        "symbols_broken": "*"
+      },
+      {
+        "id": "scooter",
+        "label": "Scooter",
+        "symbols": "#",
+        "symbols_broken": "*"
+      }
     ]
   },
   {
@@ -160,11 +228,17 @@
     "item": "sheet",
     "folded_volume": "1000 ml",
     "location": "anywhere",
-    "requirements": { "repair": { "skills": [ [ "tailor", 2 ] ], "time": "200 s", "using": [ [ "sewing_standard", 4 ] ] } },
-    "breaks_into": [ { "item": "cotton_patchwork", "count": [ 1, 6 ] } ],
-    "extend": { "flags": [ "BELTABLE" ] },
-    "delete": { "flags": [ "NONBELTABLE" ] },
-    "variants": [ { "symbols": "#", "symbols_broken": "*" } ]
+    "requirements": {
+      "repair": {
+        "skills": [["tailor", 2]],
+        "time": "200 s",
+        "using": [["sewing_standard", 4]]
+      }
+    },
+    "breaks_into": [{ "item": "cotton_patchwork", "count": [1, 6] }],
+    "extend": { "flags": ["BELTABLE"] },
+    "delete": { "flags": ["NONBELTABLE"] },
+    "variants": [{ "symbols": "#", "symbols_broken": "*" }]
   },
   {
     "id": "metal_bench",
@@ -178,9 +252,21 @@
     "//": "more metal here so bigger weld cost - 20 cm weld per damage quadrant",
     "name": { "str": "steel bench" },
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 1 ] ], "time": "60 m", "using": [ [ "welding_standard", 5 ] ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": "vehicle_weld_removal" },
-      "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "60 m", "using": [ [ "repair_welding_standard", 2 ] ] }
+      "install": {
+        "skills": [["mechanics", 1]],
+        "time": "60 m",
+        "using": [["welding_standard", 5]]
+      },
+      "removal": {
+        "skills": [["mechanics", 2]],
+        "time": "30 m",
+        "using": "vehicle_weld_removal"
+      },
+      "repair": {
+        "skills": [["mechanics", 2]],
+        "time": "60 m",
+        "using": [["repair_welding_standard", 2]]
+      }
     },
     "type": "vehicle_part"
   }

--- a/data/json/vehicleparts/seats.json
+++ b/data/json/vehicleparts/seats.json
@@ -1,10 +1,10 @@
 [
   {
     "entries": [
-      { "count": [2, 8], "item": "nylon" },
-      { "count": [1, 3], "item": "pipe" },
-      { "count": [0, 2], "item": "spring" },
-      { "count": [3, 5], "item": "scrap" }
+      { "count": [ 2, 8 ], "item": "nylon" },
+      { "count": [ 1, 3 ], "item": "pipe" },
+      { "count": [ 0, 2 ], "item": "spring" },
+      { "count": [ 3, 5 ], "item": "scrap" }
     ],
     "id": "ig_vp_seat",
     "subtype": "collection",
@@ -12,11 +12,11 @@
   },
   {
     "entries": [
-      { "count": [1, 5], "item": "leather" },
-      { "count": [1, 3], "item": "nylon" },
-      { "count": [1, 3], "item": "pipe" },
-      { "count": [0, 2], "item": "spring" },
-      { "count": [3, 5], "item": "scrap" }
+      { "count": [ 1, 5 ], "item": "leather" },
+      { "count": [ 1, 3 ], "item": "nylon" },
+      { "count": [ 1, 3 ], "item": "pipe" },
+      { "count": [ 0, 2 ], "item": "spring" },
+      { "count": [ 3, 5 ], "item": "scrap" }
     ],
     "id": "ig_vp_seat_leather",
     "subtype": "collection",
@@ -26,14 +26,14 @@
     "id": "seat",
     "breaks_into": "ig_vp_seat",
     "broken_color": "red",
-    "categories": ["operations", "passengers"],
+    "categories": [ "operations", "passengers" ],
     "color": "red",
     "comfort": 2,
     "damage_modifier": 60,
     "damage_reduction": { "all": 2, "bash": 5 },
     "description": "A soft upholstered car seat, contoured to hold one person.",
     "durability": 300,
-    "flags": ["SEAT", "BOARDABLE", "CARGO", "BELTABLE"],
+    "flags": [ "SEAT", "BOARDABLE", "CARGO", "BELTABLE" ],
     "floor_bedding_warmth": 200,
     "item": "seat",
     "location": "center",
@@ -41,63 +41,24 @@
     "//": "weld repairs would mostly be the frame and springs of the seat, so low 6 cm cost per quadrant",
     "name": { "str": "bucket seat" },
     "requirements": {
-      "install": {
-        "skills": [["mechanics", 1]],
-        "time": "30 m",
-        "using": [["vehicle_wrench_2", 1]]
-      },
-      "removal": {
-        "skills": [["mechanics", 2]],
-        "time": "15 m",
-        "using": [["vehicle_wrench_2", 1]]
-      },
+      "install": { "skills": [ [ "mechanics", 1 ] ], "time": "30 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
+      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "15 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
       "repair": {
-        "skills": [["mechanics", 2]],
+        "skills": [ [ "mechanics", 2 ] ],
         "time": "30 m",
-        "using": [
-          ["repair_welding_standard", 1],
-          ["sewing_standard", 8]
-        ]
+        "using": [ [ "repair_welding_standard", 1 ], [ "sewing_standard", 8 ] ]
       }
     },
     "size": "125 L",
     "type": "vehicle_part",
-    "variants_bases": [
-      { "id": "windshield", "label": "Windshield" },
-      { "id": "swivel_chair", "label": "Swivel Chair" }
-    ],
+    "variants_bases": [ { "id": "windshield", "label": "Windshield" }, { "id": "swivel_chair", "label": "Swivel Chair" } ],
     "variants": [
-      {
-        "id": "front",
-        "label": "Front",
-        "symbols": "#",
-        "symbols_broken": "*"
-      },
-      {
-        "id": "vertical",
-        "label": "Vertical",
-        "symbols": "#",
-        "symbols_broken": "*"
-      },
-      {
-        "id": "vertical_left",
-        "label": "Left Vertical",
-        "symbols": "#",
-        "symbols_broken": "*"
-      },
-      {
-        "id": "vertical_right",
-        "label": "Right Vertical",
-        "symbols": "#",
-        "symbols_broken": "*"
-      },
+      { "id": "front", "label": "Front", "symbols": "#", "symbols_broken": "*" },
+      { "id": "vertical", "label": "Vertical", "symbols": "#", "symbols_broken": "*" },
+      { "id": "vertical_left", "label": "Left Vertical", "symbols": "#", "symbols_broken": "*" },
+      { "id": "vertical_right", "label": "Right Vertical", "symbols": "#", "symbols_broken": "*" },
       { "id": "left", "label": "Left", "symbols": "#", "symbols_broken": "*" },
-      {
-        "id": "right",
-        "label": "Right",
-        "symbols": "#",
-        "symbols_broken": "*"
-      },
+      { "id": "right", "label": "Right", "symbols": "#", "symbols_broken": "*" },
       { "id": "rear", "label": "Rear", "symbols": "#", "symbols_broken": "*" }
     ]
   },
@@ -109,7 +70,7 @@
     "name": { "str": "leather bucket seat" },
     "description": "A leather car seat for one.",
     "type": "vehicle_part",
-    "variants_bases": [{ "id": "windshield", "label": "Windshield" }]
+    "variants_bases": [ { "id": "windshield", "label": "Windshield" } ]
   },
   {
     "id": "reclining_seat",
@@ -121,9 +82,9 @@
     "size": "115 L",
     "floor_bedding_warmth": 350,
     "name": { "str": "reclining bucket seat" },
-    "extend": { "flags": ["BED"] },
+    "extend": { "flags": [ "BED" ] },
     "type": "vehicle_part",
-    "variants_bases": [{ "id": "windshield", "label": "Windshield" }]
+    "variants_bases": [ { "id": "windshield", "label": "Windshield" } ]
   },
   {
     "id": "reclining_seat_leather",
@@ -133,7 +94,7 @@
     "looks_like": "seat_leather",
     "name": { "str": "reclining leather bucket seat" },
     "type": "vehicle_part",
-    "variants_bases": [{ "id": "windshield", "label": "Windshield" }]
+    "variants_bases": [ { "id": "windshield", "label": "Windshield" } ]
   },
   {
     "id": "seat_back",
@@ -144,7 +105,7 @@
     "item": "seat_bench",
     "size": "115 L",
     "name": { "str": "bench seat" },
-    "extend": { "flags": ["BED"] },
+    "extend": { "flags": [ "BED" ] },
     "type": "vehicle_part"
   },
   {
@@ -169,52 +130,23 @@
     "comfort": 1,
     "item": "saddle",
     "requirements": {
-      "install": {
-        "skills": [["mechanics", 1]],
-        "time": "200 s",
-        "using": [["vehicle_wrench_2", 1]]
-      },
-      "removal": {
-        "skills": [["mechanics", 1]],
-        "time": "200 s",
-        "using": [["vehicle_wrench_2", 1]]
-      },
+      "install": { "skills": [ [ "mechanics", 1 ] ], "time": "200 s", "using": [ [ "vehicle_wrench_2", 1 ] ] },
+      "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "200 s", "using": [ [ "vehicle_wrench_2", 1 ] ] },
       "repair": {
-        "skills": [["mechanics", 2]],
+        "skills": [ [ "mechanics", 2 ] ],
         "time": "20 m",
-        "using": [
-          ["repair_welding_standard", 1],
-          ["sewing_standard", 4]
-        ]
+        "using": [ [ "repair_welding_standard", 1 ], [ "sewing_standard", 4 ] ]
       }
     },
-    "breaks_into": [
-      { "item": "leather", "prob": 50 },
-      { "item": "scrap", "count": [1, 2] }
-    ],
+    "breaks_into": [ { "item": "leather", "prob": 50 }, { "item": "scrap", "count": [ 1, 2 ] } ],
     "size": "0 ml",
-    "extend": { "flags": ["NONBELTABLE"] },
-    "delete": { "flags": ["BELTABLE", "CARGO"] },
-    "variants_bases": [],
+    "extend": { "flags": [ "NONBELTABLE" ] },
+    "delete": { "flags": [ "BELTABLE", "CARGO" ] },
+    "variants_bases": [  ],
     "variants": [
-      {
-        "id": "pedal",
-        "label": "Pedals",
-        "symbols": "#",
-        "symbols_broken": "*"
-      },
-      {
-        "id": "motor",
-        "label": "Motorcycle",
-        "symbols": "#",
-        "symbols_broken": "*"
-      },
-      {
-        "id": "scooter",
-        "label": "Scooter",
-        "symbols": "#",
-        "symbols_broken": "*"
-      }
+      { "id": "pedal", "label": "Pedals", "symbols": "#", "symbols_broken": "*" },
+      { "id": "motor", "label": "Motorcycle", "symbols": "#", "symbols_broken": "*" },
+      { "id": "scooter", "label": "Scooter", "symbols": "#", "symbols_broken": "*" }
     ]
   },
   {
@@ -228,17 +160,11 @@
     "item": "sheet",
     "folded_volume": "1000 ml",
     "location": "anywhere",
-    "requirements": {
-      "repair": {
-        "skills": [["tailor", 2]],
-        "time": "200 s",
-        "using": [["sewing_standard", 4]]
-      }
-    },
-    "breaks_into": [{ "item": "cotton_patchwork", "count": [1, 6] }],
-    "extend": { "flags": ["BELTABLE"] },
-    "delete": { "flags": ["NONBELTABLE"] },
-    "variants": [{ "symbols": "#", "symbols_broken": "*" }]
+    "requirements": { "repair": { "skills": [ [ "tailor", 2 ] ], "time": "200 s", "using": [ [ "sewing_standard", 4 ] ] } },
+    "breaks_into": [ { "item": "cotton_patchwork", "count": [ 1, 6 ] } ],
+    "extend": { "flags": [ "BELTABLE" ] },
+    "delete": { "flags": [ "NONBELTABLE" ] },
+    "variants": [ { "symbols": "#", "symbols_broken": "*" } ]
   },
   {
     "id": "metal_bench",
@@ -252,21 +178,9 @@
     "//": "more metal here so bigger weld cost - 20 cm weld per damage quadrant",
     "name": { "str": "steel bench" },
     "requirements": {
-      "install": {
-        "skills": [["mechanics", 1]],
-        "time": "60 m",
-        "using": [["welding_standard", 5]]
-      },
-      "removal": {
-        "skills": [["mechanics", 2]],
-        "time": "30 m",
-        "using": "vehicle_weld_removal"
-      },
-      "repair": {
-        "skills": [["mechanics", 2]],
-        "time": "60 m",
-        "using": [["repair_welding_standard", 2]]
-      }
+      "install": { "skills": [ [ "mechanics", 1 ] ], "time": "60 m", "using": [ [ "welding_standard", 5 ] ] },
+      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": "vehicle_weld_removal" },
+      "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "60 m", "using": [ [ "repair_welding_standard", 2 ] ] }
     },
     "type": "vehicle_part"
   }

--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -4,9 +4,9 @@
     "id": "ig_vp_frame",
     "subtype": "collection",
     "entries": [
-      { "item": "steel_lump", "count": [ 4, 6 ] },
-      { "item": "steel_chunk", "count": [ 4, 6 ] },
-      { "item": "scrap", "count": [ 4, 6 ] }
+      { "item": "steel_lump", "count": [4, 6] },
+      { "item": "steel_chunk", "count": [4, 6] },
+      { "item": "scrap", "count": [4, 6] }
     ]
   },
   {
@@ -14,10 +14,10 @@
     "id": "ig_vp_prison_bench",
     "subtype": "collection",
     "entries": [
-      { "item": "steel_lump", "count": [ 3, 6 ] },
-      { "item": "steel_chunk", "count": [ 3, 6 ] },
-      { "item": "scrap", "count": [ 2, 4 ] },
-      { "item": "chain", "count": [ 1, 4 ] }
+      { "item": "steel_lump", "count": [3, 6] },
+      { "item": "steel_chunk", "count": [3, 6] },
+      { "item": "scrap", "count": [2, 4] },
+      { "item": "chain", "count": [1, 4] }
     ]
   },
   {
@@ -25,31 +25,31 @@
     "id": "ig_vp_hdframe",
     "subtype": "collection",
     "entries": [
-      { "item": "steel_lump", "count": [ 4, 6 ] },
-      { "item": "steel_chunk", "count": [ 4, 6 ] },
-      { "item": "scrap", "count": [ 4, 6 ] }
+      { "item": "steel_lump", "count": [4, 6] },
+      { "item": "steel_chunk", "count": [4, 6] },
+      { "item": "scrap", "count": [4, 6] }
     ]
   },
   {
     "type": "item_group",
     "id": "ig_vp_wood_plate",
     "subtype": "collection",
-    "entries": [ { "item": "splinter", "count": [ 7, 9 ] } ]
+    "entries": [{ "item": "splinter", "count": [7, 9] }]
   },
   {
     "type": "item_group",
     "id": "ig_vp_cloth",
     "subtype": "collection",
-    "entries": [ { "item": "cotton_patchwork", "count": [ 3, 6 ] } ]
+    "entries": [{ "item": "cotton_patchwork", "count": [3, 6] }]
   },
   {
     "type": "item_group",
     "id": "ig_vp_sheet_metal",
     "subtype": "collection",
     "entries": [
-      { "item": "steel_lump", "count": [ 3, 4 ] },
-      { "item": "steel_chunk", "count": [ 4, 6 ] },
-      { "item": "scrap", "count": [ 8, 10 ] }
+      { "item": "steel_lump", "count": [3, 4] },
+      { "item": "steel_chunk", "count": [4, 6] },
+      { "item": "scrap", "count": [8, 10] }
     ]
   },
   {
@@ -57,9 +57,9 @@
     "id": "ig_vp_steel_plate",
     "subtype": "collection",
     "entries": [
-      { "item": "steel_lump", "count": [ 4, 7 ] },
-      { "item": "steel_chunk", "count": [ 5, 6 ] },
-      { "item": "scrap", "count": [ 4, 6 ] }
+      { "item": "steel_lump", "count": [4, 7] },
+      { "item": "steel_chunk", "count": [5, 6] },
+      { "item": "scrap", "count": [4, 6] }
     ]
   },
   {
@@ -68,30 +68,30 @@
     "subtype": "collection",
     "entries": [
       { "item": "plastic_chunk", "prob": 50 },
-      { "item": "cable", "charges": [ 1, 4 ] },
-      { "item": "e_scrap", "count": [ 0, 2 ] },
-      { "item": "scrap", "count": [ 1, 3 ] }
+      { "item": "cable", "charges": [1, 4] },
+      { "item": "e_scrap", "count": [0, 2] },
+      { "item": "scrap", "count": [1, 3] }
     ]
   },
   {
     "type": "vehicle_part",
     "id": "null",
     "name": { "str": "null part" },
-    "categories": [ "other" ],
+    "categories": ["other"],
     "color": "red",
     "broken_color": "red",
     "durability": 100,
     "item": "null",
-    "flags": [ "NO_INSTALL_HIDDEN" ],
-    "breaks_into": [  ],
-    "variants": [ { "symbols": "?", "symbols_broken": "?" } ]
+    "flags": ["NO_INSTALL_HIDDEN"],
+    "breaks_into": [],
+    "variants": [{ "symbols": "?", "symbols_broken": "?" }]
   },
   {
     "type": "vehicle_part",
     "id": "yoke_harness",
     "name": { "str": "yoke and harness" },
     "looks_like": "frame_wood_cross",
-    "categories": [ "movement", "operations" ],
+    "categories": ["movement", "operations"],
     "color": "brown",
     "broken_color": "red",
     "damage_modifier": 10,
@@ -103,13 +103,25 @@
     "contact_area": 60,
     "rolling_resistance": 1.5,
     "wheel_offroad_rating": 0.7,
-    "wheel_terrain_modifiers": { "FLAT": [ 0, 3 ], "ROAD": [ 0, 1 ] },
+    "wheel_terrain_modifiers": { "FLAT": [0, 3], "ROAD": [0, 1] },
     "description": "Attach this part to a beast of burden to allow it to pull your vehicle.",
     "location": "structure",
     "requirements": {
-      "install": { "skills": [ [ "fabrication", 1 ] ], "time": "100 s", "using": [ [ "vehicle_screw", 1 ] ] },
-      "removal": { "skills": [ [ "fabrication", 1 ] ], "time": "100 s", "using": [ [ "vehicle_screw", 1 ] ] },
-      "repair": { "skills": [ [ "fabrication", 1 ] ], "time": "20 s", "using": [ [ "adhesive", 1 ] ] }
+      "install": {
+        "skills": [["fabrication", 1]],
+        "time": "100 s",
+        "using": [["vehicle_screw", 1]]
+      },
+      "removal": {
+        "skills": [["fabrication", 1]],
+        "time": "100 s",
+        "using": [["vehicle_screw", 1]]
+      },
+      "repair": {
+        "skills": [["fabrication", 1]],
+        "time": "20 s",
+        "using": [["adhesive", 1]]
+      }
     },
     "breaks_into": "ig_vp_wood_plate",
     "flags": [
@@ -125,14 +137,14 @@
       "HUGE_OK"
     ],
     "damage_reduction": { "all": 2 },
-    "variants": [ { "symbols": "H", "symbols_broken": "M" } ]
+    "variants": [{ "symbols": "H", "symbols_broken": "M" }]
   },
   {
     "type": "vehicle_part",
     "id": "yoke_harness_heavyduty",
     "name": { "str": "reinforced yoke and harness" },
     "looks_like": "yoke_harness",
-    "categories": [ "movement", "operations" ],
+    "categories": ["movement", "operations"],
     "color": "dark_gray",
     "broken_color": "dark_gray",
     "noise_factor": 10,
@@ -143,19 +155,31 @@
     "contact_area": 60,
     "rolling_resistance": 1.5,
     "wheel_offroad_rating": 0.7,
-    "wheel_terrain_modifiers": { "FLAT": [ 0, 3 ], "ROAD": [ 0, 1 ] },
+    "wheel_terrain_modifiers": { "FLAT": [0, 3], "ROAD": [0, 1] },
     "description": "Attach this part to a beast of burden to allow it to pull your vehicle.  This one is reinforced with heavy chains and steel.",
     "location": "structure",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 1 ] ], "time": "20 m", "using": [ [ "welding_standard", 10 ] ] },
-      "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "10 m", "using": "vehicle_weld_removal" },
-      "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "5 m", "using": [ [ "repair_welding_standard", 1 ] ] }
+      "install": {
+        "skills": [["mechanics", 1]],
+        "time": "20 m",
+        "using": [["welding_standard", 10]]
+      },
+      "removal": {
+        "skills": [["mechanics", 1]],
+        "time": "10 m",
+        "using": "vehicle_weld_removal"
+      },
+      "repair": {
+        "skills": [["mechanics", 1]],
+        "time": "5 m",
+        "using": [["repair_welding_standard", 1]]
+      }
     },
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 3, 5 ] },
-      { "item": "steel_chunk", "count": [ 3, 5 ] },
-      { "item": "scrap", "charges": [ 4, 8 ] },
-      { "item": "splinter", "count": [ 5, 9 ] }
+      { "item": "steel_lump", "count": [3, 5] },
+      { "item": "steel_chunk", "count": [3, 5] },
+      { "item": "scrap", "charges": [4, 8] },
+      { "item": "splinter", "count": [5, 9] }
     ],
     "flags": [
       "ENGINE",
@@ -170,14 +194,14 @@
       "HUGE_OK"
     ],
     "damage_reduction": { "all": 20 },
-    "variants": [ { "symbols": "H", "symbols_broken": "M" } ]
+    "variants": [{ "symbols": "H", "symbols_broken": "M" }]
   },
   {
     "type": "vehicle_part",
     "id": "cart_handle",
     "name": { "str": "cart handle" },
     "looks_like": "frame_wood_horizontal",
-    "categories": [ "movement", "operations" ],
+    "categories": ["movement", "operations"],
     "color": "white",
     "broken_color": "red",
     "damage_modifier": 10,
@@ -189,11 +213,23 @@
     "//": "10 cm weld per damage quadrant to repair, 10 cm weld to install",
     "location": "structure",
     "requirements": {
-      "install": { "skills": [ [ "fabrication", 1 ] ], "time": "150 s", "using": [ [ "welding_standard", 5 ] ] },
-      "removal": { "skills": [ [ "fabrication", 1 ] ], "time": "100 s", "using": [ [ "vehicle_weld_removal", 1 ] ] },
-      "repair": { "skills": [ [ "fabrication", 1 ] ], "time": "5 m", "using": [ [ "repair_welding_standard", 1 ] ] }
+      "install": {
+        "skills": [["fabrication", 1]],
+        "time": "150 s",
+        "using": [["welding_standard", 5]]
+      },
+      "removal": {
+        "skills": [["fabrication", 1]],
+        "time": "100 s",
+        "using": [["vehicle_weld_removal", 1]]
+      },
+      "repair": {
+        "skills": [["fabrication", 1]],
+        "time": "5 m",
+        "using": [["repair_welding_standard", 1]]
+      }
     },
-    "breaks_into": [ { "item": "scrap", "charges": [ 4, 6 ] } ],
+    "breaks_into": [{ "item": "scrap", "charges": [4, 6] }],
     "flags": [
       "ENGINE",
       "BOARDABLE",
@@ -205,14 +241,14 @@
       "HUGE_OK"
     ],
     "damage_reduction": { "all": 2 },
-    "variants": [ { "symbols": "-", "symbols_broken": "~" } ]
+    "variants": [{ "symbols": "-", "symbols_broken": "~" }]
   },
   {
     "type": "vehicle_part",
     "id": "bed",
     "name": { "str": "bed" },
     "looks_like": "f_bed",
-    "categories": [ "passengers" ],
+    "categories": ["passengers"],
     "color": "magenta",
     "broken_color": "magenta",
     "damage_modifier": 60,
@@ -225,31 +261,42 @@
     "location": "center",
     "//": "10 cm weld per damage quadrant to repair, 30 cm weld to install",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 1 ] ], "time": "15 m", "using": [ [ "welding_standard", 30 ] ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_weld_removal", 1 ] ] },
+      "install": {
+        "skills": [["mechanics", 1]],
+        "time": "15 m",
+        "using": [["welding_standard", 30]]
+      },
+      "removal": {
+        "skills": [["mechanics", 2]],
+        "time": "30 m",
+        "using": [["vehicle_weld_removal", 1]]
+      },
       "repair": {
-        "skills": [ [ "mechanics", 2 ] ],
+        "skills": [["mechanics", 2]],
         "time": "20 m",
-        "using": [ [ "repair_welding_standard", 1 ], [ "sewing_standard", 10 ] ]
+        "using": [
+          ["repair_welding_standard", 1],
+          ["sewing_standard", 10]
+        ]
       }
     },
-    "flags": [ "BED", "BOARDABLE", "CARGO", "MOUNTABLE", "NONBELTABLE" ],
+    "flags": ["BED", "BOARDABLE", "CARGO", "MOUNTABLE", "NONBELTABLE"],
     "breaks_into": [
-      { "count": [ 0, 2 ], "item": "sheet_cotton" },
-      { "count": [ 0, 5 ], "item": "cotton_patchwork" },
-      { "count": [ 9, 50 ], "item": "scrap_cotton" },
-      { "count": [ 0, 1 ], "item": "spring" },
-      { "count": [ 0, 2 ], "item": "wire" },
-      { "charges": [ 3, 8 ], "item": "scrap" }
+      { "count": [0, 2], "item": "sheet_cotton" },
+      { "count": [0, 5], "item": "cotton_patchwork" },
+      { "count": [9, 50], "item": "scrap_cotton" },
+      { "count": [0, 1], "item": "spring" },
+      { "count": [0, 2], "item": "wire" },
+      { "charges": [3, 8], "item": "scrap" }
     ],
     "damage_reduction": { "all": 3, "bash": 5 },
-    "variants": [ { "symbols": "#", "symbols_broken": "*" } ]
+    "variants": [{ "symbols": "#", "symbols_broken": "*" }]
   },
   {
     "type": "vehicle_part",
     "id": "frame_handle",
     "name": { "str": "handle" },
-    "categories": [ "hull" ],
+    "categories": ["hull"],
     "color": "light_cyan",
     "broken_color": "light_cyan",
     "durability": 30,
@@ -259,21 +306,36 @@
     "item": "pipe",
     "location": "structure",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 1 ] ], "time": "5 m", "using": [ [ "welding_standard", 10 ] ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "15 m", "using": [ [ "vehicle_weld_removal", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "5 m", "using": [ [ "repair_welding_standard", 1 ] ] }
+      "install": {
+        "skills": [["mechanics", 1]],
+        "time": "5 m",
+        "using": [["welding_standard", 10]]
+      },
+      "removal": {
+        "skills": [["mechanics", 2]],
+        "time": "15 m",
+        "using": [["vehicle_weld_removal", 1]]
+      },
+      "repair": {
+        "skills": [["mechanics", 2]],
+        "time": "5 m",
+        "using": [["repair_welding_standard", 1]]
+      }
     },
-    "flags": [ "MOUNTABLE" ],
-    "breaks_into": [ { "item": "steel_chunk", "count": [ 0, 1 ] }, { "item": "scrap", "charges": [ 3, 7 ] } ],
+    "flags": ["MOUNTABLE"],
+    "breaks_into": [
+      { "item": "steel_chunk", "count": [0, 1] },
+      { "item": "scrap", "charges": [3, 7] }
+    ],
     "damage_reduction": { "all": 5 },
-    "variants": [ { "symbols": "^", "symbols_broken": "#" } ]
+    "variants": [{ "symbols": "^", "symbols_broken": "#" }]
   },
   {
     "type": "vehicle_part",
     "id": "frame_wood_handle",
     "name": { "str": "wooden handle" },
     "looks_like": "frame_wood_cover",
-    "categories": [ "hull" ],
+    "categories": ["hull"],
     "color": "light_red",
     "broken_color": "brown",
     "durability": 150,
@@ -281,20 +343,35 @@
     "item": "frame_wood",
     "location": "structure",
     "requirements": {
-      "install": { "skills": [ [ "fabrication", 1 ] ], "time": "30 m", "using": [ [ "vehicle_nail_install", 1 ] ] },
-      "removal": { "skills": [ [ "fabrication", 2 ] ], "time": "15 m", "using": [ [ "vehicle_nail_removal", 1 ] ] },
-      "repair": { "skills": [ [ "fabrication", 2 ] ], "time": "30 m", "using": [ [ "adhesive", 2 ] ] }
+      "install": {
+        "skills": [["fabrication", 1]],
+        "time": "30 m",
+        "using": [["vehicle_nail_install", 1]]
+      },
+      "removal": {
+        "skills": [["fabrication", 2]],
+        "time": "15 m",
+        "using": [["vehicle_nail_removal", 1]]
+      },
+      "repair": {
+        "skills": [["fabrication", 2]],
+        "time": "30 m",
+        "using": [["adhesive", 2]]
+      }
     },
-    "breaks_into": [ { "item": "splinter", "count": [ 7, 9 ] }, { "item": "nail", "charges": [ 5, 10 ] } ],
+    "breaks_into": [
+      { "item": "splinter", "count": [7, 9] },
+      { "item": "nail", "charges": [5, 10] }
+    ],
     "damage_reduction": { "all": 4 },
-    "variants": [ { "symbols": "^", "symbols_broken": "#" } ]
+    "variants": [{ "symbols": "^", "symbols_broken": "#" }]
   },
   {
     "type": "vehicle_part",
     "id": "frame_wood_light_handle",
     "name": { "str": "light wooden handle" },
     "looks_like": "frame_wood_light_cover",
-    "categories": [ "hull" ],
+    "categories": ["hull"],
     "color": "light_red",
     "broken_color": "brown",
     "durability": 100,
@@ -302,53 +379,81 @@
     "item": "frame_wood_light",
     "location": "structure",
     "breaks_into": [
-      { "item": "splinter", "count": [ 5, 8 ] },
-      { "item": "string_36", "count": [ 1, 3 ] },
-      { "item": "string_6", "count": [ 1, 4 ] }
+      { "item": "splinter", "count": [5, 8] },
+      { "item": "string_36", "count": [1, 3] },
+      { "item": "string_6", "count": [1, 4] }
     ],
     "requirements": {
-      "install": { "skills": [ [ "fabrication", 0 ] ], "time": "10 m", "using": [ [ "rope_natural_short", 1 ] ] },
-      "repair": { "skills": [ [ "fabrication", 1 ] ], "time": "5 m", "using": [ [ "adhesive", 1 ] ] }
+      "install": {
+        "skills": [["fabrication", 0]],
+        "time": "10 m",
+        "using": [["rope_natural_short", 1]]
+      },
+      "repair": {
+        "skills": [["fabrication", 1]],
+        "time": "5 m",
+        "using": [["adhesive", 1]]
+      }
     },
-    "variants": [ { "symbols": "^", "symbols_broken": "#" } ]
+    "variants": [{ "symbols": "^", "symbols_broken": "#" }]
   },
   {
     "type": "vehicle_part",
     "id": "aisle",
     "name": { "str": "aisle" },
     "looks_like": "t_metal_floor",
-    "categories": [ "hull", "passengers" ],
+    "categories": ["hull", "passengers"],
     "color": "white",
     "durability": 400,
     "description": "An aisle.",
-    "size": "100 L",
+    "size": "120 L",
     "item": "sheet_metal",
     "location": "center",
     "//": ".5 m square sheet of metal, likely affixed with bolts in places, assume 200 cm weld to install and 50 cm weld to repair",
     "requirements": {
       "install": {
-        "skills": [ [ "mechanics", 1 ] ],
+        "skills": [["mechanics", 1]],
         "time": "30 m",
-        "using": [ [ "welding_standard", 200 ], [ "vehicle_bolt_install", 2 ] ]
+        "using": [
+          ["welding_standard", 200],
+          ["vehicle_bolt_install", 2]
+        ]
       },
       "removal": {
-        "skills": [ [ "mechanics", 2 ] ],
+        "skills": [["mechanics", 2]],
         "time": "30 m",
-        "using": [ [ "vehicle_weld_removal", 1 ], [ "vehicle_wrench_2", 1 ] ]
+        "using": [
+          ["vehicle_weld_removal", 1],
+          ["vehicle_wrench_2", 1]
+        ]
       },
-      "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "6 m", "using": [ [ "repair_welding_standard", 5 ] ] }
+      "repair": {
+        "skills": [["mechanics", 2]],
+        "time": "6 m",
+        "using": [["repair_welding_standard", 5]]
+      }
     },
-    "flags": [ "AISLE", "BOARDABLE", "CARGO" ],
+    "flags": ["AISLE", "BOARDABLE", "CARGO"],
     "breaks_into": [
-      { "item": "sheet_metal_small", "count": [ 0, 1 ] },
-      { "item": "steel_lump", "count": [ 1, 2 ] },
-      { "item": "steel_chunk", "count": [ 1, 3 ] },
-      { "item": "scrap", "charges": [ 4, 8 ] }
+      { "item": "sheet_metal_small", "count": [0, 1] },
+      { "item": "steel_lump", "count": [1, 2] },
+      { "item": "steel_chunk", "count": [1, 3] },
+      { "item": "scrap", "charges": [4, 8] }
     ],
     "damage_reduction": { "all": 28 },
     "variants": [
-      { "id": "horizontal", "label": "Horizontal", "symbols": "┃┃━┃┃┃━┃", "symbols_broken": "#" },
-      { "id": "vertical", "label": "Vertical", "symbols": "━━┃━━━┃━", "symbols_broken": "#" }
+      {
+        "id": "horizontal",
+        "label": "Horizontal",
+        "symbols": "┃┃━┃┃┃━┃",
+        "symbols_broken": "#"
+      },
+      {
+        "id": "vertical",
+        "label": "Vertical",
+        "symbols": "━━┃━━━┃━",
+        "symbols_broken": "#"
+      }
     ]
   },
   {
@@ -361,11 +466,26 @@
     "durability": 200,
     "item": "frame_wood",
     "requirements": {
-      "install": { "skills": [ [ "fabrication", 1 ] ], "time": "30 m", "using": [ [ "vehicle_nail_install", 1 ] ] },
-      "removal": { "skills": [ [ "fabrication", 2 ] ], "time": "15 m", "using": [ [ "vehicle_nail_removal", 1 ] ] },
-      "repair": { "skills": [ [ "fabrication", 2 ] ], "time": "30 m", "using": [ [ "adhesive", 2 ] ] }
+      "install": {
+        "skills": [["fabrication", 1]],
+        "time": "30 m",
+        "using": [["vehicle_nail_install", 1]]
+      },
+      "removal": {
+        "skills": [["fabrication", 2]],
+        "time": "15 m",
+        "using": [["vehicle_nail_removal", 1]]
+      },
+      "repair": {
+        "skills": [["fabrication", 2]],
+        "time": "30 m",
+        "using": [["adhesive", 2]]
+      }
     },
-    "breaks_into": [ { "item": "splinter", "count": [ 7, 9 ] }, { "item": "nail", "charges": [ 5, 10 ] } ],
+    "breaks_into": [
+      { "item": "splinter", "count": [7, 9] },
+      { "item": "nail", "charges": [5, 10] }
+    ],
     "damage_reduction": { "all": 16 }
   },
   {
@@ -377,15 +497,18 @@
     "description": "A collapsible aisle.",
     "folded_volume": "12500 ml",
     "item": "foldwoodframe",
-    "breaks_into": [ { "item": "splinter", "count": [ 7, 11 ] }, { "item": "nail", "charges": [ 5, 10 ] } ],
-    "flags": [ "AISLE", "BOARDABLE", "CARGO" ]
+    "breaks_into": [
+      { "item": "splinter", "count": [7, 11] },
+      { "item": "nail", "charges": [5, 10] }
+    ],
+    "flags": ["AISLE", "BOARDABLE", "CARGO"]
   },
   {
     "type": "vehicle_part",
     "id": "trunk_floor",
     "name": { "str": "floor trunk" },
     "looks_like": "t_carpet_red",
-    "categories": [ "cargo" ],
+    "categories": ["cargo"],
     "color": "white",
     "durability": 400,
     "description": "An aisle.  A hatch lets you access a cargo space beneath it, keeping items stored here out of the way.",
@@ -395,32 +518,49 @@
     "//": "same requirements as aisle to install but higher repair costs due to more mass",
     "requirements": {
       "install": {
-        "skills": [ [ "mechanics", 1 ] ],
+        "skills": [["mechanics", 1]],
         "time": "30 m",
-        "using": [ [ "welding_standard", 200 ], [ "vehicle_bolt_install", 2 ] ]
+        "using": [
+          ["welding_standard", 200],
+          ["vehicle_bolt_install", 2]
+        ]
       },
       "removal": {
-        "skills": [ [ "mechanics", 2 ] ],
+        "skills": [["mechanics", 2]],
         "time": "30 m",
-        "using": [ [ "vehicle_weld_removal", 1 ], [ "vehicle_wrench_2", 1 ] ]
+        "using": [
+          ["vehicle_weld_removal", 1],
+          ["vehicle_wrench_2", 1]
+        ]
       },
-      "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "10 m", "using": [ [ "repair_welding_standard", 6 ] ] }
+      "repair": {
+        "skills": [["mechanics", 2]],
+        "time": "10 m",
+        "using": [["repair_welding_standard", 6]]
+      }
     },
-    "flags": [ "AISLE", "BOARDABLE", "CARGO", "CARGO_PASSABLE", "LOCKABLE_CARGO", "COVERED" ],
+    "flags": [
+      "AISLE",
+      "BOARDABLE",
+      "CARGO",
+      "CARGO_PASSABLE",
+      "LOCKABLE_CARGO",
+      "COVERED"
+    ],
     "breaks_into": [
-      { "item": "sheet_metal_small", "count": [ 1, 3 ] },
-      { "item": "steel_lump", "count": [ 2, 4 ] },
-      { "item": "steel_chunk", "count": [ 2, 8 ] },
-      { "item": "scrap", "charges": [ 11, 17 ] }
+      { "item": "sheet_metal_small", "count": [1, 3] },
+      { "item": "steel_lump", "count": [2, 4] },
+      { "item": "steel_chunk", "count": [2, 8] },
+      { "item": "scrap", "charges": [11, 17] }
     ],
     "damage_reduction": { "all": 28 },
-    "variants": [ { "symbols": "=", "symbols_broken": "#" } ]
+    "variants": [{ "symbols": "=", "symbols_broken": "#" }]
   },
   {
     "type": "vehicle_part",
     "id": "roof_cloth",
     "name": { "str": "cloth roof" },
-    "categories": [ "hull" ],
+    "categories": ["hull"],
     "broken_color": "dark_gray",
     "durability": 15,
     "description": "A cloth roof.",
@@ -428,18 +568,33 @@
     "item": "sheet",
     "location": "roof",
     "requirements": {
-      "install": { "time": "5 m", "components": [ [ [ "string_6", 2 ], [ "duct_tape", 25 ] ] ] },
-      "repair": { "skills": [ [ "tailor", 1 ] ], "time": "150 s", "using": [ [ "sewing_standard", 50 ], [ "fabric_standard", 1 ] ] }
+      "install": {
+        "time": "5 m",
+        "components": [
+          [
+            ["string_6", 2],
+            ["duct_tape", 25]
+          ]
+        ]
+      },
+      "repair": {
+        "skills": [["tailor", 1]],
+        "time": "150 s",
+        "using": [
+          ["sewing_standard", 50],
+          ["fabric_standard", 1]
+        ]
+      }
     },
-    "flags": [ "ROOF" ],
+    "flags": ["ROOF"],
     "breaks_into": "ig_vp_cloth",
-    "variants": [ { "symbols": "#", "symbols_broken": "#" } ]
+    "variants": [{ "symbols": "#", "symbols_broken": "#" }]
   },
   {
     "type": "vehicle_part",
     "id": "roof",
     "name": { "str": "roof" },
-    "categories": [ "hull" ],
+    "categories": ["hull"],
     "broken_color": "dark_gray",
     "durability": 240,
     "description": "A metal roof.",
@@ -448,27 +603,37 @@
     "//": "same requirements as aisle",
     "requirements": {
       "install": {
-        "skills": [ [ "mechanics", 1 ] ],
+        "skills": [["mechanics", 1]],
         "time": "30 m",
-        "using": [ [ "welding_standard", 200 ], [ "vehicle_bolt_install", 2 ] ]
+        "using": [
+          ["welding_standard", 200],
+          ["vehicle_bolt_install", 2]
+        ]
       },
       "removal": {
-        "skills": [ [ "mechanics", 2 ] ],
+        "skills": [["mechanics", 2]],
         "time": "30 m",
-        "using": [ [ "vehicle_weld_removal", 1 ], [ "vehicle_wrench_2", 1 ] ]
+        "using": [
+          ["vehicle_weld_removal", 1],
+          ["vehicle_wrench_2", 1]
+        ]
       },
-      "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "6 m", "using": [ [ "repair_welding_standard", 5 ] ] }
+      "repair": {
+        "skills": [["mechanics", 2]],
+        "time": "6 m",
+        "using": [["repair_welding_standard", 5]]
+      }
     },
-    "flags": [ "ROOF" ],
+    "flags": ["ROOF"],
     "breaks_into": "ig_vp_sheet_metal",
     "damage_reduction": { "all": 20 },
-    "variants": [ { "symbols": "#", "symbols_broken": "#" } ]
+    "variants": [{ "symbols": "#", "symbols_broken": "#" }]
   },
   {
     "type": "vehicle_part",
     "id": "hdroof",
     "name": { "str": "heavy-duty roof" },
-    "categories": [ "hull" ],
+    "categories": ["hull"],
     "color": "dark_gray",
     "broken_color": "dark_gray",
     "durability": 1000,
@@ -478,27 +643,37 @@
     "location": "roof",
     "requirements": {
       "install": {
-        "skills": [ [ "mechanics", 1 ] ],
+        "skills": [["mechanics", 1]],
         "time": "50 m",
-        "using": [ [ "welding_standard", 300 ], [ "vehicle_bolt_install", 3 ] ]
+        "using": [
+          ["welding_standard", 300],
+          ["vehicle_bolt_install", 3]
+        ]
       },
       "removal": {
-        "skills": [ [ "mechanics", 2 ] ],
+        "skills": [["mechanics", 2]],
         "time": "30 m",
-        "using": [ [ "vehicle_weld_removal", 1 ], [ "vehicle_wrench_2", 1 ] ]
+        "using": [
+          ["vehicle_weld_removal", 1],
+          ["vehicle_wrench_2", 1]
+        ]
       },
-      "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "10 m", "using": [ [ "repair_welding_standard", 6 ] ] }
+      "repair": {
+        "skills": [["mechanics", 2]],
+        "time": "10 m",
+        "using": [["repair_welding_standard", 6]]
+      }
     },
-    "flags": [ "ROOF" ],
+    "flags": ["ROOF"],
     "breaks_into": "ig_vp_steel_plate",
     "damage_reduction": { "all": 30 },
-    "variants": [ { "symbols": "#", "symbols_broken": "#" } ]
+    "variants": [{ "symbols": "#", "symbols_broken": "#" }]
   },
   {
     "type": "vehicle_part",
     "id": "programmable_autopilot",
     "name": { "str": "programmable autopilot" },
-    "categories": [ "other" ],
+    "categories": ["other"],
     "color": "light_blue",
     "broken_color": "red",
     "damage_modifier": 80,
@@ -508,33 +683,47 @@
     "item": "programmable_autopilot",
     "looks_like": "cam_control",
     "epower": "-15 W",
-    "flags": [ "ENABLED_DRAINS_EPOWER", "AUTOPILOT" ],
+    "flags": ["ENABLED_DRAINS_EPOWER", "AUTOPILOT"],
     "requirements": {
       "install": {
         "time": "12 m",
-        "skills": [ [ "mechanics", 5 ], [ "electronics", 5 ], [ "computer", 5 ] ],
-        "qualities": [ { "id": "SCREW", "level": 1 } ]
+        "skills": [
+          ["mechanics", 5],
+          ["electronics", 5],
+          ["computer", 5]
+        ],
+        "qualities": [{ "id": "SCREW", "level": 1 }]
       },
-      "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "3 m", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 8 ] ] },
-      "removal": { "skills": [ [ "mechanics", 3 ] ], "qualities": [ { "id": "SCREW", "level": 1 } ] }
+      "repair": {
+        "skills": [["mechanics", 3]],
+        "time": "3 m",
+        "using": [
+          ["adhesive", 1],
+          ["soldering_standard", 8]
+        ]
+      },
+      "removal": {
+        "skills": [["mechanics", 3]],
+        "qualities": [{ "id": "SCREW", "level": 1 }]
+      }
     },
     "breaks_into": [
       { "item": "RAM", "prob": 10 },
-      { "item": "steel_lump", "count": [ 0, 2 ] },
-      { "item": "steel_chunk", "count": [ 2, 4 ] },
-      { "item": "scrap", "charges": [ 5, 12 ] },
-      { "item": "e_scrap", "count": [ 2, 5 ] },
-      { "item": "plastic_chunk", "count": [ 3, 6 ] },
-      { "item": "cable", "charges": [ 9, 17 ] }
+      { "item": "steel_lump", "count": [0, 2] },
+      { "item": "steel_chunk", "count": [2, 4] },
+      { "item": "scrap", "charges": [5, 12] },
+      { "item": "e_scrap", "count": [2, 5] },
+      { "item": "plastic_chunk", "count": [3, 6] },
+      { "item": "cable", "charges": [9, 17] }
     ],
     "damage_reduction": { "all": 8 },
-    "variants": [ { "symbols": "A", "symbols_broken": "#" } ]
+    "variants": [{ "symbols": "A", "symbols_broken": "#" }]
   },
   {
     "type": "vehicle_part",
     "id": "storage_battery_mount",
     "name": { "str": "swappable storage battery case" },
-    "categories": [ "energy" ],
+    "categories": ["energy"],
     "broken_color": "red",
     "damage_modifier": 80,
     "durability": 300,
@@ -544,31 +733,41 @@
     "location": "fuel_source",
     "requirements": {
       "install": {
-        "skills": [ [ "mechanics", 2 ] ],
+        "skills": [["mechanics", 2]],
         "time": "10 m",
-        "using": [ [ "welding_standard", 40 ], [ "vehicle_bolt_install", 1 ] ]
+        "using": [
+          ["welding_standard", 40],
+          ["vehicle_bolt_install", 1]
+        ]
       },
       "removal": {
-        "skills": [ [ "mechanics", 2 ] ],
+        "skills": [["mechanics", 2]],
         "time": "10 m",
-        "using": [ [ "vehicle_weld_removal", 1 ], [ "vehicle_wrench_2", 1 ] ]
+        "using": [
+          ["vehicle_weld_removal", 1],
+          ["vehicle_wrench_2", 1]
+        ]
       },
-      "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "5 m", "using": [ [ "repair_welding_standard", 1 ] ] }
+      "repair": {
+        "skills": [["mechanics", 3]],
+        "time": "5 m",
+        "using": [["repair_welding_standard", 1]]
+      }
     },
-    "flags": [ "BATTERY_MOUNT" ],
+    "flags": ["BATTERY_MOUNT"],
     "breaks_into": [
       { "item": "steel_lump", "prob": 50 },
-      { "item": "steel_chunk", "count": [ 1, 2 ] },
-      { "item": "scrap", "charges": [ 0, 3 ] }
+      { "item": "steel_chunk", "count": [1, 2] },
+      { "item": "scrap", "charges": [0, 3] }
     ],
     "damage_reduction": { "all": 8, "bash": 10 },
-    "variants": [ { "symbols": "O", "symbols_broken": "#" } ]
+    "variants": [{ "symbols": "O", "symbols_broken": "#" }]
   },
   {
     "type": "vehicle_part",
     "id": "handheld_battery_mount",
     "name": { "str": "tool battery mount" },
-    "categories": [ "energy" ],
+    "categories": ["energy"],
     "broken_color": "red",
     "damage_modifier": 80,
     "durability": 100,
@@ -577,14 +776,32 @@
     "item": "it_handheld_battery_mount",
     "location": "fuel_source",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 2 ] ], "time": "10 m", "qualities": [ { "id": "WRENCH", "level": 1 } ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "5 m", "qualities": [ { "id": "WRENCH", "level": 1 } ] },
-      "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "5 m", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 3 ] ] }
+      "install": {
+        "skills": [["mechanics", 2]],
+        "time": "10 m",
+        "qualities": [{ "id": "WRENCH", "level": 1 }]
+      },
+      "removal": {
+        "skills": [["mechanics", 2]],
+        "time": "5 m",
+        "qualities": [{ "id": "WRENCH", "level": 1 }]
+      },
+      "repair": {
+        "skills": [["mechanics", 3]],
+        "time": "5 m",
+        "using": [
+          ["adhesive", 1],
+          ["soldering_standard", 3]
+        ]
+      }
     },
-    "flags": [ "HANDHELD_BATTERY_MOUNT" ],
-    "breaks_into": [ { "item": "power_supply", "prob": 50 }, { "item": "scrap", "charges": [ 1, 4 ] } ],
+    "flags": ["HANDHELD_BATTERY_MOUNT"],
+    "breaks_into": [
+      { "item": "power_supply", "prob": 50 },
+      { "item": "scrap", "charges": [1, 4] }
+    ],
     "damage_reduction": { "all": 4, "bash": 5 },
-    "variants": [ { "symbols": "O", "symbols_broken": "#" } ]
+    "variants": [{ "symbols": "O", "symbols_broken": "#" }]
   },
   {
     "type": "vehicle_part",
@@ -593,26 +810,35 @@
     "item": "black_box",
     "description": "An armored black box, a device meant to record and preserve data of a military vehicle in the field in case it gets destroyed.",
     "durability": 400,
-    "categories": [ "other" ],
+    "categories": ["other"],
     "broken_color": "dark_gray",
-    "flags": [ "NO_REPAIR" ],
+    "flags": ["NO_REPAIR"],
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 2 ] ], "qualities": [ { "id": "SCREW", "level": 3 }, { "id": "WRENCH", "level": 3 } ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "using": [ [ "vehicle_screw", 1 ] ] }
+      "install": {
+        "skills": [["mechanics", 2]],
+        "qualities": [
+          { "id": "SCREW", "level": 3 },
+          { "id": "WRENCH", "level": 3 }
+        ]
+      },
+      "removal": {
+        "skills": [["mechanics", 2]],
+        "using": [["vehicle_screw", 1]]
+      }
     },
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 0, 2 ] },
-      { "item": "steel_chunk", "count": [ 1, 3 ] },
-      { "item": "e_scrap", "count": [ 1, 2 ] }
+      { "item": "steel_lump", "count": [0, 2] },
+      { "item": "steel_chunk", "count": [1, 3] },
+      { "item": "e_scrap", "count": [1, 2] }
     ],
     "damage_reduction": { "all": 80 },
-    "variants": [ { "symbols": ";", "symbols_broken": "*" } ]
+    "variants": [{ "symbols": ";", "symbols_broken": "*" }]
   },
   {
     "type": "vehicle_part",
     "id": "minireactor",
     "name": { "str": "minireactor" },
-    "categories": [ "energy" ],
+    "categories": ["energy"],
     "color": "light_green",
     "broken_color": "red",
     "damage_modifier": 80,
@@ -626,58 +852,69 @@
     "location": "fuel_source",
     "requirements": {
       "install": {
-        "skills": [ [ "mechanics", 6 ] ],
+        "skills": [["mechanics", 6]],
         "time": "30 m",
-        "using": [ [ "welding_standard", 5 ], [ "vehicle_bolt_install", 1 ] ]
+        "using": [
+          ["welding_standard", 5],
+          ["vehicle_bolt_install", 1]
+        ]
       },
       "removal": {
-        "skills": [ [ "mechanics", 4 ] ],
+        "skills": [["mechanics", 4]],
         "time": "30 m",
-        "using": [ [ "vehicle_weld_removal", 1 ], [ "vehicle_wrench_2", 1 ] ]
+        "using": [
+          ["vehicle_weld_removal", 1],
+          ["vehicle_wrench_2", 1]
+        ]
       },
       "repair": {
-        "skills": [ [ "mechanics", 7 ] ],
+        "skills": [["mechanics", 7]],
         "time": "60 m",
-        "using": [ [ "repair_welding_standard", 5 ], [ "repair_welding_alloys", 2 ], [ "vehicle_wrench_2", 1 ], [ "vehicle_screw", 1 ] ]
+        "using": [
+          ["repair_welding_standard", 5],
+          ["repair_welding_alloys", 2],
+          ["vehicle_wrench_2", 1],
+          ["vehicle_screw", 1]
+        ]
       }
     },
-    "flags": [ "REACTOR" ],
+    "flags": ["REACTOR"],
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 6, 11 ] },
-      { "item": "steel_chunk", "count": [ 6, 11 ] },
-      { "item": "scrap", "charges": [ 6, 11 ] }
+      { "item": "steel_lump", "count": [6, 11] },
+      { "item": "steel_chunk", "count": [6, 11] },
+      { "item": "scrap", "charges": [6, 11] }
     ],
     "damage_reduction": { "all": 50 },
-    "variants": [ { "symbols": "O", "symbols_broken": "#" } ]
+    "variants": [{ "symbols": "O", "symbols_broken": "#" }]
   },
   {
     "type": "vehicle_part",
     "id": "minifridge",
-    "delete": { "flags": [ "APPLIANCE", "CTRL_ELECTRONIC" ] },
+    "delete": { "flags": ["APPLIANCE", "CTRL_ELECTRONIC"] },
     "copy-from": "ap_minifridge"
   },
   {
     "type": "vehicle_part",
     "id": "big_portable_fridge",
-    "delete": { "flags": [ "APPLIANCE", "CTRL_ELECTRONIC" ] },
+    "delete": { "flags": ["APPLIANCE", "CTRL_ELECTRONIC"] },
     "copy-from": "ap_big_portable_fridge"
   },
   {
     "type": "vehicle_part",
     "id": "minifreezer",
-    "delete": { "flags": [ "APPLIANCE", "CTRL_ELECTRONIC" ] },
+    "delete": { "flags": ["APPLIANCE", "CTRL_ELECTRONIC"] },
     "copy-from": "ap_minifreezer"
   },
   {
     "type": "vehicle_part",
     "id": "chest_minifreezer",
-    "delete": { "flags": [ "APPLIANCE", "CTRL_ELECTRONIC" ] },
+    "delete": { "flags": ["APPLIANCE", "CTRL_ELECTRONIC"] },
     "copy-from": "ap_chest_minifreezer"
   },
   {
     "type": "vehicle_part",
     "id": "big_portable_freezer",
-    "delete": { "flags": [ "APPLIANCE", "CTRL_ELECTRONIC" ] },
+    "delete": { "flags": ["APPLIANCE", "CTRL_ELECTRONIC"] },
     "copy-from": "ap_big_portable_freezer"
   },
   {
@@ -685,7 +922,7 @@
     "id": "washing_machine",
     "name": { "str": "washing machine" },
     "looks_like": "f_washer",
-    "categories": [ "utility" ],
+    "categories": ["utility"],
     "color": "light_blue",
     "broken_color": "light_blue",
     "damage_modifier": 80,
@@ -697,32 +934,49 @@
     "location": "center",
     "//1": "20 cm weld per quadrant of damage",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 3 ] ], "time": "60 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
+      "install": {
+        "skills": [["mechanics", 3]],
+        "time": "60 m",
+        "using": [["vehicle_wrench_2", 1]]
+      },
+      "removal": {
+        "skills": [["mechanics", 2]],
+        "time": "30 m",
+        "using": [["vehicle_wrench_2", 1]]
+      },
       "repair": {
-        "skills": [ [ "mechanics", 4 ] ],
+        "skills": [["mechanics", 4]],
         "time": "20 m",
-        "using": [ [ "repair_welding_standard", 4 ], [ "soldering_standard", 8 ] ]
+        "using": [
+          ["repair_welding_standard", 4],
+          ["soldering_standard", 8]
+        ]
       }
     },
-    "flags": [ "CARGO", "OBSTACLE", "WASHING_MACHINE", "COVERED", "ENABLED_DRAINS_EPOWER" ],
+    "flags": [
+      "CARGO",
+      "OBSTACLE",
+      "WASHING_MACHINE",
+      "COVERED",
+      "ENABLED_DRAINS_EPOWER"
+    ],
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 8, 13 ] },
-      { "item": "steel_chunk", "count": [ 8, 13 ] },
-      { "item": "scrap", "charges": [ 8, 13 ] },
+      { "item": "steel_lump", "count": [8, 13] },
+      { "item": "steel_chunk", "count": [8, 13] },
+      { "item": "scrap", "charges": [8, 13] },
       { "item": "hose", "prob": 50 },
       { "item": "scrap_copper", "prob": 15 },
-      { "item": "cable", "charges": [ 1, 3 ] },
-      { "item": "copper", "charges": [ 7, 30 ] }
+      { "item": "cable", "charges": [1, 3] },
+      { "item": "copper", "charges": [7, 30] }
     ],
     "damage_reduction": { "all": 32 },
-    "variants": [ { "symbols": "H", "symbols_broken": "#" } ]
+    "variants": [{ "symbols": "H", "symbols_broken": "#" }]
   },
   {
     "type": "vehicle_part",
     "id": "dishwasher",
     "name": { "str": "portable dishwasher" },
-    "categories": [ "utility" ],
+    "categories": ["utility"],
     "color": "light_blue",
     "broken_color": "light_blue",
     "damage_modifier": 80,
@@ -735,32 +989,49 @@
     "looks_like": "washing_machine",
     "//1": "20 cm weld per quadrant of damage",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 3 ] ], "time": "60 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
+      "install": {
+        "skills": [["mechanics", 3]],
+        "time": "60 m",
+        "using": [["vehicle_wrench_2", 1]]
+      },
+      "removal": {
+        "skills": [["mechanics", 2]],
+        "time": "30 m",
+        "using": [["vehicle_wrench_2", 1]]
+      },
       "repair": {
-        "skills": [ [ "mechanics", 4 ] ],
+        "skills": [["mechanics", 4]],
         "time": "20 m",
-        "using": [ [ "repair_welding_standard", 4 ], [ "soldering_standard", 5 ] ]
+        "using": [
+          ["repair_welding_standard", 4],
+          ["soldering_standard", 5]
+        ]
       }
     },
-    "flags": [ "CARGO", "OBSTACLE", "DISHWASHER", "COVERED", "ENABLED_DRAINS_EPOWER" ],
+    "flags": [
+      "CARGO",
+      "OBSTACLE",
+      "DISHWASHER",
+      "COVERED",
+      "ENABLED_DRAINS_EPOWER"
+    ],
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 8, 13 ] },
-      { "item": "steel_chunk", "count": [ 8, 13 ] },
-      { "item": "scrap", "charges": [ 8, 13 ] },
+      { "item": "steel_lump", "count": [8, 13] },
+      { "item": "steel_chunk", "count": [8, 13] },
+      { "item": "scrap", "charges": [8, 13] },
       { "item": "hose", "prob": 50 },
       { "item": "scrap_copper", "prob": 15 },
-      { "item": "cable", "charges": [ 1, 3 ] },
-      { "item": "copper", "charges": [ 7, 30 ] }
+      { "item": "cable", "charges": [1, 3] },
+      { "item": "copper", "charges": [7, 30] }
     ],
-    "variants": [ { "symbols": "d", "symbols_broken": "#" } ]
+    "variants": [{ "symbols": "d", "symbols_broken": "#" }]
   },
   {
     "type": "vehicle_part",
     "id": "autoclave",
     "name": { "str": "autoclave" },
     "looks_like": "dishwasher",
-    "categories": [ "utility" ],
+    "categories": ["utility"],
     "color": "yellow",
     "broken_color": "light_blue",
     "damage_modifier": 80,
@@ -772,28 +1043,46 @@
     "location": "center",
     "//1": "20 cm weld per quadrant of damage",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 3 ] ], "time": "60 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 4 ] ], "time": "20 m", "using": [ [ "repair_welding_standard", 20 ] ] }
+      "install": {
+        "skills": [["mechanics", 3]],
+        "time": "60 m",
+        "using": [["vehicle_wrench_2", 1]]
+      },
+      "removal": {
+        "skills": [["mechanics", 2]],
+        "time": "30 m",
+        "using": [["vehicle_wrench_2", 1]]
+      },
+      "repair": {
+        "skills": [["mechanics", 4]],
+        "time": "20 m",
+        "using": [["repair_welding_standard", 20]]
+      }
     },
-    "flags": [ "CARGO", "OBSTACLE", "AUTOCLAVE", "COVERED", "ENABLED_DRAINS_EPOWER" ],
+    "flags": [
+      "CARGO",
+      "OBSTACLE",
+      "AUTOCLAVE",
+      "COVERED",
+      "ENABLED_DRAINS_EPOWER"
+    ],
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 8, 13 ] },
-      { "item": "steel_chunk", "count": [ 8, 13 ] },
-      { "item": "scrap", "charges": [ 8, 13 ] },
+      { "item": "steel_lump", "count": [8, 13] },
+      { "item": "steel_chunk", "count": [8, 13] },
+      { "item": "scrap", "charges": [8, 13] },
       { "item": "hose", "prob": 50 },
       { "item": "scrap_copper", "prob": 15 },
-      { "item": "cable", "charges": [ 1, 3 ] },
-      { "item": "copper", "charges": [ 7, 30 ] }
+      { "item": "cable", "charges": [1, 3] },
+      { "item": "copper", "charges": [7, 30] }
     ],
-    "variants": [ { "symbols": "A", "symbols_broken": "#" } ]
+    "variants": [{ "symbols": "A", "symbols_broken": "#" }]
   },
   {
     "type": "vehicle_part",
     "id": "trunk",
     "name": { "str": "trunk" },
     "looks_like": "f_locker",
-    "categories": [ "cargo" ],
+    "categories": ["cargo"],
     "color": "brown",
     "broken_color": "brown",
     "damage_modifier": 80,
@@ -805,28 +1094,38 @@
     "location": "center",
     "requirements": {
       "install": {
-        "skills": [ [ "mechanics", 1 ] ],
+        "skills": [["mechanics", 1]],
         "time": "20 m",
-        "using": [ [ "welding_standard", 120 ], [ "vehicle_bolt_install", 1 ] ]
+        "using": [
+          ["welding_standard", 120],
+          ["vehicle_bolt_install", 1]
+        ]
       },
       "removal": {
-        "skills": [ [ "mechanics", 2 ] ],
+        "skills": [["mechanics", 2]],
         "time": "20 m",
-        "using": [ [ "vehicle_weld_removal", 1 ], [ "vehicle_wrench_2", 1 ] ]
+        "using": [
+          ["vehicle_weld_removal", 1],
+          ["vehicle_wrench_2", 1]
+        ]
       },
-      "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "5 m", "using": [ [ "repair_welding_standard", 3 ] ] }
+      "repair": {
+        "skills": [["mechanics", 2]],
+        "time": "5 m",
+        "using": [["repair_welding_standard", 3]]
+      }
     },
-    "flags": [ "CARGO", "LOCKABLE_CARGO", "COVERED", "BOARDABLE", "SIMPLE_PART" ],
+    "flags": ["CARGO", "LOCKABLE_CARGO", "COVERED", "BOARDABLE", "SIMPLE_PART"],
     "breaks_into": "ig_vp_frame",
     "damage_reduction": { "all": 30 },
-    "variants": [ { "symbols": "H", "symbols_broken": "#" } ]
+    "variants": [{ "symbols": "H", "symbols_broken": "#" }]
   },
   {
     "type": "vehicle_part",
     "id": "trunk_sedan",
     "name": { "str": "sedan trunk" },
     "looks_like": "trunk",
-    "categories": [ "cargo" ],
+    "categories": ["cargo"],
     "color": "brown",
     "broken_color": "brown",
     "damage_modifier": 80,
@@ -838,28 +1137,44 @@
     "location": "center",
     "requirements": {
       "install": {
-        "skills": [ [ "mechanics", 1 ] ],
+        "skills": [["mechanics", 1]],
         "time": "20 m",
-        "using": [ [ "welding_standard", 120 ], [ "vehicle_bolt_install", 1 ] ]
+        "using": [
+          ["welding_standard", 120],
+          ["vehicle_bolt_install", 1]
+        ]
       },
       "removal": {
-        "skills": [ [ "mechanics", 2 ] ],
+        "skills": [["mechanics", 2]],
         "time": "20 m",
-        "using": [ [ "vehicle_weld_removal", 1 ], [ "vehicle_wrench_2", 1 ] ]
+        "using": [
+          ["vehicle_weld_removal", 1],
+          ["vehicle_wrench_2", 1]
+        ]
       },
-      "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "5 m", "using": [ [ "repair_welding_standard", 3 ] ] }
+      "repair": {
+        "skills": [["mechanics", 2]],
+        "time": "5 m",
+        "using": [["repair_welding_standard", 3]]
+      }
     },
-    "flags": [ "CARGO", "LOCKABLE_CARGO", "COVERED", "SIMPLE_PART", "HALF_BOARD" ],
+    "flags": [
+      "CARGO",
+      "LOCKABLE_CARGO",
+      "COVERED",
+      "SIMPLE_PART",
+      "HALF_BOARD"
+    ],
     "breaks_into": "ig_vp_frame",
     "damage_reduction": { "all": 30 },
-    "variants": [ { "symbols": "H", "symbols_broken": "#" } ]
+    "variants": [{ "symbols": "H", "symbols_broken": "#" }]
   },
   {
     "type": "vehicle_part",
     "id": "travois",
     "name": { "str": "travois" },
     "looks_like": "frame_wood_light_cross",
-    "categories": [ "cargo" ],
+    "categories": ["cargo"],
     "color": "brown",
     "broken_color": "brown",
     "damage_modifier": 60,
@@ -867,25 +1182,25 @@
     "size": "75 L",
     "item": "frame_wood_light",
     "location": "center",
-    "flags": [ "CARGO", "BOARDABLE", "COVERED", "HUGE_OK", "CARGO_PASSABLE" ],
+    "flags": ["CARGO", "BOARDABLE", "COVERED", "HUGE_OK", "CARGO_PASSABLE"],
     "breaks_into": [
-      { "item": "splinter", "count": [ 5, 8 ] },
-      { "item": "string_36", "count": [ 1, 3 ] },
-      { "item": "string_6", "count": [ 1, 4 ] }
+      { "item": "splinter", "count": [5, 8] },
+      { "item": "string_36", "count": [1, 3] },
+      { "item": "string_6", "count": [1, 4] }
     ],
     "requirements": {
-      "install": { "time": "10 m", "using": [ [ "rope_natural_short", 1 ] ] },
-      "repair": { "time": "5 m", "using": [ [ "adhesive", 1 ] ] }
+      "install": { "time": "10 m", "using": [["rope_natural_short", 1]] },
+      "repair": { "time": "5 m", "using": [["adhesive", 1]] }
     },
     "damage_reduction": { "all": 4 },
-    "variants": [ { "symbols": "o", "symbols_broken": "#" } ]
+    "variants": [{ "symbols": "o", "symbols_broken": "#" }]
   },
   {
     "type": "vehicle_part",
     "id": "wood box",
     "name": { "str": "wood box" },
     "looks_like": "f_crate_o",
-    "categories": [ "cargo" ],
+    "categories": ["cargo"],
     "color": "brown",
     "broken_color": "brown",
     "damage_modifier": 60,
@@ -894,21 +1209,42 @@
     "item": "frame_wood",
     "location": "center",
     "requirements": {
-      "install": { "skills": [ [ "fabrication", 1 ] ], "time": "30 m", "using": [ [ "vehicle_nail_install", 1 ] ] },
-      "removal": { "skills": [ [ "fabrication", 1 ] ], "time": "15 m", "using": [ [ "vehicle_nail_removal", 1 ] ] },
-      "repair": { "skills": [ [ "fabrication", 1 ] ], "time": "30 m", "using": [ [ "adhesive", 2 ] ] }
+      "install": {
+        "skills": [["fabrication", 1]],
+        "time": "30 m",
+        "using": [["vehicle_nail_install", 1]]
+      },
+      "removal": {
+        "skills": [["fabrication", 1]],
+        "time": "15 m",
+        "using": [["vehicle_nail_removal", 1]]
+      },
+      "repair": {
+        "skills": [["fabrication", 1]],
+        "time": "30 m",
+        "using": [["adhesive", 2]]
+      }
     },
-    "flags": [ "CARGO", "BOARDABLE", "COVERED", "LOCKABLE_CARGO", "CARGO_PASSABLE" ],
-    "breaks_into": [ { "item": "splinter", "count": [ 3, 5 ] }, { "item": "nail", "charges": [ 10, 15 ] } ],
+    "flags": [
+      "CARGO",
+      "BOARDABLE",
+      "COVERED",
+      "LOCKABLE_CARGO",
+      "CARGO_PASSABLE"
+    ],
+    "breaks_into": [
+      { "item": "splinter", "count": [3, 5] },
+      { "item": "nail", "charges": [10, 15] }
+    ],
     "damage_reduction": { "all": 5 },
-    "variants": [ { "symbols": "o", "symbols_broken": "#" } ]
+    "variants": [{ "symbols": "o", "symbols_broken": "#" }]
   },
   {
     "type": "vehicle_part",
     "id": "folding wood box",
     "name": { "str": "folding wood box" },
     "looks_like": "wood box",
-    "categories": [ "cargo" ],
+    "categories": ["cargo"],
     "color": "brown",
     "broken_color": "brown",
     "damage_modifier": 60,
@@ -918,21 +1254,42 @@
     "item": "foldwoodframe",
     "location": "center",
     "requirements": {
-      "install": { "skills": [ [ "fabrication", 1 ] ], "time": "30 m", "using": [ [ "vehicle_nail_install", 1 ] ] },
-      "removal": { "skills": [ [ "fabrication", 2 ] ], "time": "15 m", "using": [ [ "vehicle_nail_removal", 1 ] ] },
-      "repair": { "skills": [ [ "fabrication", 2 ] ], "time": "30 m", "using": [ [ "adhesive", 2 ] ] }
+      "install": {
+        "skills": [["fabrication", 1]],
+        "time": "30 m",
+        "using": [["vehicle_nail_install", 1]]
+      },
+      "removal": {
+        "skills": [["fabrication", 2]],
+        "time": "15 m",
+        "using": [["vehicle_nail_removal", 1]]
+      },
+      "repair": {
+        "skills": [["fabrication", 2]],
+        "time": "30 m",
+        "using": [["adhesive", 2]]
+      }
     },
-    "flags": [ "CARGO", "BOARDABLE", "COVERED", "LOCKABLE_CARGO", "CARGO_PASSABLE" ],
-    "breaks_into": [ { "item": "splinter", "count": [ 4, 7 ] }, { "item": "nail", "charges": [ 10, 15 ] } ],
+    "flags": [
+      "CARGO",
+      "BOARDABLE",
+      "COVERED",
+      "LOCKABLE_CARGO",
+      "CARGO_PASSABLE"
+    ],
+    "breaks_into": [
+      { "item": "splinter", "count": [4, 7] },
+      { "item": "nail", "charges": [10, 15] }
+    ],
     "damage_reduction": { "all": 4 },
-    "variants": [ { "symbols": "o", "symbols_broken": "#" } ]
+    "variants": [{ "symbols": "o", "symbols_broken": "#" }]
   },
   {
     "type": "vehicle_part",
     "id": "veh_table",
     "name": { "str": "table" },
     "looks_like": "f_table",
-    "categories": [ "utility" ],
+    "categories": ["utility"],
     "color": "red",
     "damage_modifier": 60,
     "durability": 145,
@@ -940,22 +1297,38 @@
     "item": "v_table",
     "location": "center",
     "requirements": {
-      "install": { "skills": [ [ "fabrication", 1 ] ], "time": "15 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
-      "removal": { "skills": [ [ "fabrication", 2 ] ], "time": "15 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
-      "repair": { "skills": [ [ "fabrication", 2 ] ], "time": "15 m", "using": [ [ "adhesive", 2 ] ] }
+      "install": {
+        "skills": [["fabrication", 1]],
+        "time": "15 m",
+        "using": [["vehicle_wrench_2", 1]]
+      },
+      "removal": {
+        "skills": [["fabrication", 2]],
+        "time": "15 m",
+        "using": [["vehicle_wrench_2", 1]]
+      },
+      "repair": {
+        "skills": [["fabrication", 2]],
+        "time": "15 m",
+        "using": [["adhesive", 2]]
+      }
     },
-    "flags": [ "CARGO", "OBSTACLE", "FLAT_SURF", "WORKBENCH" ],
-    "breaks_into": [ { "item": "2x4", "prob": 5 }, { "item": "splinter", "count": [ 4, 8 ] }, { "item": "nail", "charges": [ 4, 7 ] } ],
+    "flags": ["CARGO", "OBSTACLE", "FLAT_SURF", "WORKBENCH"],
+    "breaks_into": [
+      { "item": "2x4", "prob": 5 },
+      { "item": "splinter", "count": [4, 8] },
+      { "item": "nail", "charges": [4, 7] }
+    ],
     "workbench": { "multiplier": 1.1, "mass": 150000, "volume": "20 L" },
     "damage_reduction": { "all": 24 },
-    "variants": [ { "symbols": "#", "symbols_broken": "#" } ]
+    "variants": [{ "symbols": "#", "symbols_broken": "#" }]
   },
   {
     "type": "vehicle_part",
     "id": "veh_table_wood",
     "name": { "str": "wood table" },
     "looks_like": "f_table",
-    "categories": [ "utility" ],
+    "categories": ["utility"],
     "color": "red",
     "damage_modifier": 60,
     "durability": 145,
@@ -963,22 +1336,38 @@
     "item": "w_table",
     "location": "center",
     "requirements": {
-      "install": { "skills": [ [ "fabrication", 1 ] ], "time": "15 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
-      "removal": { "skills": [ [ "fabrication", 2 ] ], "time": "15 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
-      "repair": { "skills": [ [ "fabrication", 2 ] ], "time": "15 m", "using": [ [ "adhesive", 2 ] ] }
+      "install": {
+        "skills": [["fabrication", 1]],
+        "time": "15 m",
+        "using": [["vehicle_wrench_2", 1]]
+      },
+      "removal": {
+        "skills": [["fabrication", 2]],
+        "time": "15 m",
+        "using": [["vehicle_wrench_2", 1]]
+      },
+      "repair": {
+        "skills": [["fabrication", 2]],
+        "time": "15 m",
+        "using": [["adhesive", 2]]
+      }
     },
-    "flags": [ "CARGO", "OBSTACLE", "FLAT_SURF", "WORKBENCH" ],
-    "breaks_into": [ { "item": "2x4", "prob": 5 }, { "item": "splinter", "count": [ 4, 8 ] }, { "item": "nail", "charges": [ 4, 7 ] } ],
+    "flags": ["CARGO", "OBSTACLE", "FLAT_SURF", "WORKBENCH"],
+    "breaks_into": [
+      { "item": "2x4", "prob": 5 },
+      { "item": "splinter", "count": [4, 8] },
+      { "item": "nail", "charges": [4, 7] }
+    ],
     "workbench": { "multiplier": 1.1, "mass": 150000, "volume": "20 L" },
     "damage_reduction": { "all": 16 },
-    "variants": [ { "symbols": "#", "symbols_broken": "#" } ]
+    "variants": [{ "symbols": "#", "symbols_broken": "#" }]
   },
   {
     "type": "vehicle_part",
     "id": "veh_table_foldable",
     "name": { "str": "flat-packable table" },
     "looks_like": "veh_table_wood",
-    "categories": [ "utility" ],
+    "categories": ["utility"],
     "color": "red",
     "damage_modifier": 30,
     "durability": 70,
@@ -987,21 +1376,36 @@
     "folded_volume": "12500 ml",
     "location": "center",
     "requirements": {
-      "install": { "skills": [ [ "fabrication", 1 ] ], "time": "15 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
-      "removal": { "skills": [ [ "fabrication", 2 ] ], "time": "15 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
-      "repair": { "skills": [ [ "fabrication", 2 ] ], "time": "15 m", "using": [ [ "adhesive", 2 ] ] }
+      "install": {
+        "skills": [["fabrication", 1]],
+        "time": "15 m",
+        "using": [["vehicle_wrench_2", 1]]
+      },
+      "removal": {
+        "skills": [["fabrication", 2]],
+        "time": "15 m",
+        "using": [["vehicle_wrench_2", 1]]
+      },
+      "repair": {
+        "skills": [["fabrication", 2]],
+        "time": "15 m",
+        "using": [["adhesive", 2]]
+      }
     },
-    "flags": [ "CARGO", "OBSTACLE", "FLAT_SURF" ],
-    "breaks_into": [ { "item": "splinter", "count": [ 4, 7 ] }, { "item": "nail", "charges": [ 10, 15 ] } ],
+    "flags": ["CARGO", "OBSTACLE", "FLAT_SURF"],
+    "breaks_into": [
+      { "item": "splinter", "count": [4, 7] },
+      { "item": "nail", "charges": [10, 15] }
+    ],
     "damage_reduction": { "all": 16 },
-    "variants": [ { "symbols": "#", "symbols_broken": "#" } ]
+    "variants": [{ "symbols": "#", "symbols_broken": "#" }]
   },
   {
     "type": "vehicle_part",
     "id": "workbench",
     "name": { "str": "workbench" },
     "looks_like": "veh_table_wood",
-    "categories": [ "utility" ],
+    "categories": ["utility"],
     "color": "red",
     "damage_modifier": 60,
     "durability": 300,
@@ -1010,22 +1414,34 @@
     "location": "center",
     "//": "20 cm weld per quadrant of damage",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 1 ] ], "time": "15 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "15 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "3 m", "using": [ [ "repair_welding_standard", 2 ] ] }
+      "install": {
+        "skills": [["mechanics", 1]],
+        "time": "15 m",
+        "using": [["vehicle_wrench_2", 1]]
+      },
+      "removal": {
+        "skills": [["mechanics", 2]],
+        "time": "15 m",
+        "using": [["vehicle_wrench_2", 1]]
+      },
+      "repair": {
+        "skills": [["mechanics", 2]],
+        "time": "3 m",
+        "using": [["repair_welding_standard", 2]]
+      }
     },
-    "flags": [ "CARGO", "BOARDABLE", "FLAT_SURF", "WORKBENCH" ],
+    "flags": ["CARGO", "BOARDABLE", "FLAT_SURF", "WORKBENCH"],
     "breaks_into": [
       { "item": "pipe", "prob": 25 },
       { "item": "sheet_metal", "prob": 5 },
-      { "item": "sheet_metal_small", "count": [ 5, 14 ] },
-      { "item": "steel_lump", "count": [ 1, 3 ] },
-      { "item": "steel_chunk", "count": [ 7, 12 ] },
-      { "item": "scrap", "charges": [ 15, 30 ] }
+      { "item": "sheet_metal_small", "count": [5, 14] },
+      { "item": "steel_lump", "count": [1, 3] },
+      { "item": "steel_chunk", "count": [7, 12] },
+      { "item": "scrap", "charges": [15, 30] }
     ],
     "workbench": { "multiplier": 1.2, "mass": 300000, "volume": "30 L" },
     "damage_reduction": { "all": 29 },
-    "variants": [ { "symbols": "#", "symbols_broken": "#" } ]
+    "variants": [{ "symbols": "#", "symbols_broken": "#" }]
   },
   {
     "type": "vehicle_part",
@@ -1038,21 +1454,40 @@
     "item": "workbench_with_recharger",
     "//": "20 cm weld per quadrant of damage",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 1 ] ], "time": "15 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "15 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "15 m", "using": [ [ "repair_welding_standard", 2 ] ] }
+      "install": {
+        "skills": [["mechanics", 1]],
+        "time": "15 m",
+        "using": [["vehicle_wrench_2", 1]]
+      },
+      "removal": {
+        "skills": [["mechanics", 2]],
+        "time": "15 m",
+        "using": [["vehicle_wrench_2", 1]]
+      },
+      "repair": {
+        "skills": [["mechanics", 3]],
+        "time": "15 m",
+        "using": [["repair_welding_standard", 2]]
+      }
     },
-    "flags": [ "CARGO", "MOUNTABLE", "FLAT_SURF", "WORKBENCH", "ENABLED_DRAINS_EPOWER", "RECHARGE" ],
+    "flags": [
+      "CARGO",
+      "MOUNTABLE",
+      "FLAT_SURF",
+      "WORKBENCH",
+      "ENABLED_DRAINS_EPOWER",
+      "RECHARGE"
+    ],
     "breaks_into": [
       { "item": "pipe", "prob": 25 },
       { "item": "sheet_metal", "prob": 5 },
-      { "item": "sheet_metal_small", "count": [ 5, 14 ] },
-      { "item": "steel_lump", "count": [ 1, 3 ] },
-      { "item": "steel_chunk", "count": [ 7, 12 ] },
-      { "item": "scrap", "charges": [ 15, 30 ] },
+      { "item": "sheet_metal_small", "count": [5, 14] },
+      { "item": "steel_lump", "count": [1, 3] },
+      { "item": "steel_chunk", "count": [7, 12] },
+      { "item": "scrap", "charges": [15, 30] },
       { "item": "plastic_chunk", "prob": 50 },
-      { "item": "cable", "charges": [ 1, 4 ] },
-      { "item": "e_scrap", "count": [ 0, 2 ] }
+      { "item": "cable", "charges": [1, 4] },
+      { "item": "e_scrap", "count": [0, 2] }
     ],
     "size": "29500 ml",
     "workbench": { "volume": "29 L" },
@@ -1064,21 +1499,33 @@
     "name": { "str": "wooden boat hull" },
     "description": "A wooden board that keeps the water out of your boat.",
     "looks_like": "t_wall_log",
-    "categories": [ "hull" ],
+    "categories": ["hull"],
     "color": "brown",
     "damage_modifier": 50,
     "durability": 40,
     "item": "boat_board",
     "location": "under",
     "requirements": {
-      "install": { "skills": [ [ "fabrication", 2 ] ], "time": "30 m", "using": [ [ "vehicle_nail_install", 1 ] ] },
-      "removal": { "skills": [ [ "fabrication", 2 ] ], "time": "15 m", "using": [ [ "vehicle_nail_removal", 1 ] ] },
-      "repair": { "skills": [ [ "fabrication", 3 ] ], "time": "30 m", "using": [ [ "adhesive", 2 ] ] }
+      "install": {
+        "skills": [["fabrication", 2]],
+        "time": "30 m",
+        "using": [["vehicle_nail_install", 1]]
+      },
+      "removal": {
+        "skills": [["fabrication", 2]],
+        "time": "15 m",
+        "using": [["vehicle_nail_removal", 1]]
+      },
+      "repair": {
+        "skills": [["fabrication", 3]],
+        "time": "30 m",
+        "using": [["adhesive", 2]]
+      }
     },
-    "flags": [ "FLOATS" ],
-    "breaks_into": [ { "item": "splinter", "count": [ 10, 20 ] } ],
+    "flags": ["FLOATS"],
+    "breaks_into": [{ "item": "splinter", "count": [10, 20] }],
     "damage_reduction": { "all": 10 },
-    "variants": [ { "symbols": "o", "symbols_broken": "x" } ]
+    "variants": [{ "symbols": "o", "symbols_broken": "x" }]
   },
   {
     "type": "vehicle_part",
@@ -1086,28 +1533,40 @@
     "name": { "str": "raft boat hull" },
     "description": "Logs tied together that will keep your boat out of the water.",
     "looks_like": "t_wall_log",
-    "categories": [ "hull" ],
+    "categories": ["hull"],
     "color": "brown",
     "damage_modifier": 50,
     "durability": 30,
     "item": "raft_board",
     "location": "under",
     "requirements": {
-      "install": { "skills": [ [ "fabrication", 1 ] ], "time": "30 m", "using": [ [ "rope_natural_short", 2 ] ] },
-      "removal": { "skills": [ [ "fabrication", 1 ] ], "time": "15 m", "qualities": [ { "id": "CUT", "level": 2 } ] },
-      "repair": { "skills": [ [ "fabrication", 2 ] ], "time": "15 m", "using": [ [ "rope_natural_short", 1 ] ] }
+      "install": {
+        "skills": [["fabrication", 1]],
+        "time": "30 m",
+        "using": [["rope_natural_short", 2]]
+      },
+      "removal": {
+        "skills": [["fabrication", 1]],
+        "time": "15 m",
+        "qualities": [{ "id": "CUT", "level": 2 }]
+      },
+      "repair": {
+        "skills": [["fabrication", 2]],
+        "time": "15 m",
+        "using": [["rope_natural_short", 1]]
+      }
     },
-    "flags": [ "FLOATS" ],
-    "breaks_into": [ { "item": "splinter", "count": [ 10, 20 ] } ],
+    "flags": ["FLOATS"],
+    "breaks_into": [{ "item": "splinter", "count": [10, 20] }],
     "damage_reduction": { "all": 5 },
-    "variants": [ { "symbols": "o", "symbols_broken": "x" } ]
+    "variants": [{ "symbols": "o", "symbols_broken": "x" }]
   },
   {
     "type": "vehicle_part",
     "id": "plastic_boat_hull",
     "name": { "str": "plastic boat hull" },
     "description": "A rigid plastic sheet that keeps water out of your boat.",
-    "categories": [ "hull" ],
+    "categories": ["hull"],
     "color": "brown",
     "looks_like": "boat_board",
     "damage_modifier": 50,
@@ -1115,21 +1574,36 @@
     "item": "plastic_boat_hull",
     "location": "under",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 3 ] ], "time": "40 m", "using": [ [ "vehicle_screw", 1 ], [ "drilling_standard", 40 ] ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_screw", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 4 ] ], "time": "30 m", "using": [ [ "soldering_standard", 15 ] ] }
+      "install": {
+        "skills": [["mechanics", 3]],
+        "time": "40 m",
+        "using": [
+          ["vehicle_screw", 1],
+          ["drilling_standard", 40]
+        ]
+      },
+      "removal": {
+        "skills": [["mechanics", 2]],
+        "time": "30 m",
+        "using": [["vehicle_screw", 1]]
+      },
+      "repair": {
+        "skills": [["mechanics", 4]],
+        "time": "30 m",
+        "using": [["soldering_standard", 15]]
+      }
     },
-    "flags": [ "FLOATS" ],
-    "breaks_into": [ { "item": "plastic_chunk", "count": [ 4, 8 ] } ],
+    "flags": ["FLOATS"],
+    "breaks_into": [{ "item": "plastic_chunk", "count": [4, 8] }],
     "damage_reduction": { "all": 12, "stab": 4, "cut": 4 },
-    "variants": [ { "symbols": "o", "symbols_broken": "x" } ]
+    "variants": [{ "symbols": "o", "symbols_broken": "x" }]
   },
   {
     "type": "vehicle_part",
     "id": "metal_boat_hull",
     "name": { "str": "metal boat hull" },
     "description": "A metal sheet that keeps the water out of your boat.",
-    "categories": [ "hull" ],
+    "categories": ["hull"],
     "color": "dark_gray",
     "looks_like": "boat_board",
     "damage_modifier": 50,
@@ -1139,28 +1613,38 @@
     "//": "240 cm weld to install, 60 cm of weld per quadrant of damage",
     "requirements": {
       "install": {
-        "skills": [ [ "mechanics", 4 ] ],
+        "skills": [["mechanics", 4]],
         "time": "40 m",
-        "using": [ [ "welding_standard", 240 ], [ "vehicle_bolt_install", 2 ] ]
+        "using": [
+          ["welding_standard", 240],
+          ["vehicle_bolt_install", 2]
+        ]
       },
       "removal": {
-        "skills": [ [ "mechanics", 2 ] ],
+        "skills": [["mechanics", 2]],
         "time": "30 m",
-        "using": [ [ "vehicle_weld_removal", 1 ], [ "vehicle_wrench_2", 1 ] ]
+        "using": [
+          ["vehicle_weld_removal", 1],
+          ["vehicle_wrench_2", 1]
+        ]
       },
-      "repair": { "skills": [ [ "mechanics", 5 ] ], "time": "10 m", "using": [ [ "repair_welding_standard", 6 ] ] }
+      "repair": {
+        "skills": [["mechanics", 5]],
+        "time": "10 m",
+        "using": [["repair_welding_standard", 6]]
+      }
     },
-    "flags": [ "FLOATS" ],
+    "flags": ["FLOATS"],
     "breaks_into": "ig_vp_sheet_metal",
     "damage_reduction": { "all": 28 },
-    "variants": [ { "symbols": "o", "symbols_broken": "x" } ]
+    "variants": [{ "symbols": "o", "symbols_broken": "x" }]
   },
   {
     "type": "vehicle_part",
     "id": "carbonfiber_boat_hull",
     "name": { "str": "carbon fiber boat hull" },
     "description": "A light weight, advanced carbon fiber rigid sheet that keeps the water out of your boat.",
-    "categories": [ "hull" ],
+    "categories": ["hull"],
     "color": "brown",
     "looks_like": "boat_board",
     "damage_modifier": 50,
@@ -1168,21 +1652,36 @@
     "item": "carbonfiber_boat_hull",
     "location": "under",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 6 ] ], "time": "40 m", "using": [ [ "vehicle_screw", 1 ], [ "drilling_standard", 40 ] ] },
-      "removal": { "skills": [ [ "mechanics", 4 ] ], "time": "30 m", "using": [ [ "vehicle_screw", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 7 ] ], "time": "60 m", "using": [ [ "adhesive", 3 ] ] }
+      "install": {
+        "skills": [["mechanics", 6]],
+        "time": "40 m",
+        "using": [
+          ["vehicle_screw", 1],
+          ["drilling_standard", 40]
+        ]
+      },
+      "removal": {
+        "skills": [["mechanics", 4]],
+        "time": "30 m",
+        "using": [["vehicle_screw", 1]]
+      },
+      "repair": {
+        "skills": [["mechanics", 7]],
+        "time": "60 m",
+        "using": [["adhesive", 3]]
+      }
     },
-    "flags": [ "FLOATS", "BOARDABLE" ],
-    "breaks_into": [ { "item": "rigid_kevlar_plate", "count": [ 1, 3 ] } ],
+    "flags": ["FLOATS", "BOARDABLE"],
+    "breaks_into": [{ "item": "rigid_kevlar_plate", "count": [1, 3] }],
     "damage_reduction": { "all": 14 },
-    "variants": [ { "symbols": "o", "symbols_broken": "x" } ]
+    "variants": [{ "symbols": "o", "symbols_broken": "x" }]
   },
   {
     "type": "vehicle_part",
     "id": "inflatable_section",
     "name": { "str": "inflatable section" },
     "looks_like": "inflatable_airbag",
-    "categories": [ "hull" ],
+    "categories": ["hull"],
     "color": "green",
     "size": "85 L",
     "durability": 50,
@@ -1190,23 +1689,44 @@
     "location": "structure",
     "folded_volume": "750 ml",
     "folding_time": "60 seconds",
-    "unfolding_tools": [ "hand_pump" ],
+    "unfolding_tools": ["hand_pump"],
     "unfolding_time": "150 seconds",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 3 ] ], "time": "60 m", "using": [ [ "vehicle_screw", 1 ], [ "drilling_standard", 10 ] ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_screw", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 4 ] ], "time": "60 m", "using": [ [ "adhesive", 2 ] ] }
+      "install": {
+        "skills": [["mechanics", 3]],
+        "time": "60 m",
+        "using": [
+          ["vehicle_screw", 1],
+          ["drilling_standard", 10]
+        ]
+      },
+      "removal": {
+        "skills": [["mechanics", 2]],
+        "time": "30 m",
+        "using": [["vehicle_screw", 1]]
+      },
+      "repair": {
+        "skills": [["mechanics", 4]],
+        "time": "60 m",
+        "using": [["adhesive", 2]]
+      }
     },
-    "flags": [ "MOUNTABLE", "BOARDABLE", "CARGO", "NO_INSTALL_HIDDEN", "NO_UNINSTALL" ],
-    "breaks_into": [ { "item": "plastic_chunk", "count": [ 10, 20 ] } ],
+    "flags": [
+      "MOUNTABLE",
+      "BOARDABLE",
+      "CARGO",
+      "NO_INSTALL_HIDDEN",
+      "NO_UNINSTALL"
+    ],
+    "breaks_into": [{ "item": "plastic_chunk", "count": [10, 20] }],
     "damage_reduction": { "bash": 10 },
-    "variants": [ { "symbols": "O", "symbols_broken": "#" } ]
+    "variants": [{ "symbols": "O", "symbols_broken": "#" }]
   },
   {
     "type": "vehicle_part",
     "id": "inflatable_airbag",
     "name": { "str": "inflatable airbag" },
-    "categories": [ "hull" ],
+    "categories": ["hull"],
     "color": "green",
     "damage_modifier": 50,
     "durability": 40,
@@ -1214,23 +1734,41 @@
     "location": "under",
     "folded_volume": "750 ml",
     "folding_time": "60 seconds",
-    "unfolding_tools": [ "hand_pump" ],
+    "unfolding_tools": ["hand_pump"],
     "unfolding_time": "150 seconds",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 2 ] ], "time": "60 m", "using": [ [ "vehicle_screw", 1 ], [ "drilling_standard", 10 ] ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_screw", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "60 m", "using": [ [ "adhesive_rubber", 2 ], [ "tire_rubber", 2 ] ] }
+      "install": {
+        "skills": [["mechanics", 2]],
+        "time": "60 m",
+        "using": [
+          ["vehicle_screw", 1],
+          ["drilling_standard", 10]
+        ]
+      },
+      "removal": {
+        "skills": [["mechanics", 2]],
+        "time": "30 m",
+        "using": [["vehicle_screw", 1]]
+      },
+      "repair": {
+        "skills": [["mechanics", 3]],
+        "time": "60 m",
+        "using": [
+          ["adhesive_rubber", 2],
+          ["tire_rubber", 2]
+        ]
+      }
     },
-    "flags": [ "FLOATS", "VARIABLE_SIZE", "NO_INSTALL_HIDDEN", "NO_UNINSTALL" ],
-    "breaks_into": [ { "item": "plastic_chunk", "count": [ 10, 20 ] } ],
+    "flags": ["FLOATS", "VARIABLE_SIZE", "NO_INSTALL_HIDDEN", "NO_UNINSTALL"],
+    "breaks_into": [{ "item": "plastic_chunk", "count": [10, 20] }],
     "damage_reduction": { "bash": 10 },
-    "variants": [ { "symbols": "O", "symbols_broken": "x" } ]
+    "variants": [{ "symbols": "O", "symbols_broken": "x" }]
   },
   {
     "type": "vehicle_part",
     "id": "sail",
     "name": { "str": "sail" },
-    "categories": [ "movement", "operations" ],
+    "categories": ["movement", "operations"],
     "broken_color": "red",
     "damage_modifier": 50,
     "durability": 20,
@@ -1238,24 +1776,42 @@
     "fuel_type": "wind",
     "noise_factor": 1,
     "m2c": 90,
-    "exclusions": [ "wind" ],
+    "exclusions": ["wind"],
     "item": "sail",
     "location": "engine_block",
     "folded_volume": "500 ml",
     "requirements": {
-      "install": { "skills": [ [ "fabrication", 2 ] ], "time": "30 m" },
-      "removal": { "skills": [ [ "fabrication", 2 ] ], "time": "60 m" },
-      "repair": { "skills": [ [ "tailor", 1 ] ], "time": "150 s", "using": [ [ "sewing_standard", 50 ], [ "fabric_standard", 1 ] ] }
+      "install": { "skills": [["fabrication", 2]], "time": "30 m" },
+      "removal": { "skills": [["fabrication", 2]], "time": "60 m" },
+      "repair": {
+        "skills": [["tailor", 1]],
+        "time": "150 s",
+        "using": [
+          ["sewing_standard", 50],
+          ["fabric_standard", 1]
+        ]
+      }
     },
-    "flags": [ "ENGINE", "CONTROLS", "PROTRUSION", "E_STARTS_INSTANTLY", "WIND_POWERED", "STABLE", "UNMOUNT_ON_DAMAGE" ],
-    "breaks_into": [ { "item": "splinter", "count": [ 2, 4 ] }, { "item": "cotton_patchwork", "count": [ 1, 3 ] } ],
-    "variants": [ { "symbols": "M", "symbols_broken": "#" } ]
+    "flags": [
+      "ENGINE",
+      "CONTROLS",
+      "PROTRUSION",
+      "E_STARTS_INSTANTLY",
+      "WIND_POWERED",
+      "STABLE",
+      "UNMOUNT_ON_DAMAGE"
+    ],
+    "breaks_into": [
+      { "item": "splinter", "count": [2, 4] },
+      { "item": "cotton_patchwork", "count": [1, 3] }
+    ],
+    "variants": [{ "symbols": "M", "symbols_broken": "#" }]
   },
   {
     "type": "vehicle_part",
     "id": "controls",
     "name": { "str": "controls" },
-    "categories": [ "operations" ],
+    "categories": ["operations"],
     "broken_color": "red",
     "damage_modifier": 10,
     "durability": 250,
@@ -1266,90 +1822,116 @@
     "item": "vehicle_controls",
     "requirements": {
       "install": {
-        "skills": [ [ "mechanics", 2 ] ],
+        "skills": [["mechanics", 2]],
         "time": "60 m",
-        "using": [ [ "welding_standard", 120 ], [ "vehicle_bolt_install", 2 ] ]
+        "using": [
+          ["welding_standard", 120],
+          ["vehicle_bolt_install", 2]
+        ]
       },
       "removal": {
-        "skills": [ [ "mechanics", 2 ] ],
+        "skills": [["mechanics", 2]],
         "time": "15 m",
-        "using": [ [ "vehicle_weld_removal", 15 ], [ "vehicle_wrench_2", 1 ] ]
+        "using": [
+          ["vehicle_weld_removal", 15],
+          ["vehicle_wrench_2", 1]
+        ]
       },
       "repair": {
-        "skills": [ [ "mechanics", 3 ] ],
+        "skills": [["mechanics", 3]],
         "time": "30 m",
-        "using": [ [ "repair_welding_standard", 3 ], [ "soldering_standard", 8 ], [ "vehicle_wrench_1", 1 ], [ "vehicle_screw", 1 ] ]
+        "using": [
+          ["repair_welding_standard", 3],
+          ["soldering_standard", 8],
+          ["vehicle_wrench_1", 1],
+          ["vehicle_screw", 1]
+        ]
       }
     },
-    "flags": [ "CONTROLS", "NEED_LEG", "INOPERABLE_SMALL" ],
+    "flags": ["CONTROLS", "NEED_LEG", "INOPERABLE_SMALL"],
     "breaks_into": [
       { "item": "steel_lump" },
-      { "item": "steel_chunk", "count": [ 1, 3 ] },
-      { "item": "scrap", "charges": [ 1, 3 ] },
-      { "item": "cable", "charges": [ 0, 4 ] }
+      { "item": "steel_chunk", "count": [1, 3] },
+      { "item": "scrap", "charges": [1, 3] },
+      { "item": "cable", "charges": [0, 4] }
     ],
     "damage_reduction": { "all": 6 },
-    "variants": [ { "symbols": "$", "symbols_broken": "$" } ]
+    "variants": [{ "symbols": "$", "symbols_broken": "$" }]
   },
   {
     "type": "vehicle_part",
     "id": "hand_controls",
     "name": { "str": "hand controls" },
-    "categories": [ "other" ],
+    "categories": ["other"],
     "broken_color": "red",
     "durability": 250,
     "description": "A pair of adjustable rods with a simple trigger.  They easily can be easily installed on top of vehicle controls and will allow a car or similar vehicle to be driven by those who can't use their legs to do so, whether due to disability or small stature.  These are designed for automobiles and will not work on bicycle style foot pedals.",
     "bonus": 10,
     "folded_volume": "740 ml",
     "item": "hand_controls",
-    "flags": [ "IGNORE_LEG_REQUIREMENT", "IGNORE_HEIGHT_REQUIREMENT", "ON_CONTROLS" ],
-    "breaks_into": [ { "item": "scrap", "count": [ 0, 2 ] }, { "item": "pipe", "count": [ 0, 1 ] } ],
-    "variants": [ { "symbols": "/", "symbols_broken": "/" } ]
+    "flags": [
+      "IGNORE_LEG_REQUIREMENT",
+      "IGNORE_HEIGHT_REQUIREMENT",
+      "ON_CONTROLS"
+    ],
+    "breaks_into": [
+      { "item": "scrap", "count": [0, 2] },
+      { "item": "pipe", "count": [0, 1] }
+    ],
+    "variants": [{ "symbols": "/", "symbols_broken": "/" }]
   },
   {
     "type": "vehicle_part",
     "id": "pedal_extenders",
     "name": { "str": "pedal extenders" },
-    "categories": [ "other" ],
+    "categories": ["other"],
     "broken_color": "red",
     "durability": 250,
     "description": "Thick rubber pads which can be easily clamped onto gas and brake pedals to allow vehicle controls to be used even by people who are very short.",
     "bonus": 10,
     "folded_volume": "2 L",
     "item": "pedal_extenders",
-    "flags": [ "IGNORE_HEIGHT_REQUIREMENT", "ON_CONTROLS" ],
+    "flags": ["IGNORE_HEIGHT_REQUIREMENT", "ON_CONTROLS"],
     "breaks_into": [
-      { "item": "rubber_tire_chunk", "count": [ 0, 1 ] },
-      { "item": "rubber_tire_chunk", "count": [ 0, 8 ] },
-      { "item": "clamp", "count": [ 0, 1 ] },
-      { "item": "scrap", "charges": [ 0, 2 ] }
+      { "item": "rubber_tire_chunk", "count": [0, 1] },
+      { "item": "rubber_tire_chunk", "count": [0, 8] },
+      { "item": "clamp", "count": [0, 1] },
+      { "item": "scrap", "charges": [0, 2] }
     ],
-    "variants": [ { "symbols": ",", "symbols_broken": "," } ]
+    "variants": [{ "symbols": ",", "symbols_broken": "," }]
   },
   {
     "type": "vehicle_part",
     "id": "pedal_extenders_makeshift",
     "name": { "str": "makeshift pedal extenders" },
-    "categories": [ "other" ],
+    "categories": ["other"],
     "broken_color": "red",
     "durability": 50,
     "description": "Blocks of wood, taped to the pedals to allow vehicle controls to be used even by people who are very short.",
     "bonus": 10,
     "folded_volume": "2 L",
     "item": "pedal_extenders_makeshift",
-    "flags": [ "IGNORE_HEIGHT_REQUIREMENT", "ON_CONTROLS" ],
+    "flags": ["IGNORE_HEIGHT_REQUIREMENT", "ON_CONTROLS"],
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 1 ] ], "time": "350 s", "components": [ [ [ "duct_tape", 25 ] ] ] },
-      "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "80 s", "using": [ [ "adhesive", 1 ] ] }
+      "install": {
+        "skills": [["mechanics", 1]],
+        "time": "350 s",
+        "components": [[["duct_tape", 25]]]
+      },
+      "repair": {
+        "skills": [["mechanics", 1]],
+        "time": "80 s",
+        "using": [["adhesive", 1]]
+      }
     },
-    "breaks_into": [ { "item": "splinter", "count": [ 0, 4 ] } ],
-    "variants": [ { "symbols": ",", "symbols_broken": "," } ]
+    "breaks_into": [{ "item": "splinter", "count": [0, 4] }],
+    "variants": [{ "symbols": ",", "symbols_broken": "," }]
   },
   {
     "type": "vehicle_part",
     "id": "dashboard",
     "name": { "str": "dashboard" },
-    "categories": [ "energy", "lighting" ],
+    "categories": ["energy", "lighting"],
     "color": "light_cyan",
     "broken_color": "red",
     "damage_modifier": 10,
@@ -1359,18 +1941,40 @@
     "epower": "-25 W",
     "item": "vehicle_dashboard",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 1 ], [ "electronics", 1 ] ], "time": "350 s", "using": [ [ "vehicle_screw", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "350 s", "using": [ [ "vehicle_screw", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "80 s", "using": [ [ "adhesive", 1 ] ] }
+      "install": {
+        "skills": [
+          ["mechanics", 1],
+          ["electronics", 1]
+        ],
+        "time": "350 s",
+        "using": [["vehicle_screw", 1]]
+      },
+      "removal": {
+        "skills": [["mechanics", 1]],
+        "time": "350 s",
+        "using": [["vehicle_screw", 1]]
+      },
+      "repair": {
+        "skills": [["mechanics", 1]],
+        "time": "80 s",
+        "using": [["adhesive", 1]]
+      }
     },
-    "flags": [ "CTRL_ELECTRONIC", "DOME_LIGHT", "ENABLED_DRAINS_EPOWER", "WATCH", "ALARMCLOCK", "CABLE_PORTS" ],
-    "breaks_into": [
-      { "item": "cable", "charges": [ 0, 2 ] },
-      { "item": "plastic_chunk", "count": [ 4, 8 ] },
-      { "item": "e_scrap", "count": [ 1, 3 ] },
-      { "item": "scrap", "charges": [ 1, 2 ] }
+    "flags": [
+      "CTRL_ELECTRONIC",
+      "DOME_LIGHT",
+      "ENABLED_DRAINS_EPOWER",
+      "WATCH",
+      "ALARMCLOCK",
+      "CABLE_PORTS"
     ],
-    "variants": [ { "symbols": "$", "symbols_broken": "$" } ]
+    "breaks_into": [
+      { "item": "cable", "charges": [0, 2] },
+      { "item": "plastic_chunk", "count": [4, 8] },
+      { "item": "e_scrap", "count": [1, 3] },
+      { "item": "scrap", "charges": [1, 2] }
+    ],
+    "variants": [{ "symbols": "$", "symbols_broken": "$" }]
   },
   {
     "id": "mountable_heater",
@@ -1378,27 +1982,45 @@
     "name": { "str": "vehicle-mounted heater" },
     "item": "mountable_heater",
     "location": "on_roof",
-    "categories": [ "utility" ],
+    "categories": ["utility"],
     "color": "red",
     "durability": 400,
     "//": "700 W average assuming relatively small target-actual difference",
     "epower": "-700 W",
     "bonus": 10,
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 1 ], [ "electronics", 1 ] ], "time": "2 m", "using": [ [ "vehicle_screw", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "1 m", "using": [ [ "vehicle_screw", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "30 s", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 5 ] ] }
+      "install": {
+        "skills": [
+          ["mechanics", 1],
+          ["electronics", 1]
+        ],
+        "time": "2 m",
+        "using": [["vehicle_screw", 1]]
+      },
+      "removal": {
+        "skills": [["mechanics", 1]],
+        "time": "1 m",
+        "using": [["vehicle_screw", 1]]
+      },
+      "repair": {
+        "skills": [["mechanics", 1]],
+        "time": "30 s",
+        "using": [
+          ["adhesive", 1],
+          ["soldering_standard", 5]
+        ]
+      }
     },
-    "flags": [ "CTRL_ELECTRONIC", "ENABLED_DRAINS_EPOWER", "SPACE_HEATER" ],
-    "emissions": [ "emit_heater_vehicle" ],
+    "flags": ["CTRL_ELECTRONIC", "ENABLED_DRAINS_EPOWER", "SPACE_HEATER"],
+    "emissions": ["emit_heater_vehicle"],
     "breaks_into": [
       { "item": "steel_lump" },
-      { "item": "steel_chunk", "count": [ 1, 3 ] },
-      { "item": "scrap", "charges": [ 1, 3 ] },
-      { "item": "element", "count": [ 0, 2 ] }
+      { "item": "steel_chunk", "count": [1, 3] },
+      { "item": "scrap", "charges": [1, 3] },
+      { "item": "element", "count": [0, 2] }
     ],
     "damage_reduction": { "all": 15 },
-    "variants": [ { "symbols": ";", "symbols_broken": ":" } ]
+    "variants": [{ "symbols": ";", "symbols_broken": ":" }]
   },
   {
     "copy-from": "mountable_heater",
@@ -1410,16 +2032,34 @@
     "epower": "-350 W",
     "folded_volume": "3750 ml",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 1 ], [ "electronics", 1 ] ], "time": "2 m", "using": [ [ "vehicle_screw", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "1 m", "using": [ [ "vehicle_screw", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "30 s", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 4 ] ] }
+      "install": {
+        "skills": [
+          ["mechanics", 1],
+          ["electronics", 1]
+        ],
+        "time": "2 m",
+        "using": [["vehicle_screw", 1]]
+      },
+      "removal": {
+        "skills": [["mechanics", 1]],
+        "time": "1 m",
+        "using": [["vehicle_screw", 1]]
+      },
+      "repair": {
+        "skills": [["mechanics", 1]],
+        "time": "30 s",
+        "using": [
+          ["adhesive", 1],
+          ["soldering_standard", 4]
+        ]
+      }
     },
-    "flags": [ "CTRL_ELECTRONIC", "ENABLED_DRAINS_EPOWER", "SPACE_HEATER" ],
-    "emissions": [ "emit_hot_air2_stream" ],
+    "flags": ["CTRL_ELECTRONIC", "ENABLED_DRAINS_EPOWER", "SPACE_HEATER"],
+    "emissions": ["emit_hot_air2_stream"],
     "breaks_into": [
       { "item": "steel_lump" },
-      { "item": "steel_chunk", "count": [ 1, 3 ] },
-      { "item": "scrap", "charges": [ 1, 3 ] },
+      { "item": "steel_chunk", "count": [1, 3] },
+      { "item": "scrap", "charges": [1, 3] },
       { "item": "element", "prob": 80 }
     ],
     "damage_reduction": { "all": 15 }
@@ -1432,12 +2072,18 @@
     "type": "vehicle_part",
     "location": "",
     "name": { "str": "small integrated heater" },
-    "extend": { "flags": [ "NO_INSTALL_HIDDEN" ] },
-    "requirements": { "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "5 m", "qualities": [ { "id": "SAW_M", "level": 2 } ] } },
+    "extend": { "flags": ["NO_INSTALL_HIDDEN"] },
+    "requirements": {
+      "removal": {
+        "skills": [["mechanics", 1]],
+        "time": "5 m",
+        "qualities": [{ "id": "SAW_M", "level": 2 }]
+      }
+    },
     "breaks_into": [
       { "item": "steel_lump", "prob": 70 },
-      { "item": "steel_chunk", "count": [ 1, 2 ] },
-      { "item": "scrap", "charges": [ 1, 3 ] }
+      { "item": "steel_chunk", "count": [1, 2] },
+      { "item": "scrap", "charges": [1, 3] }
     ]
   },
   {
@@ -1446,27 +2092,42 @@
     "name": { "str": "vehicle-mounted cooler" },
     "item": "mountable_cooler",
     "location": "on_roof",
-    "categories": [ "utility" ],
+    "categories": ["utility"],
     "color": "light_cyan",
     "durability": 400,
     "epower": "-120 W",
     "bonus": 10,
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 1 ], [ "electronics", 1 ] ], "time": "2 m", "using": [ [ "vehicle_screw", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "1 m", "using": [ [ "vehicle_screw", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "30 s", "using": [ [ "adhesive", 1 ] ] }
+      "install": {
+        "skills": [
+          ["mechanics", 1],
+          ["electronics", 1]
+        ],
+        "time": "2 m",
+        "using": [["vehicle_screw", 1]]
+      },
+      "removal": {
+        "skills": [["mechanics", 1]],
+        "time": "1 m",
+        "using": [["vehicle_screw", 1]]
+      },
+      "repair": {
+        "skills": [["mechanics", 1]],
+        "time": "30 s",
+        "using": [["adhesive", 1]]
+      }
     },
-    "flags": [ "CTRL_ELECTRONIC", "ENABLED_DRAINS_EPOWER", "COOLER" ],
-    "emissions": [ "emit_cooler_vehicle" ],
-    "exhaust": [ "emit_heater_vehicle" ],
+    "flags": ["CTRL_ELECTRONIC", "ENABLED_DRAINS_EPOWER", "COOLER"],
+    "emissions": ["emit_cooler_vehicle"],
+    "exhaust": ["emit_heater_vehicle"],
     "breaks_into": [
       { "item": "steel_lump" },
-      { "item": "steel_chunk", "count": [ 1, 3 ] },
-      { "item": "scrap", "charges": [ 1, 3 ] },
-      { "item": "cable", "charges": [ 2, 10 ] }
+      { "item": "steel_chunk", "count": [1, 3] },
+      { "item": "scrap", "charges": [1, 3] },
+      { "item": "cable", "charges": [2, 10] }
     ],
     "damage_reduction": { "all": 15 },
-    "variants": [ { "symbols": "C", "symbols_broken": ":" } ]
+    "variants": [{ "symbols": "C", "symbols_broken": ":" }]
   },
   {
     "id": "integrated_cooler",
@@ -1477,16 +2138,34 @@
     "description": "Small set of mechanisms, that cool the vehicle out when turned on.",
     "item": "integrated_cooler",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 4 ], [ "electronics", 1 ] ], "time": "3 h", "using": [ [ "vehicle_screw", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 4 ], [ "electronics", 1 ] ], "time": "3 h", "using": [ [ "vehicle_screw", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "60 s", "using": [ [ "adhesive", 1 ] ] }
+      "install": {
+        "skills": [
+          ["mechanics", 4],
+          ["electronics", 1]
+        ],
+        "time": "3 h",
+        "using": [["vehicle_screw", 1]]
+      },
+      "removal": {
+        "skills": [
+          ["mechanics", 4],
+          ["electronics", 1]
+        ],
+        "time": "3 h",
+        "using": [["vehicle_screw", 1]]
+      },
+      "repair": {
+        "skills": [["mechanics", 3]],
+        "time": "60 s",
+        "using": [["adhesive", 1]]
+      }
     }
   },
   {
     "type": "vehicle_part",
     "id": "controls_electronic",
     "name": { "str": "electronics control unit" },
-    "categories": [ "energy", "lighting" ],
+    "categories": ["energy", "lighting"],
     "color": "yellow",
     "broken_color": "red",
     "damage_modifier": 10,
@@ -1497,24 +2176,47 @@
     "description": "Some switches and knobs to control the vehicle's electrical systems.",
     "folded_volume": "750 ml",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 3 ], [ "electronics", 3 ] ], "time": "350 s", "using": [ [ "vehicle_screw", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 3 ] ], "time": "350 s", "using": [ [ "vehicle_screw", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "80 s", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 10 ] ] }
+      "install": {
+        "skills": [
+          ["mechanics", 3],
+          ["electronics", 3]
+        ],
+        "time": "350 s",
+        "using": [["vehicle_screw", 1]]
+      },
+      "removal": {
+        "skills": [["mechanics", 3]],
+        "time": "350 s",
+        "using": [["vehicle_screw", 1]]
+      },
+      "repair": {
+        "skills": [["mechanics", 2]],
+        "time": "80 s",
+        "using": [
+          ["adhesive", 1],
+          ["soldering_standard", 10]
+        ]
+      }
     },
-    "flags": [ "CTRL_ELECTRONIC", "DOME_LIGHT", "ENABLED_DRAINS_EPOWER", "CABLE_PORTS" ],
+    "flags": [
+      "CTRL_ELECTRONIC",
+      "DOME_LIGHT",
+      "ENABLED_DRAINS_EPOWER",
+      "CABLE_PORTS"
+    ],
     "breaks_into": [
-      { "item": "cable", "charges": [ 0, 1 ] },
-      { "item": "plastic_chunk", "count": [ 2, 4 ] },
-      { "item": "e_scrap", "count": [ 1, 2 ] }
+      { "item": "cable", "charges": [0, 1] },
+      { "item": "plastic_chunk", "count": [2, 4] },
+      { "item": "e_scrap", "count": [1, 2] }
     ],
     "damage_reduction": { "all": 6 },
-    "variants": [ { "symbols": "$", "symbols_broken": "$" } ]
+    "variants": [{ "symbols": "$", "symbols_broken": "$" }]
   },
   {
     "type": "vehicle_part",
     "id": "muffler",
     "name": { "str": "muffler" },
-    "categories": [ "other" ],
+    "categories": ["other"],
     "damage_modifier": 10,
     "durability": 50,
     "description": "A metal pipe that somewhat reduces engine noise.  Also vents heat from an installed vehicle cooler.",
@@ -1523,31 +2225,41 @@
     "item": "muffler",
     "requirements": {
       "install": {
-        "skills": [ [ "mechanics", 2 ] ],
+        "skills": [["mechanics", 2]],
         "time": "45 m",
-        "using": [ [ "welding_standard", 80 ], [ "vehicle_bolt_install", 1 ] ]
+        "using": [
+          ["welding_standard", 80],
+          ["vehicle_bolt_install", 1]
+        ]
       },
       "removal": {
-        "skills": [ [ "mechanics", 2 ] ],
+        "skills": [["mechanics", 2]],
         "time": "30 m",
-        "using": [ [ "vehicle_weld_removal", 1 ], [ "vehicle_wrench_2", 1 ] ]
+        "using": [
+          ["vehicle_weld_removal", 1],
+          ["vehicle_wrench_2", 1]
+        ]
       },
-      "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "10 m", "using": [ [ "repair_welding_standard", 2 ] ] }
+      "repair": {
+        "skills": [["mechanics", 3]],
+        "time": "10 m",
+        "using": [["repair_welding_standard", 2]]
+      }
     },
-    "flags": [ "MUFFLER" ],
+    "flags": ["MUFFLER"],
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 1, 3 ] },
-      { "item": "steel_chunk", "count": [ 2, 4 ] },
-      { "item": "scrap", "charges": [ 4, 9 ] }
+      { "item": "steel_lump", "count": [1, 3] },
+      { "item": "steel_chunk", "count": [2, 4] },
+      { "item": "scrap", "charges": [4, 9] }
     ],
     "damage_reduction": { "all": 9 },
-    "variants": [ { "symbols": "/", "symbols_broken": "/" } ]
+    "variants": [{ "symbols": "/", "symbols_broken": "/" }]
   },
   {
     "type": "vehicle_part",
     "id": "seatbelt",
     "name": { "str": "seatbelt" },
-    "categories": [ "operations", "passengers" ],
+    "categories": ["operations", "passengers"],
     "broken_color": "red",
     "damage_modifier": 10,
     "durability": 35,
@@ -1557,19 +2269,31 @@
     "item": "seatbelt",
     "location": "on_seat",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 1 ] ], "time": "150 s", "using": [ [ "vehicle_screw", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "150 s", "using": [ [ "vehicle_screw", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "20 s", "using": [ [ "adhesive", 1 ] ] }
+      "install": {
+        "skills": [["mechanics", 1]],
+        "time": "150 s",
+        "using": [["vehicle_screw", 1]]
+      },
+      "removal": {
+        "skills": [["mechanics", 1]],
+        "time": "150 s",
+        "using": [["vehicle_screw", 1]]
+      },
+      "repair": {
+        "skills": [["mechanics", 1]],
+        "time": "20 s",
+        "using": [["adhesive", 1]]
+      }
     },
-    "flags": [ "SEATBELT", "SIMPLE_PART" ],
+    "flags": ["SEATBELT", "SIMPLE_PART"],
     "damage_reduction": { "bash": 15 },
-    "variants": [ { "symbols": ",", "symbols_broken": "," } ]
+    "variants": [{ "symbols": ",", "symbols_broken": "," }]
   },
   {
     "type": "vehicle_part",
     "id": "vehicle_alarm",
     "name": { "str": "security system" },
-    "categories": [ "other" ],
+    "categories": ["other"],
     "color": "light_red",
     "broken_color": "red",
     "damage_modifier": 10,
@@ -1582,25 +2306,31 @@
     "location": "on_controls",
     "requirements": {
       "install": {
-        "skills": [ [ "mechanics", 4 ], [ "electronics", 4 ] ],
+        "skills": [
+          ["mechanics", 4],
+          ["electronics", 4]
+        ],
         "time": "5 m",
-        "qualities": [ { "id": "SCREW_FINE", "level": 1 } ]
+        "qualities": [{ "id": "SCREW_FINE", "level": 1 }]
       },
       "removal": {
-        "skills": [ [ "mechanics", 4 ], [ "electronics", 4 ] ],
+        "skills": [
+          ["mechanics", 4],
+          ["electronics", 4]
+        ],
         "time": "5 m",
-        "qualities": [ { "id": "SCREW_FINE", "level": 1 } ]
+        "qualities": [{ "id": "SCREW_FINE", "level": 1 }]
       }
     },
-    "flags": [ "ON_CONTROLS", "SECURITY", "ENABLED_DRAINS_EPOWER" ],
+    "flags": ["ON_CONTROLS", "SECURITY", "ENABLED_DRAINS_EPOWER"],
     "breaks_into": "ig_vp_device",
-    "variants": [ { "symbols": ",", "symbols_broken": "," } ]
+    "variants": [{ "symbols": ",", "symbols_broken": "," }]
   },
   {
     "type": "vehicle_part",
     "id": "smart_engine_controller",
     "name": { "str": "smart engine controller" },
-    "categories": [ "other" ],
+    "categories": ["other"],
     "broken_color": "red",
     "damage_modifier": 10,
     "durability": 35,
@@ -1610,25 +2340,35 @@
     "item": "processor",
     "requirements": {
       "install": {
-        "skills": [ [ "mechanics", 4 ], [ "electronics", 4 ] ],
+        "skills": [
+          ["mechanics", 4],
+          ["electronics", 4]
+        ],
         "time": "5 m",
-        "qualities": [ { "id": "SCREW_FINE", "level": 1 } ]
+        "qualities": [{ "id": "SCREW_FINE", "level": 1 }]
       },
       "removal": {
-        "skills": [ [ "mechanics", 4 ], [ "electronics", 4 ] ],
+        "skills": [
+          ["mechanics", 4],
+          ["electronics", 4]
+        ],
         "time": "5 m",
-        "qualities": [ { "id": "SCREW_FINE", "level": 1 } ]
+        "qualities": [{ "id": "SCREW_FINE", "level": 1 }]
       }
     },
-    "flags": [ "ON_CONTROLS", "ENABLED_DRAINS_EPOWER", "SMART_ENGINE_CONTROLLER" ],
+    "flags": [
+      "ON_CONTROLS",
+      "ENABLED_DRAINS_EPOWER",
+      "SMART_ENGINE_CONTROLLER"
+    ],
     "breaks_into": "ig_vp_device",
-    "variants": [ { "symbols": "'", "symbols_broken": "'" } ]
+    "variants": [{ "symbols": "'", "symbols_broken": "'" }]
   },
   {
     "type": "vehicle_part",
     "id": "seatbelt_heavyduty",
     "name": { "str": "5-point harness" },
-    "categories": [ "operations", "passengers" ],
+    "categories": ["operations", "passengers"],
     "broken_color": "red",
     "damage_modifier": 10,
     "durability": 100,
@@ -1638,20 +2378,32 @@
     "item": "five-point_harness",
     "location": "on_seat",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 2 ] ], "time": "5 m", "using": [ [ "vehicle_screw", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "5 m", "using": [ [ "vehicle_screw", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "20 s", "using": [ [ "adhesive", 1 ] ] }
+      "install": {
+        "skills": [["mechanics", 2]],
+        "time": "5 m",
+        "using": [["vehicle_screw", 1]]
+      },
+      "removal": {
+        "skills": [["mechanics", 2]],
+        "time": "5 m",
+        "using": [["vehicle_screw", 1]]
+      },
+      "repair": {
+        "skills": [["mechanics", 2]],
+        "time": "20 s",
+        "using": [["adhesive", 1]]
+      }
     },
-    "flags": [ "SEATBELT", "SIMPLE_PART" ],
+    "flags": ["SEATBELT", "SIMPLE_PART"],
     "damage_reduction": { "bash": 15 },
-    "variants": [ { "symbols": ",", "symbols_broken": "," } ]
+    "variants": [{ "symbols": ",", "symbols_broken": "," }]
   },
   {
     "type": "vehicle_part",
     "id": "v_curtain",
     "name": { "str": "curtain" },
     "looks_like": "t_door_curtain_c",
-    "categories": [ "other" ],
+    "categories": ["other"],
     "color": "dark_gray",
     "damage_modifier": 1,
     "durability": 200,
@@ -1660,24 +2412,47 @@
     "item": "sheet",
     "location": "on_windshield",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 1 ] ], "time": "5 m", "using": [ [ "vehicle_screw", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "5 m", "using": [ [ "vehicle_screw", 1 ] ] },
-      "repair": { "skills": [ [ "tailor", 1 ] ], "time": "150 s", "using": [ [ "sewing_standard", 50 ], [ "fabric_standard", 1 ] ] }
+      "install": {
+        "skills": [["mechanics", 1]],
+        "time": "5 m",
+        "using": [["vehicle_screw", 1]]
+      },
+      "removal": {
+        "skills": [["mechanics", 1]],
+        "time": "5 m",
+        "using": [["vehicle_screw", 1]]
+      },
+      "repair": {
+        "skills": [["tailor", 1]],
+        "time": "150 s",
+        "using": [
+          ["sewing_standard", 50],
+          ["fabric_standard", 1]
+        ]
+      }
     },
-    "flags": [ "OPENABLE", "OPENCLOSE_INSIDE", "OPAQUE", "CURTAIN", "MULTISQUARE", "NEEDS_WINDOW", "SIMPLE_PART" ],
-    "breaks_into": [
-      { "item": "sheet_cotton", "count": [ 1, 3 ] },
-      { "item": "cotton_patchwork", "count": [ 5, 11 ] },
-      { "item": "scrap_cotton", "count": [ 8, 19 ] }
+    "flags": [
+      "OPENABLE",
+      "OPENCLOSE_INSIDE",
+      "OPAQUE",
+      "CURTAIN",
+      "MULTISQUARE",
+      "NEEDS_WINDOW",
+      "SIMPLE_PART"
     ],
-    "variants": [ { "symbols": "\"", "symbols_broken": "0" } ]
+    "breaks_into": [
+      { "item": "sheet_cotton", "count": [1, 3] },
+      { "item": "cotton_patchwork", "count": [5, 11] },
+      { "item": "scrap_cotton", "count": [8, 19] }
+    ],
+    "variants": [{ "symbols": "\"", "symbols_broken": "0" }]
   },
   {
     "type": "vehicle_part",
     "id": "aisle_curtain",
     "name": { "str": "aisle curtain" },
     "looks_like": "v_curtain",
-    "categories": [ "other" ],
+    "categories": ["other"],
     "color": "dark_gray",
     "damage_modifier": 1,
     "durability": 200,
@@ -1687,26 +2462,51 @@
     "location": "on_ceiling",
     "requirements": {
       "install": {
-        "skills": [ [ "mechanics", 1 ], [ "tailor", 1 ] ],
+        "skills": [
+          ["mechanics", 1],
+          ["tailor", 1]
+        ],
         "time": "5 m",
-        "using": [ [ "rope_natural_short", 1 ], [ "vehicle_screw", 1 ], [ "sewing_standard", 1 ] ]
+        "using": [
+          ["rope_natural_short", 1],
+          ["vehicle_screw", 1],
+          ["sewing_standard", 1]
+        ]
       },
-      "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "5 m", "using": [ [ "vehicle_screw", 1 ] ] },
-      "repair": { "skills": [ [ "tailor", 1 ] ], "time": "150 s", "using": [ [ "sewing_standard", 50 ], [ "fabric_standard", 1 ] ] }
+      "removal": {
+        "skills": [["mechanics", 1]],
+        "time": "5 m",
+        "using": [["vehicle_screw", 1]]
+      },
+      "repair": {
+        "skills": [["tailor", 1]],
+        "time": "150 s",
+        "using": [
+          ["sewing_standard", 50],
+          ["fabric_standard", 1]
+        ]
+      }
     },
-    "flags": [ "OPENABLE", "OPAQUE", "OPENCLOSE_INSIDE", "CURTAIN", "MULTISQUARE", "SIMPLE_PART" ],
-    "breaks_into": [
-      { "item": "sheet_cotton", "count": [ 1, 3 ] },
-      { "item": "cotton_patchwork", "count": [ 5, 11 ] },
-      { "item": "scrap_cotton", "count": [ 8, 19 ] }
+    "flags": [
+      "OPENABLE",
+      "OPAQUE",
+      "OPENCLOSE_INSIDE",
+      "CURTAIN",
+      "MULTISQUARE",
+      "SIMPLE_PART"
     ],
-    "variants": [ { "symbols": "\"", "symbols_broken": "0" } ]
+    "breaks_into": [
+      { "item": "sheet_cotton", "count": [1, 3] },
+      { "item": "cotton_patchwork", "count": [5, 11] },
+      { "item": "scrap_cotton", "count": [8, 19] }
+    ],
+    "variants": [{ "symbols": "\"", "symbols_broken": "0" }]
   },
   {
     "type": "vehicle_part",
     "id": "water_wheel",
     "name": { "str": "water wheel" },
-    "categories": [ "energy" ],
+    "categories": ["energy"],
     "color": "yellow",
     "broken_color": "yellow",
     "damage_modifier": 10,
@@ -1715,29 +2515,41 @@
     "epower": "80 W",
     "item": "water_wheel",
     "location": "center",
-    "flags": [ "WATER_WHEEL", "OBSTACLE" ],
+    "flags": ["WATER_WHEEL", "OBSTACLE"],
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 2 ] ], "time": "250 s", "qualities": [ { "id": "WRENCH", "level": 1 } ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "250 s", "qualities": [ { "id": "WRENCH", "level": 1 } ] },
-      "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "20 s", "using": [ [ "rope_natural_short", 1 ] ] }
+      "install": {
+        "skills": [["mechanics", 2]],
+        "time": "250 s",
+        "qualities": [{ "id": "WRENCH", "level": 1 }]
+      },
+      "removal": {
+        "skills": [["mechanics", 2]],
+        "time": "250 s",
+        "qualities": [{ "id": "WRENCH", "level": 1 }]
+      },
+      "repair": {
+        "skills": [["mechanics", 3]],
+        "time": "20 s",
+        "using": [["rope_natural_short", 1]]
+      }
     },
     "breaks_into": [
-      { "item": "splinter", "count": [ 40, 60 ] },
-      { "item": "steel_chunk", "count": [ 1, 3 ] },
-      { "item": "scrap", "charges": [ 6, 15 ] },
-      { "item": "cable", "charges": [ 90, 180 ] },
-      { "item": "nail", "charges": [ 21, 35 ] },
-      { "item": "nuts_bolts", "charges": [ 3, 6 ] }
+      { "item": "splinter", "count": [40, 60] },
+      { "item": "steel_chunk", "count": [1, 3] },
+      { "item": "scrap", "charges": [6, 15] },
+      { "item": "cable", "charges": [90, 180] },
+      { "item": "nail", "charges": [21, 35] },
+      { "item": "nuts_bolts", "charges": [3, 6] }
     ],
     "damage_reduction": { "all": 15, "stab": 6, "cut": 8 },
-    "variants": [ { "symbols": "*", "symbols_broken": "x" } ]
+    "variants": [{ "symbols": "*", "symbols_broken": "x" }]
   },
   {
     "type": "vehicle_part",
     "id": "xl_water_wheel",
     "name": { "str": "large water wheel" },
     "looks_like": "water_wheel",
-    "categories": [ "energy" ],
+    "categories": ["energy"],
     "color": "yellow",
     "broken_color": "yellow",
     "damage_modifier": 10,
@@ -1746,29 +2558,41 @@
     "epower": "180 W",
     "item": "xl_water_wheel",
     "location": "center",
-    "flags": [ "WATER_WHEEL", "OBSTACLE", "EXTRA_DRAG" ],
+    "flags": ["WATER_WHEEL", "OBSTACLE", "EXTRA_DRAG"],
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 4 ] ], "time": "750 s", "qualities": [ { "id": "WRENCH", "level": 1 } ] },
-      "removal": { "skills": [ [ "mechanics", 4 ] ], "time": "750 s", "qualities": [ { "id": "WRENCH", "level": 1 } ] },
-      "repair": { "skills": [ [ "mechanics", 5 ] ], "time": "60 s", "using": [ [ "rope_natural_short", 2 ] ] }
+      "install": {
+        "skills": [["mechanics", 4]],
+        "time": "750 s",
+        "qualities": [{ "id": "WRENCH", "level": 1 }]
+      },
+      "removal": {
+        "skills": [["mechanics", 4]],
+        "time": "750 s",
+        "qualities": [{ "id": "WRENCH", "level": 1 }]
+      },
+      "repair": {
+        "skills": [["mechanics", 5]],
+        "time": "60 s",
+        "using": [["rope_natural_short", 2]]
+      }
     },
     "breaks_into": [
-      { "item": "splinter", "count": [ 60, 100 ] },
-      { "item": "steel_lump", "count": [ 1, 3 ] },
-      { "item": "steel_chunk", "count": [ 4, 9 ] },
-      { "item": "scrap", "charges": [ 20, 35 ] },
-      { "item": "cable", "charges": [ 225, 400 ] },
-      { "item": "nail", "charges": [ 80, 130 ] },
-      { "item": "nuts_bolts", "charges": [ 5, 12 ] }
+      { "item": "splinter", "count": [60, 100] },
+      { "item": "steel_lump", "count": [1, 3] },
+      { "item": "steel_chunk", "count": [4, 9] },
+      { "item": "scrap", "charges": [20, 35] },
+      { "item": "cable", "charges": [225, 400] },
+      { "item": "nail", "charges": [80, 130] },
+      { "item": "nuts_bolts", "charges": [5, 12] }
     ],
     "damage_reduction": { "all": 16, "stab": 6, "cut": 8 },
-    "variants": [ { "symbols": "o", "symbols_broken": "x" } ]
+    "variants": [{ "symbols": "o", "symbols_broken": "x" }]
   },
   {
     "type": "vehicle_part",
     "id": "solar_panel",
     "name": { "str": "solar panel" },
-    "categories": [ "energy" ],
+    "categories": ["energy"],
     "color": "yellow",
     "broken_color": "yellow",
     "damage_modifier": 10,
@@ -1778,28 +2602,40 @@
     "item": "solar_panel",
     "location": "on_roof",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 4 ] ], "time": "60 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
+      "install": {
+        "skills": [["mechanics", 4]],
+        "time": "60 m",
+        "using": [["vehicle_wrench_2", 1]]
+      },
+      "removal": {
+        "skills": [["mechanics", 2]],
+        "time": "30 m",
+        "using": [["vehicle_wrench_2", 1]]
+      },
       "repair": {
-        "skills": [ [ "electronics", 6 ] ],
+        "skills": [["electronics", 6]],
         "time": "50 m",
-        "using": [ [ "vehicle_screw", 1 ], [ "solar_panel", 1 ], [ "soldering_standard", 8 ] ]
+        "using": [
+          ["vehicle_screw", 1],
+          ["solar_panel", 1],
+          ["soldering_standard", 8]
+        ]
       }
     },
-    "flags": [ "SOLAR_PANEL" ],
+    "flags": ["SOLAR_PANEL"],
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 2, 4 ] },
-      { "item": "steel_chunk", "count": [ 2, 4 ] },
-      { "item": "scrap", "charges": [ 2, 4 ] },
-      { "item": "solar_cell", "count": [ 1, 4 ] }
+      { "item": "steel_lump", "count": [2, 4] },
+      { "item": "steel_chunk", "count": [2, 4] },
+      { "item": "scrap", "charges": [2, 4] },
+      { "item": "solar_cell", "count": [1, 4] }
     ],
-    "variants": [ { "symbols": "#", "symbols_broken": "x" } ]
+    "variants": [{ "symbols": "#", "symbols_broken": "x" }]
   },
   {
     "type": "vehicle_part",
     "id": "wind_turbine",
     "name": { "str": "wind turbine" },
-    "categories": [ "energy" ],
+    "categories": ["energy"],
     "color": "yellow",
     "broken_color": "yellow",
     "damage_modifier": 10,
@@ -1810,33 +2646,44 @@
     "location": "on_roof",
     "//": "20 cm weld per quadrant of damage",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 1 ] ], "time": "150 s", "qualities": [ { "id": "WRENCH", "level": 1 } ] },
-      "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "150 s", "qualities": [ { "id": "WRENCH", "level": 1 } ] },
+      "install": {
+        "skills": [["mechanics", 1]],
+        "time": "150 s",
+        "qualities": [{ "id": "WRENCH", "level": 1 }]
+      },
+      "removal": {
+        "skills": [["mechanics", 1]],
+        "time": "150 s",
+        "qualities": [{ "id": "WRENCH", "level": 1 }]
+      },
       "repair": {
-        "skills": [ [ "mechanics", 1 ] ],
+        "skills": [["mechanics", 1]],
         "time": "15 m",
-        "using": [ [ "repair_welding_standard", 2 ], [ "soldering_standard", 4 ] ]
+        "using": [
+          ["repair_welding_standard", 2],
+          ["soldering_standard", 4]
+        ]
       }
     },
-    "flags": [ "WIND_TURBINE" ],
+    "flags": ["WIND_TURBINE"],
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 1, 2 ] },
-      { "item": "steel_chunk", "count": [ 2, 4 ] },
-      { "item": "scrap", "charges": [ 2, 6 ] },
-      { "item": "e_scrap", "count": [ 2, 4 ] },
-      { "item": "splinter", "count": [ 2, 8 ] },
-      { "item": "cable", "charges": [ 80, 115 ] },
-      { "item": "nail", "charges": [ 2, 6 ] }
+      { "item": "steel_lump", "count": [1, 2] },
+      { "item": "steel_chunk", "count": [2, 4] },
+      { "item": "scrap", "charges": [2, 6] },
+      { "item": "e_scrap", "count": [2, 4] },
+      { "item": "splinter", "count": [2, 8] },
+      { "item": "cable", "charges": [80, 115] },
+      { "item": "nail", "charges": [2, 6] }
     ],
     "damage_reduction": { "all": 8 },
-    "variants": [ { "symbols": "T", "symbols_broken": "X" } ]
+    "variants": [{ "symbols": "T", "symbols_broken": "X" }]
   },
   {
     "type": "vehicle_part",
     "id": "xl_wind_turbine",
     "name": { "str": "large wind turbine" },
     "looks_like": "wind_turbine",
-    "categories": [ "energy" ],
+    "categories": ["energy"],
     "color": "yellow",
     "broken_color": "yellow",
     "damage_modifier": 10,
@@ -1848,27 +2695,38 @@
     "power": "-3000 W",
     "//": "30 cm weld per quadrant of damage",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 3 ] ], "time": "450 s", "qualities": [ { "id": "WRENCH", "level": 1 } ] },
-      "removal": { "skills": [ [ "mechanics", 3 ] ], "time": "450 s", "qualities": [ { "id": "WRENCH", "level": 1 } ] },
+      "install": {
+        "skills": [["mechanics", 3]],
+        "time": "450 s",
+        "qualities": [{ "id": "WRENCH", "level": 1 }]
+      },
+      "removal": {
+        "skills": [["mechanics", 3]],
+        "time": "450 s",
+        "qualities": [{ "id": "WRENCH", "level": 1 }]
+      },
       "repair": {
-        "skills": [ [ "mechanics", 3 ] ],
+        "skills": [["mechanics", 3]],
         "time": "20 m",
-        "using": [ [ "repair_welding_standard", 3 ], [ "soldering_standard", 10 ] ]
+        "using": [
+          ["repair_welding_standard", 3],
+          ["soldering_standard", 10]
+        ]
       }
     },
-    "flags": [ "WIND_TURBINE", "EXTRA_DRAG" ],
+    "flags": ["WIND_TURBINE", "EXTRA_DRAG"],
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 1, 2 ] },
-      { "item": "steel_chunk", "count": [ 3, 6 ] },
-      { "item": "scrap", "charges": [ 10, 20 ] },
-      { "item": "e_scrap", "count": [ 8, 16 ] },
-      { "item": "splinter", "count": [ 25, 50 ] },
-      { "item": "cable", "charges": [ 300, 500 ] },
-      { "item": "nail", "charges": [ 8, 15 ] },
-      { "item": "nuts_bolts", "charges": [ 4, 7 ] }
+      { "item": "steel_lump", "count": [1, 2] },
+      { "item": "steel_chunk", "count": [3, 6] },
+      { "item": "scrap", "charges": [10, 20] },
+      { "item": "e_scrap", "count": [8, 16] },
+      { "item": "splinter", "count": [25, 50] },
+      { "item": "cable", "charges": [300, 500] },
+      { "item": "nail", "charges": [8, 15] },
+      { "item": "nuts_bolts", "charges": [4, 7] }
     ],
     "damage_reduction": { "all": 9 },
-    "variants": [ { "symbols": "Y", "symbols_broken": "X" } ]
+    "variants": [{ "symbols": "Y", "symbols_broken": "X" }]
   },
   {
     "type": "vehicle_part",
@@ -1884,16 +2742,21 @@
     "item": "reinforced_solar_panel",
     "requirements": {
       "repair": {
-        "skills": [ [ "electronics", 6 ] ],
+        "skills": [["electronics", 6]],
         "time": "50 m",
-        "using": [ [ "vehicle_screw", 1 ], [ "solar_panel", 1 ], [ "soldering_standard", 8 ], [ "repair_welding_standard", 1 ] ]
+        "using": [
+          ["vehicle_screw", 1],
+          ["solar_panel", 1],
+          ["soldering_standard", 8],
+          ["repair_welding_standard", 1]
+        ]
       }
     },
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 4, 7 ] },
-      { "item": "steel_chunk", "count": [ 4, 7 ] },
-      { "item": "scrap", "charges": [ 4, 7 ] },
-      { "item": "solar_cell", "count": [ 1, 4 ] }
+      { "item": "steel_lump", "count": [4, 7] },
+      { "item": "steel_chunk", "count": [4, 7] },
+      { "item": "scrap", "charges": [4, 7] },
+      { "item": "solar_cell", "count": [1, 4] }
     ],
     "damage_reduction": { "all": 12 }
   },
@@ -1906,19 +2769,23 @@
     "item": "solar_panel_v2",
     "proportional": { "epower": 2.0 },
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 6 ] ] },
-      "removal": { "skills": [ [ "mechanics", 4 ] ] },
+      "install": { "skills": [["mechanics", 6]] },
+      "removal": { "skills": [["mechanics", 4]] },
       "repair": {
-        "skills": [ [ "electronics", 8 ] ],
+        "skills": [["electronics", 8]],
         "time": "75 m",
-        "using": [ [ "vehicle_screw", 1 ], [ "solar_panel_v2", 1 ], [ "soldering_standard", 16 ] ]
+        "using": [
+          ["vehicle_screw", 1],
+          ["solar_panel_v2", 1],
+          ["soldering_standard", 16]
+        ]
       }
     },
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 2, 4 ] },
-      { "item": "steel_chunk", "count": [ 2, 4 ] },
-      { "item": "scrap", "charges": [ 2, 4 ] },
-      { "item": "solar_cell_v2", "count": [ 1, 6 ] }
+      { "item": "steel_lump", "count": [2, 4] },
+      { "item": "steel_chunk", "count": [2, 4] },
+      { "item": "scrap", "charges": [2, 4] },
+      { "item": "solar_cell_v2", "count": [1, 6] }
     ]
   },
   {
@@ -1936,16 +2803,21 @@
     "item": "reinforced_solar_panel_v2",
     "requirements": {
       "repair": {
-        "skills": [ [ "electronics", 8 ] ],
+        "skills": [["electronics", 8]],
         "time": "75 m",
-        "using": [ [ "vehicle_screw", 1 ], [ "solar_panel_v2", 1 ], [ "soldering_standard", 16 ], [ "repair_welding_standard", 1 ] ]
+        "using": [
+          ["vehicle_screw", 1],
+          ["solar_panel_v2", 1],
+          ["soldering_standard", 16],
+          ["repair_welding_standard", 1]
+        ]
       }
     },
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 4, 7 ] },
-      { "item": "steel_chunk", "count": [ 4, 7 ] },
-      { "item": "scrap", "charges": [ 4, 7 ] },
-      { "item": "solar_cell", "count": [ 1, 6 ] }
+      { "item": "steel_lump", "count": [4, 7] },
+      { "item": "steel_chunk", "count": [4, 7] },
+      { "item": "scrap", "charges": [4, 7] },
+      { "item": "solar_cell", "count": [1, 6] }
     ],
     "damage_reduction": { "all": 10 }
   },
@@ -1954,7 +2826,7 @@
     "id": "compact_ASRG_containment",
     "name": { "str": "advanced Stirling radioisotope generator" },
     "looks_like": "f_compact_ASRG_containment",
-    "categories": [ "energy" ],
+    "categories": ["energy"],
     "color": "green_white",
     "broken_color": "blue",
     "damage_modifier": 80,
@@ -1966,27 +2838,30 @@
     "item": "compact_ASRG_containment",
     "requirements": {
       "repair": {
-        "skills": [ [ "mechanics", 5 ] ],
+        "skills": [["mechanics", 5]],
         "time": "25 m",
-        "using": [ [ "repair_welding_standard", 4 ], [ "soldering_standard", 5 ] ]
+        "using": [
+          ["repair_welding_standard", 4],
+          ["soldering_standard", 5]
+        ]
       }
     },
-    "flags": [ "OBSTACLE", "RADIOACTIVE", "COVERED", "PERPETUAL", "REACTOR" ],
+    "flags": ["OBSTACLE", "RADIOACTIVE", "COVERED", "PERPETUAL", "REACTOR"],
     "breaks_into": [
-      { "item": "scrap", "charges": [ 4, 16 ] },
-      { "item": "steel_chunk", "count": [ 1, 6 ] },
-      { "item": "plutonium", "count": [ 0, 2 ] },
-      { "item": "lead", "charges": [ 12, 18 ] }
+      { "item": "scrap", "charges": [4, 16] },
+      { "item": "steel_chunk", "count": [1, 6] },
+      { "item": "plutonium", "count": [0, 2] },
+      { "item": "lead", "charges": [12, 18] }
     ],
     "damage_reduction": { "all": 58 },
-    "variants": [ { "symbols": "0", "symbols_broken": "#" } ]
+    "variants": [{ "symbols": "0", "symbols_broken": "#" }]
   },
   {
     "type": "vehicle_part",
     "id": "water_faucet",
     "name": { "str": "water faucet" },
     "looks_like": "f_sink",
-    "categories": [ "utility" ],
+    "categories": ["utility"],
     "damage_modifier": 10,
     "description": "A water faucet.",
     "durability": 45,
@@ -1994,20 +2869,32 @@
     "item": "water_faucet",
     "//": "10 cm weld per damage quadrant",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 1 ] ], "time": "5 m", "qualities": [ { "id": "WRENCH", "level": 1 } ] },
-      "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "5 m", "qualities": [ { "id": "WRENCH", "level": 1 } ] },
-      "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "5 m", "using": [ [ "repair_welding_standard", 1 ] ] }
+      "install": {
+        "skills": [["mechanics", 1]],
+        "time": "5 m",
+        "qualities": [{ "id": "WRENCH", "level": 1 }]
+      },
+      "removal": {
+        "skills": [["mechanics", 1]],
+        "time": "5 m",
+        "qualities": [{ "id": "WRENCH", "level": 1 }]
+      },
+      "repair": {
+        "skills": [["mechanics", 1]],
+        "time": "5 m",
+        "using": [["repair_welding_standard", 1]]
+      }
     },
-    "pseudo_tools": [ { "id": "water_faucet" } ],
-    "breaks_into": [ { "item": "scrap", "charges": [ 1, 3 ] } ],
+    "pseudo_tools": [{ "id": "water_faucet" }],
+    "breaks_into": [{ "item": "scrap", "charges": [1, 3] }],
     "damage_reduction": { "all": 6 },
-    "variants": [ { "symbols": "u", "symbols_broken": "-" } ]
+    "variants": [{ "symbols": "u", "symbols_broken": "-" }]
   },
   {
     "type": "vehicle_part",
     "id": "towel_hanger",
     "name": { "str": "towel hanger" },
-    "categories": [ "utility" ],
+    "categories": ["utility"],
     "color": "brown",
     "broken_color": "brown",
     "damage_modifier": 10,
@@ -2017,44 +2904,70 @@
     "//": "10 cm weld per damage quadrant",
     "item": "towel_hanger",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 1 ] ], "time": "5 m", "qualities": [ { "id": "WRENCH", "level": 1 } ] },
-      "removal": { "skills": [ [ "mechanics", 1 ] ], "qualities": [ { "id": "WRENCH", "level": 1 } ] },
-      "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "5 m", "using": [ [ "repair_welding_standard", 1 ] ] }
+      "install": {
+        "skills": [["mechanics", 1]],
+        "time": "5 m",
+        "qualities": [{ "id": "WRENCH", "level": 1 }]
+      },
+      "removal": {
+        "skills": [["mechanics", 1]],
+        "qualities": [{ "id": "WRENCH", "level": 1 }]
+      },
+      "repair": {
+        "skills": [["mechanics", 1]],
+        "time": "5 m",
+        "using": [["repair_welding_standard", 1]]
+      }
     },
-    "pseudo_tools": [ { "id": "towel", "hotkey": "t" } ],
-    "breaks_into": [ { "item": "scrap", "charges": [ 1, 3 ] }, { "item": "cotton_patchwork", "count": [ 1, 6 ] } ],
-    "variants": [ { "symbols": "h", "symbols_broken": "-" } ]
+    "pseudo_tools": [{ "id": "towel", "hotkey": "t" }],
+    "breaks_into": [
+      { "item": "scrap", "charges": [1, 3] },
+      { "item": "cotton_patchwork", "count": [1, 6] }
+    ],
+    "variants": [{ "symbols": "h", "symbols_broken": "-" }]
   },
   {
     "type": "vehicle_part",
     "id": "plating_wood",
     "name": { "str": "wooden armor" },
-    "categories": [ "warfare" ],
+    "categories": ["warfare"],
     "color": "brown",
     "broken_color": "brown",
     "durability": 250,
     "item": "wood_plate",
     "location": "armor",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_nail_install", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "15 m", "using": [ [ "vehicle_nail_removal", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "30 m", "using": [ [ "adhesive", 2 ] ] }
+      "install": {
+        "skills": [["mechanics", 2]],
+        "time": "30 m",
+        "using": [["vehicle_nail_install", 1]]
+      },
+      "removal": {
+        "skills": [["mechanics", 2]],
+        "time": "15 m",
+        "using": [["vehicle_nail_removal", 1]]
+      },
+      "repair": {
+        "skills": [["mechanics", 3]],
+        "time": "30 m",
+        "using": [["adhesive", 2]]
+      }
     },
-    "flags": [ "ARMOR" ],
+    "flags": ["ARMOR"],
     "breaks_into": [
-      { "item": "splinter", "count": [ 4, 8 ] },
-      { "item": "string_36", "count": [ 2, 3 ] },
-      { "item": "string_6", "count": [ 3, 6 ] },
-      { "item": "nail", "charges": [ 1, 3 ] }
+      { "item": "splinter", "count": [4, 8] },
+      { "item": "string_36", "count": [2, 3] },
+      { "item": "string_6", "count": [3, 6] },
+      { "item": "nail", "charges": [1, 3] }
     ],
     "damage_reduction": { "all": 16, "cut": 8, "stab": 8 },
-    "variants": [ { "symbols": ")", "symbols_broken": ")" } ]
+    "variants": [{ "symbols": ")", "symbols_broken": ")" }]
   },
   {
     "type": "vehicle_part",
     "id": "plating_steel",
     "name": { "str": "steel plating" },
-    "categories": [ "warfare" ],
+    "categories": ["warfare"],
     "color": "light_cyan",
     "broken_color": "light_cyan",
     "durability": 660,
@@ -2063,27 +2976,37 @@
     "//": "240 cm weld to install, 60 cm weld per damage quadrant",
     "requirements": {
       "install": {
-        "skills": [ [ "mechanics", 2 ] ],
+        "skills": [["mechanics", 2]],
         "time": "50 m",
-        "using": [ [ "welding_standard", 240 ], [ "vehicle_bolt_install", 3 ] ]
+        "using": [
+          ["welding_standard", 240],
+          ["vehicle_bolt_install", 3]
+        ]
       },
       "removal": {
-        "skills": [ [ "mechanics", 2 ] ],
+        "skills": [["mechanics", 2]],
         "time": "30 m",
-        "using": [ [ "vehicle_weld_removal", 1 ], [ "vehicle_wrench_2", 1 ] ]
+        "using": [
+          ["vehicle_weld_removal", 1],
+          ["vehicle_wrench_2", 1]
+        ]
       },
-      "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "10 m", "using": [ [ "repair_welding_standard", 6 ] ] }
+      "repair": {
+        "skills": [["mechanics", 3]],
+        "time": "10 m",
+        "using": [["repair_welding_standard", 6]]
+      }
     },
-    "flags": [ "ARMOR" ],
+    "flags": ["ARMOR"],
     "breaks_into": "ig_vp_steel_plate",
     "damage_reduction": { "all": 56 },
-    "variants": [ { "symbols": ")", "symbols_broken": ")" } ]
+    "variants": [{ "symbols": ")", "symbols_broken": ")" }]
   },
   {
     "type": "vehicle_part",
     "id": "plating_superalloy",
     "name": { "str": "superalloy plating" },
-    "categories": [ "warfare" ],
+    "categories": ["warfare"],
     "color": "dark_gray",
     "broken_color": "dark_gray",
     "durability": 600,
@@ -2092,31 +3015,41 @@
     "//": "240 cm weld to install, 60 cm weld per damage quadrant",
     "requirements": {
       "install": {
-        "skills": [ [ "mechanics", 4 ] ],
+        "skills": [["mechanics", 4]],
         "time": "50 m",
-        "using": [ [ "welding_standard", 240 ], [ "vehicle_bolt_install", 3 ] ]
+        "using": [
+          ["welding_standard", 240],
+          ["vehicle_bolt_install", 3]
+        ]
       },
       "removal": {
-        "skills": [ [ "mechanics", 2 ] ],
+        "skills": [["mechanics", 2]],
         "time": "30 m",
-        "using": [ [ "vehicle_weld_removal", 1 ], [ "vehicle_wrench_2", 1 ] ]
+        "using": [
+          ["vehicle_weld_removal", 1],
+          ["vehicle_wrench_2", 1]
+        ]
       },
-      "repair": { "skills": [ [ "mechanics", 5 ] ], "time": "10 m", "using": [ [ "repair_welding_standard", 6 ] ] }
+      "repair": {
+        "skills": [["mechanics", 5]],
+        "time": "10 m",
+        "using": [["repair_welding_standard", 6]]
+      }
     },
-    "flags": [ "ARMOR" ],
+    "flags": ["ARMOR"],
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 4, 6 ] },
-      { "item": "steel_chunk", "count": [ 4, 6 ] },
-      { "item": "scrap", "charges": [ 4, 6 ] }
+      { "item": "steel_lump", "count": [4, 6] },
+      { "item": "steel_chunk", "count": [4, 6] },
+      { "item": "scrap", "charges": [4, 6] }
     ],
     "damage_reduction": { "all": 56 },
-    "variants": [ { "symbols": ")", "symbols_broken": ")" } ]
+    "variants": [{ "symbols": ")", "symbols_broken": ")" }]
   },
   {
     "type": "vehicle_part",
     "id": "plating_spiked",
     "name": { "str": "spiked plating" },
-    "categories": [ "warfare" ],
+    "categories": ["warfare"],
     "color": "red",
     "broken_color": "red",
     "damage_modifier": 150,
@@ -2127,32 +3060,42 @@
     "//": "240 cm weld to install, 60 cm weld per damage quadrant",
     "requirements": {
       "install": {
-        "skills": [ [ "mechanics", 3 ] ],
+        "skills": [["mechanics", 3]],
         "time": "50 m",
-        "using": [ [ "welding_standard", 240 ], [ "vehicle_bolt_install", 3 ] ]
+        "using": [
+          ["welding_standard", 240],
+          ["vehicle_bolt_install", 3]
+        ]
       },
       "removal": {
-        "skills": [ [ "mechanics", 2 ] ],
+        "skills": [["mechanics", 2]],
         "time": "30 m",
-        "using": [ [ "vehicle_weld_removal", 1 ], [ "vehicle_wrench_2", 1 ] ]
+        "using": [
+          ["vehicle_weld_removal", 1],
+          ["vehicle_wrench_2", 1]
+        ]
       },
-      "repair": { "skills": [ [ "mechanics", 4 ] ], "time": "10 m", "using": [ [ "repair_welding_standard", 6 ] ] }
+      "repair": {
+        "skills": [["mechanics", 4]],
+        "time": "10 m",
+        "using": [["repair_welding_standard", 6]]
+      }
     },
-    "flags": [ "ARMOR", "SHARP" ],
+    "flags": ["ARMOR", "SHARP"],
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 1, 2 ] },
-      { "item": "steel_chunk", "count": [ 2, 4 ] },
-      { "item": "scrap", "charges": [ 5, 8 ] },
-      { "item": "spike", "count": [ 1, 2 ] }
+      { "item": "steel_lump", "count": [1, 2] },
+      { "item": "steel_chunk", "count": [2, 4] },
+      { "item": "scrap", "charges": [5, 8] },
+      { "item": "spike", "count": [1, 2] }
     ],
     "damage_reduction": { "all": 48 },
-    "variants": [ { "symbols": ")", "symbols_broken": ")" } ]
+    "variants": [{ "symbols": ")", "symbols_broken": ")" }]
   },
   {
     "type": "vehicle_part",
     "id": "plating_hard",
     "name": { "str": "hard plating" },
-    "categories": [ "warfare" ],
+    "categories": ["warfare"],
     "color": "cyan",
     "broken_color": "cyan",
     "durability": 780,
@@ -2161,31 +3104,41 @@
     "//": "300 cm weld to install, 80 cm weld per damage quadrant",
     "requirements": {
       "install": {
-        "skills": [ [ "mechanics", 4 ] ],
+        "skills": [["mechanics", 4]],
         "time": "60 m",
-        "using": [ [ "welding_standard", 300 ], [ "vehicle_bolt_install", 4 ] ]
+        "using": [
+          ["welding_standard", 300],
+          ["vehicle_bolt_install", 4]
+        ]
       },
       "removal": {
-        "skills": [ [ "mechanics", 2 ] ],
+        "skills": [["mechanics", 2]],
         "time": "30 m",
-        "using": [ [ "vehicle_weld_removal_cut_resistant", 1 ], [ "vehicle_wrench_2", 1 ] ]
+        "using": [
+          ["vehicle_weld_removal_cut_resistant", 1],
+          ["vehicle_wrench_2", 1]
+        ]
       },
-      "repair": { "skills": [ [ "mechanics", 5 ] ], "time": "15 m", "using": [ [ "repair_welding_standard", 8 ] ] }
+      "repair": {
+        "skills": [["mechanics", 5]],
+        "time": "15 m",
+        "using": [["repair_welding_standard", 8]]
+      }
     },
-    "flags": [ "ARMOR" ],
+    "flags": ["ARMOR"],
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 4, 6 ] },
-      { "item": "steel_chunk", "count": [ 5, 8 ] },
-      { "item": "scrap", "charges": [ 6, 12 ] }
+      { "item": "steel_lump", "count": [4, 6] },
+      { "item": "steel_chunk", "count": [5, 8] },
+      { "item": "scrap", "charges": [6, 12] }
     ],
     "damage_reduction": { "all": 70 },
-    "variants": [ { "symbols": ")", "symbols_broken": ")" } ]
+    "variants": [{ "symbols": ")", "symbols_broken": ")" }]
   },
   {
     "type": "vehicle_part",
     "id": "plating_military",
     "name": { "str": "military composite armor plating" },
-    "categories": [ "warfare" ],
+    "categories": ["warfare"],
     "color": "green",
     "broken_color": "green",
     "durability": 700,
@@ -2194,31 +3147,37 @@
     "//": "300 cm weld to install",
     "requirements": {
       "install": {
-        "skills": [ [ "mechanics", 6 ] ],
+        "skills": [["mechanics", 6]],
         "time": "60 m",
-        "using": [ [ "welding_standard", 300 ], [ "vehicle_bolt_install", 4 ] ]
+        "using": [
+          ["welding_standard", 300],
+          ["vehicle_bolt_install", 4]
+        ]
       },
       "removal": {
-        "skills": [ [ "mechanics", 4 ] ],
+        "skills": [["mechanics", 4]],
         "time": "30 m",
-        "using": [ [ "vehicle_weld_removal_cut_resistant", 1 ], [ "vehicle_wrench_2", 1 ] ]
+        "using": [
+          ["vehicle_weld_removal_cut_resistant", 1],
+          ["vehicle_wrench_2", 1]
+        ]
       }
     },
-    "flags": [ "ARMOR", "NO_REPAIR" ],
+    "flags": ["ARMOR", "NO_REPAIR"],
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 4, 6 ] },
-      { "item": "steel_chunk", "count": [ 4, 6 ] },
-      { "item": "scrap", "charges": [ 4, 6 ] },
-      { "item": "ceramic_armor", "count": [ 0, 4 ] }
+      { "item": "steel_lump", "count": [4, 6] },
+      { "item": "steel_chunk", "count": [4, 6] },
+      { "item": "scrap", "charges": [4, 6] },
+      { "item": "ceramic_armor", "count": [0, 4] }
     ],
     "damage_reduction": { "all": 60, "bullet": 105 },
-    "variants": [ { "symbols": ")", "symbols_broken": ")" } ]
+    "variants": [{ "symbols": ")", "symbols_broken": ")" }]
   },
   {
     "type": "vehicle_part",
     "id": "horn_bicycle",
     "name": { "str": "bicycle horn" },
-    "categories": [ "other" ],
+    "categories": ["other"],
     "broken_color": "red",
     "damage_modifier": 10,
     "durability": 75,
@@ -2227,19 +3186,34 @@
     "bonus": 45,
     "item": "horn_bicycle",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 1 ] ], "time": "150 s", "using": [ [ "vehicle_screw", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "150 s", "using": [ [ "vehicle_screw", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "20 s", "using": [ [ "adhesive", 1 ] ] }
+      "install": {
+        "skills": [["mechanics", 1]],
+        "time": "150 s",
+        "using": [["vehicle_screw", 1]]
+      },
+      "removal": {
+        "skills": [["mechanics", 1]],
+        "time": "150 s",
+        "using": [["vehicle_screw", 1]]
+      },
+      "repair": {
+        "skills": [["mechanics", 1]],
+        "time": "20 s",
+        "using": [["adhesive", 1]]
+      }
     },
-    "flags": [ "HORN" ],
-    "breaks_into": [ { "item": "scrap_aluminum", "prob": 10 }, { "item": "plastic_chunk", "prob": 35 } ],
-    "variants": [ { "symbols": "*", "symbols_broken": "*" } ]
+    "flags": ["HORN"],
+    "breaks_into": [
+      { "item": "scrap_aluminum", "prob": 10 },
+      { "item": "plastic_chunk", "prob": 35 }
+    ],
+    "variants": [{ "symbols": "*", "symbols_broken": "*" }]
   },
   {
     "type": "vehicle_part",
     "id": "horn_car",
     "name": { "str": "car horn" },
-    "categories": [ "other" ],
+    "categories": ["other"],
     "broken_color": "red",
     "damage_modifier": 10,
     "durability": 100,
@@ -2247,19 +3221,37 @@
     "bonus": 100,
     "item": "horn_car",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 2 ] ], "time": "150 s", "using": [ [ "vehicle_screw", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "150 s", "using": [ [ "vehicle_screw", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "20 s", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 1 ] ] }
+      "install": {
+        "skills": [["mechanics", 2]],
+        "time": "150 s",
+        "using": [["vehicle_screw", 1]]
+      },
+      "removal": {
+        "skills": [["mechanics", 2]],
+        "time": "150 s",
+        "using": [["vehicle_screw", 1]]
+      },
+      "repair": {
+        "skills": [["mechanics", 2]],
+        "time": "20 s",
+        "using": [
+          ["adhesive", 1],
+          ["soldering_standard", 1]
+        ]
+      }
     },
-    "flags": [ "HORN" ],
-    "breaks_into": [ { "item": "scrap", "charges": [ 0, 2 ] }, { "item": "plastic_chunk", "count": [ 1, 2 ] } ],
-    "variants": [ { "symbols": "*", "symbols_broken": "*" } ]
+    "flags": ["HORN"],
+    "breaks_into": [
+      { "item": "scrap", "charges": [0, 2] },
+      { "item": "plastic_chunk", "count": [1, 2] }
+    ],
+    "variants": [{ "symbols": "*", "symbols_broken": "*" }]
   },
   {
     "type": "vehicle_part",
     "id": "horn_big",
     "name": { "str": "truck horn" },
-    "categories": [ "other" ],
+    "categories": ["other"],
     "broken_color": "red",
     "damage_modifier": 10,
     "durability": 125,
@@ -2267,23 +3259,38 @@
     "bonus": 120,
     "item": "horn_big",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 1 ] ], "time": "150 s", "using": [ [ "vehicle_screw", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "150 s", "using": [ [ "vehicle_screw", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "20 s", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 2 ] ] }
+      "install": {
+        "skills": [["mechanics", 1]],
+        "time": "150 s",
+        "using": [["vehicle_screw", 1]]
+      },
+      "removal": {
+        "skills": [["mechanics", 1]],
+        "time": "150 s",
+        "using": [["vehicle_screw", 1]]
+      },
+      "repair": {
+        "skills": [["mechanics", 1]],
+        "time": "20 s",
+        "using": [
+          ["adhesive", 1],
+          ["soldering_standard", 2]
+        ]
+      }
     },
-    "flags": [ "HORN" ],
+    "flags": ["HORN"],
     "breaks_into": [
       { "item": "steel_chunk", "prob": 50 },
-      { "item": "scrap", "charges": [ 0, 2 ] },
-      { "item": "plastic_chunk", "count": [ 1, 2 ] }
+      { "item": "scrap", "charges": [0, 2] },
+      { "item": "plastic_chunk", "count": [1, 2] }
     ],
-    "variants": [ { "symbols": "*", "symbols_broken": "*" } ]
+    "variants": [{ "symbols": "*", "symbols_broken": "*" }]
   },
   {
     "type": "vehicle_part",
     "id": "beeper",
     "name": { "str": "back-up beeper" },
-    "categories": [ "other" ],
+    "categories": ["other"],
     "broken_color": "dark_gray",
     "damage_modifier": 10,
     "durability": 90,
@@ -2292,20 +3299,35 @@
     "folded_volume": "250 ml",
     "item": "beeper",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 2 ] ], "time": "150 s", "using": [ [ "vehicle_screw", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "150 s", "using": [ [ "vehicle_screw", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "20 s", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 1 ] ] }
+      "install": {
+        "skills": [["mechanics", 2]],
+        "time": "150 s",
+        "using": [["vehicle_screw", 1]]
+      },
+      "removal": {
+        "skills": [["mechanics", 2]],
+        "time": "150 s",
+        "using": [["vehicle_screw", 1]]
+      },
+      "repair": {
+        "skills": [["mechanics", 2]],
+        "time": "20 s",
+        "using": [
+          ["adhesive", 1],
+          ["soldering_standard", 1]
+        ]
+      }
     },
-    "flags": [ "BEEPER", "ODDTURN" ],
+    "flags": ["BEEPER", "ODDTURN"],
     "breaks_into": "ig_vp_device",
-    "variants": [ { "symbols": "*", "symbols_broken": "*" } ]
+    "variants": [{ "symbols": "*", "symbols_broken": "*" }]
   },
   {
     "type": "vehicle_part",
     "id": "cargo_space",
     "name": { "str": "cargo space" },
     "looks_like": "box",
-    "categories": [ "cargo" ],
+    "categories": ["cargo"],
     "broken_color": "dark_gray",
     "durability": 250,
     "size": "500 L",
@@ -2315,34 +3337,44 @@
     "location": "center",
     "requirements": {
       "install": {
-        "skills": [ [ "mechanics", 1 ] ],
+        "skills": [["mechanics", 1]],
         "time": "40 m",
-        "using": [ [ "welding_standard", 240 ], [ "vehicle_bolt_install", 4 ] ]
+        "using": [
+          ["welding_standard", 240],
+          ["vehicle_bolt_install", 4]
+        ]
       },
       "removal": {
-        "skills": [ [ "mechanics", 2 ] ],
+        "skills": [["mechanics", 2]],
         "time": "30 m",
-        "using": [ [ "vehicle_weld_removal", 1 ], [ "vehicle_wrench_2", 1 ] ]
+        "using": [
+          ["vehicle_weld_removal", 1],
+          ["vehicle_wrench_2", 1]
+        ]
       },
-      "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "20 m", "using": [ [ "repair_welding_standard", 12 ] ] }
+      "repair": {
+        "skills": [["mechanics", 2]],
+        "time": "20 m",
+        "using": [["repair_welding_standard", 12]]
+      }
     },
-    "flags": [ "BOARDABLE", "CARGO", "COVERED", "HUGE_OK" ],
+    "flags": ["BOARDABLE", "CARGO", "COVERED", "HUGE_OK"],
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 12, 19 ] },
-      { "item": "steel_chunk", "count": [ 7, 12 ] },
-      { "item": "scrap", "charges": [ 14, 25 ] },
-      { "item": "rope_6", "count": [ 0, 2 ] },
-      { "item": "string_36", "count": [ 10, 25 ] },
-      { "item": "string_6", "count": [ 15, 28 ] }
+      { "item": "steel_lump", "count": [12, 19] },
+      { "item": "steel_chunk", "count": [7, 12] },
+      { "item": "scrap", "charges": [14, 25] },
+      { "item": "rope_6", "count": [0, 2] },
+      { "item": "string_36", "count": [10, 25] },
+      { "item": "string_6", "count": [15, 28] }
     ],
     "damage_reduction": { "all": 28 },
-    "variants": [ { "symbols": "=", "symbols_broken": "#" } ]
+    "variants": [{ "symbols": "=", "symbols_broken": "#" }]
   },
   {
     "type": "vehicle_part",
     "id": "livestock_stall",
     "name": { "str": "livestock stall" },
-    "categories": [ "passengers", "cargo" ],
+    "categories": ["passengers", "cargo"],
     "looks_like": "cargo_space",
     "broken_color": "dark_gray",
     "durability": 250,
@@ -2354,25 +3386,43 @@
     "location": "center",
     "requirements": {
       "install": {
-        "skills": [ [ "mechanics", 1 ] ],
+        "skills": [["mechanics", 1]],
         "time": "40 m",
-        "using": [ [ "welding_standard", 240 ], [ "vehicle_bolt_install", 4 ] ]
+        "using": [
+          ["welding_standard", 240],
+          ["vehicle_bolt_install", 4]
+        ]
       },
       "removal": {
-        "skills": [ [ "mechanics", 1 ] ],
+        "skills": [["mechanics", 1]],
         "time": "30 m",
-        "using": [ [ "vehicle_weld_removal", 1 ], [ "vehicle_wrench_2", 1 ] ]
+        "using": [
+          ["vehicle_weld_removal", 1],
+          ["vehicle_wrench_2", 1]
+        ]
       },
-      "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "20 m", "using": [ [ "repair_welding_standard", 12 ] ] }
+      "repair": {
+        "skills": [["mechanics", 2]],
+        "time": "20 m",
+        "using": [["repair_welding_standard", 12]]
+      }
     },
-    "flags": [ "BOARDABLE", "CARGO", "COVERED", "CAPTURE_MONSTER_VEH", "HUGE_OK", "BED", "BELTABLE" ],
+    "flags": [
+      "BOARDABLE",
+      "CARGO",
+      "COVERED",
+      "CAPTURE_MONSTER_VEH",
+      "HUGE_OK",
+      "BED",
+      "BELTABLE"
+    ],
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 6, 8 ] },
-      { "item": "steel_chunk", "count": [ 6, 8 ] },
-      { "item": "scrap", "charges": [ 6, 8 ] }
+      { "item": "steel_lump", "count": [6, 8] },
+      { "item": "steel_chunk", "count": [6, 8] },
+      { "item": "scrap", "charges": [6, 8] }
     ],
     "damage_reduction": { "all": 30 },
-    "variants": [ { "symbols": "=", "symbols_broken": "#" } ]
+    "variants": [{ "symbols": "=", "symbols_broken": "#" }]
   },
   {
     "type": "vehicle_part",
@@ -2383,14 +3433,17 @@
     "description": "A large locker for transporting smaller animals.  'e'xamine it to capture an animal next to you, or to release the animal currently contained.  When selecting an animal to capture, choose its tile relative to you, not the part.",
     "size": "50 L",
     "item": "animal_locker",
-    "flags": [ "CARGO", "COVERED", "CAPTURE_MONSTER_VEH", "OBSTACLE" ],
-    "breaks_into": [ { "item": "steel_chunk", "count": [ 1, 2 ] }, { "item": "scrap", "charges": [ 3, 4 ] } ]
+    "flags": ["CARGO", "COVERED", "CAPTURE_MONSTER_VEH", "OBSTACLE"],
+    "breaks_into": [
+      { "item": "steel_chunk", "count": [1, 2] },
+      { "item": "scrap", "charges": [3, 4] }
+    ]
   },
   {
     "type": "vehicle_part",
     "id": "recharge_station",
     "name": { "str": "recharging station" },
-    "categories": [ "utility" ],
+    "categories": ["utility"],
     "color": "light_green",
     "broken_color": "blue",
     "damage_modifier": 10,
@@ -2401,19 +3454,34 @@
     "item": "recharge_station",
     "location": "on_cargo",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 3 ] ], "time": "30 m", "using": [ [ "vehicle_screw", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_screw", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 4 ] ], "time": "30 m", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 8 ] ] }
+      "install": {
+        "skills": [["mechanics", 3]],
+        "time": "30 m",
+        "using": [["vehicle_screw", 1]]
+      },
+      "removal": {
+        "skills": [["mechanics", 2]],
+        "time": "30 m",
+        "using": [["vehicle_screw", 1]]
+      },
+      "repair": {
+        "skills": [["mechanics", 4]],
+        "time": "30 m",
+        "using": [
+          ["adhesive", 1],
+          ["soldering_standard", 8]
+        ]
+      }
     },
-    "flags": [ "INTERNAL", "RECHARGE" ],
+    "flags": ["INTERNAL", "RECHARGE"],
     "folded_volume": "2 L",
     "breaks_into": [
-      { "item": "steel_chunk", "count": [ 0, 2 ] },
-      { "item": "scrap", "charges": [ 1, 2 ] },
-      { "item": "cable", "charges": [ 1, 3 ] }
+      { "item": "steel_chunk", "count": [0, 2] },
+      { "item": "scrap", "charges": [1, 2] },
+      { "item": "cable", "charges": [1, 3] }
     ],
     "damage_reduction": { "all": 10 },
-    "variants": [ { "symbols": "o", "symbols_broken": "#" } ]
+    "variants": [{ "symbols": "o", "symbols_broken": "#" }]
   },
   {
     "type": "vehicle_part",
@@ -2425,9 +3493,24 @@
     "bonus": 15,
     "item": "battery_charger",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 1 ] ], "time": "5 m", "using": [ [ "vehicle_screw", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "5 m", "using": [ [ "vehicle_screw", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "30 m", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 4 ] ] }
+      "install": {
+        "skills": [["mechanics", 1]],
+        "time": "5 m",
+        "using": [["vehicle_screw", 1]]
+      },
+      "removal": {
+        "skills": [["mechanics", 1]],
+        "time": "5 m",
+        "using": [["vehicle_screw", 1]]
+      },
+      "repair": {
+        "skills": [["mechanics", 3]],
+        "time": "30 m",
+        "using": [
+          ["adhesive", 1],
+          ["soldering_standard", 4]
+        ]
+      }
     },
     "folded_volume": "250 ml",
     "breaks_into": "ig_vp_device",
@@ -2437,7 +3520,7 @@
     "type": "vehicle_part",
     "id": "stereo",
     "name": { "str": "stereo system" },
-    "categories": [ "other" ],
+    "categories": ["other"],
     "color": "red",
     "damage_modifier": 0,
     "durability": 60,
@@ -2447,19 +3530,34 @@
     "bonus": 80,
     "item": "stereo",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 2 ] ], "time": "60 m", "using": [ [ "vehicle_screw", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_screw", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "30 m", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 3 ] ] }
+      "install": {
+        "skills": [["mechanics", 2]],
+        "time": "60 m",
+        "using": [["vehicle_screw", 1]]
+      },
+      "removal": {
+        "skills": [["mechanics", 2]],
+        "time": "30 m",
+        "using": [["vehicle_screw", 1]]
+      },
+      "repair": {
+        "skills": [["mechanics", 3]],
+        "time": "30 m",
+        "using": [
+          ["adhesive", 1],
+          ["soldering_standard", 3]
+        ]
+      }
     },
-    "flags": [ "STEREO", "ENABLED_DRAINS_EPOWER" ],
+    "flags": ["STEREO", "ENABLED_DRAINS_EPOWER"],
     "breaks_into": "ig_vp_device",
-    "variants": [ { "symbols": "&", "symbols_broken": "&" } ]
+    "variants": [{ "symbols": "&", "symbols_broken": "&" }]
   },
   {
     "type": "vehicle_part",
     "id": "chimes",
     "name": { "str": "chimes" },
-    "categories": [ "other" ],
+    "categories": ["other"],
     "color": "red",
     "damage_modifier": 0,
     "durability": 40,
@@ -2467,26 +3565,41 @@
     "epower": "-50 W",
     "item": "chimes",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 2 ] ], "time": "60 m", "using": [ [ "vehicle_screw", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_screw", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "30 m", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 1 ] ] }
+      "install": {
+        "skills": [["mechanics", 2]],
+        "time": "60 m",
+        "using": [["vehicle_screw", 1]]
+      },
+      "removal": {
+        "skills": [["mechanics", 2]],
+        "time": "30 m",
+        "using": [["vehicle_screw", 1]]
+      },
+      "repair": {
+        "skills": [["mechanics", 3]],
+        "time": "30 m",
+        "using": [
+          ["adhesive", 1],
+          ["soldering_standard", 1]
+        ]
+      }
     },
-    "flags": [ "CHIMES", "ENABLED_DRAINS_EPOWER" ],
+    "flags": ["CHIMES", "ENABLED_DRAINS_EPOWER"],
     "location": "on_roof",
     "breaks_into": [
-      { "item": "scrap", "charges": [ 3, 5 ] },
-      { "item": "cable", "charges": [ 2, 4 ] },
-      { "item": "e_scrap", "count": [ 1, 2 ] },
+      { "item": "scrap", "charges": [3, 5] },
+      { "item": "cable", "charges": [2, 4] },
+      { "item": "e_scrap", "count": [1, 2] },
       { "item": "scrap_aluminum", "prob": 80 },
-      { "item": "plastic_chunk", "count": [ 0, 2 ] }
+      { "item": "plastic_chunk", "count": [0, 2] }
     ],
-    "variants": [ { "symbols": "&", "symbols_broken": "&" } ]
+    "variants": [{ "symbols": "&", "symbols_broken": "&" }]
   },
   {
     "type": "vehicle_part",
     "id": "jumper_cable",
     "name": { "str": "jumper cable" },
-    "categories": [ "other" ],
+    "categories": ["other"],
     "color": "yellow",
     "broken_color": "dark_gray",
     "damage_modifier": 10,
@@ -2496,15 +3609,18 @@
     "description": "Thick copper cable with leads on either end.  Attach one end to one vehicle and the other to another, and you can transfer electrical power between the two.",
     "item": "jumper_cable",
     "requirements": { "removal": { "time": "5 s" } },
-    "flags": [ "NO_INSTALL_HIDDEN", "UNMOUNT_ON_DAMAGE", "POWER_TRANSFER" ],
-    "breaks_into": [ { "item": "cable", "charges": [ 10, 30 ] }, { "item": "plastic_chunk", "count": [ 1, 2 ] } ],
-    "variants": [ { "symbols": "{", "symbols_broken": "*" } ]
+    "flags": ["NO_INSTALL_HIDDEN", "UNMOUNT_ON_DAMAGE", "POWER_TRANSFER"],
+    "breaks_into": [
+      { "item": "cable", "charges": [10, 30] },
+      { "item": "plastic_chunk", "count": [1, 2] }
+    ],
+    "variants": [{ "symbols": "{", "symbols_broken": "*" }]
   },
   {
     "type": "vehicle_part",
     "id": "extension_cable",
     "name": { "str": "extension cord" },
-    "categories": [ "other" ],
+    "categories": ["other"],
     "color": "yellow",
     "broken_color": "dark_gray",
     "damage_modifier": 10,
@@ -2514,15 +3630,18 @@
     "description": "A long orange extension cord for connecting appliances.  Currently plugged in.",
     "item": "extension_cable",
     "requirements": { "removal": { "time": "5 s" } },
-    "flags": [ "NO_INSTALL_HIDDEN", "UNMOUNT_ON_DAMAGE", "POWER_TRANSFER" ],
-    "breaks_into": [ { "item": "cable", "charges": [ 45, 90 ] }, { "item": "plastic_chunk", "count": [ 2, 3 ] } ],
-    "variants": [ { "symbols": "{", "symbols_broken": "*" } ]
+    "flags": ["NO_INSTALL_HIDDEN", "UNMOUNT_ON_DAMAGE", "POWER_TRANSFER"],
+    "breaks_into": [
+      { "item": "cable", "charges": [45, 90] },
+      { "item": "plastic_chunk", "count": [2, 3] }
+    ],
+    "variants": [{ "symbols": "{", "symbols_broken": "*" }]
   },
   {
     "type": "vehicle_part",
     "id": "long_extension_cable",
     "name": { "str": "outdoor extension cord" },
-    "categories": [ "other" ],
+    "categories": ["other"],
     "color": "yellow",
     "broken_color": "dark_gray",
     "damage_modifier": 10,
@@ -2532,15 +3651,18 @@
     "description": "An extra long 30 m orange extension cord for connecting outdoor appliances.  Currently plugged in.",
     "item": "long_extension_cable",
     "requirements": { "removal": { "time": "5 s" } },
-    "flags": [ "NO_INSTALL_HIDDEN", "UNMOUNT_ON_DAMAGE", "POWER_TRANSFER" ],
-    "breaks_into": [ { "item": "cable", "charges": [ 135, 270 ] }, { "item": "plastic_chunk", "count": [ 4, 6 ] } ],
-    "variants": [ { "symbols": "{", "symbols_broken": "*" } ]
+    "flags": ["NO_INSTALL_HIDDEN", "UNMOUNT_ON_DAMAGE", "POWER_TRANSFER"],
+    "breaks_into": [
+      { "item": "cable", "charges": [135, 270] },
+      { "item": "plastic_chunk", "count": [4, 6] }
+    ],
+    "variants": [{ "symbols": "{", "symbols_broken": "*" }]
   },
   {
     "type": "vehicle_part",
     "id": "jumper_cable_heavy",
     "name": { "str": "heavy-duty jumper cable" },
-    "categories": [ "other" ],
+    "categories": ["other"],
     "color": "yellow",
     "broken_color": "dark_gray",
     "damage_modifier": 10,
@@ -2550,15 +3672,18 @@
     "//": "Epower for POWER_TRANSFER stuff is how much percentage-wise loss there is in transmission",
     "item": "jumper_cable_heavy",
     "requirements": { "removal": { "time": "5 s" } },
-    "flags": [ "NO_INSTALL_HIDDEN", "UNMOUNT_ON_DAMAGE", "POWER_TRANSFER" ],
-    "breaks_into": [ { "item": "cable", "charges": [ 97, 195 ] }, { "item": "plastic_chunk", "count": [ 4, 8 ] } ],
-    "variants": [ { "symbols": "{", "symbols_broken": "*" } ]
+    "flags": ["NO_INSTALL_HIDDEN", "UNMOUNT_ON_DAMAGE", "POWER_TRANSFER"],
+    "breaks_into": [
+      { "item": "cable", "charges": [97, 195] },
+      { "item": "plastic_chunk", "count": [4, 8] }
+    ],
+    "variants": [{ "symbols": "{", "symbols_broken": "*" }]
   },
   {
     "type": "vehicle_part",
     "id": "hd_tow_cable",
     "name": { "str": "heavy-duty tow cable" },
-    "categories": [ "other" ],
+    "categories": ["other"],
     "color": "light_blue",
     "broken_color": "dark_gray",
     "damage_modifier": 10,
@@ -2566,21 +3691,21 @@
     "description": "A heavy-duty tow cable, if the other end was attached to another vehicle, it could pull it.",
     "item": "hd_tow_cable",
     "requirements": { "removal": { "time": "5 s" } },
-    "flags": [ "NO_INSTALL_HIDDEN", "UNMOUNT_ON_DAMAGE", "TOW_CABLE" ],
+    "flags": ["NO_INSTALL_HIDDEN", "UNMOUNT_ON_DAMAGE", "TOW_CABLE"],
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 5, 10 ] },
-      { "item": "steel_chunk", "count": [ 7, 14 ] },
-      { "item": "scrap", "charges": [ 17, 34 ] },
+      { "item": "steel_lump", "count": [5, 10] },
+      { "item": "steel_chunk", "count": [7, 14] },
+      { "item": "scrap", "charges": [17, 34] },
       { "item": "grip_hook", "prob": 80 },
-      { "item": "cable", "charges": [ 1, 3 ] }
+      { "item": "cable", "charges": [1, 3] }
     ],
-    "variants": [ { "symbols": "{", "symbols_broken": "*" } ]
+    "variants": [{ "symbols": "{", "symbols_broken": "*" }]
   },
   {
     "type": "vehicle_part",
     "id": "jumper_cable_debug",
     "name": { "str": "shiny debug cable" },
-    "categories": [ "other" ],
+    "categories": ["other"],
     "color": "yellow",
     "broken_color": "dark_gray",
     "//": "Epower for POWER_TRANSFER stuff is how much percentage-wise loss there is in transmission",
@@ -2588,16 +3713,16 @@
     "durability": 120,
     "item": "jumper_cable_debug",
     "requirements": { "removal": { "time": "5 s" } },
-    "flags": [ "NO_INSTALL_HIDDEN", "UNMOUNT_ON_DAMAGE", "POWER_TRANSFER" ],
-    "breaks_into": [ { "item": "jumper_cable_debug" } ],
-    "variants": [ { "symbols": "{", "symbols_broken": "*" } ]
+    "flags": ["NO_INSTALL_HIDDEN", "UNMOUNT_ON_DAMAGE", "POWER_TRANSFER"],
+    "breaks_into": [{ "item": "jumper_cable_debug" }],
+    "variants": [{ "symbols": "{", "symbols_broken": "*" }]
   },
   {
     "type": "vehicle_part",
     "id": "seat_wood_flimsy",
     "name": { "str": "flimsy wooden seat" },
     "looks_like": "seat",
-    "categories": [ "operations", "passengers" ],
+    "categories": ["operations", "passengers"],
     "color": "brown",
     "broken_color": "brown",
     "damage_modifier": 20,
@@ -2606,25 +3731,37 @@
     "item": "frame_wood_light",
     "location": "center",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 1 ] ], "time": "30 m", "using": [ [ "rope_natural_short", 2 ] ] },
-      "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "15 m", "qualities": [ { "id": "CUT", "level": 2 } ] },
-      "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "rope_natural_short", 1 ] ] }
+      "install": {
+        "skills": [["mechanics", 1]],
+        "time": "30 m",
+        "using": [["rope_natural_short", 2]]
+      },
+      "removal": {
+        "skills": [["mechanics", 1]],
+        "time": "15 m",
+        "qualities": [{ "id": "CUT", "level": 2 }]
+      },
+      "repair": {
+        "skills": [["mechanics", 2]],
+        "time": "30 m",
+        "using": [["rope_natural_short", 1]]
+      }
     },
-    "flags": [ "SEAT", "BOARDABLE", "BELTABLE" ],
+    "flags": ["SEAT", "BOARDABLE", "BELTABLE"],
     "breaks_into": [
-      { "item": "splinter", "count": [ 4, 7 ] },
-      { "item": "string_36", "count": [ 3, 6 ] },
-      { "item": "string_6", "count": [ 9, 18 ] }
+      { "item": "splinter", "count": [4, 7] },
+      { "item": "string_36", "count": [3, 6] },
+      { "item": "string_6", "count": [9, 18] }
     ],
     "damage_reduction": { "all": 6 },
-    "variants": [ { "symbols": "#", "symbols_broken": "*" } ]
+    "variants": [{ "symbols": "#", "symbols_broken": "*" }]
   },
   {
     "type": "vehicle_part",
     "id": "seat_wood",
     "name": { "str": "wooden seat" },
     "looks_like": "seat",
-    "categories": [ "operations", "passengers" ],
+    "categories": ["operations", "passengers"],
     "color": "brown",
     "broken_color": "brown",
     "damage_modifier": 60,
@@ -2635,14 +3772,29 @@
     "location": "center",
     "size": "85 L",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 1 ] ], "time": "30 m", "using": [ [ "vehicle_nail_install", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "15 m", "using": [ [ "vehicle_nail_removal", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "adhesive", 2 ] ] }
+      "install": {
+        "skills": [["mechanics", 1]],
+        "time": "30 m",
+        "using": [["vehicle_nail_install", 1]]
+      },
+      "removal": {
+        "skills": [["mechanics", 2]],
+        "time": "15 m",
+        "using": [["vehicle_nail_removal", 1]]
+      },
+      "repair": {
+        "skills": [["mechanics", 2]],
+        "time": "30 m",
+        "using": [["adhesive", 2]]
+      }
     },
-    "flags": [ "SEAT", "BOARDABLE", "BELTABLE", "CARGO" ],
-    "breaks_into": [ { "item": "splinter", "count": [ 7, 9 ] }, { "item": "nail", "charges": [ 6, 12 ] } ],
+    "flags": ["SEAT", "BOARDABLE", "BELTABLE", "CARGO"],
+    "breaks_into": [
+      { "item": "splinter", "count": [7, 9] },
+      { "item": "nail", "charges": [6, 12] }
+    ],
     "damage_reduction": { "all": 8 },
-    "variants": [ { "symbols": "#", "symbols_broken": "*" } ]
+    "variants": [{ "symbols": "#", "symbols_broken": "*" }]
   },
   {
     "type": "vehicle_part",
@@ -2657,46 +3809,65 @@
     "type": "vehicle_part",
     "id": "roof_wood",
     "name": { "str": "wooden roof" },
-    "categories": [ "hull" ],
+    "categories": ["hull"],
     "broken_color": "dark_gray",
     "durability": 130,
     "description": "A wooden roof.",
     "item": "frame_wood",
     "location": "roof",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 1 ] ], "time": "30 m", "using": [ [ "vehicle_nail_install", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "15 m", "using": [ [ "vehicle_nail_removal", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "adhesive", 2 ] ] }
+      "install": {
+        "skills": [["mechanics", 1]],
+        "time": "30 m",
+        "using": [["vehicle_nail_install", 1]]
+      },
+      "removal": {
+        "skills": [["mechanics", 2]],
+        "time": "15 m",
+        "using": [["vehicle_nail_removal", 1]]
+      },
+      "repair": {
+        "skills": [["mechanics", 2]],
+        "time": "30 m",
+        "using": [["adhesive", 2]]
+      }
     },
-    "flags": [ "ROOF" ],
-    "breaks_into": [ { "item": "splinter", "count": [ 7, 9 ] }, { "item": "nail", "charges": [ 6, 12 ] } ],
+    "flags": ["ROOF"],
+    "breaks_into": [
+      { "item": "splinter", "count": [7, 9] },
+      { "item": "nail", "charges": [6, 12] }
+    ],
     "damage_reduction": { "all": 16 },
-    "variants": [ { "symbols": "#", "symbols_broken": "#" } ]
+    "variants": [{ "symbols": "#", "symbols_broken": "#" }]
   },
   {
     "type": "vehicle_part",
     "id": "plating_chitin",
     "name": { "str": "chitin plating" },
-    "categories": [ "warfare" ],
+    "categories": ["warfare"],
     "color": "yellow",
     "durability": 200,
     "item": "chitin_plate",
     "location": "armor",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 2 ] ], "time": "10 m" },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "5 m" },
-      "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "5 m", "using": [ [ "adhesive", 1 ] ] }
+      "install": { "skills": [["mechanics", 2]], "time": "10 m" },
+      "removal": { "skills": [["mechanics", 2]], "time": "5 m" },
+      "repair": {
+        "skills": [["mechanics", 2]],
+        "time": "5 m",
+        "using": [["adhesive", 1]]
+      }
     },
-    "flags": [ "ARMOR" ],
+    "flags": ["ARMOR"],
     "breaks_into": [
-      { "item": "chitin_piece", "count": [ 4, 8 ] },
-      { "item": "meal_chitin_piece", "count": [ 2, 6 ] },
+      { "item": "chitin_piece", "count": [4, 8] },
+      { "item": "meal_chitin_piece", "count": [2, 6] },
       { "item": "rope_6", "prob": 75 },
-      { "item": "string_36", "count": [ 2, 4 ] },
-      { "item": "string_6", "count": [ 7, 14 ] }
+      { "item": "string_36", "count": [2, 4] },
+      { "item": "string_6", "count": [7, 14] }
     ],
     "damage_reduction": { "all": 20 },
-    "variants": [ { "symbols": ")", "symbols_broken": ")" } ]
+    "variants": [{ "symbols": ")", "symbols_broken": ")" }]
   },
   {
     "type": "vehicle_part",
@@ -2706,11 +3877,11 @@
     "proportional": { "durability": 1.1 },
     "item": "acidchitin_plate",
     "breaks_into": [
-      { "item": "acidchitin_piece", "count": [ 6, 19 ] },
-      { "item": "meal_chitin_piece", "count": [ 2, 6 ] },
+      { "item": "acidchitin_piece", "count": [6, 19] },
+      { "item": "meal_chitin_piece", "count": [2, 6] },
       { "item": "rope_6", "prob": 75 },
-      { "item": "string_36", "count": [ 2, 4 ] },
-      { "item": "string_6", "count": [ 7, 14 ] }
+      { "item": "string_36", "count": [2, 4] },
+      { "item": "string_6", "count": [7, 14] }
     ],
     "damage_reduction": { "all": 24 }
   },
@@ -2718,7 +3889,7 @@
     "type": "vehicle_part",
     "id": "door_motor",
     "name": { "str": "door motor" },
-    "categories": [ "other" ],
+    "categories": ["other"],
     "color": "light_green",
     "damage_modifier": 10,
     "durability": 50,
@@ -2726,25 +3897,40 @@
     "item": "motor_tiny",
     "folded_volume": "250 ml",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_screw", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_screw", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "30 m", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 3 ] ] }
+      "install": {
+        "skills": [["mechanics", 2]],
+        "time": "30 m",
+        "using": [["vehicle_screw", 1]]
+      },
+      "removal": {
+        "skills": [["mechanics", 2]],
+        "time": "30 m",
+        "using": [["vehicle_screw", 1]]
+      },
+      "repair": {
+        "skills": [["mechanics", 3]],
+        "time": "30 m",
+        "using": [
+          ["adhesive", 1],
+          ["soldering_standard", 3]
+        ]
+      }
     },
-    "flags": [ "BOARD_INTERNAL", "DOOR_MOTOR", "UNMOUNT_ON_DAMAGE" ],
+    "flags": ["BOARD_INTERNAL", "DOOR_MOTOR", "UNMOUNT_ON_DAMAGE"],
     "breaks_into": [
-      { "item": "scrap", "charges": [ 1, 3 ] },
-      { "item": "cable", "charges": [ 3, 7 ] },
+      { "item": "scrap", "charges": [1, 3] },
+      { "item": "cable", "charges": [3, 7] },
       { "item": "e_scrap", "prob": 75 },
-      { "item": "bearing", "count": [ 0, 2 ] }
+      { "item": "bearing", "count": [0, 2] }
     ],
     "damage_reduction": { "all": 12 },
-    "variants": [ { "symbols": "*", "symbols_broken": "#" } ]
+    "variants": [{ "symbols": "*", "symbols_broken": "#" }]
   },
   {
     "type": "vehicle_part",
     "id": "drive_by_wire_controls",
     "name": { "str": "drive by wire controls" },
-    "categories": [ "operations" ],
+    "categories": ["operations"],
     "color": "light_red",
     "broken_color": "red",
     "damage_modifier": 10,
@@ -2755,30 +3941,43 @@
     "item": "drive_by_wire_controls",
     "requirements": {
       "install": {
-        "skills": [ [ "mechanics", 3 ] ],
+        "skills": [["mechanics", 3]],
         "time": "60 m",
-        "using": [ [ "welding_standard", 120 ], [ "vehicle_bolt_install", 2 ] ]
+        "using": [
+          ["welding_standard", 120],
+          ["vehicle_bolt_install", 2]
+        ]
       },
       "removal": {
-        "skills": [ [ "mechanics", 2 ] ],
+        "skills": [["mechanics", 2]],
         "time": "30 m",
-        "using": [ [ "vehicle_weld_removal", 1 ], [ "vehicle_wrench_2", 1 ] ]
+        "using": [
+          ["vehicle_weld_removal", 1],
+          ["vehicle_wrench_2", 1]
+        ]
       },
       "repair": {
-        "skills": [ [ "mechanics", 4 ] ],
+        "skills": [["mechanics", 4]],
         "time": "20 m",
-        "using": [ [ "repair_welding_standard", 6 ], [ "soldering_standard", 5 ] ]
+        "using": [
+          ["repair_welding_standard", 6],
+          ["soldering_standard", 5]
+        ]
       }
     },
-    "flags": [ "CONTROLS", "REMOTE_CONTROLS" ],
-    "breaks_into": [ { "item": "motor_tiny" }, { "item": "steel_chunk", "count": [ 1, 3 ] }, { "item": "scrap", "count": [ 1, 3 ] } ],
-    "variants": [ { "symbols": "$", "symbols_broken": "$" } ]
+    "flags": ["CONTROLS", "REMOTE_CONTROLS"],
+    "breaks_into": [
+      { "item": "motor_tiny" },
+      { "item": "steel_chunk", "count": [1, 3] },
+      { "item": "scrap", "count": [1, 3] }
+    ],
+    "variants": [{ "symbols": "$", "symbols_broken": "$" }]
   },
   {
     "type": "vehicle_part",
     "id": "cam_control",
     "name": { "str": "camera control system" },
-    "categories": [ "operations" ],
+    "categories": ["operations"],
     "color": "light_blue",
     "broken_color": "blue",
     "damage_modifier": 20,
@@ -2788,23 +3987,38 @@
     "item": "camera_control",
     "epower": "-20 W",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 3 ] ], "time": "60 m", "using": [ [ "vehicle_screw", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_screw", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 4 ] ], "time": "60 m", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 2 ] ] }
+      "install": {
+        "skills": [["mechanics", 3]],
+        "time": "60 m",
+        "using": [["vehicle_screw", 1]]
+      },
+      "removal": {
+        "skills": [["mechanics", 2]],
+        "time": "30 m",
+        "using": [["vehicle_screw", 1]]
+      },
+      "repair": {
+        "skills": [["mechanics", 4]],
+        "time": "60 m",
+        "using": [
+          ["adhesive", 1],
+          ["soldering_standard", 2]
+        ]
+      }
     },
-    "flags": [ "VISION", "CAMERA", "CAMERA_CONTROL", "ENABLED_DRAINS_EPOWER" ],
+    "flags": ["VISION", "CAMERA", "CAMERA_CONTROL", "ENABLED_DRAINS_EPOWER"],
     "breaks_into": [
-      { "item": "e_scrap", "count": [ 4, 10 ] },
-      { "item": "plastic_chunk", "count": [ 2, 8 ] },
-      { "item": "cable", "charges": [ 2, 4 ] }
+      { "item": "e_scrap", "count": [4, 10] },
+      { "item": "plastic_chunk", "count": [2, 8] },
+      { "item": "cable", "charges": [2, 4] }
     ],
-    "variants": [ { "symbols": "#", "symbols_broken": "#" } ]
+    "variants": [{ "symbols": "#", "symbols_broken": "#" }]
   },
   {
     "type": "vehicle_part",
     "id": "omnicam",
     "name": { "str": "security camera" },
-    "categories": [ "operations" ],
+    "categories": ["operations"],
     "color": "light_red",
     "broken_color": "red",
     "damage_modifier": 10,
@@ -2817,48 +4031,78 @@
     "epower": "-10 W",
     "location": "on_roof",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 4 ] ], "time": "60 m", "using": [ [ "vehicle_screw", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_screw", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 5 ] ], "time": "60 m", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 3 ] ] }
+      "install": {
+        "skills": [["mechanics", 4]],
+        "time": "60 m",
+        "using": [["vehicle_screw", 1]]
+      },
+      "removal": {
+        "skills": [["mechanics", 2]],
+        "time": "30 m",
+        "using": [["vehicle_screw", 1]]
+      },
+      "repair": {
+        "skills": [["mechanics", 5]],
+        "time": "60 m",
+        "using": [
+          ["adhesive", 1],
+          ["soldering_standard", 3]
+        ]
+      }
     },
-    "flags": [ "VISION", "CAMERA", "ENABLED_DRAINS_EPOWER" ],
+    "flags": ["VISION", "CAMERA", "ENABLED_DRAINS_EPOWER"],
     "breaks_into": [
-      { "item": "e_scrap", "count": [ 3, 7 ] },
-      { "item": "cable", "charges": [ 3, 7 ] },
-      { "item": "plastic_chunk", "count": [ 4, 10 ] },
+      { "item": "e_scrap", "count": [3, 7] },
+      { "item": "cable", "charges": [3, 7] },
+      { "item": "plastic_chunk", "count": [4, 10] },
       { "item": "lens", "prob": 35 }
     ],
-    "variants": [ { "symbols": "o", "symbols_broken": "#" } ]
+    "variants": [{ "symbols": "o", "symbols_broken": "#" }]
   },
   {
     "type": "vehicle_part",
     "id": "omnicamera_reinforced",
     "copy-from": "omnicam",
     "name": { "str": "reinforced security camera" },
-    "categories": [ "operations" ],
+    "categories": ["operations"],
     "durability": 300,
     "description": "A small camera encased in a protective metal cage.  Will relay what it can see to a camera control station.",
     "item": "omnicamera_reinforced",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 4 ] ], "time": "60 m", "using": [ [ "vehicle_screw", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_screw", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 5 ] ], "time": "60 m", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 4 ] ] }
+      "install": {
+        "skills": [["mechanics", 4]],
+        "time": "60 m",
+        "using": [["vehicle_screw", 1]]
+      },
+      "removal": {
+        "skills": [["mechanics", 2]],
+        "time": "30 m",
+        "using": [["vehicle_screw", 1]]
+      },
+      "repair": {
+        "skills": [["mechanics", 5]],
+        "time": "60 m",
+        "using": [
+          ["adhesive", 1],
+          ["soldering_standard", 4]
+        ]
+      }
     },
-    "flags": [ "VISION", "CAMERA", "ENABLED_DRAINS_EPOWER" ],
+    "flags": ["VISION", "CAMERA", "ENABLED_DRAINS_EPOWER"],
     "breaks_into": [
-      { "item": "e_scrap", "count": [ 3, 7 ] },
-      { "item": "cable", "charges": [ 3, 7 ] },
-      { "item": "plastic_chunk", "count": [ 4, 10 ] },
+      { "item": "e_scrap", "count": [3, 7] },
+      { "item": "cable", "charges": [3, 7] },
+      { "item": "plastic_chunk", "count": [4, 10] },
       { "item": "lens", "prob": 35 },
-      { "item": "scrap", "charges": [ 1, 3 ] }
+      { "item": "scrap", "charges": [1, 3] }
     ],
-    "variants": [ { "symbols": "o", "symbols_broken": "#" } ]
+    "variants": [{ "symbols": "o", "symbols_broken": "#" }]
   },
   {
     "type": "vehicle_part",
     "id": "robot_controls",
     "name": { "str": "robot controls" },
-    "categories": [ "operations" ],
+    "categories": ["operations"],
     "color": "white",
     "damage_modifier": 10,
     "durability": 300,
@@ -2869,55 +4113,76 @@
     "location": "center",
     "requirements": {
       "install": {
-        "skills": [ [ "mechanics", 4 ] ],
+        "skills": [["mechanics", 4]],
         "time": "60 m",
-        "using": [ [ "welding_standard", 120 ], [ "vehicle_bolt_install", 2 ] ]
+        "using": [
+          ["welding_standard", 120],
+          ["vehicle_bolt_install", 2]
+        ]
       },
       "removal": {
-        "skills": [ [ "mechanics", 2 ] ],
+        "skills": [["mechanics", 2]],
         "time": "30 m",
-        "using": [ [ "vehicle_weld_removal", 1 ], [ "vehicle_wrench_2", 1 ] ]
+        "using": [
+          ["vehicle_weld_removal", 1],
+          ["vehicle_wrench_2", 1]
+        ]
       },
       "repair": {
-        "skills": [ [ "mechanics", 5 ] ],
+        "skills": [["mechanics", 5]],
         "time": "20 m",
-        "using": [ [ "repair_welding_standard", 3 ], [ "soldering_standard", 3 ] ]
+        "using": [
+          ["repair_welding_standard", 3],
+          ["soldering_standard", 3]
+        ]
       }
     },
-    "flags": [ "REMOTE_CONTROLS", "OBSTACLE", "CABLE_PORTS" ],
+    "flags": ["REMOTE_CONTROLS", "OBSTACLE", "CABLE_PORTS"],
     "breaks_into": [
-      { "item": "motor_tiny", "count": [ 1, 3 ] },
-      { "item": "steel_chunk", "count": [ 1, 3 ] },
-      { "item": "e_scrap", "count": [ 1, 5 ] }
+      { "item": "motor_tiny", "count": [1, 3] },
+      { "item": "steel_chunk", "count": [1, 3] },
+      { "item": "e_scrap", "count": [1, 5] }
     ],
-    "variants": [ { "symbols": "&", "symbols_broken": "x" } ]
+    "variants": [{ "symbols": "&", "symbols_broken": "x" }]
   },
   {
     "type": "vehicle_part",
     "id": "vehicle_clock",
     "name": { "str": "makeshift clock" },
-    "categories": [ "other" ],
+    "categories": ["other"],
     "broken_color": "dark_gray",
     "durability": 20,
     "description": "A clock, so you know what time it is.",
     "folded_volume": "250 ml",
     "item": "wristwatch",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 1 ] ], "time": "150 s", "using": [ [ "vehicle_screw", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "150 s", "using": [ [ "vehicle_screw", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "20 s", "using": [ [ "adhesive", 1 ] ] }
+      "install": {
+        "skills": [["mechanics", 1]],
+        "time": "150 s",
+        "using": [["vehicle_screw", 1]]
+      },
+      "removal": {
+        "skills": [["mechanics", 1]],
+        "time": "150 s",
+        "using": [["vehicle_screw", 1]]
+      },
+      "repair": {
+        "skills": [["mechanics", 1]],
+        "time": "20 s",
+        "using": [["adhesive", 1]]
+      }
     },
-    "flags": [ "WATCH", "ALARMCLOCK" ],
-    "breaks_into": [ { "item": "scrap", "prob": 50 } ],
+    "flags": ["WATCH", "ALARMCLOCK"],
+    "breaks_into": [{ "item": "scrap", "prob": 50 }],
     "damage_reduction": { "bash": 5 },
-    "variants": [ { "symbols": ":", "symbols_broken": ";" } ]
+    "variants": [{ "symbols": ":", "symbols_broken": ";" }]
   },
   {
     "type": "vehicle_part",
     "id": "leather_funnel",
     "name": { "str": "leather funnel" },
     "looks_like": "funnel",
-    "categories": [ "other" ],
+    "categories": ["other"],
     "color": "brown",
     "damage_modifier": 5,
     "durability": 80,
@@ -2927,20 +4192,32 @@
     "location": "on_roof",
     "folded_volume": "250 ml",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 1 ] ], "time": "6 m", "using": [ [ "vehicle_nail_install", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "3 m", "using": [ [ "vehicle_nail_removal", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "6 m", "using": [ [ "adhesive", 2 ] ] }
+      "install": {
+        "skills": [["mechanics", 1]],
+        "time": "6 m",
+        "using": [["vehicle_nail_install", 1]]
+      },
+      "removal": {
+        "skills": [["mechanics", 2]],
+        "time": "3 m",
+        "using": [["vehicle_nail_removal", 1]]
+      },
+      "repair": {
+        "skills": [["mechanics", 2]],
+        "time": "6 m",
+        "using": [["adhesive", 2]]
+      }
     },
-    "flags": [ "FUNNEL" ],
-    "breaks_into": [ { "item": "leather", "count": [ 1, 2 ] } ],
-    "variants": [ { "symbols": "V", "symbols_broken": "*" } ]
+    "flags": ["FUNNEL"],
+    "breaks_into": [{ "item": "leather", "count": [1, 2] }],
+    "variants": [{ "symbols": "V", "symbols_broken": "*" }]
   },
   {
     "type": "vehicle_part",
     "id": "birchbark_funnel",
     "name": { "str": "birchbark funnel" },
     "looks_like": "funnel",
-    "categories": [ "other" ],
+    "categories": ["other"],
     "color": "white",
     "damage_modifier": 5,
     "durability": 60,
@@ -2950,20 +4227,32 @@
     "location": "on_roof",
     "folded_volume": "250 ml",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 2 ] ], "time": "6 m", "using": [ [ "vehicle_nail_install", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "3 m", "using": [ [ "vehicle_nail_removal", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "6 m", "using": [ [ "adhesive", 2 ] ] }
+      "install": {
+        "skills": [["mechanics", 2]],
+        "time": "6 m",
+        "using": [["vehicle_nail_install", 1]]
+      },
+      "removal": {
+        "skills": [["mechanics", 2]],
+        "time": "3 m",
+        "using": [["vehicle_nail_removal", 1]]
+      },
+      "repair": {
+        "skills": [["mechanics", 3]],
+        "time": "6 m",
+        "using": [["adhesive", 2]]
+      }
     },
-    "flags": [ "FUNNEL" ],
-    "breaks_into": [ { "item": "birchbark", "count": [ 1, 2 ] } ],
-    "variants": [ { "symbols": "V", "symbols_broken": "*" } ]
+    "flags": ["FUNNEL"],
+    "breaks_into": [{ "item": "birchbark", "count": [1, 2] }],
+    "variants": [{ "symbols": "V", "symbols_broken": "*" }]
   },
   {
     "type": "vehicle_part",
     "id": "makeshift_funnel",
     "name": { "str": "makeshift funnel" },
     "looks_like": "funnel",
-    "categories": [ "other" ],
+    "categories": ["other"],
     "color": "yellow",
     "damage_modifier": 5,
     "durability": 80,
@@ -2973,19 +4262,31 @@
     "location": "on_roof",
     "folded_volume": "250 ml",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 1 ] ], "time": "6 m", "using": [ [ "vehicle_nail_install", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "3 m", "using": [ [ "vehicle_nail_removal", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "6 m", "using": [ [ "adhesive", 2 ] ] }
+      "install": {
+        "skills": [["mechanics", 1]],
+        "time": "6 m",
+        "using": [["vehicle_nail_install", 1]]
+      },
+      "removal": {
+        "skills": [["mechanics", 2]],
+        "time": "3 m",
+        "using": [["vehicle_nail_removal", 1]]
+      },
+      "repair": {
+        "skills": [["mechanics", 2]],
+        "time": "6 m",
+        "using": [["adhesive", 2]]
+      }
     },
-    "flags": [ "FUNNEL" ],
-    "breaks_into": [ { "item": "plastic_chunk", "count": [ 1, 2 ] } ],
-    "variants": [ { "symbols": "V", "symbols_broken": "*" } ]
+    "flags": ["FUNNEL"],
+    "breaks_into": [{ "item": "plastic_chunk", "count": [1, 2] }],
+    "variants": [{ "symbols": "V", "symbols_broken": "*" }]
   },
   {
     "type": "vehicle_part",
     "id": "funnel",
     "name": { "str": "funnel" },
-    "categories": [ "other" ],
+    "categories": ["other"],
     "color": "yellow",
     "damage_modifier": 5,
     "durability": 200,
@@ -2994,20 +4295,32 @@
     "item": "funnel",
     "location": "on_roof",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 1 ] ], "time": "6 m", "using": [ [ "vehicle_screw", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "3 m", "using": [ [ "vehicle_screw", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "6 m", "using": [ [ "adhesive", 1 ] ] }
+      "install": {
+        "skills": [["mechanics", 1]],
+        "time": "6 m",
+        "using": [["vehicle_screw", 1]]
+      },
+      "removal": {
+        "skills": [["mechanics", 2]],
+        "time": "3 m",
+        "using": [["vehicle_screw", 1]]
+      },
+      "repair": {
+        "skills": [["mechanics", 2]],
+        "time": "6 m",
+        "using": [["adhesive", 1]]
+      }
     },
-    "flags": [ "FUNNEL" ],
-    "breaks_into": [ { "item": "plastic_chunk", "count": [ 1, 2 ] } ],
-    "variants": [ { "symbols": "V", "symbols_broken": "*" } ]
+    "flags": ["FUNNEL"],
+    "breaks_into": [{ "item": "plastic_chunk", "count": [1, 2] }],
+    "variants": [{ "symbols": "V", "symbols_broken": "*" }]
   },
   {
     "type": "vehicle_part",
     "id": "metal_funnel",
     "name": { "str": "metal funnel" },
     "looks_like": "funnel",
-    "categories": [ "other" ],
+    "categories": ["other"],
     "damage_modifier": 30,
     "durability": 300,
     "description": "A funnel that will collect rainwater into the tank beneath it.",
@@ -3015,20 +4328,32 @@
     "item": "metal_funnel",
     "location": "on_roof",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 1 ] ], "time": "5 m", "using": [ [ "welding_standard", 10 ] ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "2 m", "using": [ [ "vehicle_weld_removal", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "1 m", "using": [ [ "repair_welding_standard", 1 ] ] }
+      "install": {
+        "skills": [["mechanics", 1]],
+        "time": "5 m",
+        "using": [["welding_standard", 10]]
+      },
+      "removal": {
+        "skills": [["mechanics", 2]],
+        "time": "2 m",
+        "using": [["vehicle_weld_removal", 1]]
+      },
+      "repair": {
+        "skills": [["mechanics", 2]],
+        "time": "1 m",
+        "using": [["repair_welding_standard", 1]]
+      }
     },
-    "flags": [ "FUNNEL" ],
-    "breaks_into": [ { "item": "scrap", "count": [ 8, 12 ] } ],
+    "flags": ["FUNNEL"],
+    "breaks_into": [{ "item": "scrap", "count": [8, 12] }],
     "damage_reduction": { "all": 12 },
-    "variants": [ { "symbols": "V", "symbols_broken": "*" } ]
+    "variants": [{ "symbols": "V", "symbols_broken": "*" }]
   },
   {
     "type": "vehicle_part",
     "id": "vehicle_scoop",
     "name": { "str": "scoop" },
-    "categories": [ "utility" ],
+    "categories": ["utility"],
     "broken_color": "dark_gray",
     "durability": 100,
     "description": "A scoop.  Use the vehicle controls to turn it on or off.  When turned on, it will scoop up loose items that it travels over until it's full.",
@@ -3039,36 +4364,46 @@
     "//1": "100 cm weld to install, 30 cm weld per damage quadrant to repair",
     "requirements": {
       "install": {
-        "skills": [ [ "mechanics", 1 ] ],
+        "skills": [["mechanics", 1]],
         "time": "50 m",
-        "using": [ [ "welding_standard", 100 ], [ "vehicle_bolt_install", 1 ] ]
+        "using": [
+          ["welding_standard", 100],
+          ["vehicle_bolt_install", 1]
+        ]
       },
       "removal": {
-        "skills": [ [ "mechanics", 1 ] ],
+        "skills": [["mechanics", 1]],
         "time": "30 m",
-        "using": [ [ "vehicle_weld_removal", 1 ], [ "vehicle_wrench_1", 1 ] ]
+        "using": [
+          ["vehicle_weld_removal", 1],
+          ["vehicle_wrench_1", 1]
+        ]
       },
-      "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "12 m", "using": [ [ "repair_welding_standard", 3 ] ] }
+      "repair": {
+        "skills": [["mechanics", 2]],
+        "time": "12 m",
+        "using": [["repair_welding_standard", 3]]
+      }
     },
-    "flags": [ "SCOOP", "CARGO", "ENABLED_DRAINS_EPOWER" ],
+    "flags": ["SCOOP", "CARGO", "ENABLED_DRAINS_EPOWER"],
     "location": "under",
     "breaks_into": [
-      { "item": "sheet_metal_small", "count": [ 4, 8 ] },
-      { "item": "scrap", "charges": [ 21, 42 ] },
-      { "item": "bearing", "count": [ 1, 3 ] },
-      { "item": "e_scrap", "count": [ 2, 6 ] },
-      { "item": "cable", "charges": [ 300, 600 ] },
-      { "item": "plastic_chunk", "count": [ 1, 2 ] },
-      { "item": "nuts_bolts", "count": [ 2, 5 ] }
+      { "item": "sheet_metal_small", "count": [4, 8] },
+      { "item": "scrap", "charges": [21, 42] },
+      { "item": "bearing", "count": [1, 3] },
+      { "item": "e_scrap", "count": [2, 6] },
+      { "item": "cable", "charges": [300, 600] },
+      { "item": "plastic_chunk", "count": [1, 2] },
+      { "item": "nuts_bolts", "count": [2, 5] }
     ],
     "damage_reduction": { "all": 24 },
-    "variants": [ { "symbols": "R", "symbols_broken": ";" } ]
+    "variants": [{ "symbols": "R", "symbols_broken": ";" }]
   },
   {
     "type": "vehicle_part",
     "id": "water_purifier",
     "name": { "str": "water purifier" },
-    "categories": [ "utility" ],
+    "categories": ["utility"],
     "color": "blue",
     "broken_color": "light_blue",
     "damage_modifier": 40,
@@ -3077,26 +4412,41 @@
     "item": "water_purifier",
     "location": "anywhere",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 4 ] ], "time": "30 m", "using": [ [ "vehicle_screw", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "15 m", "using": [ [ "vehicle_screw", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 5 ] ], "time": "15 m", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 2 ] ] }
+      "install": {
+        "skills": [["mechanics", 4]],
+        "time": "30 m",
+        "using": [["vehicle_screw", 1]]
+      },
+      "removal": {
+        "skills": [["mechanics", 2]],
+        "time": "15 m",
+        "using": [["vehicle_screw", 1]]
+      },
+      "repair": {
+        "skills": [["mechanics", 5]],
+        "time": "15 m",
+        "using": [
+          ["adhesive", 1],
+          ["soldering_standard", 2]
+        ]
+      }
     },
-    "flags": [  ],
-    "pseudo_tools": [ { "id": "water_purifier", "hotkey": "p" } ],
+    "flags": [],
+    "pseudo_tools": [{ "id": "water_purifier", "hotkey": "p" }],
     "breaks_into": [
-      { "item": "scrap", "charges": [ 1, 3 ] },
-      { "item": "glass_shard", "count": [ 2, 5 ] },
-      { "item": "cable", "charges": [ 0, 2 ] },
+      { "item": "scrap", "charges": [1, 3] },
+      { "item": "glass_shard", "count": [2, 5] },
+      { "item": "cable", "charges": [0, 2] },
       { "item": "hose", "prob": 25 }
     ],
     "damage_reduction": { "all": 26 },
-    "variants": [ { "symbols": "&", "symbols_broken": "*" } ]
+    "variants": [{ "symbols": "&", "symbols_broken": "*" }]
   },
   {
     "type": "vehicle_part",
     "id": "plow",
     "name": { "str": "plow" },
-    "categories": [ "utility" ],
+    "categories": ["utility"],
     "color": "blue",
     "broken_color": "light_blue",
     "damage_modifier": 40,
@@ -3107,39 +4457,52 @@
     "power": "-6000 W",
     "//2": "~8 hp for a moldboard plow depth of 8 inches",
     "//1": "200 cm weld to install and 60 cm weld per damage quadrant to repair",
-    "transform_terrain": { "pre_flags": [ "PLOWABLE" ], "post_terrain": "t_dirtmound" },
+    "transform_terrain": {
+      "pre_flags": ["PLOWABLE"],
+      "post_terrain": "t_dirtmound"
+    },
     "requirements": {
       "install": {
-        "skills": [ [ "mechanics", 4 ] ],
+        "skills": [["mechanics", 4]],
         "time": "40 m",
-        "using": [ [ "welding_standard", 200 ], [ "vehicle_bolt_install", 2 ] ]
+        "using": [
+          ["welding_standard", 200],
+          ["vehicle_bolt_install", 2]
+        ]
       },
       "removal": {
-        "skills": [ [ "mechanics", 2 ] ],
+        "skills": [["mechanics", 2]],
         "time": "30 m",
-        "using": [ [ "vehicle_weld_removal", 1 ], [ "vehicle_wrench_2", 1 ] ]
+        "using": [
+          ["vehicle_weld_removal", 1],
+          ["vehicle_wrench_2", 1]
+        ]
       },
-      "repair": { "skills": [ [ "mechanics", 5 ] ], "time": "10 m", "using": [ [ "repair_welding_standard", 6 ] ] }
+      "repair": {
+        "skills": [["mechanics", 5]],
+        "time": "10 m",
+        "using": [["repair_welding_standard", 6]]
+      }
     },
-    "flags": [ "TRANSFORM_TERRAIN", "PLOW", "EXTRA_DRAG" ],
+    "flags": ["TRANSFORM_TERRAIN", "PLOW", "EXTRA_DRAG"],
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 4, 7 ] },
-      { "item": "steel_chunk", "count": [ 21, 40 ] },
-      { "item": "scrap", "charges": [ 108, 215 ] },
-      { "item": "nuts_bolts", "count": [ 7, 15 ] },
+      { "item": "steel_lump", "count": [4, 7] },
+      { "item": "steel_chunk", "count": [21, 40] },
+      { "item": "scrap", "charges": [108, 215] },
+      { "item": "nuts_bolts", "count": [7, 15] },
       { "item": "pipe_fittings", "prob": 30 },
       { "item": "rubber_tire_chunk", "prob": 35 },
-      { "item": "chunk_rubber", "count": [ 8, 19 ] },
-      { "item": "shredded_rubber", "count": [ 8, 20 ] }
+      { "item": "chunk_rubber", "count": [8, 19] },
+      { "item": "shredded_rubber", "count": [8, 20] }
     ],
     "damage_reduction": { "all": 46 },
-    "variants": [ { "symbols": "&", "symbols_broken": "*" } ]
+    "variants": [{ "symbols": "&", "symbols_broken": "*" }]
   },
   {
     "type": "vehicle_part",
     "id": "seed_drill",
     "name": { "str": "seed drill" },
-    "categories": [ "utility" ],
+    "categories": ["utility"],
     "color": "blue",
     "broken_color": "light_blue",
     "damage_modifier": 40,
@@ -3153,34 +4516,44 @@
     "//1": "200 cm weld to install and 60 cm weld per damage quadrant to repair",
     "requirements": {
       "install": {
-        "skills": [ [ "mechanics", 4 ] ],
+        "skills": [["mechanics", 4]],
         "time": "40 m",
-        "using": [ [ "welding_standard", 200 ], [ "vehicle_bolt_install", 2 ] ]
+        "using": [
+          ["welding_standard", 200],
+          ["vehicle_bolt_install", 2]
+        ]
       },
       "removal": {
-        "skills": [ [ "mechanics", 2 ] ],
+        "skills": [["mechanics", 2]],
         "time": "30 m",
-        "using": [ [ "vehicle_weld_removal", 1 ], [ "vehicle_wrench_2", 1 ] ]
+        "using": [
+          ["vehicle_weld_removal", 1],
+          ["vehicle_wrench_2", 1]
+        ]
       },
-      "repair": { "skills": [ [ "mechanics", 5 ] ], "time": "10 m", "using": [ [ "repair_welding_standard", 6 ] ] }
+      "repair": {
+        "skills": [["mechanics", 5]],
+        "time": "10 m",
+        "using": [["repair_welding_standard", 6]]
+      }
     },
-    "flags": [ "PLANTER", "PROTRUSION", "CARGO", "EXTRA_DRAG", "CARGO_PASSABLE" ],
+    "flags": ["PLANTER", "PROTRUSION", "CARGO", "EXTRA_DRAG", "CARGO_PASSABLE"],
     "breaks_into": [
-      { "item": "sheet_metal_small", "count": [ 3, 6 ] },
-      { "item": "scrap", "charges": [ 10, 21 ] },
-      { "item": "nuts_bolts", "count": [ 3, 6 ] },
+      { "item": "sheet_metal_small", "count": [3, 6] },
+      { "item": "scrap", "charges": [10, 21] },
+      { "item": "nuts_bolts", "count": [3, 6] },
       { "item": "rubber_tire_chunk", "prob": 80 },
-      { "item": "chunk_rubber", "count": [ 16, 38 ] },
-      { "item": "shredded_rubber", "count": [ 16, 40 ] }
+      { "item": "chunk_rubber", "count": [16, 38] },
+      { "item": "shredded_rubber", "count": [16, 40] }
     ],
     "damage_reduction": { "all": 16 },
-    "variants": [ { "symbols": "8", "symbols_broken": "*" } ]
+    "variants": [{ "symbols": "8", "symbols_broken": "*" }]
   },
   {
     "type": "vehicle_part",
     "id": "seed_drill_advanced",
     "name": { "str": "advanced seed drill" },
-    "categories": [ "utility" ],
+    "categories": ["utility"],
     "color": "blue",
     "broken_color": "light_blue",
     "damage_modifier": 40,
@@ -3194,37 +4567,55 @@
     "//1": "200 cm weld to install and 60 cm weld per damage quadrant to repair",
     "requirements": {
       "install": {
-        "skills": [ [ "mechanics", 4 ] ],
+        "skills": [["mechanics", 4]],
         "time": "40 m",
-        "using": [ [ "welding_standard", 200 ], [ "vehicle_bolt_install", 2 ] ]
+        "using": [
+          ["welding_standard", 200],
+          ["vehicle_bolt_install", 2]
+        ]
       },
       "removal": {
-        "skills": [ [ "mechanics", 2 ] ],
+        "skills": [["mechanics", 2]],
         "time": "30 m",
-        "using": [ [ "vehicle_weld_removal", 1 ], [ "vehicle_wrench_2", 1 ] ]
+        "using": [
+          ["vehicle_weld_removal", 1],
+          ["vehicle_wrench_2", 1]
+        ]
       },
-      "repair": { "skills": [ [ "mechanics", 5 ] ], "time": "10 m", "using": [ [ "repair_welding_standard", 6 ] ] }
+      "repair": {
+        "skills": [["mechanics", 5]],
+        "time": "10 m",
+        "using": [["repair_welding_standard", 6]]
+      }
     },
-    "flags": [ "PLANTER", "PROTRUSION", "CARGO", "ADVANCED_PLANTER", "EXTRA_DRAG", "CARGO_PASSABLE", "ENABLED_DRAINS_EPOWER" ],
+    "flags": [
+      "PLANTER",
+      "PROTRUSION",
+      "CARGO",
+      "ADVANCED_PLANTER",
+      "EXTRA_DRAG",
+      "CARGO_PASSABLE",
+      "ENABLED_DRAINS_EPOWER"
+    ],
     "breaks_into": [
-      { "item": "cable", "charges": [ 3, 6 ] },
-      { "item": "e_scrap", "count": [ 4, 10 ] },
-      { "item": "plastic_chunk", "count": [ 1, 2 ] },
-      { "item": "sheet_metal_small", "count": [ 3, 6 ] },
-      { "item": "scrap", "charges": [ 10, 21 ] },
-      { "item": "nuts_bolts", "count": [ 3, 6 ] },
+      { "item": "cable", "charges": [3, 6] },
+      { "item": "e_scrap", "count": [4, 10] },
+      { "item": "plastic_chunk", "count": [1, 2] },
+      { "item": "sheet_metal_small", "count": [3, 6] },
+      { "item": "scrap", "charges": [10, 21] },
+      { "item": "nuts_bolts", "count": [3, 6] },
       { "item": "rubber_tire_chunk", "prob": 80 },
-      { "item": "chunk_rubber", "count": [ 16, 38 ] },
-      { "item": "shredded_rubber", "count": [ 16, 40 ] }
+      { "item": "chunk_rubber", "count": [16, 38] },
+      { "item": "shredded_rubber", "count": [16, 40] }
     ],
     "damage_reduction": { "all": 18 },
-    "variants": [ { "symbols": "8", "symbols_broken": "*" } ]
+    "variants": [{ "symbols": "8", "symbols_broken": "*" }]
   },
   {
     "type": "vehicle_part",
     "id": "reaper",
     "name": { "str": "reaper" },
-    "categories": [ "utility" ],
+    "categories": ["utility"],
     "broken_color": "light_blue",
     "damage_modifier": 120,
     "bonus": 7,
@@ -3237,36 +4628,46 @@
     "//1": "200 cm weld to install and 60 cm weld per damage quadrant to repair",
     "requirements": {
       "install": {
-        "skills": [ [ "mechanics", 4 ] ],
+        "skills": [["mechanics", 4]],
         "time": "40 m",
-        "using": [ [ "welding_standard", 200 ], [ "vehicle_bolt_install", 2 ] ]
+        "using": [
+          ["welding_standard", 200],
+          ["vehicle_bolt_install", 2]
+        ]
       },
       "removal": {
-        "skills": [ [ "mechanics", 2 ] ],
+        "skills": [["mechanics", 2]],
         "time": "30 m",
-        "using": [ [ "vehicle_weld_removal", 1 ], [ "vehicle_wrench_2", 1 ] ]
+        "using": [
+          ["vehicle_weld_removal", 1],
+          ["vehicle_wrench_2", 1]
+        ]
       },
-      "repair": { "skills": [ [ "mechanics", 5 ] ], "time": "10 m", "using": [ [ "repair_welding_standard", 6 ] ] }
+      "repair": {
+        "skills": [["mechanics", 5]],
+        "time": "10 m",
+        "using": [["repair_welding_standard", 6]]
+      }
     },
-    "flags": [ "REAPER", "PROTRUSION", "EXTRA_DRAG" ],
+    "flags": ["REAPER", "PROTRUSION", "EXTRA_DRAG"],
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 3, 5 ] },
-      { "item": "steel_chunk", "count": [ 4, 8 ] },
-      { "item": "sheet_metal_small", "count": [ 3, 6 ] },
-      { "item": "scrap", "charges": [ 15, 30 ] },
-      { "item": "nuts_bolts", "count": [ 3, 6 ] },
+      { "item": "steel_lump", "count": [3, 5] },
+      { "item": "steel_chunk", "count": [4, 8] },
+      { "item": "sheet_metal_small", "count": [3, 6] },
+      { "item": "scrap", "charges": [15, 30] },
+      { "item": "nuts_bolts", "count": [3, 6] },
       { "item": "rubber_tire_chunk", "prob": 80 },
-      { "item": "chunk_rubber", "count": [ 16, 38 ] },
-      { "item": "shredded_rubber", "count": [ 16, 40 ] }
+      { "item": "chunk_rubber", "count": [16, 38] },
+      { "item": "shredded_rubber", "count": [16, 40] }
     ],
     "damage_reduction": { "all": 10 },
-    "variants": [ { "symbols": "/", "symbols_broken": "*" } ]
+    "variants": [{ "symbols": "/", "symbols_broken": "*" }]
   },
   {
     "type": "vehicle_part",
     "id": "reaper_advanced",
     "name": { "str": "advanced reaper" },
-    "categories": [ "utility" ],
+    "categories": ["utility"],
     "broken_color": "light_blue",
     "damage_modifier": 120,
     "bonus": 7,
@@ -3280,40 +4681,50 @@
     "size": "87500 ml",
     "requirements": {
       "install": {
-        "skills": [ [ "mechanics", 5 ] ],
+        "skills": [["mechanics", 5]],
         "time": "40 m",
-        "using": [ [ "welding_standard", 200 ], [ "vehicle_bolt_install", 2 ] ]
+        "using": [
+          ["welding_standard", 200],
+          ["vehicle_bolt_install", 2]
+        ]
       },
       "removal": {
-        "skills": [ [ "mechanics", 3 ] ],
+        "skills": [["mechanics", 3]],
         "time": "30 m",
-        "using": [ [ "vehicle_weld_removal", 1 ], [ "vehicle_wrench_2", 1 ] ]
+        "using": [
+          ["vehicle_weld_removal", 1],
+          ["vehicle_wrench_2", 1]
+        ]
       },
-      "repair": { "skills": [ [ "mechanics", 6 ] ], "time": "10 m", "using": [ [ "repair_welding_standard", 6 ] ] }
+      "repair": {
+        "skills": [["mechanics", 6]],
+        "time": "10 m",
+        "using": [["repair_welding_standard", 6]]
+      }
     },
-    "flags": [ "REAPER", "CARGO", "EXTRA_DRAG" ],
+    "flags": ["REAPER", "CARGO", "EXTRA_DRAG"],
     "breaks_into": [
       { "item": "motor_small" },
-      { "item": "cable", "charges": [ 3, 6 ] },
-      { "item": "e_scrap", "count": [ 4, 10 ] },
-      { "item": "plastic_chunk", "count": [ 1, 3 ] },
-      { "item": "steel_lump", "count": [ 3, 5 ] },
-      { "item": "steel_chunk", "count": [ 4, 8 ] },
-      { "item": "sheet_metal_small", "count": [ 3, 6 ] },
-      { "item": "scrap", "charges": [ 15, 30 ] },
-      { "item": "nuts_bolts", "count": [ 3, 6 ] },
+      { "item": "cable", "charges": [3, 6] },
+      { "item": "e_scrap", "count": [4, 10] },
+      { "item": "plastic_chunk", "count": [1, 3] },
+      { "item": "steel_lump", "count": [3, 5] },
+      { "item": "steel_chunk", "count": [4, 8] },
+      { "item": "sheet_metal_small", "count": [3, 6] },
+      { "item": "scrap", "charges": [15, 30] },
+      { "item": "nuts_bolts", "count": [3, 6] },
       { "item": "rubber_tire_chunk", "prob": 80 },
-      { "item": "chunk_rubber", "count": [ 16, 38 ] },
-      { "item": "shredded_rubber", "count": [ 16, 40 ] }
+      { "item": "chunk_rubber", "count": [16, 38] },
+      { "item": "shredded_rubber", "count": [16, 40] }
     ],
     "damage_reduction": { "all": 12 },
-    "variants": [ { "symbols": "=", "symbols_broken": "*" } ]
+    "variants": [{ "symbols": "=", "symbols_broken": "*" }]
   },
   {
     "type": "vehicle_part",
     "id": "cargo_lock",
     "name": { "str": "cargo lock" },
-    "categories": [ "cargo" ],
+    "categories": ["cargo"],
     "color": "dark_gray",
     "durability": 25,
     "description": "A set of locks.  Attached to a suitable cargo space, it will prevent other people from accessing the cargo and taking your stuff.",
@@ -3321,20 +4732,35 @@
     "item": "cargo_lock",
     "location": "on_lockable_cargo",
     "requirements": {
-      "install": { "skills": [ [ "mechanics", 1 ] ], "time": "12 m", "using": [ [ "vehicle_screw", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "12 m", "using": [ [ "vehicle_screw", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "6 m", "using": [ [ "adhesive", 1 ] ] }
+      "install": {
+        "skills": [["mechanics", 1]],
+        "time": "12 m",
+        "using": [["vehicle_screw", 1]]
+      },
+      "removal": {
+        "skills": [["mechanics", 2]],
+        "time": "12 m",
+        "using": [["vehicle_screw", 1]]
+      },
+      "repair": {
+        "skills": [["mechanics", 2]],
+        "time": "6 m",
+        "using": [["adhesive", 1]]
+      }
     },
-    "flags": [ "CARGO_LOCKING", "INTERNAL" ],
-    "breaks_into": [ { "item": "clockworks", "prob": 15 }, { "item": "scrap", "prob": 75 } ],
+    "flags": ["CARGO_LOCKING", "INTERNAL"],
+    "breaks_into": [
+      { "item": "clockworks", "prob": 15 },
+      { "item": "scrap", "prob": 75 }
+    ],
     "damage_reduction": { "all": 60 },
-    "variants": [ { "symbols": "+", "symbols_broken": "+" } ]
+    "variants": [{ "symbols": "+", "symbols_broken": "+" }]
   },
   {
     "type": "vehicle_part",
     "id": "turret_mount",
     "name": { "str": "turret mount" },
-    "categories": [ "warfare" ],
+    "categories": ["warfare"],
     "damage_modifier": 80,
     "durability": 320,
     "description": "A rotating, universal mount for a weapon.  If your hands are empty, you can stand on the same tile as a turret mount and 'f'ire the weapon.",
@@ -3343,32 +4769,43 @@
     "item": "turret_mount",
     "requirements": {
       "install": {
-        "skills": [ [ "mechanics", 1 ] ],
+        "skills": [["mechanics", 1]],
         "time": "20 m",
-        "using": [ [ "welding_standard", 30 ], [ "vehicle_bolt_install", 1 ] ]
+        "using": [
+          ["welding_standard", 30],
+          ["vehicle_bolt_install", 1]
+        ]
       },
-      "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "10 m", "using": "vehicle_weld_removal" },
-      "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "3 m", "using": [ [ "repair_welding_standard", 1 ] ] }
+      "removal": {
+        "skills": [["mechanics", 1]],
+        "time": "10 m",
+        "using": "vehicle_weld_removal"
+      },
+      "repair": {
+        "skills": [["mechanics", 1]],
+        "time": "3 m",
+        "using": [["repair_welding_standard", 1]]
+      }
     },
-    "flags": [ "TURRET_MOUNT" ],
+    "flags": ["TURRET_MOUNT"],
     "breaks_into": [
-      { "item": "cable", "charges": [ 10, 20 ] },
-      { "item": "e_scrap", "count": [ 1, 2 ] },
-      { "item": "plastic_chunk", "count": [ 1, 2 ] },
-      { "item": "bearing", "count": [ 1, 3 ] },
-      { "item": "steel_chunk", "count": [ 2, 4 ] },
-      { "item": "scrap", "charges": [ 6, 12 ] },
-      { "item": "nuts_bolts", "count": [ 3, 6 ] }
+      { "item": "cable", "charges": [10, 20] },
+      { "item": "e_scrap", "count": [1, 2] },
+      { "item": "plastic_chunk", "count": [1, 2] },
+      { "item": "bearing", "count": [1, 3] },
+      { "item": "steel_chunk", "count": [2, 4] },
+      { "item": "scrap", "charges": [6, 12] },
+      { "item": "nuts_bolts", "count": [3, 6] }
     ],
     "damage_reduction": { "all": 54 },
-    "variants": [ { "symbols": "X", "symbols_broken": "X" } ]
+    "variants": [{ "symbols": "X", "symbols_broken": "X" }]
   },
   {
     "type": "vehicle_part",
     "id": "door_lock",
     "name": { "str": "door lock" },
-    "variants": [ { "symbols": "*", "symbols_broken": "*" } ],
-    "categories": [ "other" ],
+    "variants": [{ "symbols": "*", "symbols_broken": "*" }],
+    "categories": ["other"],
     "color": "light_blue",
     "durability": 25,
     "description": "A lock and latching mechanism.  If installed on a door, this can be used to lock it.",
@@ -3376,22 +4813,42 @@
     "item": "door_lock",
     "requirements": {
       "install": {
-        "skills": [ [ "mechanics", 2 ], [ "traps", 1 ] ],
+        "skills": [
+          ["mechanics", 2],
+          ["traps", 1]
+        ],
         "time": "24 m",
-        "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "DRILL", "level": 2 } ]
+        "qualities": [
+          { "id": "SCREW", "level": 1 },
+          { "id": "DRILL", "level": 2 }
+        ]
       },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "24 m", "qualities": [ { "id": "SCREW", "level": 1 } ] },
-      "repair": { "skills": [ [ "mechanics", 2 ], [ "traps", 1 ] ], "time": "12 m", "using": [ [ "soldering_standard", 3 ] ] }
+      "removal": {
+        "skills": [["mechanics", 2]],
+        "time": "24 m",
+        "qualities": [{ "id": "SCREW", "level": 1 }]
+      },
+      "repair": {
+        "skills": [
+          ["mechanics", 2],
+          ["traps", 1]
+        ],
+        "time": "12 m",
+        "using": [["soldering_standard", 3]]
+      }
     },
-    "flags": [ "BOARD_INTERNAL", "DOOR_LOCKING", "UNMOUNT_ON_DAMAGE" ],
-    "breaks_into": [ { "item": "clockworks", "prob": 30 }, { "item": "scrap", "prob": 75 } ],
+    "flags": ["BOARD_INTERNAL", "DOOR_LOCKING", "UNMOUNT_ON_DAMAGE"],
+    "breaks_into": [
+      { "item": "clockworks", "prob": 30 },
+      { "item": "scrap", "prob": 75 }
+    ],
     "damage_reduction": { "all": 60 }
   },
   {
     "type": "vehicle_part",
     "id": "controls_turret",
     "name": { "str": "turret control unit" },
-    "categories": [ "warfare" ],
+    "categories": ["warfare"],
     "color": "yellow",
     "broken_color": "red",
     "damage_modifier": 10,
@@ -3400,25 +4857,38 @@
     "item": "turret_controls",
     "description": "A set of motor, camera, and an AI unit which allows for tracking targets, friend-or-foe identification, and firing the connected turret in full automatic mode.  When installed over the turret, it will enable auto targeting mode for said turret.",
     "folded_volume": "750 ml",
-    "flags": [ "ENABLED_DRAINS_EPOWER", "TURRET_CONTROLS", "UNMOUNT_ON_DAMAGE" ],
+    "flags": ["ENABLED_DRAINS_EPOWER", "TURRET_CONTROLS", "UNMOUNT_ON_DAMAGE"],
     "requirements": {
       "install": {
         "time": "40 m",
-        "skills": [ [ "mechanics", 3 ], [ "electronics", 3 ] ],
-        "qualities": [ { "id": "SCREW", "level": 1 } ]
+        "skills": [
+          ["mechanics", 3],
+          ["electronics", 3]
+        ],
+        "qualities": [{ "id": "SCREW", "level": 1 }]
       },
-      "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "3 m", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 5 ] ] },
-      "removal": { "skills": [ [ "mechanics", 3 ] ], "qualities": [ { "id": "SCREW", "level": 1 } ] }
+      "repair": {
+        "skills": [["mechanics", 2]],
+        "time": "3 m",
+        "using": [
+          ["adhesive", 1],
+          ["soldering_standard", 5]
+        ]
+      },
+      "removal": {
+        "skills": [["mechanics", 3]],
+        "qualities": [{ "id": "SCREW", "level": 1 }]
+      }
     },
     "breaks_into": "ig_vp_device",
-    "variants": [ { "symbols": "$", "symbols_broken": "$" } ]
+    "variants": [{ "symbols": "$", "symbols_broken": "$" }]
   },
   {
     "type": "vehicle_part",
     "id": "aluminum_boat_hull",
     "name": { "str": "aluminum boat hull" },
     "description": "An aluminum hull that keeps the water out of your boat.",
-    "categories": [ "hull" ],
+    "categories": ["hull"],
     "color": "dark_gray",
     "looks_like": "boat_board",
     "damage_modifier": 50,
@@ -3428,21 +4898,31 @@
     "//": "240 cm weld to install, 60 cm of weld per quadrant of damage",
     "requirements": {
       "install": {
-        "skills": [ [ "mechanics", 4 ] ],
+        "skills": [["mechanics", 4]],
         "time": "50 m",
-        "using": [ [ "welding_alloys", 240 ], [ "vehicle_bolt_install", 2 ] ]
+        "using": [
+          ["welding_alloys", 240],
+          ["vehicle_bolt_install", 2]
+        ]
       },
       "removal": {
-        "skills": [ [ "mechanics", 2 ] ],
+        "skills": [["mechanics", 2]],
         "time": "30 m",
-        "using": [ [ "vehicle_weld_removal", 1 ], [ "vehicle_wrench_2", 1 ] ]
+        "using": [
+          ["vehicle_weld_removal", 1],
+          ["vehicle_wrench_2", 1]
+        ]
       },
-      "repair": { "skills": [ [ "mechanics", 5 ] ], "time": "10 m", "using": [ [ "repair_welding_alloys", 6 ] ] }
+      "repair": {
+        "skills": [["mechanics", 5]],
+        "time": "10 m",
+        "using": [["repair_welding_alloys", 6]]
+      }
     },
-    "flags": [ "FLOATS" ],
-    "breaks_into": [ { "item": "scrap_aluminum", "count": [ 6, 14 ] } ],
+    "flags": ["FLOATS"],
+    "breaks_into": [{ "item": "scrap_aluminum", "count": [6, 14] }],
     "damage_reduction": { "all": 18 },
-    "variants": [ { "symbols": "o", "symbols_broken": "x" } ]
+    "variants": [{ "symbols": "o", "symbols_broken": "x" }]
   },
   {
     "id": "plugged_3in_ordnance_rifle",
@@ -3452,16 +4932,26 @@
     "durability": 400,
     "damage_modifier": 80,
     "location": "on_roof",
-    "categories": [ "warfare" ],
+    "categories": ["warfare"],
     "item": "cannon_3in_ordnance",
     "color": "dark_gray",
     "broken_color": "dark_gray",
-    "breaks_into": [ { "item": "scrap", "count": 72 }, { "item": "steel_chunk", "count": 30 }, { "item": "steel_lump", "count": 10 } ],
+    "breaks_into": [
+      { "item": "scrap", "count": 72 },
+      { "item": "steel_chunk", "count": 30 },
+      { "item": "steel_lump", "count": 10 }
+    ],
     "requirements": {
-      "install": { "time": "100 s", "skills": [ [ "mechanics", 3 ], [ "launcher", 1 ] ] },
-      "removal": { "time": "50 s", "skills": [ [ "mechanics", 2 ] ] }
+      "install": {
+        "time": "100 s",
+        "skills": [
+          ["mechanics", 3],
+          ["launcher", 1]
+        ]
+      },
+      "removal": { "time": "50 s", "skills": [["mechanics", 2]] }
     },
-    "flags": [  ],
-    "variants": [ { "symbols": "t", "symbols_broken": "#" } ]
+    "flags": [],
+    "variants": [{ "symbols": "t", "symbols_broken": "#" }]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Expand seats to enter with some armor on"

#### Purpose of change

Lately, the new way of calculating the volume of an entering player character on a sat tile led to a frustrating situation: Although only wearing some medium-tier armor and a weapon (sometimes just the armor!), the player couldn't enter the tile. Since driving around and scavenging is the main part of the mid-game, this led to frustrating situations where backpacks/armor/weapons were left behind due to game enforcing seat capacity limits that have not been updated in at least 6 months.

#### Describe the solution

With the exception of the 0L seat, all seat capacity was increased by 20L as to not make this buff ridiculous. This allows a normal human in ballistic armor to take a seat in a Humvee - as was actually done in e.g. Iraq.
EDIT: Also added 20 L to aisles for consistency.

#### Describe alternatives you've considered

Alternatively, the calculations of player volume could be rolled back, however, this seems an easier and more practical solution.

#### Testing

Wearing different armors and weapons, I entered the vehicle from multiple angles.

#### Additional context

CDDA always needs to  balance realism with playability. The inability to easily enter and exit vehicles in the mid-game with some armor on enforces relatively arbitrary seat volume number while heavily inhibiting playability.


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
