### PR TITLE
Fix tow

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5040,9 +5040,19 @@ monster *game::place_critter_at( const mtype_id &id, const tripoint &p )
     return place_critter_around( id, p, 0 );
 }
 
+monster *game::place_critter_at( const mtype_id &id, const tripoint_bub_ms &p )
+{
+    return place_critter_around( id, p.raw(), 0 );
+}
+
 monster *game::place_critter_at( const shared_ptr_fast<monster> &mon, const tripoint &p )
 {
     return place_critter_around( mon, p, 0 );
+}
+
+monster *game::place_critter_at( const shared_ptr_fast<monster> &mon, const tripoint_bub_ms &p )
+{
+    return place_critter_around( mon, p.raw(), 0 );
 }
 
 monster *game::place_critter_around( const mtype_id &id, const tripoint &center, const int radius )

--- a/src/game.h
+++ b/src/game.h
@@ -343,8 +343,11 @@ class game
          * the one contained in @p mon).
          */
         /** @{ */
+        // TODO: Get rid of untyped overload.
         monster *place_critter_at( const mtype_id &id, const tripoint &p );
+        monster *place_critter_at( const mtype_id &id, const tripoint_bub_ms &p );
         monster *place_critter_at( const shared_ptr_fast<monster> &mon, const tripoint &p );
+        monster *place_critter_at( const shared_ptr_fast<monster> &mon, const tripoint_bub_ms &p );
         monster *place_critter_around( const mtype_id &id, const tripoint &center, int radius );
         monster *place_critter_around( const shared_ptr_fast<monster> &mon, const tripoint &center,
                                        int radius, bool forced = false );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -10259,11 +10259,16 @@ bool item::spill_contents( Character &c )
 
 bool item::spill_contents( const tripoint &pos )
 {
+    return item::spill_contents( tripoint_bub_ms( pos ) );
+}
+
+bool item::spill_contents( const tripoint_bub_ms &pos )
+{
     if( ( !is_container() && !is_magazine() && !uses_magazine() ) ||
         is_container_empty() ) {
         return true;
     }
-    return contents.spill_contents( pos );
+    return contents.spill_contents( pos.raw() );
 }
 
 bool item::spill_open_pockets( Character &guy, const item *avoid )

--- a/src/item.h
+++ b/src/item.h
@@ -1816,7 +1816,9 @@ class item : public visitable
          * @param pos Position to dump the contents on.
          * @return If the item is now empty.
          */
+        // TODO: Get rid of untyped overload.
         bool spill_contents( const tripoint &pos );
+        bool spill_contents( const tripoint_bub_ms &pos );
         bool spill_open_pockets( Character &guy, const item *avoid = nullptr );
         // spill items that don't fit in the container
         void overflow( const tripoint &pos, const item_location &loc = item_location::nowhere );

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -129,15 +129,15 @@ bool map::build_transparency_cache( const int zlev )
 
             // calculates transparency of a single tile
             // x,y - coords in map local coords
