### PR TITLE
[Magiclysm] Add Shifter druid profession + wildshifts

### DIFF
--- a/data/mods/Magiclysm/Spells/temporary.json
+++ b/data/mods/Magiclysm/Spells/temporary.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": "druid_raven_form_fly_upward",
+    "type": "SPELL",
+    "name": "(Raven Form) Ascend",
+    "description": "Flap your wings and fly upward.",
+    "message": "",
+    "teachable": false,
+    "valid_targets": [ "self" ],
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_DRUID_SHIFTER_RAVEN_FORM_ASCEND",
+    "shape": "blast",
+    "flags": [ "NO_HANDS", "NO_LEGS", "SILENT", "NO_FAIL" ],
+    "skill": "deduction",
+    "base_casting_time": 75
+  }
+]

--- a/data/mods/Magiclysm/Spells/temporary.json
+++ b/data/mods/Magiclysm/Spells/temporary.json
@@ -10,7 +10,7 @@
     "effect": "effect_on_condition",
     "effect_str": "EOC_DRUID_SHIFTER_RAVEN_FORM_ASCEND",
     "shape": "blast",
-    "flags": [ "NO_HANDS", "NO_LEGS", "SILENT", "NO_FAIL" ],
+    "flags": [ "NO_HANDS", "NO_LEGS", "NON_MAGICAL", "SILENT", "NO_FAIL" ],
     "skill": "deduction",
     "base_casting_time": 75
   }

