### PR TITLE
Fix typo in balance scores for webbed, sludged, and sap

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -2313,7 +2313,7 @@
       { "limb_score": "lift", "modifier": 0.8, "scaling": -0.15 },
       { "limb_score": "block", "modifier": 0.8, "scaling": -0.15 },
       { "limb_score": "breathing", "modifier": 0.9, "scaling": -0.1 },
-      { "limb_score": "balance", "modifier": 8, "scaling": -0.2 }
+      { "limb_score": "balance", "modifier": 0.8, "scaling": -0.2 }
     ],
     "flags": [ "EFFECT_LIMB_SCORE_MOD" ],
     "show_in_info": true,
@@ -2331,7 +2331,7 @@
     "limb_score_mods": [
       { "limb_score": "move_speed", "modifier": 0.8, "scaling": -0.15 },
       { "limb_score": "footing", "modifier": 0.8, "scaling": -0.15 },
-      { "limb_score": "balance", "modifier": 8, "scaling": -0.2 }
+      { "limb_score": "balance", "modifier": 0.8, "scaling": -0.2 }
     ],
     "flags": [ "EFFECT_LIMB_SCORE_MOD" ],
     "show_in_info": true
@@ -2968,7 +2968,7 @@
       { "limb_score": "lift", "modifier": 0.8, "scaling": -0.15 },
       { "limb_score": "block", "modifier": 0.8, "scaling": -0.15 },
       { "limb_score": "breathing", "modifier": 0.9, "scaling": -0.1 },
-      { "limb_score": "balance", "modifier": 8, "scaling": -0.2 }
+      { "limb_score": "balance", "modifier": 0.8, "scaling": -0.2 }
     ],
     "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
   },


### PR DESCRIPTION
#### Summary

Bugfixes "Webs, sludge, and sap no longer give you superhuman dodge and melee accuracy"

#### Purpose of change

The balance modifiers for `webbed`, `sludged`, and `sap` was an 8.

#### Describe the solution

Set them to a 0.8.

#### Describe alternatives you've considered

Buffing it to a 12.

#### Testing

I double-checked to make sure that I didn't accidentally set it to 80. Also I went in-game and the dodge while webbed went from 6.0 to 2.1 while webbed instead of 88.0.