### PR TITLE
Adjust criteria for building roofs

### DIFF
--- a/data/json/construction/roofs.json
+++ b/data/json/construction/roofs.json
@@ -8,7 +8,7 @@
     "time": "120 m",
     "qualities": [ [ { "id": "SMOOTH", "level": 1 } ] ],
     "components": [ [ [ "brick", 15 ] ], [ [ "mortar_build", 1 ], [ "mortar_lime", 1 ] ], [ [ "water", 1 ], [ "water_clean", 1 ] ] ],
-    "pre_note": "Must be supported directly from below or on at least two sides.",
+    "pre_note": "Must be supported directly from below or on at least two sides.  May need a 'room' supporting a roof directly below.",
     "pre_special": [ "check_support", "check_unblocked" ],
     "post_terrain": "t_brick_roof"
   },
@@ -22,7 +22,7 @@
     "tools": [ [ [ "concrete_mix_tool", 25 ] ] ],
     "qualities": [ [ { "id": "SMOOTH", "level": 2 } ] ],
     "components": [ [ [ "concrete", 2 ] ], [ [ "water", 2 ], [ "water_clean", 2 ] ] ],
-    "pre_note": "Must be supported directly from below or on at least two sides.",
+    "pre_note": "Must be supported directly from below or on at least two sides.  May need a 'room' supporting a roof directly below.",
     "pre_special": [ "check_support", "check_unblocked" ],
     "post_terrain": "t_concrete_roof"
   },
@@ -35,7 +35,7 @@
     "time": "60 m",
     "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
     "components": [ [ [ "wood_sheet", 1 ], [ "wood_panel", 2 ] ], [ [ "2x4", 6 ] ], [ [ "nails", 40, "LIST" ] ] ],
-    "pre_note": "Must be supported directly from below or on at least two sides.",
+    "pre_note": "Must be supported directly from below or on at least two sides.  May need a 'room' supporting a roof directly below.",
     "pre_special": [ "check_support", "check_unblocked" ],
     "post_terrain": "t_flat_roof"
   },
@@ -66,7 +66,7 @@
       [ [ "material_soil", 40 ] ],
       [ [ "birchbark", 12 ], [ "pine_bough", 12 ] ]
     ],
-    "pre_note": "Must be supported directly from below or on at least two sides.",
+    "pre_note": "Must be supported directly from below or on at least two sides.  May need a 'room' supporting a roof directly below.",
     "pre_special": [ "check_support", "check_unblocked" ],
     "post_terrain": "t_log_sod_roof"
   },
@@ -80,7 +80,7 @@
     "tools": [ [ [ "oxy_torch", 5 ], [ "welder", 25 ], [ "welder_crude", 40 ], [ "toolset", 40 ] ] ],
     "qualities": [ [ { "id": "SAW_M", "level": 2 } ], [ { "id": "GLARE", "level": 1 } ] ],
     "components": [ [ [ "steel_lump", 4 ], [ "steel_chunk", 12 ], [ "scrap", 36 ] ], [ [ "sheet_metal", 10 ] ] ],
-    "pre_note": "Must be supported directly from below or on at least two sides.",
+    "pre_note": "Must be supported directly from below or on at least two sides.  May need a 'room' supporting a roof directly below.",
     "pre_special": [ "check_support", "check_unblocked" ],
     "post_terrain": "t_metal_roof"
   },
@@ -94,7 +94,7 @@
     "qualities": [ { "id": "GLARE", "level": 1 } ],
     "tools": [ [ [ "oxy_torch", 5 ], [ "welder", 25 ], [ "welder_crude", 40 ], [ "toolset", 40 ] ] ],
     "components": [ [ [ "steel_plate", 2 ] ] ],
-    "pre_note": "Must be supported directly from below or on at least two sides.",
+    "pre_note": "Must be supported directly from below or on at least two sides.  May need a 'room' supporting a roof directly below.",
     "pre_special": [ "check_support", "check_unblocked" ],
     "post_terrain": "t_metal_flat_roof"
   },
