### PR TITLE
[MoM] Add gremlin, a Nether-touched fox, plus small monster tweaks

### DIFF
--- a/data/mods/MindOverMatter/effectoncondition/eoc_on_power_use_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_on_power_use_events.json
@@ -587,6 +587,9 @@
           "+=",
           "rng( 3,8 ) * (u_vitamin('vitamin_maintained_powers')) / (( u_val('intelligence') / 4) + (u_bonus_concentration_powers) + (concentration_trait_bonuses()))"
         ]
+      },
+      {
+        "math": [ "u_skill_exp('metaphysics', 'format': 'raw')", "+=", "(15 * u_latest_channeled_power_difficulty)" ]
       }
     ],
     "false_effect": [
@@ -597,6 +600,9 @@
           "EOC_NETHER_ATTUNEMENT_FEEDBACK_CHECK_CONCENTRATION",
           "EOC_CONCENTRATION_SUCCESS_REDUCE_FOCUS"
         ]
+      },
+      {
+        "math": [ "u_skill_exp('metaphysics', 'format': 'raw')", "+=", "(75 * u_latest_channeled_power_difficulty)" ]
       }
     ]
   },

--- a/data/mods/MindOverMatter/effectoncondition/eoc_on_power_use_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_on_power_use_events.json
@@ -587,9 +587,6 @@
           "+=",
           "rng( 3,8 ) * (u_vitamin('vitamin_maintained_powers')) / (( u_val('intelligence') / 4) + (u_bonus_concentration_powers) + (concentration_trait_bonuses()))"
         ]
-      },
-      {
-        "math": [ "u_skill_exp('metaphysics', 'format': 'raw')", "+=", "(15 * u_latest_channeled_power_difficulty)" ]
       }
     ],
     "false_effect": [
@@ -600,9 +597,6 @@
           "EOC_NETHER_ATTUNEMENT_FEEDBACK_CHECK_CONCENTRATION",
           "EOC_CONCENTRATION_SUCCESS_REDUCE_FOCUS"
         ]
-      },
-      {
-        "math": [ "u_skill_exp('metaphysics', 'format': 'raw')", "+=", "(75 * u_latest_channeled_power_difficulty)" ]
       }
     ]
   },

