### PR TITLE
[Xedra Evolved] Paraclesian morale effects scale

### DIFF
--- a/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_eocs.json
@@ -148,6 +148,7 @@
           ]
         }
       },
+      { "u_lose_morale": "morale_forest_unity" },
       {
         "u_add_morale": "morale_forest_unity",
         "bonus": {

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_eocs.json
@@ -150,8 +150,12 @@
       },
       {
         "u_add_morale": "morale_forest_unity",
-        "bonus": 10,
-        "max_bonus": 15,
+        "bonus": {
+          "math": [
+            "(5 + u_spell_level('arvore_commune_with_nature') ) * scaling_factor(u_val('perception') ) * paraclesian_post_threshold_doubler(1)"
+          ]
+        },
+        "max_bonus": 40,
         "duration": {
           "math": [
             "( 600 + (u_spell_level('arvore_commune_with_nature') * 240) ) * scaling_factor(u_val('perception') ) * paraclesian_post_threshold_doubler(1)"

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_eocs.json
@@ -55,8 +55,8 @@
     "id": "EOC_HOMULLUS_SELF_DECEPTION",
     "effect": {
       "u_add_morale": "morale_homullus_self_deception",
-      "bonus": 10,
-      "max_bonus": 30,
+      "bonus": { "math": [ "( 5 + u_spell_level('homullus_self_deception_spell') ) * scaling_factor(u_val('perception') )" ] },
+      "max_bonus": 40,
       "duration": {
         "math": [ "( 3600 + (u_spell_level('homullus_self_deception_spell') * 900) ) * scaling_factor(u_val('perception') )" ]
       },

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_eocs.json
@@ -53,17 +53,20 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_HOMULLUS_SELF_DECEPTION",
-    "effect": {
-      "u_add_morale": "morale_homullus_self_deception",
-      "bonus": { "math": [ "( 5 + u_spell_level('homullus_self_deception_spell') ) * scaling_factor(u_val('perception') )" ] },
-      "max_bonus": 40,
-      "duration": {
-        "math": [ "( 3600 + (u_spell_level('homullus_self_deception_spell') * 900) ) * scaling_factor(u_val('perception') )" ]
-      },
-      "decay_start": {
-        "math": [ "( 3600 + (u_spell_level('homullus_self_deception_spell') * 900) ) * scaling_factor(u_val('perception') ) / 2" ]
+    "effect": [
+      { "u_lose_morale": "morale_homullus_self_deception" },
+      {
+        "u_add_morale": "morale_homullus_self_deception",
+        "bonus": { "math": [ "( 5 + u_spell_level('homullus_self_deception_spell') ) * scaling_factor(u_val('perception') )" ] },
+        "max_bonus": 40,
+        "duration": {
+          "math": [ "( 3600 + (u_spell_level('homullus_self_deception_spell') * 900) ) * scaling_factor(u_val('perception') )" ]
+        },
+        "decay_start": {
+          "math": [ "( 3600 + (u_spell_level('homullus_self_deception_spell') * 900) ) * scaling_factor(u_val('perception') ) / 2" ]
+        }
       }
-    }
+    ]
   },
   {
     "type": "effect_on_condition",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Xedra Evolved] Paraclesian morale effects scale"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Morale effects can scale with math, so they should. 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Makes the morale bonus of the Arvore spell Commune with Nature and the Homullus spell Everything Will Be Fine scale with spell level and attributes. 

Since the max bonus is now much higher, the spell removes the previous morale before adding a new one, to prevent stacking it too high. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Morale bonus is variable, effects do not stack. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
