### PR TITLE
Added deconstruction to deployed_items needing it

### DIFF
--- a/data/json/furniture_and_terrain/furniture-decorative.json
+++ b/data/json/furniture_and_terrain/furniture-decorative.json
@@ -130,6 +130,7 @@
     "required_str": 5,
     "flags": [ "PLACE_ITEM", "TRANSPARENT", "FLAMMABLE", "EASY_DECONSTRUCT" ],
     "deployed_item": "mannequin",
+    "deconstruct": { "items": [ { "item": "mannequin", "count": 1 } ] },
     "examine_action": "deployed_furniture",
     "bash": {
       "str_min": 6,

--- a/data/json/furniture_and_terrain/furniture-fireplaces.json
+++ b/data/json/furniture_and_terrain/furniture-fireplaces.json
@@ -56,6 +56,7 @@
     "crafting_pseudo_item": "fake_fireplace",
     "flags": [ "PLACE_ITEM", "TRANSPARENT", "FIRE_CONTAINER", "EASY_DECONSTRUCT" ],
     "deployed_item": "brazier",
+    "deconstruct": { "items": [ { "item": "brazier", "count": 1 } ] },
     "examine_action": "fireplace",
     "bash": {
       "str_min": 8,
@@ -84,6 +85,7 @@
     "crafting_pseudo_item": "fake_fireplace",
     "flags": [ "PLACE_ITEM", "TRANSPARENT", "FIRE_CONTAINER", "EASY_DECONSTRUCT" ],
     "deployed_item": "makeshift_brazier",
+    "deconstruct": { "items": [ { "item": "makeshift_brazier", "count": 1 } ] },
     "examine_action": "fireplace",
     "bash": {
       "str_min": 8,
@@ -109,6 +111,7 @@
     "required_str": 4,
     "flags": [ "PLACE_ITEM", "TRANSPARENT", "FIRE_CONTAINER", "EASY_DECONSTRUCT" ],
     "deployed_item": "hobo_stove",
+    "deconstruct": { "items": [ { "item": "hobo_stove", "count": 1 } ] },
     "examine_action": "fireplace",
     "max_volume": "680 ml",
     "bash": {
@@ -161,6 +164,7 @@
     "required_str": 8,
     "flags": [ "PLACE_ITEM", "TRANSPARENT", "FIRE_CONTAINER", "EASY_DECONSTRUCT" ],
     "deployed_item": "55gal_firebarrel",
+    "deconstruct": { "items": [ { "item": "55gal_firebarrel", "count": 1 } ] },
     "examine_action": "fireplace",
     "bash": {
       "str_min": 8,
@@ -187,6 +191,7 @@
     "required_str": 8,
     "flags": [ "PLACE_ITEM", "TRANSPARENT", "FIRE_CONTAINER", "EASY_DECONSTRUCT" ],
     "deployed_item": "30gal_firebarrel",
+    "deconstruct": { "items": [ { "item": "30gal_firebarrel", "count": 1 } ] },
     "examine_action": "fireplace",
     "bash": {
       "str_min": 8,

--- a/data/json/furniture_and_terrain/furniture-terrains.json
+++ b/data/json/furniture_and_terrain/furniture-terrains.json
@@ -458,7 +458,6 @@
     "flags": [ "TRANSPARENT", "INDOORS", "NOCOLLIDE", "SUN_ROOF_ABOVE" ],
     "examine_action": "portable_structure",
     "deployed_item": "large_shelter_kit",
-    "deconstruct": { "items": [ { "item": "large_shelter_kit", "count": 1 } ] },
     "bash": {
       "str_min": 1,
       "str_max": 8,
@@ -624,7 +623,6 @@
     "flags": [ "TRANSPARENT", "INDOORS", "NOCOLLIDE", "SUN_ROOF_ABOVE" ],
     "examine_action": "portable_structure",
     "deployed_item": "tent_kit",
-    "deconstruct": { "items": [ { "item": "tent_kit", "count": 1 } ] },
     "bash": {
       "str_min": 1,
       "str_max": 8,
@@ -669,7 +667,6 @@
     "flags": [ "TRANSPARENT", "INDOORS", "NOCOLLIDE", "SUN_ROOF_ABOVE" ],
     "examine_action": "portable_structure",
     "deployed_item": "large_tent_kit",
-    "deconstruct": { "items": [ { "item": "large_tent_kit", "count": 1 } ] },
     "bash": {
       "str_min": 1,
       "str_max": 8,
@@ -781,7 +778,6 @@
     "flags": [ "TRANSPARENT", "INDOORS", "NOCOLLIDE", "SUN_ROOF_ABOVE" ],
     "examine_action": "portable_structure",
     "deployed_item": "shelter_kit",
-    "deconstruct": { "items": [ { "item": "shelter_kit", "count": 1 } ] },
     "bash": {
       "str_min": 1,
       "str_max": 8,

--- a/data/json/furniture_and_terrain/furniture-terrains.json
+++ b/data/json/furniture_and_terrain/furniture-terrains.json
@@ -458,6 +458,7 @@
     "flags": [ "TRANSPARENT", "INDOORS", "NOCOLLIDE", "SUN_ROOF_ABOVE" ],
     "examine_action": "portable_structure",
     "deployed_item": "large_shelter_kit",
+    "deconstruct": { "items": [ { "item": "large_shelter_kit", "count": 1 } ] },
     "bash": {
       "str_min": 1,
       "str_max": 8,
@@ -623,6 +624,7 @@
     "flags": [ "TRANSPARENT", "INDOORS", "NOCOLLIDE", "SUN_ROOF_ABOVE" ],
     "examine_action": "portable_structure",
     "deployed_item": "tent_kit",
+    "deconstruct": { "items": [ { "item": "tent_kit", "count": 1 } ] },
     "bash": {
       "str_min": 1,
       "str_max": 8,
@@ -667,6 +669,7 @@
     "flags": [ "TRANSPARENT", "INDOORS", "NOCOLLIDE", "SUN_ROOF_ABOVE" ],
     "examine_action": "portable_structure",
     "deployed_item": "large_tent_kit",
+    "deconstruct": { "items": [ { "item": "large_tent_kit", "count": 1 } ] },
     "bash": {
       "str_min": 1,
       "str_max": 8,
@@ -778,6 +781,7 @@
     "flags": [ "TRANSPARENT", "INDOORS", "NOCOLLIDE", "SUN_ROOF_ABOVE" ],
     "examine_action": "portable_structure",
     "deployed_item": "shelter_kit",
+    "deconstruct": { "items": [ { "item": "shelter_kit", "count": 1 } ] },
     "bash": {
       "str_min": 1,
       "str_max": 8,


### PR DESCRIPTION

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #74775, i.e. failure to deconstruct furniture that has neither a deconstruct entry nor an examine_action of deployed_furniture or portable_structure.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add a deconstruct entry to needy deployed items.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Figure out how to wrangle the code to use the information already provided in the form of the deployed_item entry.
Turning that into the weirdo list thingy fed into the macro (probably called lambda) was too hard.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested that each of the modified items could be taken down after being deployed.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I only verified the crash on the brazier and the mannequin, so it's possible some entry may be redundant.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
