### PR TITLE
Remove roof magic and a work around to deal with it

### DIFF
--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1374,35 +1374,6 @@ void complete_construction( Character *you )
                     }
                 }
             }
-
-            if( ter_id( built.post_terrain )->has_flag( "EMPTY_SPACE" ) ) {
-                const tripoint_bub_ms below = terp + tripoint_below;
-                if( below.z() > -OVERMAP_DEPTH && here.ter( below ).obj().has_flag( "SUPPORTS_ROOF" ) ) {
-                    const map_bash_info bash_info = here.ter( below ).obj().bash;
-                    // ter_set_bashed_from_above should default to ter_set
-                    if( bash_info.ter_set_bashed_from_above.id() == t_null ) {
-                        if( below.z() >= -1 ) {
-                            // Stupid to set soil at above the ground level, but if they haven't defined
-                            // anything for the terrain that's what you'll get.
-                            // Trying to get the regional version of soil. There ought to be a sane way to do this...
-                            ter_id converted_terrain = ter_t_dirt;
-                            regional_settings settings = g->get_cur_om().get_settings();
-                            std::map<std::string, int> soil_map =
-                                settings.region_terrain_and_furniture.unfinalized_terrain.find( "t_region_soil" )->second;
-                            if( !soil_map.empty() ) {
-                                converted_terrain = ter_id(
-                                                        settings.region_terrain_and_furniture.unfinalized_terrain.find( "t_region_soil" )->second.begin()->first );
-                            }
-                            here.ter_set( below, converted_terrain );
-                        } else {
-                            // At the time of writing there doesn't seem to be any regional definition of "rock" (which would have to be smashed to get a floor).
-                            here.ter_set( below, ter_t_rock_floor );
-                        }
-                    } else {
-                        here.ter_set( below, bash_info.ter_set_bashed_from_above.id() );
-                    }
-                }
-            }
         }
     }
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -8395,7 +8395,7 @@ void map::loadn( const point &grid, bool update_vehicles )
         }
 
         if( zlevels ) {
-            add_roofs( tripoint_rel_sm( grid.x, grid.y, z ) );
+            add_tree_tops( tripoint_rel_sm( grid.x, grid.y, z ) );
         }
     }
 }
@@ -8832,27 +8832,27 @@ void map::actualize( const tripoint_rel_sm &grid )
     tmpsub->last_touched = calendar::turn;
 }
 
-void map::add_roofs( const tripoint_rel_sm &grid )
+void map::add_tree_tops( const tripoint_rel_sm &grid )
 {
     if( !zlevels ) {
-        // No roofs required!
-        // Why not? Because submaps below and above don't exist yet
+        // Can't add things on the level above when the map doesn't contain that level.
         return;
     }
 
     submap *const sub_here = get_submap_at_grid( grid );
     if( sub_here == nullptr ) {
-        debugmsg( "Tried to add roofs/floors on null submap on %d,%d,%d",
+        debugmsg( "Tried to add tree tops on null submap on %d,%d,%d",
                   grid.x(), grid.y(), grid.z() );
         return;
     }
 
-    bool check_roof = grid.z() > -OVERMAP_DEPTH;
+    bool check_tree_tops = grid.z() > -OVERMAP_DEPTH;
 
-    submap *const sub_below = check_roof ? get_submap_at_grid( grid + tripoint_rel_sm_below ) : nullptr;
+    submap *const sub_below = check_tree_tops ? get_submap_at_grid( grid + tripoint_rel_sm_below ) :
+                              nullptr;
 
-    if( check_roof && sub_below == nullptr ) {
-        debugmsg( "Tried to add roofs to sm at %d,%d,%d, but sm below doesn't exist",
+    if( check_tree_tops && sub_below == nullptr ) {
+        debugmsg( "Tried to add tree tops to sm at %d,%d,%d, but sm below doesn't exist",
                   grid.x(), grid.y(), grid.z() );
         return;
     }
@@ -8860,19 +8860,18 @@ void map::add_roofs( const tripoint_rel_sm &grid )
     for( int x = 0; x < SEEX; x++ ) {
         for( int y = 0; y < SEEY; y++ ) {
             const ter_id ter_here = sub_here->get_ter( { x, y } );
-            if( ter_here.id() != ter_t_open_air ) {
+            if( !ter_here.id()->has_flag( "EMPTY_SPACE" ) ) {
                 continue;
             }
 
-            if( !check_roof ) {
-                // Make sure we don't have open air at lowest z-level
+            if( !check_tree_tops ) {
+                // Make sure we don't have empty space at lowest z-level
                 sub_here->set_ter( { x, y }, ter_t_rock_floor );
                 continue;
             }
 
             const ter_t &ter_below = sub_below->get_ter( { x, y } ).obj();
-            if( ter_below.roof ) {
-                // TODO: Make roof variable a ter_id to speed this up
+            if( ter_below.has_flag( "TREE" ) && ter_below.roof ) {
                 sub_here->set_ter( { x, y }, ter_below.roof.id() );
             }
         }

--- a/src/map.h
+++ b/src/map.h
@@ -2092,9 +2092,11 @@ class map
          */
         void actualize( const tripoint_rel_sm &grid );
         /**
-         * Hacks in missing roofs. Should be removed when 3D mapgen is done.
+         * Hacks in missing tree tops. It CAN be done in other ways, but it would be a lot of work
+         * to get regional translation code to deal with chunks instead of terrain, and then use these
+         * chunks everywhere instead of tree terrain tokens. Maybe some day...
          */
-        void add_roofs( const tripoint_rel_sm &grid );
+        void add_tree_tops( const tripoint_rel_sm &grid );
         /**
          * Try to fill funnel based items here. Simulates rain from @p since till now.
          * @param p The location in this map where to fill funnels.


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
- Remove roof magic in favor of explicit placement of roofs in order to get rid of unwanted side effects of said roof magic (e.g. holes closing up on save/load cycles).
- Remove the hole digging work around to deal with roof magic hole closing reported by #72758 as it's no longer needed.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Transform add_roofs into add_tree_tops, so the code only adds "roofs", a.k.a. treetops to trees but nothing else.
Modified the check for open air to check for empty space. This could affect two cases:
- Someone deciding they wanted water "trees", such as kelp. Note that the code does NOT block such "trees" from extending into the air.
- The corner case of a tree with "rooved" air and similar odd air versions (hole?) above it. They'd now get a treetop.

Retains the repair code for the bugged case of the map bottom being empty space (was check for open air).

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Add JSON changes to construction "recipes" for stuff that included roofs but now won't get them. This will instead be a separate PR made immediately after this one to keep PRs tackling a minimum number of topics.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
- Loaded the save from #72758 and verified the hole dug remained a hole after save/reload, walking away and back, and teleporting away and back.
- Teleported to an unexplored forest area, debug spawned the clairvoyance mutations, and verified treetops were indeed generated.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
The time until this PR's merging is the last call to implement roofs in mods as per #74002.
@John-Candlebury: You mentioned Xedra Evolved requiring work. I haven't checked if it has been updated, but if it hasn't been and you somehow need help with the implementation I can provide that, but not the testing of it, as that would require figuring out the mod.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
