### PR TITLE
Artificial Night Generator do not grant invis

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -1275,13 +1275,7 @@
     "description": "When active, this bionic eliminates all light within a 2 tile radius through destructive interference.",
     "occupied_bodyparts": [ [ "torso", 16 ] ],
     "flags": [ "BIONIC_TOGGLED" ],
-    "enchantments": [
-      {
-        "condition": "ACTIVE",
-        "ench_effects": [ { "effect": "invisibility", "intensity": 1 } ],
-        "emitter": "emit_shadow_field"
-      }
-    ],
+    "enchantments": [ { "condition": "ACTIVE", "emitter": "emit_shadow_field" } ],
     "act_cost": "9 kJ",
     "react_cost": "9 kJ",
     "time": "1 s"

--- a/data/json/items/bionics.json
+++ b/data/json/items/bionics.json
@@ -692,7 +692,7 @@
     "type": "BIONIC_ITEM",
     "name": { "str": "Artificial Night Generator CBM" },
     "looks_like": "bio_int_enhancer",
-    "description": "When active, this bionic eliminates all light within a 15-tile radius of the user through destructive interference.",
+    "description": "When active, this bionic eliminates all light within a 2 tile radius of the user through destructive interference.",
     "price": "8 kUSD 500 USD",
     "price_postapoc": "80 USD",
     "difficulty": 5


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
The invis field in night generator appeared from nowhere when it was migrated from code to enchantment, without any reason
Close #74366
#### Describe the solution
Make it not give invis, so it is useful against monsters that do not have a good night vision, but is useless against one that do, instead of being Cloaking System but cheaper
#### Testing
Debug installed cbm, turned on, zombies do not see me, night stalkers do see me