### PR TITLE
Audit Hub 01 armor repair fees and timeframes

### DIFF
--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_prototypes.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_prototypes.json
@@ -206,28 +206,8 @@
       {
         "text": "How are my armor repairs coming?",
         "condition": {
-          "and": [
-            { "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_hub)", "<", "time('1 d')" ] },
-            { "u_has_var": "dialogue_hub_rnd_u_current_project", "value": "phase_immersion_suit" }
-          ]
-        },
-        "topic": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_ONGOING"
-      },
-      {
-        "text": "How are my armor repairs coming?",
-        "condition": {
-          "and": [
-            { "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_hub)", ">", "time('1 d')" ] },
-            { "u_has_var": "dialogue_hub_rnd_u_current_project", "value": "phase_immersion_suit" }
-          ]
-        },
-        "topic": "TALK_ROBOFAC_INTERCOM_PHASE_REPAIR_COMPLETE"
-      },
-      {
-        "text": "How are my armor repairs coming?",
-        "condition": {
-          "and": [
-            { "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_hub)", "<", "time('1 d')" ] },
+          "or": [
+            { "u_has_var": "dialogue_hub_rnd_u_current_project", "value": "phase_immersion_suit" },
             { "u_has_var": "dialogue_hub_rnd_u_current_project", "value": "rm13_armor" }
           ]
         },
@@ -237,7 +217,17 @@
         "text": "How are my armor repairs coming?",
         "condition": {
           "and": [
-            { "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_hub)", ">", "time('1 d')" ] },
+            { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "<", "time('now')" ] },
+            { "u_has_var": "dialogue_hub_rnd_u_current_project", "value": "phase_immersion_suit" }
+          ]
+        },
+        "topic": "TALK_ROBOFAC_INTERCOM_PHASE_REPAIR_COMPLETE"
+      },
+      {
+        "text": "How are my armor repairs coming?",
+        "condition": {
+          "and": [
+            { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "<", "time('now')" ] },
             { "u_has_var": "dialogue_hub_rnd_u_current_project", "value": "rm13_armor" }
           ]
         },
