### PR TITLE
[MoM] Add Sensor Jamming Photokinetic power

### DIFF
--- a/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
+++ b/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
@@ -557,6 +557,15 @@ Powers causing photokinetic damage have a 40% chance to blind the target for 3 s
 *Effects*: Open the psion up to radio waves, allowing them to scan any remaining radio broadcasts or broadcast to anyone with a functional radio.<br />
 *Prerequisites*: Field of Light 8 *or* Photon Beam 7, Lucent Barrier 6<br />
 
+## Sensor Interference (C)
+*Difficulty*: 5<br />
+*Target*: An area of effect with radius 1 square, plus 1 square per 4 power levels to a maximum of 20 squares, at a range of 3 squares plus 0.8 squares per power level to a maximum of 50 squares<br />
+*Duration*: 2 to 3 seconds plus three-quarters of a second to a second and a half per power level.<br />
+*Stamina Cost*: 6000, minus 150 per level to a minimum of 2200<br />
+*Channeling Time*: 200 moves, minus 9.5 moves per level to a minimum of 80<br />
+*Effects*: Unleash a burst of electromagnetic waves, overloading any electronic sensors within the target area.  Any robots caught in the blast will be unable to perceive their environment for the power's duration.<br />
+*Prerequisites*: Star Flash 5 *or* Photon Beam 4, Radio Transception 6<br />
+
 ## Veil of Light
 *Difficulty*: 6<br />
 *Target*: Self<br />

--- a/data/mods/MindOverMatter/effectoncondition/eoc_learn_recipes.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_learn_recipes.json
@@ -439,6 +439,7 @@
           "EOC_CHECK_GAMEBEGIN_PHOTOKIN_RECIPE_HIDE_UGLY",
           "EOC_CHECK_GAMEBEGIN_PHOTOKIN_RECIPE_LIGHT_IMAGE",
           "EOC_CHECK_GAMEBEGIN_PHOTOKIN_RECIPE_RADIO",
+          "EOC_CHECK_GAMEBEGIN_PHOTOKIN_RECIPE_STUN_ROBOTS",
           "EOC_CHECK_GAMEBEGIN_PHOTOKIN_RECIPE_INVISIBILITY",
           "EOC_CHECK_GAMEBEGIN_PHOTOKIN_RECIPE_LIGHT_FLASH",
           "EOC_CHECK_GAMEBEGIN_PHOTOKIN_RECIPE_BLINDING_GLARE",