--- a/data/mods/Magiclysm/effects/effects.json
+++ b/data/mods/Magiclysm/effects/effects.json
@@ -1251,6 +1251,14 @@
   },
   {
     "type": "effect_type",
+    "id": "effect_druid_shifter_raven_form_levitation",
+    "//": "Hidden effect, used because LEVITATION flag does not work on mutations",
+    "name": [ "" ],
+    "desc": [ "" ],
+    "flags": [ "LEVITATION" ]
+  },
+  {
+    "type": "effect_type",
     "id": "telepathic_ignorance",
     "//": "id is hardcoded, used by the Animist spell A Shadow in the Crowd",
     "name": [ "" ],

--- a/data/mods/Magiclysm/effects/eoc_game_start.json
+++ b/data/mods/Magiclysm/effects/eoc_game_start.json
@@ -1,0 +1,42 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_DRUID_SHIFTER_GIVE_FORM",
+    "eoc_type": "EVENT",
+    "required_event": "game_start",
+    "condition": { "u_profession": "shifter_druid" },
+    "effect": [ { "queue_eocs": "EOC_DRUID_SHIFTER_GIVE_FORM_2", "time_in_future": 0 } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_DRUID_SHIFTER_GIVE_FORM_2",
+    "effect": [
+      {
+        "run_eoc_selector": [ "EOC_DRUID_SHIFTER_GIVE_FORM_BEAR", "EOC_DRUID_SHIFTER_GIVE_FORM_DEER", "EOC_DRUID_SHIFTER_GIVE_FORM_RAVEN" ],
+        "title": "Which form did you learn how to shift into?",
+        "names": [ "Bear Form", "Deer Form", "Raven Form" ],
+        "keys": [ "a", "b", "c" ],
+        "descriptions": [
+          "You learned how to transform into a bear",
+          "You learned how to transform into a deer",
+          "You learned how to transform into a raven"
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_DRUID_SHIFTER_GIVE_FORM_BEAR",
+    "effect": [ { "u_add_trait": "DRUID_SHIFTER_BEAR_FORM" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_DRUID_SHIFTER_GIVE_FORM_DEER",
+    "effect": [ { "u_add_trait": "DRUID_SHIFTER_DEER_FORM" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_DRUID_SHIFTER_GIVE_FORM_RAVEN",
+    "effect": [ { "u_add_trait": "DRUID_SHIFTER_RAVEN_FORM" } ]
+  }
+]

--- a/data/mods/Magiclysm/effects/eoc_transformations.json
+++ b/data/mods/Magiclysm/effects/eoc_transformations.json
@@ -1,0 +1,79 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_DRUID_SHIFTER_RAVEN_FORM_activated",
+    "condition": { "not": { "u_has_any_trait": [ "DRUID_SHIFTER_BEAR_FORM_TRAITS", "DRUID_SHIFTER_DEER_FORM_TRAITS" ] } },
+    "effect": [
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_DRUID_SHIFTER_RAVEN_FORM_activated_2",
+            "condition": { "not": { "u_has_trait": "DRUID_SHIFTER_RAVEN_FORM_TRAITS" } },
+            "effect": [
+              {
+                "run_eocs": [
+                  {
+                    "id": "EOC_DRUID_SHIFTER_RAVEN_FORM_activated_3",
+                    "condition": { "math": [ "u_val('mana')", ">=", "50" ] },
+                    "effect": [
+                      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+                      { "math": [ "u_val('mana')", ">=", "50" ] },
+                      { "u_add_trait": "DRUID_SHIFTER_RAVEN_FORM_TRAITS" },
+                      { "math": [ "u_spell_level('druid_raven_form_fly_upward')", "=", "0" ] },
+                      { "math": [ "u_calories()", "/=", "4" ] },
+                      {
+                        "u_message": "Your body shifts and changes as you concentrate and you take wing as a raven.",
+                        "type": "good"
+                      }
+                    ],
+                    "false_effect": [
+                      { "u_message": "You don't have enough mana to transform into a raven.", "type": "bad" },
+                      { "queue_eocs": "EOC_DRUID_SHIFTER_RAVEN_FORM_deactivate_future", "time_in_future": 0 }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "false_effect": [
+              {
+                "run_eocs": [
+                  {
+                    "id": "EOC_DRUID_SHIFTER_RAVEN_FORM_deactivated",
+                    "condition": { "u_has_trait": "DRUID_SHIFTER_RAVEN_FORM_TRAITS" },
+                    "effect": [
+                      { "u_message": "Your body shifts and changes and you return to your humanoid form.", "type": "neutral" },
+                      { "u_lose_trait": "DRUID_SHIFTER_RAVEN_FORM_TRAITS" },
+                      { "math": [ "u_spell_level('druid_raven_form_fly_upward')", "=", "-1" ] },
+                      { "math": [ "u_calories()", "*=", "4" ] }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "false_effect": [
+      { "u_message": "You cannot transform into a raven if you are already in an animal form.", "type": "mixed" },
+      { "queue_eocs": "EOC_DRUID_SHIFTER_RAVEN_FORM_deactivate_future", "time_in_future": 0 }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_DRUID_SHIFTER_RAVEN_FORM_deactivate_future",
+    "//": "This is necessary because calling u_deactivate_trait from within the trait EoC does not work",
+    "effect": { "u_deactivate_trait": "DRUID_SHIFTER_RAVEN_FORM" }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_DRUID_SHIFTER_RAVEN_FORM_ASCEND",
+    "condition": "u_is_outside",
+    "effect": [
+      { "u_location_variable": { "context_val": "raven_form_fly_up_location" }, "z_adjust": 1, "outdoor_only": true },
+      { "u_message": "Your wings carry you upward.", "type": "good" },
+      { "u_teleport": { "context_val": "raven_form_fly_up_location" } }
+    ],
+    "false_effect": [ { "u_message": "You cannot fly up with a ceiling above you!", "type": "bad" } ]
+  }
+]

--- a/data/mods/Magiclysm/effects/eoc_transformations.json
+++ b/data/mods/Magiclysm/effects/eoc_transformations.json
@@ -1,6 +1,89 @@
 [
   {
     "type": "effect_on_condition",
+    "id": "EOC_DRUID_SHIFTER_BEAR_FORM_activated",
+    "condition": { "not": { "u_has_any_trait": [ "DRUID_SHIFTER_DEER_FORM_TRAITS", "DRUID_SHIFTER_RAVEN_FORM_TRAITS" ] } },
+    "effect": [
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_DRUID_SHIFTER_BEAR_FORM_activated_2",
+            "condition": { "not": { "u_has_trait": "DRUID_SHIFTER_BEAR_FORM_TRAITS" } },
+            "effect": [
+              {
+                "run_eocs": [
+                  {
+                    "id": "EOC_DRUID_SHIFTER_BEAR_FORM_activated_3",
+                    "condition": { "math": [ "u_val('mana')", ">=", "50" ] },
+                    "effect": [
+                      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+                      { "math": [ "u_val('mana')", "-=", "50" ] },
+                      { "math": [ "u_preshift_size", "=", "u_val('size')" ] },
+                      {
+                        "switch": { "math": [ "u_preshift_size" ] },
+                        "cases": [
+                          { "case": 1, "effect": [ { "math": [ "u_calories()", "*=", "12" ] } ] },
+                          { "case": 2, "effect": [ { "math": [ "u_calories()", "*=", "6" ] } ] },
+                          { "case": 3, "effect": [ { "math": [ "u_calories()", "*=", "2" ] } ] },
+                          { "case": 4, "effect": [ { "math": [ "u_calories()", "*=", "1.5" ] } ] },
+                          { "case": 5, "effect": [  ] }
+                        ]
+                      },
+                      { "u_add_trait": "DRUID_SHIFTER_BEAR_FORM_TRAITS" },
+                      {
+                        "u_message": "Your body shifts and expands as fur sprouts from your skin and your mouth and teeth lengthen.",
+                        "type": "good"
+                      }
+                    ],
+                    "false_effect": [
+                      { "u_message": "You don't have enough mana to transform into a bear.", "type": "bad" },
+                      { "queue_eocs": "EOC_DRUID_SHIFTER_BEAR_FORM_deactivate_future", "time_in_future": 0 }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "false_effect": [
+              {
+                "run_eocs": [
+                  {
+                    "id": "EOC_DRUID_SHIFTER_BEAR_FORM_deactivated",
+                    "condition": { "u_has_trait": "EOC_DRUID_SHIFTER_BEAR_FORM_TRAITS" },
+                    "effect": [
+                      { "u_message": "Your body shifts and contracts and you return to your humanoid form.", "type": "neutral" },
+                      { "u_lose_trait": "EOC_DRUID_SHIFTER_BEAR_FORM_TRAITS" },
+                      {
+                        "switch": { "math": [ "u_preshift_size" ] },
+                        "cases": [
+                          { "case": 1, "effect": [ { "math": [ "u_calories()", "/=", "12" ] } ] },
+                          { "case": 2, "effect": [ { "math": [ "u_calories()", "/=", "6" ] } ] },
+                          { "case": 3, "effect": [ { "math": [ "u_calories()", "/=", "2" ] } ] },
+                          { "case": 4, "effect": [ { "math": [ "u_calories()", "/=", "1.5" ] } ] },
+                          { "case": 5, "effect": [  ] }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "false_effect": [
+      { "u_message": "You cannot transform into a bear if you are already in an animal form.", "type": "mixed" },
+      { "queue_eocs": "EOC_DRUID_SHIFTER_BEAR_FORM_deactivate_future", "time_in_future": 0 }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_DRUID_SHIFTER_BEAR_FORM_deactivate_future",
+    "//": "This is necessary because calling u_deactivate_trait from within the trait EoC does not work",
+    "effect": { "u_deactivate_trait": "DRUID_SHIFTER_BEAR_FORM" }
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_DRUID_SHIFTER_RAVEN_FORM_activated",
     "condition": { "not": { "u_has_any_trait": [ "DRUID_SHIFTER_BEAR_FORM_TRAITS", "DRUID_SHIFTER_DEER_FORM_TRAITS" ] } },
     "effect": [
@@ -17,10 +100,20 @@
                     "condition": { "math": [ "u_val('mana')", ">=", "50" ] },
                     "effect": [
                       { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
-                      { "math": [ "u_val('mana')", ">=", "50" ] },
+                      { "math": [ "u_val('mana')", "-=", "50" ] },
+                      { "math": [ "u_preshift_size", "=", "u_val('size')" ] },
+                      {
+                        "switch": { "math": [ "u_preshift_size" ] },
+                        "cases": [
+                          { "case": 1, "effect": [  ] },
+                          { "case": 2, "effect": [ { "math": [ "u_calories()", "/=", "2" ] } ] },
+                          { "case": 3, "effect": [ { "math": [ "u_calories()", "/=", "4" ] } ] },
+                          { "case": 4, "effect": [ { "math": [ "u_calories()", "/=", "6" ] } ] },
+                          { "case": 5, "effect": [ { "math": [ "u_calories()", "/=", "10" ] } ] }
+                        ]
+                      },
                       { "u_add_trait": "DRUID_SHIFTER_RAVEN_FORM_TRAITS" },
                       { "math": [ "u_spell_level('druid_raven_form_fly_upward')", "=", "0" ] },
-                      { "math": [ "u_calories()", "/=", "4" ] },
                       {
                         "u_message": "Your body shifts and changes as you concentrate and you take wing as a raven.",
                         "type": "good"
@@ -44,7 +137,16 @@
                       { "u_message": "Your body shifts and changes and you return to your humanoid form.", "type": "neutral" },
                       { "u_lose_trait": "DRUID_SHIFTER_RAVEN_FORM_TRAITS" },
                       { "math": [ "u_spell_level('druid_raven_form_fly_upward')", "=", "-1" ] },
-                      { "math": [ "u_calories()", "*=", "4" ] }
+                      {
+                        "switch": { "math": [ "u_preshift_size" ] },
+                        "cases": [
+                          { "case": 1, "effect": [  ] },
+                          { "case": 2, "effect": [ { "math": [ "u_calories()", "*=", "2" ] } ] },
+                          { "case": 3, "effect": [ { "math": [ "u_calories()", "*=", "4" ] } ] },
+                          { "case": 4, "effect": [ { "math": [ "u_calories()", "*=", "6" ] } ] },
+                          { "case": 5, "effect": [ { "math": [ "u_calories()", "*=", "10" ] } ] }
+                        ]
+                      }
                     ]
                   }
                 ]

--- a/data/mods/Magiclysm/effects/eoc_transformations.json
+++ b/data/mods/Magiclysm/effects/eoc_transformations.json
@@ -17,7 +17,7 @@
                     "condition": { "math": [ "u_val('mana')", ">=", "50" ] },
                     "effect": [
                       { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
-                      { "math": [ "u_val('mana')", "-=", "50" ] },
+                      { "math": [ "u_transformed_mana", "=", "u_val('mana') - 50" ] },
                       { "math": [ "u_preshift_size", "=", "u_val('size')" ] },
                       {
                         "switch": { "math": [ "u_preshift_size" ] },
@@ -50,8 +50,13 @@
                     "id": "EOC_DRUID_SHIFTER_BEAR_FORM_deactivated",
                     "condition": { "u_has_trait": "EOC_DRUID_SHIFTER_BEAR_FORM_TRAITS" },
                     "effect": [
-                      { "u_message": "Your body shifts and contracts and you return to your humanoid form.", "type": "neutral" },
+                      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+                      {
+                        "u_message": "Your body shifts and contracts and you return to your humanoid form.",
+                        "type": "neutral"
+                      },
                       { "u_lose_trait": "EOC_DRUID_SHIFTER_BEAR_FORM_TRAITS" },
+                      { "math": [ "u_val('mana')", "=", "u_transformed_mana" ] },
                       {
                         "switch": { "math": [ "u_preshift_size" ] },
                         "cases": [
@@ -84,6 +89,94 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_DRUID_SHIFTER_DEER_FORM_activated",
+    "condition": { "not": { "u_has_any_trait": [ "DRUID_SHIFTER_BEAR_FORM_TRAITS", "DRUID_SHIFTER_RAVEN_FORM_TRAITS" ] } },
+    "effect": [
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_DRUID_SHIFTER_DEER_FORM_activated_2",
+            "condition": { "not": { "u_has_trait": "DRUID_SHIFTER_DEER_FORM_TRAITS" } },
+            "effect": [
+              {
+                "run_eocs": [
+                  {
+                    "id": "EOC_DRUID_SHIFTER_DEER_FORM_activated_3",
+                    "condition": { "math": [ "u_val('mana')", ">=", "50" ] },
+                    "effect": [
+                      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+                      { "math": [ "u_transformed_mana", "=", "u_val('mana') - 50" ] },
+                      { "math": [ "u_preshift_size", "=", "u_val('size')" ] },
+                      {
+                        "switch": { "math": [ "u_preshift_size" ] },
+                        "cases": [
+                          { "case": 1, "effect": [ { "math": [ "u_calories()", "/=", "4" ] } ] },
+                          { "case": 2, "effect": [ { "math": [ "u_calories()", "/=", "2" ] } ] },
+                          { "case": 3, "effect": [  ] },
+                          { "case": 4, "effect": [ { "math": [ "u_calories()", "*=", "1.5" ] } ] },
+                          { "case": 5, "effect": [ { "math": [ "u_calories()", "*=", "3" ] } ] }
+                        ]
+                      },
+                      { "u_add_trait": "DRUID_SHIFTER_DEER_FORM_TRAITS" },
+                      {
+                        "u_message": "Your body shifts and warps as your fingers and feet fuse into hooves and majestic antlers sprout from your head.",
+                        "type": "good"
+                      }
+                    ],
+                    "false_effect": [
+                      { "u_message": "You don't have enough mana to transform into a deer.", "type": "bad" },
+                      { "queue_eocs": "EOC_DRUID_SHIFTER_DEER_FORM_deactivate_future", "time_in_future": 0 }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "false_effect": [
+              {
+                "run_eocs": [
+                  {
+                    "id": "EOC_DRUID_SHIFTER_DEER_FORM_deactivated",
+                    "condition": { "u_has_trait": "EOC_DRUID_SHIFTER_DEER_FORM_TRAITS" },
+                    "effect": [
+                      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+                      {
+                        "u_message": "Your body shifts and your fingers separate as you return to your humanoid form.",
+                        "type": "neutral"
+                      },
+                      { "u_lose_trait": "EOC_DRUID_SHIFTER_DEER_FORM_TRAITS" },
+                      { "math": [ "u_val('mana')", "=", "u_transformed_mana" ] },
+                      {
+                        "switch": { "math": [ "u_preshift_size" ] },
+                        "cases": [
+                          { "case": 1, "effect": [ { "math": [ "u_calories()", "*=", "4" ] } ] },
+                          { "case": 2, "effect": [ { "math": [ "u_calories()", "*=", "2" ] } ] },
+                          { "case": 3, "effect": [  ] },
+                          { "case": 4, "effect": [ { "math": [ "u_calories()", "/=", "1.5" ] } ] },
+                          { "case": 5, "effect": [ { "math": [ "u_calories()", "/=", "3" ] } ] }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "false_effect": [
+      { "u_message": "You cannot transform into a deer if you are already in an animal form.", "type": "mixed" },
+      { "queue_eocs": "EOC_DRUID_SHIFTER_DEER_FORM_deactivate_future", "time_in_future": 0 }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_DRUID_SHIFTER_DEER_FORM_deactivate_future",
+    "//": "This is necessary because calling u_deactivate_trait from within the trait EoC does not work",
+    "effect": { "u_deactivate_trait": "DRUID_SHIFTER_DEER_FORM" }
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_DRUID_SHIFTER_RAVEN_FORM_activated",
     "condition": { "not": { "u_has_any_trait": [ "DRUID_SHIFTER_BEAR_FORM_TRAITS", "DRUID_SHIFTER_DEER_FORM_TRAITS" ] } },
     "effect": [
@@ -101,6 +194,7 @@
                     "effect": [
                       { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
                       { "math": [ "u_val('mana')", "-=", "50" ] },
+                      { "math": [ "u_transformed_mana", "=", "u_val('mana') - 50" ] },
                       { "math": [ "u_preshift_size", "=", "u_val('size')" ] },
                       {
                         "switch": { "math": [ "u_preshift_size" ] },
@@ -134,9 +228,14 @@
                     "id": "EOC_DRUID_SHIFTER_RAVEN_FORM_deactivated",
                     "condition": { "u_has_trait": "DRUID_SHIFTER_RAVEN_FORM_TRAITS" },
                     "effect": [
-                      { "u_message": "Your body shifts and changes and you return to your humanoid form.", "type": "neutral" },
+                      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+                      {
+                        "u_message": "Your body shifts and changes and you return to your humanoid form.",
+                        "type": "neutral"
+                      },
                       { "u_lose_trait": "DRUID_SHIFTER_RAVEN_FORM_TRAITS" },
                       { "math": [ "u_spell_level('druid_raven_form_fly_upward')", "=", "-1" ] },
+                      { "math": [ "u_val('mana')", "=", "u_transformed_mana" ] },
                       {
                         "switch": { "math": [ "u_preshift_size" ] },
                         "cases": [

--- a/data/mods/Magiclysm/effects/eoc_transformations.json
+++ b/data/mods/Magiclysm/effects/eoc_transformations.json
@@ -48,14 +48,14 @@
                 "run_eocs": [
                   {
                     "id": "EOC_DRUID_SHIFTER_BEAR_FORM_deactivated",
-                    "condition": { "u_has_trait": "EOC_DRUID_SHIFTER_BEAR_FORM_TRAITS" },
+                    "condition": { "u_has_trait": "DRUID_SHIFTER_BEAR_FORM_TRAITS" },
                     "effect": [
                       { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
                       {
                         "u_message": "Your body shifts and contracts and you return to your humanoid form.",
                         "type": "neutral"
                       },
-                      { "u_lose_trait": "EOC_DRUID_SHIFTER_BEAR_FORM_TRAITS" },
+                      { "u_lose_trait": "DRUID_SHIFTER_BEAR_FORM_TRAITS" },
                       { "math": [ "u_val('mana')", "=", "u_transformed_mana" ] },
                       {
                         "switch": { "math": [ "u_preshift_size" ] },
@@ -136,14 +136,14 @@
                 "run_eocs": [
                   {
                     "id": "EOC_DRUID_SHIFTER_DEER_FORM_deactivated",
-                    "condition": { "u_has_trait": "EOC_DRUID_SHIFTER_DEER_FORM_TRAITS" },
+                    "condition": { "u_has_trait": "DRUID_SHIFTER_DEER_FORM_TRAITS" },
                     "effect": [
                       { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
                       {
                         "u_message": "Your body shifts and your fingers separate as you return to your humanoid form.",
                         "type": "neutral"
                       },
-                      { "u_lose_trait": "EOC_DRUID_SHIFTER_DEER_FORM_TRAITS" },
+                      { "u_lose_trait": "DRUID_SHIFTER_DEER_FORM_TRAITS" },
                       { "math": [ "u_val('mana')", "=", "u_transformed_mana" ] },
                       {
                         "switch": { "math": [ "u_preshift_size" ] },

--- a/data/mods/Magiclysm/items/integrated.json
+++ b/data/mods/Magiclysm/items/integrated.json
@@ -18,5 +18,30 @@
     "description": "A set of lizardfolk teeth, made for biting chunks of out their prey.",
     "techniques": [ "FANGS_BITE_LIZARDFOLK", "LIZARDFOLK_BITE_CRIT" ],
     "melee_damage": { "stab": 20 }
+  },
+  {
+    "id": "integrated_antlers",
+    "type": "ARMOR",
+    "category": "armor",
+    "name": { "str_sp": "deer antlers" },
+    "description": "You have a majestic crown of antlers.",
+    "weight": "2000 g",
+    "volume": "2500 ml",
+    "price": "0 cent",
+    "price_postapoc": "0 cent",
+    "material": [ "bone" ],
+    "symbol": "V",
+    "color": "dark_gray",
+    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "AURA", "PADDED", "NO_SALVAGE" ],
+    "armor": [
+      {
+        "material": [ { "type": "bone", "covered_by_mat": 100, "thickness": 3 } ],
+        "covers": [ "head" ],
+        "specifically_covers": [ "hand_fingers_l", "hand_fingers_r" ],
+        "coverage": 20,
+        "encumbrance": 2
+      }
+    ],
+    "melee_damage": { "bash": 6 }
   }
 ]

--- a/data/mods/Magiclysm/mutations/magical.json
+++ b/data/mods/Magiclysm/mutations/magical.json
@@ -1,8 +1,65 @@
 [
   {
     "type": "mutation",
-    "id": "DRUID_SHIFTER_RAVEN_FORM",
+    "id": "DRUID_SHIFTER_BEAR_FORM",
     "name": { "str": "Form of the Forest King" },
+    "points": 0,
+    "description": "You can transform yourself into a bear.  Roar.",
+    "starting_trait": false,
+    "purifiable": false,
+    "valid": false,
+    "active": true,
+    "activated_is_setup": true,
+    "activated_eocs": [ "EOC_DRUID_SHIFTER_BEAR_FORM_activated" ],
+    "deactivated_eocs": [ "EOC_DRUID_SHIFTER_BEAR_FORM_deactivated" ]
+  },
+  {
+    "type": "mutation",
+    "id": "DRUID_SHIFTER_BEAR_FORM_TRAITS",
+    "name": { "str": "Bear Form" },
+    "points": 99,
+    "description": "You are a bear.  This provides the actual effects of bear form.  Should not be player-visible",
+    "valid": false,
+    "starting_trait": false,
+    "purifiable": false,
+    "player_display": false,
+    "//": "The second enchantment takes into account the effects of the mutations added by the first enchantment, whose own enchantments do not transfer over due to bug #74994.  If that bug is fixed, it can be deleted.",
+    "enchantments": [
+      {
+        "condition": "ALWAYS",
+        "values": [
+          { "value": "MAX_HP", "multiply": 0.5 },
+          { "value": "SPEED", "multiply": 0.2 },
+          { "value": "RANGE", "multiply": -1 },
+          { "value": "DEXTERITY", "add": 2 },
+          { "value": "STRENGTH", "add": 10 },
+          { "value": "NIGHT_VIS", "add": 5 },
+          { "value": "MELEE_DAMAGE", "multiply": 0.4 },
+          { "value": "CLIMATE_CONTROL_HEAT", "add": 25 },
+          { "value": "CRAFTING_SPEED_MULTIPLIER", "multiply": -1000 }
+        ],
+        "mutations": [ "FANGS", "MUZZLE_BEAR", "TAIL_STUB", "PAWS_LARGE", "URSINE_FUR", "URSINE_EARS", "PRED3" ]
+      },
+      { "condition": { "condition": "ALWAYS" }, "values": [ { "value": "HEARING_MULT", "multiply": 0.25 } ] },
+      {
+        "condition": { "and": [ { "u_has_flag": "QUADRUPED_CROUCH" }, { "u_has_flag": "QUADRUPED_RUN" }, { "not": "u_can_drop_weapon" } ] },
+        "values": [ { "value": "MOVE_COST", "multiply": -0.15 } ],
+        "ench_effects": [ { "effect": "natural_stance", "intensity": 1 }, { "effect": "quadruped_full", "intensity": 1 } ]
+      },
+      { "condition": { "u_has_move_mode": "run" }, "values": [ { "value": "MOVE_COST", "multiply": -0.25 } ] },
+      {
+        "condition": "u_has_weapon",
+        "values": [ { "value": "MELEE_DAMAGE", "multiply": -1 }, { "value": "RANGE", "multiply": -1 } ]
+      }
+    ],
+    "flags": [ "HUGE", "MUTE", "MYOPIC_IN_LIGHT", "PRED3", "QUADRUPED_CROUCH", "QUADRUPED_RUN", "TOUGH_FEET" ],
+    "override_look": { "id": "mon_bear", "tile_category": "monster" },
+    "integrated_armor": [ "integrated_claws_st", "integrated_fangs", "integrated_ursine_fur" ]
+  },
+  {
+    "type": "mutation",
+    "id": "DRUID_SHIFTER_RAVEN_FORM",
+    "name": { "str": "Form of the Soaring Wings" },
     "points": 0,
     "description": "You can transform yourself into a raven and take wing.",
     "starting_trait": false,
@@ -23,16 +80,30 @@
     "purifiable": false,
     "valid": false,
     "player_display": false,
+    "//": "The second enchantment, as well as bodytemp modifiers, takes into account the effects of the mutations added by the first enchantment, whose own enchantments do not transfer over due to bug #74994.  If that bug is fixed, it can be deleted.",
+    "bodytemp_modifiers": [ 300, 800 ],
     "enchantments": [
       {
         "condition": "ALWAYS",
         "values": [
           { "value": "SPEED", "multiply": 0.1 },
           { "value": "MELEE_DAMAGE", "multiply": -0.95 },
-          { "value": "DEXTERITY", "add": 8 }
+          { "value": "DEXTERITY", "add": 8 },
+          { "value": "PERCEPTION", "add": 4 },
+          { "value": "CRAFTING_SPEED_MULTIPLIER", "multiply": -1000 }
         ],
         "ench_effects": [ { "effect": "effect_druid_shifter_raven_form_levitation", "intensity": 1 } ],
-        "skills": [ { "value": "dodge", "add": 8 } ]
+        "skills": [ { "value": "dodge", "add": 6 } ],
+        "mutations": [ "BIRD_EYE", "DOWN", "EAGLEEYED", "LIGHTEATER" ]
+      },
+      {
+        "condition": "ALWAYS",
+        "values": [
+          { "value": "PERCEPTION", "add": 4 },
+          { "value": "BODYTEMP_SLEEP", "add": 0.5 },
+          { "value": "OVERMAP_SIGHT", "add": 4 },
+          { "value": "METABOLISM", "multiply": -0.333 }
+        ]
       },
       {
         "condition": "u_has_weapon",

--- a/data/mods/Magiclysm/mutations/magical.json
+++ b/data/mods/Magiclysm/mutations/magical.json
@@ -36,11 +36,12 @@
           { "value": "NIGHT_VIS", "add": 5 },
           { "value": "MELEE_DAMAGE", "multiply": 0.4 },
           { "value": "CLIMATE_CONTROL_HEAT", "add": 25 },
-          { "value": "CRAFTING_SPEED_MULTIPLIER", "multiply": -1000 }
+          { "value": "CRAFTING_SPEED_MULTIPLIER", "multiply": -1000 },
+          { "value": "MAX_MANA", "multiply": -1000 }
         ],
         "mutations": [ "FANGS", "MUZZLE_BEAR", "TAIL_STUB", "PAWS_LARGE", "URSINE_FUR", "URSINE_EARS", "PRED3" ]
       },
-      { "condition": { "condition": "ALWAYS" }, "values": [ { "value": "HEARING_MULT", "multiply": 0.25 } ] },
+      { "condition": "ALWAYS", "values": [ { "value": "HEARING_MULT", "multiply": 0.25 } ] },
       {
         "condition": { "and": [ { "u_has_flag": "QUADRUPED_CROUCH" }, { "u_has_flag": "QUADRUPED_RUN" }, { "not": "u_can_drop_weapon" } ] },
         "values": [ { "value": "MOVE_COST", "multiply": -0.15 } ],
@@ -52,9 +53,64 @@
         "values": [ { "value": "MELEE_DAMAGE", "multiply": -1 }, { "value": "RANGE", "multiply": -1 } ]
       }
     ],
-    "flags": [ "HUGE", "MUTE", "MYOPIC_IN_LIGHT", "PRED3", "QUADRUPED_CROUCH", "QUADRUPED_RUN", "TOUGH_FEET" ],
+    "flags": [ "HUGE", "MUTE", "MYOPIC_IN_LIGHT", "NO_SPELLCASTING", "PRED3", "QUADRUPED_CROUCH", "QUADRUPED_RUN", "TOUGH_FEET" ],
     "override_look": { "id": "mon_bear", "tile_category": "monster" },
     "integrated_armor": [ "integrated_claws_st", "integrated_fangs", "integrated_ursine_fur" ]
+  },
+  {
+    "type": "mutation",
+    "id": "DRUID_SHIFTER_DEER_FORM",
+    "name": { "str": "Form of the Swift Runner" },
+    "points": 0,
+    "description": "You can transform yourself into a deer.",
+    "starting_trait": false,
+    "purifiable": false,
+    "valid": false,
+    "active": true,
+    "activated_is_setup": true,
+    "activated_eocs": [ "EOC_DRUID_SHIFTER_DEER_FORM_activated" ],
+    "deactivated_eocs": [ "EOC_DRUID_SHIFTER_DEER_FORM_deactivated" ]
+  },
+  {
+    "type": "mutation",
+    "id": "DRUID_SHIFTER_DEER_FORM_TRAITS",
+    "name": { "str": "Deer Form" },
+    "points": 99,
+    "description": "You are a deer.  This provides the actual effects of deer form.  Should not be player-visible",
+    "valid": false,
+    "starting_trait": false,
+    "purifiable": false,
+    "player_display": false,
+    "enchantments": [
+      {
+        "condition": "ALWAYS",
+        "values": [
+          { "value": "MAX_HP", "multiply": 0.1 },
+          { "value": "SPEED", "multiply": 0.2 },
+          { "value": "MOVE_COST", "multiply": -0.5 },
+          { "value": "DEXTERITY", "add": 3 },
+          { "value": "NIGHT_VIS", "add": 6 },
+          { "value": "CRAFTING_SPEED_MULTIPLIER", "multiply": -1000 },
+          { "value": "MAX_MANA", "multiply": -1000 }
+        ],
+        "skills": [ { "value": "dodge", "add": 2 } ],
+        "mutations": [ "ANTLERS", "HOOVES" ]
+      },
+      { "condition": { "u_has_move_mode": "run" }, "values": [ { "value": "MOVE_COST", "multiply": -0.25 } ] },
+      {
+        "condition": "u_has_weapon",
+        "values": [ { "value": "MELEE_DAMAGE", "multiply": -1 }, { "value": "RANGE", "multiply": -1 } ]
+      }
+    ],
+    "attacks": {
+      "attack_text_u": "You kick %s with your hooves!",
+      "attack_text_npc": "%1$s kicks %2$s with their hooves!",
+      "chance": 15,
+      "strength_damage": { "damage_type": "bash", "amount": 3 }
+    },
+    "flags": [ "MUTE", "NO_SPELLCASTING", "QUADRUPED_CROUCH", "QUADRUPED_RUN", "TOUGH_FEET" ],
+    "override_look": { "id": "mon_deer", "tile_category": "monster" },
+    "integrated_armor": [ "integrated_antlers", "integrated_feline_fur" ]
   },
   {
     "type": "mutation",
@@ -86,11 +142,14 @@
       {
         "condition": "ALWAYS",
         "values": [
+          { "value": "MAX_HP", "multiply": -0.75 },
           { "value": "SPEED", "multiply": 0.1 },
           { "value": "MELEE_DAMAGE", "multiply": -0.95 },
           { "value": "DEXTERITY", "add": 8 },
           { "value": "PERCEPTION", "add": 4 },
-          { "value": "CRAFTING_SPEED_MULTIPLIER", "multiply": -1000 }
+          { "value": "NIGHT_VIS", "add": 4 },
+          { "value": "CRAFTING_SPEED_MULTIPLIER", "multiply": -1000 },
+          { "value": "MAX_MANA", "multiply": -1000 }
         ],
         "ench_effects": [ { "effect": "effect_druid_shifter_raven_form_levitation", "intensity": 1 } ],
         "skills": [ { "value": "dodge", "add": 6 } ],

--- a/data/mods/Magiclysm/mutations/magical.json
+++ b/data/mods/Magiclysm/mutations/magical.json
@@ -1,0 +1,47 @@
+[
+  {
+    "type": "mutation",
+    "id": "DRUID_SHIFTER_RAVEN_FORM",
+    "name": { "str": "Form of the Forest King" },
+    "points": 0,
+    "description": "You can transform yourself into a raven and take wing.",
+    "starting_trait": false,
+    "purifiable": false,
+    "valid": false,
+    "active": true,
+    "activated_is_setup": true,
+    "activated_eocs": [ "EOC_DRUID_SHIFTER_RAVEN_FORM_activated" ],
+    "deactivated_eocs": [ "EOC_DRUID_SHIFTER_RAVEN_FORM_deactivated" ]
+  },
+  {
+    "type": "mutation",
+    "id": "DRUID_SHIFTER_RAVEN_FORM_TRAITS",
+    "name": { "str": "Raven Form" },
+    "points": 0,
+    "description": "You are a raven.  This provides the actual effects of raven form.  Should not be player-visible.",
+    "starting_trait": false,
+    "purifiable": false,
+    "valid": false,
+    "player_display": false,
+    "encumbrance_always": [ [ "arm_l", 200 ], [ "arm_r", 200 ], [ "hand_l", 200 ], [ "hand_r", 200 ] ],
+    "enchantments": [
+      {
+        "condition": "ALWAYS",
+        "values": [
+          { "value": "SPEED", "multiply": 0.1 },
+          { "value": "MELEE_DAMAGE", "multiply": -0.95 },
+          { "value": "DEXTERITY", "add": 8 }
+        ],
+        "ench_effects": [ { "effect": "effect_druid_shifter_raven_form_levitation", "intensity": 1 } ],
+        "skills": [ { "value": "dodge", "add": 8 } ]
+      },
+      {
+        "condition": "u_has_weapon",
+        "values": [ { "value": "MELEE_DAMAGE", "multiply": -1 }, { "value": "RANGE", "multiply": -1 } ]
+      },
+      { "condition": { "u_is_on_terrain": "t_open_air" }, "values": [ { "value": "MOVE_COST", "multiply": -0.6 } ] }
+    ],
+    "flags": [ "LEVITATION", "MUTE", "TINY" ],
+    "override_look": { "id": "mon_raven", "tile_category": "monster" }
+  }
+]

--- a/data/mods/Magiclysm/mutations/magical.json
+++ b/data/mods/Magiclysm/mutations/magical.json
@@ -23,7 +23,6 @@
     "purifiable": false,
     "valid": false,
     "player_display": false,
-    "encumbrance_always": [ [ "arm_l", 200 ], [ "arm_r", 200 ], [ "hand_l", 200 ], [ "hand_r", 200 ] ],
     "enchantments": [
       {
         "condition": "ALWAYS",
@@ -41,7 +40,7 @@
       },
       { "condition": { "u_is_on_terrain": "t_open_air" }, "values": [ { "value": "MOVE_COST", "multiply": -0.6 } ] }
     ],
-    "flags": [ "LEVITATION", "MUTE", "TINY" ],
+    "flags": [ "LEVITATION", "MUTE", "NO_SPELLCASTING", "TINY" ],
     "override_look": { "id": "mon_raven", "tile_category": "monster" }
   }
 ]

--- a/data/mods/Magiclysm/professions.json
+++ b/data/mods/Magiclysm/professions.json
@@ -1314,5 +1314,30 @@
       "male": { "entries": [ { "item": "boxer_shorts" } ] },
       "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     }
+  },
+  {
+    "type": "profession",
+    "id": "shifter_druid",
+    "name": "Shifter Druid",
+    "description": "The ancient druidic art of taking animal forms had mostly fallen out of favor by the modern era, since most people didn't need to be a bear in their daily lives and even if they did transform into a raven, they still had to physically fly to their destination and couldn't check the internet for directions.  You, however, studied the ancient arts and gained the ability to transform yourself.  It's come in very handy since the world ended.",
+    "points": 6,
+    "spells": [ { "id": "druid_natures_commune", "level": 3 } ],
+    "skills": [ { "level": 3, "name": "survival" }, { "level": 2, "name": "spellcraft" } ],
+    "traits": [ "DRUID", "ANIMALEMPATH" ],
+    "items": {
+      "both": {
+        "entries": [
+          { "item": "robe" },
+          { "item": "chestwrap" },
+          { "item": "loincloth" },
+          { "item": "leathersandals" },
+          { "item": "gloves_wraps" },
+          { "item": "cloak" },
+          { "item": "leather_pouch" },
+          { "item": "water_clean", "container-item": "waterskin" },
+          { "item": "primitive_knife", "container-item": "sheath" }
+        ]
+      }
+    }
   }
 ]

--- a/doc/MAGIC.md
+++ b/doc/MAGIC.md
@@ -280,7 +280,7 @@ Flag                       | Description
 `NO_HANDS`                 | Hands do not affect spell energy cost.
 `NO_LEGS`                  | Legs do not affect casting time.
 `NO_PROJECTILE`            | The "projectile" portion of the spell phases through walls, the epicenter of the spell effect is exactly where you target it, with no regards to obstacles.
-`NON_MAGICAL`              | Ignores spell resistance when calculating damage mitigation.
+`NON_MAGICAL`              | Ignores spell resistance when calculating damage mitigation and cannot be blocked by the NO_SPELLCASTING character flag.
 `PAIN_NORESIST`            | Pain altering spells can't be resisted (like with the deadened trait).
 `PERCENTAGE_DAMAGE`        | The spell deals damage based on the target's current hp.  This means that the spell can't directly kill the target.
 `PERMANENT`                | Items or creatures spawned with this spell do not disappear and die as normal.  Items can only be permanent at maximum spell level; creatures can be permanent at any spell level.

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1099,6 +1099,10 @@ bool spell::is_spell_class( const trait_id &mid ) const
 
 bool spell::can_cast( const Character &guy ) const
 {
+    if( has_flag( spell_flag::NON_MAGICAL ) ) {
+        return true;
+    };
+
     if( guy.has_flag( json_flag_NO_SPELLCASTING ) && !has_flag( spell_flag::PSIONIC ) ) {
         return false;
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Magiclysm] Add Shifter druid profession + wildshifts"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I had the idea to add a surviving druid you could go to a quest for and, if you're a druid, they would teach you the ancient druidic art of transforming into an animal...but I realized doing the entire thing in one PR would be huge, so here's the actual transformations and a profession that starts with 1. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the Shifter Druid profession, a druid who concentrated more on the ancient art of transformation than druidic magic. They start with the ability to transform into one type of animal: bear (tough, good in combat, strong), deer (fast, very good at running, can fight with antlers if necessary), or raven (can't fight basically at all, very fragile, but can fly). An EoC lets them pick one at the beginning of the game.

Since they spent most of their time studying the art of shifting, they only start with a single spell (Nature's Communion). 

It costs 50 mana to transform and you can spend as long as you like in each form, but the form cannot cast spells and you do not regenerate mana while transformed. You cannot talk to anyone in animal form and you cannot craft anything, and hopefully eventually you won't be able to pick anything up or open doors in animal form either, but at the moment there's no easy way to prevent those while still allowing you to do other things. 

To help with infrastructure for this (and future similar projects), I edited the NON_MAGICAL spell flag, currently used only three times (and not at all in Magiclysm) so that spells with it are not blocked by the NO_SPELLCASTING character flag. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Each form works, forms are mutually exclusive, and you cannot transform into a form if you already have a form. NON_MAGICAL allows spell (ravens flying upward implemented as a spell) even through NO_SPELLCASTING.

The disadvantage I'm not sure how to overcome is size flags--bears are HUGE and ravens are TINY, but the flags are checked in order from smallest to largest. That means if you're a goblin, who have the TINY flag, the checking stops there and your size isn't actually increased when you transform into a bear. 

Looks like I might need to add special handling to mutation.cpp line 488 to handle shapeshifted size (`SHAPESHIFT_SIZE_TINY` etc and a `TEMPORARY_SHAPESHIFT` flag ), so they're checked before regular size. I can do that in a follow-up PR. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
