### PR TITLE
craftable super loud noisemaker

### DIFF
--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -980,8 +980,8 @@
             }
           }
         }
-	    ]
-	  },
+      ]
+    },
     "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "TRADER_AVOID", "WATER_BREAK", "POWERED" ]
   }
 ]

--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -914,5 +914,72 @@
       "menu_text": "Turn off",
       "type": "transform"
     }
-  }
+  },
+  {
+    "id": "noise_emitter_super",
+    "type": "TOOL",
+    "name": { "str": "super noise emitter (off)", "str_pl": "super noise emitters (off)" },
+    "description": "This is a noisemaker that has been further enhanced with a series of amplifiers.  It's about as loud something can get without making you vomit from sound-induced nausea, and it's as sure to attract every zombie in town as it is to give you permanent hearing damage.",
+    "//": "I estimate this thing is about 130 decibels.  Commercial amps can hit similar noise levels at a 100-200w of power input, the survivor's is less efficient.",
+    "weight": "3600 g",
+    "volume": "4 L",
+    "price": "0 cent",
+    "price_postapoc": "90 cent",
+    "to_hit": -1,
+    "material": [ "plastic", "aluminum" ],
+    "symbol": ";",
+    "color": "yellow",
+    "ammo": [ "battery" ],
+    "charges_per_use": 1,
+    "use_action": {
+      "target": "super_noise_emitter_on",
+      "msg": "You turn the super noise emitter on.",
+      "menu_text": "Turn off",
+      "active": true,
+      "type": "transform"
+    },
+    "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "WATER_BREAK" ],
+    "pocket_data": [
+      {
+        "pocket_type": "MAGAZINE_WELL",
+        "rigid": true,
+        "flag_restriction": [ "BATTERY_LIGHT", "BATTERY_ULTRA_LIGHT" ],
+        "default_magazine": "medium_battery_cell"
+      }
+    ],
+    "melee_damage": { "bash": 6 }
+  },
+  {
+    "id": "noise_emitter_super_on",
+    "copy-from": "noise_emitter_super",
+    "type": "TOOL",
+    "name": { "str": "super noise emitter (on)", "str_pl": "super noise emitters (on)" },
+    "description": "This is a noisemaker that has been further enhanced with a series of amplifiers.  It's currently making an extraordinary amount of noise - hopefully you have hearing protection.",
+    "power_draw": "250 W",
+    "revert_to": "noise_emitter_super",
+    "use_action": {
+      "target": "noise_emitter_super",
+      "msg": "The infernal racket dies as the super noise emitter turns off.",
+      "menu_text": "Turn off",
+      "active": false,
+      "type": "transform"
+    },
+    "tick_action": {
+      "type": "effect_on_conditions",
+      "effect_on_conditions": [
+        {
+          "id": "EOC_toolweapon_running__supernoisemaker",
+          "effect": {
+            "run_eoc_with": "EOC_toolweapon_running",
+            "variables": {
+              "sound_chance": "100",
+              "sound_message": { "i18n": true, "str": "Your super noise emitter produces an unholy blast of sonic chaos." },
+              "volume": "300",
+              "revert_to": "noise_emitter_super"
+            }
+          }
+        }
+      ]
+    "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "TRADER_AVOID", "WATER_BREAK" ]
+  },
 ]

--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -921,18 +921,19 @@
     "name": { "str": "super noise emitter (off)", "str_pl": "super noise emitters (off)" },
     "description": "This is a noisemaker that has been further enhanced with a series of amplifiers.  It's about as loud something can get without making you vomit from sound-induced nausea, and it's as sure to attract every zombie in town as it is to give you permanent hearing damage.",
     "//": "I estimate this thing is about 130 decibels.  Commercial amps can hit similar noise levels at a 100-200w of power input, the survivor's is less efficient.",
-    "weight": "3600 g",
+    "weight": "6000 g",
     "volume": "4 L",
+    "longest_side": "30 cm",
     "price": "0 cent",
     "price_postapoc": "90 cent",
     "to_hit": -1,
