### PR TITLE
Sōjutsu "Way of the spear" martial art *actually* uses spears now

### DIFF
--- a/data/json/martialarts.json
+++ b/data/json/martialarts.json
@@ -1308,7 +1308,7 @@
       }
     ],
     "techniques": [ "tec_sojutsu_feint", "tec_sojutsu_shove", "tec_sojutsu_trip", "tec_sojutsu_jab" ],
-    "weapon_category": [ "POLEARMS" ]
+    "weapon_category": [ "POLEARMS", "SPEARS" ]
   },
   {
     "type": "martial_art",


### PR DESCRIPTION

#### Summary

None

#### Purpose of change

The only weapon category that Sōjutsu uses is POLEARMS, despite SPEARS also being an applicable category. I spoke to some people and this feels like an oversight more than anything.

#### Describe the solution

Wrote "SPEARS" in the weapon_category line for sojutsu in martialarts.json

#### Describe alternatives you've considered

N/A

#### Testing

N/A

