### PR TITLE
[TropiCata] Velvet worm audit

### DIFF
--- a/data/mods/TropiCataclysm/monsters/tropical_insect_spider.json
+++ b/data/mods/TropiCataclysm/monsters/tropical_insect_spider.json
@@ -236,7 +236,7 @@
     "name": { "str": "oversized velvet worm" },
     "description": "A mutated velvet worm the size of a large dog.",
     "copy-from": "mon_onicophore",
-    "proportional": { "hp": 0.5, "speed": 1.1, "morale": 0.5, "melee_dice_sides": 0.67, "dodge": 1.2 },
+    "proportional": { "hp": 0.5, "morale": 0.5, "melee_dice_sides": 0.67, "dodge": 1.2 },
     "volume": "62500 ml",
     "weight": "62500 g",
     "aggression": 4,

--- a/data/mods/TropiCataclysm/monsters/tropical_insect_spider.json
+++ b/data/mods/TropiCataclysm/monsters/tropical_insect_spider.json
@@ -152,7 +152,7 @@
         "type": "spell",
         "spell_data": { "id": "spread_glue" },
         "cooldown": 20,
-        "monster_message": "The termite sprays a sticky chemical out of its head!"
+        "monster_message": "The %s sprays some chemical out of its head!"
       }
     ],
     "armor": { "bash": 10, "cut": 12, "bullet": 10, "electric": 2 },
