### PR TITLE
Updates to debug menu

### DIFF
--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -479,6 +479,29 @@ static int player_uilist()
     return uilist( _( "Player…" ), uilist_initializer );
 }
 
+static void normalize_body( Character &u )
+{
+    u.clear_effects();
+    u.clear_morale();
+    u.clear_vitamins();
+    u.set_all_parts_hp_to_max();
+    u.set_sleepiness( 0 );
+    u.set_focus( 100 );
+    u.set_hunger( 0 );
+    u.set_pain( 0 );
+    u.set_rad( 0 );
+    u.set_sleep_deprivation( 0 );
+    u.set_stamina( u.get_stamina_max() );
+    u.set_stored_kcal( u.get_healthy_kcal() );
+    u.set_thirst( 0 );
+}
+
+static tripoint_abs_ms player_picks_tile()
+{
+    std::optional<tripoint> newpos = g->look_around();
+    return newpos ? get_map().getglobal( *newpos ) : get_player_character().get_location();
+}
+
 static void monster_ammo_edit( monster &mon )
 {
     uilist smenu;
@@ -683,14 +706,14 @@ static void monster_edit_menu()
             break;
         }
         case D_TELE: {
-            if( const std::optional<tripoint> newpos = g->look_around() ) {
-                critter->setpos( *newpos );
+            if( tripoint_abs_ms newpos = player_picks_tile(); newpos != get_avatar().get_location() ) {
+                critter->setpos( get_map().bub_from_abs( newpos ) );
             }
             break;
         }
         case D_WANDER_DES: {
-            if( const std::optional<tripoint> newpos = g->look_around() ) {
-                critter->wander_to( get_map().getglobal( *newpos ), 1000 );
+            if( tripoint_abs_ms newpos = player_picks_tile(); newpos != get_avatar().get_location() ) {
+                critter->wander_to( newpos, 1000 );
             }
             break;
         }
@@ -2174,7 +2197,7 @@ static void character_edit_menu()
 
     enum {
         D_DESC, D_SKILLS, D_THEORY, D_PROF, D_STATS, D_SPELLS, D_ITEMS, D_DELETE_ITEMS, D_DROP_ITEMS, D_ITEM_WORN,
-        D_HP, D_STAMINA, D_MORALE, D_PAIN, D_NEEDS, D_HEALTHY, D_STATUS, D_MISSION_ADD, D_MISSION_EDIT,
+        D_HP, D_STAMINA, D_MORALE, D_PAIN, D_NEEDS, D_NORMALIZE_BODY, D_HEALTHY, D_STATUS, D_MISSION_ADD, D_MISSION_EDIT,
         D_TELE, D_MUTATE, D_BIONICS, D_CLASS, D_ATTITUDE, D_OPINION, D_PERSONALITY, D_ADD_EFFECT, D_ASTHMA, D_PRINT_VARS,
         D_WRITE_EOCS, D_KILL_XP, D_CHECK_TEMP, D_EDIT_VARS, D_FACTION
     };
@@ -2195,6 +2218,7 @@ static void character_edit_menu()
     nmenu.addentry( D_PAIN, true, 'p', "%s", _( "Cause pain" ) );
     nmenu.addentry( D_HEALTHY, true, 'a', "%s", _( "Set health" ) );
     nmenu.addentry( D_NEEDS, true, 'n', "%s", _( "Set needs" ) );
+    nmenu.addentry( D_NORMALIZE_BODY, true, 'N', "%s", _( "Normalize body stats" ) );
     if( get_option<bool>( "STATS_THROUGH_KILLS" ) ) {
         nmenu.addentry( D_KILL_XP, true, 'X', "%s", _( "Set kill XP" ) );
     }
@@ -2319,6 +2343,9 @@ static void character_edit_menu()
         break;
         case D_NEEDS:
             character_edit_needs_menu( you );
+            break;
+        case D_NORMALIZE_BODY:
+            normalize_body( you );
             break;
         case D_MUTATE: {
             uilist smenu;
@@ -3081,24 +3108,6 @@ static cata_path prepare_export_dir_and_find_unused_name( const std::string &cha
     return ret;
 }
 
-static void normalize_body()
-{
-    Character &u = get_avatar();
-    u.clear_effects();
-    u.clear_morale();
-    u.clear_vitamins();
-    u.set_all_parts_hp_to_max();
-    u.set_sleepiness( 0 );
-    u.set_focus( 100 );
-    u.set_hunger( 0 );
-    u.set_pain( 0 );
-    u.set_rad( 0 );
-    u.set_sleep_deprivation( 0 );
-    u.set_stamina( u.get_stamina_max() );
-    u.set_stored_kcal( u.get_healthy_kcal() );
-    u.set_thirst( 0 );
-}
-
 static void bleed_self()
 {
     uilist smenu;
@@ -3469,7 +3478,7 @@ static void unlock_all()
 static void vehicle_battery_charge()
 {
 
-    optional_vpart_position v_part_pos = get_map().veh_at( get_avatar().pos() );
+    optional_vpart_position v_part_pos = get_map().veh_at( player_picks_tile() );
     if( !v_part_pos ) {
         add_msg( m_bad, _( "There's no vehicle there." ) );
         return;
@@ -4040,7 +4049,7 @@ void debug()
 
         case debug_menu_index::VEHICLE_DELETE: {
 
-            if( const optional_vpart_position ovp = here.veh_at( player_character.pos() ) ) {
+            if( const optional_vpart_position ovp = here.veh_at( player_picks_tile() ) ) {
                 here.destroy_vehicle( &ovp->vehicle() );
                 break;
             }
@@ -4079,8 +4088,14 @@ void debug()
         }
 
         case debug_menu_index::QUICK_SETUP: {
+            if( !debug_mode ) {
+                // Turn on debug mode if not already on, but without any filters enabled (to prevent log spam).
+                // Save a few keypresses.
+                debug_mode = true;
+                debugmode::enabled_filters.clear();
+            }
             Character &u = get_avatar();
-            normalize_body();
+            normalize_body( u );
             // Specifically only adds mutations instead of toggling them.
             u.set_mutations( setup_traits );
             u.remove_weapon();
@@ -4102,7 +4117,7 @@ void debug()
         }
 
         case debug_menu_index::NORMALIZE_BODY_STAT: {
-            normalize_body();
+            normalize_body( get_avatar() );
             break;
         }
 

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1909,12 +1909,12 @@ static void handle_debug_mode()
     auto debugmode_entry_setup = []( uilist_entry & entry, bool active ) -> void {
         if( active )
         {
-            entry.extratxt.txt = _( "A" );
+            entry.extratxt.txt = entry.hotkey->short_description() + " " + _( "A" );
             entry.extratxt.color = c_white_green;
             entry.text_color = c_green;
         } else
         {
-            entry.extratxt.txt = " ";
+            entry.extratxt.txt = entry.hotkey->short_description() + " ";
             entry.extratxt.color = c_unset;
             entry.text_color = c_light_gray;
         }
@@ -1945,10 +1945,20 @@ static void handle_debug_mode()
 
     dbmenu.addentry( 1, true, 't', _( "Toggle all filters" ) );
     bool toggle_value = true;
+    const hotkey_queue &hotkeys = hotkey_queue::alpha_digits();
+    input_event assigned_hotkey = ctxt.first_unassigned_hotkey( hotkeys );
+    int reserved_character_d = 'd';
+    int reserved_character_t = 't';
 
     for( int i = 0; i < debugmode::DF_LAST; ++i ) {
-        uilist_entry entry( i + 2, true, 0,
-                            debugmode::filter_name( static_cast<debugmode::debug_filter>( i ) ) );
+        uilist_entry entry( i + 2, true, assigned_hotkey,
+                            "  " + debugmode::filter_name( static_cast<debugmode::debug_filter>( i ) ) );
+        assigned_hotkey = ctxt.next_unassigned_hotkey( hotkeys, assigned_hotkey );
+        // Skip d and t, special cased
+        if( assigned_hotkey.sequence.front() == reserved_character_d ||
+            assigned_hotkey.sequence.front() == reserved_character_t ) {
+            assigned_hotkey = hotkeys.next( assigned_hotkey );
+        }
 
         entry.extratxt.left = 1;
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
More debug power

#### Describe the solution
Changed quick setup to turn debug mode on (if not already on) instead of requiring a separate menu waffling. This is useful as [some things](https://github.com/CleverRaven/Cataclysm-DDA/pull/74906) are gated by debug mode and not the debug menu. To be super safe and not annoy people it doesn't turn any filters on.

Also added hotkeys to the debug mode (again, not debug menu) window while I was thinking about it. It's kinda scuffed, but it works.

Expanded normalize body stats out so it can be used outside of the quick setup menu. Can be called from the edit player/NPC menus

Changed the vehicle functions to actually accept a player-selected position, instead of just gaslighting you that they gave you the option.

Updated some of my monster edit menu functions to use the same function for consistencies' sake. Plus more use of tripoint_abs_ms over raw tripoints (typeify = GOOD)

#### Testing
Compiled it, used the functions I changed, everything seemed good.

#### Additional context

