### PR TITLE
Debug info to trace item group spawning

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -2536,6 +2536,8 @@ void item::debug_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
         if( g != nullptr ) {
             info.emplace_back( "BASE", string_format( "itype_id: %s",
                                typeId().str() ) );
+            info.emplace_back( "BASE", string_format( "%s",
+                               debug_trace ) );
             if( !old_owner.is_null() ) {
                 info.emplace_back( "BASE", string_format( _( "Old owner: %s" ),
                                    _( get_old_owner_name() ) ) );

--- a/src/item.h
+++ b/src/item.h
@@ -532,6 +532,9 @@ class item : public visitable
         void final_info( std::vector<iteminfo> &info, const iteminfo_query *parts, int batch,
                          bool debug ) const;
 
+        // NOLINTNEXTLINE(cata-serialize)
+        std::string debug_trace = _( "spawned via item group(s):" );
+
         /**
          * Calculate all burning calculations, but don't actually apply them to item.
          * DO apply them to @ref fire_data argument, though.

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -34,10 +34,10 @@ static const std::string null_item_id( "null" );
 static const itype_id itype_corpse( "corpse" );
 
 std::size_t Item_spawn_data::create( ItemList &list,
-                                     const time_point &birthday, spawn_flags flags ) const
+                                     const time_point &birthday, spawn_flags flags, std::string add_ctxt ) const
 {
     RecursionList rec;
-    return create( list, birthday, rec, flags );
+    return create( list, birthday, rec, flags, context() );
 }
 
 item Item_spawn_data::create_single( const time_point &birthday ) const
@@ -125,11 +125,14 @@ static void put_into_container(
     std::shuffle( items.end() - num_items, items.end(), rng_get_engine() );
 
     item ctr( *container_type, birthday );
+    ctr.debug_trace.append( context );
     if( container_variant ) {
         ctr.set_itype_variant( *container_variant );
     }
     Item_spawn_data::ItemList excess;
     for( auto it = items.end() - num_items; it != items.end(); ++it ) {
+        // Extra space at beginning, for readability.
+        it->debug_trace.append( string_format( " spawned inside container %s", ctr.type_name() ) );
         ret_val<void> ret = ctr.can_contain_directly( *it );
         if( ret.success() ) {
             const pocket_type pk_type = guess_pocket_for( ctr, *it );
@@ -179,6 +182,7 @@ Single_item_creator::Single_item_creator( const std::string &_id, Type _type, in
 item Single_item_creator::create_single( const time_point &birthday, RecursionList &rec ) const
 {
     item tmp = create_single_without_container( birthday, rec );
+    tmp.debug_trace.append( context() );
     if( container_item ) {
         tmp = tmp.in_container( *container_item, tmp.count(), sealed,
                                 container_item_variant.value_or( "" ) );
@@ -260,7 +264,7 @@ item Single_item_creator::create_single_without_container( const time_point &bir
 }
 
 std::size_t Single_item_creator::create( ItemList &list,
-        const time_point &birthday, RecursionList &rec, spawn_flags flags ) const
+        const time_point &birthday, RecursionList &rec, spawn_flags flags, std::string add_ctxt ) const
 {
     std::size_t prev_list_size = list.size();
     int cnt = 1;
@@ -277,6 +281,8 @@ std::size_t Single_item_creator::create( ItemList &list,
     for( ; cnt > 0; cnt-- ) {
         if( type == S_ITEM ) {
             item itm = create_single_without_container( birthday, rec );
+            itm.debug_trace.append( add_ctxt );
+            itm.debug_trace.append( context() );
             if( flags & spawn_flags::use_spawn_rate && !itm.has_flag( STATIC( flag_id( "MISSION_ITEM" ) ) ) &&
                 rng_float( 0, 1 ) > spawn_rate ) {
                 continue;
@@ -296,7 +302,8 @@ std::size_t Single_item_creator::create( ItemList &list,
                 debugmsg( "unknown item spawn list %s", id.c_str() );
                 return list.size() - prev_list_size;
             }
-            std::size_t tmp_list_size = isd->create( list, birthday, rec, flags );
+            std::size_t tmp_list_size = isd->create( list, birthday, rec, flags,
+                                        add_ctxt + "" + context() + "" );
             cata_assert( list.size() >= tmp_list_size );
             rec.pop_back();
             if( modifier ) {
@@ -876,7 +883,7 @@ void Item_group::finalize( const itype_id &container )
 }
 
 std::size_t Item_group::create( Item_spawn_data::ItemList &list,
-                                const time_point &birthday, RecursionList &rec, spawn_flags flags ) const
+                                const time_point &birthday, RecursionList &rec, spawn_flags flags, std::string add_ctxt ) const
 {
     std::size_t prev_list_size = list.size();
     if( type == G_COLLECTION ) {
@@ -884,7 +891,7 @@ std::size_t Item_group::create( Item_spawn_data::ItemList &list,
             if( !( flags & spawn_flags::maximized ) && rng( 0, 99 ) >= elem->get_probability( false ) ) {
                 continue;
             }
-            elem->create( list, birthday, rec, flags );
+            elem->create( list, birthday, rec, flags, add_ctxt + "" );
         }
     } else if( type == G_DISTRIBUTION ) {
         int p = rng( 0, sum_prob - 1 );
@@ -896,13 +903,13 @@ std::size_t Item_group::create( Item_spawn_data::ItemList &list,
             if( ( ev_based && prob == 0 ) || p >= 0 ) {
                 continue;
             }
-            elem->create( list, birthday, rec, flags );
+            elem->create( list, birthday, rec, flags, add_ctxt + "" );
             break;
         }
     }
     const std::size_t items_created = list.size() - prev_list_size;
     put_into_container( list, items_created, container_item, container_item_variant, sealed, birthday,
-                        on_overflow, context() );
+                        on_overflow, add_ctxt + "" );
 
     return list.size() - prev_list_size;
 }
@@ -1033,7 +1040,7 @@ item_group::ItemList item_group::items_from( const item_group_id &group_id,
     }
     ItemList result;
     result.reserve( 20 );
-    group->create( result, birthday, flags );
+    group->create( result, birthday, flags, group_id.str() );
     return result;
 }
 

--- a/src/item_group.h
+++ b/src/item_group.h
@@ -152,14 +152,14 @@ class Item_spawn_data
          * @return The number of new items appended to the list
          */
         virtual std::size_t create( ItemList &list, const time_point &birthday, RecursionList &rec,
-                                    spawn_flags = spawn_flags::none ) const = 0;
+                                    spawn_flags = spawn_flags::none, std::string add_ctxt = "" ) const = 0;
         /**
         * Instead of calculating at run-time, give a step to finalize those item_groups that has count-min but not count-max.
         * The reason is
         */
         virtual void finalize( const itype_id & ) = 0;
         std::size_t create( ItemList &list, const time_point &birthday,
-                            spawn_flags = spawn_flags::none ) const;
+                            spawn_flags = spawn_flags::none, std::string add_ctxt = "" ) const;
         /**
          * The same as create, but create a single item only.
          * The returned item might be a null item!
@@ -338,7 +338,7 @@ class Single_item_creator : public Item_spawn_data
         void inherit_ammo_mag_chances( int ammo, int mag );
 
         std::size_t create( ItemList &list, const time_point &birthday, RecursionList &rec,
-                            spawn_flags ) const override;
+                            spawn_flags, std::string add_ctxt = "" ) const override;
         void finalize( const itype_id &container = itype_id::NULL_ID() ) override;
         item create_single( const time_point &birthday, RecursionList &rec ) const override;
         item create_single_without_container( const time_point &birthday, RecursionList &rec ) const;
@@ -390,7 +390,7 @@ class Item_group : public Item_spawn_data
         void add_entry( std::unique_ptr<Item_spawn_data> ptr );
         void finalize( const itype_id &container = itype_id::NULL_ID() )override;
         std::size_t create( ItemList &list, const time_point &birthday, RecursionList &rec,
-                            spawn_flags ) const override;
+                            spawn_flags, std::string add_ctxt = "" ) const override;
         item create_single( const time_point &birthday, RecursionList &rec ) const override;
         void check_consistency( bool actually_spawn ) const override;
         bool remove_item( const itype_id &itemid ) override;


### PR DESCRIPTION
#### Summary
Interface "Debug info to trace item group spawning"

#### Purpose of change
It has often come up (e.g. #65450 ) that something mysteriously appears in a location which clearly shouldn't be there, but the provenance of the item is very difficult to trace. Normally the only way to do so is to check the mapgen for the tile it spawned on and go through every possibility. Item groups can contain other item groups which can contain others which... [etc] which means that you could be searching thousands of lines of json for one entry, jumping back and forth across files.


#### Describe the solution
Just (temporarily) store this information on the item. 

When spawning a new group, pass the ID through the incredibly confusing item group spawning functions. Continue passing it through as it recurses, adding new context when new context is had. Then make the information available when debug *mode* is enabled.

**Note that this information is not preserved across savegames, on purpose.** Doing so would cause a lot of save bloat for no real gain. In cases where this is useful, debug functions can already be used to force suspects to spawn repeatedly until another incident is seen. This function just makes backtracking it much simpler.


#### Describe alternatives you've considered
🤷 some sort of outside-cdda interactive GUI tool which expands item groups and searches through them, and also optionally works by recursing? Outside my skillset, really

#### Testing
The formatting is truly awful and I have grown tired of figuring out where to put the spaces.

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/0668ca38-f510-4ddb-af0b-73c9e6524b40)

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/1581318d-6da1-4c8f-97fa-779f9823e2fb)

Clang will probably yell about not passing strings by reference, will see what I have to do about that

#### Additional context

