### PR TITLE
Update 48x-"Locutus" effect wording

### DIFF
--- a/data/json/effects_on_condition/medicine_eocs/regen_serum_eoc.json
+++ b/data/json/effects_on_condition/medicine_eocs/regen_serum_eoc.json
@@ -52,10 +52,10 @@
     "id": "regen_serum_main",
     "name": [ "Injected 48x-\"Locutus\"" ],
     "desc": [
-      "You just take a shot of some weird stuff.  You feel sleepiness, nauseous, and overall weakened, but you wounds close up at unnatural pace."
+      "You just took a shot of some weird stuff.  You feel sleepy, nauseous, and generally weak, but your wounds are closing up at an unnatural pace."
     ],
-    "apply_message": "Without hesitation, you draw the liquid from the ampule, smack it a bit to release an air, and put right into your veins, in hope it won't kill you.",
-    "remove_message": "You feel your rapid regeneration turn back to normal, but some negative effects are still presented.",
+    "apply_message": "Without hesitation, you draw the liquid from the ampule, smack it a bit to release an air, and put it right into your veins, hoping it won't kill you.",
+    "remove_message": "You feel your rapid regeneration fade away, but you still feel sick.",
     "rating": "mixed",
     "flags": [ "MEND_ALL" ],
     "enchantments": [
@@ -99,3 +99,4 @@
     "enchantments": [ { "values": [ { "value": "STAMINA_REGEN_MOD", "multiply": -0.5 }, { "value": "SLEEPINESS", "multiply": 1 } ] } ]
   }
 ]
+

--- a/data/json/effects_on_condition/medicine_eocs/regen_serum_eoc.json
+++ b/data/json/effects_on_condition/medicine_eocs/regen_serum_eoc.json
@@ -54,7 +54,7 @@
     "desc": [
       "You just took a shot of some weird stuff.  You feel sleepy, nauseous, and generally weak, but your wounds are closing up at an unnatural pace."
     ],
-    "apply_message": "Without hesitation, you draw the liquid from the ampule, smack it a bit to release an air, and inject it right into a vein, hoping it won't kill you.",
+    "apply_message": "Without hesitation, you draw the liquid from the ampule, smack it a bit to release any air, and inject it right into a vein, hoping it won't kill you.",
     "remove_message": "You feel your rapid regeneration fade away, but you still feel sick.",
     "rating": "mixed",
     "flags": [ "MEND_ALL" ],

--- a/data/json/effects_on_condition/medicine_eocs/regen_serum_eoc.json
+++ b/data/json/effects_on_condition/medicine_eocs/regen_serum_eoc.json
@@ -99,4 +99,3 @@
     "enchantments": [ { "values": [ { "value": "STAMINA_REGEN_MOD", "multiply": -0.5 }, { "value": "SLEEPINESS", "multiply": 1 } ] } ]
   }
 ]
-

--- a/data/json/effects_on_condition/medicine_eocs/regen_serum_eoc.json
+++ b/data/json/effects_on_condition/medicine_eocs/regen_serum_eoc.json
@@ -54,7 +54,7 @@
     "desc": [
       "You just took a shot of some weird stuff.  You feel sleepy, nauseous, and generally weak, but your wounds are closing up at an unnatural pace."
     ],
-    "apply_message": "Without hesitation, you draw the liquid from the ampule, smack it a bit to release an air, and put it right into your veins, hoping it won't kill you.",
+    "apply_message": "Without hesitation, you draw the liquid from the ampule, smack it a bit to release an air, and inject it right into a vein, hoping it won't kill you.",
     "remove_message": "You feel your rapid regeneration fade away, but you still feel sick.",
     "rating": "mixed",
     "flags": [ "MEND_ALL" ],


### PR DESCRIPTION
#### Summary
 None
#### Purpose of change
I was lab diving and realized the wording of the regeneration effect of the 48x-"locutus" serum was a bit clunky. This hopefully makes it a bit easier to read.
#### Describe the solution
Slightly alter the wording of the effect to make more grammatical sense.
#### Describe alternatives you've considered
None
#### Testing
Created new character, took the serum, saw status window effects, saw it was easier to understand.
#### Additional context
This is my 1st PR so hopefully I didn't screw up too many things.
