### PR TITLE
[XEDRA] Add MOM Electron Overflow compatibility by adding "ELECTROKINETIC_CHARGEABLE" flag to powered inventor items

### DIFF
--- a/data/mods/Xedra_Evolved/flags.json
+++ b/data/mods/Xedra_Evolved/flags.json
@@ -18,5 +18,10 @@
     "id": "ARVORE_POLLEN_IMMUNE",
     "type": "json_flag",
     "info": "This character cannot be affected by Arvore pollens."
+  },
+  {
+    "id": "ELECTROKINETIC_CHARGEABLE",
+    "type": "json_flag",
+    "info": "This item can be recharged by an electrokinetic"
   }
 ]

--- a/data/mods/Xedra_Evolved/items/inventor/armor.json
+++ b/data/mods/Xedra_Evolved/items/inventor/armor.json
@@ -52,7 +52,7 @@
       }
     ],
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "WATERPROOF", "STURDY", "PADDED", "TRADER_AVOID", "PSYSHIELD_PARTIAL", "MUNDANE", "INVENTOR_CRAFTED" ]
+    "flags": [ "WATERPROOF", "STURDY", "PADDED", "TRADER_AVOID", "PSYSHIELD_PARTIAL", "MUNDANE", "INVENTOR_CRAFTED", "RECHARGE" ]
   },
   {
     "id": "helmet_inventor_on",
@@ -165,7 +165,7 @@
     "symbol": "[",
     "looks_like": "legguard_hard",
     "color": "light_red",
-    "flags": [ "STURDY", "OUTER", "BELTED", "MUNDANE", "INVENTOR_CRAFTED" ],
+    "flags": [ "STURDY", "OUTER", "BELTED", "MUNDANE", "INVENTOR_CRAFTED", "RECHARGE" ],
     "ammo": "battery",
     "use_action": {
       "target": "inventor_leg_weight_on",
@@ -227,7 +227,7 @@
     "symbol": "[",
     "looks_like": "legguard_hard",
     "color": "light_red",
-    "flags": [ "STURDY", "OUTER", "SOFT", "MUNDANE", "INVENTOR_CRAFTED" ],
+    "flags": [ "STURDY", "OUTER", "SOFT", "MUNDANE", "INVENTOR_CRAFTED", "RECHARGE" ],
     "ammo": "battery",
     "charges_per_use": 150,
     "use_action": { "type": "cast_spell", "spell_id": "jump_boots_leap", "no_fail": true, "level": 0 },
@@ -339,7 +339,7 @@
       }
     ],
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "WATERPROOF", "STURDY", "SOFT", "TRADER_AVOID", "BELTED", "MUNDANE", "INVENTOR_CRAFTED" ]
+    "flags": [ "WATERPROOF", "STURDY", "SOFT", "TRADER_AVOID", "BELTED", "MUNDANE", "INVENTOR_CRAFTED", "RECHARGE" ]
   },
   {
     "id": "aura_force_on",
@@ -382,7 +382,7 @@
     ],
     "ammo": [ "battery" ],
     "material_thickness": 0.1,
