### PR TITLE
prevent book scanning in darkness

### DIFF
--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -9023,6 +9023,10 @@ std::optional<int> iuse::ebooksave( Character *p, item *it, const tripoint & )
         return std::nullopt;
     }
 
+    if( p->fine_detail_vision_mod() > 4 ) {
+        p->add_msg_if_player( m_info, _( "You can't see to do that!" ) );
+        return std::nullopt;
+    }
     item_location ereader = item_location( *p, it );
     const drop_locations to_scan = game_menus::inv::ebooksave( *p, ereader );
     if( to_scan.empty() ) {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fixes #74475 
More generally,  book scanning was working with no light. 

#### Describe the solution
Add a light check to the ebooksave iuse.

#### Describe alternatives you've considered
Potentially this could check for the device having the ability to provide light itself and toggle it on, but that seems like more trouble than it's worth.