### PR TITLE
Allow getting in vehicles anyway

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -11126,10 +11126,7 @@ void Character::process_effects()
     }
 
     // Being stuck in tight spaces sucks. TODO: could be expanded to apply to non-vehicle conditions.
-    bool cramped = false;
-    // return is intentionally discarded, sets cramped if appropriate
-    can_move_to_vehicle_tile( get_map().getglobal( pos() ), cramped );
-    if( cramped ) {
+    if( will_be_cramped_in_vehicle_tile( get_map().getglobal( pos() ) ) ) {
         if( is_npc() && !has_effect( effect_narcosis ) ) {
             npc &as_npc = dynamic_cast<npc &>( *this );
             as_npc.complain_about( "cramped_vehicle", 30_minutes, "<cramped_vehicle>", false );

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -217,12 +217,12 @@ void Creature::setpos( const tripoint_bub_ms &p )
     Creature::setpos( p.raw() );
 }
 
-bool Creature::can_move_to_vehicle_tile( const tripoint_abs_ms &loc, bool &cramped ) const
+bool Creature::will_be_cramped_in_vehicle_tile( const tripoint_abs_ms &loc ) const
 {
     map &here = get_map();
     const optional_vpart_position vp_there = here.veh_at( loc );
     if( !vp_there ) {
-        return true;
+        return false;
     }
 
     const monster *mon = as_monster();
@@ -257,12 +257,12 @@ bool Creature::can_move_to_vehicle_tile( const tripoint_abs_ms &loc, bool &cramp
         }
 
         if( critter_volume > free_cargo ) {
-            return false;
+            return true;
         }
 
         if( size == creature_size::huge &&
             !vp_there.part_with_feature( "HUGE_OK", false ) ) {
-            return false;
+            return true;
         }
 
         // free_cargo * 0.75 < critter_volume && critter_volume <= free_cargo
@@ -270,23 +270,17 @@ bool Creature::can_move_to_vehicle_tile( const tripoint_abs_ms &loc, bool &cramp
             if( !mon || !( mon->type->bodytype == "snake" || mon->type->bodytype == "blob" ||
                            mon->type->bodytype == "fish" ||
                            has_flag( mon_flag_PLASTIC ) || has_flag( mon_flag_SMALL_HIDER ) ) ) {
-                cramped = true;
+                return true;
             }
         }
 
         if( size == creature_size::huge && !vp_there.part_with_feature( "AISLE", false ) &&
             !vp_there.part_with_feature( "HUGE_OK", false ) ) {
-            cramped = true;
+            return true;
         }
     }
 
-    return true;
-}
-
-bool Creature::can_move_to_vehicle_tile( const tripoint_abs_ms &loc ) const
-{
-    bool dummy = false;
-    return can_move_to_vehicle_tile( loc, dummy );
+    return false;
 }
 
 void Creature::move_to( const tripoint_abs_ms &loc )

--- a/src/creature.h
+++ b/src/creature.h
@@ -321,10 +321,8 @@ class Creature : public viewer
         void setpos( const tripoint &p );
         void setpos( const tripoint_bub_ms &p );
 
-        /** Checks if the creature fits into a given tile. Set the boolean argument to true if the creature would barely fit. */
-        bool can_move_to_vehicle_tile( const tripoint_abs_ms &loc, bool &cramped ) const;
-        /** Helper overload for when the boolean is discardable */
-        bool can_move_to_vehicle_tile( const tripoint_abs_ms &loc ) const;
+        /** Checks if the creature fits confortably into a given tile. */
+        bool will_be_cramped_in_vehicle_tile( const tripoint_abs_ms &loc ) const;
         /** Moves the creature to the given location and calls the on_move() handler. */
         void move_to( const tripoint_abs_ms &loc );
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10502,12 +10502,6 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool 
     }
     u.set_underwater( false );
 
