### PR TITLE
Construct `glass trap` in construction menu

### DIFF
--- a/data/json/construction/furniture_traps.json
+++ b/data/json/construction/furniture_traps.json
@@ -1,0 +1,14 @@
+[
+  {
+    "type": "construction",
+    "id": "constr_trap_glass",
+    "group": "build_trap_glass",
+    "category": "OTHER",
+    "time": "2 s",
+    "//": "use place_trap",
+    "components": [ [ [ "glass_shard", 1 ] ] ],
+    "required_skills": [ [ "fabrication", 0 ] ],
+    "pre_special": "check_empty",
+    "post_terrain": "tr_glass"
+  }
+]

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -321,6 +321,11 @@
   },
   {
     "type": "construction_group",
+    "id": "build_trap_glass",
+    "name": "Build Glass Trap"
+  },
+  {
+    "type": "construction_group",
     "id": "build_treadmill_mechanical",
     "name": "Build Gravity Treadmill"
   },


### PR DESCRIPTION
#### Summary
Features "Allow placing the glass trap in the construction menu"

#### Purpose of change

Resolves #74316

#### Describe the solution

Not done, but I plan to do the following:

 - [ ] Add construction recipe for traps.
   - Currently, the committed code tries to add furniture, but `tr_glass` is a trap, not a furniture. 
 - [ ] Use `map::trap_set`, or a version of it that takes 0 moves so that the time in construction and placing traps doesn't add up and it is visible to the player the construction doesn't take 0 seconds.
 - `map::trap_set` adds the trap to traps known by the `player_character` (not by the `Character`), check it works for NPCs too.
    - [ ] Check that `avatar` remembers the construction properly, if they construct it.
    - [ ] Make it work for NPCs since they can construct.
       - [ ] Can NPCs place traps?
    - [ ] What if a friendly NPC builds traps on the avatar commands? Shouldn't the avatar get the information from the NPC somehow? Not getting the memo is stupid.
 - [ ] Write a test to check the use case (building glass traps all over 5x5 square)

#### Describe alternatives you've considered

 - [ ] Allow only the player_character to construct traps for now, not NPCs.

#### Testing

Doesn't work.

#### Additional context

NPCs (to my knowledge) cannot set traps. This would allow them to set traps through the construction menu.