@@ -516,6 +517,12 @@
     "id": "EOC_CHECK_GAMEBEGIN_PHOTOKIN_RECIPE_RADIO",
     "condition": { "and": [ { "u_has_trait": "PHOTOKINETIC" }, { "math": [ "u_spell_level('photokinetic_radio')", ">=", "0" ] } ] },
     "effect": [ { "u_learn_recipe": "practice_photokinetic_radio" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CHECK_GAMEBEGIN_PHOTOKIN_RECIPE_STUN_ROBOTS",
+    "condition": { "and": [ { "u_has_trait": "PHOTOKINETIC" }, { "math": [ "u_spell_level('photokinetic_stun_robots')", ">=", "0" ] } ] },
+    "effect": [ { "u_learn_recipe": "practice_photokinetic_stun_robots" } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/MindOverMatter/powers/learning_eocs/photokinesis.json
+++ b/data/mods/MindOverMatter/powers/learning_eocs/photokinesis.json
@@ -366,6 +366,50 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_PHOTOKIN_LEARNING_STUN_ROBOTS",
+    "recurrence": [
+      { "math": [ "jmath_photokinesis_learning_eocs_modifiers(global_tier_two_power_learning_time_low)" ] },
+      { "math": [ "jmath_photokinesis_learning_eocs_modifiers(global_tier_two_power_learning_time_high)" ] }
+    ],
+    "condition": {
+      "and": [
+        { "u_has_trait": "PHOTOKINETIC" },
+        { "math": [ "u_vitamin('vitamin_psi_learning_counter')", "==", "1" ] },
+        {
+          "or": [
+            { "test_eoc": "EOC_CONDITION_ODDS_OF_RANDOM_TIER_TWO_POWER_INSIGHT" },
+            {
+              "or": [
+                { "math": [ "u_spell_level('photokinetic_light_flash')", ">=", "5" ] },
+                {
+                  "and": [
+                    { "math": [ "u_spell_level('photokinetic_radio')", ">=", "6" ] },
+                    { "math": [ "u_spell_level('photokinetic_light_beam')", ">=", "4" ] }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        { "test_eoc": "EOC_PSI_LEARNING_BANNED_EFFECTS" },
+        { "math": [ "u_spell_level('photokinetic_stun_robots')", "<=", "0" ] },
+        { "not": { "u_know_recipe": "practice_photokinetic_stun_robots" } }
+      ]
+    },
+    "deactivate_condition": {
+      "or": [ { "not": { "u_has_trait": "PHOTOKINETIC" } }, { "math": [ "u_spell_level('photokinetic_stun_robots')", ">=", "1" ] } ]
+    },
+    "effect": [
+      { "math": [ "u_vitamin('vitamin_psi_learning_counter')", "=", "0" ] },
+      { "u_learn_recipe": "practice_photokinetic_stun_robots" },
+      {
+        "u_message": "Use of your powers has led to an insight.  Electronics are vulnerable to electromagnetic waves, and light is an electromagnetic wave.  While you couldn't destroy electronics, you can overload them and cause them to fail for a brief time.",
+        "popup": true
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_PHOTOKIN_LEARNING_INVISIBILITY",
     "recurrence": [
       { "math": [ "jmath_photokinesis_learning_eocs_modifiers(global_tier_two_power_learning_time_low)" ] },

--- a/data/mods/MindOverMatter/powers/photokinesis.json
+++ b/data/mods/MindOverMatter/powers/photokinesis.json
@@ -500,6 +500,56 @@
     }
   },
   {
+    "id": "photokinetic_stun_robots",
+    "type": "SPELL",
+    "name": "[Ψ]Sensor Jamming",
+    "description": "Unleash a localized burst of electromagnetic radiation, overloading any electronic sensory equipment in the area.",
+    "message": "You unleash an electromagnetic wave!",
+    "teachable": false,
+    "valid_targets": [ "ground", "hostile" ],
+    "spell_class": "PHOTOKINETIC",
+    "skill": "metaphysics",
+    "flags": [ "PSIONIC", "CONCENTRATE", "NO_HANDS", "NO_LEGS", "SILENT", "RANDOM_DAMAGE" ],
+    "difficulty": 6,
+    "max_level": { "math": [ "int_to_level(1)" ] },
+    "effect": "attack",
+    "effect_str": "sensor_stun",
+    "shape": "blast",
+    "min_duration": {
+      "math": [
+        "( (u_spell_level('photokinetic_stun_robots') * 200) + 75) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
+      ]
+    },
+    "max_duration": {
+      "math": [
+        "( (u_spell_level('photokinetic_stun_robots') * 300) + 150) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
+      ]
+    },
+    "min_range": {
+      "math": [
+        "min( (( (u_spell_level('photokinetic_stun_robots') * 0.8) + 3) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling), 50)"
+      ]
+    },
+    "max_range": 50,
+    "min_aoe": {
+      "math": [
+        "min( (( (u_spell_level('photokinetic_stun_robots') * 0.25) + 1) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling), 20)"
+      ]
+    },
+    "max_aoe": {
+      "math": [
+        "min( (( (u_spell_level('photokinetic_stun_robots') * 0.25) + 1) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling), 20)"
+      ]
+    },
+    "energy_source": "STAMINA",
+    "base_energy_cost": 6000,
+    "final_energy_cost": 2200,
+    "energy_increment": -150,
+    "base_casting_time": 200,
+    "final_casting_time": 80,
+    "casting_time_increment": -9.5
+  },
+  {
     "id": "photokinetic_invisibility",
     "type": "SPELL",
     "name": "[Ψ]Veil of Light",
@@ -537,7 +587,7 @@
     "id": "photokinetic_light_flash",
     "type": "SPELL",
     "name": "[Ψ]Star Flash",
-    "description": "Create a destructive flash of light.",
+    "description": "Create a destructive flash of light in a line, damaging all targets caught in the beam.",
     "message": "You fire a searing wave of light!",
     "teachable": false,
     "valid_targets": [ "ground", "hostile" ],

--- a/data/mods/MindOverMatter/powers/photokinesis.json
+++ b/data/mods/MindOverMatter/powers/photokinesis.json
@@ -547,7 +547,8 @@
     "energy_increment": -150,
     "base_casting_time": 200,
     "final_casting_time": 80,
-    "casting_time_increment": -9.5
+    "casting_time_increment": -9.5,
+    "targeted_monster_species": [ "ROBOT", "ROBOT_FLYING", "CYBORG" ]
   },
   {
     "id": "photokinetic_invisibility",

--- a/data/mods/MindOverMatter/recipes/practice/photokinesis_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/photokinesis_practice.json
@@ -20,6 +20,7 @@
       "practice_photokinetic_hide_ugly",
       "practice_photokinetic_light_image",
       "practice_photokinetic_radio",
+      "practice_photokinetic_stun_robots",
       "practice_photokinetic_invisibility",
       "practice_photokinetic_light_flash",
       "practice_photokinetic_light_blinding_glare",
@@ -841,6 +842,90 @@
                 "popup": true
               },
               { "math": [ "u_spell_level('photokinetic_radio')", "=", "1" ] },
+              { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 25,50)" ] }
+            ],
+            "false_effect": [
+              { "u_message": "You just couldn't manage to grasp the technique.  You'll have to try again.", "popup": true },
+              { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 25,50 )" ] }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "name": "contemplation: sensor jamming",
+    "id": "practice_photokinetic_stun_robots",
+    "description": "Contemplate your powers and improve your ability to overload the sensors of robots and other electronics.",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "metaphysics",
+    "difficulty": 4,
+    "time": "0 s",
+    "autolearn": false,
+    "proficiencies": [ { "proficiency": "prof_contemplation_photokinesis", "required": false } ],
+    "tools": [
+      [ [ "matrix_crystal_drained", -1 ], [ "black_nether_crystal_pseudo_tool", -1 ], [ "matrix_crystal_photokinesis", -1 ] ]
+    ],
+    "flags": [ "SECRET", "BLIND_EASY", "NO_MANIP", "AFFECTED_BY_PAIN", "NO_BENCH", "NO_ENCHANTMENT" ],
+    "result_eocs": [
+      {
+        "id": "EOC_PRACTICE_PHOTOKIN_STUN_ROBOTS",
+        "condition": { "math": [ "u_spell_level('photokinetic_stun_robots')", ">=", "1" ] },
+        "effect": [
+          { "set_string_var": "photokinetic_stun_robots", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "set_string_var": "prof_contemplation_photokinesis",
+            "target_var": { "u_val": "latest_studied_power_proficiency" }
+          },
+          { "math": [ "u_latest_studied_power_difficulty", "=", "5" ] },
+          { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] }
+        ],
+        "false_effect": [
+          { "u_message": "You attempt to unlock new capabilities within your mind." },
+          { "u_assign_activity": "ACT_PSI_LEARNING_NEW_POWER", "duration": "16 hours" },
+          { "u_add_effect": "effect_psi_learning_new_power", "duration": "16 hours" },
+          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" },
+          {
+            "queue_eocs": "EOC_PRACTICE_PHOTOKIN_STUN_ROBOTS_LEARNING",
+            "time_in_future": [ { "math": [ "learn_new_power_lower_time_bound(5)" ] }, { "math": [ "learn_new_power_upper_time_bound(5)" ] } ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PRACTICE_PHOTOKIN_STUN_ROBOTS_LEARNING",
+    "condition": {
+      "and": [
+        { "u_has_effect": "effect_psi_learning_new_power" },
+        {
+          "not": { "u_has_any_effect": [ "sleep", "effect_vitakin_wakeful_resting", "lack_sleep", "sleep_deprived", "under_operation" ] }
+        }
+      ]
+    },
+    "effect": [
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_PRACTICE_PHOTOKIN_STUN_ROBOTS_LEARNING_2",
+            "condition": {
+              "and": [
+                {
+                  "roll_contested": { "math": [ "u_skill('metaphysics') + u_has_proficiency('prof_contemplation_photokinesis')" ] },
+                  "difficulty": 9
+                }
+              ]
+            },
+            "effect": [
+              {
+                "u_message": "As you meditate, all the pieces suddenly come together.  You've unlocked the Sensor Jamming power.",
+                "popup": true
+              },
+              { "math": [ "u_spell_level('photokinetic_stun_robots')", "=", "1" ] },
               { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 25,50)" ] }
             ],
             "false_effect": [


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Add Sensor Jamming Photokinetic power"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Had this idea for a while but there's just so much to do. 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the Sensor Jamming photokinetic power, which does an AoE of the `sensor_stun` effect (the same thing the dazzle rifle does). It stuns robots for a short time. Unlike with electrokinetic powers affecting robots, Yrax constructs are *not* immune to this power.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Sensors = jammed
![image](https://github.com/user-attachments/assets/6ade95f9-6a51-433b-a8a8-1dcee0b837c4)

Power is also learnable from the recipe
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Creating an EMP is a good Difficulty 9/10 Photokinetic power but there's currently no way for the power system to do that (the `explosion` spell effect doesn't include EMPs), so that idea's on the shelf at the moment. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
