### PR TITLE
Various improvements to Barry Isherwood's rescue

### DIFF
--- a/data/json/effects_on_condition/npc_eocs/isherwood_barry_rescue_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/isherwood_barry_rescue_eocs.json
@@ -138,37 +138,81 @@
     "required_event": "avatar_enters_omt",
     "condition": {
       "and": [
-        { "u_has_mission": "MISSION_ISHERWOOD_CHRIS_1" },
+        { "not": { "math": [ "isherwood_barry_rescued", "==", "1" ] } },
         { "u_has_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" },
-        { "u_near_om_location": "horse_farm_isherwood_13", "range": 17 }
+        { "u_near_om_location": "horse_farm_isherwood_13", "range": 30 }
       ]
     },
     "effect": [
-      { "finish_mission": "MISSION_ISHERWOOD_CHRIS_1", "success": true },
       {
         "u_message": "Barry raises a hand to signal you to stop.  \"This is it.  Thank you so much.  I can't believe I'm here, alive.  It almost feels like I'm dreaming, like it can't be real.\"  He stares at you, his eyes glistening.  \"Whoever you are, thank you.  I'm going to head the rest of the way now and catch up to my family.  Come by and talk to me later when I've had a moment to rest.\"",
         "type": "good",
         "popup": true
       },
       {
-        "u_run_npc_eocs": [
+        "if": { "u_has_mission": "MISSION_ISHERWOOD_CHRIS_1" },
+        "then": [
           {
-            "id": "EOC_BARRY_LEAVE",
-            "effect": [
+            "u_run_npc_eocs": [
               {
-                "u_location_variable": { "global_val": "invasion_map" },
-                "target_params": { "om_terrain": "barry_mi-go_scout_tower_1", "search_range": 500, "z": 0 }
-              },
-              { "u_teleport": { "global_val": "invasion_map" }, "force": true },
-              {
-                "mapgen_update": "remove_barry_and_company",
-                "om_terrain": "barry_mi-go_scout_tower_1",
-                "om_special": "Barry's Mi-Go Scout Tower"
+                "id": "EOC_BARRY_LEAVE",
+                "effect": [
+                  {
+                    "u_location_variable": { "global_val": "invasion_map" },
+                    "target_params": { "om_terrain": "horse_farm_isherwood_13", "search_range": 500, "z": 0 }
+                  },
+                  { "u_teleport": { "global_val": "invasion_map" }, "force": true },
+                  {
+                    "mapgen_update": "remove_barry_and_company",
+                    "om_terrain": "horse_farm_isherwood_13",
+                    "om_special": "Isherwood Farm Mutable"
+                  }
+                ]
               }
-            ]
+            ],
+            "unique_ids": [ "BARRY_MISSION", "CHRIS_MISSION", "LISA_MISSION" ]
           }
         ],
-        "unique_ids": [ "BARRY_MISSION", "CHRIS_MISSION", "LISA_MISSION" ]
+        "else": {
+          "u_run_npc_eocs": [
+            {
+              "id": "EOC_BARRY_ONLY_LEAVE",
+              "effect": [
+                {
+                  "u_location_variable": { "global_val": "invasion_map" },
+                  "target_params": { "om_terrain": "horse_farm_isherwood_13", "search_range": 500, "z": 0 }
+                },
+                { "u_teleport": { "global_val": "invasion_map" }, "force": true },
+                {
+                  "mapgen_update": "remove_barry_and_company",
+                  "om_terrain": "horse_farm_isherwood_13",
+                  "om_special": "Isherwood Farm Mutable"
+                }
+              ]
+            }
+          ],
+          "unique_ids": [ "BARRY_MISSION" ]
+        }
+      },
+      {
+        "if": { "u_has_mission": "MISSION_ISHERWOOD_CHRIS_1" },
+        "then": [ { "finish_mission": "MISSION_ISHERWOOD_CHRIS_1", "success": true } ],
+        "else": {
+          "if": { "u_has_mission": "MISSION_ISHERWOOD_BARRY_RETURN_TO_FARM" },
+          "then": [ { "finish_mission": "MISSION_ISHERWOOD_BARRY_RETURN_TO_FARM", "success": true } ],
+          "else": {
+            "if": {
+              "and": [
+                { "not": { "u_has_mission": "MISSION_ISHERWOOD_CHRIS_1" } },
+                { "not": { "u_has_mission": "MISSION_ISHERWOOD_BARRY_RETURN_TO_FARM" } }
+              ]
+            },
+            "then": [
+              { "assign_mission": "MISSION_ISHERWOOD_BARRY_RETURN_TO_FARM" },
+              { "finish_mission": "MISSION_ISHERWOOD_BARRY_RETURN_TO_FARM", "success": true }
+            ]
+          }
+        }
       }
     ]
   },

