### PR TITLE
[XE/Magiclysm] Update Giant Growth with new `TEMPORARY_SHAPESHIFT` flag

### DIFF
--- a/data/mods/Magiclysm/Spells/biomancer.json
+++ b/data/mods/Magiclysm/Spells/biomancer.json
@@ -487,8 +487,18 @@
     "condition": { "and": [ { "not": { "u_has_trait": "HUGE" } }, { "not": { "u_has_trait": "HUGE_OK" } } ] },
     "effect": [
       { "u_message": "Your body swells and warps as your size increases!", "type": "good" },
+      { "math": [ "u_preshift_size", "=", "u_val('size')" ] },
+      {
+        "switch": { "math": [ "u_preshift_size" ] },
+        "cases": [
+          { "case": 1, "effect": [ { "math": [ "u_calories()", "*=", "12" ] } ] },
+          { "case": 2, "effect": [ { "math": [ "u_calories()", "*=", "6" ] } ] },
+          { "case": 3, "effect": [ { "math": [ "u_calories()", "*=", "2" ] } ] },
+          { "case": 4, "effect": [ { "math": [ "u_calories()", "*=", "1.5" ] } ] },
+          { "case": 5, "effect": [  ] }
+        ]
+      },
       { "u_add_trait": "BIO_GIANT_GROWTH" },
-      { "math": [ "u_calories()", "+=", "100000" ] },
       {
         "queue_eocs": "EOC_GIANT_GROWTH_MUTATION_REMOVE",
         "time_in_future": { "math": [ "(( u_spell_level('biomancer_giant_growth') * 40 ) + 300 )" ] }
@@ -501,8 +511,17 @@
     "id": "EOC_GIANT_GROWTH_MUTATION_REMOVE",
     "effect": [
       { "u_message": "Your body shrinks and warps as your size decreases!", "type": "bad" },
-      { "u_lose_trait": "BIO_GIANT_GROWTH" },
-      { "math": [ "u_calories()", "-=", "100000" ] }
+      {
+        "switch": { "math": [ "u_preshift_size" ] },
+        "cases": [
+          { "case": 1, "effect": [ { "math": [ "u_calories()", "/=", "12" ] } ] },
+          { "case": 2, "effect": [ { "math": [ "u_calories()", "/=", "6" ] } ] },
+          { "case": 3, "effect": [ { "math": [ "u_calories()", "/=", "2" ] } ] },
+          { "case": 4, "effect": [ { "math": [ "u_calories()", "/=", "1.5" ] } ] },
+          { "case": 5, "effect": [  ] }
+        ]
+      },
+      { "u_lose_trait": "BIO_GIANT_GROWTH" }
     ]
   },
   {

--- a/data/mods/Magiclysm/mutations/temporary.json
+++ b/data/mods/Magiclysm/mutations/temporary.json
@@ -9,7 +9,7 @@
     "ugliness": 8,
     "mixed_effect": true,
     "description": "Magic has made you grow to enormous size!",
-    "flags": [ "HUGE" ],
+    "flags": [ "TEMPORARY_SHAPESHIFT", "SHAPESHIFT_SIZE_HUGE" ],
     "restricts_gear": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r" ],
     "social_modifiers": { "intimidate": 15 },
     "enchantments": [

--- a/data/mods/Xedra_Evolved/items/comestibles/goblin_fruits.json
+++ b/data/mods/Xedra_Evolved/items/comestibles/goblin_fruits.json
@@ -452,8 +452,18 @@
     "condition": { "and": [ { "not": { "u_has_trait": "HUGE" } }, { "not": { "u_has_trait": "HUGE_OK" } } ] },
     "effect": [
       { "u_message": "Your body swells and warps as your size increases!", "type": "good" },
+      { "math": [ "u_preshift_size", "=", "u_val('size')" ] },
+      {
+        "switch": { "math": [ "u_preshift_size" ] },
+        "cases": [
+          { "case": 1, "effect": [ { "math": [ "u_calories()", "*=", "12" ] } ] },
+          { "case": 2, "effect": [ { "math": [ "u_calories()", "*=", "6" ] } ] },
+          { "case": 3, "effect": [ { "math": [ "u_calories()", "*=", "2" ] } ] },
+          { "case": 4, "effect": [ { "math": [ "u_calories()", "*=", "1.5" ] } ] },
+          { "case": 5, "effect": [  ] }
+        ]
+      },
       { "u_add_trait": "GOBLIN_FRUIT_GIANT_GROWTH" },
-      { "math": [ "u_calories()", "+=", "100000" ] },
       { "queue_eocs": "EOC_GOBLIN_FRUIT_GIANT_GROWTH_REMOVE", "time_in_future": { "math": [ "3000 + rand(10000)" ] } }
     ],
     "false_effect": [ { "u_message": "You eat the goblin fruit but nothing happens.  Oh well." } ]
@@ -463,8 +473,17 @@
     "id": "EOC_GOBLIN_FRUIT_GIANT_GROWTH_REMOVE",
     "effect": [
       { "u_message": "Your body shrinks and warps as your size decreases!", "type": "mixed" },
-      { "u_lose_trait": "GOBLIN_FRUIT_GIANT_GROWTH" },
-      { "math": [ "u_calories()", "-=", "100000" ] }
+      {
+        "switch": { "math": [ "u_preshift_size" ] },
+        "cases": [
+          { "case": 1, "effect": [ { "math": [ "u_calories()", "/=", "12" ] } ] },
+          { "case": 2, "effect": [ { "math": [ "u_calories()", "/=", "6" ] } ] },
+          { "case": 3, "effect": [ { "math": [ "u_calories()", "/=", "2" ] } ] },
+          { "case": 4, "effect": [ { "math": [ "u_calories()", "/=", "1.5" ] } ] },
+          { "case": 5, "effect": [  ] }
+        ]
+      },
+      { "u_lose_trait": "GOBLIN_FRUIT_GIANT_GROWTH" }
     ]
   }
 ]

--- a/data/mods/Xedra_Evolved/mutations/temporary.json
+++ b/data/mods/Xedra_Evolved/mutations/temporary.json
@@ -9,7 +9,7 @@
     "ugliness": 8,
     "mixed_effect": true,
     "description": "Eating that goblin fruit has made you grow to enormous size!",
-    "flags": [ "HUGE" ],
+    "flags": [ "TEMPORARY_SHAPESHIFT", "SHAPESHIFT_SIZE_HUGE" ],
     "restricts_gear": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r" ],
     "social_modifiers": { "intimidate": 15 },
     "enchantments": [


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[XE/Magiclysm] Update Giant Growth with new `TEMPORARY_SHAPESHIFT` flag"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Both XE and Magiclysm have a "Giant Growth" effect that makes you huge, so it needs to be updated to account for the new `TEMPORARY_SHAPESHIFT` flag.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add `TEMPORARY_SHAPESHIFT` and `SHAPESHIFT_SIZE_HUGE` flag, update EoC so calorie counts don't just assume the user is medium size. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