--- a/data/mods/MindOverMatter/monstergroups/monstergroups_edited.json
+++ b/data/mods/MindOverMatter/monstergroups/monstergroups_edited.json
@@ -191,7 +191,10 @@
   {
     "type": "monstergroup",
     "name": "GROUP_WILDERNESS_FOREST_MAMMAL_WINTER",
-    "monsters": [ { "monster": "mon_hidebehind", "weight": 1, "starts": "21 days", "cost_multiplier": 10 } ]
+    "monsters": [
+      { "monster": "mon_hidebehind", "weight": 1, "starts": "21 days", "cost_multiplier": 10 },
+      { "monster": "mon_psi_gremlin", "weight": 1, "starts": "21 days", "cost_multiplier": 10 }
+    ]
   },
   {
     "name": "GROUP_COWS",
@@ -202,6 +205,18 @@
     "name": "GROUP_COWS_DAIRY",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_hodag", "weight": 10, "starts": "14 days", "cost_multiplier": 20 } ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_FOREST",
+    "default": "mon_null",
+    "is_animal": true,
+    "monsters": [
+      { "group": "GROUP_ANIMAL_PSIONS", "weight": 15, "cost_multiplier": 5 },
+      { "group": "GROUP_ANIMAL_PSIONS", "weight": 15, "starts": "14 days", "cost_multiplier": 5 },
+      { "group": "GROUP_ANIMAL_PSIONS", "weight": 15, "starts": "28 days", "cost_multiplier": 5 },
+      { "group": "GROUP_ANIMAL_PSIONS", "weight": 15, "starts": "90 days", "cost_multiplier": 5 }
+    ]
   },
   {
     "type": "monstergroup",
@@ -218,21 +233,20 @@
     "name": "GROUP_ROOF_ANIMAL",
     "default": "mon_null",
     "is_animal": true,
-    "monsters": [ { "monster": "mon_cockatrice", "weight": 2, "starts": "10 days", "cost_multiplier": 2 } ]
-  },
-  {
-    "type": "monstergroup",
-    "name": "GROUP_ROOF_ANIMAL",
-    "default": "mon_null",
-    "is_animal": true,
-    "monsters": [ { "monster": "mon_cockatrice", "weight": 10, "starts": "10 days", "cost_multiplier": 10, "pack_size": [ 3, 5 ] } ]
+    "monsters": [
+      { "monster": "mon_cockatrice", "weight": 2, "starts": "10 days", "cost_multiplier": 2 },
+      { "monster": "mon_cockatrice", "weight": 10, "starts": "10 days", "cost_multiplier": 10, "pack_size": [ 3, 5 ] }
+    ]
   },
   {
     "type": "monstergroup",
     "name": "GROUP_SAFE",
     "default": "mon_null",
     "is_animal": true,
-    "monsters": [ { "monster": "mon_cockatrice", "weight": 2, "starts": "10 days" } ]
+    "monsters": [
+      { "monster": "mon_cockatrice", "weight": 2, "starts": "10 days" },
+      { "monster": "mon_psi_gremlin", "weight": 2, "starts": "21 days" }
+    ]
   },
   {
     "type": "monstergroup",

--- a/data/mods/MindOverMatter/monstergroups/monstergroups_new.json
+++ b/data/mods/MindOverMatter/monstergroups/monstergroups_new.json
@@ -1,5 +1,22 @@
 [
   {
+    "name": "GROUP_ANIMAL_PSIONS",
+    "type": "monstergroup",
+    "default": "mon_null",
+    "is_animal": true,
+    "monsters": [
+      { "monster": "mon_hidebehind", "weight": 20 },
+      { "monster": "mon_psi_gremlin", "weight": 100 },
+      { "monster": "mon_psi_gremlin", "weight": 15, "pack_size": [ 2, 3 ] },
+      { "monster": "mon_cockatrice", "weight": 75 },
+      { "monster": "mon_cockatrice", "weight": 10, "pack_size": [ 3, 5 ] },
+      { "monster": "mon_hodag", "weight": 10 },
+      { "monster": "mon_bandersnatch", "weight": 5 },
+      { "monster": "mon_fear_hawk", "weight": 10 },
+      { "monster": "mon_cockatrice", "weight": 2, "pack_size": [ 2, 2 ] }
+    ]
+  },
+  {
     "name": "GROUP_FERAL_PSYCHIC",
     "type": "monstergroup",
     "monsters": [

--- a/data/mods/MindOverMatter/monsters/animal_psychics.json
+++ b/data/mods/MindOverMatter/monsters/animal_psychics.json
@@ -300,7 +300,7 @@
     "looks_like": "mon_fox_red",
     "name": { "str": "gremlin" },
     "//": "A Nether-affected fox",
-    "description": "The red fox, an omnivorous canine and largest of the true foxes, it is a wily hunter with a combative, suspicious temperament.  Sparks occasionally crackle over its fur and its distorts oddly as it moves, covering more ground with each stride than the length of its legs would indicate.",
+    "description": "The red fox, an omnivorous canine and largest of the true foxes, it is a wily hunter with a combative, suspicious temperament.  Sparks occasionally crackle over its fur and its body distorts oddly as it moves, covering more ground with each stride than the length of its legs would indicate.",
     "speed": 170,
     "dodge": 7,
     "special_attacks": [

--- a/data/mods/MindOverMatter/monsters/animal_psychics.json
+++ b/data/mods/MindOverMatter/monsters/animal_psychics.json
@@ -37,10 +37,19 @@
         "miss_msg_npc": "",
         "no_dmg_msg_u": "",
         "no_dmg_msg_npc": ""
+      },
+      {
+        "id": "psi_bandersnatch_inertial_barrier",
+        "type": "spell",
+        "spell_data": { "id": "telekinetic_barrier_monster" },
+        "cooldown": 1,
+        "condition": {
+          "and": [ { "not": { "u_has_effect": "effect_psi_null" } }, { "not": { "u_has_effect": "effect_monster_inertial_barrier" } } ]
+        },
+        "monster_message": "The air around %1$s distorts."
       }
     ],
-    "armor": { "bash": 10, "electric": 1, "bullet": 40, "psi_telekinetic_damage": 35 },
-    "extend": { "flags": [ "CLIMBS" ] }
+    "extend": { "flags": [ "CLIMBS" ], "armor": { "psi_telekinetic_damage": 35 } }
   },
   {
     "id": "mon_fear_hawk",
@@ -283,5 +292,29 @@
       "KEEP_DISTANCE",
       "HARDTOSHOOT"
     ]
+  },
+  {
+    "id": "mon_psi_gremlin",
+    "copy-from": "mon_fox_red",
+    "type": "MONSTER",
+    "looks_like": "mon_fox_red",
+    "name": { "str": "gremlin" },
+    "//": "A Nether-affected fox",
+    "description": "The red fox, an omnivorous canine and largest of the true foxes, it is a wily hunter with a combative, suspicious temperament.  Sparks occasionally crackle over its fur and its distorts oddly as it moves, covering more ground with each stride than the length of its legs would indicate.",
+    "speed": 170,
+    "dodge": 7,
+    "special_attacks": [
+      {
+        "id": "psi_gremlin_power_draining_spell",
+        "type": "spell",
+        "spell_data": { "id": "electrokinetic_power_draining" },
+        "cooldown": { "math": [ "rand(10) + 15" ] },
+        "allow_no_target": true,
+        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "monster_message": "Sparks flicker over %1$'s fur."
+      }
+    ],
+    "armor": { "electric": 40 },
+    "special_when_hit": [ "ZAPBACK", 75 ]
   }
 ]

