### PR TITLE
Burning Buildings Bugfix

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4242,8 +4242,13 @@ void map::bash_ter_furn( const tripoint_bub_ms &p, bash_params &params )
     const map_bash_info *bash = nullptr;
 
     tripoint_bub_ms below = p + tripoint_rel_ms_below;
-    const ter_str_id below_tile_roof = get_roof( below, false );
-    bool roof_of_below_tile = ( terid.id.id() == below_tile_roof.id() );
+    ter_str_id below_tile_roof = ter_t_dirt;
+    bool roof_of_below_tile = false;
+
+    if( zlevels ) {
+        below_tile_roof = get_roof( below, false );
+        roof_of_below_tile = ( terid.id.id() == below_tile_roof.id() );
+    }
 
     bool success = false;
 
@@ -4480,8 +4485,8 @@ void map::bash_ter_furn( const tripoint_bub_ms &p, bash_params &params )
         spawn_items( p, item_group::items_from( bash->drop_group, calendar::turn ) );
     }
     //regenerates roofs for tiles that should be walkable from above
-    if( smash_ter && ter( p )->has_flag( "EMPTY_SPACE" ) && ter( below )->has_flag( "WALL" ) &&
-        zlevels && !set_to_air ) {
+    if( zlevels && smash_ter && !set_to_air  && ter( p )->has_flag( "EMPTY_SPACE" ) &&
+        ter( below )->has_flag( "WALL" ) ) {
         const ter_str_id roof = get_roof( below, params.bash_floor && ter( below ).obj().movecost != 0 );
         ter_set( p, roof );
     }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4240,10 +4240,10 @@ void map::bash_ter_furn( const tripoint_bub_ms &p, bash_params &params )
     bool smash_furn = false;
     bool smash_ter = false;
     const map_bash_info *bash = nullptr;
-    
+
     tripoint_bub_ms below = p + tripoint_rel_ms_below;
-    const ter_str_id below_tile_roof = get_roof(below, false);
-    bool roof_of_below_tile = ( terid.id.id() == below_tile_roof.id());
+    const ter_str_id below_tile_roof = get_roof( below, false );
+    bool roof_of_below_tile = ( terid.id.id() == below_tile_roof.id() );
 
     bool success = false;
 
@@ -4457,7 +4457,7 @@ void map::bash_ter_furn( const tripoint_bub_ms &p, bash_params &params )
         // If this terrain is being bashed from above and this terrain
         // has a valid post-destroy bashed-from-above terrain, set it
         ter_set( p, bash->ter_set_bashed_from_above );
-    } else if( bash->ter_set && !roof_of_below_tile) {
+    } else if( bash->ter_set && !roof_of_below_tile ) {
         // If the terrain has a valid post-destroy terrain, set it
         ter_set( p, bash->ter_set );
     } else {
@@ -4466,10 +4466,12 @@ void map::bash_ter_furn( const tripoint_bub_ms &p, bash_params &params )
             // When bashing the tile below, don't allow bashing the floor
             bash_params params_below = params; // Make a copy
             params_below.bashing_from_above = true;
+            //the roof tile will be destroyed, so the below tile should also be destroyed
+            params_below.destroy = true;
             bash_ter_furn( below, params_below );
         }
 
-        set_to_air = roof_of_below_tile; //do not add a roof for the tile below if it was already removed
+        set_to_air = roof_of_below_tile; //do not add the roof for the tile below if it was already removed
         furn_set( p, furn_str_id::NULL_ID() );
         ter_set( p, ter_t_open_air );
     }
@@ -4477,8 +4479,9 @@ void map::bash_ter_furn( const tripoint_bub_ms &p, bash_params &params )
     if( !tent ) {
         spawn_items( p, item_group::items_from( bash->drop_group, calendar::turn ) );
     }