-    "material": [ "plastic", "aluminum" ],
+    "material": [ "plastic", "aluminum", "steel" ],
     "symbol": ";",
     "color": "yellow",
     "ammo": [ "battery" ],
     "charges_per_use": 1,
     "use_action": {
-      "target": "super_noise_emitter_on",
+      "target": "noise_emitter_super_on",
       "msg": "You turn the super noise emitter on.",
       "menu_text": "Turn off",
       "active": true,
@@ -943,7 +944,7 @@
       {
         "pocket_type": "MAGAZINE_WELL",
         "rigid": true,
-        "flag_restriction": [ "BATTERY_LIGHT", "BATTERY_ULTRA_LIGHT" ],
+        "flag_restriction": [ "BATTERY_MEDIUM" ],
         "default_magazine": "medium_battery_cell"
       }
     ],
@@ -972,14 +973,15 @@
           "effect": {
             "run_eoc_with": "EOC_toolweapon_running",
             "variables": {
-              "sound_chance": "100",
+              "sound_chance": "0",
               "sound_message": { "i18n": true, "str": "Your super noise emitter produces an unholy blast of sonic chaos." },
               "volume": "300",
               "revert_to": "noise_emitter_super"
             }
           }
         }
-      ]
-    "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "TRADER_AVOID", "WATER_BREAK" ]
+	    ]
+	  },
+    "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "TRADER_AVOID", "WATER_BREAK", "POWERED" ]
   }
 ]

--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -981,5 +981,5 @@
         }
       ]
     "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "TRADER_AVOID", "WATER_BREAK" ]
-  },
+  }
 ]

--- a/data/json/recipes/tools/tools_electronic.json
+++ b/data/json/recipes/tools/tools_electronic.json
@@ -875,5 +875,27 @@
       [ [ "draw_plate", 1 ] ],
       [ [ "cable", 10 ] ]
     ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "result": "noise_emitter_super",
+    "category": "CC_ELECTRONIC",
+    "subcategory": "CSC_ELECTRONIC_TOOLS",
+    "skill_used": "electronics",
+    "difficulty": 3,
+    "time": "40 m",
+    "autolearn": true,
+    "book_learn": [ [ "radio_book", 2 ], [ "textbook_anarch", 3 ] ],
+    "using": [ [ "soldering_standard", 15 ] ],
+    "proficiencies": [ { "proficiency": "prof_elec_soldering" } ],
+    "qualities": [ { "id": "SCREW", "level": 1 } ],
+    "components": [
+      [ [ "noise_emitter", 1 ], [ "horn_big", 1 ] ],
+      [ [ "amplifier", 4 ] ],
+      [ [ "power_supply", 2 ] ],
+      [ [ "e_scrap", 5 ] ],
+      [ [ "amplifier_head", 1 ] ]
+    ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "super duper loud noise emitter for the reckless"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I wanted to deliberately make a super loud device to attract all the zombies in town to my location so that I didn't have to hunt them down as much when clearing towns on a late game character. But there was no native tool to do this, as existing sources of noise are at best barely louder than yelling.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Implement a super loud noisemaker. Super heavy, and it's loud enough (300 noise) to make you deaf if you don't have hearing protection. I'm aiming for about 130 decibels here, as that's about the top end of commercial amps and isn't so loud that it will start doing things other than make you deaf (at 140+ db you start uncomfortably vibrating, potentially leading to nausea and vomiting). It's less efficient than a commercial model (I saw 100-200w estimates for 130w speakers) drawing 250w of power.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Make it even louder and implement adverse symptoms of extreme noise levels. We don't have tinnitus etc and this is something that should just shred your ears forever if you use it without sound protection.
It uses an EOC unlike the hardcoded existing noisemaker item, I could probably also do away with the hardcode and make that noisemaker just use the EOC too since it's functionally redundant code that could be jsonified.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Confirmed functional in game. It makes you deaf as expected. It's louder than .300 winchester but quieter than .338 lapua.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
![image](https://github.com/user-attachments/assets/274193e2-4c86-485b-b7f5-f830251d2312)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