--- a/data/mods/MindOverMatter/monsters/animal_psychics.json
+++ b/data/mods/MindOverMatter/monsters/animal_psychics.json
@@ -308,10 +308,10 @@
         "id": "psi_gremlin_power_draining_spell",
         "type": "spell",
         "spell_data": { "id": "electrokinetic_power_draining" },
-        "cooldown": { "math": [ "rand(10) + 15" ] },
+        "cooldown": { "math": [ "rand(45) + 5" ] },
         "allow_no_target": true,
         "condition": { "not": { "u_has_effect": "effect_psi_null" } },
-        "monster_message": "Sparks flicker over %1$'s fur."
+        "monster_message": "Sparks flicker over %1$s's fur."
       }
     ],
     "armor": { "electric": 40 },

--- a/data/mods/MindOverMatter/monsters/monster_eoc_spells.json
+++ b/data/mods/MindOverMatter/monsters/monster_eoc_spells.json
@@ -281,21 +281,32 @@
           {
             "id": "EOC_ELECTRONKINETIC_MONSTER_POWER_DRAINING_CHARACTER_CHECK",
             "condition": { "x_in_y_chance": { "x": 1, "y": 3 } },
-            "effect": {
-              "u_run_inv_eocs": "random",
-              "search_data": [
-                { "flags": [ "RECHARGE" ] },
-                { "flags": [ "ELECTRONIC" ] },
-                { "flags": [ "ELECTROKINETIC_CHARGEABLE" ] },
-                { "flags": [ "USE_UPS" ] }
-              ],
-              "true_eocs": [
-                {
-                  "id": "EOC_ELECTRONKINETIC_MONSTER_POWER_DRAINING_INV_RESULT",
-                  "effect": [ { "math": [ "n_val('power')", "-=", "rand(200) + 50" ] } ]
-                }
-              ]
-            }
+            "effect": [
+              {
+                "run_eocs": [
+                  {
+                    "id": "EOC_ELECTRONKINETIC_MONSTER_POWER_DRAINING_ELECTROKINETIC_CHECK",
+                    "condition": { "not": { "u_has_effect": "effect_electrokin_personal_battery" } },
+                    "effect": {
+                      "u_run_inv_eocs": "random",
+                      "search_data": [
+                        { "flags": [ "RECHARGE" ] },
+                        { "flags": [ "ELECTRONIC" ] },
+                        { "flags": [ "ELECTROKINETIC_CHARGEABLE" ] },
+                        { "flags": [ "USE_UPS" ] }
+                      ],
+                      "true_eocs": [
+                        {
+                          "id": "EOC_ELECTRONKINETIC_MONSTER_POWER_DRAINING_INV_RESULT",
+                          "effect": [ { "math": [ "n_val('power')", "-=", "rand(200) + 50" ] } ]
+                        }
+                      ]
+                    },
+                    "false_effect": [ { "math": [ "u_val('stamina')", "-=", "rand(350) + 300" ] } ]
+                  }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/data/mods/MindOverMatter/monsters/monster_eoc_spells.json
+++ b/data/mods/MindOverMatter/monsters/monster_eoc_spells.json
@@ -245,8 +245,8 @@
     "description": "The monster uses its powers to suck the energy out of battery devices.  If you see this, it's a bug.",
     "message": "",
     "teachable": false,
-    "valid_targets": [ "self" ],
-    "flags": [ "PSIONIC", "CONCENTRATE", "SILENT", "NO_HANDS", "NO_LEGS", "RANDOM_AOE" ],
+    "valid_targets": [ "self", "ally", "hostile" ],
+    "flags": [ "PSIONIC", "CONCENTRATE", "SILENT", "NO_HANDS", "NO_LEGS", "RANDOM_AOE", "IGNORE_WALLS" ],
     "max_level": 20,
     "effect": "effect_on_condition",
     "effect_str": "EOC_ELECTRONKINETIC_MONSTER_POWER_DRAINING",
@@ -268,29 +268,48 @@
     "damage_type": "pure",
     "max_level": 1,
     "min_damage": 10,
-    "max_damage": 35
+    "max_damage": 55
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_ELECTRONKINETIC_MONSTER_POWER_DRAINING",
+    "//": "x_in_y chance is because the power is an aura, to simulate it only hitting certain people instead of the player and all their followers.  If it becomes targeted, that will not be necessary.",
     "condition": "u_is_character",
     "effect": [
       {
-        "u_run_inv_eocs": "random",
-        "search_data": [
-          { "flags": [ "RECHARGE" ] },
-          { "flags": [ "ELECTRONIC" ] },
-          { "flags": [ "ELECTROKINETIC_CHARGEABLE" ] },
-          { "flags": [ "USE_UPS" ] }
-        ],
-        "true_eocs": [
+        "run_eocs": [
           {
-            "id": "EOC_ELECTRONKINETIC_MONSTER_POWER_DRAINING_INV_RESULT",
-            "effect": [ { "math": [ "n_val('power')", "-=", "rand(200) + 50" ] } ]
+            "id": "EOC_ELECTRONKINETIC_MONSTER_POWER_DRAINING_CHARACTER_CHECK",
+            "condition": { "x_in_y_chance": { "x": 1, "y": 3 } },
+            "effect": {
+              "u_run_inv_eocs": "random",
+              "search_data": [
+                { "flags": [ "RECHARGE" ] },
+                { "flags": [ "ELECTRONIC" ] },
+                { "flags": [ "ELECTROKINETIC_CHARGEABLE" ] },
+                { "flags": [ "USE_UPS" ] }
+              ],
+              "true_eocs": [
+                {
+                  "id": "EOC_ELECTRONKINETIC_MONSTER_POWER_DRAINING_INV_RESULT",
+                  "effect": [ { "math": [ "n_val('power')", "-=", "rand(200) + 50" ] } ]
+                }
+              ]
+            }
           }
         ]
       }
     ],
-    "false_effect": [ { "u_cast_spell": { "id": "electrokinetic_power_draining_electric_monster" } } ]
+    "false_effect": [
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_ELECTRONKINETIC_MONSTER_POWER_DRAINING_MONSTER_CHECK",
+            "condition": { "and": [ { "x_in_y_chance": { "x": 1, "y": 3 } }, { "u_has_flag": "ELECTRIC" } ] },
+            "effect": { "u_cast_spell": { "id": "electrokinetic_power_draining_electric_monster" } }
+          }
+        ]
+      }
+    ]
   }
 ]