@@ -108,7 +108,7 @@
     "time": "60 m",
     "//": "Fairly time consuming as you have to extrude the resin slowly and wait for it to dry, then layer it on itself",
     "components": [ [ [ "alien_pod_resin", 1 ] ] ],
-    "pre_note": "Must be supported directly from below or on at least two sides.",
+    "pre_note": "Must be supported directly from below or on at least two sides.  May need a 'room' supporting a roof directly below.",
     "pre_special": [ "check_support", "check_unblocked" ],
     "post_terrain": "t_resin_roof"
   },
@@ -121,7 +121,7 @@
     "time": "60 m",
     "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
     "components": [ [ [ "wood_panel", 1 ] ], [ [ "2x4", 8 ] ], [ [ "nails", 20, "LIST" ] ] ],
-    "pre_note": "Must be supported directly from below or on at least two sides.",
+    "pre_note": "Must be supported directly from below or on at least two sides.  May need a 'room' supporting a roof directly below.",
     "pre_special": [ "check_support", "check_unblocked" ],
     "post_terrain": "t_shingle_flat_roof"
   },
@@ -138,7 +138,7 @@
       [ [ "straw_pile", 60 ], [ "withered", 60 ] ],
       [ [ "cordage", 8, "LIST" ] ]
     ],
-    "pre_note": "Must be supported directly from below or on at least two sides.",
+    "pre_note": "Must be supported directly from below or on at least two sides.  May need a 'room' supporting a roof directly below.",
     "pre_special": [ "check_support", "check_unblocked" ],
     "post_terrain": "t_thatch_roof"
   },
@@ -151,7 +151,7 @@
     "time": "60 m",
     "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
     "components": [ [ [ "wood_sheet", 1 ], [ "wood_panel", 2 ] ], [ [ "2x4", 6 ] ], [ [ "nails", 40, "LIST" ] ] ],
-    "pre_note": "Must be supported directly from below or on at least two sides.",
+    "pre_note": "Must be supported directly from below or on at least two sides.  May need a 'room' supporting a roof directly below.",
     "pre_special": [ "check_support", "check_unblocked" ],
     "post_terrain": "t_wood_treated_roof"
   },
@@ -164,7 +164,7 @@
     "time": "60 m",
     "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_W", "level": 2 } ] ],
     "components": [ [ [ "wood_sheet", 1 ], [ "wood_panel", 2 ] ], [ [ "2x4", 6 ] ], [ [ "nails", 40, "LIST" ] ] ],
