### PR TITLE
Prevent automatic assignment of hotkeys to passive bionics

### DIFF
--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -2745,7 +2745,8 @@ bionic_uid Character::add_bionic( const bionic_id &b, bionic_uid parent_uid,
 
     bionic_uid bio_uid = generate_bionic_uid();
 
-    my_bionics->emplace_back( b, get_free_invlet( *this ), bio_uid, parent_uid );
+    const char invlet = b->activated ? get_free_invlet( *this ) : ' ';
+    my_bionics->emplace_back( b, invlet, bio_uid, parent_uid );
     bionic &bio = my_bionics->back();
     if( bio.id->activated_on_install ) {
         activate_bionic( bio );


### PR DESCRIPTION
#### Summary
Interface "Prevent automatically assigning keys to passive bionics"

#### Purpose of change
Stops passive bionics being automatically assigned characters since, as far as I'm aware, activating passive bionics does nothing.

#### Describe the solution
When installing a bionic, assign ' ' as the invlet unless the bionic is classified as active.

#### Describe alternatives you've considered
Only prevent assignment to bionics that allow multiple copies to be installed.

#### Testing
Created a new world. Debug installed all bionics. Only active bionics had hotkeys. Repeated test in a previous build. Hotkeys were spread between passive and active bionics.

#### Additional context
The hotkeys on passive bionics instantly select them when in examine mode so they do technically do something, but it's probably not particularly useful.