### PR TITLE
Fix conjunctivitis duration stacking and eyedrops

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -2106,7 +2106,6 @@
     "rating": "bad",
     "resist_traits": [ "POISRESIST", "PER_SLIME_OK" ],
     "immune_flags": [ "POISIMMUNE", "SEESLEEP" ],
-    "int_dur_factor": "50 m",
     "base_mods": { "per_mod": [ -1 ], "pain_min": [ 1 ], "pain_chance": [ 400, 1000 ] },
     "limb_score_mods": [ { "limb_score": "vision", "modifier": 0.85, "resist_modifier": 0.925 } ],
     "miss_messages": [ [ "It feels like there's sand in your eye.", 1 ] ],

--- a/data/json/effects_on_condition/misc_effect_on_condition.json
+++ b/data/json/effects_on_condition/misc_effect_on_condition.json
@@ -210,7 +210,10 @@
       ]
     },
     "effect": [
-      { "if": { "u_has_effect": "conjunctivitis", "bodypart": "eyes" }, "then": { "u_lose_effect": "conjunctivitis" } },
+      {
+        "if": { "u_has_effect": "conjunctivitis", "bodypart": "eyes" },
+        "then": { "u_lose_effect": "conjunctivitis", "target_part": "eyes" }
+      },
       {
         "u_add_effect": "conjunctivitis",
         "duration": { "math": [ "( 1 - u_coverage('eyes') / 100 ) * rand(259200) + 172800" ] },

--- a/data/json/effects_on_condition/misc_effect_on_condition.json
+++ b/data/json/effects_on_condition/misc_effect_on_condition.json
@@ -202,7 +202,6 @@
       "and": [
         { "compare_string": [ "boomered", { "context_val": "effect" } ] },
         { "compare_string": [ "eyes", { "context_val": "bodypart" } ] },
-        { "not": { "u_has_effect": "conjunctivitis" } },
         { "not": { "u_has_trait": "COMPOUND_EYES" } },
         { "not": { "u_has_trait": "SEESLEEP" } },
         { "not": { "u_has_bionics": "armor_bio_eyes" } },
@@ -211,6 +210,7 @@
       ]
     },
     "effect": [
+      { "if": { "u_has_effect": "conjunctivitis", "bodypart": "eyes" }, "then": { "u_lose_effect": "conjunctivitis" } },
       {
         "u_add_effect": "conjunctivitis",
         "duration": { "math": [ "( 1 - u_coverage('eyes') / 100 ) * rand(259200) + 172800" ] },

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -676,8 +676,8 @@ std::optional<int> iuse::eyedrops( Character *p, item *it, const tripoint & )
         p->remove_effect( effect_boomered );
         p->add_msg_if_player( m_good, _( "You wash the slime from your eyes." ) );
     }
-    if( p->has_effect( effect_conjunctivitis ) ) {
-        effect &eff = p->get_effect( effect_conjunctivitis );
+    if( p->has_effect( effect_conjunctivitis, bodypart_id( "eyes" ) ) ) {
+        effect &eff = p->get_effect( effect_conjunctivitis, bodypart_id( "eyes" ) );
         if( eff.get_duration() > 2_days ) {
             p->add_msg_if_player( m_good, _( "You wash some of the chemical irritant from your eyes." ) );
             eff.set_duration( 2_days );

--- a/tests/iuse_test.cpp
+++ b/tests/iuse_test.cpp
@@ -53,6 +53,9 @@ static const morale_type morale_wet( "morale_wet" );
 TEST_CASE( "eyedrops", "[iuse][eyedrops]" )
 {
     avatar dummy;
+    //Give eyes to our dummy
+    dummy.set_body();
+    REQUIRE( dummy.has_part( bodypart_id( "eyes" ) ) );
     dummy.normalize();
 
     item eyedrops( "saline", calendar::turn_zero, item::default_charges_tag{} );
@@ -81,9 +84,9 @@ TEST_CASE( "eyedrops", "[iuse][eyedrops]" )
     REQUIRE( charges_before > 0 );
 
     GIVEN( "avatar gets conjunctivitis" ) {
-        dummy.add_effect( effect_conjunctivitis, 72_hours );
-        REQUIRE( dummy.has_effect( effect_conjunctivitis ) );
-        REQUIRE( dummy.get_effect_dur( effect_conjunctivitis ) > 48_hours );
+        dummy.add_effect( effect_conjunctivitis, 72_hours, bodypart_id( "eyes" ) );
+        REQUIRE( dummy.has_effect( effect_conjunctivitis, bodypart_id( "eyes" ) ) );
+        REQUIRE( dummy.get_effect_dur( effect_conjunctivitis, bodypart_id( "eyes" ) ) > 48_hours );
 
         WHEN( "they use eye drops" ) {
             dummy.consume( eyedrops );
@@ -92,7 +95,7 @@ TEST_CASE( "eyedrops", "[iuse][eyedrops]" )
                 CHECK( eyedrops.charges == charges_before - 1 );
 
                 AND_THEN( "it shortens the duration of conjunctivitis" ) {
-                    CHECK( dummy.get_effect_dur( effect_conjunctivitis ) <= 48_hours );
+                    CHECK( dummy.get_effect_dur( effect_conjunctivitis, bodypart_id( "eyes" ) ) <= 48_hours );
                 }
             }
         }

--- a/tests/iuse_test.cpp
+++ b/tests/iuse_test.cpp
@@ -63,6 +63,10 @@ TEST_CASE( "eyedrops", "[iuse][eyedrops]" )
     GIVEN( "avatar is boomered" ) {
         dummy.add_effect( effect_boomered, 1_hours );
         REQUIRE( dummy.has_effect( effect_boomered ) );
+        dummy.process_effects();
+        REQUIRE( dummy.has_effect( effect_conjunctivitis ) );
+        const time_duration conjunctivitis_clock = dummy.get_effect_dur( effect_conjunctivitis );
+        REQUIRE( conjunctivitis_clock > 48_hours );
 
         WHEN( "they use eye drops" ) {
             dummy.consume( eyedrops );
@@ -74,10 +78,6 @@ TEST_CASE( "eyedrops", "[iuse][eyedrops]" )
                     CHECK_FALSE( dummy.has_effect( effect_boomered ) );
                 }
 
-                REQUIRE( dummy.has_effect( effect_conjunctivitis ) );
-                const time_duration conjunctivitis_clock = dummy.get_effect_dur( effect_conjunctivitis );
-                REQUIRE( conjunctivitis_clock > 48_hours );
-                dummy.process_effects();
                 THEN( "duration of conjunctivitis shortens" ) {
                     CHECK( conjunctivitis_clock > dummy.get_effect_dur( effect_conjunctivitis ) );
                 }

--- a/tests/iuse_test.cpp
+++ b/tests/iuse_test.cpp
@@ -76,10 +76,10 @@ TEST_CASE( "eyedrops", "[iuse][eyedrops]" )
             }
         }
     }
-    
+
     charges_before = eyedrops.charges;
     REQUIRE( charges_before > 0 );
-    
+
     GIVEN( "avatar gets conjunctivitis" ) {
         dummy.add_effect( effect_conjunctivitis, 72_hours );
         REQUIRE( dummy.has_effect( effect_conjunctivitis ) );
@@ -100,7 +100,7 @@ TEST_CASE( "eyedrops", "[iuse][eyedrops]" )
 
     charges_before = eyedrops.charges;
     REQUIRE( charges_before > 0 );
-    
+
     GIVEN( "avatar is underwater" ) {
         dummy.set_underwater( true );
 

--- a/tests/iuse_test.cpp
+++ b/tests/iuse_test.cpp
@@ -18,6 +18,7 @@ static const efftype_id effect_asthma( "asthma" );
 static const efftype_id effect_bloodworms( "bloodworms" );
 static const efftype_id effect_boomered( "boomered" );
 static const efftype_id effect_brainworms( "brainworms" );
+static const efftype_id effect_conjunctivitis( "conjunctivitis" );
 static const efftype_id effect_cureall( "cureall" );
 static const efftype_id effect_dermatik( "dermatik" );
 static const efftype_id effect_fungus( "fungus" );
@@ -71,6 +72,13 @@ TEST_CASE( "eyedrops", "[iuse][eyedrops]" )
 
                 AND_THEN( "it removes the boomered effect" ) {
                     CHECK_FALSE( dummy.has_effect( effect_boomered ) );
+                }
+
+                const time_duration conjunctivitis_clock = dummy.get_effect_dur( effect_conjunctivitis );
+                REQUIRE( conjunctivitis_clock > 48_hours );
+                dummy.process_effects();
+                THEN( "duration of conjunctivitis shortens" ) {
+                    CHECK( conjunctivitis_clock > dummy.get_effect_dur( effect_conjunctivitis ) );
                 }
             }
         }

--- a/tests/iuse_test.cpp
+++ b/tests/iuse_test.cpp
@@ -63,10 +63,6 @@ TEST_CASE( "eyedrops", "[iuse][eyedrops]" )
     GIVEN( "avatar is boomered" ) {
         dummy.add_effect( effect_boomered, 1_hours );
         REQUIRE( dummy.has_effect( effect_boomered ) );
-        dummy.process_effects();
-        REQUIRE( dummy.has_effect( effect_conjunctivitis ) );
-        const time_duration conjunctivitis_clock = dummy.get_effect_dur( effect_conjunctivitis );
-        REQUIRE( conjunctivitis_clock > 48_hours );
 
         WHEN( "they use eye drops" ) {
             dummy.consume( eyedrops );
@@ -77,14 +73,34 @@ TEST_CASE( "eyedrops", "[iuse][eyedrops]" )
                 AND_THEN( "it removes the boomered effect" ) {
                     CHECK_FALSE( dummy.has_effect( effect_boomered ) );
                 }
+            }
+        }
+    }
+    
+    charges_before = eyedrops.charges;
+    REQUIRE( charges_before > 0 );
+    
+    GIVEN( "avatar gets conjunctivitis" ) {
+        dummy.add_effect( effect_conjunctivitis, 72_hours );
+        REQUIRE( dummy.has_effect( effect_conjunctivitis ) );
+        REQUIRE( dummy.get_effect_dur( effect_conjunctivitis ) > 48_hours );
 
-                THEN( "duration of conjunctivitis shortens" ) {
-                    CHECK( conjunctivitis_clock > dummy.get_effect_dur( effect_conjunctivitis ) );
+        WHEN( "they use eye drops" ) {
+            dummy.consume( eyedrops );
+
+            THEN( "one dose is depleted" ) {
+                CHECK( eyedrops.charges == charges_before - 1 );
+
+                AND_THEN( "it shortens the duration of conjunctivitis" ) {
+                    CHECK( dummy.get_effect_dur( effect_conjunctivitis ) <= 48_hours );
                 }
             }
         }
     }
 
+    charges_before = eyedrops.charges;
+    REQUIRE( charges_before > 0 );
+    
     GIVEN( "avatar is underwater" ) {
         dummy.set_underwater( true );
 

--- a/tests/iuse_test.cpp
+++ b/tests/iuse_test.cpp
@@ -74,6 +74,7 @@ TEST_CASE( "eyedrops", "[iuse][eyedrops]" )
                     CHECK_FALSE( dummy.has_effect( effect_boomered ) );
                 }
 
+                REQUIRE( dummy.has_effect( effect_conjunctivitis ) );
                 const time_duration conjunctivitis_clock = dummy.get_effect_dur( effect_conjunctivitis );
                 REQUIRE( conjunctivitis_clock > 48_hours );
                 dummy.process_effects();


### PR DESCRIPTION
#### Summary
Bugfixes "Fix conjunctivitis duration stacking and eyedrops"

#### Purpose of change

The duration of conjunctivitis was accumulating for every boomer bile splash eaten. Also, eyedrops weren't doing anything.

#### Describe the solution

Make the EOC remove conjunctivitis if it exists before reapplying it. Fix the eyedrops, and add conjunctivitis to the eyedrops test.

#### Describe alternatives you've considered

Letting the bile accumulate.

#### Testing

I verified that the conjunctivitis duration was stacking, then verified that it wasn't anymore. The eyedrops test will verify that it is functional.