-    "pre_note": "Must be supported directly from below or on at least two sides.",
+    "pre_note": "Must be supported directly from below or on at least two sides.  May need a 'room' supporting a roof directly below.",
     "pre_special": [ "check_support", "check_unblocked" ],
     "post_terrain": "t_wood_roof"
   }

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1489,7 +1489,7 @@ bool construct::check_support( const tripoint_bub_ms &p )
     // floor before you may be able to build a roof above it.
     int num_supports = 0;
     for( const point &offset : four_adjacent_offsets ) {
-        if( ( here.has_flag( ter_furn_flag::TFLAG_SUPPORTS_ROOF, p + offset ) ) ||
+        if( here.has_flag( ter_furn_flag::TFLAG_SUPPORTS_ROOF, p + offset ) ||
             ( !here.ter( p + offset )->has_flag( "EMPTY_SPACE" ) &&
               here.has_flag( ter_furn_flag::TFLAG_SUPPORTS_ROOF, p + offset + tripoint_below ) ) ) {
             num_supports++;

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1482,10 +1482,19 @@ bool construct::check_support( const tripoint_bub_ms &p )
     if( here.impassable( p ) ) {
         return false;
     }
+
+    // The current collapse logic is based on the level below supporting a "roof" rather
+    // than the orthogonal tiles supporting a roof tile. Thus, the construction logic
+    // uses similar criteria, which means you may have to first change grass into a dirt
+    // floor before you may be able to build a roof above it.
     int num_supports = 0;
     for( const point &offset : four_adjacent_offsets ) {
-        if( here.has_flag( ter_furn_flag::TFLAG_SUPPORTS_ROOF, p + offset ) &&
-            !here.has_flag( ter_furn_flag::TFLAG_SINGLE_SUPPORT, p + offset ) ) {
+        if( here.has_flag( ter_furn_flag::TFLAG_SUPPORTS_ROOF, p + offset ) ) {
+            num_supports++;
+        }
+
+        else if (!here.ter(p+offset)->has_flag("EMPTY_SPACE") &&
+            here.has_flag(ter_furn_flag::TFLAG_SUPPORTS_ROOF, p + offset + tripoint_below)) {
             num_supports++;
         }
     }

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1493,8 +1493,8 @@ bool construct::check_support( const tripoint_bub_ms &p )
             num_supports++;
         }
 
-        else if (!here.ter(p+offset)->has_flag("EMPTY_SPACE") &&
-            here.has_flag(ter_furn_flag::TFLAG_SUPPORTS_ROOF, p + offset + tripoint_below)) {
+        else if( !here.ter( p + offset )->has_flag( "EMPTY_SPACE" ) &&
+                 here.has_flag( ter_furn_flag::TFLAG_SUPPORTS_ROOF, p + offset + tripoint_below ) ) {
             num_supports++;
         }
     }

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1489,12 +1489,9 @@ bool construct::check_support( const tripoint_bub_ms &p )
     // floor before you may be able to build a roof above it.
     int num_supports = 0;
     for( const point &offset : four_adjacent_offsets ) {
-        if( here.has_flag( ter_furn_flag::TFLAG_SUPPORTS_ROOF, p + offset ) ) {
-            num_supports++;
-        }
-
-        else if( !here.ter( p + offset )->has_flag( "EMPTY_SPACE" ) &&
-                 here.has_flag( ter_furn_flag::TFLAG_SUPPORTS_ROOF, p + offset + tripoint_below ) ) {
+        if( ( here.has_flag( ter_furn_flag::TFLAG_SUPPORTS_ROOF, p + offset ) ) ||
+            ( !here.ter( p + offset )->has_flag( "EMPTY_SPACE" ) &&
+              here.has_flag( ter_furn_flag::TFLAG_SUPPORTS_ROOF, p + offset + tripoint_below ) ) ) {
             num_supports++;
         }
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #74942, i.e. inability to repair a destroyed roof.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Change the criteria for when you can build a roof to work with the current set of flags and with the current collapse logic.
This means checking that at least two of the orthogonal tiles aren't open space and either are "floors" or "walls" (have the support roof flag), or has such "support" below them.

The alternative remains unchanged, i.e. being built on top of a "wall".

Also updated the texts for roof construction to indicate that you may need to build "floors" on the level below if you're not allowed to build a roof. The text is not precise (building "floors" under orthogonal tiles can also help), but the text needs to be kept short.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Change the rather bizarre logic resulting from the 2D era where the presence of terrain designated a floor (having the support roof flag) guide whether a floor or roof is supported with logic built on direct support from below (essentially unchanged) or support from the sides, ideally with logic that determines how far from a wall you can build a roof/floor. This could be comparatively simple in the form of a flag on terrain that can support terrain to it side (or a flag stating it doesn't provide sideways support if those tiles are fewer) and a fixed range you can build from a tile supported from beneath. It could also be a bit more complex where all supporting tiles are equal, but the range depends on how many supporting walls you have within a maximum range. Further complexity would be to not use a flag but a support strength, so some tiles can span longer stretches without support from below than others. You could also complicate things with propagating "weight" down from levels above if a support (wall, pillar, etc.) isn't supported directly below. That may require the ability to distinguish between structural and dividing walls, however.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Load the save from the bug report and build a shingle roof.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