@@ -738,18 +728,47 @@
   },
   {
     "id": "TALK_ROBOFAC_INTERCOM_PHASE_REPAIR",
-    "//": "repairing Phase Immersion Suit",
     "type": "talk_topic",
-    "dynamic_line": "Certainly; for a fee of one coin, repairs and adjustments could be completed by tomorrow.  We'll also pull suit metrics and haptic data to better understand the situation on the ground.  I'd ask you to make sure everything has been removed from the suit before giving it to us.",
+    "dynamic_line": [
+      {
+        "npc_has_var": "phase_suit_reverse_engineered",
+        "value": "yes",
+        "yes": "Certainly; for a fee of ten coins, repairs and adjustments could be completed in two weeks.  We'll also pull suit metrics and haptic data to better understand the situation on the ground.  I'd ask you to make sure everything has been removed from the suit before giving it to us.",
+        "no": "The camera starts scanning the armor, after a moment the intercom cracks back to life, 'this technology is currently not within our database, we can probably repair it but we'll need to reverse-engineer it first.  We estimate the repairs to take around a month and a half, and they'll have an increased fee of 12 coins.  Please make sure everything has been removed from the suit before giving it to us.'"
+      }
+    ],
     "responses": [
       {
-        "text": "[1 HGC, suit] See you tomorrow.",
-        "condition": { "u_has_items": { "item": "RobofacCoin", "count": 1 } },
+        "text": "[10 HGC] Alright.",
+        "condition": {
+          "and": [
+            { "u_has_items": { "item": "RobofacCoin", "count": 10 } },
+            { "npc_has_var": "phase_suit_reverse_engineered", "value": "yes" }
+          ]
+        },
         "effect": [
-          { "u_sell_item": "RobofacCoin", "count": 1 },
+          { "u_sell_item": "RobofacCoin", "count": 10 },
           { "u_consume_item": "phase_immersion_suit", "count": 1, "popup": true },
           { "u_add_faction_trust": 1 },
-          { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "=", "time('now')" ] },
+          { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "=", "time('now') + time('14 day')" ] },
+          { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" },
+          { "u_add_var": "dialogue_hub_rnd_u_current_project", "value": "phase_immersion_suit" }
+        ],
+        "topic": "TALK_ROBOFAC_INTERCOM_REPAIR_STARTED"
+      },
+      {
+        "text": "[12 HGC] Fine.",
+        "condition": {
+          "and": [
+            { "u_has_items": { "item": "RobofacCoin", "count": 12 } },
+            { "not": { "npc_has_var": "phase_suit_reverse_engineered", "value": "yes" } }
+          ]
+        },
+        "effect": [
+          { "u_sell_item": "RobofacCoin", "count": 12 },
+          { "u_consume_item": "phase_immersion_suit", "count": 1, "popup": true },
+          { "u_add_faction_trust": 1 },
+          { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "=", "time('now') + time('44 day')" ] },
           { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" },
           { "u_add_var": "dialogue_hub_rnd_u_current_project", "value": "phase_immersion_suit" }
         ],
@@ -771,6 +790,7 @@
         "effect": [
           { "u_add_var": "dialogue_hub_rnd_u_current_project", "value": "none" },
           { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "no" },
+          { "u_add_var": "phase_suit_reverse_engineered", "value": "yes" },
           { "u_spawn_item": "phase_immersion_suit" }
         ],
         "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
@@ -779,18 +799,47 @@
   },
   {
     "id": "TALK_ROBOFAC_INTERCOM_RM13_REPAIR",
-    "//": "repairing RM13 Armor, same price as phase immersion because they get to do some research on Rivtech armor during repairs",
     "type": "talk_topic",
-    "dynamic_line": "Yes, that is within our capabilities.  For one coin, repairs and adjustments completed by tomorrow; we will recharge the internal battery as well.  Please note that if you have made any modifications to the armor, it will be reverted to factory standard as part of the repairs.",
+    "dynamic_line": [
+      {
+        "npc_has_var": "rm13_reverse_engineered",
+        "value": "yes",
+        "yes": "Yes, that is within our capabilities.  For ten coins, repairs and adjustments can be completed by tomorrow; we will recharge the internal battery as well.  Please note that if you have made any modifications to the armor, it will be reverted to factory standard as part of the repairs.",
+        "no": "The camera starts scanning the armor, after a moment the intercom cracks back to life, 'this technology is currently not within our database, we can probably repair it but we'll need to reverse-engineer it first.  We estimate the repairs to take around a month and a half, and they'll have an increased fee of 12 coins.  Please make sure everything has been removed from the suit before giving it to us.'"
+      }
+    ],
     "responses": [
       {
-        "text": "[1 HGC, armor] See you tomorrow.",
-        "condition": { "u_has_items": { "item": "RobofacCoin", "count": 1 } },
+        "text": "[10 HGC] Alright.",
+        "condition": {
+          "and": [
+            { "u_has_items": { "item": "RobofacCoin", "count": 10 } },
+            { "npc_has_var": "combat_exoskeleton_reverse_engineered", "value": "yes" }
+          ]
+        },
         "effect": [
-          { "u_sell_item": "RobofacCoin", "count": 1 },
+          { "u_sell_item": "RobofacCoin", "count": 10 },
           { "u_consume_item": "rm13_armor", "count": 1, "popup": true },
           { "u_add_faction_trust": 1 },
-          { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "=", "time('now')" ] },
+          { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "=", "time('now') + time('14 day')" ] },
+          { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" },
+          { "u_add_var": "dialogue_hub_rnd_u_current_project", "value": "rm13_armor" }
+        ],
+        "topic": "TALK_ROBOFAC_INTERCOM_REPAIR_STARTED"
+      },
+      {
+        "text": "[12 HGC] Fine.",
+        "condition": {
+          "and": [
+            { "u_has_items": { "item": "RobofacCoin", "count": 12 } },
+            { "not": { "npc_has_var": "combat_exoskeleton_reverse_engineered", "value": "yes" } }
+          ]
+        },
+        "effect": [
+          { "u_sell_item": "RobofacCoin", "count": 12 },
+          { "u_consume_item": "rm13_armor", "count": 1, "popup": true },
+          { "u_add_faction_trust": 1 },
+          { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "=", "time('now') + time('44 day')" ] },
           { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" },
           { "u_add_var": "dialogue_hub_rnd_u_current_project", "value": "rm13_armor" }
         ],
@@ -812,6 +861,7 @@
         "effect": [
           { "u_add_var": "dialogue_hub_rnd_u_current_project", "value": "none" },
           { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "no" },
+          { "u_add_var": "rm13_reverse_engineered", "value": "yes" },
           { "u_spawn_item": "rm13_armor" }
         ],
         "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_prototypes.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_prototypes.json
@@ -790,7 +790,7 @@
         "effect": [
           { "u_add_var": "dialogue_hub_rnd_u_current_project", "value": "none" },
           { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "no" },
-          { "u_add_var": "phase_suit_reverse_engineered", "value": "yes" },
+          { "npc_add_var": "phase_suit_reverse_engineered", "value": "yes" },
           { "u_spawn_item": "phase_immersion_suit" }
         ],
         "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
@@ -814,7 +814,7 @@
         "condition": {
           "and": [
             { "u_has_items": { "item": "RobofacCoin", "count": 10 } },
-            { "npc_has_var": "combat_exoskeleton_reverse_engineered", "value": "yes" }
+            { "npc_has_var": "rm13_reverse_engineered", "value": "yes" }
           ]
         },
         "effect": [
@@ -832,7 +832,7 @@
         "condition": {
           "and": [
             { "u_has_items": { "item": "RobofacCoin", "count": 12 } },
-            { "not": { "npc_has_var": "combat_exoskeleton_reverse_engineered", "value": "yes" } }
+            { "not": { "npc_has_var": "rm13_reverse_engineered", "value": "yes" } }
           ]
         },
         "effect": [
@@ -861,7 +861,7 @@
         "effect": [
           { "u_add_var": "dialogue_hub_rnd_u_current_project", "value": "none" },
           { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "no" },
-          { "u_add_var": "rm13_reverse_engineered", "value": "yes" },
+          { "npc_add_var": "rm13_reverse_engineered", "value": "yes" },
           { "u_spawn_item": "rm13_armor" }
         ],
         "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "update Hub 01 armor repair fees and timeframes"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
While working on #74962 it came to my knowledge that the repair times and fees for our current armor repairs have been greatly underestimated.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
The first time the phase suit and rm13 are repaired, the fee will be 12 coins and the repair times a month and a half.

Once the repairs have been done at least once, the armors are considered "reverse-engineered", from this point onward following repairs will only take 2 weeks, and cost 10 coins.

I also took the liberty of removing one of the conditional dialogue to check on how the repairs are going, we only need one dialogue to check, and the check as also been simplified, now we only check if the armor is currently an ongoing project.

The timers setups and timer checks have been slightly modified to accommodate the different dialogue options.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

- Instead of having the different variables be stored on the player have them stored on the npc the same way I did with the reverse-engineered variables, for better interactions with character swapping. Not sure how to go about it yet, and is out of scope anyway.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Spawned char, spawned Hub 01, talked with intercom, stuff seems to work ok. I touched a few variables since then but it should work the same.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
The writing is awful, feel free to suggest better dialogue.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