--- a/data/mods/MindOverMatter/monsters/monster_eoc_spells.json
+++ b/data/mods/MindOverMatter/monsters/monster_eoc_spells.json
@@ -237,5 +237,60 @@
         "max_radius": 6
       }
     ]
+  },
+  {
+    "id": "electrokinetic_power_draining",
+    "type": "SPELL",
+    "name": "[Ψ]Electrokinetic Power Draining Spell",
+    "description": "The monster uses its powers to suck the energy out of battery devices.  If you see this, it's a bug.",
+    "message": "",
+    "teachable": false,
+    "valid_targets": [ "self" ],
+    "flags": [ "PSIONIC", "CONCENTRATE", "SILENT", "NO_HANDS", "NO_LEGS", "RANDOM_AOE" ],
+    "max_level": 20,
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_ELECTRONKINETIC_MONSTER_POWER_DRAINING",
+    "shape": "blast",
+    "min_range": 0,
+    "max_range": 0,
+    "min_aoe": 5,
+    "max_aoe": 25
+  },
+  {
+    "id": "electrokinetic_power_draining_electric_monster",
+    "type": "SPELL",
+    "name": "[Ψ]Electrokinetic Power Draining monster attack",
+    "description": "Gremlin's power to damage electric monsters.  It's a bug if you have it.",
+    "valid_targets": [ "self" ],
+    "flags": [ "NO_PROJECTILE", "NO_EXPLOSION_SFX", "RANDOM_DAMAGE" ],
+    "effect": "attack",
+    "shape": "blast",
+    "damage_type": "pure",
+    "max_level": 1,
+    "min_damage": 10,
+    "max_damage": 35
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_ELECTRONKINETIC_MONSTER_POWER_DRAINING",
+    "condition": "u_is_character",
+    "effect": [
+      {
+        "u_run_inv_eocs": "random",
+        "search_data": [
+          { "flags": [ "RECHARGE" ] },
+          { "flags": [ "ELECTRONIC" ] },
+          { "flags": [ "ELECTROKINETIC_CHARGEABLE" ] },
+          { "flags": [ "USE_UPS" ] }
+        ],
+        "true_eocs": [
+          {
+            "id": "EOC_ELECTRONKINETIC_MONSTER_POWER_DRAINING_INV_RESULT",
+            "effect": [ { "math": [ "n_val('power')", "-=", "rand(200) + 50" ] } ]
+          }
+        ]
+      }
+    ],
+    "false_effect": [ { "u_cast_spell": { "id": "electrokinetic_power_draining_electric_monster" } } ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Add gremlin, a Nether-touched fox, plus small monster tweaks"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Had this idea for a week or so, time to get it out.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the gremlin, a Nether-touched fox that's gained electrical power draining powers. They'll occasionally drain energy from anything nearby with a battery (or do damage to `ELECTRIC` flagged monsters). They're slightly faster than a normal fox, but otherwise they're a fox. If you're an electrokinetic with the Electron Overflow power active, you lose stamina instead of having your devices drained.

Ideally they would only use their ability on one target instead of an aura, but it's tricky getting non-aggroed monsters to still use monster spells on specific targets. 

I also added an animal psion monster group and put all the psychic animals (hodags, hidebehinds, fear hawks, etc) into it, and made it spawn in the forest with increasing commonality as time goes on. 

Finally, I took away the bandersnatch's innate armor and gave it the inertial barrier power. It doesn't use it until it goes hostile, so you can drop them early if you alpha strike them. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Gremlin appears and acts like a fox except when it's draining your batteries.  Batteries do get drained, and electric-flagged enemies do get attacked.  The drain does not always hit (to counteract the requirement to make the power an AoE aura)

Bandersnatches use inertial barrier
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Next up: making hidebehind invisibility actually telepathic so that if you have telepathic shield up, you can see them.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