-    "flags": [ "WATCH", "ALARMCLOCK", "SKINTIGHT", "WATER_BREAK", "CALORIES_INTAKE", "ELECTRONIC", "MUNDANE", "INVENTOR_CRAFTED" ],
+    "flags": [ "WATCH", "ALARMCLOCK", "SKINTIGHT", "WATER_BREAK", "CALORIES_INTAKE", "ELECTRONIC", "MUNDANE", "INVENTOR_CRAFTED", "RECHARGE" ],
     "pocket_data": [
       {
         "pocket_type": "MAGAZINE_WELL",
@@ -529,7 +529,7 @@
     "weight": "300 g",
     "longest_side": "25 cm",
     "ammo": [ "battery" ],
-    "flags": [ "ONLY_ONE", "TRADER_AVOID", "MUNDANE", "INVENTOR_CRAFTED" ],
+    "flags": [ "ONLY_ONE", "TRADER_AVOID", "MUNDANE", "INVENTOR_CRAFTED", "RECHARGE" ],
     "use_action": [
       {
         "target": "inventor_electric_fist_act",
@@ -592,7 +592,7 @@
     "color": "dark_gray",
     "material_thickness": 0.4,
     "environmental_protection": 4,
-    "flags": [ "MUNDANE", "INVENTOR_CRAFTED" ],
+    "flags": [ "MUNDANE", "INVENTOR_CRAFTED", "RECHARGE" ],
     "relic_data": {
       "passive_effects": [ { "has": "WORN", "condition": "ACTIVE", "values": [ { "value": "REGEN_STAMINA", "multiply": 0.6 } ] } ]
     },

--- a/data/mods/Xedra_Evolved/items/inventor/armor.json
+++ b/data/mods/Xedra_Evolved/items/inventor/armor.json
@@ -52,7 +52,16 @@
       }
     ],
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "WATERPROOF", "STURDY", "PADDED", "TRADER_AVOID", "PSYSHIELD_PARTIAL", "MUNDANE", "INVENTOR_CRAFTED", "ELECTROKINETIC_CHARGEABLE" ]
+    "flags": [
+      "WATERPROOF",
+      "STURDY",
+      "PADDED",
+      "TRADER_AVOID",
+      "PSYSHIELD_PARTIAL",
+      "MUNDANE",
+      "INVENTOR_CRAFTED",
+      "ELECTROKINETIC_CHARGEABLE"
+    ]
   },
   {
     "id": "helmet_inventor_on",

--- a/data/mods/Xedra_Evolved/items/inventor/armor.json
+++ b/data/mods/Xedra_Evolved/items/inventor/armor.json
@@ -382,7 +382,17 @@
     ],
     "ammo": [ "battery" ],
     "material_thickness": 0.1,
