### PR TITLE
[Magiclysm] Add Iron Intolerance starting trait

### DIFF
--- a/data/mods/Magiclysm/effects/effects.json
+++ b/data/mods/Magiclysm/effects/effects.json
@@ -61,6 +61,50 @@
   },
   {
     "type": "effect_type",
+    "id": "effect_iron_allergy_wearing_iron",
+    "name": [ "Touching Iron" ],
+    "desc": [ "You are in contact with iron.  It will cause you pain and discomfort until removed." ],
+    "rating": "bad",
+    "apply_message": "As the iron touches you, your skin begins to burn.",
+    "remove_message": "The burning from the iron finally fades.",
+    "base_mods": {
+      "pain_amount": [ 5 ],
+      "pain_min": [ 1 ],
+      "pain_max": [ 3 ],
+      "pain_chance": [ 3 ],
+      "pain_max_val": [ 100 ],
+      "pain_tick": [ 120 ]
+    },
+    "limb_score_mods": [
+      { "limb_score": "balance", "modifier": 0.9 },
+      { "limb_score": "breathing", "modifier": 0.85 },
+      { "limb_score": "lift", "modifier": 0.9 },
+      { "limb_score": "grip", "modifier": 0.9 },
+      { "limb_score": "reaction", "modifier": 0.9 }
+    ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_iron_allergy_wearing_steel",
+    "name": [ "Touching Steel" ],
+    "desc": [ "You are in contact with steel.  It will cause you pain and discomfort until removed." ],
+    "rating": "bad",
+    "apply_message": "As the steel touches you, your skin begins to itch.",
+    "remove_message": "The itching from the steel finally fades.",
+    "base_mods": {
+      "pain_amount": [ 2 ],
+      "pain_min": [ 1 ],
+      "pain_max": [ 3 ],
+      "pain_chance": [ 6 ],
+      "pain_max_val": [ 50 ],
+      "pain_tick": [ 120 ]
+    },
+    "limb_score_mods": [ { "limb_score": "breathing", "modifier": 0.95 } ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
+  },
+  {
+    "type": "effect_type",
     "id": "enchant_windrun",
     "name": [ "Windrunning" ],
     "desc": [ "You are bolstered and pushed along by the power of the wind." ],

--- a/data/mods/Magiclysm/mutations/mutation_eocs.json
+++ b/data/mods/Magiclysm/mutations/mutation_eocs.json
@@ -1,0 +1,84 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_IRON_ALLERGY_WEARING_IRON_OR_STEEL",
+    "eoc_type": "EVENT",
+    "required_event": "character_wears_item",
+    "condition": { "u_has_trait": "IRON_ALLERGY" },
+    "effect": [ { "run_eocs": [ "EOC_IRON_ALLERGY_WEARING_IRON_FOLLOWUP", "EOC_IRON_ALLERGY_WEARING_STEEL_FOLLOWUP" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_IRON_ALLERGY_WIELDING_IRON_OR_STEEL",
+    "eoc_type": "EVENT",
+    "required_event": "character_wields_item",
+    "condition": { "u_has_trait": "IRON_ALLERGY" },
+    "effect": [ { "run_eocs": [ "EOC_IRON_ALLERGY_WEARING_IRON_FOLLOWUP", "EOC_IRON_ALLERGY_WEARING_STEEL_FOLLOWUP" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_IRON_ALLERGY_WEARING_IRON_FOLLOWUP",
+    "effect": {
+      "u_run_inv_eocs": "all",
+      "search_data": [ { "material": "iron", "worn_only": true }, { "material": "iron", "wielded_only": true } ],
+      "true_eocs": [
+        {
+          "id": "EOC_IRON_ALLERGY_WEARING_IRON_RESULT_TRUE",
+          "effect": [
+            { "u_add_effect": "effect_iron_allergy_wearing_iron", "duration": "PERMANENT" },
+            { "queue_eocs": "EOC_IRON_ALLERGY_WEARING_IRON_FOLLOWUP", "time_in_future": 60 }
+          ]
+        }
+      ],
+      "false_eocs": [
+        {
+          "id": "EOC_IRON_ALLERGY_WEARING_IRON_RESULT_FALSE",
+          "effect": [ { "u_lose_effect": "effect_iron_allergy_wearing_iron" } ]
+        }
+      ]
+    }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_IRON_ALLERGY_WEARING_STEEL_FOLLOWUP",
+    "effect": {
+      "u_run_inv_eocs": "all",
+      "search_data": [
+        { "material": "steel", "worn_only": true },
+        { "material": "lc_steel", "worn_only": true },
+        { "material": "mc_steel", "worn_only": true },
+        { "material": "hc_steel", "worn_only": true },
+        { "material": "ch_steel", "worn_only": true },
+        { "material": "lc_steel_chain", "worn_only": true },
+        { "material": "mc_steel_chain", "worn_only": true },
+        { "material": "hc_steel_chain", "worn_only": true },
+        { "material": "ch_steel_chain", "worn_only": true },
+        { "material": "steel", "wielded_only": true },
+        { "material": "lc_steel", "wielded_only": true },
+        { "material": "mc_steel", "wielded_only": true },
+        { "material": "hc_steel", "wielded_only": true },
+        { "material": "ch_steel", "wielded_only": true },
+        { "material": "lc_steel_chain", "wielded_only": true },
+        { "material": "mc_steel_chain", "worn_only": true },
+        { "material": "hc_steel_chain", "wielded_only": true },
+        { "material": "ch_steel_chain", "wielded_only": true }
+      ],
+      "true_eocs": [
+        {
+          "id": "EOC_IRON_ALLERGY_WEARING_STEEL_RESULT_TRUE",
+          "effect": [
+            { "u_add_effect": "effect_iron_allergy_wearing_steel", "duration": "PERMANENT" },
+            { "queue_eocs": "EOC_IRON_ALLERGY_WEARING_STEEL_FOLLOWUP", "time_in_future": 60 }
+          ],
+          "false_effect": [ { "u_lose_effect": "effect_iron_allergy_wearing_steel" } ]
+        }
+      ],
+      "false_eocs": [
+        {
+          "id": "EOC_IRON_ALLERGY_WEARING_STEEL_RESULT_FALSE",
+          "effect": [ { "u_lose_effect": "effect_iron_allergy_wearing_steel" } ]
+        }
+      ]
+    }
+  }
+]

--- a/data/mods/Magiclysm/mutations/mutations.json
+++ b/data/mods/Magiclysm/mutations/mutations.json
@@ -869,7 +869,7 @@
   {
     "type": "mutation",
     "id": "IRON_ALLERGY",
-    "name": { "str": "Iron Allergy" },
+    "name": { "str": "Iron Intolerance" },
     "points": -4,
     "description": "You were born with an allergy to iron and, to a lesser extent, steel.  Wearing or touching anything made of iron or steel will cause you pain and discomfort.",
     "starting_trait": true

--- a/data/mods/Magiclysm/mutations/mutations.json
+++ b/data/mods/Magiclysm/mutations/mutations.json
@@ -865,5 +865,13 @@
       "threshreq": [ "THRESH_DRAGON_BLACK" ],
       "prereqs2": [ "PRED3_DRAGON", "PRED4_DRAGON" ]
     }
+  },
+  {
+    "type": "mutation",
+    "id": "IRON_ALLERGY",
+    "name": { "str": "Iron Allergy" },
+    "points": -4,
+    "description": "You were born with an allergy to iron and, to a lesser extent, steel.  Wearing or touching anything made of iron or steel will cause you pain and discomfort.",
+    "starting_trait": true
   }
 ]

--- a/data/mods/Magiclysm/npc/trait_groups.json
+++ b/data/mods/Magiclysm/npc/trait_groups.json
@@ -173,7 +173,8 @@
       { "trait": "ANTIJUNK" },
       { "trait": "WEAKSTOMACH" },
       { "trait": "DISIMMUNE" },
-      { "trait": "PICKYEATER" }
+      { "trait": "PICKYEATER" },
+      { "trait": "IRON_ALLERGY", "prob": 15 }
     ]
   },
   {
@@ -221,7 +222,8 @@
       { "trait": "TUNNEL_FIGHTER" },
       { "trait": "NOCTURNAL" },
       { "trait": "TROGLO2" },
-      { "trait": "MOODSWINGS" }
+      { "trait": "MOODSWINGS" },
+      { "trait": "IRON_ALLERGY", "prob": 5 }
     ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Magiclysm] Add Iron Intolerance starting trait"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I already did the work on this for Xedra Evolved's Paraclesians, and I thought it'd be a nice addition to Magiclysm for people who want to play more fey elves or goblins (or just want a challenge)
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the Iron Intolerance starting trait. It works the way it does in XE--if you wear or wield something with iron in it, you suffer limb score penalties and pain. If you wear or wield something with steel in it, you suffer much less. This is based on the less serious XE version from earth/fire fae, so it doesn't represent a life-threatening allergy. 

Also added it to the possible NPC traits for goblins and elves--5% chance for goblins, 15% chance for elves. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Taking Iron Intolerance and then wearing a wristwatch is a bad idea: 
![image](https://github.com/user-attachments/assets/5da4828c-dce8-44d2-a01a-8cf29287fa2d)
(screenshot pre name change)

I guess we know who all those people who learned Knowing the Day and the Hour were.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I do plan to add this to XE as well, just using the same ID so there's no conflict and there won't be two traits in the main menu that do the same thing. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
