### PR TITLE
fix negative KCAL and VITAMIN_ABSORB_MOD enchantments

### DIFF
--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -716,7 +716,7 @@
     "id": "perk_eating_window",
     "name": { "str": "Compressed Eating Window" },
     "points": 0,
-    "description": "You're so used to squeezing all your meals into a short time that your body has adapted to it.  You gain +250% kcal and vitamins from any meals eaten between noon and 6 p.m., but 0 calories and vitamins for any meals eaten outside that time period.",
+    "description": "You're so used to squeezing all your meals into a short time that your body has adapted to it.  You gain 2.5 times as many calories and vitamins from any meals eaten between noon and 6 p.m., but 0 calories and vitamins for any meals eaten outside that time period.",
     "category": [ "perk" ],
     "enchantments": [
       {

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -716,7 +716,7 @@
     "id": "perk_eating_window",
     "name": { "str": "Compressed Eating Window" },
     "points": 0,
-    "description": "You're so used to squeezing all your meals into a short time that your body has adapted to it.  You gain +150% kcal and vitamins from any meals eaten between noon and 6 p.m., but 0 calories and vitamins for any meals eaten outside that time period.",
+    "description": "You're so used to squeezing all your meals into a short time that your body has adapted to it.  You gain +250% kcal and vitamins from any meals eaten between noon and 6 p.m., but 0 calories and vitamins for any meals eaten outside that time period.",
     "category": [ "perk" ],
     "enchantments": [
       {
@@ -735,7 +735,7 @@
             { "math": [ "time_since('midnight', 'unit': 'hours') > 18" ] }
           ]
         },
-        "values": [ { "value": "KCAL", "multiply": -1.0 }, { "value": "VITAMIN_ABSORB_MOD", "multiply": -1.0 } ]
+        "values": [ { "value": "KCAL", "multiply": -50 }, { "value": "VITAMIN_ABSORB_MOD", "multiply": -50 } ]
       }
     ]
   },

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -245,7 +245,8 @@ static int compute_default_effective_kcal( const item &comest, const Character &
     }
 
     kcal = you.enchantment_cache->modify_value( enchant_vals::mod::KCAL, kcal );
-    kcal = std:max( 0, kcal );
+kcal = std:
+           max( 0, kcal );
 
     return static_cast<int>( kcal );
 }
@@ -289,7 +290,8 @@ static std::map<vitamin_id, int> compute_default_effective_vitamins(
     for( std::pair<const vitamin_id, int> &vit : res ) {
         vit.second = you.enchantment_cache->modify_value( enchant_vals::mod::VITAMIN_ABSORB_MOD,
                      vit.second );
-        vit.second = std:max( 0, vit.second );
+vit.second = std:
+                     max( 0, vit.second );
     }
     return res;
 }

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -245,8 +245,7 @@ static int compute_default_effective_kcal( const item &comest, const Character &
     }
 
     kcal = you.enchantment_cache->modify_value( enchant_vals::mod::KCAL, kcal );
-kcal = std:
-           max( 0, kcal );
+kcal = std::max( 0, kcal );
 
     return static_cast<int>( kcal );
 }
@@ -290,8 +289,7 @@ static std::map<vitamin_id, int> compute_default_effective_vitamins(
     for( std::pair<const vitamin_id, int> &vit : res ) {
         vit.second = you.enchantment_cache->modify_value( enchant_vals::mod::VITAMIN_ABSORB_MOD,
                      vit.second );
-vit.second = std:
-                     max( 0, vit.second );
+vit.second = std::max( 0, vit.second );
     }
     return res;
 }

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -245,7 +245,7 @@ static int compute_default_effective_kcal( const item &comest, const Character &
     }
 
     kcal = you.enchantment_cache->modify_value( enchant_vals::mod::KCAL, kcal );
-    kcal = std::max( 0, kcal );
+    kcal = std::max( 0.0f, kcal );
 
     return static_cast<int>( kcal );
 }

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -245,7 +245,7 @@ static int compute_default_effective_kcal( const item &comest, const Character &
     }
 
     kcal = you.enchantment_cache->modify_value( enchant_vals::mod::KCAL, kcal );
-kcal = std::max( 0, kcal );
+    kcal = std::max( 0, kcal );
 
     return static_cast<int>( kcal );
 }
@@ -289,7 +289,7 @@ static std::map<vitamin_id, int> compute_default_effective_vitamins(
     for( std::pair<const vitamin_id, int> &vit : res ) {
         vit.second = you.enchantment_cache->modify_value( enchant_vals::mod::VITAMIN_ABSORB_MOD,
                      vit.second );
-vit.second = std::max( 0, vit.second );
+        vit.second = std::max( 0, vit.second );
     }
     return res;
 }

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -245,6 +245,7 @@ static int compute_default_effective_kcal( const item &comest, const Character &
     }
 
     kcal = you.enchantment_cache->modify_value( enchant_vals::mod::KCAL, kcal );
+    kcal = std:max( 0, kcal );
 
     return static_cast<int>( kcal );
 }
@@ -288,6 +289,7 @@ static std::map<vitamin_id, int> compute_default_effective_vitamins(
     for( std::pair<const vitamin_id, int> &vit : res ) {
         vit.second = you.enchantment_cache->modify_value( enchant_vals::mod::VITAMIN_ABSORB_MOD,
                      vit.second );
+        vit.second = std:max( 0, vit.second );
     }
     return res;
 }


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fix #74974
#### Describe the solution
Prevent the enchantment from making food with negative calories and vitamins
Throw a ludicriously high negative multiplier for enchantments in perk_eating_window trait, so no another enchantment can move it
Replace `150% bonus` text in description to one that people understand more clearly, `250% bonus`