### PR TITLE
Fixed deconstruction save/load item_location loss and screwed progress

### DIFF
--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -1256,7 +1256,7 @@ class disassemble_activity_actor : public activity_actor
         int moves_total;
         float activity_override = NO_EXERCISE; // NOLINT(cata-serialize)
         float cached_workbench_multiplier; // NOLINT(cata-serialize)
-        bool use_cached_workbench_multiplier; // NOLINT(cata-serialize)
+        bool use_cached_workbench_multiplier = false; // NOLINT(cata-serialize)
     public:
         item_location target;
 

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -471,8 +471,13 @@ const
 VisitResponse map_cursor::visit_items(
     const std::function<VisitResponse( item *, item * )> &func ) const
 {
-    map &here = get_map();
-    tripoint p = pos().raw();
+    smallmap here;  // tinymap would work as well, as we're only looking at a single position.
+    // pos returns the pos_bub location of the target relative to the reality bubble
+    // even if the location isn't actually inside of it. Thus, we're loading a map
+    // around that location to do our work.
+    tripoint_abs_ms abs_pos = get_map().getglobal( pos() );
+    here.load( project_to<coords::omt>( abs_pos ), false );
+    tripoint_omt_ms p = tripoint_omt_ms( here.getlocal( abs_pos ) );
 
     // check furniture pseudo items
     if( here.furn( p ) != furn_str_id::NULL_ID() ) {
@@ -486,12 +491,12 @@ VisitResponse map_cursor::visit_items(
     }
 
     // skip inaccessible items
-    if( here.has_flag( ter_furn_flag::TFLAG_SEALED, p ) &&
-        !here.has_flag( ter_furn_flag::TFLAG_LIQUIDCONT, p ) ) {
+    if( here.has_flag( ter_furn_flag::TFLAG_SEALED, p.raw() ) &&
+        !here.has_flag( ter_furn_flag::TFLAG_LIQUIDCONT, p.raw() ) ) {
         return VisitResponse::NEXT;
     }
 
-    for( item &e : here.i_at( p ) ) {
+    for( item &e : here.i_at( p.raw() ) ) {
         if( visit_internal( func, &e ) == VisitResponse::ABORT ) {
             return VisitResponse::ABORT;
         }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #75006 and #72250, i.e. in-progress deconstruction being lost on save/load cycles when the companion crafter is outside of the reality bubble, and silly negative progress showing up on deconstructions.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Load a map around the location of the in-progress deconstruction item and search for the item there, rather than loading the reality bubble and fail to find it when outside of the bubble.
- Initialize use_cached_workbench_multiplier to calculate it, rather than use a random bit pattern (255 in my case) as the boolean when loading a deconstruction activity,and then -NaN, or possibly a random bit pattern, for cached_workbench_multiplier (I got -NaN each time when debugging, but that may just be my environment).

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Reduce the coordinate juggling mess by introducing an operation to return the absolute coordinate stored in the item_locator. I try to touch as little as possible in order not to get hit with "conflicts" with the typifying PRs.
- Serialize/deserialize the absolute item_locator coordinates rather than the bubble ones. Would probably be better, but would also require dealing with save compatibility. Out of bounds reality bubble coordinates work, even if it's a bit weird, and the item_locator is loaded with the save (not the companion's map) so the bubble will be in the same place it was when the data was saved.
- Set the use_cached_workbench_multiplier element when deserializing the disassemble_activity_actor. That would probably correct this as well, and I don't think there are other uncovered places the actor is constructed, but it's probably safer to default the cache to not being valid.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
- Loaded a copy of the local save prior to the one attached to #75006 (standing by the workbench).
- Waited a turn and noted the progress on the in-progress deconstruction no longer turning a huge negative.
- Waited a bunch of additional turns to verify progress was actually made.
- Walked away to be well out of reality bubble range of the companion and then back.
- Checked the progress (increased a bit), waited a while to verify progress was still made.
- Walked away to approximately the bug report save was made.
- Saved and quit.
- Loaded the updated save.
- Walked back to Liam.
- Checked that the in-progress deconstruction object had progressed since leaving.
- Checked waited a while and verified progress was still being made.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
