### PR TITLE
remove the social and scent making effects from skunk spray

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -2085,18 +2085,7 @@
     "apply_message": "You're covered in a foul smelling fluid!",
     "rating": "bad",
     "max_duration": "5 hours",
-    "base_mods": { "per_mod": [ -1 ], "int_mod": [ -1 ], "vomit_chance": [ 2000 ] },
-    "enchantments": [
-      {
-        "values": [
-          { "value": "SOCIAL_PERSUADE", "add": -10 },
-          { "value": "SOCIAL_LIE", "add": -4 },
-          { "value": "SOCIAL_INTIMIDATE", "add": 2 },
-          { "value": "UGLINESS", "add": 5 },
-          { "value": "SCENT_MASK", "add": 300 }
-        ]
-      }
-    ]
+    "base_mods": { "per_mod": [ -1 ], "int_mod": [ -1 ], "vomit_chance": [ 2000 ] }
   },
   {
     "type": "effect_type",


### PR DESCRIPTION
These are kind of random and unjustified,  and I'm already seeing copycats.

#### Summary
None

#### Purpose of change
It was brought to my attention in #74920 that skunk spray had these weird social modifiers.

If we're going to have "you smell bad/you're dirty/etc therefore you have social penalties,  it needs to be some intermediate effect that we can keep track of, not "every effect in the game potentially does arbitrary things to your social checks".

That's a big if, it's quite a stretch that, "you smell bad therefore npcs assume you're lying".

Likewise something else that keeps coming up,  almost nothing should have the scent masking effect, scent doesn't work like that. Dogs might not track someone that has been sprayed by a skunk,  but that's not because they *can't*, it's because they *won't*. Meanwhile zombies don't care,  and they're the dominant creator we care about wrt scent. 

#### Describe the solution
Remove the extra effects.