### PR TITLE
Typified a bit of map.h/cpp

### DIFF
--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -714,7 +714,7 @@ void avatar::grab( object_type grab_type_new, const tripoint_rel_ms &grab_point_
             if( erase ) {
                 memorize_clear_decoration( m.getglobal( pos_bub() + gpoint ) );
             }
-            m.memory_cache_dec_set_dirty( ( pos_bub() + gpoint ).raw(), true );
+            m.memory_cache_dec_set_dirty( pos_bub() + gpoint, true );
         }
     };
     // Mark the area covered by the previous vehicle/furniture/etc for re-memorizing.

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -659,7 +659,7 @@ void avatar_action::swim( map &m, avatar &you, const tripoint &p )
     }
     bool diagonal = p.x != you.posx() && p.y != you.posy();
     if( you.in_vehicle ) {
-        m.unboard_vehicle( you.pos() );
+        m.unboard_vehicle( you.pos_bub() );
     }
     if( you.is_mounted() && m.veh_at( you.pos() ).part_with_feature( VPFLAG_BOARDABLE, true ) ) {
         add_msg( m_warning, _( "You cannot board a vehicle while mounted." ) );
@@ -676,8 +676,8 @@ void avatar_action::swim( map &m, avatar &you, const tripoint &p )
 
     cata_event_dispatch::avatar_moves( old_abs_pos, you, m );
 
-    if( m.veh_at( you.pos() ).part_with_feature( VPFLAG_BOARDABLE, true ) ) {
-        m.board_vehicle( you.pos(), &you );
+    if( m.veh_at( you.pos_bub() ).part_with_feature( VPFLAG_BOARDABLE, true ) ) {
+        m.board_vehicle( you.pos_bub(), &you );
     }
     you.mod_moves( -( ( movecost > 200 ? 200 : movecost ) * ( trigdist && diagonal ? M_SQRT2 : 1 ) ) );
     you.inv->rust_iron_items();
@@ -920,7 +920,7 @@ bool avatar_action::eat_here( avatar &you )
         } else {
             item food( item( "grass", calendar::turn, 1 ) );
             you.assign_activity( consume_activity_actor( food ) );
-            here.ter_set( you.pos(), here.get_ter_transforms_into( you.pos() ) );
+            here.ter_set( you.pos_bub(), here.get_ter_transforms_into( you.pos_bub() ) );
             return true;
         }
     }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2024,21 +2024,21 @@ bool Character::uncanny_dodge()
     }
 
     map &here = get_map();
