### PR TITLE
Remove the cotton_salted material used in the ichcahuipilli

### DIFF
--- a/data/json/items/armor/torso_armor.json
+++ b/data/json/items/armor/torso_armor.json
@@ -298,7 +298,7 @@
       {
         "material": [
           { "type": "cotton_quilted_salted", "covered_by_mat": 100, "thickness": 2.5 },
-          { "type": "cotton_salted", "covered_by_mat": 95, "thickness": 20 },
+          { "type": "cotton", "covered_by_mat": 95, "thickness": 20 },
           { "type": "cotton_quilted_salted", "covered_by_mat": 100, "thickness": 2.5 }
         ],
         "covers": [ "torso" ],

--- a/data/json/materials.json
+++ b/data/json/materials.json
@@ -628,14 +628,6 @@
   },
   {
     "type": "material",
-    "id": "cotton_salted",
-    "name": "Salt Hardened Cotton",
-    "copy-from": "cotton",
-    "repaired_with": "null",
-    "resist": { "bash": 2, "cut": 2, "acid": 5, "heat": 10, "bullet": 1.5 }
-  },
-  {
-    "type": "material",
     "id": "cotton_quilted_salted",
     "name": "Salt Hardened Quilted Cotton",
     "copy-from": "cotton",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
There was no rationale for this being a special material, and it was massively inflating the protective value of the affected armor.
When the ichcahuipilli was proposed in #71783 the suggestion was to have a thick "cotton" layer, with relatively low protection, but the actual PR added a new "cotton_salted" material with significantly increased stats, giving the resulting armor massive protection values.

#### Describe the solution
Roll back to a thick cotton layer as initially proposed.
Remove the salted cotton material as it's no longer used.