--- a/data/json/mapgen/mi-go/mi-go_scout_tower.json
+++ b/data/json/mapgen/mi-go/mi-go_scout_tower.json
@@ -93,7 +93,7 @@
   {
     "type": "mapgen",
     "method": "json",
-    "om_terrain": [ "barry_mi-go_scout_tower_3", "mi-go_scout_tower_3" ],
+    "om_terrain": [ "mi-go_scout_tower_3" ],
     "object": {
       "fill_ter": "t_floor_resin",
       "rows": [
@@ -127,6 +127,55 @@
         { "chunks": [ "mi-go_scout_tower_cells" ], "x": 4, "y": 3 },
         { "chunks": [ "mi-go_encampment1_room17" ], "x": 1, "y": 14 }
       ],
+      "place_monster": [
+        {
+          "group": "GROUP_MI-GO_SCOUT_TOWER",
+          "x": 12,
+          "y": 12,
+          "pack_size": [ 1, 2 ],
+          "spawn_data": { "patrol": [ { "x": [ 8, 16 ], "y": [ 8, 16 ] } ] }
+        }
+      ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": "barry_mi-go_scout_tower_3",
+    "object": {
+      "fill_ter": "t_floor_resin",
+      "rows": [
+        "vvvvvvvvvvvvvvvvvvvvvvvv",
+        "vvvvvvvvvvvvvvvvvvvvvvvv",
+        "vvvvvvvvvvvvvvvvvvvvvvvv",
+        "vvvvvvvvvvvv||vvvvvvvvvv",
+        "vvvvvvvvvv||||||vvvvvvvv",
+        "vvvvvvvv|||    |||vvvvvv",
+        "vvvvvv|||        |||vvvv",
+        "vvvv|||            ||vvv",
+        "vvv||<              |vvv",
+        "vvv||>       6      ||vv",
+        "vvvv||               |vv",
+        "vvvvv|               |vv",
+        "vvvvv|              ||vv",
+        "vvvv||              |vvv",
+        "vv|||               |vvv",
+        "||| +              ||vvv",
+        "||  |||          |||vvvv",
+        "|| 14 ||||||||  ||vvvvvv",
+        "v|   ||vvvvvv||||vvvvvvv",
+        "v|||||vvvvvvvvvvvvvvvvvv",
+        "vvvvvvvvvvvvvvvvvvvvvvvv",
+        "vvvvvvvvvvvvvvvvvvvvvvvv",
+        "vvvvvvvvvvvvvvvvvvvvvvvv",
+        "vvvvvvvvvvvvvvvvvvvvvvvv"
+      ],
+      "palettes": [ "mi-go_palette" ],
+      "place_nested": [
+        { "chunks": [ "mi-go_scout_tower_cells" ], "x": 4, "y": 3 },
+        { "chunks": [ "mi-go_encampment1_room17" ], "x": 1, "y": 14 }
+      ],
+      "place_npcs": [ { "class": "isherwood_barry", "x": 18, "y": 15, "unique_id": "BARRY_MISSION" } ],
       "place_monster": [
         {
           "group": "GROUP_MI-GO_SCOUT_TOWER",

--- a/data/json/npcs/isherwood_farm/NPC_Barry_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Barry_Isherwood.json
@@ -42,7 +42,16 @@
     "id": "TALK_ISHERWOOD_BARRY_RESCUE",
     "dynamic_line": "*crouches on the bottom of his cell, shivering, then looks up as you approach.  He blinks a few times, then stands up.  He's totally nude, and his tanned body is covered in tiny, precise-looking scars of varying ages.  \"I can't believe my eyes.  Please get me outta here…\"",
     "responses": [
-      { "text": "Are you Barry Isherwood?", "topic": "TALK_ISHERWOOD_BARRY_ID" },
+      {
+        "text": "Are you Barry Isherwood?",
+        "topic": "TALK_ISHERWOOD_BARRY_ID",
+        "condition": { "u_has_mission": "MISSION_ISHERWOOD_CHRIS_1" }
+      },
+      {
+        "text": "I'll get you out of here, just stay calm.  Let's hit the road.",
+        "topic": "TALK_ISHERWOOD_BARRY_Escaping",
+        "condition": { "not": { "u_has_mission": "MISSION_ISHERWOOD_CHRIS_1" } }
+      },
       {
         "text": "I'm Luke Skywalker, I'm here to rescue you.",
         "effect": { "u_add_var": "too_short_to_be_a_stormtrooper", "value": "unclear" },
@@ -56,10 +65,19 @@
     "id": "TALK_ISHERWOOD_BARRY_BADJOKE",
     "dynamic_line": "What?\"  The naked, traumatized man stares at you blankly, as though he'd never seen Star Wars, which is clearly ridiculous.  \"Rescue me?  Yes, oh please yes!",
     "responses": [
-      { "text": "Are you Barry Isherwood?", "topic": "TALK_ISHERWOOD_BARRY_ID" },
+      {
+        "text": "Are you Barry Isherwood?",
+        "topic": "TALK_ISHERWOOD_BARRY_ID",
+        "condition": { "u_has_mission": "MISSION_ISHERWOOD_CHRIS_1" }
+      },
       {
         "text": "Let's go.",
-        "effect": [ "follow", { "u_add_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" } ],
+        "effect": [
+          "follow_only",
+          { "u_add_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" },
+          { "math": [ "u_timer_barry_rescue", "=", "time('now')" ] },
+          { "npc_first_topic": "TALK_ISHERWOOD_BARRY" }
+        ],
         "topic": "TALK_DONE"
       },
       { "text": "Hang on.  I've got questions.", "topic": "TALK_ISHERWOOD_BARRY_ID2" },
@@ -72,8 +90,13 @@
     "dynamic_line": "*gulps.  \"I sure as hell am.  Did my family send you?  Please, we gotta go.  There are more of those things.  They're everywhere.\"",
     "responses": [
       {
-        "text": "Yeah, they did.  Let's go.",
-        "effect": [ "follow", { "u_add_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" } ],
+        "text": "Yeah, they did.  let's go.",
+        "effect": [
+          "follow_only",
+          { "u_add_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" },
+          { "math": [ "u_timer_barry_rescue", "=", "time('now')" ] },
+          { "npc_first_topic": "TALK_ISHERWOOD_BARRY" }
+        ],
         "topic": "TALK_DONE"
       },
       { "text": "Hang on.  I've got questions.", "topic": "TALK_ISHERWOOD_BARRY_ID2" },
@@ -87,12 +110,22 @@
     "responses": [
       {
         "text": "Okay, me too.  Let's go.",
-        "effect": [ "follow", { "u_add_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" } ],
+        "effect": [
+          "follow_only",
+          { "u_add_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" },
+          { "math": [ "u_timer_barry_rescue", "=", "time('now')" ] },
+          { "npc_first_topic": "TALK_ISHERWOOD_BARRY" }
+        ],
         "topic": "TALK_DONE"
       },
       {
         "text": "All right, we're leaving, but you better not test me again.",
-        "effect": [ "follow", { "u_add_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" } ],
+        "effect": [
+          "follow_only",
+          { "u_add_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" },
+          { "math": [ "u_timer_barry_rescue", "=", "time('now')" ] },
+          { "npc_first_topic": "TALK_ISHERWOOD_BARRY" }
+        ],
         "topic": "TALK_DONE"
       },
       { "text": "Pff.  If you're gonna treat me like that, you can stay here.", "topic": "TALK_DONE" }
@@ -102,7 +135,42 @@
     "type": "talk_topic",
     "id": "TALK_ISHERWOOD_BARRY_Escaping",
     "dynamic_line": "Let's get back to the farm, as fast as possible.",
-    "responses": [ { "text": "Okay.", "topic": "TALK_DONE" } ]
+    "responses": [
+      {
+        "text": "What farm?",
+        "topic": "TALK_ISHERWOOD_BARRY_Escaping_What_Farm",
+        "condition": { "not": { "u_has_mission": "MISSION_ISHERWOOD_CHRIS_1" } },
+        "effect": { "u_add_var": "u_dont_know_about_farm", "type": "general", "context": "knowledge", "value": "yes" }
+      },
+      {
+        "text": "That shouldn't take long, your family's outside waiting.",
+        "topic": "TALK_DONE",
+        "condition": { "u_has_mission": "MISSION_ISHERWOOD_CHRIS_1" },
+        "effect": [
+          "follow_only",
+          { "u_add_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" },
+          { "math": [ "u_timer_barry_rescue", "=", "time('now')" ] },
+          { "npc_first_topic": "TALK_ISHERWOOD_BARRY" }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_ISHERWOOD_BARRY_Escaping_What_Farm",
+    "dynamic_line": "\"Oh, so my family didn't send you then.\"  Barry looks downtrodden for a brief moment.  \"Look, we just need to get out of here first, I'll tell you about it later.\"",
+    "responses": [
+      {
+        "text": "Okay, sounds good to me.  Let's go.",
+        "topic": "TALK_DONE",
+        "effect": [
+          "follow_only",
+          { "u_add_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" },
+          { "math": [ "u_timer_barry_rescue", "=", "time('now')" ] },
+          { "npc_first_topic": "TALK_ISHERWOOD_BARRY" }
+        ]
+      }
+    ]
   },
   {
     "type": "talk_topic",
@@ -111,39 +179,153 @@
       {
         "text": "Sorry about the Luke Skywalker joke.",
         "topic": "TALK_ISHERWOOD_BARRY_Skywalker",
-        "condition": { "u_has_var": "too_short_to_be_a_stormtrooper", "value": "unclear" }
+        "condition": {
+          "and": [
+            { "u_has_var": "too_short_to_be_a_stormtrooper", "value": "unclear" },
+            {
+              "and": [
+                { "not": { "npc_near_om_location": "barry_mi-go_scout_tower_1", "range": 3 } },
+                { "not": { "npc_near_om_location": "barry_mi-go_scout_tower_2", "range": 3 } },
+                { "not": { "npc_near_om_location": "barry_mi-go_scout_tower_3", "range": 3 } },
+                { "not": { "npc_near_om_location": "barry_mi-go_scout_tower_4", "range": 3 } }
+              ]
+            }
+          ]
+        }
       },
       {
         "text": "Hey buddy, feel like talking about what you saw in that tower?",
         "topic": "TALK_ISHERWOOD_BARRY_TOWER_no",
-        "condition": { "math": [ "u_timer_barry_rescue", "<", "time('5 d')" ] }
+        "condition": {
+          "and": [
+            { "math": [ "u_timer_barry_rescue", "<", "time('5 d')" ] },
+            {
+              "and": [
+                { "not": { "npc_near_om_location": "barry_mi-go_scout_tower_1", "range": 3 } },
+                { "not": { "npc_near_om_location": "barry_mi-go_scout_tower_2", "range": 3 } },
+                { "not": { "npc_near_om_location": "barry_mi-go_scout_tower_3", "range": 3 } },
+                { "not": { "npc_near_om_location": "barry_mi-go_scout_tower_4", "range": 3 } }
+              ]
+            }
+          ]
+        }
       },
       {
         "text": "Hey buddy, feel like talking about what you saw in that tower?",
         "topic": "TALK_ISHERWOOD_BARRY_TOWER_fresh1",
-        "condition": { "math": [ "u_timer_barry_rescue", ">", "time('5 d')" ] }
+        "condition": {
+          "and": [
+            { "math": [ "u_timer_barry_rescue", ">", "time('5 d')" ] },
+            {
+              "and": [
+                { "not": { "npc_near_om_location": "barry_mi-go_scout_tower_1", "range": 3 } },
+                { "not": { "npc_near_om_location": "barry_mi-go_scout_tower_2", "range": 3 } },
+                { "not": { "npc_near_om_location": "barry_mi-go_scout_tower_3", "range": 3 } },
+                { "not": { "npc_near_om_location": "barry_mi-go_scout_tower_4", "range": 3 } }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "text": "What farm were you going to tell me about earlier?",
+        "topic": "TALK_ISHERWOOD_BARRY_TOWER_farm",
+        "condition": {
+          "and": [
+            { "u_has_var": "u_dont_know_about_farm", "type": "general", "context": "knowledge", "value": "yes" },
+            { "not": { "u_has_mission": "MISSION_ISHERWOOD_BARRY_RETURN_TO_FARM" } },
+            {
+              "and": [
+                { "not": { "npc_near_om_location": "barry_mi-go_scout_tower_1", "range": 3 } },
+                { "not": { "npc_near_om_location": "barry_mi-go_scout_tower_2", "range": 3 } },
+                { "not": { "npc_near_om_location": "barry_mi-go_scout_tower_3", "range": 3 } },
+                { "not": { "npc_near_om_location": "barry_mi-go_scout_tower_4", "range": 3 } }
+              ]
+            }
+          ]
+        }
       },
       {
         "text": "Maybe let's talk about you a little bit.  What's your role in this family?",
         "topic": "TALK_ISHERWOOD_BARRY_TOWER_family1",
-        "condition": { "math": [ "barry_PTSD_freakouts", ">=", "1" ] }
+        "condition": {
+          "and": [
+            { "math": [ "barry_PTSD_freakouts", ">=", "1" ] },
+            {
+              "and": [
+                { "not": { "npc_near_om_location": "barry_mi-go_scout_tower_1", "range": 3 } },
+                { "not": { "npc_near_om_location": "barry_mi-go_scout_tower_2", "range": 3 } },
+                { "not": { "npc_near_om_location": "barry_mi-go_scout_tower_3", "range": 3 } },
+                { "not": { "npc_near_om_location": "barry_mi-go_scout_tower_4", "range": 3 } }
+              ]
+            }
+          ]
+        }
       },
-      { "text": "I'd better get going.", "topic": "TALK_DONE" }
+      {
+        "text": "I'd better get going.",
+        "topic": "TALK_DONE",
+        "condition": {
+          "and": [
+            { "not": { "npc_near_om_location": "barry_mi-go_scout_tower_1", "range": 3 } },
+            { "not": { "npc_near_om_location": "barry_mi-go_scout_tower_2", "range": 3 } },
+            { "not": { "npc_near_om_location": "barry_mi-go_scout_tower_3", "range": 3 } },
+            { "not": { "npc_near_om_location": "barry_mi-go_scout_tower_4", "range": 3 } }
+          ]
+        }
+      },
+      {
+        "text": "Alright, let's get going.",
+        "topic": "TALK_DONE",
+        "condition": {
+          "or": [
+            { "npc_near_om_location": "barry_mi-go_scout_tower_1", "range": 3 },
+            { "npc_near_om_location": "barry_mi-go_scout_tower_2", "range": 3 },
+            { "npc_near_om_location": "barry_mi-go_scout_tower_3", "range": 3 },
+            { "npc_near_om_location": "barry_mi-go_scout_tower_4", "range": 3 }
+          ]
+        }
+      }
     ]
   },
   {
     "type": "talk_topic",
     "id": "TALK_ISHERWOOD_BARRY",
     "dynamic_line": {
-      "concatenate": [
-        "*lights up as you approach, but also looks wary.  \"",
-        {
-          "u_has_var": "too_short_to_be_a_stormtrooper",
-          "value": "unclear",
-          "yes": "Hey, Jedi.\"",
-          "no": "Hey, <name_g>.\""
+      "npc_near_om_location": "barry_mi-go_scout_tower_1",
+      "range": 3,
+      "yes": "Come on, let's get out of here while we still can.  I don't want to spend any longer around here then we need too.",
+      "no": {
+        "npc_near_om_location": "barry_mi-go_scout_tower_2",
+        "range": 3,
+        "yes": "Come on, let's get out of here while we still can.  I don't want to spend any longer around here then we need too.",
+        "no": {
+          "npc_near_om_location": "barry_mi-go_scout_tower_3",
+          "range": 3,
+          "yes": "Come on, let's get out of here while we still can.  I don't want to spend any longer around here then we need too.",
+          "no": {
+            "npc_near_om_location": "barry_mi-go_scout_tower_4",
+            "range": 3,
+            "yes": "Come on, let's get out of here while we still can.  I don't want to spend any longer around here then we need too.",
+            "no": {
+              "concatenate": [
+                "*lights up as you approach, but also looks wary.  \"",
+                {
+                  "u_has_var": "too_short_to_be_a_stormtrooper",
+                  "value": "unclear",
+                  "yes": "Hey, Jedi.\"",
+                  "no": "Hey, <name_g>.\""
+                },
+                {
+                  "u_has_mission": "MISSION_ISHERWOOD_CHRIS_1",
+                  "yes": "I can't wait to get back home and see everyone.\"",
+                  "no": ""
+                }
+              ]
+            }
+          }
         }
-      ]
+      }
     }
   },
   {
@@ -181,7 +363,7 @@
     "dynamic_line": "*shivers, though the room is warm, and moves his mouth wordlessly for a few seconds.  \"It's hard to remember details.  The air in that place messes with your brain, makes it all feel like some kind of dream.  Makes it so you can't fight back.  Not that I could have anyway.\"  He stares into space for a moment, then swallows hard.  \"They cut into me, over and over.  I don't think they took anything out.  They just opened me up, poked around.  I was awake for all of it, as awake as for anything else.  Sometimes I felt pain, other times they did something to me so I could feel it but it didn't hurt.  There were big, pale ones that did the cutting.\"  His voice gets increasingly detached as he speaks, and his shaking grows worse.  You're not sure it would be wise for him to go further.",
     "speaker_effect": { "sentinel": "barry_PTSD1", "effect": { "math": [ "barry_PTSD_freakouts", "+=", "1" ] } },
     "responses": [
-      { "text": "[Let him continue.]", "topic": "TALK_ISHERWOOD_BARRY_TOWER_fresh3" },
+      { "text": "(Let him continue)", "topic": "TALK_ISHERWOOD_BARRY_TOWER_fresh3" },
       { "text": "That's enough for now, Barry.", "topic": "TALK_ISHERWOOD_BARRY_TOWER_fresh_stop" },
       { "text": "On second thought, I think you should recover more.", "topic": "TALK_DONE" }
     ]
@@ -190,7 +372,7 @@
     "type": "talk_topic",
     "id": "TALK_ISHERWOOD_BARRY_TOWER_fresh3",
     "dynamic_line": "*shudders, looking like he might vomit.  \"What did they want?  Why me?  Every time, they'd put me back together again, seal it up and make it look almost like nothing happened.\"  He yanks up his shirt to show the scars.  \"But I know what happened, it was REAL, goddammit!\"  He drops the shirt, bends forward, and dry heaves for a few seconds.  Wordless, he hides his face in his hands, and stops responding.",
-    "responses": [ { "text": "[Leave.]", "topic": "TALK_DONE" } ]
+    "responses": [ { "text": "(Leave)", "topic": "TALK_DONE" } ]
   },
   {
     "type": "talk_topic",
@@ -221,7 +403,7 @@
     "speaker_effect": { "effect": { "u_add_var": "u_knows_barry_family_story", "value": "yes" } },
     "responses": [
       {
-        "text": "[PER 9] Was your choice in partners part of the problem with your father?",
+        "text": "[PERCEPTION] Was your choice in partners part of the problem with your father?",
         "topic": "TALK_ISHERWOOD_BARRY_TOWER_family3",
         "condition": { "u_has_perception": 9 }
       },
@@ -246,18 +428,43 @@
     ]
   },
   {
-    "id": "MISSION_ISHERWOOD_BARRY_1",
+    "type": "talk_topic",
+    "id": "TALK_ISHERWOOD_BARRY_TOWER_farm",
+    "dynamic_line": "Oh, yeah, now I remember.  That farm I was talking about is where I live, almost the whole Isherwood family lives there, including me.  I just wanted to get back home as fast as possible so I can see everyone again, and so everyone knows that I'm okay.",
+    "responses": [
+      { "text": "Can you give me some directions to it?", "topic": "TALK_ISHERWOOD_BARRY_TOWER_farm_directions" },
+      {
+        "text": "That's pretty cool.  I'd like to ask you about something else.",
+        "topic": "TALK_ISHERWOOD_BARRY_askback"
+      },
+      { "text": "I'm going to head out.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_ISHERWOOD_BARRY_TOWER_farm_directions",
+    "dynamic_line": "Sure, can I please see your map?\"  Barry takes your map, orients himself, and points out a route to the farm.  \"Once we've done that, I'll head on myself so everyone won't be suprised by you coimg.  Sound good?",
+    "responses": [
+      {
+        "text": "Sounds good to me, let's hit the road.",
+        "topic": "TALK_DONE",
+        "effect": [
+          { "assign_mission": "MISSION_ISHERWOOD_BARRY_RETURN_TO_FARM" },
+          { "u_lose_var": "u_dont_know_about_farm", "type": "general", "context": "knowledge" }
+        ]
+      },
+      { "text": "I'd like to think about it some more.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "MISSION_ISHERWOOD_BARRY_RETURN_TO_FARM",
     "type": "mission_definition",
-    "name": { "str": "Return Barry to Eddie at the dairy." },
+    "name": { "str": "Return Barry to Isherwood's farm." },
     "goal": "MGOAL_GO_TO",
     "difficulty": 3,
     "value": 20000,
     "destination": "dairy_farm_isherwood_W",
     "start": {
-      "effect": [
-        { "u_add_var": "u_saved_barry_isherwood", "value": "in-progress" },
-        { "npc_first_topic": "TALK_ISHERWOOD_BARRY_Escaping" }
-      ],
       "assign_mission_target": {
         "om_terrain": "dairy_farm_isherwood_W",
         "om_special": "Isherwood Farm Mutable",
@@ -265,29 +472,19 @@
         "search_range": 240
       }
     },
-    "end": {
-      "opinion": { "trust": 5, "value": 5 },
-      "effect": [
-        "leave",
-        { "u_add_var": "u_saved_barry_isherwood", "value": "yes" },
-        { "npc_add_var": "barry_isherwood_saved", "value": "yes" },
-        { "math": [ "barry_PTSD_freakouts", "=", "0" ] },
-        { "math": [ "u_timer_barry_rescue", "=", "time('now')" ] },
-        { "npc_first_topic": "TALK_ISHERWOOD_BARRY" },
-        { "u_spawn_item": "hsurvivor_jumpsuit", "count": 1 }
-      ]
-    },
+    "end": { "effect": [ { "math": [ "isherwood_barry_rescued", "=", "1" ] } ] },
     "origins": [ "ORIGIN_SECONDARY" ],
+    "//": "Dialogue is handled externally.",
     "dialogue": {
-      "describe": "I just want to go home.",
-      "offer": "I can't believe you are here, please take me back to the ranch.",
-      "accepted": "Thank you, I thought I was dead.",
-      "rejected": "Please god no!",
-      "advice": "We shouldn't stay here too long, more might show up.",
-      "inquire": "How much further?",
-      "success": "Thanks, we'll never be able to repay you, Here's a token of my gratitude, I made these suits for my family and always keep a few extra around.",
-      "success_lie": "I don't feel saved…",
-      "failure": "Tell my family that I love them…"
+      "describe": ".",
+      "offer": ".",
+      "accepted": ".",
+      "rejected": "",
+      "advice": ".",
+      "inquire": ".",
+      "success": ".",
+      "success_lie": ".",
+      "failure": "."
     }
   }
 ]

--- a/data/json/npcs/isherwood_farm/NPC_Barry_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Barry_Isherwood.json
@@ -443,7 +443,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_ISHERWOOD_BARRY_TOWER_farm_directions",
-    "dynamic_line": "Sure, can I please see your map?\"  Barry takes your map, orients himself, and points out a route to the farm.  \"Once we've done that, I'll head on myself so everyone won't be suprised by you coimg.  Sound good?",
+    "dynamic_line": "Sure, can I please see your map?\"  Barry takes your map, orients himself, and points out a route to the farm.  \"Once we've done that, I'll head on myself so everyone won't be surprised by you coming.  Sound good?",
     "responses": [
       {
         "text": "Sounds good to me, let's hit the road.",

--- a/data/json/npcs/isherwood_farm/NPC_Chris_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Chris_Isherwood.json
@@ -734,8 +734,7 @@
     "difficulty": 5,
     "value": 50000,
     "start": {
-      "assign_mission_target": { "om_terrain": "barry_mi-go_scout_tower_3", "om_special": "Barry's Mi-Go Scout Tower", "reveal_radius": 3 },
-      "update_mapgen": { "place_npcs": [ { "class": "isherwood_barry", "x": 18, "y": 15, "unique_id": "BARRY_MISSION", "target": true } ] }
+      "assign_mission_target": { "om_terrain": "barry_mi-go_scout_tower_3", "om_special": "Barry's Mi-Go Scout Tower", "reveal_radius": 3 }
     },
     "origins": [ "ORIGIN_SECONDARY" ],
     "has_generic_rewards": false,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Further flesh out Barry Isherwood's rescue."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I wanted to make a few improvements to the mission given by the Isherwoods to rescue Barry, so this PR does that.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
First, Barry Isherwood now spawns within his unique mi-go tower upon its generation, rather than having the quest given by Chris place him there. This allows players to possibly find Barry before meeting the Isherwoods if they clear out this particular mi-go tower, and I added some branching dialogue to his speech tree based on if you were sent there by Chris or not, along with some minor changes where Barry won't initiate deeper conversations until he's sufficiently far away from the tower. If the player found him before accepting the mission, then Barry can give them his own quest to take him back to the farm, which reuses the completion EOC for going it alone when sent by Chris. Otherwise, Barry will simply follow the player around if they rescue him, without joining the player's faction.
Second, I changed the teleport destination for removing Barry to be the horse farm, rather than the mi-go tower. This was done to ensure that no situation existed where the game could fail to find the tower as a teleport destination if it was further than 500 tiles away.
Third, I extended the range of the completion EOC out to 30 tiles instead of 17, since the farm is now a mutable rather than a static OM special. This seemed more logical since Barry would likely know a wide swathe of area around the farm, and the 17-tile range created situations where it wouldn't trigger until going onto the property, and this seemed a bit silly for Barry to not recognize parts of his own farm. I also fixed a small error where the completion EOC would repeatedly trigger, so I had it deactivate when Barry was successfully rescued.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not doing this.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested multiple times, everything works wonderfully.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I plan to change parts of the completion EOC to have Barry path his way back to the farm, instead of teleporting and disappearing. This will preserve variables and such by keeping the same NPC across multiple stages and simulate his logical presence on the farm for future conversation. It would be nice for all of the other Isherwoods to give you dialogue for rescuing Barry, but that's a bigger project for another day.

I also plan to make the unique mi-go tower simply sit beside a road, and be surrounded by a clearing, rather than having a one-way connection to it. This still allows for a unique target teleportation tile for the EOCs, and makes the tower look more natural, like regular ones you'd see generate in the game.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
