### PR TITLE
fix vitamin enchantment condition

### DIFF
--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -1397,11 +1397,11 @@ std::function<double( dialogue & )> vision_range_eval( char scope,
         std::vector<diag_value> const &/* params */, diag_kwargs const &/* kwargs */ )
 {
     return[beta = is_beta( scope )]( dialogue const & d ) {
-        talker const* const actor = d.actor(beta);
-        if (Character const* const chr = actor->get_character(); chr != nullptr) {
+        talker const *const actor = d.actor( beta );
+        if( Character const *const chr = actor->get_character(); chr != nullptr ) {
             return chr->unimpaired_range();
         }
-        debugmsg("Tried to access vision range of a non-Character talker");
+        debugmsg( "Tried to access vision range of a non-Character talker" );
         return 0;
     };
 }
@@ -1464,13 +1464,13 @@ std::function<double( dialogue & )> vitamin_eval( char scope,
         std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
 {
     return[beta = is_beta( scope ), id = params[0]]( dialogue const & d ) {
-        talker const* const actor = d.actor(beta);
-        if (Character const* const chr = actor->get_character(); chr != nullptr) {
-            return chr->vitamin_get(vitamin_id(id.str(d)));
+        talker const *const actor = d.actor( beta );
+        if( Character const *const chr = actor->get_character(); chr != nullptr ) {
+            return chr->vitamin_get( vitamin_id( id.str( d ) ) );
         }
-         debugmsg("Tried to access vitamins of a non-Character talker");
+        debugmsg( "Tried to access vitamins of a non-Character talker" );
         return 0;
-        };
+    };
 }
 
 std::function<void( dialogue &, double )> vitamin_ass( char scope,

--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -1464,13 +1464,13 @@ std::function<double( dialogue & )> vitamin_eval( char scope,
         std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
 {
     return[beta = is_beta( scope ), id = params[0]]( dialogue const & d ) {
-        if( d.actor( beta )->get_character() ) {
-            return static_cast<talker const *>( d.actor( beta ) )
-                   ->get_character()
-                   ->vitamin_get( vitamin_id( id.str( d ) ) );
+        talker const* const actor = d.actor(beta);
+        if (Character const* const chr = actor->get_character(); chr != nullptr) {
+            return chr->vitamin_get(vitamin_id(id.str(d)));
         }
+         debugmsg("Tried to access vitamins of a non-Character talker");
         return 0;
-    };
+        };
 }
 
 std::function<void( dialogue &, double )> vitamin_ass( char scope,

--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -1397,11 +1397,11 @@ std::function<double( dialogue & )> vision_range_eval( char scope,
         std::vector<diag_value> const &/* params */, diag_kwargs const &/* kwargs */ )
 {
     return[beta = is_beta( scope )]( dialogue const & d ) {
-        if( d.actor( beta )->get_character() ) {
-            return static_cast<talker const *>( d.actor( beta ) )
-                   ->get_character()
-                   ->unimpaired_range();
+        talker const* const actor = d.actor(beta);
+        if (Character const* const chr = actor->get_character(); chr != nullptr) {
+            return chr->unimpaired_range();
         }
+        debugmsg("Tried to access vision range of a non-Character talker");
         return 0;
     };
 }


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
fix #74923
#### Describe the solution
Apply fix suggested by Andrei
Also fix vision_range in the same manner
#### Testing
Compiled, applied next traits
```json

  {
    "type": "mutation",
    "id": "DEBUG_TEST",
    "name": { "str": "DEBUG_TEST" },
    "points": 2,
    "description": "DEBUG_TEST.",
    "enchantments": [ { "values": [ { "value": "LUMINATION", "add": { "math": [ "u_vitamin('bad_food') * 10" ] } } ] } ]
  },
  {
    "type": "mutation",
    "id": "DEBUG_TEST",
    "name": { "str": "DEBUG_TEST" },
    "points": 2,
    "description": "DEBUG_TEST.",
    "enchantments": [ { "values": [ { "value": "LUMINATION", "add": { "math": [ "u_vision_range()" ] } } ] } ]
  },
```
For first, consumed some protein rations, observed me glowing more the more vitamins got processed
For second, saw the 6 range of light with default character, debugged near-sighted mutation, got only 2 tile range of light
#### Additional context
~~Andrei told vision_range need a same treatment, but i sadly have difficulties to bite what this code does, so it's hard to apply~~ fixed