-
-    if( smash_ter && ter( p )->has_flag( "EMPTY_SPACE" ) && zlevels && !set_to_air ) {
+    //regenerates roofs for tiles that should be walkable from above
+    if( smash_ter && ter( p )->has_flag( "EMPTY_SPACE" ) && ter( below )->has_flag( "WALL" ) &&
+        zlevels && !set_to_air ) {
         const ter_str_id roof = get_roof( below, params.bash_floor && ter( below ).obj().movecost != 0 );
         ter_set( p, roof );
     }

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -1087,7 +1087,7 @@ void field_processor_fd_fire( const tripoint &p, field_entry &cur, field_proc_da
             smoke += static_cast<int>( windpower / 5 );
             if( cur.get_field_intensity() > 1 &&
                 one_in( 200 - cur.get_field_intensity() * 50 ) ) {
-                here.destroy( p, false );
+                here.bash(p, 999, false, true);
             }
 
         } else if( ter_furn_has_flag( ter, frn, ter_furn_flag::TFLAG_FLAMMABLE_HARD ) &&
@@ -1098,7 +1098,7 @@ void field_processor_fd_fire( const tripoint &p, field_entry &cur, field_proc_da
             smoke += static_cast<int>( windpower / 5 );
             if( cur.get_field_intensity() > 1 &&
                 one_in( 200 - cur.get_field_intensity() * 50 ) ) {
-                here.destroy( p, false );
+                here.bash(p, 999, false, true);
             }
 
         } else if( ter.has_flag( ter_furn_flag::TFLAG_FLAMMABLE_ASH ) ) {

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -1087,7 +1087,7 @@ void field_processor_fd_fire( const tripoint &p, field_entry &cur, field_proc_da
             smoke += static_cast<int>( windpower / 5 );
             if( cur.get_field_intensity() > 1 &&
                 one_in( 200 - cur.get_field_intensity() * 50 ) ) {
-                here.bash(p, 999, false, true);
+                here.bash( p, 999, false, true, true );
             }
 
         } else if( ter_furn_has_flag( ter, frn, ter_furn_flag::TFLAG_FLAMMABLE_HARD ) &&
@@ -1098,7 +1098,7 @@ void field_processor_fd_fire( const tripoint &p, field_entry &cur, field_proc_da
             smoke += static_cast<int>( windpower / 5 );
             if( cur.get_field_intensity() > 1 &&
                 one_in( 200 - cur.get_field_intensity() * 50 ) ) {
-                here.bash(p, 999, false, true);
+                here.bash( p, 999, false, true, true );
             }
 
         } else if( ter.has_flag( ter_furn_flag::TFLAG_FLAMMABLE_ASH ) ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "bugfixes related to burning buildings"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

- Fixes #56242
- Fixes #60973
- Fixes #66822
- Fixes #74014

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

There were multiple issues, largely caused by this snippet of code in bash_ter_furn():
`if( smash_ter && ter( p )->has_flag( "EMPTY_SPACE" ) && zlevels ) {`
`     tripoint_bub_ms below = p + tripoint_rel_ms_below; `
`    const ter_str_id roof = get_roof( below, params.bash_floor && ter( below ).obj().movecost != 0 );`
`    ter_set( p, roof );`
`}`
When a tile above terrain with the "roof" field is destroyed, the code above adds that roof. It failed to account for that tile already being that roof, so e.g. t_wood_roof above t_door_c could burn forever because it'd get immediately replaced. If there happened to be e.g. f_rubble on the tile, then you'd get the ALLOW_ON_OPEN_AIR debug spam. Example: molotovs on t_wood_roof with t_door_c below versus without for in-game hours:
![fire1](https://github.com/user-attachments/assets/69c1c513-f093-46ca-ac0b-3a4bf2256e11)

This also caused another error (probably unreported): because get_roof() returns t_dirt or t_open_air by default, dirt tiles would propagate upwards when terrain without the "roof" was destroyed, and air tiles would be placed onto f_rubble, also throwing the debug error. Example (before/after fix):
![fire2](https://github.com/user-attachments/assets/d3657275-c459-484a-9c46-0470435820cb)

Finally, fixing all of this also revealed yet another error with explosions: one-tile-deep pits were being automatically filled in by the above snippet, so explosion craters were smaller and steeper than they should have been. Example: 100L bomb (before/after fix):
![bomb1](https://github.com/user-attachments/assets/1c777cb0-9892-4e66-b5f3-d7816c685684)

These issues were fixed by:
1) Having roof replacement check for same tile and if the tile below has the WALL flag
2) Fires use bash_floor because they should destroy floors
3) If a floor is destroyed and it has bash_below=true, then also destroy the tile underneath

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Burnt down different types of buildings, including multi-story buildings. I didn't see any errors, but report them again if you see them.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Pinging @PatrikLundell because this is roof work and map.cpp was changed

Terrain roofs need an audit. For example, t_wall is FLAMMABLE, but its "roof" (t_flat_roof) is not. 

Implied, but #66352 did not fix #56242 because it only took into account fire processing of tiles with FLAMMABLE_ASH.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
