### PR TITLE
[Magiclysm] Diviner can send you to druid tower

### DIFF
--- a/data/mods/Magiclysm/npc/TALK_FORGE_DIVINER.json
+++ b/data/mods/Magiclysm/npc/TALK_FORGE_DIVINER.json
@@ -111,6 +111,7 @@
       { "text": "An attunement altar.", "topic": "TALK_FORGE_LORD_DIVINER_ATTUNEMENT" },
       { "text": "A magic academy.", "topic": "TALK_FORGE_LORD_DIVINER_ACADEMY" },
       { "text": "A wizard tower.", "topic": "TALK_FORGE_LORD_DIVINER_TOWER" },
+      { "text": "A druid tower.", "topic": "TALK_FORGE_LORD_DIVINER_DRUID_TOWER" },
       { "text": "A goblin city.", "topic": "TALK_FORGE_LORD_DIVINER_GOBLIN" },
       { "text": "About something else…", "topic": "TALK_NONE" },
       { "text": "Nevermind.", "topic": "TALK_DONE" }
@@ -775,6 +776,31 @@
     ]
   },
   {
+    "id": "TALK_FORGE_LORD_DIVINER_DRUID_TOWER",
+    "type": "talk_topic",
+    "dynamic_line": "Poor druids, they were hit hardest by the rise of technology.  Magi, technomancers, animists, they can just close the windows and keep their chanting low so to not bother the neighbors.  Even earthshapers can just go into the backyard, but druids had to move out to the middle of nowhere.  That's where their tower will be, mind.  There won't be a road there, so you're in for quite the trip.  I'll mark one on your map for one denarius.",
+    "responses": [
+      {
+        "text": "I could use a nice walk.",
+        "topic": "TALK_DONE",
+        "condition": { "u_has_item": "denarius" },
+        "effect": [
+          {
+            "assign_mission": "MISSION_FORGE_DIVINER_DRUID_TOWER"
+          },
+          { "u_consume_item": "denarius" }
+        ]
+      },
+      {
+        "text": "I can't afford that right now.",
+        "topic": "TALK_FORGE_LORD_DIVINER_GET_MONEY",
+        "condition": { "not": { "u_has_item": "denarius" } }
+      },
+      { "text": "About something else…", "topic": "TALK_NONE" },
+      { "text": "Nevermind.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
     "id": "TALK_FORGE_LORD_DIVINER_RIVER",
     "type": "talk_topic",
     "dynamic_line": "Rivers.  Water, sand, clay, fish, giant mutant bugs.  Generally pretty big.  If you're still having trouble finding one, I'll mark one on your map for one denarius.",
@@ -915,7 +941,7 @@
   {
     "id": "TALK_FORGE_LORD_DIVINER_OTHER_FORGE",
     "type": "talk_topic",
-    "dynamic_line": "There is only one Forge of Wonders, it's not like this a multidimensional franchise opportunity.",
+    "dynamic_line": "There is only one Forge of Wonders, it's not like this is a multidimensional franchise opportunity.",
     "responses": [ { "text": "About something else…", "topic": "TALK_NONE" }, { "text": "Nevermind.", "topic": "TALK_DONE" } ]
   },
   {

--- a/data/mods/Magiclysm/npc/TALK_FORGE_DIVINER.json
+++ b/data/mods/Magiclysm/npc/TALK_FORGE_DIVINER.json
@@ -784,12 +784,7 @@
         "text": "I could use a nice walk.",
         "topic": "TALK_DONE",
         "condition": { "u_has_item": "denarius" },
-        "effect": [
-          {
-            "assign_mission": "MISSION_FORGE_DIVINER_DRUID_TOWER"
-          },
-          { "u_consume_item": "denarius" }
-        ]
+        "effect": [ { "assign_mission": "MISSION_FORGE_DIVINER_DRUID_TOWER" }, { "u_consume_item": "denarius" } ]
       },
       {
         "text": "I can't afford that right now.",

--- a/data/mods/Magiclysm/npc/forge_diviner_missions.json
+++ b/data/mods/Magiclysm/npc/forge_diviner_missions.json
@@ -449,6 +449,19 @@
     }
   },
   {
+    "id": "MISSION_FORGE_DIVINER_DRUID_TOWER",
+    "type": "mission_definition",
+    "name": { "str": "Visit the druid tower" },
+    "goal": "MGOAL_GO_TO_TYPE",
+    "difficulty": 0,
+    "value": 0,
+    "description": "The diviner told you that there would be a druid tower here.",
+    "destination": "druid_ritual_home_z0",
+    "start": {
+      "assign_mission_target": { "om_terrain": "druid_ritual_home_z0", "reveal_radius": 3, "cant_see": true, "search_range": 180 }
+    }
+  },
+  {
     "id": "MISSION_FORGE_DIVINER_RIVER",
     "type": "mission_definition",
     "name": { "str": "Visit the river" },

--- a/data/mods/Magiclysm/npc/forge_diviner_missions.json
+++ b/data/mods/Magiclysm/npc/forge_diviner_missions.json
@@ -458,7 +458,13 @@
     "description": "The diviner told you that there would be a druid tower here.",
     "destination": "druid_ritual_home_z0",
     "start": {
-      "assign_mission_target": { "om_terrain": "druid_ritual_home_z0", "reveal_radius": 3, "cant_see": true, "search_range": 180 }
+      "assign_mission_target": {
+        "om_terrain": "druid_ritual_home_z0",
+        "om_special": "druid_tower",
+        "reveal_radius": 3,
+        "cant_see": true,
+        "search_range": 180
+      }
     }
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Magiclysm] Diviner can send you to druid tower"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Druid tower didn't have a diviner mission associated with it.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the dialogue and the mission.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Topic appears and finds a druid tower.

![image](https://github.com/user-attachments/assets/c6280fb9-3613-42a9-85af-398322af4552)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Hmm, is there a way to specify spawns away from roads? That druid tower location makes no sense, because they'd be unable to use a chunk of their magic. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