-    bool cramped = false;
-    if( vp_there && !u.can_move_to_vehicle_tile( get_map().getglobal( dest_loc ), cramped ) ) {
-        add_msg( m_warning, _( "There's not enough room for you to fit there." ) );
-        return false;
-    }
-
     if( !shifting_furniture && !pushing && is_dangerous_tile( dest_loc ) ) {
         std::vector<std::string> harmful_stuff = get_dangerous_tile( dest_loc );
         if( harmful_stuff.size() == 1 && harmful_stuff[0] == "ledge" ) {
@@ -10722,7 +10716,7 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool 
         start_hauling( oldpos );
     }
 
-    if( cramped ) { // passed by reference, can_move_to_vehicle_tile sets to true if actually cramped
+    if( u.will_be_cramped_in_vehicle_tile( get_map().getglobal( dest_loc ) ) ) {
         if( u.get_size() == creature_size::huge ) {
             add_msg( m_warning, _( "You barely fit in this tiny human vehicle." ) );
         } else if( u.get_total_volume() > u.get_base_volume() )  {

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1624,8 +1624,8 @@ bool monster::bash_at( const tripoint &p )
         return false;
     }
 
-    const bool too_cramped = !can_move_to_vehicle_tile( get_map().getglobal( p ) );
-    bool try_bash = !can_move_to( p ) || one_in( 3 ) || too_cramped;
+    const bool cramped = will_be_cramped_in_vehicle_tile( get_map().getglobal( p ) );
+    bool try_bash = !can_move_to( p ) || one_in( 3 ) || cramped;
     if( !try_bash ) {
         return false;
     }
@@ -1635,7 +1635,7 @@ bool monster::bash_at( const tripoint &p )
     }
 
     map &here = get_map();
-    if( !( here.is_bashable_furn( p ) || here.veh_at( p ).obstacle_at_part() || too_cramped ) ) {
+    if( !( here.is_bashable_furn( p ) || here.veh_at( p ).obstacle_at_part() || cramped ) ) {
         // if the only thing here is road or flat, rarely bash it
         bool flat_ground = here.has_flag( ter_furn_flag::TFLAG_ROAD, p ) ||
                            here.has_flag( ter_furn_flag::TFLAG_FLAT, p );
@@ -1806,11 +1806,6 @@ bool monster::move_to( const tripoint &p, bool force, bool step_on_critter,
         }
     }
 
-    bool cramped = false; // applies an effect if monster does end up moving there
-    if( !can_move_to_vehicle_tile( here.getglobal( p ), cramped ) ) {
-        return false;
-    }
-
     // Allows climbing monsters to move on terrain with movecost <= 0
     Creature *critter = get_creature_tracker().creature_at( destination, is_hallucination() );
     if( here.has_flag( ter_furn_flag::TFLAG_CLIMBABLE, destination ) ) {
@@ -1905,7 +1900,7 @@ bool monster::move_to( const tripoint &p, bool force, bool step_on_critter,
     optional_vpart_position vp_dest = here.veh_at( destination );
     if( vp_dest ) {
         vp_dest->vehicle().invalidate_mass();
-        if( cramped ) {
+        if( will_be_cramped_in_vehicle_tile( here.getglobal( p ) ) ) {
             add_effect( effect_cramped_space, 2_turns, true );
         }
     }

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3365,10 +3365,7 @@ void monster::process_effects()
         }
     }
 
-    bool cramped = false;
-    // return is intentionally discarded, sets cramped if appropriate
-    can_move_to_vehicle_tile( get_map().getglobal( pos() ), cramped );
-    if( !cramped ) {
+    if( !will_be_cramped_in_vehicle_tile( get_map().getglobal( pos() ) ) ) {
         remove_effect( effect_cramped_space );
     }
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -3358,7 +3358,7 @@ std::function<bool( const tripoint & )> npc::get_path_avoid() const
         if( sees_dangerous_field( p ) ) {
             return true;
         }
-        if( !can_move_to_vehicle_tile( here.getglobal( p ) ) ) {
+        if( will_be_cramped_in_vehicle_tile( here.getglobal( p ) ) ) {
             return true;
         }
         return false;

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -3358,9 +3358,6 @@ std::function<bool( const tripoint & )> npc::get_path_avoid() const
         if( sees_dangerous_field( p ) ) {
             return true;
         }
-        if( will_be_cramped_in_vehicle_tile( here.getglobal( p ) ) ) {
-            return true;
-        }
         return false;
     };
 }

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -404,9 +404,6 @@ bool npc::could_move_onto( const tripoint &p ) const
     if( !here.passable( p ) ) {
         return false;
     }
-    if( !can_move_to_vehicle_tile( here.getglobal( p ) ) ) {
-        return false;
-    }
 
     if( !sees_dangerous_field( p ) ) {
         return true;
@@ -2900,20 +2897,6 @@ void npc::move_to( const tripoint &pt, bool no_bashing, std::set<tripoint> *nomo
         }
     }
 
-    if( !can_move_to_vehicle_tile( here.getglobal( p ) ) ) {
-        auto other_points = here.get_dir_circle( pos(), p );
-        for( const tripoint &ot : other_points ) {
-            if( could_move_onto( ot ) && ( nomove == nullptr || nomove->find( ot ) == nomove->end() ) ) {
-                p = ot;
-                break;
-            } else {
-                path.clear();
-                move_pause();
-                return;
-            }
-        }
-    }
-
     recoil = MAX_RECOIL;
 
     if( has_effect( effect_stunned ) || has_effect( effect_psi_stunned ) ) {
@@ -3144,10 +3127,7 @@ void npc::move_to( const tripoint &pt, bool no_bashing, std::set<tripoint> *nomo
         here.creature_on_trap( *this );
         here.creature_in_field( *this );
 
-        bool cramped = false;
-        if( !can_move_to_vehicle_tile( here.getglobal( p ), cramped ) ) {
-            debugmsg( "NPC %s somehow moved to a too-cramped vehicle tile", disp_name() );
-        } else if( cramped ) { //set by above call to Creature::can_move_to_vehicle_tile
+        if( will_be_cramped_in_vehicle_tile( here.getglobal( p ) ) ) {
             if( !has_effect( effect_cramped_space ) ) {
                 add_msg_if_player_sees( *this, m_warning,
                                         string_format( _( "%s has to really cram their huge body to fit." ), disp_name() ) );

--- a/tests/char_volume_test.cpp
+++ b/tests/char_volume_test.cpp
@@ -81,7 +81,6 @@ TEST_CASE( "character_at_volume_will_be_cramped_in_vehicle", "[volume]" )
 
     // Empty aisle
     dest_loc = dest_loc + tripoint_north_west;
-    bool cramped = false;
     CHECK( !you.will_be_cramped_in_vehicle_tile( dest_loc ) );
     dest_loc = you.get_location(); //reset
 
@@ -89,7 +88,6 @@ TEST_CASE( "character_at_volume_will_be_cramped_in_vehicle", "[volume]" )
     dest_loc = dest_loc + tripoint_north;
     CHECK( you.will_be_cramped_in_vehicle_tile( dest_loc ) );
     dest_loc = you.get_location(); //reset
-    cramped = false;
 
     // Empty aisle, but we've put on a backpack and a 10L rock in that backpack
     item backpack( itype_backpack_giant );
@@ -101,7 +99,6 @@ TEST_CASE( "character_at_volume_will_be_cramped_in_vehicle", "[volume]" )
     dest_loc = dest_loc + tripoint_north_west;
     CHECK( you.will_be_cramped_in_vehicle_tile( dest_loc ) );
     dest_loc = you.get_location(); //reset
-    cramped = false;
 
     // Try the cramped aisle with a rock again, but now we are tiny, so it is easy.
     CHECK( your_volume_with_trait( trait_SMALL2 ) == 23326_ml );

--- a/tests/char_volume_test.cpp
+++ b/tests/char_volume_test.cpp
@@ -61,7 +61,7 @@ TEST_CASE( "character_baseline_volumes", "[volume]" )
     CHECK( your_volume_with_trait( trait_HUGE ) == 156228_ml );
 }
 
-TEST_CASE( "character_at_volume_can_or_cannot_enter_vehicle", "[volume]" )
+TEST_CASE( "character_at_volume_will_be_cramped_in_vehicle", "[volume]" )
 {
     clear_avatar();
     clear_map();

--- a/tests/char_volume_test.cpp
+++ b/tests/char_volume_test.cpp
@@ -82,14 +82,12 @@ TEST_CASE( "character_at_volume_can_or_cannot_enter_vehicle", "[volume]" )
     // Empty aisle
     dest_loc = dest_loc + tripoint_north_west;
     bool cramped = false;
-    CHECK( you.can_move_to_vehicle_tile( dest_loc, cramped ) );
-    CHECK( !cramped );
+    CHECK( !you.will_be_cramped_in_vehicle_tile( dest_loc ) );
     dest_loc = you.get_location(); //reset
 
     // Aisle with 10L rock, a tight fit but not impossible
     dest_loc = dest_loc + tripoint_north;
-    CHECK( you.can_move_to_vehicle_tile( dest_loc, cramped ) );
-    CHECK( cramped );
+    CHECK( you.will_be_cramped_in_vehicle_tile( dest_loc ) );
     dest_loc = you.get_location(); //reset
     cramped = false;
 
@@ -101,8 +99,7 @@ TEST_CASE( "character_at_volume_can_or_cannot_enter_vehicle", "[volume]" )
     CHECK( 75_liter <= you.get_total_volume() );
     CHECK( you.get_total_volume() <= 100_liter );
     dest_loc = dest_loc + tripoint_north_west;
-    CHECK( you.can_move_to_vehicle_tile( dest_loc, cramped ) );
-    CHECK( cramped );
+    CHECK( you.will_be_cramped_in_vehicle_tile( dest_loc ) );
     dest_loc = you.get_location(); //reset
     cramped = false;
 
@@ -110,18 +107,17 @@ TEST_CASE( "character_at_volume_can_or_cannot_enter_vehicle", "[volume]" )
     CHECK( your_volume_with_trait( trait_SMALL2 ) == 23326_ml );
     you.setpos( test_pos ); // set our position again, clear_avatar() moved us
     dest_loc = dest_loc + tripoint_north;
-    CHECK( you.can_move_to_vehicle_tile( dest_loc, cramped ) );
-    CHECK( !cramped );
+    CHECK( !you.will_be_cramped_in_vehicle_tile( dest_loc ) );
     dest_loc = you.get_location(); //reset
 
     // Same aisle, but now we have HUGE GUTS. We will never fit.
     CHECK( your_volume_with_trait( trait_HUGE ) == 156228_ml );
     you.setpos( test_pos ); // set our position again, clear_avatar() moved us
     dest_loc = dest_loc + tripoint_north;
-    CHECK( !you.can_move_to_vehicle_tile( dest_loc ) );
+    CHECK( you.will_be_cramped_in_vehicle_tile( dest_loc ) );
     dest_loc = you.get_location(); //reset
 
     // And finally, check that our HUGE body won't fit even into an empty aisle.
     dest_loc = dest_loc + tripoint_north_west;
-    CHECK( !you.can_move_to_vehicle_tile( dest_loc ) );
+    CHECK( you.will_be_cramped_in_vehicle_tile( dest_loc ) );
 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Just allow getting in vehicles regardless of encumbrance, while we figure this out

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

- Rename `can_move_to_vehicle_tile` to `will_be_cramped_in_vehicle_tile` 
- Have it return wether or not the creature will be cramped in the tile
- Change checks accordingly for Characters
- Monster will still avoid pathing in cramped tiles as if they were impassable in the previous iteration

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

- get a XXXL traper character
- Get a big rucksac
- Fill it with 200L of water
- Get in a vehicle > yes I can
- Walk on trunks > game tells me I'm squeezed but I cna still walk on the trunk 
- Freakishly huge XXXL NPC friend can also just get in the car
#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