-            auto calc_transp = [&]( const point & p ) {
-                const point sp = p - sm_offset;
+            auto calc_transp = [&]( const point_sm_ms & p ) {
+                const point_sm_ms sp = p - sm_offset;
                 float value = LIGHT_TRANSPARENCY_OPEN_AIR;
 
                 if( !( cur_submap->get_ter( sp ).obj().transparent &&
                        cur_submap->get_furn( sp ).obj().transparent ) ) {
                     return std::make_pair( LIGHT_TRANSPARENCY_SOLID, LIGHT_TRANSPARENCY_SOLID );
                 }
-                if( outside_cache[p.x][p.y] ) {
+                if( outside_cache[p.x()][p.y()] ) {
                     // FIXME: Places inside vehicles haven't been marked as
                     // inside yet so this is incorrectly penalising for
                     // weather in vehicles.
@@ -159,7 +159,7 @@ bool map::build_transparency_cache( const int zlev )
             if( cur_submap->is_uniform() ) {
                 float value;
                 float dummy;
-                std::tie( value, dummy ) = calc_transp( sm_offset );
+                std::tie( value, dummy ) = calc_transp( point_sm_ms( sm_offset ) );
                 // if rebuild_all==true all values were already set to LIGHT_TRANSPARENCY_OPEN_AIR
                 if( !rebuild_all || value != LIGHT_TRANSPARENCY_OPEN_AIR ) {
                     bool opaque = value <= LIGHT_TRANSPARENCY_SOLID;

--- a/src/map.h
+++ b/src/map.h
@@ -1859,7 +1859,9 @@ class map
         // TODO: Get rid of untyped overload
         bool has_floor( const tripoint &p ) const;
         bool has_floor( const tripoint_bub_ms &p ) const;
+        // TODO: Get rid of untyped overload
         bool has_floor_or_water( const tripoint &p ) const;
+        bool has_floor_or_water( const tripoint_bub_ms &p ) const;
         /** Does this tile support vehicles and furniture above it */
         bool supports_above( const tripoint &p ) const;
         bool has_floor_or_support( const tripoint &p ) const;
@@ -2075,9 +2077,10 @@ class map
         void rotten_item_spawn( const item &item, const tripoint &p );
     private:
         // Helper #1 - spawns monsters on one submap
-        void spawn_monsters_submap( const tripoint &gp, bool ignore_sight, bool spawn_nonlocal = false );
+        void spawn_monsters_submap( const tripoint_rel_sm &gp, bool ignore_sight,
+                                    bool spawn_nonlocal = false );
         // Helper #2 - spawns monsters on one submap and from one group on this submap
-        void spawn_monsters_submap_group( const tripoint &gp, mongroup &group,
+        void spawn_monsters_submap_group( const tripoint_rel_sm &gp, mongroup &group,
                                           bool ignore_sight );
 
     protected:
@@ -2087,11 +2090,11 @@ class map
          * Fast forward a submap that has just been loading into this map.
          * This is used to rot and remove rotten items, grow plants, fill funnels etc.
          */
-        void actualize( const tripoint &grid );
+        void actualize( const tripoint_rel_sm &grid );
         /**
          * Hacks in missing roofs. Should be removed when 3D mapgen is done.
          */
-        void add_roofs( const tripoint &grid );
+        void add_roofs( const tripoint_rel_sm &grid );
         /**
          * Try to fill funnel based items here. Simulates rain from @p since till now.
          * @param p The location in this map where to fill funnels.
@@ -2136,7 +2139,7 @@ class map
          */
         void shift_traps( const tripoint &shift );
 
-        void copy_grid( const tripoint &to, const tripoint &from );
+        void copy_grid( const tripoint_rel_sm &to, const tripoint_rel_sm &from );
         void draw_map( mapgendata &dat );
 
         void draw_lab( mapgendata &dat );
@@ -2203,7 +2206,7 @@ class map
         // TODO: fix point types (remove the first overload)
         inline submap *unsafe_get_submap_at( const tripoint &p ) {
             cata_assert( inbounds( p ) );
-            return get_submap_at_grid( { p.x / SEEX, p.y / SEEY, p.z } );
+            return get_submap_at_grid( tripoint_rel_sm{ p.x / SEEX, p.y / SEEY, p.z } );
         }
         inline submap *unsafe_get_submap_at( const tripoint_bub_ms &p ) {
             return unsafe_get_submap_at( p.raw() );
@@ -2219,7 +2222,7 @@ class map
         // TODO: Get rid of untyped overload
         submap *get_submap_at( const tripoint &p );
         submap *get_submap_at( const tripoint_bub_ms &p );
-        const submap *get_submap_at( const tripoint &p ) const;
+        const submap *get_submap_at( const tripoint_bub_ms &p ) const;
         submap *get_submap_at( const point &p ) {
             return get_submap_at( tripoint( p, abs_sub.z() ) );
         }
@@ -2266,9 +2269,9 @@ class map
             offset_p.y() = p.y() % SEEY;
             return get_submap_at( p );
         }
-        const submap *get_submap_at( const tripoint &p, point &offset_p ) const {
-            offset_p.x = p.x % SEEX;
-            offset_p.y = p.y % SEEY;
+        const submap *get_submap_at( const tripoint_bub_ms &p, point_sm_ms &offset_p ) const {
+            offset_p.x() = p.x() % SEEX;
+            offset_p.y() = p.y() % SEEY;
             return get_submap_at( p );
         }
         submap *get_submap_at( const point &p, point &offset_p ) {
@@ -2285,17 +2288,17 @@ class map
         const submap *get_submap_at_grid( const point &gridp ) const {
             return getsubmap( get_nonant( gridp ) );
         }
-        submap *get_submap_at_grid( const tripoint &gridp );
-        const submap *get_submap_at_grid( const tripoint &gridp ) const;
+        submap *get_submap_at_grid( const tripoint_rel_sm &gridp );
+        const submap *get_submap_at_grid( const tripoint_rel_sm &gridp ) const;
     protected:
         /**
          * Get the index of a submap pointer in the grid given by grid coordinates. The grid
          * coordinates must be valid: 0 <= x < my_MAPSIZE, same for y.
          * Version with z-levels checks for z between -OVERMAP_DEPTH and OVERMAP_HEIGHT
          */
-        size_t get_nonant( const tripoint &gridp ) const;
+        size_t get_nonant( const tripoint_rel_sm &gridp ) const;
         size_t get_nonant( const point &gridp ) const {
-            return get_nonant( { gridp, abs_sub.z() } );
+            return get_nonant( tripoint_rel_sm{ gridp.x, gridp.y, abs_sub.z() } );
         }
         /**
          * Set the submap pointer in @ref grid at the give index. This is the inverse of
@@ -2369,7 +2372,7 @@ class map
         void process_items();
     private:
         // Iterates over every item on the map, passing each item to the provided function.
-        void process_items_in_submap( submap &current_submap, const tripoint &gridp );
+        void process_items_in_submap( submap &current_submap, const tripoint_rel_sm &gridp );
         void process_items_in_vehicles( submap &current_submap );
         void process_items_in_vehicle( vehicle &cur_veh, submap &current_submap );
 

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -427,9 +427,9 @@ void map::process_fields_in_submap( submap *const current_submap,
     scent_block sblk( submap, get_scent() );
 
     // Initialize the map tile wrapper
-    maptile map_tile( current_submap, point_zero );
-    int &locx = map_tile.pos_.x;
-    int &locy = map_tile.pos_.y;
+    maptile map_tile( current_submap, point_sm_ms_zero );
+    int &locx = map_tile.pos_.x();
+    int &locy = map_tile.pos_.y();
     const point sm_offset = sm_to_ms_copy( submap.xy() );
 
     field_proc_data pd{
@@ -456,7 +456,7 @@ void map::process_fields_in_submap( submap *const current_submap,
             }
 
             // This is a translation from local coordinates to submap coordinates.
-            const tripoint p = tripoint( map_tile.pos() + sm_offset, submap.z );
+            const tripoint_sm_ms p = tripoint_sm_ms( map_tile.pos() + sm_offset, submap.z );
 
             for( auto it = curfield.begin(); it != curfield.end(); ) {
                 // Iterating through all field effects in the submap's field.
@@ -468,7 +468,7 @@ void map::process_fields_in_submap( submap *const current_submap,
 
                 // The field might have been killed by processing a neighbor field
                 if( prev_intensity == 0 ) {
-                    on_field_modified( p, *pd.cur_fd_type );
+                    on_field_modified( p.raw(), *pd.cur_fd_type );
                     --current_submap->field_count;
                     curfield.remove_field( it++ );
                     continue;
@@ -478,19 +478,19 @@ void map::process_fields_in_submap( submap *const current_submap,
                 if( cur.get_field_age() == 0_turns ) {
                     cur.do_decay();
                     if( !cur.is_field_alive() || cur.get_field_intensity() != prev_intensity ) {
-                        on_field_modified( p, *pd.cur_fd_type );
+                        on_field_modified( p.raw(), *pd.cur_fd_type );
                     }
                     it++;
                     continue;
                 }
 
                 for( const FieldProcessorPtr &proc : pd.cur_fd_type->get_processors() ) {
-                    proc( p, cur, pd );
+                    proc( p.raw(), cur, pd );
                 }
 
                 cur.do_decay();
                 if( !cur.is_field_alive() || cur.get_field_intensity() != prev_intensity ) {
-                    on_field_modified( p, *pd.cur_fd_type );
+                    on_field_modified( p.raw(), *pd.cur_fd_type );
                 }
                 it++;
             }
@@ -1146,9 +1146,9 @@ void field_processor_fd_fire( const tripoint &p, field_entry &cur, field_proc_da
          count != neighs.size();
          i = ( i + 1 ) % neighs.size(), count++ ) {
         const maptile &neigh = neighs[i].second;
-        if( ( neigh.pos().x != remove_tile.pos().x && neigh.pos().y != remove_tile.pos().y ) ||
-            ( neigh.pos().x != remove_tile2.pos().x && neigh.pos().y != remove_tile2.pos().y ) ||
-            ( neigh.pos().x != remove_tile3.pos().x && neigh.pos().y != remove_tile3.pos().y ) ||
+        if( ( neigh.pos().x() != remove_tile.pos().x() && neigh.pos().y() != remove_tile.pos().y() ) ||
+            ( neigh.pos().x() != remove_tile2.pos().x() && neigh.pos().y() != remove_tile2.pos().y() ) ||
+            ( neigh.pos().x() != remove_tile3.pos().x() && neigh.pos().y() != remove_tile3.pos().y() ) ||
             x_in_y( 1, std::max( 2, windpower ) ) ) {
             neighbour_vec.push_back( i );
         }

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -232,7 +232,7 @@ void map::generate( const tripoint_abs_omt &p, const time_point &when, bool save
     for( int gridx = 0; gridx < my_MAPSIZE; gridx++ ) {
         for( int gridy = 0; gridy < my_MAPSIZE; gridy++ ) {
             for( int gridz = -OVERMAP_DEPTH; gridz <= OVERMAP_HEIGHT; gridz++ ) {
-                const tripoint pos( gridx, gridy, gridz );
+                const tripoint_rel_sm pos( gridx, gridy, gridz );
                 const size_t grid_pos = get_nonant( pos );
                 if( !save_results || MAPBUFFER.lookup_submap( p_sm_base.xy() + pos ) == nullptr ) {
                     setsubmap( grid_pos, new submap() );
@@ -270,7 +270,7 @@ void map::generate( const tripoint_abs_omt &p, const time_point &when, bool save
 
         for( int gridx = 0; gridx <= 1; gridx++ ) {
             for( int gridy = 0; gridy <= 1; gridy++ ) {
-                const tripoint pos( gridx, gridy, gridz );
+                const tripoint_rel_sm pos( gridx, gridy, gridz );
                 const size_t grid_pos = get_nonant( pos );
                 if( ( !save_results || MAPBUFFER.lookup_submap( p_sm_base.xy() + pos ) == nullptr ) &&
                     !getsubmap( grid_pos )->is_uniform() &&
@@ -308,7 +308,7 @@ void map::generate( const tripoint_abs_omt &p, const time_point &when, bool save
         // Merge the overlays generated earlier into the current Z level now we have the base map on it.
         for( int gridx = 0; gridx <= 1; gridx++ ) {
             for( int gridy = 0; gridy <= 1; gridy++ ) {
-                const tripoint pos( gridx, gridy, gridz );
+                const tripoint_rel_sm pos( gridx, gridy, gridz );
                 const size_t index = gridx + gridy * 2;
                 if( saved_overlay.at( index ) != nullptr ) {
                     const size_t grid_pos = get_nonant( pos );
@@ -384,7 +384,7 @@ void map::generate( const tripoint_abs_omt &p, const time_point &when, bool save
         for( int gridx = 0; gridx < my_MAPSIZE; gridx++ ) {
             for( int gridy = 0; gridy < my_MAPSIZE; gridy++ ) {
                 for( int gridz = -OVERMAP_DEPTH; gridz <= OVERMAP_HEIGHT; gridz++ ) {
-                    const tripoint pos( gridx, gridy, gridz );
+                    const tripoint_rel_sm pos( gridx, gridy, gridz );
                     const size_t grid_pos = get_nonant( pos );
                     if( gridx <= 1 && gridy <= 1 ) {
                         if( MAPBUFFER.lookup_submap( p_sm_base.xy() + pos ) == nullptr ) {
@@ -6828,10 +6828,10 @@ void map::add_spawn(
         debugmsg( "Out of bounds add_spawn(%s, %d, %d, %d)", type.c_str(), count, p.x(), p.y() );
         return;
     }
-    point offset;
-    submap *place_on_submap = get_submap_at( p.raw(), offset );
+    point_sm_ms offset;
+    submap *place_on_submap = get_submap_at( p, offset );
     if( place_on_submap == nullptr ) {
-        debugmsg( "Tried to add spawn at (%d,%d) but the submap is not loaded", offset.x, offset.y );
+        debugmsg( "Tried to add spawn at (%d,%d) but the submap is not loaded", offset.x(), offset.y() );
         return;
     }
 
@@ -6877,7 +6877,7 @@ vehicle *map::add_vehicle( const vproto_id &type, const tripoint &p, const units
     vehicle *placed_vehicle = placed_vehicle_up.get();
 
     if( placed_vehicle != nullptr ) {
-        submap *place_on_submap = get_submap_at_grid( placed_vehicle->sm_pos );
+        submap *place_on_submap = get_submap_at_grid( tripoint_rel_sm( placed_vehicle->sm_pos ) );
         if( place_on_submap == nullptr ) {
             debugmsg( "Tried to add vehicle at (%d,%d,%d) but the submap is not loaded",
                       placed_vehicle->sm_pos.x, placed_vehicle->sm_pos.y, placed_vehicle->sm_pos.z );
@@ -7072,10 +7072,10 @@ computer *map::add_computer( const tripoint &p, const std::string &name, int sec
 {
     // TODO: Turn this off?
     furn_set( p, furn_f_console );
-    point l;
-    submap *const place_on_submap = get_submap_at( p, l );
+    point_sm_ms l;
+    submap *const place_on_submap = get_submap_at( tripoint_bub_ms( p ), l );
     if( place_on_submap == nullptr ) {
-        debugmsg( "Tried to add computer at (%d,%d) but the submap is not loaded", l.x, l.y );
+        debugmsg( "Tried to add computer at (%d,%d) but the submap is not loaded", l.x(), l.y() );
         static computer null_computer = computer( name, security, p );
         return &null_computer;
     }
@@ -7158,10 +7158,10 @@ void map::rotate( int turns, const bool setpos_safe )
     for( int z_level = bottom_level; z_level <= top_level; z_level++ ) {
         clear_vehicle_list( z_level );
 
-        submap *pz = get_submap_at_grid( tripoint( point_zero, z_level ) );
-        submap *pse = get_submap_at_grid( tripoint( point_south_east, z_level ) );
-        submap *pe = get_submap_at_grid( tripoint( point_east, z_level ) );
-        submap *ps = get_submap_at_grid( tripoint( point_south, z_level ) );
+        submap *pz = get_submap_at_grid( { point_rel_sm_zero, z_level } );
+        submap *pse = get_submap_at_grid( { point_rel_sm_south_east, z_level } );
+        submap *pe = get_submap_at_grid( { point_rel_sm_east, z_level } );
+        submap *ps = get_submap_at_grid( { point_rel_sm_south, z_level } );
         if( pz == nullptr || pse == nullptr || pe == nullptr || ps == nullptr ) {
             debugmsg( "Tried to rotate map at (%d,%d) but the submap is not loaded", point_zero.x,
                       point_zero.y );
@@ -7181,7 +7181,7 @@ void map::rotate( int turns, const bool setpos_safe )
             for( int k = 0; k < 4; ++k ) {
                 p = p.rotate( turns, { 2, 2 } );
                 point tmpp = point_south_east - p;
-                submap *psep = get_submap_at_grid( tripoint( tmpp, z_level ) );
+                submap *psep = get_submap_at_grid( tripoint_rel_sm( tmpp.x, tmpp.y, z_level ) );
                 if( psep == nullptr ) {
                     debugmsg( "Tried to rotate map at (%d,%d) but the submap is not loaded", tmpp.x, tmpp.y );
                     continue;
@@ -7194,7 +7194,7 @@ void map::rotate( int turns, const bool setpos_safe )
         for( int j = 0; j < 2; ++j ) {
             for( int i = 0; i < 2; ++i ) {
                 point p( i, j );
-                submap *sm = get_submap_at_grid( tripoint( p, z_level ) );
+                submap *sm = get_submap_at_grid( tripoint_rel_sm( p.x, p.y, z_level ) );
                 if( sm == nullptr ) {
                     debugmsg( "Tried to rotate map at (%d,%d) but the submap is not loaded", p.x, p.y );
                     continue;
@@ -7252,10 +7252,11 @@ void map::mirror( bool mirror_horizontal, bool mirror_vertical )
 
     for( int z_level = zlevels ? -OVERMAP_DEPTH : abs_sub.z();
          z_level <= ( zlevels ? OVERMAP_HEIGHT : abs_sub.z() ); z_level++ ) {
-        submap *pz = get_submap_at_grid( tripoint( point_zero, z_level ) );
-        submap *pse = get_submap_at_grid( tripoint( point_south_east, z_level ) );
-        submap *pe = get_submap_at_grid( tripoint( point_east, z_level ) );
-        submap *ps = get_submap_at_grid( tripoint( point_south, z_level ) );
+        submap *pz = get_submap_at_grid( { point_rel_sm_zero, z_level } );
+        submap *pse = get_submap_at_grid( { point_rel_sm_south_east, z_level } );
+        submap *pe = get_submap_at_grid( {point_rel_sm_east, z_level
+                                         } );
+        submap *ps = get_submap_at_grid( { point_rel_sm_south, z_level } );
         if( pz == nullptr || pse == nullptr || pe == nullptr || ps == nullptr ) {
             debugmsg( "Tried to mirror map at (%d, %d, %d) but the submap is not loaded", point_zero.x,
                       point_zero.y, z_level );
@@ -7275,10 +7276,11 @@ void map::mirror( bool mirror_horizontal, bool mirror_vertical )
         // Then mirror them.
         for( int j = 0; j < 2; ++j ) {
             for( int i = 0; i < 2; ++i ) {
-                point p( i, j );
-                submap *sm = get_submap_at_grid( tripoint( p, z_level ) );
+                point_rel_sm p( i, j );
+                submap *sm = get_submap_at_grid( { p, z_level } );
                 if( sm == nullptr ) {
-                    debugmsg( "Tried to mirror map at (%d, %d, %d) but the submap is not loaded", p.x, p.y, z_level );
+                    debugmsg( "Tried to mirror map at (%d, %d, %d) but the submap is not loaded", p.x(), p.y(),
+                              z_level );
                     continue;
                 }
 

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -285,6 +285,11 @@ bool monster::can_move_to( const tripoint &p ) const
     return can_reach_to( p ) && will_move_to( p );
 }
 
+bool monster::can_move_to( const tripoint_bub_ms &p ) const
+{
+    return monster::can_move_to( p.raw() );
+}
+
 float monster::rate_target( Creature &c, float best, bool smart ) const
 {
     const FastDistanceApproximation d = rl_dist_fast( pos(), c.pos() );

--- a/src/monster.h
+++ b/src/monster.h
@@ -209,7 +209,9 @@ class monster : public Creature
          * can_move_to() is a wrapper for both of them.
          * know_danger_at() checks for fire, trap etc. (flag PATH_AVOID_)
          */
+        // TODO: Get rid of untyped overload
         bool can_move_to( const tripoint &p ) const;
+        bool can_move_to( const tripoint_bub_ms &p ) const;
         bool can_reach_to( const tripoint &p ) const;
         bool will_move_to( const tripoint &p ) const;
         bool know_danger_at( const tripoint &p ) const;

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -1537,7 +1537,7 @@ void timed_event_manager::unserialize_all( const JsonArray &ja )
         jo.read( "type", type );
         jo.read( "when", when );
         jo.read( "key", key );
-        point pt;
+        point_sm_ms pt;
         if( jo.has_string( "revert" ) ) {
             revert.set_all_ter( ter_id( jo.get_string( "revert" ) ), true );
         } else {
@@ -1555,9 +1555,9 @@ void timed_event_manager::unserialize_all( const JsonArray &ja )
                 }
                 // We didn't always save the point, this is the original logic, it doesn't work right but for older saves at least they won't crash
                 if( !jp.has_member( "point" ) ) {
-                    if( pt.x++ < SEEX ) {
-                        pt.x = 0;
-                        pt.y++;
+                    if( pt.x()++ < SEEX ) {
+                        pt.x() = 0;
+                        pt.y()++;
                     }
                 }
             }
@@ -1636,14 +1636,14 @@ void timed_event_manager::serialize_all( JsonOut &jsout )
         jsout.member( "when", elem.when );
         jsout.member( "key", elem.key );
         if( elem.revert.is_uniform() ) {
-            jsout.member( "revert", elem.revert.get_ter( point_zero ) );
+            jsout.member( "revert", elem.revert.get_ter( point_sm_ms_zero ) );
         } else {
             jsout.member( "revert" );
             jsout.start_array();
             for( int y = 0; y < SEEY; y++ ) {
                 for( int x = 0; x < SEEX; x++ ) {
                     jsout.start_object();
-                    point pt( x, y );
+                    point_sm_ms pt( x, y );
                     jsout.member( "point", pt );
                     jsout.member( "furn", elem.revert.get_furn( pt ) );
                     jsout.member( "ter", elem.revert.get_ter( pt ) );

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -4703,7 +4703,7 @@ void submap::store( JsonOut &jsout ) const
     int count = 0;
     for( int j = 0; j < SEEY; j++ ) {
         for( int i = 0; i < SEEX; i++ ) {
-            const point p( i, j );
+            const point_sm_ms p( i, j );
             // Save radiation, re-examine this because it doesn't look like it works right
             int r = get_radiation( p );
             if( r == lastrad ) {
@@ -4725,12 +4725,12 @@ void submap::store( JsonOut &jsout ) const
     jsout.start_array();
     for( int j = 0; j < SEEY; j++ ) {
         for( int i = 0; i < SEEX; i++ ) {
-            const point p( i, j );
+            const point_sm_ms p( i, j );
             // Save furniture
             if( get_furn( p ) ) {
                 jsout.start_array();
-                jsout.write( p.x );
-                jsout.write( p.y );
+                jsout.write( p.x() );
+                jsout.write( p.y() );
                 jsout.write( get_furn( p ).obj().id );
                 jsout.end_array();
             }
@@ -4756,12 +4756,12 @@ void submap::store( JsonOut &jsout ) const
     jsout.start_array();
     for( int j = 0; j < SEEY; j++ ) {
         for( int i = 0; i < SEEX; i++ ) {
-            const point p( i, j );
+            const point_sm_ms p( i, j );
             // Save traps
             if( get_trap( p ) ) {
                 jsout.start_array();
-                jsout.write( p.x );
-                jsout.write( p.y );
+                jsout.write( p.x() );
+                jsout.write( p.y() );
                 const trap_id &trap_at = get_trap( p );
                 // TODO: jsout should support writing an id like jsout.write( trap_id )
                 jsout.write( trap_at.id().str() );
@@ -4798,8 +4798,8 @@ void submap::store( JsonOut &jsout ) const
     jsout.start_array();
     for( const submap::cosmetic_t &cosm : cosmetics ) {
         jsout.start_array();
-        jsout.write( cosm.pos.x );
-        jsout.write( cosm.pos.y );
+        jsout.write( cosm.pos.x() );
+        jsout.write( cosm.pos.y() );
         jsout.write( cosm.type );
         jsout.write( cosm.str );
         jsout.end_array();
@@ -4814,8 +4814,8 @@ void submap::store( JsonOut &jsout ) const
         // TODO: json should know how to write string_ids
         jsout.write( elem.type.str() );
         jsout.write( elem.count );
-        jsout.write( elem.pos.x );
-        jsout.write( elem.pos.y );
+        jsout.write( elem.pos.x() );
+        jsout.write( elem.pos.y() );
         jsout.write( elem.faction_id );
         jsout.write( elem.mission_id );
         jsout.write( elem.friendly );
@@ -5000,13 +5000,13 @@ void submap::load( const JsonValue &jv, const std::string &member_name, int vers
         while( items_json.has_more() ) {
             int i = items_json.next_int();
             int j = items_json.next_int();
-            const point p( i, j );
+            const point_sm_ms p( i, j );
 
-            if( !items_json.next_value().read( m->itm[p.x][p.y], false ) ) {
+            if( !items_json.next_value().read( m->itm[p.x()][p.y()], false ) ) {
                 debugmsg( "Items array is corrupt in submap at: %s, skipping", p.to_string() );
             }
             // some portion could've been read even if error occurred
-            for( item &it : m->itm[p.x][p.y] ) {
+            for( item &it : m->itm[p.x()][p.y()] ) {
                 if( it.is_emissive() ) {
                     update_lum_add( p, it );
                 }
@@ -5062,7 +5062,7 @@ void submap::load( const JsonValue &jv, const std::string &member_name, int vers
         for( JsonArray graffiti_entry : graffiti_json ) {
             int i = graffiti_entry.next_int();
             int j = graffiti_entry.next_int();
-            const point p( i, j );
+            const point_sm_ms p( i, j );
             set_graffiti( p, graffiti_entry.next_string() );
             if( graffiti_entry.size() > 3 ) {
                 graffiti_entry.throw_error( "Too many values for graffiti" );
@@ -5075,7 +5075,7 @@ void submap::load( const JsonValue &jv, const std::string &member_name, int vers
         for( JsonArray cosmetic_entry : cosmetics_json ) {
             int i = cosmetic_entry.next_int();
             int j = cosmetic_entry.next_int();
-            const point p( i, j );
+            const point_sm_ms p( i, j );
             std::string type;
             std::string str;
             JsonValue cosmetic_value = cosmetic_entry.next_value();
@@ -5113,7 +5113,7 @@ void submap::load( const JsonValue &jv, const std::string &member_name, int vers
             if( spawn_entry.has_more() ) {
                 spawn_entry.throw_error( "Too many values for spawn" );
             }
-            spawn_point tmp( type, count, p, faction_id, mission_id, friendly, name );
+            spawn_point tmp( type, count, point_sm_ms( p ), faction_id, mission_id, friendly, name );
             spawns.push_back( tmp );
         }
     } else if( member_name == "vehicles" ) {

--- a/src/submap.cpp
+++ b/src/submap.cpp
@@ -19,15 +19,15 @@ static const furn_str_id furn_f_console( "f_console" );
 
 static const trap_str_id tr_ledge( "tr_ledge" );
 
-void maptile_soa::swap_soa_tile( const point &p1, const point &p2 )
+void maptile_soa::swap_soa_tile( const point_sm_ms &p1, const point_sm_ms &p2 )
 {
-    std::swap( ter[p1.x][p1.y], ter[p2.x][p2.y] );
-    std::swap( frn[p1.x][p1.y], frn[p2.x][p2.y] );
-    std::swap( lum[p1.x][p1.y], lum[p2.x][p2.y] );
-    std::swap( itm[p1.x][p1.y], itm[p2.x][p2.y] );
-    std::swap( fld[p1.x][p1.y], fld[p2.x][p2.y] );
-    std::swap( trp[p1.x][p1.y], trp[p2.x][p2.y] );
-    std::swap( rad[p1.x][p1.y], rad[p2.x][p2.y] );
+    std::swap( ter[p1.x()][p1.y()], ter[p2.x()][p2.y()] );
+    std::swap( frn[p1.x()][p1.y()], frn[p2.x()][p2.y()] );
+    std::swap( lum[p1.x()][p1.y()], lum[p2.x()][p2.y()] );
+    std::swap( itm[p1.x()][p1.y()], itm[p2.x()][p2.y()] );
+    std::swap( fld[p1.x()][p1.y()], fld[p2.x()][p2.y()] );
+    std::swap( trp[p1.x()][p1.y()], trp[p2.x()][p2.y()] );
+    std::swap( rad[p1.x()][p1.y()], rad[p2.x()][p2.y()] );
 }
 
 submap::submap( submap && ) noexcept( map_is_noexcept ) = default;
@@ -35,7 +35,7 @@ submap::~submap() = default;
 
 submap &submap::operator=( submap && ) noexcept = default;
 
-void submap::clear_fields( const point &p )
+void submap::clear_fields( const point_sm_ms &p )
 {
     field &f = get_field( p );
     field_count -= f.field_count();
@@ -59,7 +59,7 @@ static cosmetic_find_result make_result( bool b, int ndx )
     return result;
 }
 static cosmetic_find_result find_cosmetic(
-    const std::vector<submap::cosmetic_t> &cosmetics, const point &p, const std::string &type )
+    const std::vector<submap::cosmetic_t> &cosmetics, const point_sm_ms &p, const std::string &type )
 {
     for( size_t i = 0; i < cosmetics.size(); ++i ) {
         if( cosmetics[i].pos == p && cosmetics[i].type == type ) {
@@ -69,12 +69,12 @@ static cosmetic_find_result find_cosmetic(
     return make_result( false, -1 );
 }
 
-bool submap::has_graffiti( const point &p ) const
+bool submap::has_graffiti( const point_sm_ms &p ) const
 {
     return find_cosmetic( cosmetics, p, COSMETICS_GRAFFITI ).result;
 }
 
-const std::string &submap::get_graffiti( const point &p ) const
+const std::string &submap::get_graffiti( const point_sm_ms &p ) const
 {
     const cosmetic_find_result fresult = find_cosmetic( cosmetics, p, COSMETICS_GRAFFITI );
     if( fresult.result ) {
@@ -83,7 +83,7 @@ const std::string &submap::get_graffiti( const point &p ) const
     return STRING_EMPTY;
 }
 
-void submap::set_graffiti( const point &p, const std::string &new_graffiti )
+void submap::set_graffiti( const point_sm_ms &p, const std::string &new_graffiti )
 {
     ensure_nonuniform();
     // Find signage at p if available
@@ -95,7 +95,7 @@ void submap::set_graffiti( const point &p, const std::string &new_graffiti )
     }
 }
 
-void submap::delete_graffiti( const point &p )
+void submap::delete_graffiti( const point_sm_ms &p )
 {
     const cosmetic_find_result fresult = find_cosmetic( cosmetics, p, COSMETICS_GRAFFITI );
     if( fresult.result ) {
@@ -104,17 +104,17 @@ void submap::delete_graffiti( const point &p )
         cosmetics.pop_back();
     }
 }
-bool submap::has_signage( const point &p ) const
+bool submap::has_signage( const point_sm_ms &p ) const
 {
-    if( !is_uniform() && m->frn[p.x][p.y].obj().has_flag( ter_furn_flag::TFLAG_SIGN ) ) {
+    if( !is_uniform() && m->frn[p.x()][p.y()].obj().has_flag( ter_furn_flag::TFLAG_SIGN ) ) {
         return find_cosmetic( cosmetics, p, COSMETICS_SIGNAGE ).result;
     }
 
     return false;
 }
-std::string submap::get_signage( const point &p ) const
+std::string submap::get_signage( const point_sm_ms &p ) const
 {
-    if( !is_uniform() && m->frn[p.x][p.y].obj().has_flag( ter_furn_flag::TFLAG_SIGN ) ) {
+    if( !is_uniform() && m->frn[p.x()][p.y()].obj().has_flag( ter_furn_flag::TFLAG_SIGN ) ) {
         const cosmetic_find_result fresult = find_cosmetic( cosmetics, p, COSMETICS_SIGNAGE );
         if( fresult.result ) {
             return cosmetics[ fresult.ndx ].str;
@@ -123,7 +123,7 @@ std::string submap::get_signage( const point &p ) const
 
     return STRING_EMPTY;
 }
-void submap::set_signage( const point &p, const std::string &s )
+void submap::set_signage( const point_sm_ms &p, const std::string &s )
 {
     ensure_nonuniform();
     // Find signage at p if available
@@ -134,7 +134,7 @@ void submap::set_signage( const point &p, const std::string &s )
         insert_cosmetic( p, COSMETICS_SIGNAGE, s );
     }
 }
-void submap::delete_signage( const point &p )
+void submap::delete_signage( const point_sm_ms &p )
 {
     const cosmetic_find_result fresult = find_cosmetic( cosmetics, p, COSMETICS_SIGNAGE );
     if( fresult.result ) {
@@ -144,12 +144,12 @@ void submap::delete_signage( const point &p )
     }
 }
 
-bool submap::has_computer( const point &p ) const
+bool submap::has_computer( const point_sm_ms &p ) const
 {
     return !is_uniform() && computers.find( p ) != computers.end();
 }
 
-const computer *submap::get_computer( const point &p ) const
+const computer *submap::get_computer( const point_sm_ms &p ) const
 {
     // the returned object will not get modified (should not, at least), so we
     // don't yet need to update to std::map
@@ -160,7 +160,7 @@ const computer *submap::get_computer( const point &p ) const
     return nullptr;
 }
 
-computer *submap::get_computer( const point &p )
+computer *submap::get_computer( const point_sm_ms &p )
 {
     const auto it = computers.find( p );
     if( it != computers.end() ) {
@@ -169,12 +169,7 @@ computer *submap::get_computer( const point &p )
     return nullptr;
 }
 
-computer *submap::get_computer( const point_sm_ms &p )
-{
-    return submap::get_computer( p.raw() );
-}
-
-void submap::set_computer( const point &p, const computer &c )
+void submap::set_computer( const point_sm_ms &p, const computer &c )
 {
     const auto it = computers.find( p );
     if( it != computers.end() ) {
@@ -184,7 +179,7 @@ void submap::set_computer( const point &p, const computer &c )
     }
 }
 
-void submap::delete_computer( const point &p )
+void submap::delete_computer( const point_sm_ms &p )
 {
     computers.erase( p );
 }
@@ -199,7 +194,7 @@ bool submap::contains_vehicle( vehicle *veh )
     return match != vehicles.end();
 }
 
-bool submap::is_open_air( const point &p ) const
+bool submap::is_open_air( const point_sm_ms &p ) const
 {
     ter_id t = get_ter( p );
     return t->trap == tr_ledge;
@@ -227,26 +222,26 @@ void submap::rotate( int turns )
         // Swap horizontal stripes.
         for( int j = 0, je = SEEY / 2; j < je; ++j ) {
             for( int i = j, ie = SEEX - j; i < ie; ++i ) {
-                m->swap_soa_tile( { i, j }, rotate_point( { i, j } ) );
+                m->swap_soa_tile( { i, j }, point_sm_ms( rotate_point( { i, j } ) ) );
             }
         }
         // Swap vertical stripes so that they don't overlap with
         // the already swapped horizontals.
         for( int i = 0, ie = SEEX / 2; i < ie; ++i ) {
             for( int j = i + 1, je = SEEY - i - 1; j < je; ++j ) {
-                m->swap_soa_tile( { i, j }, rotate_point( { i, j } ) );
+                m->swap_soa_tile( { i, j }, point_sm_ms( rotate_point( { i, j } ) ) );
             }
         }
     } else {
         for( int j = 0, je = SEEY / 2; j < je; ++j ) {
             for( int i = j, ie = SEEX - j - 1; i < ie; ++i ) {
-                point p = point{ i, j };
-                point pp = p;
+                point_sm_ms p = point_sm_ms{ i, j };
+                point_sm_ms pp = p;
                 // three swaps are enough to perform the circular shift of four elements:
                 // 0123 -> 3120 -> 3102 -> 3012
                 for( int k = 0; k < 3; ++k ) {
                     p = pp;
-                    pp = rotate_point_ccw( pp );
+                    pp = point_sm_ms( rotate_point_ccw( pp.raw() ) );
                     m->swap_soa_tile( p, pp );
                 }
             }
@@ -256,17 +251,17 @@ void submap::rotate( int turns )
     active_items.rotate_locations( turns, { SEEX, SEEY } );
 
     for( submap::cosmetic_t &elem : cosmetics ) {
-        elem.pos = rotate_point( elem.pos );
+        elem.pos = point_sm_ms( rotate_point( elem.pos.raw() ) );
     }
 
     for( spawn_point &elem : spawns ) {
-        elem.pos = rotate_point( elem.pos );
+        elem.pos = point_sm_ms( rotate_point( elem.pos.raw() ) );
     }
 
     for( auto &elem : vehicles ) {
-        const point new_pos = rotate_point( elem->pos );
+        const point_sm_ms new_pos = point_sm_ms( rotate_point( elem->pos ) );
 
-        elem->pos = new_pos;
+        elem->pos = new_pos.raw();
         // turn the steering wheel, vehicle::turn does not actually
         // move the vehicle.
         elem->turn( turns * 90_degrees );
@@ -275,9 +270,9 @@ void submap::rotate( int turns )
         elem->precalc_mounts( 0, elem->turn_dir, elem->pivot_anchor[0] );
     }
 
-    std::map<point, computer> rot_comp;
+    std::map<point_sm_ms, computer> rot_comp;
     for( auto &elem : computers ) {
-        rot_comp.emplace( rotate_point( elem.first ), elem.second );
+        rot_comp.emplace( rotate_point( elem.first.raw() ), elem.second );
     }
     computers = rot_comp;
 }
@@ -287,7 +282,7 @@ void submap::mirror( bool horizontally )
     if( is_uniform() ) {
         return;
     }
-    std::map<point, computer> mirror_comp;
+    std::map<point_sm_ms, computer> mirror_comp;
 
     if( horizontally ) {
         for( int i = 0, ie = SEEX / 2; i < ie; i++ ) {
@@ -297,13 +292,13 @@ void submap::mirror( bool horizontally )
         }
 
         for( submap::cosmetic_t &elem : cosmetics ) {
-            elem.pos = point( -elem.pos.x, elem.pos.y ) + point( SEEX - 1, 0 );
+            elem.pos = point_sm_ms( -elem.pos.x(), elem.pos.y() ) + point( SEEX - 1, 0 );
         }
 
         active_items.mirror( { SEEX, SEEY }, true );
 
         for( auto &elem : computers ) {
-            mirror_comp.emplace( point( -elem.first.x, elem.first.y ) + point( SEEX - 1, 0 ), elem.second );
+            mirror_comp.emplace( point( -elem.first.x(), elem.first.y() ) + point( SEEX - 1, 0 ), elem.second );
         }
         computers = mirror_comp;
     } else {
@@ -314,13 +309,13 @@ void submap::mirror( bool horizontally )
         }
 
         for( submap::cosmetic_t &elem : cosmetics ) {
-            elem.pos = point( elem.pos.x, -elem.pos.y ) + point( 0, SEEY - 1 );
+            elem.pos = point_sm_ms( elem.pos.x(), -elem.pos.y() ) + point( 0, SEEY - 1 );
         }
 
         active_items.mirror( { SEEX, SEEY }, false );
 
         for( auto &elem : computers ) {
-            mirror_comp.emplace( point( elem.first.x, -elem.first.y ) + point( 0, SEEY - 1 ), elem.second );
+            mirror_comp.emplace( point( elem.first.x(), -elem.first.y() ) + point( 0, SEEY - 1 ), elem.second );
         }
         computers = mirror_comp;
     }
@@ -331,14 +326,14 @@ void submap::revert_submap( submap &sr )
     reverted = true;
     if( sr.is_uniform() ) {
         m.reset();
-        set_all_ter( sr.get_ter( point_zero ), true );
+        set_all_ter( sr.get_ter( point_sm_ms_zero ), true );
         return;
     }
 
     ensure_nonuniform();
     for( int x = 0; x < SEEX; x++ ) {
         for( int y = 0; y < SEEY; y++ ) {
-            point pt( x, y );
+            point_sm_ms pt( x, y );
             m->frn[x][y] = sr.get_furn( pt );
             m->ter[x][y] = sr.get_ter( pt );
             m->trp[x][y] = sr.get_trap( pt );
@@ -364,27 +359,27 @@ submap submap::get_revert_submap() const
     return ret;
 }
 
-void submap::update_lum_rem( const point &p, const item &i )
+void submap::update_lum_rem( const point_sm_ms &p, const item &i )
 {
     ensure_nonuniform();
     if( !i.is_emissive() ) {
         return;
-    } else if( m->lum[p.x][p.y] && m->lum[p.x][p.y] < 255 ) {
-        m->lum[p.x][p.y]--;
+    } else if( m->lum[p.x()][p.y()] && m->lum[p.x()][p.y()] < 255 ) {
+        m->lum[p.x()][p.y()]--;
         return;
     }
 
     // Have to scan through all items to be sure removing i will actually lower
     // the count below 255.
     int count = 0;
-    for( const item &it : m->itm[p.x][p.y] ) {
+    for( const item &it : m->itm[p.x()][p.y()] ) {
         if( it.is_emissive() ) {
             count++;
         }
     }
 
     if( count <= 256 ) {
-        m->lum[p.x][p.y] = static_cast<uint8_t>( count - 1 );
+        m->lum[p.x()][p.y()] = static_cast<uint8_t>( count - 1 );
     }
 }
 
@@ -484,8 +479,8 @@ void submap::merge_submaps( submap *copy_from, bool copy_from_is_overlay )
         debugmsg( "Camp found on copied submap when none is expected." );
     }
 
-    for( const std::pair<const point, computer>  &comp : copy_from->computers ) {
-        if( this->m->frn[comp.first.x][comp.first.y] == furn_f_console &&
+    for( const std::pair<const point_sm_ms, computer>  &comp : copy_from->computers ) {
+        if( this->m->frn[comp.first.x()][comp.first.y()] == furn_f_console &&
             !this->get_computer( comp.first ) ) {
             this->set_computer( comp.first, comp.second );
         }

--- a/src/submap.h
+++ b/src/submap.h
@@ -20,6 +20,7 @@
 #include "compatibility.h"
 #include "computer.h"
 #include "construction.h"
+#include "coordinate_constants.h"
 #include "field.h"
 #include "game_constants.h"
 #include "item.h"
@@ -37,7 +38,7 @@ struct furn_t;
 struct ter_t;
 
 struct spawn_point {
-    point pos;
+    point_sm_ms pos;
     int count;
     mtype_id type;
     int faction_id;
@@ -45,7 +46,8 @@ struct spawn_point {
     bool friendly;
     std::optional<std::string> name;
     spawn_data data;
-    explicit spawn_point( const mtype_id &T = mtype_id::NULL_ID(), int C = 0, point P = point_zero,
+    explicit spawn_point( const mtype_id &T = mtype_id::NULL_ID(), int C = 0,
+                          point_sm_ms P = point_sm_ms_zero,
                           int FAC = -1, int MIS = -1, bool F = false,
                           const std::optional<std::string> &N = std::nullopt, const spawn_data &SD = spawn_data() ) :
         pos( P ), count( C ), type( T ), faction_id( FAC ),
@@ -63,7 +65,7 @@ struct maptile_soa {
     cata::mdarray<trap_id, point_sm_ms>            trp; // Trap on each square
     cata::mdarray<int, point_sm_ms>                rad; // Irradiation of each square
 
-    void swap_soa_tile( const point &p1, const point &p2 );
+    void swap_soa_tile( const point_sm_ms &p1, const point_sm_ms &p2 );
 };
 
 class submap
@@ -90,16 +92,16 @@ class submap
 
         submap get_revert_submap() const;
 
-        trap_id get_trap( const point &p ) const {
+        trap_id get_trap( const point_sm_ms &p ) const {
             if( is_uniform() ) {
                 return tr_null;
             }
-            return m->trp[p.x][p.y];
+            return m->trp[p.x()][p.y()];
         }
 
-        void set_trap( const point &p, trap_id trap ) {
+        void set_trap( const point_sm_ms &p, trap_id trap ) {
             ensure_nonuniform();
-            m->trp[p.x][p.y] = trap;
+            m->trp[p.x()][p.y()] = trap;
         }
 
         void set_all_traps( const trap_id &trap ) {
@@ -107,16 +109,16 @@ class submap
             std::uninitialized_fill_n( &m->trp[0][0], elements, trap );
         }
 
-        furn_id get_furn( const point &p ) const {
+        furn_id get_furn( const point_sm_ms &p ) const {
             if( is_uniform() ) {
                 return furn_str_id::NULL_ID();
             }
-            return m->frn[p.x][p.y];
+            return m->frn[p.x()][p.y()];
         }
 
-        void set_furn( const point &p, furn_id furn ) {
+        void set_furn( const point_sm_ms &p, furn_id furn ) {
             ensure_nonuniform();
-            m->frn[p.x][p.y] = furn;
+            m->frn[p.x()][p.y()] = furn;
         }
 
         void set_all_furn( const furn_id &furn ) {
@@ -135,16 +137,16 @@ class submap
             ephemeral_data[p] = { dmg };
         }
 
-        ter_id get_ter( const point &p ) const {
+        ter_id get_ter( const point_sm_ms &p ) const {
             if( is_uniform() ) {
                 return uniform_ter;
             }
-            return m->ter[p.x][p.y];
+            return m->ter[p.x()][p.y()];
         }
 
-        void set_ter( const point &p, ter_id terr ) {
+        void set_ter( const point_sm_ms &p, ter_id terr ) {
             ensure_nonuniform();
-            m->ter[p.x][p.y] = terr;
+            m->ter[p.x()][p.y()] = terr;
         }
 
         void set_all_ter( const ter_id &terr, bool uniform_ok = false ) {
@@ -158,32 +160,28 @@ class submap
             }
         }
 
-        int get_radiation( const point &p ) const {
+        int get_radiation( const point_sm_ms &p ) const {
             if( is_uniform() ) {
                 return 0;
             }
-            return m->rad[p.x][p.y];
+            return m->rad[p.x()][p.y()];
         }
 
-        void set_radiation( const point &p, const int radiation ) {
+        void set_radiation( const point_sm_ms &p, const int radiation ) {
             ensure_nonuniform();
-            m->rad[p.x][p.y] = radiation;
+            m->rad[p.x()][p.y()] = radiation;
         }
 
-        uint8_t get_lum( const point &p ) const {
+        uint8_t get_lum( const point_sm_ms &p ) const {
             if( is_uniform() ) {
                 return 0;
             }
-            return m->lum[p.x][p.y];
+            return m->lum[p.x()][p.y()];
         }
 
-        void set_lum( const point &p, uint8_t luminance ) {
+        void set_lum( const point_sm_ms &p, uint8_t luminance ) {
             ensure_nonuniform();
-            m->lum[p.x][p.y] = luminance;
-        }
-
-        void update_lum_add( const point &p, const item &i ) {
-            update_lum_add( point_sm_ms( p ), i );
+            m->lum[p.x()][p.y()] = luminance;
         }
 
         void update_lum_add( const point_sm_ms &p, const item &i ) {
@@ -193,14 +191,9 @@ class submap
             }
         }
 
-        void update_lum_rem( const point &p, const item &i );
+        void update_lum_rem( const point_sm_ms &p, const item &i );
 
         // TODO: Replace this as it essentially makes itm public
-        // TODO: Get rid of untyped overload.
-        cata::colony<item> &get_items( const point &p ) {
-            return get_items( point_sm_ms( p ) );
-        }
-
         cata::colony<item> &get_items( const point_sm_ms &p ) {
             if( is_uniform() ) {
                 cata::colony<item> static noitems;
@@ -209,40 +202,40 @@ class submap
             return m->itm[p.x()][p.y()];
         }
 
-        const cata::colony<item> &get_items( const point &p ) const {
+        const cata::colony<item> &get_items( const point_sm_ms &p ) const {
             if( is_uniform() ) {
                 cata::colony<item> static noitems;
                 return noitems;
             }
-            return m->itm[p.x][p.y];
+            return m->itm[p.x()][p.y()];
         }
 
         // TODO: Replace this as it essentially makes fld public
-        field &get_field( const point &p ) {
+        field &get_field( const point_sm_ms &p ) {
             if( is_uniform() ) {
                 field static nofield;
                 return nofield;
             }
-            return m->fld[p.x][p.y];
+            return m->fld[p.x()][p.y()];
         }
 
-        const field &get_field( const point &p ) const {
+        const field &get_field( const point_sm_ms &p ) const {
             if( is_uniform() ) {
                 field static nofield;
                 return nofield;
             }
-            return m->fld[p.x][p.y];
+            return m->fld[p.x()][p.y()];
         }
 
-        void clear_fields( const point &p );
+        void clear_fields( const point_sm_ms &p );
 
         struct cosmetic_t {
-            point pos;
+            point_sm_ms pos;
             std::string type;
             std::string str;
         };
 
-        void insert_cosmetic( const point &p, const std::string &type, const std::string &str ) {
+        void insert_cosmetic( const point_sm_ms &p, const std::string &type, const std::string &str ) {
             cosmetic_t ins;
 
             ins.pos = p;
@@ -260,33 +253,31 @@ class submap
             temperature_mod = units::to_fahrenheit_delta( new_temperature_mod );
         }
 
-        bool has_graffiti( const point &p ) const;
-        const std::string &get_graffiti( const point &p ) const;
-        void set_graffiti( const point &p, const std::string &new_graffiti );
-        void delete_graffiti( const point &p );
+        bool has_graffiti( const point_sm_ms &p ) const;
+        const std::string &get_graffiti( const point_sm_ms &p ) const;
+        void set_graffiti( const point_sm_ms &p, const std::string &new_graffiti );
+        void delete_graffiti( const point_sm_ms &p );
 
         // Signage is a pretend union between furniture on a square and stored
         // writing on the square. When both are present, we have signage.
         // Its effect is meant to be cosmetic and atmospheric only.
-        bool has_signage( const point &p ) const;
+        bool has_signage( const point_sm_ms &p ) const;
         // Dependent on furniture + cosmetics.
-        std::string get_signage( const point &p ) const;
+        std::string get_signage( const point_sm_ms &p ) const;
         // Can be used anytime (prevents code from needing to place sign first.)
-        void set_signage( const point &p, const std::string &s );
+        void set_signage( const point_sm_ms &p, const std::string &s );
         // Can be used anytime (prevents code from needing to place sign first.)
-        void delete_signage( const point &p );
+        void delete_signage( const point_sm_ms &p );
 
-        bool has_computer( const point &p ) const;
-        const computer *get_computer( const point &p ) const;
-        // TOD: Get rid of untyped overload.
-        computer *get_computer( const point &p );
+        bool has_computer( const point_sm_ms &p ) const;
+        const computer *get_computer( const point_sm_ms &p ) const;
         computer *get_computer( const point_sm_ms &p );
-        void set_computer( const point &p, const computer &c );
-        void delete_computer( const point &p );
+        void set_computer( const point_sm_ms &p, const computer &c );
+        void delete_computer( const point_sm_ms &p );
 
         bool contains_vehicle( vehicle * );
 
-        bool is_open_air( const point & ) const;
+        bool is_open_air( const point_sm_ms & ) const;
 
         void rotate( int turns );
         void mirror( bool horizontally );
@@ -332,7 +323,7 @@ class submap
 
     private:
         std::map<point_sm_ms, tile_data> ephemeral_data;
-        std::map<point, computer> computers;
+        std::map<point_sm_ms, computer> computers;
         std::unique_ptr<maptile_soa> m;
         ter_id uniform_ter = t_null;
         int temperature_mod = 0; // delta in F
@@ -357,9 +348,9 @@ class maptile_impl
         friend map; // To allow "sliding" the tile in x/y without bounds checks
         friend submap;
         Submap *sm;
-        point pos_;
+        point_sm_ms pos_;
 
-        maptile_impl( Submap *sub, const point &p ) :
+        maptile_impl( Submap *sub, const point_sm_ms &p ) :
             sm( sub ), pos_( p ) { }
         template<typename OtherSubmap>
         // NOLINTNEXTLINE(google-explicit-constructor)
@@ -369,7 +360,7 @@ class maptile_impl
         Submap *wrapped_submap() const {
             return sm;
         }
-        inline point pos() const {
+        inline point_sm_ms pos() const {
             return pos_;
         }
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -7873,8 +7873,8 @@ static bool is_sm_tile_over_water( const tripoint &real_global_pos )
     }
 
     // TODO: fix point types
-    return ( sm->get_ter( p.raw() ).obj().has_flag( ter_furn_flag::TFLAG_CURRENT ) ||
-             sm->get_furn( p.raw() ).obj().has_flag( ter_furn_flag::TFLAG_CURRENT ) );
+    return ( sm->get_ter( p ).obj().has_flag( ter_furn_flag::TFLAG_CURRENT ) ||
+             sm->get_furn( p ).obj().has_flag( ter_furn_flag::TFLAG_CURRENT ) );
 }
 
 static bool is_sm_tile_outside( const tripoint &real_global_pos )
@@ -7895,8 +7895,8 @@ static bool is_sm_tile_outside( const tripoint &real_global_pos )
     }
 
     // TODO: fix point types
-    return !( sm->get_ter( p.raw() ).obj().has_flag( ter_furn_flag::TFLAG_INDOORS ) ||
-              sm->get_furn( p.raw() ).obj().has_flag( ter_furn_flag::TFLAG_INDOORS ) );
+    return !( sm->get_ter( p ).obj().has_flag( ter_furn_flag::TFLAG_INDOORS ) ||
+              sm->get_furn( p ).obj().has_flag( ter_furn_flag::TFLAG_INDOORS ) );
 }
 
 void vehicle::update_time( const time_point &update_to )

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -6732,7 +6732,6 @@ void vehicle::do_towing_move()
     if( towed_veh->tow_data.tow_direction == TOW_FRONT ) {
         towed_veh->selfdrive( point( turn_x, accel_y ) );
     } else if( towed_veh->tow_data.tow_direction == TOW_BACK ) {
-        accel_y = 10;
         towed_veh->selfdrive( point( turn_x, accel_y ) );
     } else {
         towed_veh->skidding = true;

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -699,12 +699,12 @@ std::list<item> map_cursor::remove_items_with( const
     // fetch the appropriate item stack
     point_sm_ms offset;
     submap *sub = here.get_submap_at( pos(), offset );
-    cata::colony<item> &stack = sub->get_items( offset.raw() );
+    cata::colony<item> &stack = sub->get_items( offset );
 
     for( auto iter = stack.begin(); iter != stack.end(); ) {
         if( filter( *iter ) ) {
             // if necessary remove item from the luminosity map
-            sub->update_lum_rem( offset.raw(), *iter );
+            sub->update_lum_rem( offset, *iter );
 
             // finally remove the item
             res.push_back( *iter );

--- a/tests/map_helpers.cpp
+++ b/tests/map_helpers.cpp
@@ -94,8 +94,8 @@ void clear_fields( const int zlevel )
     const int mapsize = here.getmapsize() * SEEX;
     for( int x = 0; x < mapsize; ++x ) {
         for( int y = 0; y < mapsize; ++y ) {
-            const tripoint p( x, y, zlevel );
-            point offset;
+            const tripoint_bub_ms p( x, y, zlevel );
+            point_sm_ms offset;
 
             submap *sm = here.get_submap_at( p, offset );
             if( sm ) {

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -150,7 +150,7 @@ void map::check_submap_active_item_consistency()
     for( int z = -OVERMAP_DEPTH; z < OVERMAP_HEIGHT; ++z ) {
         for( int x = 0; x < MAPSIZE; ++x ) {
             for( int y = 0; y < MAPSIZE; ++y ) {
-                tripoint p( x, y, z );
+                tripoint_rel_sm p( x, y, z );
                 submap *s = get_submap_at_grid( p );
                 REQUIRE( s != nullptr );
                 bool submap_has_active_items = !s->active_items.empty();

--- a/tests/submap_load_test.cpp
+++ b/tests/submap_load_test.cpp
@@ -46,11 +46,11 @@ static const ter_str_id ter_test_t_migration_new_id( "test_t_migration_new_id" )
 // NOLINTNEXTLINE(cata-static-declarations)
 extern const int savegame_version;
 
-static const point &corner_ne = point_zero;
-static const point corner_nw( SEEX - 1, 0 );
-static const point corner_se( 0, SEEY - 1 );
-static const point corner_sw( SEEX - 1, SEEY - 1 );
-static const point random_pt( 4, 7 );
+static const point_sm_ms &corner_ne = point_sm_ms_zero;
+static const point_sm_ms corner_nw( SEEX - 1, 0 );
+static const point_sm_ms corner_se( 0, SEEY - 1 );
+static const point_sm_ms corner_sw( SEEX - 1, SEEY - 1 );
+static const point_sm_ms random_pt( 4, 7 );
 
 static std::string submap_empty_ss(
     "{\n"
@@ -1044,7 +1044,7 @@ TEST_CASE( "submap_furniture_load", "[submap][load]" )
     // Also, check we have no other furniture
     for( int x = 0; x < SEEX; ++x ) {
         for( int y = 0; y < SEEY; ++y ) {
-            point tested{ x, y };
+            point_sm_ms tested{ x, y };
             if( tested == corner_nw || tested == corner_ne || tested == corner_sw || tested == corner_se ||
                 tested == random_pt ) {
                 continue;
@@ -1085,7 +1085,7 @@ TEST_CASE( "submap_trap_load", "[submap][load]" )
     // Also, check we have no other traps
     for( int x = 0; x < SEEX; ++x ) {
         for( int y = 0; y < SEEY; ++y ) {
-            point tested{ x, y };
+            point_sm_ms tested{ x, y };
             if( tested == corner_nw || tested == corner_ne || tested == corner_sw || tested == corner_se ||
                 tested == random_pt ) {
                 continue;
@@ -1133,7 +1133,7 @@ TEST_CASE( "submap_rad_load", "[submap][load]" )
             rad = -1;
         }
         for( int x = 0; x < SEEX; ++x ) {
-            point tested{ x, y };
+            point_sm_ms tested{ x, y };
             if( tested == corner_nw || tested == corner_ne || tested == corner_sw || tested == corner_se ||
                 tested == random_pt ) {
                 rads[x] = sm.get_radiation( tested );
@@ -1202,7 +1202,7 @@ TEST_CASE( "submap_item_load", "[submap][load]" )
     // Also, check we have no other items
     for( int y = 0; y < SEEY; ++y ) {
         for( int x = 0; x < SEEX; ++x ) {
-            point tested{ x, y };
+            point_sm_ms tested{ x, y };
             if( tested == corner_nw || tested == corner_ne || tested == corner_sw || tested == corner_se ||
                 tested == random_pt ) {
                 continue;
@@ -1275,7 +1275,7 @@ TEST_CASE( "submap_field_load", "[submap][load]" )
     // Also, check we have no other fields
     for( int y = 0; y < SEEY; ++y ) {
         for( int x = 0; x < SEEX; ++x ) {
-            point tested{ x, y };
+            point_sm_ms tested{ x, y };
             if( tested == corner_nw || tested == corner_ne || tested == corner_sw || tested == corner_se ||
                 tested == random_pt ) {
                 continue;
@@ -1382,15 +1382,15 @@ TEST_CASE( "submap_spawns_load", "[submap][load]" )
     } );
 
     // We placed a unique spawn in a couple of places. Check that those are correct
-    INFO( string_format( "nw: [%d, %d] %d %s %s %s", nw.pos.x, nw.pos.y, nw.count, nw.type.str(),
+    INFO( string_format( "nw: [%d, %d] %d %s %s %s", nw.pos.x(), nw.pos.y(), nw.count, nw.type.str(),
                          nw.friendly ? "friendly" : "hostile", nw.name.value_or( "NONE" ) ) );
-    INFO( string_format( "ne: [%d, %d] %d %s %s %s", ne.pos.x, ne.pos.y, ne.count, ne.type.str(),
+    INFO( string_format( "ne: [%d, %d] %d %s %s %s", ne.pos.x(), ne.pos.y(), ne.count, ne.type.str(),
                          ne.friendly ? "friendly" : "hostile", ne.name.value_or( "NONE" ) ) );
-    INFO( string_format( "sw: [%d, %d] %d %s %s %s", sw.pos.x, sw.pos.y, sw.count, sw.type.str(),
+    INFO( string_format( "sw: [%d, %d] %d %s %s %s", sw.pos.x(), sw.pos.y(), sw.count, sw.type.str(),
                          sw.friendly ? "friendly" : "hostile", sw.name.value_or( "NONE" ) ) );
-    INFO( string_format( "se: [%d, %d] %d %s %s %s", se.pos.x, se.pos.y, se.count, se.type.str(),
+    INFO( string_format( "se: [%d, %d] %d %s %s %s", se.pos.x(), se.pos.y(), se.count, se.type.str(),
                          se.friendly ? "friendly" : "hostile", se.name.value_or( "NONE" ) ) );
-    INFO( string_format( "ra: [%d, %d] %d %s %s %s", ra.pos.x, ra.pos.y, ra.count, ra.type.str(),
+    INFO( string_format( "ra: [%d, %d] %d %s %s %s", ra.pos.x(), ra.pos.y(), ra.count, ra.type.str(),
                          ra.friendly ? "friendly" : "hostile", ra.name.value_or( "NONE" ) ) );
     // Require to prevent the lower CHECK from being spammy
     CHECK( nw.count == 3 );
@@ -1464,7 +1464,7 @@ TEST_CASE( "submap_computer_load", "[submap][load]" )
     REQUIRE( is_normal_submap( sm, checks ) );
     // Just check there are computers in the right place
     // Checking more is complicated
-    REQUIRE( sm.has_computer( point_south ) );
+    REQUIRE( sm.has_computer( point_sm_ms( point_south ) ) );
     REQUIRE( sm.has_computer( {3, 5} ) );
 }
 

--- a/tests/submap_test.cpp
+++ b/tests/submap_test.cpp
@@ -8,15 +8,15 @@
 TEST_CASE( "submap_rotation", "[submap]" )
 {
     // Corners are labelled starting from the upper-left one, clockwise.
-    constexpr point corner_1{};
-    constexpr point corner_2 = point{ SEEX - 1, 0 };
-    constexpr point corner_3 = point{ SEEX - 1, SEEY - 1 };
-    constexpr point corner_4 = point{ 0, SEEY - 1 };
+    constexpr point_sm_ms corner_1{};
+    constexpr point_sm_ms corner_2 = { SEEX - 1, 0 };
+    constexpr point_sm_ms corner_3 = { SEEX - 1, SEEY - 1 };
+    constexpr point_sm_ms corner_4 = { 0, SEEY - 1 };
 
-    constexpr point center_1 = point{ SEEX / 2 - 1, SEEY / 2 - 1 };
-    constexpr point center_2 = point{ SEEX / 2, SEEY / 2 - 1 };
-    constexpr point center_3 = point{ SEEX / 2, SEEY / 2 };
-    constexpr point center_4 = point{ SEEX / 2 - 1, SEEY / 2 };
+    constexpr point_sm_ms center_1 = { SEEX / 2 - 1, SEEY / 2 - 1 };
+    constexpr point_sm_ms center_2 = { SEEX / 2, SEEY / 2 - 1 };
+    constexpr point_sm_ms center_3 = { SEEX / 2, SEEY / 2 };
+    constexpr point_sm_ms center_4 = { SEEX / 2 - 1, SEEY / 2 };
 
     GIVEN( "a submap with marks" ) {
         submap sm;
@@ -107,8 +107,8 @@ TEST_CASE( "submap_rotation2", "[submap]" )
 
     for( int x = 0; x < SEEX; x++ ) {
         for( int y = 0; y < SEEY; y++ ) {
-            point p( x, y );
-            point p_after_rotation = p.rotate( rotation_turns, {SEEX, SEEY} );
+            point_sm_ms p( x, y );
+            point_sm_ms p_after_rotation = point_sm_ms( p.raw().rotate( rotation_turns, {SEEX, SEEY} ) );
 
             CAPTURE( p, p_after_rotation );
             CHECK( sm.get_radiation( p_after_rotation ) == sm_copy.get_radiation( p ) );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #74907, i.e. towing a vehicle rearwards causes it to instantly accelerate to a very high velocity, smash into the towing vehicle, and shoot off into the distance.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Remove a weird line that destroys the logic by replacing a value that's expected to be either 1 or -1 with 10. I have no idea what this line is supposed to achieve (or how it was tested...), but the operation called immediately after setting the value makes the assumption the value is either 1 or -1 to indicate it breaking or accelerating (0 might be steady: I didn't look for that case), so instead of accelerating as the code leading up to this had concluded, 10 resulted in it not being 1, and so had to be breaking. This, in turn seems to have resulted in code for breaking being called with acceleration values, which, in turn, gave bizarre results when feeding into what what supposed to be a limiting operation (min of two negative values does NOT result in the one closest to zero...).

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Try to figure out why this "random" line was entered. However, I don't know how to search for where and when code was changed.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
- Got into the towing car and towed the vehicle a bit, noting that towing behaved as I expected from previous towing experience.
- Reloaded the bug report save and moved the towing vehicle and cable to the front and towed forwards, again noting that towing behaved as I expected (and as it did with the same save before the change).

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