-    const optional_vpart_position veh_part = here.veh_at( pos() );
+    const optional_vpart_position veh_part = here.veh_at( pos_bub() );
     if( in_vehicle && veh_part && veh_part.avail_part_with_feature( "SEATBELT" ) ) {
         return false;
     }
 
     //uncanny dodge triggered in car and wasn't secured by seatbelt
     if( in_vehicle && veh_part ) {
-        here.unboard_vehicle( pos() );
+        here.unboard_vehicle( pos_bub() );
     }
     if( adjacent.x != posx() || adjacent.y != posy() ) {
         set_pos_only( adjacent );
 
         //landed in a vehicle tile
-        if( here.veh_at( pos() ) ) {
-            here.board_vehicle( pos(), this );
+        if( here.veh_at( pos_bub() ) ) {
+            here.board_vehicle( pos_bub(), this );
         }
 
         if( is_u ) {
@@ -10484,7 +10484,7 @@ bool Character::sees_with_infrared( const Creature &critter ) const
 
     map &here = get_map();
 
-    return here.sees( pos(), critter.pos(), unimpaired_range(), false );
+    return here.sees( pos_bub(), critter.pos_bub(), unimpaired_range(), false );
 }
 
 bool Character::is_visible_in_range( const Creature &critter, const int range ) const
@@ -10506,7 +10506,7 @@ std::vector<Creature *> Character::get_targetable_creatures( const int range, bo
     return g->get_creatures_if( [this, range, melee, &here]( const Creature & critter ) -> bool {
         //the call to map.sees is to make sure that even if we can see it through walls
         //via a mutation or cbm we only attack targets with a line of sight
-        bool can_see = ( ( sees( critter ) || sees_with_infrared( critter ) ) && here.sees( pos(), critter.pos(), 100 ) );
+        bool can_see = ( ( sees( critter ) || sees_with_infrared( critter ) ) && here.sees( pos_bub(), critter.pos_bub(), 100 ) );
         if( can_see && melee )  //handles the case where we can see something with glass in the way for melee attacks
         {
             std::vector<tripoint> path = here.find_clear_path( pos(), critter.pos() );

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -1460,8 +1460,8 @@ conditional_t::func f_follower_present( const JsonObject &jo, std::string_view m
         !npc_to_check->is_following() ) {
             return false;
         }
-        return rl_dist( npc_to_check->pos_bub().raw(), d_npc->pos_bub().raw() ) < 5 &&
-               get_map().clear_path( npc_to_check->pos_bub().raw(), d_npc->pos_bub().raw(), 5, 0, 100 );
+        return rl_dist( npc_to_check->pos_bub(), d_npc->pos_bub() ) < 5 &&
+               get_map().clear_path( npc_to_check->pos_bub(), d_npc->pos_bub(), 5, 0, 100 );
     };
 }
 

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1513,7 +1513,7 @@ bool construct::check_support_below( const tripoint_bub_ms &p )
     // - Then we have traps, and, unfortunately, there are "ledge" traps on all the open
     //   space tiles adjacent to passable tiles, so we can't just reject all traps outright,
     //   but have to accept those.
-    if( !( here.passable( p.raw() ) || here.has_flag( ter_furn_flag::TFLAG_LIQUID, p ) ||
+    if( !( here.passable( p ) || here.has_flag( ter_furn_flag::TFLAG_LIQUID, p ) ||
            here.has_flag( ter_furn_flag::TFLAG_NO_FLOOR, p ) ) ||
         blocking_creature || here.has_furn( p ) || !( here.tr_at( p ).is_null() ||
                 here.tr_at( p ).id == tr_ledge  || here.tr_at( p ).has_flag( json_flag_PIT ) ) ||

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -3099,7 +3099,7 @@ std::vector<Character *> Character::get_crafting_helpers() const
                && !guy.in_sleep_state()
                && guy.is_obeying( *this )
                && rl_dist( guy.pos(), pos() ) < PICKUP_RANGE
-               && get_map().clear_path( pos(), guy.pos(), PICKUP_RANGE, 1, 100 );
+               && get_map().clear_path( pos_bub(), guy.pos_bub(), PICKUP_RANGE, 1, 100 );
     } );
 }
 
@@ -3108,7 +3108,7 @@ std::vector<Character *> Character::get_crafting_group() const
     return g->get_characters_if( [this]( const Character & guy ) {
         return guy.is_ally( *this )
                && rl_dist( guy.pos(), pos() ) < PICKUP_RANGE
-               && get_map().clear_path( pos(), guy.pos(), PICKUP_RANGE, 1, 100 );
+               && get_map().clear_path( pos_bub(), guy.pos_bub(), PICKUP_RANGE, 1, 100 );
     } );
 }
 

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -501,7 +501,8 @@ bool Creature::sees( const Creature &critter ) const
     // Can always see adjacent monsters on the same level.
     // We also bypass lighting for vertically adjacent monsters, but still check for floors.
     if( target_range <= 1 ) {
-        return ( posz() == critter.posz() || here.sees( pos(), critter.pos(), 1 ) ) && visible( ch );
+        return ( posz() == critter.posz() || here.sees( pos_bub(), critter.pos_bub(), 1 ) ) &&
+               visible( ch );
     }
 
     // If we cannot see without any of the penalties below, bail now.
@@ -543,7 +544,7 @@ bool Creature::sees( const Creature &critter ) const
     if( ch != nullptr ) {
         if( ch->is_crouching() || ch->has_effect( effect_all_fours ) || ch->is_prone() ||
             pos().z != critter.pos().z ) {
-            const int coverage = std::max( here.obstacle_coverage( pos(), critter.pos() ),
+            const int coverage = std::max( here.obstacle_coverage( pos_bub(), critter.pos_bub() ),
                                            here.ledge_coverage( *this, critter.pos() ) );
             if( coverage < 30 ) {
                 return visible( ch );

--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -268,7 +268,8 @@ void monmove()
 
     for( monster &critter : g->all_monsters() ) {
         // Critters in impassable tiles get pushed away, unless it's not impassable for them
-        if( !critter.is_dead() && m.impassable( critter.pos() ) && !critter.can_move_to( critter.pos() ) ) {
+        if( !critter.is_dead() && m.impassable( critter.pos_bub() ) &&
+            !critter.can_move_to( critter.pos_bub() ) ) {
             dbg( D_ERROR ) << "game:monmove: " << critter.name()
                            << " can't move to its location!  (" << critter.posx()
                            << ":" << critter.posy() << ":" << critter.posz() << "), "
@@ -486,7 +487,7 @@ bool do_turn()
     u.gravity_check();
 
     // If you're inside a wall or something and haven't been telefragged, let's get you out.
-    if( m.impassable( u.pos() ) && !m.has_flag( ter_furn_flag::TFLAG_CLIMBABLE, u.pos() ) ) {
+    if( m.impassable( u.pos_bub() ) && !m.has_flag( ter_furn_flag::TFLAG_CLIMBABLE, u.pos() ) ) {
         u.stagger();
     }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -998,8 +998,8 @@ bool game::start_game()
     // This can happen in lab starts
     if( !spawn_near ) {
         for( monster &critter : all_monsters() ) {
-            if( rl_dist( critter.pos(), u.pos() ) <= 5 ||
-                m.clear_path( critter.pos(), u.pos(), 40, 1, 100 ) ) {
+            if( rl_dist( critter.pos_bub(), u.pos_bub() ) <= 5 ||
+                m.clear_path( critter.pos_bub(), u.pos_bub(), 40, 1, 100 ) ) {
                 remove_zombie( critter );
             }
         }
@@ -2755,7 +2755,7 @@ bool game::is_game_over()
     }
     if( uquit == QUIT_DIED ) {
         if( u.in_vehicle ) {
-            m.unboard_vehicle( u.pos() );
+            m.unboard_vehicle( u.pos_bub() );
         }
         u.place_corpse();
         return true;
@@ -2763,7 +2763,7 @@ bool game::is_game_over()
     if( uquit == QUIT_SUICIDE ) {
         bury_screen();
         if( u.in_vehicle ) {
-            m.unboard_vehicle( u.pos() );
+            m.unboard_vehicle( u.pos_bub() );
         }
         return true;
     }
@@ -4052,7 +4052,7 @@ void game::draw_critter( const Creature &critter, const tripoint &center )
         static constexpr tripoint up_tripoint( tripoint_above );
         if( critter.posz() == center.z - 1 &&
             ( debug_mode || u.sees( critter ) ) &&
-            m.valid_move( critter.pos(), critter.pos() + up_tripoint, false, true ) ) {
+            m.valid_move( critter.pos_bub(), critter.pos_bub() + up_tripoint, false, true ) ) {
             // Monster is below
             // TODO: Make this show something more informative than just green 'v'
             // TODO: Allow looking at this mon with look command
@@ -4060,7 +4060,7 @@ void game::draw_critter( const Creature &critter, const tripoint &center )
         }
         if( critter.posz() == center.z + 1 &&
             ( debug_mode || u.sees( critter ) ) &&
-            m.valid_move( critter.pos(), critter.pos() + tripoint_below, false, true ) ) {
+            m.valid_move( critter.pos_bub(), critter.pos_bub() + tripoint_below, false, true ) ) {
             // Monster is above
             init_draw_blink_curses( tripoint( critter.pos().xy(), center.z ), "^", c_green_cyan );
         }
@@ -4244,7 +4244,7 @@ Creature *game::is_hostile_within( int distance, bool dangerous )
 
                 const pathfinding_settings pf_settings = pathfinding_settings{ 8, distance, distance * 2, 4, true, true, false, true, false, false };
 
-                if( !get_map().route( u.pos(), critter->pos(), pf_settings ).empty() ) {
+                if( !get_map().route( u.pos_bub(), critter->pos_bub(), pf_settings ).empty() ) {
                     return critter;
                 }
                 continue;
@@ -5238,11 +5238,11 @@ bool game::swap_critters( Creature &a, Creature &b )
     Character *other_npc = dynamic_cast< Character * >( &second );
 
     if( u_or_npc->in_vehicle ) {
-        m.unboard_vehicle( u_or_npc->pos() );
+        m.unboard_vehicle( u_or_npc->pos_bub() );
     }
 
     if( other_npc && other_npc->in_vehicle ) {
-        m.unboard_vehicle( other_npc->pos() );
+        m.unboard_vehicle( other_npc->pos_bub() );
     }
 
     tripoint temp = second.pos();
@@ -5252,13 +5252,13 @@ bool game::swap_critters( Creature &a, Creature &b )
         walk_move( temp );
     } else {
         first.setpos( temp );
-        if( m.veh_at( u_or_npc->pos() ).part_with_feature( VPFLAG_BOARDABLE, true ) ) {
-            m.board_vehicle( u_or_npc->pos(), u_or_npc );
+        if( m.veh_at( u_or_npc->pos_bub() ).part_with_feature( VPFLAG_BOARDABLE, true ) ) {
+            m.board_vehicle( u_or_npc->pos_bub(), u_or_npc );
         }
     }
 
-    if( other_npc && m.veh_at( other_npc->pos() ).part_with_feature( VPFLAG_BOARDABLE, true ) ) {
-        m.board_vehicle( other_npc->pos(), other_npc );
+    if( other_npc && m.veh_at( other_npc->pos_bub() ).part_with_feature( VPFLAG_BOARDABLE, true ) ) {
+        m.board_vehicle( other_npc->pos_bub(), other_npc );
     }
     return true;
 }
@@ -5282,11 +5282,16 @@ bool game::is_in_sunlight( const tripoint &p )
 
 bool game::is_sheltered( const tripoint &p )
 {
+    return game::is_sheltered( tripoint_bub_ms( p ) );
+}
+
+bool game::is_sheltered( const tripoint_bub_ms &p )
+{
     const optional_vpart_position vp = m.veh_at( p );
     bool is_inside = vp && vp->is_inside();
 
     return !m.is_outside( p ) ||
-           p.z < 0 ||
+           p.z() < 0 ||
            is_inside;
 }
 
@@ -5584,7 +5589,7 @@ void game::moving_vehicle_dismount( const tripoint &dest_loc )
     // TODO:: make dir() const correct!
     const units::angle d = ray.dir();
     add_msg( _( "You dive from the %s." ), veh->name );
-    m.unboard_vehicle( u.pos() );
+    m.unboard_vehicle( u.pos_bub() );
     u.mod_moves( -to_moves<int>( 2_seconds ) );
     // Dive three tiles in the direction of tox and toy
     fling_creature( &u, d, 30, true, true );
@@ -10877,7 +10882,7 @@ point game::place_player( const tripoint &dest_loc, bool quick )
         if( u.pos() == dest_loc ) {
             was_in_control_same_pos = true;
         } else {
-            m.unboard_vehicle( u.pos() );
+            m.unboard_vehicle( u.pos_bub() );
         }
     }
     // Move the player
@@ -11003,7 +11008,7 @@ point game::place_player( const tripoint &dest_loc, bool quick )
 
     // If the new tile is a boardable part, board it
     if( !was_in_control_same_pos && vp1.part_with_feature( "BOARDABLE", true ) && !u.is_mounted() ) {
-        m.board_vehicle( u.pos(), &u );
+        m.board_vehicle( u.pos_bub(), &u );
     }
 
     // Traps!
@@ -11129,7 +11134,7 @@ void game::place_player_overmap( const tripoint_abs_omt &om_dest, bool move_play
         despawn_monster( critter );
     }
     if( u.in_vehicle ) {
-        m.unboard_vehicle( u.pos() );
+        m.unboard_vehicle( u.pos_bub() );
     }
     for( int z = -OVERMAP_DEPTH; z <= OVERMAP_HEIGHT; z++ ) {
         m.clear_vehicle_list( z );
@@ -11202,7 +11207,7 @@ bool game::phasing_move( const tripoint &dest_loc, const bool via_ramp )
 
     if( tunneldist != 0 ) {
         if( u.in_vehicle ) {
-            m.unboard_vehicle( u.pos() );
+            m.unboard_vehicle( u.pos_bub() );
         }
 
         add_msg( _( "You quantum tunnel through the %d-tile wide barrier!" ), tunneldist );
@@ -11211,8 +11216,8 @@ bool game::phasing_move( const tripoint &dest_loc, const bool via_ramp )
         u.mod_moves( -to_moves<int>( 1_seconds ) ); //tunneling takes exactly one second
         u.setpos( dest );
 
-        if( m.veh_at( u.pos() ).part_with_feature( "BOARDABLE", true ) ) {
-            m.board_vehicle( u.pos(), &u );
+        if( m.veh_at( u.pos_bub() ).part_with_feature( "BOARDABLE", true ) ) {
+            m.board_vehicle( u.pos_bub(), &u );
         }
 
         u.grab( object_type::NONE );
@@ -11716,7 +11721,7 @@ bool game::fling_creature( Creature *c, const units::angle &dir, float flvel, bo
         if( thru ) {
             if( you != nullptr ) {
                 if( you->in_vehicle ) {
-                    m.unboard_vehicle( you->pos() );
+                    m.unboard_vehicle( you->pos_bub() );
                 }
                 // If we're flinging the player around, make sure the map stays centered on them.
                 if( is_u ) {
@@ -12529,7 +12534,7 @@ point game::update_map( int &x, int &y, bool z_level_changed )
     point remaining_shift = shift;
     while( remaining_shift != point_zero ) {
         point this_shift = clamp( remaining_shift, size_1 );
-        m.shift( this_shift );
+        m.shift( point_rel_sm( this_shift ) );
         remaining_shift -= this_shift;
     }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -230,7 +230,7 @@ static const activity_id ACT_TRAIN_TEACHER( "ACT_TRAIN_TEACHER" );
 static const activity_id ACT_TRAVELLING( "ACT_TRAVELLING" );
 static const activity_id ACT_VIEW_RECIPE( "ACT_VIEW_RECIPE" );
 
-static const ascii_art_id ascii_tombstone( "ascii_tombstone" );
+static const ascii_art_id ascii_art_ascii_tombstone( "ascii_tombstone" );
 
 static const bionic_id bio_jointservo( "bio_jointservo" );
 static const bionic_id bio_probability_travel( "bio_probability_travel" );
@@ -2844,7 +2844,7 @@ void end_screen_ui_impl::draw_controls()
 {
     text[0] = '\0';
     avatar &u = get_avatar();
-    ascii_art_id art = ascii_tombstone;
+    ascii_art_id art = ascii_art_ascii_tombstone;
     dialogue d( get_talker_for( u ), nullptr );
     std::string input_label;
     std::vector<std::pair<std::pair<int, int>, std::string>> added_info;

--- a/src/game.h
+++ b/src/game.h
@@ -496,7 +496,9 @@ class game
         /** Returns true if p is outdoors and it is sunny. */
         bool is_in_sunlight( const tripoint &p );
         /** Returns true if p is indoors, underground, or in a car. */
+        // TODO: Get rid of untyped overload.
         bool is_sheltered( const tripoint &p );
+        bool is_sheltered( const tripoint_bub_ms &p );
         /**
          * Revives a corpse at given location. The monster type and some of its properties are
          * deducted from the corpse. If reviving succeeds, the location is guaranteed to have a

--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -197,7 +197,7 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
 
     u.grab_point = next_grab;
 
-    m.displace_vehicle( *grabbed_vehicle, final_dp_veh.raw() );
+    m.displace_vehicle( *grabbed_vehicle, final_dp_veh );
     m.rebuild_vehicle_level_caches();
 
     if( grabbed_vehicle ) {
@@ -206,7 +206,7 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
         if( grabbed_vehicle->is_falling ) {
             add_msg( _( "You let go of the %1$s as it starts to fall." ), grabbed_vehicle->disp_name() );
             u.grab( object_type::NONE );
-            m.set_seen_cache_dirty( grabbed_vehicle->pos_bub().raw() );
+            m.set_seen_cache_dirty( grabbed_vehicle->pos_bub() );
             return true;
         }
     } else {

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1580,7 +1580,7 @@ void iexamine::chainfence( Character &you, const tripoint &examp )
     }
     Character &player_character = get_player_character();
     sfx::play_variant_sound( "plmove", "clear_obstacle",
-                             sfx::get_heard_volume( player_character.pos() ) );
+                             sfx::get_heard_volume( player_character.pos_bub() ) );
     add_msg_debug( debugmode::DF_IEXAMINE,
                    "Move cost to vault: %d, limb score modifier %.1f", move_cost,
                    you.get_modifier( character_modifier_obstacle_climb_mod ) );
@@ -1589,7 +1589,7 @@ void iexamine::chainfence( Character &you, const tripoint &examp )
                    "Final move cost %d", move_cost );
     you.mod_moves( -move_cost );
     if( you.in_vehicle ) {
-        here.unboard_vehicle( you.pos() );
+        here.unboard_vehicle( you.pos_bub() );
     }
     you.setpos( examp );
     if( examp.x < HALF_MAPSIZE_X || examp.y < HALF_MAPSIZE_Y ||

--- a/src/iexamine_actors.cpp
+++ b/src/iexamine_actors.cpp
@@ -135,7 +135,7 @@ bool cardreader_examine_actor::apply( const tripoint &examp ) const
             debugmsg( "Failed to apply magen function %s", mapgen_id.str() );
         }
         set_queued_points();
-        here.set_seen_cache_dirty( examp );
+        here.set_seen_cache_dirty( tripoint_bub_ms( examp ) );
         here.set_transparency_cache_dirty( examp.z );
     } else {
         open = false;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -7931,6 +7931,7 @@ std::vector<tripoint> map::find_clear_path( const tripoint &source,
     const std::vector<tripoint_bub_ms> temp = map::find_clear_path( tripoint_bub_ms( source ),
             tripoint_bub_ms( destination ) );
     std::vector<tripoint> result;
+    result.reserve( temp.size() );
 
     for( tripoint_bub_ms pt : temp ) {
         result.push_back( pt.raw() );
@@ -8185,6 +8186,7 @@ std::vector<tripoint> map::get_dir_circle( const tripoint &f, const tripoint &t 
     const std::vector<tripoint_bub_ms> temp = map::get_dir_circle( tripoint_bub_ms( f ),
             tripoint_bub_ms( t ) );
     std::vector<tripoint> result;
+    result.reserve( temp.size() );
 
     for( const tripoint_bub_ms pt : temp ) {
         result.push_back( pt.raw() );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -287,26 +287,26 @@ void map::set_transparency_cache_dirty( const int zlev )
     }
 }
 
-void map::set_transparency_cache_dirty( const tripoint &p, bool field )
+void map::set_transparency_cache_dirty( const tripoint_bub_ms &p, bool field )
 {
     if( inbounds( p ) ) {
-        const tripoint smp = ms_to_sm_copy( p );
-        get_cache( smp.z ).transparency_cache_dirty.set( smp.x * MAPSIZE + smp.y );
+        const tripoint_bub_ms smp = tripoint_bub_ms( ms_to_sm_copy( p.raw() ) );
+        get_cache( smp.z() ).transparency_cache_dirty.set( smp.x() * MAPSIZE + smp.y() );
         if( !field ) {
             get_creature_tracker().invalidate_reachability_cache();
         }
     }
 }
 
-void map::set_seen_cache_dirty( const tripoint &change_location )
+void map::set_seen_cache_dirty( const tripoint_bub_ms &change_location )
 {
     if( inbounds( change_location ) ) {
-        level_cache &cache = get_cache( change_location.z );
+        level_cache &cache = get_cache( change_location.z() );
         if( cache.seen_cache_dirty ) {
             return;
         }
-        if( cache.seen_cache[change_location.x][change_location.y] != 0.0 ||
-            cache.camera_cache[change_location.x][change_location.y] != 0.0 ) {
+        if( cache.seen_cache[change_location.x()][change_location.y()] != 0.0 ||
+            cache.camera_cache[change_location.x()][change_location.y()] != 0.0 ) {
             cache.seen_cache_dirty = true;
         }
     }
@@ -336,38 +336,58 @@ void map::set_floor_cache_dirty( const int zlev )
 
 bool map::memory_cache_dec_is_dirty( const tripoint &p ) const
 {
+    return map::memory_cache_dec_is_dirty( tripoint_bub_ms( p ) );
+}
+
+bool map::memory_cache_dec_is_dirty( const tripoint_bub_ms &p ) const
+{
     if( !inbounds( p ) ) {
         debugmsg( "memory_cache_dec_is_dirty called on out of bounds position" );
         return true;
     }
-    return !get_cache( p.z ).map_memory_cache_dec[p.x + p.y * MAPSIZE_Y];
+    return !get_cache( p.z() ).map_memory_cache_dec[p.x() + p.y() * MAPSIZE_Y];
 }
 
 void map::memory_cache_dec_set_dirty( const tripoint &p, bool value ) const
+{
+    map::memory_cache_dec_set_dirty( tripoint_bub_ms( p ), value );
+}
+
+void map::memory_cache_dec_set_dirty( const tripoint_bub_ms &p, bool value ) const
 {
     if( !inbounds( p ) ) {
         debugmsg( "memory_cache_dec_set_dirty called on out of bounds position" );
         return;
     }
-    get_cache( p.z ).map_memory_cache_dec[p.x + p.y * MAPSIZE_Y] = !value;
+    get_cache( p.z() ).map_memory_cache_dec[p.x() + p.y() * MAPSIZE_Y] = !value;
 }
 
 bool map::memory_cache_ter_is_dirty( const tripoint &p ) const
+{
+    return map::memory_cache_ter_is_dirty( tripoint_bub_ms( p ) );
+}
+
+bool map::memory_cache_ter_is_dirty( const tripoint_bub_ms &p ) const
 {
     if( !inbounds( p ) ) {
         debugmsg( "memory_cache_ter_is_dirty called on out of bounds position" );
         return true;
     }
-    return !get_cache( p.z ).map_memory_cache_ter[p.x + p.y * MAPSIZE_Y];
+    return !get_cache( p.z() ).map_memory_cache_ter[p.x() + p.y() * MAPSIZE_Y];
 }
 
 void map::memory_cache_ter_set_dirty( const tripoint &p, bool value ) const
+{
+    map::memory_cache_ter_set_dirty( tripoint_bub_ms( p ), value );
+}
+
+void map::memory_cache_ter_set_dirty( const tripoint_bub_ms &p, bool value ) const
 {
     if( !inbounds( p ) ) {
         debugmsg( "memory_cache_ter_set_dirty called on out of bounds position" );
         return;
     }
-    get_cache( p.z ).map_memory_cache_ter[p.x + p.y * MAPSIZE_Y] = !value;
+    get_cache( p.z() ).map_memory_cache_ter[p.x() + p.y() * MAPSIZE_Y] = !value;
 }
 
 void map::memory_clear_vehicle_points( const vehicle &veh ) const
@@ -423,16 +443,26 @@ maptile map::maptile_at( const tripoint_bub_ms &p )
 
 const_maptile map::maptile_at_internal( const tripoint &p ) const
 {
+    return map::maptile_at_internal( tripoint_bub_ms( p ) );
+}
+
+const_maptile map::maptile_at_internal( const tripoint_bub_ms &p ) const
+{
     point_sm_ms l;
-    const submap *const sm = get_submap_at( tripoint_bub_ms( p ), l );
+    const submap *const sm = get_submap_at( p, l );
 
     return const_maptile( sm, l );
 }
 
 maptile map::maptile_at_internal( const tripoint &p )
 {
+    return map::maptile_at_internal( tripoint_bub_ms( p ) );
+}
+
+maptile map::maptile_at_internal( const tripoint_bub_ms &p )
+{
     point_sm_ms l;
-    submap *const sm = get_submap_at( tripoint_bub_ms( p ), l );
+    submap *const sm = get_submap_at( p, l );
 
     return maptile( sm, l );
 }
@@ -761,21 +791,26 @@ static bool sees_veh( const Creature &c, vehicle &veh, bool force_recalc )
 
 vehicle *map::move_vehicle( vehicle &veh, const tripoint &dp, const tileray &facing )
 {
-    if( dp == tripoint_zero ) {
+    return map::move_vehicle( veh, tripoint_rel_ms( dp ), facing );
+}
+
+vehicle *map::move_vehicle( vehicle &veh, const tripoint_rel_ms &dp, const tileray &facing )
+{
+    if( dp == tripoint_rel_ms_zero ) {
         debugmsg( "Empty displacement vector" );
         return &veh;
-    } else if( std::abs( dp.x ) > 1 || std::abs( dp.y ) > 1 || std::abs( dp.z ) > 1 ) {
-        debugmsg( "Invalid displacement vector: %d, %d, %d", dp.x, dp.y, dp.z );
+    } else if( std::abs( dp.x() ) > 1 || std::abs( dp.y() ) > 1 || std::abs( dp.z() ) > 1 ) {
+        debugmsg( "Invalid displacement vector: %d, %d, %d", dp.x(), dp.y(), dp.z() );
         return &veh;
     }
     // Split the movement into horizontal and vertical for easier processing
-    if( dp.xy() != point_zero && dp.z != 0 ) {
-        vehicle *const new_pointer = move_vehicle( veh, tripoint( dp.xy(), 0 ), facing );
+    if( dp.xy() != point_rel_ms_zero && dp.z() != 0 ) {
+        vehicle *const new_pointer = move_vehicle( veh, tripoint_rel_ms( dp.xy(), 0 ), facing );
         if( !new_pointer ) {
             return nullptr;
         }
 
-        vehicle *const result = move_vehicle( *new_pointer, tripoint( 0, 0, dp.z ), facing );
+        vehicle *const result = move_vehicle( *new_pointer, tripoint_rel_ms( 0, 0, dp.z() ), facing );
         if( !result ) {
             return nullptr;
         }
@@ -783,11 +818,11 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint &dp, const tileray &fac
         result->is_falling = false;
         return result;
     }
-    const bool vertical = dp.z != 0;
+    const bool vertical = dp.z() != 0;
     // Ensured by the splitting above
-    cata_assert( vertical == ( dp.xy() == point_zero ) );
+    cata_assert( vertical == ( dp.xy() == point_rel_ms_zero ) );
 
-    const int target_z = dp.z + veh.sm_pos.z;
+    const int target_z = dp.z() + veh.sm_pos.z;
     // limit vehicles to at most OVERMAP_HEIGHT - 1; this mitigates getting to zlevel 10 easily
     // and causing `get_cache_ref( zlev + 1 );` call in map::build_sunlight_cache overflowing
     if( target_z < -OVERMAP_DEPTH || target_z > OVERMAP_HEIGHT - 1 ) {
@@ -797,7 +832,7 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint &dp, const tileray &fac
     veh.precalc_mounts( 1, veh.skidding ? veh.turn_dir : facing.dir(), veh.pivot_point() );
 
     // cancel out any movement of the vehicle due only to a change in pivot
-    tripoint dp1 = dp - veh.pivot_displacement();
+    tripoint_rel_ms dp1 = dp - veh.pivot_displacement();
 
     int impulse = 0;
 
@@ -819,7 +854,7 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint &dp, const tileray &fac
     size_t collision_attempts = 10;
     do {
         collisions.clear();
-        veh.collision( collisions, dp1, false );
+        veh.collision( collisions, dp1.raw(), false );
 
         // Vehicle collisions
         std::map<vehicle *, std::vector<veh_collision> > veh_collisions;
@@ -830,7 +865,7 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint &dp, const tileray &fac
 
             veh_veh_coll_flag = true;
             // Only collide with each vehicle once
-            veh_collisions[ static_cast<vehicle *>( coll.target ) ].push_back( coll );
+            veh_collisions[static_cast<vehicle *>( coll.target )].push_back( coll );
         }
 
         for( auto &pair : veh_collisions ) {
@@ -871,7 +906,7 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint &dp, const tileray &fac
 
     const int velocity_after = coll_velocity;
     bool can_move = velocity_after != 0 && sgn( velocity_after ) == sgn( velocity_before );
-    if( dp.z != 0 && veh.is_rotorcraft() ) {
+    if( dp.z() != 0 && veh.is_rotorcraft() ) {
         can_move = true;
     }
     units::angle coll_turn = 0_degrees;
@@ -891,7 +926,7 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint &dp, const tileray &fac
 
     // If not enough wheels, mess up the ground a bit.
     if( !vertical && !veh.valid_wheel_config() && !( veh.is_watercraft() && veh.can_float() ) &&
-        !veh.is_flying_in_air() && dp.z == 0 ) {
+        !veh.is_flying_in_air() && dp.z() == 0 ) {
         veh.velocity -= std::clamp( veh.velocity, -2000, 2000 ); // extra drag
         for( const tripoint &p : veh.get_points() ) {
             const ter_id &pter = ter( p );
@@ -961,13 +996,13 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint &dp, const tileray &fac
         for( const int vp_wheel_idx : wheel_indices ) {
             vehicle_part &vp_wheel = veh.part( vp_wheel_idx );
             const vpart_info &vpi_wheel = vp_wheel.info();
-            const tripoint wheel_p = veh.global_part_pos3( vp_wheel );
+            const tripoint_bub_ms wheel_p = veh.bub_part_pos( vp_wheel );
             if( one_in( 2 ) && displace_water( wheel_p ) ) {
-                sounds::sound( wheel_p, 4,  sounds::sound_t::movement, _( "splash!" ), false,
+                sounds::sound( wheel_p, 4, sounds::sound_t::movement, _( "splash!" ), false,
                                "environment", "splash" );
             }
 
-            veh.handle_trap( wheel_p, vp_wheel );
+            veh.handle_trap( wheel_p.raw(), vp_wheel );
             // dont use vp_wheel or vp_wheel_idx below this - handle_trap might've removed it from parts
 
             if( !has_flag( ter_furn_flag::TFLAG_SEALED, wheel_p ) ) {
@@ -1345,20 +1380,25 @@ optional_vpart_position map::veh_at( const tripoint_bub_ms &p ) const
 
 const vehicle *map::veh_at_internal( const tripoint &p, int &part_num ) const
 {
+    return map::veh_at_internal( tripoint_bub_ms( p ), part_num );
+}
+
+const vehicle *map::veh_at_internal( const tripoint_bub_ms &p, int &part_num ) const
+{
     // This function is called A LOT. Move as much out of here as possible.
-    const level_cache &ch = get_cache( p.z );
-    if( !ch.get_veh_in_active_range() || !ch.get_veh_exists_at( p ) ) {
+    const level_cache &ch = get_cache( p.z() );
+    if( !ch.get_veh_in_active_range() || !ch.get_veh_exists_at( p.raw() ) ) {
         part_num = -1;
         return nullptr; // Clear cache indicates no vehicle. This should optimize a great deal.
     }
 
-    std::pair<vehicle *, int> ret = ch.get_veh_cached_parts( p );
+    std::pair<vehicle *, int> ret = ch.get_veh_cached_parts( p.raw() );
     if( ret.first ) {
         part_num = ret.second;
         return ret.first;
     }
 
-    debugmsg( "vehicle part cache indicated vehicle not found: %d %d %d", p.x, p.y, p.z );
+    debugmsg( "vehicle part cache indicated vehicle not found: %d %d %d", p.x(), p.y(), p.z() );
     part_num = -1;
     return nullptr;
 }
@@ -1431,6 +1471,11 @@ void map::unboard_vehicle( const vpart_reference &vp, Character *passenger, bool
 
 void map::unboard_vehicle( const tripoint &p, bool dead_passenger )
 {
+    map::unboard_vehicle( tripoint_bub_ms( p ), dead_passenger );
+}
+
+void map::unboard_vehicle( const tripoint_bub_ms &p, bool dead_passenger )
+{
     const std::optional<vpart_reference> vp = veh_at( p ).part_with_feature( VPFLAG_BOARDABLE, false );
     Character *passenger = nullptr;
     if( !vp ) {
@@ -1450,6 +1495,12 @@ void map::unboard_vehicle( const tripoint &p, bool dead_passenger )
 bool map::displace_vehicle( vehicle &veh, const tripoint &dp, const bool adjust_pos,
                             const std::set<int> &parts_to_move )
 {
+    return map::displace_vehicle( veh, tripoint_rel_ms( dp ), adjust_pos, parts_to_move );
+}
+
+bool map::displace_vehicle( vehicle &veh, const tripoint_rel_ms &dp, const bool adjust_pos,
+                            const std::set<int> &parts_to_move )
+{
     const tripoint_bub_ms src = veh.pos_bub();
     // handle vehicle ramps
     int ramp_offset = 0;
@@ -1464,7 +1515,7 @@ bool map::displace_vehicle( vehicle &veh, const tripoint &dp, const bool adjust_
     }
 
     const tripoint_bub_ms dst =
-        src + ( adjust_pos ? ( dp + tripoint( 0, 0, ramp_offset ) ) : tripoint_zero );
+        src + ( adjust_pos ? ( dp + tripoint( 0, 0, ramp_offset ) ) : tripoint_rel_ms_zero );
 
     if( !inbounds( src ) ) {
         add_msg_debug( debugmode::DF_MAP,
@@ -1473,13 +1524,13 @@ bool map::displace_vehicle( vehicle &veh, const tripoint &dp, const bool adjust_
         return false;
     }
 
-    point src_offset;
-    point dst_offset;
-    submap *src_submap = get_submap_at( src.raw(), src_offset );
-    submap *const dst_submap = get_submap_at( dst.raw(), dst_offset );
+    point_sm_ms src_offset;
+    point_sm_ms dst_offset;
+    submap *src_submap = get_submap_at( src, src_offset );
+    submap *const dst_submap = get_submap_at( dst, dst_offset );
     if( src_submap == nullptr || dst_submap == nullptr ) {
-        debugmsg( "Tried to displace vehicle at (%d,%d) but the submap is not loaded", src_offset.x,
-                  src_offset.y );
+        debugmsg( "Tried to displace vehicle at (%d,%d) but the submap is not loaded", src_offset.x(),
+                  src_offset.y() );
         return true;
     }
     std::set<int> smzs;
@@ -1512,7 +1563,7 @@ bool map::displace_vehicle( vehicle &veh, const tripoint &dp, const bool adjust_
         veh.stop();
         // Silent debug
         dbg( D_ERROR ) << "map:displace_vehicle: Stopping vehicle, displaced dp=("
-                       << dp.x << ", " << dp.y << ", " << dp.z << ")";
+                       << dp.x() << ", " << dp.y() << ", " << dp.z() << ")";
         return true;
     }
 
@@ -1543,19 +1594,19 @@ bool map::displace_vehicle( vehicle &veh, const tripoint &dp, const bool adjust_
                 continue;
             }
             Creature *psg = r.psg;
-            const tripoint part_pos = veh.global_part_pos3( prt );
+            const tripoint_bub_ms part_pos = veh.bub_part_pos( prt );
             if( psg == nullptr ) {
                 debugmsg( "Empty passenger for part #%d at %d,%d,%d player at %d,%d,%d?",
-                          prt, part_pos.x, part_pos.y, part_pos.z,
+                          prt, part_pos.x(), part_pos.y(), part_pos.z(),
                           player_character.posx(), player_character.posy(), player_character.posz() );
                 veh.part( prt ).remove_flag( vp_flag::passenger_flag );
                 r.moved = true;
                 continue;
             }
 
-            if( psg->pos() != part_pos ) {
+            if( psg->pos_bub() != part_pos ) {
                 add_msg_debug( debugmode::DF_MAP, "Part/passenger position mismatch: part #%d at %d,%d,%d "
-                               "passenger at %d,%d,%d", prt, part_pos.x, part_pos.y, part_pos.z,
+                               "passenger at %d,%d,%d", prt, part_pos.x(), part_pos.y(), part_pos.z(),
                                psg->posx(), psg->posy(), psg->posz() );
             }
             const vehicle_part &veh_part = veh.part( prt );
@@ -1582,7 +1633,7 @@ bool map::displace_vehicle( vehicle &veh, const tripoint &dp, const bool adjust_
             if( psg->is_avatar() ) {
                 // If passenger is you, we need to update the map
                 need_update = true;
-                z_change = psgp.z() - part_pos.z;
+                z_change = psgp.z() - part_pos.z();
             }
 
             psg->setpos( psgp.raw() );
@@ -1591,7 +1642,7 @@ bool map::displace_vehicle( vehicle &veh, const tripoint &dp, const bool adjust_
     }
 
     veh.shed_loose_parts( trinary::SOME, &dst );
-    smzs = veh.advance_precalc_mounts( dst_offset, src.raw(), dp, ramp_offset,
+    smzs = veh.advance_precalc_mounts( dst_offset.raw(), src.raw(), dp.raw(), ramp_offset,
                                        adjust_pos, parts_to_move );
     veh.update_active_fakes();
 
@@ -1651,7 +1702,7 @@ void map::level_vehicle( vehicle &veh )
     }
 }
 
-bool map::displace_water( const tripoint &p )
+bool map::displace_water( const tripoint_bub_ms &p )
 {
     // Check for shallow water
     if( has_flag_ter( ter_furn_flag::TFLAG_SHALLOW_WATER, p ) ) {
@@ -1665,7 +1716,7 @@ bool map::displace_water( const tripoint &p )
                 sel_place = rng( 0, dis_places - 1 );
                 dis_places = 0;
             }
-            for( const tripoint &temp : points_in_radius( p, 1 ) ) {
+            for( const tripoint_bub_ms &temp : points_in_radius( p, 1 ) ) {
                 if( temp != p
                     || impassable_ter_furn( temp )
                     || has_flag( ter_furn_flag::TFLAG_DEEP_WATER, temp ) ) {
@@ -1692,6 +1743,11 @@ bool map::displace_water( const tripoint &p )
 
 void map::set( const tripoint &p, const ter_id &new_terrain, const furn_id &new_furniture )
 {
+    map::set( tripoint_bub_ms( p ), new_terrain, new_furniture );
+}
+
+void map::set( const tripoint_bub_ms &p, const ter_id &new_terrain, const furn_id &new_furniture )
+{
     furn_set( p, new_furniture );
     ter_set( p, new_terrain );
 }
@@ -1707,6 +1763,11 @@ std::string map::name( const tripoint_bub_ms &p )
 }
 
 std::string map::disp_name( const tripoint &p )
+{
+    return map::disp_name( tripoint_bub_ms( p ) );
+}
+
+std::string map::disp_name( const tripoint_bub_ms &p )
 {
     return string_format( _( "the %s" ), name( p ) );
 }
@@ -1726,12 +1787,12 @@ std::string map::obstacle_name( const tripoint_bub_ms &p )
 
 bool map::has_furn( const tripoint &p ) const
 {
-    return furn( p ) != furn_str_id::NULL_ID();
+    return map::has_furn( tripoint_bub_ms( p ) );
 }
 
 bool map::has_furn( const tripoint_bub_ms &p ) const
 {
-    return has_furn( p.raw() );
+    return furn( p ) != furn_str_id::NULL_ID();
 }
 
 furn_id map::furn( const tripoint &p ) const
@@ -1833,8 +1894,8 @@ bool map::furn_set( const tripoint_bub_ms &p, const furn_id &new_furniture, cons
         field_furn_locs.push_back( p.raw() );
     }
     if( old_f.transparent != new_f.transparent ) {
-        set_transparency_cache_dirty( p.raw() );
-        set_seen_cache_dirty( p.raw() );
+        set_transparency_cache_dirty( p );
+        set_seen_cache_dirty( p );
     }
 
     if( old_f.has_flag( ter_furn_flag::TFLAG_INDOORS ) != new_f.has_flag(
@@ -1845,7 +1906,7 @@ bool map::furn_set( const tripoint_bub_ms &p, const furn_id &new_furniture, cons
     if( old_f.has_flag( ter_furn_flag::TFLAG_NO_FLOOR ) != new_f.has_flag(
             ter_furn_flag::TFLAG_NO_FLOOR ) ) {
         set_floor_cache_dirty( p.z() );
-        set_seen_cache_dirty( p.raw() );
+        set_seen_cache_dirty( p );
         get_creature_tracker().invalidate_reachability_cache();
     }
 
@@ -1856,7 +1917,7 @@ bool map::furn_set( const tripoint_bub_ms &p, const furn_id &new_furniture, cons
 
     invalidate_max_populated_zlev( p.z() );
 
-    memory_cache_dec_set_dirty( p.raw(), true );
+    memory_cache_dec_set_dirty( p, true );
     if( player_character.sees( p ) ) {
         player_character.memorize_clear_decoration( getglobal( p ), "f_" );
     }
@@ -1865,7 +1926,7 @@ bool map::furn_set( const tripoint_bub_ms &p, const furn_id &new_furniture, cons
         get_creature_tracker().invalidate_reachability_cache();
     }
     // TODO: Limit to changes that affect move cost, traps and stairs
-    set_pathfinding_cache_dirty( p.raw() );
+    set_pathfinding_cache_dirty( p );
 
     // Make sure the furniture falls if it needs to
     support_dirty( p.raw() );
@@ -2075,22 +2136,35 @@ uint8_t map::get_known_connections_f( const tripoint &p,
                                       const std::bitset<NUM_TERCONN> &connect_group,
                                       const std::map<tripoint, furn_id> &override ) const
 {
+    std::map<tripoint_bub_ms, furn_id> tmp_override;
+
+    for( const auto element : override ) {
+        tmp_override.insert( {tripoint_bub_ms( element.first ), element.second} );
+    }
+
+    return map::get_known_connections_f( tripoint_bub_ms( p ), connect_group, tmp_override );
+}
+
+uint8_t map::get_known_connections_f( const tripoint_bub_ms &p,
+                                      const std::bitset<NUM_TERCONN> &connect_group,
+                                      const std::map<tripoint_bub_ms, furn_id> &override ) const
+{
     if( connect_group.none() ) {
         return 0;
     }
 
-    const level_cache &ch = access_cache( p.z );
+    const level_cache &ch = access_cache( p.z() );
     uint8_t val = 0;
-    std::function<bool( const tripoint & )> is_memorized;
+    std::function<bool( const tripoint_bub_ms & )> is_memorized;
     avatar &player_character = get_avatar();
 #ifdef TILES
     if( use_tiles ) {
-        is_memorized = [&]( const tripoint & q ) {
+        is_memorized = [&]( const tripoint_bub_ms & q ) {
             return !player_character.get_memorized_tile( getglobal( q ) ).get_dec_id().empty();
         };
     } else {
 #endif
-        is_memorized = [&]( const tripoint & q ) {
+        is_memorized = [&]( const tripoint_bub_ms & q ) {
             return player_character.get_memorized_tile( getglobal( q ) ).symbol != 0;
         };
 #ifdef TILES
@@ -2098,11 +2172,11 @@ uint8_t map::get_known_connections_f( const tripoint &p,
 #endif
 
     const bool overridden = override.find( p ) != override.end();
-    const bool is_transparent = ch.transparency_cache[p.x][p.y] > LIGHT_TRANSPARENCY_SOLID;
+    const bool is_transparent = ch.transparency_cache[p.x()][p.y()] > LIGHT_TRANSPARENCY_SOLID;
 
     // populate connection information
     for( int i = 0; i < 4; ++i ) {
-        tripoint pt = p + offsets[i];
+        tripoint_bub_ms pt = p + offsets[i];
         if( !inbounds( pt ) ) {
             continue;
         }
@@ -2110,7 +2184,7 @@ uint8_t map::get_known_connections_f( const tripoint &p,
         const bool neighbour_overridden = neighbour_override != override.end();
         // if there's some non-memory terrain to show at the neighboring tile
         const bool may_connect = neighbour_overridden ||
-                                 get_visibility( ch.visibility_cache[pt.x][pt.y],
+                                 get_visibility( ch.visibility_cache[pt.x()][pt.y()],
                                          get_visibility_variables_cache() ) ==
                                  visibility_type::CLEAR ||
                                  // or if an actual center tile is transparent or
@@ -2133,6 +2207,26 @@ uint8_t map::get_known_rotates_to_f( const tripoint &p,
                                      const std::map<tripoint, ter_id> &override,
                                      const std::map<tripoint, furn_id> &override_f ) const
 {
+    std::map<tripoint_bub_ms, ter_id> temp_override;
+    std::map<tripoint_bub_ms, furn_id> temp_override_f;
+
+    for( const auto element : override ) {
+        temp_override.insert( {tripoint_bub_ms( element.first ), element.second} );
+    }
+
+    for( const auto element : override_f ) {
+        temp_override_f.insert( {tripoint_bub_ms( element.first ), element.second} );
+    }
+
+    return map::get_known_rotates_to_f( tripoint_bub_ms( p ), rotate_to_group, temp_override,
+                                        temp_override_f );
+}
+
+uint8_t map::get_known_rotates_to_f( const tripoint_bub_ms &p,
+                                     const std::bitset<NUM_TERCONN> &rotate_to_group,
+                                     const std::map<tripoint_bub_ms, ter_id> &override,
+                                     const std::map<tripoint_bub_ms, furn_id> &override_f ) const
+{
     if( rotate_to_group.none() ) {
         return CHAR_MAX;
     }
@@ -2141,7 +2235,7 @@ uint8_t map::get_known_rotates_to_f( const tripoint &p,
 
     // populate connection information
     for( int i = 0; i < 4; ++i ) {
-        tripoint pt = p + offsets[i];
+        tripoint_bub_ms pt = p + offsets[i];
         if( !inbounds( pt ) ) {
             continue;
         }
@@ -2171,10 +2265,15 @@ uint8_t map::get_known_rotates_to_f( const tripoint &p,
  */
 const harvest_id &map::get_harvest( const tripoint &pos ) const
 {
+    return map::get_harvest( tripoint_bub_ms( pos ) );
+}
+
+const harvest_id &map::get_harvest( const tripoint_bub_ms &pos ) const
+{
     const furn_id furn_here = furn( pos );
     if( !furn_here->has_flag( ter_furn_flag::TFLAG_HARVESTED ) ) {
         const harvest_id &harvest = furn_here->get_harvest();
-        if( ! harvest.is_null() ) {
+        if( !harvest.is_null() ) {
             return harvest;
         }
     }
@@ -2188,6 +2287,11 @@ const harvest_id &map::get_harvest( const tripoint &pos ) const
 }
 
 const std::set<std::string> &map::get_harvest_names( const tripoint &pos ) const
+{
+    return map::get_harvest_names( tripoint_bub_ms( pos ) );
+}
+
+const std::set<std::string> &map::get_harvest_names( const tripoint_bub_ms &pos ) const
 {
     static const std::set<std::string> null_harvest_names = {};
     const furn_id furn_here = furn( pos );
@@ -2211,6 +2315,11 @@ const std::set<std::string> &map::get_harvest_names( const tripoint &pos ) const
  * Get the terrain transforms_into id (what will the terrain transforms into)
  */
 ter_id map::get_ter_transforms_into( const tripoint &p ) const
+{
+    return map::get_ter_transforms_into( tripoint_bub_ms( p ) );
+}
+
+ter_id map::get_ter_transforms_into( const tripoint_bub_ms &p ) const
 {
     return ter( p ).obj().transforms_into.id();
 }
@@ -2294,8 +2403,8 @@ bool map::ter_set( const tripoint &p, const ter_id &new_terrain, bool avoid_crea
         field_ter_locs.push_back( p );
     }
     if( old_t.transparent != new_t.transparent ) {
-        set_transparency_cache_dirty( p );
-        set_seen_cache_dirty( p );
+        set_transparency_cache_dirty( tripoint_bub_ms( p ) );
+        set_seen_cache_dirty( tripoint_bub_ms( p ) );
     }
 
     if( old_t.has_flag( ter_furn_flag::TFLAG_INDOORS ) != new_t.has_flag(
@@ -2308,7 +2417,7 @@ bool map::ter_set( const tripoint &p, const ter_id &new_terrain, bool avoid_crea
         set_floor_cache_dirty( p.z );
         // It's a set, not a flag
         support_cache_dirty.insert( p );
-        set_seen_cache_dirty( p );
+        set_seen_cache_dirty( tripoint_bub_ms( p ) );
     }
 
     if( new_t.has_flag( "SPAWN_WITH_WATER" ) ) {
@@ -2333,7 +2442,7 @@ bool map::ter_set( const tripoint &p, const ter_id &new_terrain, bool avoid_crea
         get_creature_tracker().invalidate_reachability_cache();
     }
     // TODO: Limit to changes that affect move cost, traps and stairs
-    set_pathfinding_cache_dirty( p );
+    set_pathfinding_cache_dirty( tripoint_bub_ms( p ) );
 
     tripoint above( p.xy(), p.z + 1 );
     // Make sure that if we supported something and no longer do so, it falls down
@@ -2423,7 +2532,12 @@ int map::move_cost_internal( const furn_t &furniture, const ter_t &terrain, cons
 
 bool map::is_wall_adjacent( const tripoint &center ) const
 {
-    for( const tripoint &p : points_in_radius( center, 1 ) ) {
+    return map::is_wall_adjacent( tripoint_bub_ms( center ) );
+}
+
+bool map::is_wall_adjacent( const tripoint_bub_ms &center ) const
+{
+    for( const tripoint_bub_ms &p : points_in_radius( center, 1 ) ) {
         if( p != center && impassable( p ) ) {
             return true;
         }
@@ -2501,12 +2615,17 @@ bool map::passable( const tripoint_bub_ms &p ) const
 
 int map::move_cost_ter_furn( const tripoint &p ) const
 {
+    return map::move_cost_ter_furn( tripoint_bub_ms( p ) );
+}
+
+int map::move_cost_ter_furn( const tripoint_bub_ms &p ) const
+{
     if( !inbounds( p ) ) {
         return 0;
     }
 
     point_sm_ms l;
-    const submap *const current_submap = unsafe_get_submap_at( tripoint_bub_ms( p ), l );
+    const submap *const current_submap = unsafe_get_submap_at( p, l );
     if( current_submap == nullptr ) {
         debugmsg( "Tried process terrain at (%d,%d) but the submap is not loaded", l.x(), l.y() );
         return 0;
@@ -2528,10 +2647,20 @@ int map::move_cost_ter_furn( const tripoint &p ) const
 
 bool map::impassable_ter_furn( const tripoint &p ) const
 {
+    return impassable_ter_furn( tripoint_bub_ms( p ) );
+}
+
+bool map::impassable_ter_furn( const tripoint_bub_ms &p ) const
+{
     return !passable_ter_furn( p );
 }
 
 bool map::passable_ter_furn( const tripoint &p ) const
+{
+    return map::passable_ter_furn( tripoint_bub_ms( p ) );
+}
+
+bool map::passable_ter_furn( const tripoint_bub_ms &p ) const
 {
     return move_cost_ter_furn( p ) != 0;
 }
@@ -2540,13 +2669,22 @@ int map::combined_movecost( const tripoint &from, const tripoint &to,
                             const vehicle *ignored_vehicle,
                             const int modifier, const bool flying, const bool via_ramp ) const
 {
+    return map::combined_movecost( tripoint_bub_ms( from ), tripoint_bub_ms( to ), ignored_vehicle,
+                                   modifier, flying, via_ramp );
+}
+
+int map::combined_movecost( const tripoint_bub_ms &from, const tripoint_bub_ms &to,
+                            const vehicle *ignored_vehicle,
+                            const int modifier, const bool flying, const bool via_ramp ) const
+{
     static constexpr std::array<int, 4> mults = { 0, 50, 71, 100 };
     const int cost1 = move_cost( from, ignored_vehicle );
     const int cost2 = move_cost( to, ignored_vehicle );
     // Multiply cost depending on the number of differing axes
     // 0 if all axes are equal, 100% if only 1 differs, 141% for 2, 200% for 3
-    size_t match = trigdist ? ( from.x != to.x ) + ( from.y != to.y ) + ( from.z != to.z ) : 1;
-    if( flying || from.z == to.z ) {
+    size_t match = trigdist ? ( from.x() != to.x() ) + ( from.y() != to.y() ) +
+                   ( from.z() != to.z() ) : 1;
+    if( flying || from.z() == to.z() ) {
         return ( cost1 + cost2 + modifier ) * mults[match] / 2;
     }
 
@@ -2562,26 +2700,32 @@ int map::combined_movecost( const tripoint &from, const tripoint &to,
 bool map::valid_move( const tripoint &from, const tripoint &to,
                       const bool bash, const bool flying, const bool via_ramp ) const
 {
+    return map::valid_move( tripoint_bub_ms( from ), tripoint_bub_ms( to ), bash, flying, via_ramp );
+}
+
+bool map::valid_move( const tripoint_bub_ms &from, const tripoint_bub_ms &to,
+                      const bool bash, const bool flying, const bool via_ramp ) const
+{
     // Used to account for the fact that older versions of GCC can trip on the if statement here.
-    cata_assert( to.z > std::numeric_limits<int>::min() );
+    cata_assert( to.z() > std::numeric_limits<int>::min() );
     // Note: no need to check inbounds here, because maptile_at will do that
     // If oob tile is supplied, the maptile_at will be an unpassable "null" tile
-    if( std::abs( from.x - to.x ) > 1 || std::abs( from.y - to.y ) > 1 ||
-        std::abs( from.z - to.z ) > 1 ) {
+    if( std::abs( from.x() - to.x() ) > 1 || std::abs( from.y() - to.y() ) > 1 ||
+        std::abs( from.z() - to.z() ) > 1 ) {
         return false;
     }
 
-    if( from.z == to.z ) {
+    if( from.z() == to.z() ) {
         // But here we need to, to prevent bashing critters
         return passable( to ) || ( bash && inbounds( to ) );
     } else if( !zlevels ) {
         return false;
     }
 
-    const bool going_up = from.z < to.z;
+    const bool going_up = from.z() < to.z();
 
-    const tripoint &up_p = going_up ? to : from;
-    const tripoint &down_p = going_up ? from : to;
+    const tripoint_bub_ms &up_p = going_up ? to : from;
+    const tripoint_bub_ms &down_p = going_up ? from : to;
 
     const const_maptile up = maptile_at( up_p );
     const ter_t &up_ter = up.get_ter_t();
@@ -2613,9 +2757,9 @@ bool map::valid_move( const tripoint &from, const tripoint &to,
     if( has_floor( up_p ) && !up_ter.has_flag( ter_furn_flag::TFLAG_GOES_DOWN ) &&
         !up_is_ledge && !via_ramp ) {
         // Can't move from up to down
-        if( std::abs( from.x - to.x ) == 1 || std::abs( from.y - to.y ) == 1 ) {
+        if( std::abs( from.x() - to.x() ) == 1 || std::abs( from.y() - to.y() ) == 1 ) {
             // Break the move into two - vertical then horizontal
-            tripoint midpoint( down_p.xy(), up_p.z );
+            tripoint_bub_ms midpoint( down_p.xy(), up_p.z() );
             return valid_move( down_p, midpoint, bash, flying, via_ramp ) &&
                    valid_move( midpoint, up_p, bash, flying, via_ramp );
         }
@@ -2635,14 +2779,14 @@ bool map::valid_move( const tripoint &from, const tripoint &to,
     }
 
     int part_up;
-    const vehicle *veh_up = veh_at_internal( up_p, part_up );
+    const vehicle *veh_up = veh_at_internal( up_p.raw(), part_up );
     if( veh_up != nullptr ) {
         // TODO: Hatches below the vehicle, passable frames
         return false;
     }
 
     int part_down;
-    const vehicle *veh_down = veh_at_internal( down_p, part_down );
+    const vehicle *veh_down = veh_at_internal( down_p.raw(), part_down );
     if( veh_down != nullptr && veh_down->roof_at_part( part_down ) >= 0 ) {
         // TODO: OPEN (and only open) hatches from above
         return false;
@@ -2656,6 +2800,11 @@ bool map::valid_move( const tripoint &from, const tripoint &to,
 // End of move cost
 
 double map::ranged_target_size( const tripoint &p ) const
+{
+    return map::ranged_target_size( tripoint_bub_ms( p ) );
+}
+
+double map::ranged_target_size( const tripoint_bub_ms &p ) const
 {
     if( impassable( p ) ) {
         return 1.0;
@@ -3056,7 +3205,7 @@ void map::drop_vehicle( const tripoint &p )
         return;
     }
     vp->vehicle().is_falling = true;
-    set_seen_cache_dirty( p );
+    set_seen_cache_dirty( tripoint_bub_ms( p ) );
 }
 
 void map::drop_fields( const tripoint &p )
@@ -3893,6 +4042,11 @@ void map::collapse_at( const tripoint_bub_ms &p, const bool silent, const bool w
 
 void map::smash_items( const tripoint &p, const int power, const std::string &cause_message )
 {
+    map::smash_items( tripoint_bub_ms( p ), power, cause_message );
+}
+
+void map::smash_items( const tripoint_bub_ms &p, const int power, const std::string &cause_message )
+{
     if( !has_items( p ) || has_flag_ter_or_furn( ter_furn_flag::TFLAG_PLANT, p ) ) {
         return;
     }
@@ -3994,16 +4148,16 @@ void map::smash_items( const tripoint &p, const int power, const std::string &ca
 
     // Let the player know that the item was damaged if they can see it.
     if( items_destroyed > 1 ) {
-        add_msg_if_player_sees( p, m_bad, _( "The %s destroys several items!" ), cause_message );
-    } else if( items_destroyed == 1 && items_damaged == 1 )  {
+        add_msg_if_player_sees( p.raw(), m_bad, _( "The %s destroys several items!" ), cause_message );
+    } else if( items_destroyed == 1 && items_damaged == 1 ) {
         //~ %1$s: the cause of destruction, %2$s: destroyed item name
-        add_msg_if_player_sees( p, m_bad, _( "The %1$s destroys the %2$s!" ), cause_message,
+        add_msg_if_player_sees( p.raw(), m_bad, _( "The %1$s destroys the %2$s!" ), cause_message,
                                 damaged_item_name );
     } else if( items_damaged > 1 ) {
-        add_msg_if_player_sees( p, m_bad, _( "The %s damages several items." ), cause_message );
-    } else if( items_damaged == 1 )  {
+        add_msg_if_player_sees( p.raw(), m_bad, _( "The %s damages several items." ), cause_message );
+    } else if( items_damaged == 1 ) {
         //~ %1$s: the cause of damage, %2$s: damaged item name
-        add_msg_if_player_sees( p, m_bad, _( "The %1$s damages the %2$s." ), cause_message,
+        add_msg_if_player_sees( p.raw(), m_bad, _( "The %1$s damages the %2$s." ), cause_message,
                                 damaged_item_name );
     }
 
@@ -4014,11 +4168,16 @@ void map::smash_items( const tripoint &p, const int power, const std::string &ca
 
 ter_str_id map::get_roof( const tripoint &p, const bool allow_air ) const
 {
+    return map::get_roof( tripoint_bub_ms( p ), allow_air );
+}
+
+ter_str_id map::get_roof( const tripoint_bub_ms &p, const bool allow_air ) const
+{
     // This function should not be called from the 2D mode
     // Just use t_dirt instead
     cata_assert( zlevels );
 
-    if( p.z <= -OVERMAP_DEPTH ) {
+    if( p.z() <= -OVERMAP_DEPTH ) {
         // Could be magma/"void" instead
         return ter_t_rock_floor;
     }
@@ -4036,11 +4195,11 @@ ter_str_id map::get_roof( const tripoint &p, const bool allow_air ) const
     }
     if( roof == ter_str_id::NULL_ID() ) {
         debugmsg( "map::get_new_floor: %d,%d,%d has invalid roof type %s",
-                  p.x, p.y, p.z, roof.c_str() );
+                  p.x(), p.y(), p.z(), roof.c_str() );
         return ter_t_dirt;
     }
 
-    if( p.z == -1 && roof == ter_t_rock_floor ) {
+    if( p.z() == -1 && roof == ter_t_rock_floor ) {
         // HACK: A hack to work around not having a "solid earth" tile
         return ter_t_dirt;
     }
@@ -4050,15 +4209,15 @@ ter_str_id map::get_roof( const tripoint &p, const bool allow_air ) const
 
 // Check if there is supporting furniture cardinally adjacent to the bashed furniture
 // For example, a washing machine behind the bashed door
-static bool furn_is_supported( const map &m, const tripoint &p )
+static bool furn_is_supported( const map &m, const tripoint_bub_ms &p )
 {
-    static constexpr std::array<int8_t, 4> cx = { 0, -1, 0, 1};
-    static constexpr std::array<int8_t, 4> cy = { -1,  0, 1, 0};
+    static constexpr std::array<int8_t, 4> cx = { 0, -1, 0, 1 };
+    static constexpr std::array<int8_t, 4> cy = { -1,  0, 1, 0 };
 
     for( int i = 0; i < 4; i++ ) {
-        const point adj( p.xy() + point( cx[i], cy[i] ) );
-        if( m.has_furn( tripoint( adj, p.z ) ) &&
-            m.furn( tripoint( adj, p.z ) ).obj().has_flag( ter_furn_flag::TFLAG_BLOCKSDOOR ) ) {
+        const point_bub_ms adj( p.xy() + point( cx[i], cy[i] ) );
+        if( m.has_furn( tripoint_bub_ms( adj, p.z() ) ) &&
+            m.furn( tripoint_bub_ms( adj, p.z() ) ).obj().has_flag( ter_furn_flag::TFLAG_BLOCKSDOOR ) ) {
             return true;
         }
     }
@@ -4067,6 +4226,11 @@ static bool furn_is_supported( const map &m, const tripoint &p )
 }
 
 void map::bash_ter_furn( const tripoint &p, bash_params &params )
+{
+    map::bash_ter_furn( tripoint_bub_ms( p ), params );
+}
+
+void map::bash_ter_furn( const tripoint_bub_ms &p, bash_params &params )
 {
     int sound_volume = 0;
     std::string soundfxid;
@@ -4097,7 +4261,7 @@ void map::bash_ter_furn( const tripoint &p, bash_params &params )
         } else if( !bash->ter_set && zlevels ) {
             // HACK: A hack for destroy && !bash_floor
             // We have to check what would we create and cancel if it is what we have now
-            tripoint below( p.xy(), p.z - 1 );
+            tripoint_bub_ms below = p + tripoint_rel_ms_below;
             const ter_str_id roof = get_roof( below, false );
             if( ter( p ) == roof ) {
                 smash_ter = false;
@@ -4142,7 +4306,7 @@ void map::bash_ter_furn( const tripoint &p, bash_params &params )
         }
 
         if( bash->str_min_supported != -1 || bash->str_max_supported != -1 ) {
-            tripoint below( p.xy(), p.z - 1 );
+            tripoint_bub_ms below = p + tripoint_rel_ms_below;
             if( !zlevels || has_flag( ter_furn_flag::TFLAG_SUPPORTS_ROOF, below ) ) {
                 if( bash->str_min_supported != -1 ) {
                     smin = bash->str_min_supported;
@@ -4167,7 +4331,7 @@ void map::bash_ter_furn( const tripoint &p, bash_params &params )
             // we'll take less time to destroy it
             damage += std::max( ( params.strength - smin ) * params.roll, 1.f );
         }
-        set_map_damage( tripoint_bub_ms( p ), damage );
+        set_map_damage( p, damage );
     }
 
     if( smash_furn ) {
@@ -4199,7 +4363,7 @@ void map::bash_ter_furn( const tripoint &p, bash_params &params )
 
     if( ( smash_furn && has_flag_furn( ter_furn_flag::TFLAG_FUNGUS, p ) ) ||
         ( smash_ter && has_flag_ter( ter_furn_flag::TFLAG_FUNGUS, p ) ) ) {
-        fungal_effects().create_spores( p );
+        fungal_effects().create_spores( p.raw() );
     }
 
     if( params.destroy ) {
@@ -4229,14 +4393,14 @@ void map::bash_ter_furn( const tripoint &p, bash_params &params )
             }
         }
 
-        std::optional<std::pair<tripoint, furn_id>> tentp;
+        std::optional<std::pair<tripoint_bub_ms, furn_id>> tentp;
 
         // Find the center of the tent
         // First check if we're not currently bashing the center
         if( centers.count( furn( p ) ) > 0 ) {
             tentp.emplace( p, furn( p ) );
         } else {
-            for( const tripoint &pt : points_in_radius( p, bash->collapse_radius ) ) {
+            for( const tripoint_bub_ms &pt : points_in_radius( p, bash->collapse_radius ) ) {
                 const furn_id &f_at = furn( pt );
                 // Check if we found the center of the current tent
                 if( centers.count( f_at ) > 0 ) {
@@ -4252,7 +4416,7 @@ void map::bash_ter_furn( const tripoint &p, bash_params &params )
         } else {
             // Take the tent down
             const int rad = tentp->second.obj().bash.collapse_radius;
-            for( const tripoint &pt : points_in_radius( tentp->first, rad ) ) {
+            for( const tripoint_bub_ms &pt : points_in_radius( tentp->first, rad ) ) {
                 const furn_id frn = furn( pt );
                 if( frn == furn_str_id::NULL_ID() ) {
                     continue;
@@ -4273,7 +4437,7 @@ void map::bash_ter_furn( const tripoint &p, bash_params &params )
         soundfxvariant = "smash_cloth";
     } else if( smash_furn ) {
         furn_set( p, bash->furn_set );
-        for( item &it : i_at( p ) )  {
+        for( item &it : i_at( p ) ) {
             it.on_drop( p, *this );
         }
         // HACK: Hack alert.
@@ -4294,7 +4458,7 @@ void map::bash_ter_furn( const tripoint &p, bash_params &params )
         // If the terrain has a valid post-destroy terrain, set it
         ter_set( p, bash->ter_set );
     } else {
-        tripoint below( p.xy(), p.z - 1 );
+        tripoint_bub_ms below = p + tripoint_rel_ms_below;
         const ter_t &ter_below = ter( below ).obj();
         if( bash->bash_below && ter_below.has_flag( ter_furn_flag::TFLAG_SUPPORTS_ROOF ) ) {
             // When bashing the tile below, don't allow bashing the floor
@@ -4312,13 +4476,13 @@ void map::bash_ter_furn( const tripoint &p, bash_params &params )
     }
 
     if( smash_ter && ter( p )->has_flag( "EMPTY_SPACE" ) && zlevels ) {
-        tripoint below( p.xy(), p.z - 1 );
+        tripoint_bub_ms below = p + tripoint_rel_ms_below;
         const ter_str_id roof = get_roof( below, params.bash_floor && ter( below ).obj().movecost != 0 );
         ter_set( p, roof );
     }
 
     if( bash->explosive > 0 ) {
-        explosion_handler::explosion( nullptr, p, bash->explosive, 0.8, false );
+        explosion_handler::explosion( nullptr, p.raw(), bash->explosive, 0.8, false );
     }
 
     if( will_collapse && !has_flag( ter_furn_flag::TFLAG_SUPPORTS_ROOF, p ) ) {
@@ -4335,6 +4499,13 @@ void map::bash_ter_furn( const tripoint &p, bash_params &params )
 }
 
 bash_params map::bash( const tripoint &p, const int str,
+                       bool silent, bool destroy, bool bash_floor,
+                       const vehicle *bashing_vehicle )
+{
+    return map::bash( tripoint_bub_ms( p ), str, silent, destroy, bash_floor, bashing_vehicle );
+}
+
+bash_params map::bash( const tripoint_bub_ms &p, const int str,
                        bool silent, bool destroy, bool bash_floor,
                        const vehicle *bashing_vehicle )
 {
@@ -4373,6 +4544,11 @@ bash_params map::bash( const tripoint &p, const int str,
 
 void map::bash_items( const tripoint &p, bash_params &params )
 {
+    map::bash_items( tripoint_bub_ms( p ), params );
+}
+
+void map::bash_items( const tripoint_bub_ms &p, bash_params &params )
+{
     if( !has_items( p ) || has_flag_ter_or_furn( ter_furn_flag::TFLAG_PLANT, p ) ) {
         return;
     }
@@ -4407,6 +4583,11 @@ void map::bash_items( const tripoint &p, bash_params &params )
 
 void map::bash_vehicle( const tripoint &p, bash_params &params )
 {
+    map::bash_vehicle( tripoint_bub_ms( p ), params );
+}
+
+void map::bash_vehicle( const tripoint_bub_ms &p, bash_params &params )
+{
     // Smash vehicle if present
     if( const optional_vpart_position vp = veh_at( p ) ) {
         vp->vehicle().damage( *this, vp->part_index(), params.strength, damage_bash );
@@ -4422,6 +4603,11 @@ void map::bash_vehicle( const tripoint &p, bash_params &params )
 }
 
 void map::bash_field( const tripoint &p, bash_params &params )
+{
+    map::bash_field( tripoint_bub_ms( p ), params );
+}
+
+void map::bash_field( const tripoint_bub_ms &p, bash_params &params )
 {
     std::vector<field_type_id> to_remove;
     for( const std::pair<const field_type_id, field_entry> &fd : field_at( p ) ) {
@@ -5055,12 +5241,18 @@ map_stack map::i_at( const tripoint_bub_ms &p )
 
 map_stack::iterator map::i_rem( const tripoint &p, const map_stack::const_iterator &it )
 {
+
+    return map::i_rem( tripoint_bub_ms( p ), it );
+}
+
+map_stack::iterator map::i_rem( const tripoint_bub_ms &p, const map_stack::const_iterator &it )
+{
     point_sm_ms l;
-    submap *const current_submap = get_submap_at( tripoint_bub_ms( p ), l );
+    submap *const current_submap = get_submap_at( p, l );
     if( current_submap == nullptr ) {
         debugmsg( "Tried to remove items at (%d,%d) but the submap is not loaded", l.x(), l.y() );
         nulitems.clear();
-        return map_stack{ &nulitems, p, this } .begin();
+        return map_stack{ &nulitems, p.raw(), this} .begin();
     }
 
     current_submap->update_lum_rem( l, *it );
@@ -6321,7 +6513,7 @@ void map::partial_con_remove( const tripoint_bub_ms &p )
         return;
     }
     current_submap->partial_constructions.erase( tripoint_sm_ms( l, p.z() ) );
-    memory_cache_dec_set_dirty( p.raw(), true );
+    memory_cache_dec_set_dirty( p, true );
     avatar &player_character = get_avatar();
     if( player_character.sees( p ) ) {
         player_character.memorize_clear_decoration( getglobal( p ), "tr_" );
@@ -6369,7 +6561,7 @@ void map::trap_set( const tripoint_bub_ms &p, const trap_id &type )
         return;
     }
 
-    memory_cache_dec_set_dirty( p.raw(), true );
+    memory_cache_dec_set_dirty( p, true );
     avatar &player_character = get_avatar();
     if( player_character.sees( p ) ) {
         player_character.memorize_clear_decoration( getglobal( p ), "tr_" );
@@ -6406,7 +6598,7 @@ void map::remove_trap( const tripoint_bub_ms &p )
     trap_id tid = current_submap->get_trap( l );
     if( tid != tr_null ) {
         if( g != nullptr && this == &get_map() ) {
-            memory_cache_dec_set_dirty( p.raw(), true );
+            memory_cache_dec_set_dirty( p, true );
             avatar &player_character = get_avatar();
             if( player_character.sees( p ) ) {
                 player_character.memorize_clear_decoration( getglobal( p ), "tr_" );
@@ -6482,6 +6674,12 @@ time_duration map::mod_field_age( const tripoint &p, const field_type_id &type,
 }
 
 int map::mod_field_intensity( const tripoint &p, const field_type_id &type, const int offset )
+{
+    return mod_field_intensity( tripoint_bub_ms( p ), type, offset );
+}
+
+int map::mod_field_intensity( const tripoint_bub_ms &p, const field_type_id &type,
+                              const int offset )
 {
     return set_field_intensity( p, type, offset, true );
 }
@@ -6739,12 +6937,12 @@ void map::on_field_modified( const tripoint &p, const field_type &fd_type )
 
     // Dirty the transparency cache now that field processing doesn't always do it
     if( fd_type.dirty_transparency_cache || !fd_type.is_transparent() ) {
-        set_transparency_cache_dirty( p, true );
-        set_seen_cache_dirty( p );
+        set_transparency_cache_dirty( tripoint_bub_ms( p ), true );
+        set_seen_cache_dirty( tripoint_bub_ms( p ) );
     }
 
     if( fd_type.is_dangerous() ) {
-        set_pathfinding_cache_dirty( p );
+        set_pathfinding_cache_dirty( tripoint_bub_ms( p ) );
     }
 
     // Ensure blood type fields don't hang in the air
@@ -6754,6 +6952,11 @@ void map::on_field_modified( const tripoint &p, const field_type &fd_type )
 }
 
 void map::add_splatter( const field_type_id &type, const tripoint &where, int intensity )
+{
+    map::add_splatter( type, tripoint_bub_ms( where ), intensity );
+}
+
+void map::add_splatter( const field_type_id &type, const tripoint_bub_ms &where, int intensity )
 {
     if( intensity <= 0 ) {
         return;
@@ -6793,11 +6996,17 @@ void map::add_splatter_trail( const field_type_id &type, const tripoint &from,
 void map::add_splash( const field_type_id &type, const tripoint &center, int radius,
                       int intensity )
 {
+    return map::add_splash( type, tripoint_bub_ms( center ), radius, intensity );
+}
+
+void map::add_splash( const field_type_id &type, const tripoint_bub_ms &center, int radius,
+                      int intensity )
+{
     if( !type.id() ) {
         return;
     }
     // TODO: use Bresenham here and take obstacles into account
-    for( const tripoint &pnt : points_in_radius( center, radius ) ) {
+    for( const tripoint_bub_ms &pnt : points_in_radius( center, radius ) ) {
         if( trig_dist( pnt, center ) <= radius && !one_in( intensity ) ) {
             add_splatter( type, pnt );
         }
@@ -7460,17 +7669,17 @@ bool map::sees( const tripoint_bub_ms &F, const tripoint_bub_ms &T, const int ra
     return sees( F.raw(), T.raw(), range, dummy, with_fields );
 }
 
-point map::sees_cache_key( const tripoint &from, const tripoint &to ) const
+point map::sees_cache_key( const tripoint_bub_ms &from, const tripoint_bub_ms &to ) const
 {
 
     // Canonicalize the order of the tripoints so the cache is reflexive.
-    const tripoint &min = from < to ? from : to;
-    const tripoint &max = !( from < to ) ? from : to;
+    const tripoint_bub_ms &min = from < to ? from : to;
+    const tripoint_bub_ms &max = !( from < to ) ? from : to;
 
     // A little gross, just pack the values into a point.
     return point(
-               min.x << 16 | min.y << 8 | ( min.z + OVERMAP_DEPTH ),
-               max.x << 16 | max.y << 8 | ( max.z + OVERMAP_DEPTH )
+               min.x() << 16 | min.y() << 8 | ( min.z() + OVERMAP_DEPTH ),
+               max.x() << 16 | max.y() << 8 | ( max.z() + OVERMAP_DEPTH )
            );
 }
 
@@ -7480,10 +7689,16 @@ point map::sees_cache_key( const tripoint &from, const tripoint &to ) const
 bool map::sees( const tripoint &F, const tripoint &T, const int range,
                 int &bresenham_slope, bool with_fields ) const
 {
-    bool ( map::*f_transparent )( const tripoint & p ) const =
+    return map::sees( tripoint_bub_ms( F ), tripoint_bub_ms( T ), range, bresenham_slope, with_fields );
+}
+
+bool map::sees( const tripoint_bub_ms &F, const tripoint_bub_ms &T, const int range,
+                int &bresenham_slope, bool with_fields ) const
+{
+    bool ( map:: * f_transparent )( const tripoint & p ) const =
         with_fields ? &map::is_transparent : &map::is_transparent_wo_fields;
     lru_cache_t &skew_cache = with_fields ? skew_vision_cache : skew_vision_wo_fields_cache;
-    if( std::abs( F.z - T.z ) > fov_3d_z_range ||
+    if( std::abs( F.z() - T.z() ) > fov_3d_z_range ||
         ( range >= 0 && range < rl_dist( F, T ) ) ||
         !inbounds( T ) ) {
         bresenham_slope = 0;
@@ -7497,14 +7712,14 @@ bool map::sees( const tripoint &F, const tripoint &T, const int range,
     bool visible = true;
 
     // Ugly `if` for now
-    if( F.z == T.z ) {
-        bresenham( F.xy(), T.xy(), bresenham_slope,
+    if( F.z() == T.z() ) {
+        bresenham( F.xy().raw(), T.xy().raw(), bresenham_slope,
         [this, f_transparent, &visible, &T]( const point & new_point ) {
             // Exit before checking the last square, it's still visible even if opaque.
-            if( new_point.x == T.x && new_point.y == T.y ) {
+            if( new_point.x == T.x() && new_point.y == T.y() ) {
                 return false;
             }
-            if( !( this->*f_transparent )( tripoint( new_point, T.z ) ) ) {
+            if( !( this->*f_transparent )( tripoint( new_point, T.z() ) ) ) {
                 visible = false;
                 return false;
             }
@@ -7514,12 +7729,12 @@ bool map::sees( const tripoint &F, const tripoint &T, const int range,
         return visible;
     }
 
-    tripoint last_point = F;
-    bresenham( F, T, bresenham_slope, 0,
+    tripoint last_point = F.raw();
+    bresenham( F.raw(), T.raw(), bresenham_slope, 0,
     [this, f_transparent, &visible, &T, &last_point]( const tripoint & new_point ) {
         // Exit before checking the last square if it's not a vertical transition,
         // it's still visible even if opaque.
-        if( new_point == T && last_point.z == T.z ) {
+        if( new_point == T.raw() && last_point.z == T.z() ) {
             return false;
         }
 
@@ -7531,10 +7746,10 @@ bool map::sees( const tripoint &F, const tripoint &T, const int range,
             }
         } else {
             const int max_z = std::max( new_point.z, last_point.z );
-            if( ( has_floor_or_support( {new_point.xy(), max_z} ) ||
-                  !( this->*f_transparent )( {new_point.xy(), last_point.z} ) ) &&
-                ( has_floor_or_support( {last_point.xy(), max_z} ) ||
-                  !( this->*f_transparent )( {last_point.xy(), new_point.z} ) ) ) {
+            if( ( has_floor_or_support( { new_point.xy(), max_z } ) ||
+                  !( this->*f_transparent )( { new_point.xy(), last_point.z } ) ) &&
+                ( has_floor_or_support( { last_point.xy(), max_z } ) ||
+                  !( this->*f_transparent )( { last_point.xy(), new_point.z } ) ) ) {
                 visible = false;
                 return false;
             }
@@ -7547,17 +7762,17 @@ bool map::sees( const tripoint &F, const tripoint &T, const int range,
     return visible;
 }
 
-int map::obstacle_coverage( const tripoint &loc1, const tripoint &loc2 ) const
+int map::obstacle_coverage( const tripoint_bub_ms &loc1, const tripoint_bub_ms &loc2 ) const
 {
     // Can't hide if you are standing on furniture, or non-flat slowing-down terrain tile.
     if( furn( loc2 ).obj().id || ( move_cost( loc2 ) > 2 &&
                                    !has_flag_ter( ter_furn_flag::TFLAG_FLAT, loc2 ) ) ) {
         return 0;
     }
-    const point a( std::abs( loc1.x - loc2.x ) * 2, std::abs( loc1.y - loc2.y ) * 2 );
+    const point a( std::abs( loc1.x() - loc2.x() ) * 2, std::abs( loc1.y() - loc2.y() ) * 2 );
     int offset = std::min( a.x, a.y ) - ( std::max( a.x, a.y ) / 2 );
     tripoint obstaclepos;
-    bresenham( loc2, loc1, offset, 0, [&obstaclepos]( const tripoint & new_point ) {
+    bresenham( loc2.raw(), loc1.raw(), offset, 0, [&obstaclepos]( const tripoint & new_point ) {
         // Only adjacent tile between you and enemy is checked for cover.
         obstaclepos = new_point;
         return false;
@@ -7577,7 +7792,12 @@ int map::obstacle_coverage( const tripoint &loc1, const tripoint &loc2 ) const
 
 int map::ledge_coverage( const Creature &viewer, const tripoint &target_p ) const
 {
-    tripoint viewer_p = viewer.pos();
+    return map::ledge_coverage( viewer, tripoint_bub_ms( target_p ) );
+}
+
+int map::ledge_coverage( const Creature &viewer, const tripoint_bub_ms &target_p ) const
+{
+    tripoint_bub_ms viewer_p = viewer.pos_bub();
     creature_size viewer_size = viewer.get_size();
 
     // Viewer eye level from ground in grids
@@ -7622,23 +7842,29 @@ int map::ledge_coverage( const Creature &viewer, const tripoint &target_p ) cons
 int map::ledge_coverage( const tripoint &viewer_p, const tripoint &target_p,
                          const float &eye_level ) const
 {
-    if( viewer_p.z == target_p.z ) {
+    return map::ledge_coverage( tripoint_bub_ms( viewer_p ), tripoint_bub_ms( target_p ), eye_level );
+}
+
+int map::ledge_coverage( const tripoint_bub_ms &viewer_p, const tripoint_bub_ms &target_p,
+                         const float &eye_level ) const
+{
+    if( viewer_p.z() == target_p.z() ) {
         return 0;
     }
 
     // Find ledge between viewer and target
     // Only the first ledge found is calculated for performance reasons
-    tripoint high_p;
-    tripoint low_p;
-    if( viewer_p.z > target_p.z ) {
+    tripoint_bub_ms high_p;
+    tripoint_bub_ms low_p;
+    if( viewer_p.z() > target_p.z() ) {
         high_p = viewer_p;
         low_p = target_p;
     } else {
         high_p = target_p;
         low_p = viewer_p;
     }
-    tripoint ledge_p = high_p;
-    bresenham( tripoint( low_p.xy(), high_p.z ), high_p, 0, 0, [this,
+    tripoint ledge_p = high_p.raw();
+    bresenham( tripoint( low_p.xy().raw(), high_p.z() ), high_p.raw(), 0, 0, [this,
     &ledge_p]( const tripoint & new_point ) {
         if( dont_draw_lower_floor( new_point ) ) {
             ledge_p = new_point;
@@ -7649,19 +7875,20 @@ int map::ledge_coverage( const tripoint &viewer_p, const tripoint &target_p,
 
     // Height of each z-level in grids
     const float zlevel_to_grid_ratio = 2.0f;
-    float dist_to_ledge_base = trig_dist( viewer_p, tripoint( ledge_p.xy(), viewer_p.z ) );
+    float dist_to_ledge_base = trig_dist( viewer_p, tripoint_bub_ms( ledge_p.x, ledge_p.y,
+                                          viewer_p.z() ) );
     // Adjustment to ledge distance because ledge is assumed to be between two grids
-    dist_to_ledge_base += ( viewer_p.z < target_p.z ) ? -0.5f : 0.5f;
-    const float flat_dist = trig_dist( viewer_p, tripoint( target_p.xy(), viewer_p.z ) );
+    dist_to_ledge_base += ( viewer_p.z() < target_p.z() ) ? -0.5f : 0.5f;
+    const float flat_dist = trig_dist( viewer_p, tripoint_bub_ms( target_p.xy(), viewer_p.z() ) );
     // Absolute level of viewer's eye
-    const float abs_eye_z = viewer_p.z * zlevel_to_grid_ratio + eye_level;
+    const float abs_eye_z = viewer_p.z() * zlevel_to_grid_ratio + eye_level;
     // "Opposite" of the angle between the eye level and ledge
     const float eye_ledge_z_delta = ( ledge_p.z * zlevel_to_grid_ratio ) - abs_eye_z;
     const float tangent = eye_ledge_z_delta / dist_to_ledge_base;
     // Absolute level concealed by ledge, anything below this point is invisible
     const float covered_z = abs_eye_z + ( tangent * flat_dist );
     // Ledge coverage given by comparing covered_z and the absolute z of the target space
-    float ledge_coverage = ( covered_z - target_p.z * zlevel_to_grid_ratio ) * 100;
+    float ledge_coverage = ( covered_z - target_p.z() * zlevel_to_grid_ratio ) * 100;
 
     // Early exit if the tile is definitely not covered
     if( ledge_coverage < 0 ) {
@@ -7677,6 +7904,11 @@ int map::ledge_coverage( const tripoint &viewer_p, const tripoint &target_p,
 }
 
 int map::coverage( const tripoint &p ) const
+{
+    return map::coverage( tripoint_bub_ms( p ) );
+}
+
+int map::coverage( const tripoint_bub_ms &p ) const
 {
     if( const furn_id obstacle_f = furn( p ) ) {
         return obstacle_f->coverage;
@@ -7696,8 +7928,22 @@ int map::coverage( const tripoint &p ) const
 std::vector<tripoint> map::find_clear_path( const tripoint &source,
         const tripoint &destination ) const
 {
+    const std::vector<tripoint_bub_ms> temp = map::find_clear_path( tripoint_bub_ms( source ),
+            tripoint_bub_ms( destination ) );
+    std::vector<tripoint> result;
+
+    for( tripoint_bub_ms pt : temp ) {
+        result.push_back( pt.raw() );
+    }
+
+    return result;
+}
+
+std::vector<tripoint_bub_ms> map::find_clear_path( const tripoint_bub_ms &source,
+        const tripoint_bub_ms &destination ) const
+{
     // TODO: Push this junk down into the Bresenham method, it's already doing it.
-    const point d( destination.xy() - source.xy() );
+    const point d( destination.xy().raw() - source.xy().raw() );
     const point a( std::abs( d.x ) * 2, std::abs( d.y ) * 2 );
     const int dominant = std::max( a.x, a.y );
     const int minor = std::min( a.x, a.y );
@@ -7719,6 +7965,18 @@ std::vector<tripoint> map::find_clear_path( const tripoint &source,
 void map::reachable_flood_steps( std::vector<tripoint> &reachable_pts, const tripoint &f,
                                  int range, const int cost_min, const int cost_max ) const
 {
+    std::vector<tripoint_bub_ms> temp_points;
+    map::reachable_flood_steps( temp_points, tripoint_bub_ms( f ), range, cost_min, cost_max );
+
+    for( const tripoint_bub_ms pt : temp_points ) {
+        reachable_pts.push_back( pt.raw() );
+    }
+}
+
+void map::reachable_flood_steps( std::vector<tripoint_bub_ms> &reachable_pts,
+                                 const tripoint_bub_ms &f,
+                                 int range, const int cost_min, const int cost_max ) const
+{
     struct pq_item {
         int dist;
         int ndx;
@@ -7734,22 +7992,22 @@ void map::reachable_flood_steps( std::vector<tripoint> &reachable_pts, const tri
     const int grid_dim = range * 2 + 1;
     // init to -1 as "not visited yet"
     std::vector< int > t_grid( static_cast<size_t>( grid_dim * grid_dim ), -1 );
-    const tripoint origin_offset = {range, range, 0};
+    const tripoint_rel_ms origin_offset = { range, range, 0 };
     const int initial_visit_distance = range * range; // Large unreachable value
 
     // Fill positions that are visitable with initial_visit_distance
-    for( const tripoint &p : points_in_radius( f, range ) ) {
-        const tripoint tp = { p.xy(), f.z };
+    for( const tripoint_bub_ms &p : points_in_radius( f, range ) ) {
+        const tripoint_bub_ms tp = { p.xy(), f.z()};
         const int tp_cost = move_cost( tp );
         // rejection conditions
         if( tp_cost < cost_min || tp_cost > cost_max || is_open_air( tp ) ) {
             continue;
         }
         // set initial cost for grid point
-        tripoint origin_relative = tp - f;
+        tripoint_rel_ms origin_relative = tp - f;
         origin_relative += origin_offset;
-        int ndx = origin_relative.x + origin_relative.y * grid_dim;
-        t_grid[ ndx ] = initial_visit_distance;
+        int ndx = origin_relative.x() + origin_relative.y() * grid_dim;
+        t_grid[ndx] = initial_visit_distance;
     }
 
     auto gen_neighbors = []( const pq_item & elem, int grid_dim, std::array<pq_item, 8> &neighbors ) {
@@ -7786,8 +8044,8 @@ void map::reachable_flood_steps( std::vector<tripoint> &reachable_pts, const tri
         const pq_item item = pq.top();
         pq.pop();
 
-        if( t_grid[ item.ndx ] == initial_visit_distance ) {
-            t_grid[ item.ndx ] = item.dist;
+        if( t_grid[item.ndx] == initial_visit_distance ) {
+            t_grid[item.ndx] = item.dist;
             if( item.dist + 1 < range ) {
                 gen_neighbors( item, grid_dim, neighbor_elems );
                 for( pq_item neighbor_elem : neighbor_elems ) {
@@ -7799,14 +8057,14 @@ void map::reachable_flood_steps( std::vector<tripoint> &reachable_pts, const tri
     std::vector<char> o_grid( static_cast<size_t>( grid_dim * grid_dim ), 0 );
     for( int y = 0, ndx = 0; y < grid_dim; ++y ) {
         for( int x = 0; x < grid_dim; ++x, ++ndx ) {
-            if( t_grid[ ndx ] != -1 && t_grid[ ndx ] < initial_visit_distance ) {
+            if( t_grid[ndx] != -1 && t_grid[ndx] < initial_visit_distance ) {
                 // set self and neighbors to 1
                 for( int dy = -1; dy <= 1; ++dy ) {
                     for( int dx = -1; dx <= 1; ++dx ) {
                         point t2( dx + x, dy + y );
 
                         if( t2.x >= 0 && t2.x < grid_dim && t2.y >= 0 && t2.y < grid_dim ) {
-                            o_grid[ t2.x + t2.y * grid_dim ] = 1;
+                            o_grid[t2.x + t2.y * grid_dim] = 1;
                         }
                     }
                 }
@@ -7817,8 +8075,8 @@ void map::reachable_flood_steps( std::vector<tripoint> &reachable_pts, const tri
     // Now go over again to pull out all of the reachable points
     for( int y = 0, ndx = 0; y < grid_dim; ++y ) {
         for( int x = 0; x < grid_dim; ++x, ++ndx ) {
-            if( o_grid[ ndx ] ) {
-                tripoint t = f - origin_offset + tripoint{ x, y, 0 };
+            if( o_grid[ndx] ) {
+                tripoint_bub_ms t = f - origin_offset + tripoint{ x, y, 0 };
                 reachable_pts.push_back( t );
             }
         }
@@ -7846,7 +8104,7 @@ bool map::clear_path( const tripoint &f, const tripoint &t, const int range,
                 return false;
             }
 
-            const int cost = this->move_cost( new_point );
+            const int cost = this->move_cost( point_bub_ms( new_point ) );
             if( cost < cost_min || cost > cost_max ) {
                 is_clear = false;
                 return false;
@@ -7924,13 +8182,27 @@ bool map::accessible_items( const tripoint_bub_ms &t ) const
 
 std::vector<tripoint> map::get_dir_circle( const tripoint &f, const tripoint &t ) const
 {
-    std::vector<tripoint> circle;
+    const std::vector<tripoint_bub_ms> temp = map::get_dir_circle( tripoint_bub_ms( f ),
+            tripoint_bub_ms( t ) );
+    std::vector<tripoint> result;
+
+    for( const tripoint_bub_ms pt : temp ) {
+        result.push_back( pt.raw() );
+    }
+
+    return result;
+}
+
+std::vector<tripoint_bub_ms> map::get_dir_circle( const tripoint_bub_ms &f,
+        const tripoint_bub_ms &t ) const
+{
+    std::vector<tripoint_bub_ms> circle;
     circle.resize( 8 );
 
     // The line below can be crazy expensive - we only take the FIRST point of it
-    const std::vector<tripoint> line = line_to( f, t, 0, 0 );
-    const std::vector<tripoint> spiral = closest_points_first( f, 1 );
-    const std::vector<int> pos_index {1, 2, 4, 6, 8, 7, 5, 3};
+    const std::vector<tripoint_bub_ms> line = line_to( f, t, 0, 0 );
+    const std::vector<tripoint_bub_ms> spiral = closest_points_first( f, 1 );
+    const std::vector<int> pos_index{ 1, 2, 4, 6, 8, 7, 5, 3 };
 
     //  All possible constellations (closest_points_first goes clockwise)
     //  753  531  312  124  246  468  687  875
@@ -8085,7 +8357,7 @@ shift_bitset_cache<MAPSIZE_X, SEEX>( std::bitset<MAPSIZE_X *MAPSIZE_X> &cache,
 template void
 shift_bitset_cache<MAPSIZE, 1>( std::bitset<MAPSIZE *MAPSIZE> &cache, const point &s );
 
-void map::shift( const point &sp )
+void map::shift( const point_rel_sm &sp )
 {
     if( !zlevels ) {
         debugmsg( "map::shift called from map that doesn't support Z levels" );
@@ -8093,11 +8365,11 @@ void map::shift( const point &sp )
     }
 
     // Special case of 0-shift; refresh the map
-    if( sp == point_zero ) {
+    if( sp == point_rel_sm_zero ) {
         return; // Skip this?
     }
 
-    if( std::abs( sp.x ) > 1 || std::abs( sp.y ) > 1 ) {
+    if( std::abs( sp.x() ) > 1 || std::abs( sp.y() ) > 1 ) {
         debugmsg( "map::shift called with a shift of more than one submap" );
         return;
     }
@@ -8108,9 +8380,9 @@ void map::shift( const point &sp )
     // TODO: fix point types (sp should be relative?)
     set_abs_sub( abs + sp );
 
-    g->shift_destination_preview( point( -sp.x * SEEX, -sp.y * SEEY ) );
+    g->shift_destination_preview( point( -sp.x() * SEEX, -sp.y() * SEEY ) );
 
-    shift_traps( tripoint( sp, 0 ) );
+    shift_traps( tripoint( sp.raw(), 0 ) );
 
     vehicle *remoteveh = g->remoteveh();
 
@@ -8132,12 +8404,12 @@ void map::shift( const point &sp )
     // absx and absy are our position in the world, for saving/loading purposes.
     clear_vehicle_level_caches();
 
-    const int x_start = sp.x >= 0 ? 0 : my_MAPSIZE - 1;
-    const int x_stop = sp.x >= 0 ? my_MAPSIZE : -1;
-    const int x_step = sp.x >= 0 ? 1 : -1;
-    const int y_start = sp.y >= 0 ? 0 : my_MAPSIZE - 1;
-    const int y_stop = sp.y >= 0 ? my_MAPSIZE : -1;
-    const int y_step = sp.y >= 0 ? 1 : -1;
+    const int x_start = sp.x() >= 0 ? 0 : my_MAPSIZE - 1;
+    const int x_stop = sp.x() >= 0 ? my_MAPSIZE : -1;
+    const int x_step = sp.x() >= 0 ? 1 : -1;
+    const int y_start = sp.y() >= 0 ? 0 : my_MAPSIZE - 1;
+    const int y_stop = sp.y() >= 0 ? my_MAPSIZE : -1;
+    const int y_step = sp.y() >= 0 ? 1 : -1;
 
     for( int gridz = zmin; gridz <= zmax; gridz++ ) {
         // Clear vehicle list and rebuild after shift
@@ -8146,15 +8418,15 @@ void map::shift( const point &sp )
         clear_vehicle_list( gridz );
         level_cache *cache = get_cache_lazy( gridz );
         if( cache ) {
-            shift_bitset_cache<MAPSIZE_X, SEEX>( cache->map_memory_cache_dec, sp );
-            shift_bitset_cache<MAPSIZE_X, SEEX>( cache->map_memory_cache_ter, sp );
-            shift_bitset_cache<MAPSIZE, 1>( cache->field_cache, sp );
+            shift_bitset_cache<MAPSIZE_X, SEEX>( cache->map_memory_cache_dec, sp.raw() );
+            shift_bitset_cache<MAPSIZE_X, SEEX>( cache->map_memory_cache_ter, sp.raw() );
+            shift_bitset_cache<MAPSIZE, 1>( cache->field_cache, sp.raw() );
         }
     }
 
     for( int gridx = x_start; gridx != x_stop; gridx += x_step ) {
         for( int gridy = y_start; gridy != y_stop; gridy += y_step ) {
-            if( gridx + sp.x != x_stop && gridy + sp.y != y_stop ) {
+            if( gridx + sp.x() != x_stop && gridy + sp.y() != y_stop ) {
                 for( int gridz = zmin; gridz <= zmax; gridz++ ) {
                     const tripoint_rel_sm grid( gridx, gridy, gridz );
 
@@ -8184,7 +8456,7 @@ void map::shift( const point &sp )
         std::set<tripoint> old_cache = std::move( support_cache_dirty );
         support_cache_dirty.clear();
         for( const tripoint &pt : old_cache ) {
-            support_cache_dirty.insert( pt + point( -sp.x * SEEX, -sp.y * SEEY ) );
+            support_cache_dirty.insert( pt + point( -sp.x() * SEEX, -sp.y() * SEEY ) );
         }
     }
     // actualize after loading all submaps to prevent errors
@@ -10475,10 +10747,10 @@ void map::set_pathfinding_cache_dirty( const int zlev )
     }
 }
 
-void map::set_pathfinding_cache_dirty( const tripoint &p )
+void map::set_pathfinding_cache_dirty( const tripoint_bub_ms &p )
 {
     if( inbounds( p ) ) {
-        get_pathfinding_cache( p.z ).dirty_points.insert( p.xy() );
+        get_pathfinding_cache( p.z() ).dirty_points.insert( p.xy().raw() );
     }
 }
 
@@ -10596,6 +10868,11 @@ void map::clip_to_bounds( tripoint &p ) const
     clip_to_bounds( p.x, p.y, p.z );
 }
 
+void map::clip_to_bounds( tripoint_bub_ms &p ) const
+{
+    clip_to_bounds( p.x(), p.y(), p.z() );
+}
+
 void map::clip_to_bounds( int &x, int &y ) const
 {
     if( x < 0 ) {
@@ -10696,7 +10973,7 @@ void map::invalidate_max_populated_zlev( int zlev )
     }
 }
 
-bool map::has_potential_los( const tripoint &from, const tripoint &to ) const
+bool map::has_potential_los( const tripoint_bub_ms &from, const tripoint_bub_ms &to ) const
 {
     const point key = sees_cache_key( from, to );
     char cached = skew_vision_cache.get( key, -1 );

--- a/src/map.h
+++ b/src/map.h
@@ -408,27 +408,35 @@ class map
         // @param field denotes if change comes from the field
         //      fields are not considered for some caches, such as reachability_caches
         //      so passing field=true allows to skip rebuilding of such caches
-        void set_transparency_cache_dirty( const tripoint &p, bool field = false );
-        void set_seen_cache_dirty( const tripoint &change_location );
+        void set_transparency_cache_dirty( const tripoint_bub_ms &p, bool field = false );
+        void set_seen_cache_dirty( const tripoint_bub_ms &change_location );
 
         // invalidates seen cache for the whole zlevel unconditionally
         void set_seen_cache_dirty( int zlevel );
         void set_outside_cache_dirty( int zlev );
         void set_floor_cache_dirty( int zlev );
         void set_pathfinding_cache_dirty( int zlev );
-        void set_pathfinding_cache_dirty( const tripoint &p );
+        void set_pathfinding_cache_dirty( const tripoint_bub_ms &p );
         /*@}*/
 
         void invalidate_map_cache( int zlev );
 
         // @returns true if map memory decoration should be re/memorized
+        // TODO: Get rid of untyped overload.
         bool memory_cache_dec_is_dirty( const tripoint &p ) const;
+        bool memory_cache_dec_is_dirty( const tripoint_bub_ms &p ) const;
         // @returns true if map memory terrain should be re/memorized
+        // TODO: Get rid of untyped overload.
         bool memory_cache_ter_is_dirty( const tripoint &p ) const;
+        bool memory_cache_ter_is_dirty( const tripoint_bub_ms &p ) const;
         // sets whether map memory decoration should be re/memorized
+        // TODO: Get rid of untyped overload.
         void memory_cache_dec_set_dirty( const tripoint &p, bool value ) const;
+        void memory_cache_dec_set_dirty( const tripoint_bub_ms &p, bool value ) const;
         // sets whether map memory terrain should be re/memorized
+        // TODO: Get rid of untyped overload.
         void memory_cache_ter_set_dirty( const tripoint &p, bool value ) const;
+        void memory_cache_ter_set_dirty( const tripoint_bub_ms &p, bool value ) const;
         // clears map memory for points occupied by vehicle and marks "dirty" for re-memorizing
         void memory_clear_vehicle_points( const vehicle &veh ) const;
 
@@ -437,7 +445,7 @@ class map
          * true, if there might be a potential bresenham path between two points.
          * false, if such path definitely not possible.
          */
-        bool has_potential_los( const tripoint &from, const tripoint &to ) const;
+        bool has_potential_los( const tripoint_bub_ms &from, const tripoint_bub_ms &to ) const;
 
         /**
          * Callback invoked when a vehicle has moved.
@@ -466,8 +474,11 @@ class map
                                         const visibility_variables &cache ) const;
 
         // See field.cpp
+        // TODO: Get rid of untyped overload.
         std::tuple<maptile, maptile, maptile> get_wind_blockers( const int &winddirection,
                 const tripoint &pos );
+        std::tuple<maptile, maptile, maptile> get_wind_blockers( const int &winddirection,
+                const tripoint_bub_ms &pos );
 
         /** Draw a visible part of the map into `w`.
          *
@@ -528,7 +539,7 @@ class map
          * position of the map (@ref abs_sub) plus the shift vector.
          * Note: the map must have been loaded before this can be called.
          */
-        void shift( const point &s );
+        void shift( const point_rel_sm &s );
         /**
          * Moves the map vertically to (not by!) newz.
          * Does not actually shift anything, only forces cache updates.
@@ -547,16 +558,31 @@ class map
         maptile maptile_at( const tripoint_bub_ms &p );
     private:
         // Versions of the above that don't do bounds checks
+        // TODO: Get rid of untyped overload.
         const_maptile maptile_at_internal( const tripoint &p ) const;
+        const_maptile maptile_at_internal( const tripoint_bub_ms &p ) const;
+        // TODO: Get rid of untyped overload.
         maptile maptile_at_internal( const tripoint &p );
+        maptile maptile_at_internal( const tripoint_bub_ms &p );
+        // TODO: Get rid of untyped overload.
         std::pair<tripoint, maptile> maptile_has_bounds( const tripoint &p, bool bounds_checked );
+        std::pair<tripoint_bub_ms, maptile> maptile_has_bounds( const tripoint_bub_ms &p,
+                bool bounds_checked );
+        // TODO: Get rid of untyped overload.
         std::array<std::pair<tripoint, maptile>, 8> get_neighbors( const tripoint &p );
+        std::array<std::pair<tripoint_bub_ms, maptile>, 8> get_neighbors( const tripoint_bub_ms &p );
+        // TODO: Get rid of untyped overload.
         void spread_gas( field_entry &cur, const tripoint &p, int percent_spread,
                          const time_duration &outdoor_age_speedup, scent_block &sblk,
                          const oter_id &om_ter );
+        void spread_gas( field_entry &cur, const tripoint_bub_ms &p, int percent_spread,
+                         const time_duration &outdoor_age_speedup, scent_block &sblk,
+                         const oter_id &om_ter );
+        // TODO: get rid of untyped overload.
         void create_hot_air( const tripoint &p, int intensity );
+        void create_hot_air( const tripoint_bub_ms &p, int intensity );
         bool gas_can_spread_to( field_entry &cur, const maptile &dst );
-        void gas_spread_to( field_entry &cur, maptile &dst, const tripoint &p );
+        void gas_spread_to( field_entry &cur, maptile &dst, const tripoint_bub_ms &p );
         int burn_body_part( Character &you, field_entry &cur, const bodypart_id &bp, int scale );
     public:
 
@@ -578,25 +604,28 @@ class map
         // TODO: fix point types (remove the first overload)
         int move_cost( const tripoint &p, const vehicle *ignored_vehicle = nullptr ) const;
         int move_cost( const tripoint_bub_ms &p, const vehicle *ignored_vehicle = nullptr ) const;
-        int move_cost( const point &p, const vehicle *ignored_vehicle = nullptr ) const {
-            return move_cost( tripoint( p, abs_sub.z() ), ignored_vehicle );
+        int move_cost( const point_bub_ms &p, const vehicle *ignored_vehicle = nullptr ) const {
+            return move_cost( tripoint_bub_ms( p, abs_sub.z() ), ignored_vehicle );
         }
         // TODO: fix point types (remove the first overload)
         bool impassable( const tripoint &p ) const;
         bool impassable( const tripoint_bub_ms &p ) const;
-        bool impassable( const point &p ) const { // TODO: Get rid of untyped version
-            return !passable( p );
+        // TODO: Get rid of untyped version
+        bool impassable( const point &p ) const {
+            return !passable( point_bub_ms( p ) );
         }
         bool impassable( const point_bub_ms &p ) const {
-            return !passable( p.raw() );
+            return !passable( p );
         }
         // TODO: fix point types (remove the first overload)
         bool passable( const tripoint &p ) const;
         bool passable( const tripoint_bub_ms &p ) const;
-        bool passable( const point &p ) const {
-            return passable( tripoint( p, abs_sub.z() ) );
+        bool passable( const point_bub_ms &p ) const {
+            return passable( tripoint_bub_ms( p, abs_sub.z() ) );
         }
+        // TODO: Get rid of untyped overload.
         bool is_wall_adjacent( const tripoint &center ) const;
+        bool is_wall_adjacent( const tripoint_bub_ms &center ) const;
 
         // TODO: Get rid of untyped overload
         bool is_open_air( const tripoint & ) const;
@@ -605,19 +634,27 @@ class map
         /**
         * Similar behavior to `move_cost()`, but ignores vehicles.
         */
+        // TODO: Get rid of untyped overload.
         int move_cost_ter_furn( const tripoint &p ) const;
-        int move_cost_ter_furn( const point &p ) const {
-            return move_cost_ter_furn( tripoint( p, abs_sub.z() ) );
-        }
+        int move_cost_ter_furn( const tripoint_bub_ms &p ) const;
+        // TODO: Get rid of untyped overload.
         bool impassable_ter_furn( const tripoint &p ) const;
+        bool impassable_ter_furn( const tripoint_bub_ms &p ) const;
+        // TODO: Get rid of untyped overload.
         bool passable_ter_furn( const tripoint &p ) const;
+        bool passable_ter_furn( const tripoint_bub_ms &p ) const;
 
         /**
         * Cost to move out of one tile and into the next.
         *
         * @return The cost in turns to move out of tripoint `from` and into `to`
         */
+        // TODO: Get rid of untyped overload.
         int combined_movecost( const tripoint &from, const tripoint &to,
+                               const vehicle *ignored_vehicle = nullptr,
+                               int modifier = 0, bool flying = false, bool via_ramp = false ) const;
+
+        int combined_movecost( const tripoint_bub_ms &from, const tripoint_bub_ms &to,
                                const vehicle *ignored_vehicle = nullptr,
                                int modifier = 0, bool flying = false, bool via_ramp = false ) const;
 
@@ -626,7 +663,10 @@ class map
          * That is, if the tiles are adjacent and either on the same z-level or connected
          * by stairs or (in case of flying monsters) open air with no floors.
          */
+        // TODO: Get rid of untyped overload.
         bool valid_move( const tripoint &from, const tripoint &to,
+                         bool bash = false, bool flying = false, bool via_ramp = false ) const;
+        bool valid_move( const tripoint_bub_ms &from, const tripoint_bub_ms &to,
                          bool bash = false, bool flying = false, bool via_ramp = false ) const;
 
         /**
@@ -634,7 +674,9 @@ class map
          * Size is in percentage of tile: if 1.0, all attacks going through tile
          * should hit map objects on it, if 0.0 there is nothing to be hit (air/water).
          */
+        // TODO: Get rid of untyped overload.
         double ranged_target_size( const tripoint &p ) const;
+        double ranged_target_size( const tripoint_bub_ms &p ) const;
 
         // Sees:
         /**
@@ -655,23 +697,33 @@ class map
          * the two points, and may subsequently be used to form a path between them.
          * Set to zero if the function returns false.
         **/
+        // TODO: Get rid of untyped overload.
         bool sees( const tripoint &F, const tripoint &T, int range, int &bresenham_slope,
                    bool with_fields = true ) const;
-        point sees_cache_key( const tripoint &from, const tripoint &to ) const;
+        bool sees( const tripoint_bub_ms &F, const tripoint_bub_ms &T, int range, int &bresenham_slope,
+                   bool with_fields = true ) const;
+        point sees_cache_key( const tripoint_bub_ms &from, const tripoint_bub_ms &to ) const;
     public:
         /**
         * Returns coverage of target in relation to the observer. Target is loc2, observer is loc1.
         * First tile from the target is an obstacle, which has the coverage value.
         * If there's no obstacle adjacent to the target - no coverage.
         */
-        int obstacle_coverage( const tripoint &loc1, const tripoint &loc2 ) const;
+        int obstacle_coverage( const tripoint_bub_ms &loc1, const tripoint_bub_ms &loc2 ) const;
+        // TODO: Get rid of untyped override.
         int ledge_coverage( const Creature &viewer, const tripoint &target_p ) const;
+        int ledge_coverage( const Creature &viewer, const tripoint_bub_ms &target_p ) const;
+        // TODO: Get rid of untyped override.
         int ledge_coverage( const tripoint &viewer_p, const tripoint &target_p,
+                            const float &eye_level = 1.0f ) const;
+        int ledge_coverage( const tripoint_bub_ms &viewer_p, const tripoint_bub_ms &target_p,
                             const float &eye_level = 1.0f ) const;
         /**
         * Returns coverage value of the tile.
         */
+        // TODO: Get rid of untyped overload.
         int coverage( const tripoint &p ) const;
+        int coverage( const tripoint_bub_ms &p ) const;
         /**
          * Check whether there's a direct line of sight between `F` and
          * `T` with the additional movecost restraints.
@@ -696,7 +748,11 @@ class map
          * 1. Checks if a point is reachable using a flood fill and if it is, adds it to a vector.
          *
          */
+        // TODO: Get rid of untyped overload.
         void reachable_flood_steps( std::vector<tripoint> &reachable_pts, const tripoint &f,
+                                    int range,
+                                    int cost_min, int cost_max ) const;
+        void reachable_flood_steps( std::vector<tripoint_bub_ms> &reachable_pts, const tripoint_bub_ms &f,
                                     int range,
                                     int cost_min, int cost_max ) const;
 
@@ -705,7 +761,10 @@ class map
          * until it finds a clear line or decides there isn't one.
          * returns the line found, which may be the straight line, but blocked.
          */
+        // TODO: get rid of untyped overload.
         std::vector<tripoint> find_clear_path( const tripoint &source, const tripoint &destination ) const;
+        std::vector<tripoint_bub_ms> find_clear_path( const tripoint_bub_ms &source,
+                const tripoint_bub_ms &destination ) const;
 
         /**
          * Check whether the player can access the items located @p. Certain furniture/terrain
@@ -719,7 +778,10 @@ class map
          * Points closer to the target come first.
          * This method leads to straighter lines and prevents weird looking movements away from the target.
          */
+        // TODO: Get rid of untyped overload.
         std::vector<tripoint> get_dir_circle( const tripoint &f, const tripoint &t ) const;
+        std::vector<tripoint_bub_ms> get_dir_circle( const tripoint_bub_ms &f,
+                const tripoint_bub_ms &t ) const;
 
         /**
          * Calculate the best path using A*
@@ -743,11 +805,15 @@ class map
 
         // Get a straight route from f to t, only along non-rough terrain. Returns an empty vector
         // if that is not possible.
+        // TODO: Get rid of untyped overload.
         std::vector<tripoint> straight_route( const tripoint &f, const tripoint &t ) const;
+        std::vector<tripoint_bub_ms> straight_route( const tripoint_bub_ms &f,
+                const tripoint_bub_ms &t ) const;
     private:
         // Pathfinding cost helper that computes the cost of moving into |p| from |cur|.
         // Includes climbing, bashing and opening doors.
-        int cost_to_pass( const tripoint &cur, const tripoint &p, const pathfinding_settings &settings,
+        int cost_to_pass( const tripoint_bub_ms &cur, const tripoint_bub_ms &p,
+                          const pathfinding_settings &settings,
                           pf_special p_special ) const;
         // Pathfinding cost helper that computes the cost of moving into |p|
         // from |cur| based on perceived danger.
@@ -802,7 +868,9 @@ class map
         optional_vpart_position veh_at( const tripoint_abs_ms &p ) const;
         optional_vpart_position veh_at( const tripoint_bub_ms &p ) const;
         vehicle *veh_at_internal( const tripoint &p, int &part_num );
+        // TODO: get rid of untyped overload.
         const vehicle *veh_at_internal( const tripoint &p, int &part_num ) const;
+        const vehicle *veh_at_internal( const tripoint_bub_ms &p, int &part_num ) const;
         // Put player on vehicle at x,y
         // TODO: get rid of untyped overload
         void board_vehicle( const tripoint &p, Character *pl );
@@ -812,17 +880,22 @@ class map
         void unboard_vehicle( const vpart_reference &, Character *passenger,
                               bool dead_passenger = false );
         // Remove passenger from vehicle at p.
+        // TODO: Get rid of untyped overload.
         void unboard_vehicle( const tripoint &p, bool dead_passenger = false );
+        void unboard_vehicle( const tripoint_bub_ms &p, bool dead_passenger = false );
         // Change vehicle coordinates and move vehicle's driver along.
         // WARNING: not checking collisions!
         // optionally: include a list of parts to displace instead of the entire vehicle
+        // TODO: Get rid of untyped overload.
         bool displace_vehicle( vehicle &veh, const tripoint &dp, bool adjust_pos = true,
+                               const std::set<int> &parts_to_move = {} );
+        bool displace_vehicle( vehicle &veh, const tripoint_rel_ms &dp, bool adjust_pos = true,
                                const std::set<int> &parts_to_move = {} );
         // make sure a vehicle that is split across z-levels is properly supported
         // calls displace_vehicle() and shouldn't be called from displace_vehicle
         void level_vehicle( vehicle &veh );
         // move water under wheels. true if moved
-        bool displace_water( const tripoint &dp );
+        bool displace_water( const tripoint_bub_ms &dp );
 
         // Returns the wheel area of the vehicle multiplied by traction of the surface
         // When ignore_movement_modifiers is set to true, it returns the area of the wheels touching the ground
@@ -840,21 +913,35 @@ class map
 
         // Actually moves the vehicle
         // Unlike displace_vehicle, this one handles collisions
+        // TODO: Get rid of untyped overload.
         vehicle *move_vehicle( vehicle &veh, const tripoint &dp, const tileray &facing );
+        vehicle *move_vehicle( vehicle &veh, const tripoint_rel_ms &dp, const tileray &facing );
 
         // Furniture
+        // TODO: Get rid of untyped overload.
         void set( const tripoint &p, const ter_id &new_terrain, const furn_id &new_furniture );
-        void set( const point &p, const ter_id &new_terrain, const furn_id &new_furniture ) {
+        void set( const tripoint_bub_ms &p, const ter_id &new_terrain, const furn_id &new_furniture );
+        // TODO: Get rid of untyped overload.
+        void set( const point_bub_ms &p, const ter_id &new_terrain, const furn_id &new_furniture ) {
             furn_set( p, new_furniture );
             ter_set( p, new_terrain );
+        }
+        void set( const point &p, const ter_id &new_terrain, const furn_id &new_furniture ) {
+            set( point_bub_ms( p ), new_terrain, new_furniture );
         }
         // TODO: fix point types (remove the first overload)
         std::string name( const tripoint &p );
         std::string name( const tripoint_bub_ms &p );
-        std::string name( const point &p ) {
-            return name( tripoint( p, abs_sub.z() ) );
+        // TODO: Get rid of untyped overload.
+        std::string name( const point_bub_ms &p ) {
+            return name( tripoint_bub_ms( p, abs_sub.z() ) );
         }
+        std::string name( const point &p ) {
+            return name( point_bub_ms( p ) );
+        }
+        // TODO: Get rid of untyped overload.
         std::string disp_name( const tripoint &p );
+        std::string disp_name( const tripoint_bub_ms &p );
         /**
         * Returns the name of the obstacle at p that might be blocking movement/projectiles/etc.
         * Note that this only accounts for vehicles, terrain, and furniture.
@@ -862,17 +949,25 @@ class map
         // TODO: Get rid of untyped overload.
         std::string obstacle_name( const tripoint &p );
         std::string obstacle_name( const tripoint_bub_ms &p );
+        // TODO: Get rid of untyped overload.
         bool has_furn( const tripoint &p ) const;
-        // TODO: fix point types (remove the first overload)
         bool has_furn( const tripoint_bub_ms &p ) const;
+        // TODO: fix point types (remove the untyped overload)
+        bool has_furn( const point_bub_ms &p ) const {
+            return has_furn( tripoint_bub_ms( p, abs_sub.z() ) );
+        }
         bool has_furn( const point &p ) const {
-            return has_furn( tripoint( p, abs_sub.z() ) );
+            return has_furn( tripoint_bub_ms( p.x, p.y, abs_sub.z() ) );
         }
         // TODO: fix point types (remove the first overload)
         furn_id furn( const tripoint &p ) const;
         furn_id furn( const tripoint_bub_ms &p ) const;
+        // TODO: Get rid of untyped overload.
+        furn_id furn( const point_bub_ms &p ) const {
+            return furn( tripoint_bub_ms( p, abs_sub.z() ) );
+        }
         furn_id furn( const point &p ) const {
-            return furn( tripoint( p, abs_sub.z() ) );
+            return furn( tripoint_bub_ms( p.x, p.y, abs_sub.z() ) );
         }
         /**
         * furn_reset should be true if new_furniture is being set to f_null
@@ -883,6 +978,7 @@ class map
                        bool avoid_creatures = false );
         bool furn_set( const tripoint_bub_ms &p, const furn_id &new_furniture,
                        bool furn_reset = false, bool avoid_creatures = false );
+        // TODO: Get rid of untyped overload.
         bool furn_set( const point &p, const furn_id &new_furniture,
                        bool avoid_creatures = false ) { // TODO: Get rid of untyped version.
             return furn_set( tripoint( p, abs_sub.z() ), new_furniture, false, avoid_creatures );
@@ -890,26 +986,34 @@ class map
         bool furn_set( const point_bub_ms &p, const furn_id &new_furniture, bool avoid_creatures = false ) {
             return furn_set( tripoint_bub_ms( p, abs_sub.z() ), new_furniture, false, avoid_creatures );
         }
-        void furn_clear( const tripoint &p ) {
+        // TODO: Get rid of untyped overload.
+        void furn_clear( const tripoint_bub_ms &p ) {
             furn_set( p, furn_str_id( "f_clear" ) );
         };
+        void furn_clear( const tripoint &p ) {
+            furn_clear( tripoint_bub_ms( p ) );
+        };
+        void furn_clear( const point_bub_ms &p ) {
+            furn_clear( tripoint_bub_ms( p, abs_sub.z() ) );
+        }
         void furn_clear( const point &p ) {
-            furn_clear( tripoint( p, abs_sub.z() ) );
+            furn_clear( point_bub_ms( p ) );
         }
         // TODO: fix point types (remove the first overload)
         std::string furnname( const tripoint &p );
         std::string furnname( const tripoint_bub_ms &p );
-        std::string furnname( const point &p ) {
-            return furnname( tripoint( p, abs_sub.z() ) );
-        }
         bool can_move_furniture( const tripoint_bub_ms &pos, Character *you = nullptr ) const;
 
         // Terrain
         // TODO: fix point types (remove the first overload)
         ter_id ter( const tripoint &p ) const;
         ter_id ter( const tripoint_bub_ms &p ) const;
+        // TODO: Get rid of untyped overload.
         ter_id ter( const point &p ) const {
             return ter( tripoint( p, abs_sub.z() ) );
+        }
+        ter_id ter( const point_bub_ms &p ) const {
+            return ter( tripoint_bub_ms( p, abs_sub.z() ) );
         }
 
         int get_map_damage( const tripoint_bub_ms &p ) const;
@@ -926,8 +1030,12 @@ class map
                                        const std::bitset<NUM_TERCONN> &connect_group,
                                        const std::map<tripoint_bub_ms, ter_id> &override = {} ) const;
         // as above, but for furniture
+        // TODO: Get rid of untyped overload.
         uint8_t get_known_connections_f( const tripoint &p, const std::bitset<NUM_TERCONN> &connect_group,
                                          const std::map<tripoint, furn_id> &override = {} ) const;
+        uint8_t get_known_connections_f( const tripoint_bub_ms &p,
+                                         const std::bitset<NUM_TERCONN> &connect_group,
+                                         const std::map<tripoint_bub_ms, furn_id> &override = {} ) const;
 
         // Return a bitfield of the adjacent tiles which rotate towards the given
         // connect_group.  From least-significant bit the order is south, east,
@@ -940,19 +1048,30 @@ class map
                                       const std::bitset<NUM_TERCONN> &rotate_to_group,
                                       const std::map<tripoint_bub_ms, ter_id> &override = {} ) const;
         // as above, but for furniture (considers neighbouring terrain and furniture)
+        // TODO: Get rid of untyped overload.
         uint8_t get_known_rotates_to_f( const tripoint &p, const std::bitset<NUM_TERCONN> &rotate_to_group,
                                         const std::map<tripoint, ter_id> &override = {},
                                         const std::map<tripoint, furn_id> &override_f = {} ) const;
+        uint8_t get_known_rotates_to_f( const tripoint_bub_ms &p,
+                                        const std::bitset<NUM_TERCONN> &rotate_to_group,
+                                        const std::map<tripoint_bub_ms, ter_id> &override = {},
+                                        const std::map<tripoint_bub_ms, furn_id> &override_f = {} ) const;
 
         /**
          * Returns the full harvest list, for spawning.
          */
+        // TODO: Get rid of untyped overload.
         const harvest_id &get_harvest( const tripoint &p ) const;
+        const harvest_id &get_harvest( const tripoint_bub_ms &p ) const;
         /**
          * Returns names of the items that would be dropped.
          */
+        // TODO: Get rid of untyped overload.
         const std::set<std::string> &get_harvest_names( const tripoint &p ) const;
+        const std::set<std::string> &get_harvest_names( const tripoint_bub_ms &p ) const;
+        // TODO: Get rid of untyped overload.
         ter_id get_ter_transforms_into( const tripoint &p ) const;
+        ter_id get_ter_transforms_into( const tripoint_bub_ms &p ) const;
 
         // TODO: fix point types (remove the first overload)
         bool ter_set( const tripoint &p, const ter_id &new_terrain, bool avoid_creatures = false );
@@ -1277,7 +1396,9 @@ class map
         void collapse_at( const tripoint_bub_ms &p, bool silent, bool was_supporting = false,
                           bool destroy_pos = true );
         /** Tries to smash the items at the given tripoint. Used by the explosion code */
+        // TODO: Get rid of untyped overload.
         void smash_items( const tripoint &p, int power, const std::string &cause_message );
+        void smash_items( const tripoint_bub_ms &p, int power, const std::string &cause_message );
         /**
          * Returns a pair where first is whether anything was smashed and second is if it was destroyed.
          *
@@ -1288,7 +1409,11 @@ class map
          * @param bash_floor Allow bashing the floor and the tile that supports it
          * @param bashing_vehicle Vehicle that should NOT be bashed (because it is doing the bashing)
          */
+        // TODO: Get rid of untyped overload.
         bash_params bash( const tripoint &p, int str, bool silent = false,
+                          bool destroy = false, bool bash_floor = false,
+                          const vehicle *bashing_vehicle = nullptr );
+        bash_params bash( const tripoint_bub_ms &p, int str, bool silent = false,
                           bool destroy = false, bool bash_floor = false,
                           const vehicle *bashing_vehicle = nullptr );
 
@@ -1373,7 +1498,9 @@ class map
         }
         // i_rem() methods that return values act like container::erase(),
         // returning an iterator to the next item after removal.
+        // TODO: Get rid of untyped overload.
         map_stack::iterator i_rem( const tripoint &p, const map_stack::const_iterator &it );
+        map_stack::iterator i_rem( const tripoint_bub_ms &p, const map_stack::const_iterator &it );
         map_stack::iterator i_rem( const point &location, const map_stack::const_iterator &it ) {
             return i_rem( tripoint( location, abs_sub.z() ), it );
         }
@@ -1697,7 +1824,9 @@ class map
          * removing if intensity becomes 0.
          * @return resulting intensity, or 0 for not present (either removed or not created at all).
          */
+        // TODO: Get rid of untyped overload.
         int mod_field_intensity( const tripoint &p, const field_type_id &type, int offset );
+        int mod_field_intensity( const tripoint_bub_ms &p, const field_type_id &type, int offset );
         /**
          * Set age of field entry at point.
          * @param p Location of field
@@ -1793,9 +1922,14 @@ class map
     public:
 
         // Splatters of various kind
+        // TODO: Get rid of untyped overload.
         void add_splatter( const field_type_id &type, const tripoint &where, int intensity = 1 );
+        void add_splatter( const field_type_id &type, const tripoint_bub_ms &where, int intensity = 1 );
         void add_splatter_trail( const field_type_id &type, const tripoint &from, const tripoint &to );
+        // TODO: Get rid of untyped overload.
         void add_splash( const field_type_id &type, const tripoint &center, int radius, int intensity );
+        void add_splash( const field_type_id &type, const tripoint_bub_ms &center, int radius,
+                         int intensity );
 
         void propagate_field( const tripoint &center, const field_type_id &type,
                               int amount, int max_intensity = 0 );
@@ -2023,7 +2157,9 @@ class map
         }
 
         /** Clips the coordinates of p to fit the map bounds */
+        // TODO: Get rid of untyped overload.
         void clip_to_bounds( tripoint &p ) const;
+        void clip_to_bounds( tripoint_bub_ms &p ) const;
         void clip_to_bounds( int &x, int &y ) const;
         void clip_to_bounds( int &x, int &y, int &z ) const;
 
@@ -2358,15 +2494,25 @@ class map
 
         // Internal methods used to bash just the selected features
         // Information on what to bash/what was bashed is read from/written to the bash_params struct
+        // TODO: Get rid of untyped overload.
         void bash_ter_furn( const tripoint &p, bash_params &params );
+        void bash_ter_furn( const tripoint_bub_ms &p, bash_params &params );
+        // TODO: Get rid of untyped overload.
         void bash_items( const tripoint &p, bash_params &params );
+        void bash_items( const tripoint_bub_ms &p, bash_params &params );
+        // TODO: Get rid of untyped overload.
         void bash_vehicle( const tripoint &p, bash_params &params );
+        void bash_vehicle( const tripoint_bub_ms &p, bash_params &params );
+        // TODO: Get rid of untyped overload.
         void bash_field( const tripoint &p, bash_params &params );
+        void bash_field( const tripoint_bub_ms &p, bash_params &params );
 
         // Gets the roof type of the tile at p
         // Second argument refers to whether we have to get a roof (we're over an unpassable tile)
         // or can just return air because we bashed down an entire floor tile
+        // TODO: Get rid of untyped overload.
         ter_str_id get_roof( const tripoint &p, bool allow_air ) const;
+        ter_str_id get_roof( const tripoint_bub_ms &p, bool allow_air ) const;
 
     public:
         void process_items();

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -448,7 +448,7 @@ Creature *melee_actor::find_target( monster &z ) const
 
     if( range > 1 ) {
         if( !z.sees( *target ) ||
-            !get_map().clear_path( z.pos(), target->pos(), range, 1, 200 ) ) {
+            !get_map().clear_path( z.pos_bub(), target->pos_bub(), range, 1, 200 ) ) {
             return nullptr;
         }
 
@@ -537,7 +537,7 @@ int melee_actor::do_grab( monster &z, Creature *target, bodypart_id bp_id ) cons
 
             if( foe != nullptr ) {
                 if( foe->in_vehicle ) {
-                    here.unboard_vehicle( foe->pos() );
+                    here.unboard_vehicle( foe->pos_bub() );
                 }
 
                 if( foe->is_avatar() && ( pt.x < HALF_MAPSIZE_X || pt.y < HALF_MAPSIZE_Y ||
@@ -629,7 +629,7 @@ int melee_actor::do_grab( monster &z, Creature *target, bodypart_id bp_id ) cons
                 }
                 if( foe != nullptr ) {
                     if( foe->in_vehicle ) {
-                        here.unboard_vehicle( foe->pos() );
+                        here.unboard_vehicle( foe->pos_bub() );
                     }
                     foe->setpos( zpt );
                     if( !foe->in_vehicle && here.veh_at( zpt ).part_with_feature( VPFLAG_BOARDABLE, true ) ) {

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1474,7 +1474,7 @@ std::optional<std::tuple<matec_id, attack_vector_id, sub_bodypart_str_id>>
     }
 
     // skip wall adjacent techniques if not next to a wall
-    if( tec_id->wall_adjacent && !get_map().is_wall_adjacent( pos() ) ) {
+    if( tec_id->wall_adjacent && !get_map().is_wall_adjacent( pos_bub() ) ) {
         add_msg_debug( debugmode::DF_MELEE, "No adjacent walls found, attack discarded" );
         return std::nullopt;
     }

--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -1327,7 +1327,7 @@ npc_ptr talk_function::individual_mission( const tripoint_abs_omt &omt_pos,
         }
     }
     if( comp->in_vehicle ) {
-        get_map().unboard_vehicle( comp->pos() );
+        get_map().unboard_vehicle( comp->pos_bub() );
     }
     popup( "%s %s", comp->get_name(), desc );
     comp->set_companion_mission( omt_pos, role_id, miss_id );

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -277,7 +277,7 @@ static Creature *sting_get_target( monster *z, float range = 5.0f )
 
     // Can't see/reach target, no attack
     if( !z->sees( *target ) ||
-        !get_map().clear_path( z->pos(), target->pos(), range, 1, 100 ) ) {
+        !get_map().clear_path( z->pos_bub(), target->pos_bub(), range, 1, 100 ) ) {
         return nullptr;
     }
 
@@ -789,7 +789,7 @@ bool mattack::acid( monster *z )
     map &here = get_map();
     // Can't see/reach target, no attack
     if( !z->sees( *target ) ||
-        !here.clear_path( z->pos(), target->pos(), 10, 1, 100 ) ) {
+        !here.clear_path( z->pos_bub(), target->pos_bub(), 10, 1, 100 ) ) {
         return false;
     }
     // It takes a while
@@ -1016,7 +1016,7 @@ bool mattack::pull_metal_weapon( monster *z )
     }
 
     // Can't see/reach target, no attack
-    if( !z->sees( *target ) || !get_map().clear_path( z->pos(), target->pos(),
+    if( !z->sees( *target ) || !get_map().clear_path( z->pos_bub(), target->pos_bub(),
             max_distance, 1, 100 ) ) {
         return false;
     }
@@ -1862,8 +1862,8 @@ bool mattack::triffid_heartbeat( monster *z )
     creature_tracker &creatures = get_creature_tracker();
     static pathfinding_settings root_pathfind( 10, 20, 50, 0, false, false, false, false, false,
             false );
-    if( rl_dist( z->pos(), player_character.pos() ) > 5 &&
-        !here.route( player_character.pos(), z->pos(), root_pathfind ).empty() ) {
+    if( rl_dist( z->pos_bub(), player_character.pos_bub() ) > 5 &&
+        !here.route( player_character.pos_bub(), z->pos_bub(), root_pathfind ).empty() ) {
         add_msg( m_warning, _( "The root walls creak around you." ) );
         for( const tripoint &dest : here.points_in_radius( z->pos(), 3 ) ) {
             if( g->is_empty( dest ) && one_in( 4 ) ) {
@@ -1874,7 +1874,7 @@ bool mattack::triffid_heartbeat( monster *z )
         }
         // Open blank tiles as long as there's no possible route
         int tries = 0;
-        while( here.route( player_character.pos(), z->pos(), root_pathfind ).empty() &&
+        while( here.route( player_character.pos_bub(), z->pos_bub(), root_pathfind ).empty() &&
                tries < 20 ) {
             point p( rng( player_character.posx(), z->posx() - 3 ),
                      rng( player_character.posy(), z->posy() - 3 ) );
@@ -3615,7 +3615,7 @@ void mattack::flame( monster *z, Creature *target )
         // friendly
         // It takes a while
         z->mod_moves( -to_moves<int>( 5_seconds ) );
-        if( !here.sees( z->pos(), target->pos(), dist ) ) {
+        if( !here.sees( z->pos_bub(), target->pos_bub(), dist ) ) {
             // shouldn't happen
             debugmsg( "mattack::flame invoked on invisible target" );
         }
@@ -3638,7 +3638,7 @@ void mattack::flame( monster *z, Creature *target )
 
     // It takes a while
     z->mod_moves( -to_moves<int>( 5_seconds ) );
-    if( !here.sees( z->pos(), target->pos(), dist + 1 ) ) {
+    if( !here.sees( z->pos_bub(), target->pos_bub(), dist + 1 ) ) {
         // shouldn't happen
         debugmsg( "mattack::flame invoked on invisible target" );
     }

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -563,7 +563,7 @@ void insert_battery( monster &z )
 bool Character::can_mount( const monster &critter ) const
 {
     const auto &avoid = get_path_avoid();
-    auto route = get_map().route( pos(), critter.pos(), get_pathfinding_settings(), avoid );
+    auto route = get_map().route( pos_bub(), critter.pos_bub(), get_pathfinding_settings(), avoid );
 
     if( route.empty() ) {
         return false;

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2944,7 +2944,7 @@ void monster::die( Creature *nkiller )
                 continue;
             }
 
-            if( here.sees( critter.pos(), pos(), light ) ) {
+            if( here.sees( critter.pos_bub(), pos_bub(), light ) ) {
                 // Anger trumps fear trumps ennui
                 if( critter.type->has_anger_trigger( mon_trigger::FRIEND_DIED ) ) {
                     critter.anger += 15;
@@ -3667,7 +3667,7 @@ void monster::on_hit( Creature *source, bodypart_id,
                 continue;
             }
 
-            if( here.sees( critter.pos(), pos(), light ) ) {
+            if( here.sees( critter.pos_bub(), pos_bub(), light ) ) {
                 // Anger trumps fear trumps ennui
                 if( critter.type->has_anger_trigger( mon_trigger::FRIEND_ATTACKED ) ) {
                     critter.anger += 15;

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2845,7 +2845,7 @@ void npc::die( Creature *nkiller )
     // Need to unboard from vehicle before dying, otherwise
     // the vehicle code cannot find us
     if( in_vehicle ) {
-        get_map().unboard_vehicle( pos(), true );
+        get_map().unboard_vehicle( pos_bub(), true );
     }
     if( is_mounted() ) {
         monster *critter = mounted_creature.get();
@@ -3162,11 +3162,11 @@ void npc::on_load()
     } else if( has_effect( effect_bouldering ) ) {
         remove_effect( effect_bouldering );
     }
-    if( here.veh_at( pos() ).part_with_feature( VPFLAG_BOARDABLE, true ) && !in_vehicle ) {
-        here.board_vehicle( pos(), this );
+    if( here.veh_at( pos_bub() ).part_with_feature( VPFLAG_BOARDABLE, true ) && !in_vehicle ) {
+        here.board_vehicle( pos_bub(), this );
     }
     if( has_effect( effect_riding ) && !mounted_creature ) {
-        if( const monster *const mon = get_creature_tracker().creature_at<monster>( pos() ) ) {
+        if( const monster *const mon = get_creature_tracker().creature_at<monster>( pos_bub() ) ) {
             mounted_creature = g->shared_from( *mon );
         } else {
             add_msg_debug( debugmode::DF_NPC,

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -801,7 +801,7 @@ void npc::assess_danger()
         if( &guy == this ) {
             continue;
         }
-        if( !clairvoyant && !here.has_potential_los( pos(), guy.pos() ) ) {
+        if( !clairvoyant && !here.has_potential_los( pos_bub(), guy.pos_bub() ) ) {
             continue;
         }
 
@@ -819,7 +819,7 @@ void npc::assess_danger()
     }
 
     for( const monster &critter : g->all_monsters() ) {
-        if( !clairvoyant && !here.has_potential_los( pos(), critter.pos() ) ) {
+        if( !clairvoyant && !here.has_potential_los( pos_bub(), critter.pos_bub() ) ) {
             continue;
         }
         Creature::Attitude att = critter.attitude_to( *this );
@@ -2875,7 +2875,8 @@ bool npc::can_move_to( const tripoint &p, bool no_bashing ) const
     // Allow moving into any bashable spots, but penalize them during pathing
     // Doors are not passable for hallucinations
     return( rl_dist( pos(), p ) <= 1 && here.has_floor_or_water( p ) && !g->is_dangerous_tile( p ) &&
-            ( here.passable( p ) || ( can_open_door( p, !here.is_outside( pos() ) ) && !is_hallucination() ) ||
+            ( here.passable( p ) || ( can_open_door( p, !here.is_outside( pos_bub() ) ) &&
+                                      !is_hallucination() ) ||
               ( !no_bashing && here.bash_rating( smash_ability(), p ) > 0 ) )
           );
 }

--- a/src/pathfinding.cpp
+++ b/src/pathfinding.cpp
@@ -166,22 +166,36 @@ static bool is_disjoint( const Set1 &set1, const Set2 &set2 )
 
 std::vector<tripoint> map::straight_route( const tripoint &f, const tripoint &t ) const
 {
-    std::vector<tripoint> ret;
+    const std::vector<tripoint_bub_ms> temp = map::straight_route( tripoint_bub_ms( f ),
+            tripoint_bub_ms( t ) );
+    std::vector<tripoint> result;
+
+    for( const tripoint_bub_ms pt : temp ) {
+        result.push_back( pt.raw() );
+    }
+
+    return result;
+}
+
+std::vector<tripoint_bub_ms> map::straight_route( const tripoint_bub_ms &f,
+        const tripoint_bub_ms &t ) const
+{
+    std::vector<tripoint_bub_ms> ret;
     if( f == t || !inbounds( f ) ) {
         return ret;
     }
     if( !inbounds( t ) ) {
-        tripoint clipped = t;
+        tripoint_bub_ms clipped = t;
         clip_to_bounds( clipped );
         return straight_route( f, clipped );
     }
-    if( f.z == t.z ) {
+    if( f.z() == t.z() ) {
         ret = line_to( f, t );
-        const pathfinding_cache &pf_cache = get_pathfinding_cache_ref( f.z );
+        const pathfinding_cache &pf_cache = get_pathfinding_cache_ref( f.z() );
         // Check all points for any special case (including just hard terrain)
-        if( std::any_of( ret.begin(), ret.end(), [&pf_cache]( const tripoint & p ) {
+        if( std::any_of( ret.begin(), ret.end(), [&pf_cache]( const tripoint_bub_ms & p ) {
         constexpr pf_special non_normal = PF_SLOW | PF_WALL | PF_VEHICLE | PF_TRAP | PF_SHARP;
-        return pf_cache.special[p.x][p.y] & non_normal;
+        return pf_cache.special[p.x()][p.y()] & non_normal;
         } ) ) {
             ret.clear();
         }
@@ -191,7 +205,8 @@ std::vector<tripoint> map::straight_route( const tripoint &f, const tripoint &t 
 
 static constexpr int PF_IMPASSABLE = -1;
 static constexpr int PF_IMPASSABLE_FROM_HERE = -2;
-int map::cost_to_pass( const tripoint &cur, const tripoint &p, const pathfinding_settings &settings,
+int map::cost_to_pass( const tripoint_bub_ms &cur, const tripoint_bub_ms &p,
+                       const pathfinding_settings &settings,
                        pf_special p_special ) const
 {
     constexpr pf_special non_normal = PF_SLOW | PF_WALL | PF_VEHICLE | PF_TRAP | PF_SHARP;
@@ -337,7 +352,7 @@ int map::cost_to_avoid( const tripoint & /*cur*/, const tripoint &p,
 int map::extra_cost( const tripoint &cur, const tripoint &p, const pathfinding_settings &settings,
                      pf_special p_special ) const
 {
-    int pass_cost = cost_to_pass( cur, p, settings, p_special );
+    int pass_cost = cost_to_pass( tripoint_bub_ms( cur ), tripoint_bub_ms( p ), settings, p_special );
     if( pass_cost < 0 ) {
         return pass_cost;
     }

--- a/src/pathfinding.cpp
+++ b/src/pathfinding.cpp
@@ -169,6 +169,7 @@ std::vector<tripoint> map::straight_route( const tripoint &f, const tripoint &t 
     const std::vector<tripoint_bub_ms> temp = map::straight_route( tripoint_bub_ms( f ),
             tripoint_bub_ms( t ) );
     std::vector<tripoint> result;
+    result.reserve( temp.size() );
 
     for( const tripoint_bub_ms pt : temp ) {
         result.push_back( pt.raw() );

--- a/src/scent_block.cpp
+++ b/src/scent_block.cpp
@@ -1,3 +1,4 @@
+#include "coordinates.h"
 #include "scent_block.h"
 
 scent_block::scent_block( const tripoint &sub, scent_map &scents )
@@ -43,9 +44,9 @@ void scent_block::commit_modifications()
 }
 
 // We should be working entirely within the range, so don't range check here
-void scent_block::apply_gas( const tripoint &p, const int nintensity )
+void scent_block::apply_gas( const tripoint_bub_ms &p, const int nintensity )
 {
-    const point ndx = index( p );
+    const point ndx = index( p.raw() );
     assignment[ndx.x][ndx.y].mode = data_mode::SET;
     assignment[ndx.x][ndx.y].intensity = std::max( 0, assignment[ndx.x][ndx.y].intensity - nintensity );
     ++modification_count;

--- a/src/scent_block.h
+++ b/src/scent_block.h
@@ -6,6 +6,7 @@
 #include <array>
 
 #include "coordinate_conversions.h"
+#include "coords_fwd.h"
 #include "point.h"
 #include "scent_map.h"
 
@@ -38,7 +39,7 @@ struct scent_block {
     }
 
     // We should be working entirely within the range, so don't range check here
-    void apply_gas( const tripoint &p, int nintensity = 0 );
+    void apply_gas( const tripoint_bub_ms &p, int nintensity = 0 );
     void apply_slime( const tripoint &p, int intensity );
 };
 

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -72,7 +72,7 @@ bool teleport::teleport_to_point( Creature &critter, tripoint target, bool safe,
         return false;
     }
     if( p && p->in_vehicle ) {
-        here.unboard_vehicle( p->pos() );
+        here.unboard_vehicle( p->pos_bub() );
     }
     map tm;
     map *dest = &here;

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -1606,7 +1606,7 @@ bool trapfunc::map_regen( const tripoint &p, Creature *c, item * )
                 return false;
             }
             set_queued_points();
-            here.set_seen_cache_dirty( p );
+            here.set_seen_cache_dirty( tripoint_bub_ms( p ) );
             here.set_transparency_cache_dirty( p.z );
             return true;
         }

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -175,7 +175,7 @@ void DefaultRemovePartHandler::removed( vehicle &veh, const int part )
     here.dirty_vehicle_list.insert( &veh );
     here.clear_vehicle_point_from_cache( &veh, part_pos.raw() );
     here.add_vehicle_to_cache( &veh );
-    here.memory_cache_dec_set_dirty( part_pos.raw(), true );
+    here.memory_cache_dec_set_dirty( part_pos, true );
     player_character.memorize_clear_decoration(
         here.getglobal( part_pos ), "vp_" + vp.info().id.str() );
 }
@@ -1809,7 +1809,7 @@ bool vehicle::merge_rackable_vehicle( vehicle *carry_veh, const std::vector<int>
         here.destroy_vehicle( carry_veh );
         here.dirty_vehicle_list.insert( this );
         here.set_transparency_cache_dirty( sm_pos.z );
-        here.set_seen_cache_dirty( tripoint_zero );
+        here.set_seen_cache_dirty( tripoint_bub_ms_zero );
         here.invalidate_map_cache( here.get_abs_sub().z() );
         here.rebuild_vehicle_level_caches();
     } else {
@@ -2526,7 +2526,7 @@ bool vehicle::split_vehicles( map &here,
 
         here.dirty_vehicle_list.insert( new_vehicle );
         here.set_transparency_cache_dirty( sm_pos.z );
-        here.set_seen_cache_dirty( tripoint_zero );
+        here.set_seen_cache_dirty( tripoint_bub_ms_zero );
         if( !new_labels.empty() ) {
             new_vehicle->labels = new_labels;
         }
@@ -7159,7 +7159,7 @@ void vehicle::unboard_all() const
     map &here = get_map();
     std::vector<int> bp = boarded_parts();
     for( const int &i : bp ) {
-        here.unboard_vehicle( global_part_pos3( i ) );
+        here.unboard_vehicle( bub_part_pos( i ) );
     }
 }
 

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -24,6 +24,7 @@
 #include "character_id.h"
 #include "clzones.h"
 #include "colony.h"
+#include "coordinate_constants.h"
 #include "coords_fwd.h"
 #include "damage.h"
 #include "game_constants.h"
@@ -2426,7 +2427,7 @@ class DefaultRemovePartHandler : public RemovePartHandler
         void set_transparency_cache_dirty( const int z ) override {
             map &here = get_map();
             here.set_transparency_cache_dirty( z );
-            here.set_seen_cache_dirty( tripoint_zero );
+            here.set_seen_cache_dirty( tripoint_bub_ms_zero );
         }
         void set_floor_cache_dirty( const int z ) override {
             get_map().set_floor_cache_dirty( z );

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1326,7 +1326,7 @@ void vehicle::open_or_close( const int part_index, const bool opening )
     map &here = get_map();
     here.set_transparency_cache_dirty( sm_pos.z );
     const tripoint part_location = mount_to_tripoint( parts[part_index].mount );
-    here.set_seen_cache_dirty( part_location );
+    here.set_seen_cache_dirty( tripoint_bub_ms( part_location ) );
     const int dist = rl_dist( get_player_character().pos(), part_location );
     if( dist < 20 ) {
         sfx::play_variant_sound( opening ? "vehicle_open" : "vehicle_close",

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -16,6 +16,7 @@
 #include "character.h"
 #include "city.h"
 #include "colony.h"
+#include "coordinate_constants.h"
 #include "coordinate_conversions.h"
 #include "coordinates.h"
 #include "creature.h"
@@ -935,7 +936,7 @@ void weather_manager::update_weather()
             for( int i = -OVERMAP_DEPTH; i <= OVERMAP_HEIGHT; i++ ) {
                 here.set_transparency_cache_dirty( i );
             }
-            here.set_seen_cache_dirty( tripoint_zero );
+            here.set_seen_cache_dirty( tripoint_bub_ms_zero );
         }
         if( weather_id != old_weather ) {
             effect_on_conditions::process_reactivate();

--- a/tests/archery_damage_test.cpp
+++ b/tests/archery_damage_test.cpp
@@ -33,13 +33,13 @@
 static void test_projectile_hitting_wall( const std::string &target_type, bool smashable,
         dealt_projectile_attack &attack, const std::string &weapon_type )
 {
-    static const tripoint target_point{ 5, 5, 0 };
+    static const tripoint_bub_ms target_point{ 5, 5, 0 };
     map &here = get_map();
     for( int i = 0; i < 10; ++i ) {
         projectile projectile_copy = attack.proj;
         here.set( target_point, ter_id( target_type ), furn_id( "f_null" ) );
         CAPTURE( projectile_copy.impact.total_damage() );
-        here.shoot( target_point, projectile_copy, false );
+        here.shoot( target_point.raw(), projectile_copy, false );
         CAPTURE( target_type );
         CAPTURE( weapon_type );
         CAPTURE( ter_id( target_type ).obj().name() );

--- a/tests/char_suffer_test.cpp
+++ b/tests/char_suffer_test.cpp
@@ -511,8 +511,8 @@ TEST_CASE( "suffering_from_asphyxiation", "[char][suffer][oxygen][grab]" )
         WHEN( "crushed against two walls by two grabbers" ) {
             here.ter_set( dummy.pos() + tripoint_south, ter_t_rock_wall );
             here.ter_set( dummy.pos() + tripoint_north, ter_t_rock_wall );
-            REQUIRE( here.impassable( dummy.pos() + tripoint_south ) );
-            REQUIRE( here.impassable( dummy.pos() + tripoint_north ) );
+            REQUIRE( here.impassable( dummy.pos_bub() + tripoint_south ) );
+            REQUIRE( here.impassable( dummy.pos_bub() + tripoint_north ) );
 
             THEN( "they lose 1 oxygen per turn, just like four grabbers" ) {
                 test_suffer( dummy, 10_turns, true );

--- a/tests/field_test.cpp
+++ b/tests/field_test.cpp
@@ -169,7 +169,7 @@ TEST_CASE( "fd_acid_falls_down", "[field]" )
 {
     fields_test_setup();
 
-    const tripoint p{ 33, 33, 0 };
+    const tripoint_bub_ms p{ 33, 33, 0 };
     map &m = get_map();
 
     m.add_field( p, fd_acid, 3 );

--- a/tests/map_helpers.cpp
+++ b/tests/map_helpers.cpp
@@ -62,7 +62,7 @@ void wipe_map_terrain( map *target )
         ter_id terrain = z == 0 ? ter_t_grass : z < 0 ? ter_t_rock : ter_t_open_air;
         for( int x = 0; x < mapsize; ++x ) {
             for( int y = 0; y < mapsize; ++y ) {
-                here.set( { x, y, z}, terrain, furn_str_id::NULL_ID() );
+                here.set( tripoint_bub_ms{ x, y, z}, terrain, furn_str_id::NULL_ID() );
                 here.partial_con_remove( { x, y, z } );
             }
         }

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -31,10 +31,10 @@ TEST_CASE( "map_coordinate_conversion_functions" )
 
     // Make sure we're not in the 'easy' case where abs_sub is zero
     if( here.get_abs_sub().x() == 0 ) {
-        here.shift( point_east );
+        here.shift( point_rel_sm_east );
     }
     if( here.get_abs_sub().y() == 0 ) {
-        here.shift( point_south );
+        here.shift( point_rel_sm_south );
     }
     here.vertical_shift( z );
 

--- a/tests/mapgen_remove_vehicles_test.cpp
+++ b/tests/mapgen_remove_vehicles_test.cpp
@@ -27,11 +27,11 @@ void check_vehicle_still_works( vehicle &veh )
     veh.engine_on = true;
     veh.velocity = 1000;
     veh.cruise_velocity = veh.velocity;
-    tripoint const startp = veh.global_pos3();
+    tripoint_bub_ms const startp = veh.pos_bub();
     here.vehmove();
-    REQUIRE( veh.global_pos3() != startp );
+    REQUIRE( veh.pos_bub() != startp );
 
-    here.displace_vehicle( veh, startp - veh.global_pos3() );
+    here.displace_vehicle( veh, startp - veh.pos_bub() );
 }
 
 vehicle *add_test_vehicle( map &m, tripoint loc )

--- a/tests/vehicle_drag_test.cpp
+++ b/tests/vehicle_drag_test.cpp
@@ -41,8 +41,8 @@ static void clear_game_drag( const ter_id &terrain )
 
     map &here = get_map();
     // hard force a rebuild of caches
-    here.shift( point_south );
-    here.shift( point_north );
+    here.shift( point_rel_sm_south );
+    here.shift( point_rel_sm_north );
 }
 
 static vehicle *setup_drag_test( const vproto_id &veh_id )

--- a/tests/vehicle_part_test.cpp
+++ b/tests/vehicle_part_test.cpp
@@ -234,7 +234,7 @@ TEST_CASE( "faucet_offers_cold_water", "[vehicle][vehicle_parts]" )
         }
     }
     REQUIRE( faucet.has_value() );
-    get_map().board_vehicle( faucet->pos() + tripoint_east, &character );
+    get_map().board_vehicle( faucet->pos_bub() + tripoint_east, &character );
     veh_menu menu( veh, "TEST" );
     for( int i = 0; i < water_charges; i++ ) {
         CAPTURE( i, veh.fuel_left( itype_water_clean ) );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
- Change some of map.h/cpp from using unspecified coordinates to typed ones.
- Changed a blatantly incorrect call to get_local_windpower in map::spread_gas where a bubble coordinate was simply cast to an absolute one and fed into that operation. The casting was replaced by a call to getglobal to actually convert the coordinate.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Go through map.h and replace/complement untyped coordinate operations with typed ones modifying some other operations to match along the way (including some switching to the new operations).

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Started a save, walked down stairs with the companion, went into a car and drove a short bit. The changes should not change anything*.

* Except for the bug where a reality bubble coordinate was brazenly cast into an absolute one to fit into an operation. That call was converted into calling the operation that converts a bubble coordinate to an absolute one and fed it into the operation. I don't know where it's called so I can't test it, but whoever wrote the code didn't test it too well either..
In the worst case using proper coordinates unlocks an infinite recursion resulting in a crash like the last time. In a more normal bad case smoke is (still) drifting in the wrong direction, and in the best case it drifts in the direction of the wind at that location rather than the wind of somewhere close to absolute coordinate origo.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