-    "flags": [ "WATCH", "ALARMCLOCK", "SKINTIGHT", "WATER_BREAK", "CALORIES_INTAKE", "ELECTRONIC", "MUNDANE", "INVENTOR_CRAFTED", "RECHARGE" ],
+    "flags": [
+      "WATCH",
+      "ALARMCLOCK",
+      "SKINTIGHT",
+      "WATER_BREAK",
+      "CALORIES_INTAKE",
+      "ELECTRONIC",
+      "MUNDANE",
+      "INVENTOR_CRAFTED",
+      "RECHARGE"
+    ],
     "pocket_data": [
       {
         "pocket_type": "MAGAZINE_WELL",

--- a/data/mods/Xedra_Evolved/items/inventor/armor.json
+++ b/data/mods/Xedra_Evolved/items/inventor/armor.json
@@ -52,7 +52,7 @@
       }
     ],
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "WATERPROOF", "STURDY", "PADDED", "TRADER_AVOID", "PSYSHIELD_PARTIAL", "MUNDANE", "INVENTOR_CRAFTED", "RECHARGE" ]
+    "flags": [ "WATERPROOF", "STURDY", "PADDED", "TRADER_AVOID", "PSYSHIELD_PARTIAL", "MUNDANE", "INVENTOR_CRAFTED", "ELECTROKINETIC_CHARGEABLE" ]
   },
   {
     "id": "helmet_inventor_on",
@@ -165,7 +165,7 @@
     "symbol": "[",
     "looks_like": "legguard_hard",
     "color": "light_red",
-    "flags": [ "STURDY", "OUTER", "BELTED", "MUNDANE", "INVENTOR_CRAFTED", "RECHARGE" ],
+    "flags": [ "STURDY", "OUTER", "BELTED", "MUNDANE", "INVENTOR_CRAFTED", "ELECTROKINETIC_CHARGEABLE" ],
     "ammo": "battery",
     "use_action": {
       "target": "inventor_leg_weight_on",
@@ -227,7 +227,7 @@
     "symbol": "[",
     "looks_like": "legguard_hard",
     "color": "light_red",
-    "flags": [ "STURDY", "OUTER", "SOFT", "MUNDANE", "INVENTOR_CRAFTED", "RECHARGE" ],
+    "flags": [ "STURDY", "OUTER", "SOFT", "MUNDANE", "INVENTOR_CRAFTED", "ELECTROKINETIC_CHARGEABLE" ],
     "ammo": "battery",
     "charges_per_use": 150,
     "use_action": { "type": "cast_spell", "spell_id": "jump_boots_leap", "no_fail": true, "level": 0 },
@@ -339,7 +339,7 @@
       }
     ],
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "WATERPROOF", "STURDY", "SOFT", "TRADER_AVOID", "BELTED", "MUNDANE", "INVENTOR_CRAFTED", "RECHARGE" ]
+    "flags": [ "WATERPROOF", "STURDY", "SOFT", "TRADER_AVOID", "BELTED", "MUNDANE", "INVENTOR_CRAFTED", "ELECTROKINETIC_CHARGEABLE" ]
   },
   {
     "id": "aura_force_on",
@@ -391,7 +391,7 @@
       "ELECTRONIC",
       "MUNDANE",
       "INVENTOR_CRAFTED",
-      "RECHARGE"
+      "ELECTROKINETIC_CHARGEABLE"
     ],
     "pocket_data": [
       {
@@ -539,7 +539,7 @@
     "weight": "300 g",
     "longest_side": "25 cm",
     "ammo": [ "battery" ],
-    "flags": [ "ONLY_ONE", "TRADER_AVOID", "MUNDANE", "INVENTOR_CRAFTED", "RECHARGE" ],
+    "flags": [ "ONLY_ONE", "TRADER_AVOID", "MUNDANE", "INVENTOR_CRAFTED", "ELECTROKINETIC_CHARGEABLE" ],
     "use_action": [
       {
         "target": "inventor_electric_fist_act",
@@ -602,7 +602,7 @@
     "color": "dark_gray",
     "material_thickness": 0.4,
     "environmental_protection": 4,
-    "flags": [ "MUNDANE", "INVENTOR_CRAFTED", "RECHARGE" ],
+    "flags": [ "MUNDANE", "INVENTOR_CRAFTED", "ELECTROKINETIC_CHARGEABLE" ],
     "relic_data": {
       "passive_effects": [ { "has": "WORN", "condition": "ACTIVE", "values": [ { "value": "REGEN_STAMINA", "multiply": 0.6 } ] } ]
     },

--- a/data/mods/Xedra_Evolved/items/inventor/gun.json
+++ b/data/mods/Xedra_Evolved/items/inventor/gun.json
@@ -263,7 +263,16 @@
     "armor": [
       { "encumbrance": [ 10, 12 ], "coverage": 70, "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_back" ] }
     ],
-    "flags": [ "TRADER_AVOID", "PADDED", "BELTED", "OVERSIZE", "WATER_FRIENDLY", "MUNDANE", "INVENTOR_CRAFTED", "ELECTROKINETIC_CHARGEABLE" ]
+    "flags": [
+      "TRADER_AVOID",
+      "PADDED",
+      "BELTED",
+      "OVERSIZE",
+      "WATER_FRIENDLY",
+      "MUNDANE",
+      "INVENTOR_CRAFTED",
+      "ELECTROKINETIC_CHARGEABLE"
+    ]
   },
   {
     "id": "bio_warhead",

--- a/data/mods/Xedra_Evolved/items/inventor/gun.json
+++ b/data/mods/Xedra_Evolved/items/inventor/gun.json
@@ -382,7 +382,16 @@
     "dispersion": 15,
     "durability": 8,
     "loudness": 15,
-    "flags": [ "NEVER_JAMS", "NO_SALVAGE", "NO_REPAIR", "NON_FOULING", "NEEDS_NO_LUBE", "TRADER_AVOID", "INVENTOR_CRAFTED", "RECHARGE" ],
+    "flags": [
+      "NEVER_JAMS",
+      "NO_SALVAGE",
+      "NO_REPAIR",
+      "NON_FOULING",
+      "NEEDS_NO_LUBE",
+      "TRADER_AVOID",
+      "INVENTOR_CRAFTED",
+      "RECHARGE"
+    ],
     "pocket_data": [
       {
         "pocket_type": "MAGAZINE_WELL",

--- a/data/mods/Xedra_Evolved/items/inventor/gun.json
+++ b/data/mods/Xedra_Evolved/items/inventor/gun.json
@@ -47,7 +47,7 @@
       "TRADER_AVOID",
       "OVERHEATS",
       "INVENTOR_CRAFTED",
-      "RECHARGE"
+      "ELECTROKINETIC_CHARGEABLE"
     ],
     "pocket_data": [
       {
@@ -111,7 +111,7 @@
       "TRADER_AVOID",
       "OVERHEATS",
       "INVENTOR_CRAFTED",
-      "RECHARGE"
+      "ELECTROKINETIC_CHARGEABLE"
     ],
     "pocket_data": [
       {
@@ -175,7 +175,7 @@
       "TRADER_AVOID",
       "OVERHEATS",
       "INVENTOR_CRAFTED",
-      "RECHARGE"
+      "ELECTROKINETIC_CHARGEABLE"
     ],
     "pocket_data": [
       {
@@ -263,7 +263,7 @@
     "armor": [
       { "encumbrance": [ 10, 12 ], "coverage": 70, "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_back" ] }
     ],
-    "flags": [ "TRADER_AVOID", "PADDED", "BELTED", "OVERSIZE", "WATER_FRIENDLY", "MUNDANE", "INVENTOR_CRAFTED", "RECHARGE" ]
+    "flags": [ "TRADER_AVOID", "PADDED", "BELTED", "OVERSIZE", "WATER_FRIENDLY", "MUNDANE", "INVENTOR_CRAFTED", "ELECTROKINETIC_CHARGEABLE" ]
   },
   {
     "id": "bio_warhead",
@@ -303,7 +303,7 @@
     "color": "blue",
     "charges_per_use": 30,
     "ammo": [ "battery" ],
-    "flags": [ "TRADER_AVOID", "MUNDANE", "INVENTOR_CRAFTED", "RECHARGE" ],
+    "flags": [ "TRADER_AVOID", "MUNDANE", "INVENTOR_CRAFTED", "ELECTROKINETIC_CHARGEABLE" ],
     "use_action": { "type": "cast_spell", "spell_id": "ion_shot_1", "no_fail": true, "level": 0, "need_wielding": true },
     "pocket_data": [
       {
@@ -390,7 +390,7 @@
       "NEEDS_NO_LUBE",
       "TRADER_AVOID",
       "INVENTOR_CRAFTED",
-      "RECHARGE"
+      "ELECTROKINETIC_CHARGEABLE"
     ],
     "pocket_data": [
       {
@@ -424,7 +424,7 @@
     "range": 1,
     "ammo": "battery",
     "ranged_damage": { "damage_type": "bullet", "amount": 1 },
-    "extend": { "flags": [ "NO_TURRET", "INVENTOR_CRAFTED", "RECHARGE" ] },
+    "extend": { "flags": [ "NO_TURRET", "INVENTOR_CRAFTED", "ELECTROKINETIC_CHARGEABLE" ] },
     "modes": [  ],
     "dispersion": 150,
     "durability": 9,
@@ -717,7 +717,7 @@
       "TRADER_AVOID",
       "ELECTRONIC",
       "INVENTOR_CRAFTED",
-      "RECHARGE"
+      "ELECTROKINETIC_CHARGEABLE"
     ],
     "pocket_data": [
       {
@@ -745,7 +745,7 @@
     "color": "blue",
     "charges_per_use": 50,
     "ammo": [ "battery" ],
-    "flags": [ "TRADER_AVOID", "INVENTOR_CRAFTED", "RECHARGE" ],
+    "flags": [ "TRADER_AVOID", "INVENTOR_CRAFTED", "ELECTROKINETIC_CHARGEABLE" ],
     "use_action": { "type": "cast_spell", "spell_id": "heat_expl_gun", "no_fail": true, "level": 0, "need_wielding": true },
     "pocket_data": [
       {

--- a/data/mods/Xedra_Evolved/items/inventor/gun.json
+++ b/data/mods/Xedra_Evolved/items/inventor/gun.json
@@ -46,7 +46,8 @@
       "NEEDS_NO_LUBE",
       "TRADER_AVOID",
       "OVERHEATS",
-      "INVENTOR_CRAFTED"
+      "INVENTOR_CRAFTED",
+      "RECHARGE"
     ],
     "pocket_data": [
       {
@@ -109,7 +110,8 @@
       "NEEDS_NO_LUBE",
       "TRADER_AVOID",
       "OVERHEATS",
-      "INVENTOR_CRAFTED"
+      "INVENTOR_CRAFTED",
+      "RECHARGE"
     ],
     "pocket_data": [
       {
@@ -172,7 +174,8 @@
       "NEEDS_NO_LUBE",
       "TRADER_AVOID",
       "OVERHEATS",
-      "INVENTOR_CRAFTED"
+      "INVENTOR_CRAFTED",
+      "RECHARGE"
     ],
     "pocket_data": [
       {
@@ -260,7 +263,7 @@
     "armor": [
       { "encumbrance": [ 10, 12 ], "coverage": 70, "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_back" ] }
     ],
-    "flags": [ "TRADER_AVOID", "PADDED", "BELTED", "OVERSIZE", "WATER_FRIENDLY", "MUNDANE", "INVENTOR_CRAFTED" ]
+    "flags": [ "TRADER_AVOID", "PADDED", "BELTED", "OVERSIZE", "WATER_FRIENDLY", "MUNDANE", "INVENTOR_CRAFTED", "RECHARGE" ]
   },
   {
     "id": "bio_warhead",
@@ -300,7 +303,7 @@
     "color": "blue",
     "charges_per_use": 30,
     "ammo": [ "battery" ],
-    "flags": [ "TRADER_AVOID", "MUNDANE", "INVENTOR_CRAFTED" ],
+    "flags": [ "TRADER_AVOID", "MUNDANE", "INVENTOR_CRAFTED", "RECHARGE" ],
     "use_action": { "type": "cast_spell", "spell_id": "ion_shot_1", "no_fail": true, "level": 0, "need_wielding": true },
     "pocket_data": [
       {
@@ -379,7 +382,7 @@
     "dispersion": 15,
     "durability": 8,
     "loudness": 15,
-    "flags": [ "NEVER_JAMS", "NO_SALVAGE", "NO_REPAIR", "NON_FOULING", "NEEDS_NO_LUBE", "TRADER_AVOID", "INVENTOR_CRAFTED" ],
+    "flags": [ "NEVER_JAMS", "NO_SALVAGE", "NO_REPAIR", "NON_FOULING", "NEEDS_NO_LUBE", "TRADER_AVOID", "INVENTOR_CRAFTED", "RECHARGE" ],
     "pocket_data": [
       {
         "pocket_type": "MAGAZINE_WELL",
@@ -412,7 +415,7 @@
     "range": 1,
     "ammo": "battery",
     "ranged_damage": { "damage_type": "bullet", "amount": 1 },
-    "extend": { "flags": [ "NO_TURRET", "INVENTOR_CRAFTED" ] },
+    "extend": { "flags": [ "NO_TURRET", "INVENTOR_CRAFTED", "RECHARGE" ] },
     "modes": [  ],
     "dispersion": 150,
     "durability": 9,
@@ -704,7 +707,8 @@
       "NEEDS_NO_LUBE",
       "TRADER_AVOID",
       "ELECTRONIC",
-      "INVENTOR_CRAFTED"
+      "INVENTOR_CRAFTED",
+      "RECHARGE"
     ],
     "pocket_data": [
       {
@@ -732,7 +736,7 @@
     "color": "blue",
     "charges_per_use": 50,
     "ammo": [ "battery" ],
-    "flags": [ "TRADER_AVOID", "INVENTOR_CRAFTED" ],
+    "flags": [ "TRADER_AVOID", "INVENTOR_CRAFTED", "RECHARGE" ],
     "use_action": { "type": "cast_spell", "spell_id": "heat_expl_gun", "no_fail": true, "level": 0, "need_wielding": true },
     "pocket_data": [
       {

--- a/data/mods/Xedra_Evolved/items/inventor/melee.json
+++ b/data/mods/Xedra_Evolved/items/inventor/melee.json
@@ -54,7 +54,8 @@
       "TRADER_AVOID",
       "NONCONDUCTIVE",
       "MUNDANE",
-      "INVENTOR_CRAFTED"
+      "INVENTOR_CRAFTED",
+      "RECHARGE"
     ],
     "pocket_data": [
       {
@@ -147,7 +148,7 @@
       "need_charges_msg": "The \"Neon Angle\" battery is dead."
     },
     "techniques": [ "WBLOCK_1", "BRUTAL", "SWEEP", "PLASMA_AXE_WIDE" ],
-    "flags": [ "DURABLE_MELEE", "NONCONDUCTIVE", "SHEATH_AXE", "MUNDANE", "INVENTOR_CRAFTED" ],
+    "flags": [ "DURABLE_MELEE", "NONCONDUCTIVE", "SHEATH_AXE", "MUNDANE", "INVENTOR_CRAFTED", "RECHARGE" ],
     "weapon_category": [ "HOOKING_WEAPONRY", "GREAT_AXES" ],
     "pocket_data": [
       {

--- a/data/mods/Xedra_Evolved/items/inventor/melee.json
+++ b/data/mods/Xedra_Evolved/items/inventor/melee.json
@@ -55,7 +55,7 @@
       "NONCONDUCTIVE",
       "MUNDANE",
       "INVENTOR_CRAFTED",
-      "RECHARGE"
+      "ELECTROKINETIC_CHARGEABLE"
     ],
     "pocket_data": [
       {
@@ -148,7 +148,7 @@
       "need_charges_msg": "The \"Neon Angle\" battery is dead."
     },
     "techniques": [ "WBLOCK_1", "BRUTAL", "SWEEP", "PLASMA_AXE_WIDE" ],
-    "flags": [ "DURABLE_MELEE", "NONCONDUCTIVE", "SHEATH_AXE", "MUNDANE", "INVENTOR_CRAFTED", "RECHARGE" ],
+    "flags": [ "DURABLE_MELEE", "NONCONDUCTIVE", "SHEATH_AXE", "MUNDANE", "INVENTOR_CRAFTED", "ELECTROKINETIC_CHARGEABLE" ],
     "weapon_category": [ "HOOKING_WEAPONRY", "GREAT_AXES" ],
     "pocket_data": [
       {

--- a/data/mods/Xedra_Evolved/items/inventor/mics.json
+++ b/data/mods/Xedra_Evolved/items/inventor/mics.json
@@ -56,7 +56,7 @@
     "weight": "2000 g",
     "volume": "2500 ml",
     "material": [ "steel", "plastic" ],
-    "extend": { "flags": [ "INVENTOR_CRAFTED", "RECHARGE" ] },
+    "extend": { "flags": [ "INVENTOR_CRAFTED", "ELECTROKINETIC_CHARGEABLE" ] },
     "pocket_data": [
       {
         "pocket_type": "MAGAZINE_WELL",
@@ -84,7 +84,7 @@
     "material": [ "aluminum", "plastic" ],
     "symbol": ";",
     "color": "green",
-    "flags": [ "WATER_BREAK", "ELECTRONIC", "ALLOWS_REMOTE_USE", "INVENTOR_CRAFTED", "RECHARGE" ],
+    "flags": [ "WATER_BREAK", "ELECTRONIC", "ALLOWS_REMOTE_USE", "INVENTOR_CRAFTED", "ELECTROKINETIC_CHARGEABLE" ],
     "ammo": [ "battery" ],
     "charges_per_use": 20,
     "qualities": [ [ "COOK", 2 ], [ "BOIL", 2 ] ],

--- a/data/mods/Xedra_Evolved/items/inventor/mics.json
+++ b/data/mods/Xedra_Evolved/items/inventor/mics.json
@@ -56,7 +56,7 @@
     "weight": "2000 g",
     "volume": "2500 ml",
     "material": [ "steel", "plastic" ],
-    "extend": { "flags": [ "INVENTOR_CRAFTED" ] },
+    "extend": { "flags": [ "INVENTOR_CRAFTED", "RECHARGE" ] },
     "pocket_data": [
       {
         "pocket_type": "MAGAZINE_WELL",
@@ -84,7 +84,7 @@
     "material": [ "aluminum", "plastic" ],
     "symbol": ";",
     "color": "green",
-    "flags": [ "WATER_BREAK", "ELECTRONIC", "ALLOWS_REMOTE_USE", "INVENTOR_CRAFTED" ],
+    "flags": [ "WATER_BREAK", "ELECTRONIC", "ALLOWS_REMOTE_USE", "INVENTOR_CRAFTED", "RECHARGE" ],
     "ammo": [ "battery" ],
     "charges_per_use": 20,
     "qualities": [ [ "COOK", 2 ], [ "BOIL", 2 ] ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Add Xedra Inventor compatibility with Electrokinetic Powers"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Electrokinetics cannot charge inventor items when they should be able to
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add the "ELECTROKINETIC_CHARGEABLE" flag to inventor items
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
N/A
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Made world with XEDRA and MOM, then activate an inventor item to deplete charge.  Then used Electron Overflow to recharge them.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
One day we'll have true mod compatibility json support
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
