### PR TITLE
[MoM] You can't contemplate powers if you're too weary

### DIFF
--- a/data/mods/MindOverMatter/powers/learning_eocs/overall.json
+++ b/data/mods/MindOverMatter/powers/learning_eocs/overall.json
@@ -2,6 +2,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_PSI_STUDYING_POWER",
+    "condition": { "u_has_effect": "effect_psi_studying_power" },
     "effect": [
       { "math": [ "u_psi_studying_tick_experience_counter", "+=", "contemplation_factor(1)" ] },
       {
@@ -21,12 +22,14 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_PSI_STUDYING_POWER_BEGIN",
+    "condition": { "not": { "u_has_any_effect": [ "weary_7", "weary_8" ] } },
     "effect": [
       { "u_message": "You spend some time meditating and contemplating your powers.", "type": "good" },
       { "math": [ "u_psi_studying_tick_experience_counter", "=", "0" ] },
       { "u_add_effect": "effect_psi_studying_power", "duration": "24 hours" },
       { "u_assign_activity": "ACT_PSI_STUDYING_POWER", "duration": "24 hours" }
-    ]
+    ],
+    "false_effect": [ { "u_message": "You are much too tired to contemplate anything", "type": "bad" } ]
   },
   {
     "type": "effect_on_condition",
@@ -108,6 +111,33 @@
       ]
     },
     "effect": [ { "u_lose_effect": "effect_psi_learning_new_power" }, { "u_lose_effect": "effect_psi_studying_power" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PSI_TOO_TIRED_TO_STUDY",
+    "eoc_type": "EVENT",
+    "required_event": "character_gains_effect",
+    "condition": {
+      "and": [
+        {
+          "or": [
+            { "compare_string": [ "weary_7", { "context_val": "effect" } ] },
+            { "compare_string": [ "weary_8", { "context_val": "effect" } ] }
+          ]
+        },
+        {
+          "or": [ { "u_has_effect": "effect_psi_learning_new_power" }, { "u_has_effect": "effect_psi_studying_power" } ]
+        }
+      ]
+    },
+    "effect": [
+      { "u_lose_effect": "effect_psi_learning_new_power" },
+      { "u_lose_effect": "effect_psi_studying_power" },
+      {
+        "u_message": "You're so tired you can barely think straight, and certainly can't concentrate on studying your powers.",
+        "popup": true
+      }
+    ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/MindOverMatter/powers/learning_eocs/overall.json
+++ b/data/mods/MindOverMatter/powers/learning_eocs/overall.json
@@ -29,7 +29,7 @@
       { "u_add_effect": "effect_psi_studying_power", "duration": "24 hours" },
       { "u_assign_activity": "ACT_PSI_STUDYING_POWER", "duration": "24 hours" }
     ],
-    "false_effect": [ { "u_message": "You are much too tired to contemplate anything", "type": "bad" } ]
+    "false_effect": [ { "u_message": "You are too exhausted to contemplate anything", "type": "bad" } ]
   },
   {
     "type": "effect_on_condition",
@@ -134,7 +134,7 @@
       { "u_lose_effect": "effect_psi_learning_new_power" },
       { "u_lose_effect": "effect_psi_studying_power" },
       {
-        "u_message": "You're so tired you can barely think straight, and certainly can't concentrate on studying your powers.",
+        "u_message": "You're so exhausted you can barely think straight, and certainly can't concentrate on studying your powers.",
         "popup": true
       }
     ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] You can't contemplate powers if you're too weary"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

While working on #75013, I realized that you could still contemplate powers even at a weariness level that prevents you from using psionics, which makes no sense.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

If you gain `weary_7` or `weary_8` while contemplating, the contemplate effect is removed (so you get no further benefit or penalties), and you get a popup letting you know you're exhausted so you can interrupt the activity.

If you are already that weary, starting contemplation just tells you you're too exhausted and does nothing.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

![image](https://github.com/user-attachments/assets/9d2b2a83-31c8-48a0-8ddd-9f7dec4b22b8)

(See last commit--tired changed to exhausted to avoid confusion with being sleepy)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