@@ -231,16 +231,29 @@
     "extend": { "flags": [ "QUEEN", "BASHES" ] }
   },
   {
+    "id": "mon_onicophore_small",
+    "type": "MONSTER",
+    "name": { "str": "oversized velvet worm" },
+    "description": "A mutated velvet worm the size of a large dog.",
+    "copy-from": "mon_onicophore",
+    "proportional": { "hp": 0.5, "speed": 1.1, "morale": 0.5, "melee_dice_sides": 0.67, "dodge": 1.2 },
+    "volume": "62500 ml",
+    "weight": "62500 g",
+    "aggression": 4,
+    "upgrades": { "age_grow": 30, "into": "mon_onicophore" },
+    "extend": { "flags": [ "NO_BREED" ] }
+  },
+  {
     "id": "mon_onicophore",
     "type": "MONSTER",
-    "name": { "str": "velvet worm" },
-    "description": "A mutated velvet worm several times its normal size.  These peculiar creatures hunt at night using silent feet and sticky attacks.",
+    "name": { "str": "giant velvet worm" },
+    "description": "A mutated velvet worm larger than a person.  These peculiar creatures hunt at night using silent feet and sticky attacks.",
     "default_faction": "worm",
     "bodytype": "snake",
     "species": [ "WORM" ],
-    "volume": "92500 ml",
-    "weight": "120 kg",
-    "hp": 70,
+    "volume": "125 L",
+    "weight": "125 kg",
+    "hp": 125,
     "speed": 80,
     "material": [ "flesh" ],
     "symbol": "v",
@@ -251,54 +264,64 @@
     "melee_dice": 4,
     "melee_dice_sides": 6,
     "melee_damage": [ { "damage_type": "cut", "amount": 3 } ],
+    "dodge": 5,
+    "families": [ "prof_intro_biology", "prof_physiology", "prof_wp_basic_bug" ],
+    "vision_day": 7,
+    "vision_night": 25,
+    "reproduction": { "baby_monster": "mon_onicophore_baby", "baby_count": 4, "baby_timer": 21 },
+    "//": "Brazil has only Peripatidae velvet worms, and the american members of this family are all live bearing, so live young.",
+    "baby_flags": [ "SPRING", "SUMMER", "AUTUMN" ],
     "harvest": "mutant_meatslug",
     "special_attacks": [
       {
         "type": "spell",
-        "spell_data": { "id": "spread_sludge" },
+        "spell_data": { "id": "spread_glue" },
         "cooldown": 20,
-        "monster_message": "The velvet worm shoots sticky strings of goo from two appendages in its head!"
+        "monster_message": "The %s shoots strings of goo from the appendages on its head!"
+      },
+      {
+        "id": "impale",
+        "cooldown": 8,
+        "damage_max_instance": [ { "damage_type": "stab", "amount": 2 }, { "damage_type": "acid", "amount": 8 } ],
+        "effects": [ { "id": "corroding", "duration": [ 10, 30 ], "affect_hit_bp": true } ]
       }
     ],
-    "upgrades": { "half_life": 20, "into": "mon_onicophore_giant" },
+    "upgrades": { "age_grow": 30, "into": "mon_onicophore_giant" },
     "anger_triggers": [ "PLAYER_CLOSE", "PLAYER_WEAK" ],
     "fear_triggers": [ "FIRE", "HURT" ],
-    "flags": [ "SEES", "HEARS", "KEENNOSE", "PATH_AVOID_DANGER", "SMELLS", "CLIMBS" ],
-    "armor": { "bash": 2 }
+    "flags": [ "SEES", "HEARS", "SMELLS", "KEENNOSE", "PATH_AVOID_DANGER", "CLIMBS" ],
+    "armor": { "bash": 5, "cut": 1 }
   },
   {
     "id": "mon_onicophore_giant",
     "type": "MONSTER",
-    "name": { "str": "velvet wyrm" },
-    "description": "An enormous velvet worm the length of several humans.  Its mouthparts and skin have reinforced to hunt down and defend against the new fauna of the Cataclysm.",
+    "name": { "str": "colossal velvet worm" },
+    "description": "An enormous velvet worm the size of a small car.  Its mouthparts and skin have reinforced to hunt down and defend against the new fauna of the Cataclysm.",
+    "copy-from": "mon_onicophore",
+    "volume": "575 L",
+    "weight": "575 kg",
+    "hp": 575,
+    "speed": 95,
+    "symbol": "V",
+    "melee_skill": 6,
+    "melee_dice_sides": 7,
+    "melee_damage": [ { "damage_type": "cut", "amount": 6 } ],
+    "dodge": 4,
+    "armor": { "bash": 12, "cut": 5, "bullet": 4 }
+  },
+  {
+    "id": "mon_onicophore_baby",
+    "type": "MONSTER",
+    "name": { "str": "velvet worm larva", "str_pl": "velvet worm larvae" },
+    "description": "A pale wriggling worm with a bunch of little legs.",
+    "copy-from": "mon_larva_abstract",
     "default_faction": "worm",
     "bodytype": "snake",
     "species": [ "WORM" ],
-    "volume": "120000 ml",
-    "weight": "180 kg",
-    "hp": 140,
-    "speed": 70,
-    "material": [ "flesh" ],
-    "symbol": "V",
-    "color": "red",
-    "aggression": 30,
-    "morale": 100,
-    "melee_skill": 5,
-    "melee_dice": 5,
-    "melee_dice_sides": 6,
-    "melee_damage": [ { "damage_type": "cut", "amount": 6 } ],
-    "harvest": "meatslug",
-    "special_attacks": [
-      {
-        "type": "spell",
-        "spell_data": { "id": "spread_sludge" },
-        "cooldown": 20,
-        "monster_message": "The velvet worm shoots sticky strings of goo from two appendages in its head!"
-      }
-    ],
-    "anger_triggers": [ "PLAYER_CLOSE", "PLAYER_WEAK" ],
-    "fear_triggers": [ "FIRE", "HURT" ],
-    "flags": [ "SEES", "HEARS", "KEENNOSE", "PATH_AVOID_DANGER", "SMELLS", "CLIMBS" ],
-    "armor": { "bash": 6, "cut": 3 }
+    "symbol": "v",
+    "color": "white",
+    "weakpoint_sets": [  ],
+    "harvest": "mutant_meatslug",
+    "upgrades": { "age_grow": 30, "into": "mon_onicophore" }
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I shall prevail
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
**Default giant version**
- Renamed to actually be giant
- Slightly increased the size
- Added some cool dodge for it (it's a snakey fellow)
- Increased the HP pool to match the new size
- Slightly edited the description to not undermine how big it is
- Made the daylight vision shit but the night vision real neat - it's a nocturnal predator
- Added some dissection proficiencies
- Added reproduction - Brazilian velvet worms are live bearing
- Added an acidic impale attack similar to that of a caustic amalgamation, so that the players may know pain
- Increased the bash armor, added a little bit of cut armor
- Switched the spell it uses for its glue gun and also slightly edited the spell message

**Wyrm / Colossal**
- Renamed to colossal velvet worm so that the name doesn't look like a typo and that it's more descriptive
- Slightly edited the description
- Massive size and HP pool increase
- Added some cool dodge for it but less than the smaller version had
- Made it faster instead of slower than the giant version
- Greatly increased its armor
- Slightly increased its melee stats
- Chained it to the giant version via ``copy-from``

**Other**
- Added an oversized version for when I gotta work with the spawnpools more, and a baby version so that reproduction is possible
- Slightly edited the shooty soldier termite's spell message while I was here
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Doing some spawnpool audits - currently the oversized velvet worm doesn't spawn. Unfortunately, while looking for vanilla examples to copy, I found out our vanilla mutant spawning is hot garbage and needs an audit of its own. I'll be back
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
