### PR TITLE
Place_vending function can place unpowered machines

### DIFF
--- a/data/json/furniture_and_terrain/furniture-tools.json
+++ b/data/json/furniture_and_terrain/furniture-tools.json
@@ -1617,8 +1617,39 @@
     "move_cost_mod": -1,
     "coverage": 90,
     "required_str": 30,
-    "flags": [ "SEALED", "PLACE_ITEM", "ALARMED", "CONTAINER", "BLOCKSDOOR", "FLAMMABLE_HARD", "MINEABLE" ],
+    "flags": [ "SEALED", "PLACE_ITEM", "ALARMED", "CONTAINER", "BLOCKSDOOR", "MINEABLE" ],
     "examine_action": "vending",
+    "bash": {
+      "str_min": 150,
+      "str_max": 520,
+      "sound": "glass breaking!",
+      "sound_fail": "whack!",
+      "furn_set": "f_vending_o",
+      "items": [
+        { "item": "glass_shard", "count": [ 8, 25 ] },
+        { "item": "sheet_metal", "count": [ 0, 2 ] },
+        { "item": "steel_chunk", "count": [ 1, 5 ] },
+        { "item": "money_one", "count": [ 0, 100 ] },
+        { "item": "money_two", "count": [ 0, 20 ] },
+        { "item": "money_five", "count": [ 0, 100 ] },
+        { "item": "money_ten", "count": [ 0, 100 ] },
+        { "item": "money_twenty", "count": [ 0, 100 ] },
+        { "item": "money_fifty", "count": [ 0, 50 ] }
+      ]
+    }
+  },
+  {
+    "type": "furniture",
+    "id": "f_vending_reinforced_off",
+    "name": "reinforced vending machine (off)",
+    "looks_like": "f_vending_reinforced",
+    "description": "A bit tougher to crack open than a regular vending machine.  Out of order, for lack of power.  That just makes it all the sweeter of a target, doesn't it?",
+    "symbol": "{",
+    "color": "light_red",
+    "move_cost_mod": -1,
+    "coverage": 90,
+    "required_str": 30,
+    "flags": [ "SEALED", "PLACE_ITEM", "CONTAINER", "BLOCKSDOOR", "MINEABLE" ],
     "bash": {
       "str_min": 150,
       "str_max": 520,
@@ -1649,8 +1680,31 @@
     "move_cost_mod": -1,
     "coverage": 90,
     "required_str": 12,
-    "flags": [ "SEALED", "PLACE_ITEM", "ALARMED", "CONTAINER", "BLOCKSDOOR", "MINEABLE" ],
+    "flags": [ "SEALED", "PLACE_ITEM", "ALARMED", "CONTAINER", "BLOCKSDOOR", "MINEABLE", "TRANSPARENT" ],
     "examine_action": "vending",
+    "bash": {
+      "str_min": 20,
+      "str_max": 40,
+      "sound": "glass breaking!",
+      "sound_fail": "whack!",
+      "sound_vol": 16,
+      "sound_fail_vol": 12,
+      "furn_set": "f_vending_o",
+      "items": [ { "item": "glass_shard", "count": [ 25, 50 ] } ]
+    }
+  },
+  {
+    "type": "furniture",
+    "id": "f_vending_c_off",
+    "name": "vending machine (off)",
+    "looks_like": "f_vending_c",
+    "symbol": "{",
+    "description": "An upright metal cabinet with a see-through door.  Out of order, for lack of power.",
+    "color": "light_cyan",
+    "move_cost_mod": -1,
+    "coverage": 90,
+    "required_str": 12,
+    "flags": [ "SEALED", "PLACE_ITEM", "CONTAINER", "BLOCKSDOOR", "MINEABLE", "TRANSPARENT" ],
     "bash": {
       "str_min": 20,
       "str_max": 40,

--- a/data/mods/Aftershock/maps/mapgen/augmentation_clinic.json
+++ b/data/mods/Aftershock/maps/mapgen/augmentation_clinic.json
@@ -60,7 +60,7 @@
         "?": { "item": "autodoc_supplies", "chance": 100 }
       },
       "monster": { "ö": { "monster": "mon_skitterbot" } },
-      "vendingmachines": { "V": { "item_group": "afs_vending_medicine", "reinforced": true } }
+      "vendingmachines": { "V": { "item_group": "afs_vending_medicine", "reinforced": true, "powered": true } }
     }
   },
   {

--- a/data/mods/Aftershock/maps/mapgen/exosuit_garage_2.json
+++ b/data/mods/Aftershock/maps/mapgen/exosuit_garage_2.json
@@ -35,7 +35,7 @@
       "terrain": { "2": "t_afs_security_gate_closed", "1": "t_afs_door_metal_elocked" },
       "furniture": { "4": "f_machinery_light", "5": "f_machinery_electronic" },
       "place_monster": [ { "group": "AFS_GROUP_RUIN_MOXIE", "x": [ 0, 23 ], "y": [ 0, 23 ], "pack_size": [ 1, 3 ], "chance": 20 } ],
-      "vendingmachines": { "3": { "item_group": "afs_vending_false_meals", "reinforced": true } },
+      "vendingmachines": { "3": { "item_group": "afs_vending_false_meals", "reinforced": true, "powered": true } },
       "place_nested": [
         { "chunks": [ [ "null", 80 ], [ "afs_map_lights_on", 20 ] ], "x": 0, "y": 0 },
         {

--- a/data/mods/Aftershock/maps/mapgen/habitat_blocks/habitat_block_1.json
+++ b/data/mods/Aftershock/maps/mapgen/habitat_blocks/habitat_block_1.json
@@ -39,7 +39,7 @@
       ],
       "terrain": { "3": "t_atm" },
       "furniture": { "1": "f_washer", "2": "f_dryer" },
-      "vendingmachines": { "V": { "item_group": "afs_vending_false_meals", "reinforced": true } },
+      "vendingmachines": { "V": { "item_group": "afs_vending_false_meals", "reinforced": true, "powered": true } },
       "place_nested": [
         { "chunks": [ { "param": "variant", "fallback": "afs_habblock_1_slot1_cafe_a1" } ], "x": 0, "y": 0 },
         {

--- a/data/mods/Aftershock/maps/mapgen/habitat_blocks/habitat_block_2.json
+++ b/data/mods/Aftershock/maps/mapgen/habitat_blocks/habitat_block_2.json
@@ -317,7 +317,7 @@
       },
       "furniture": { "á": "f_bookcase", "2": "f_bathtub", "6": "f_table" },
       "items": { "á": { "item": "homebooks", "repeat": [ 2, 3 ] } },
-      "vendingmachines": { "V": { "item_group": "afs_vending_false_meals", "reinforced": true } },
+      "vendingmachines": { "V": { "item_group": "afs_vending_false_meals", "reinforced": true, "powered": true } },
       "place_monster": [
         { "group": "AFS_GROUP_RUIN_MOXIE", "x": [ 4, 13 ], "y": [ 2, 23 ], "pack_size": [ 1, 3 ], "chance": 30 },
         { "group": "AFS_GROUP_RUIN_MOXIE", "x": [ 34, 43 ], "y": [ 2, 23 ], "pack_size": [ 1, 3 ], "chance": 30 },

--- a/data/mods/Aftershock/maps/mapgen/habitat_blocks/habitat_block_3.json
+++ b/data/mods/Aftershock/maps/mapgen/habitat_blocks/habitat_block_3.json
@@ -55,7 +55,7 @@
         "é": { "item": "afs_old_food_storage", "chance": 60, "repeat": [ 1, 3 ] },
         "ê": { "item": "afs_old_beverage_storage", "chance": 60, "repeat": [ 1, 5 ] }
       },
-      "vendingmachines": { "2": { "item_group": "afs_vending_false_meals", "reinforced": true } },
+      "vendingmachines": { "2": { "item_group": "afs_vending_false_meals", "reinforced": true, "powered": true } },
       "place_monster": [ { "group": "AFS_GROUP_RUIN_MOXIE", "x": [ 0, 23 ], "y": [ 0, 23 ], "pack_size": [ 1, 5 ], "chance": 45 } ],
       "place_nested": [ { "chunks": [ { "param": "lightstatus", "fallback": "null" } ], "x": 0, "y": 0 } ]
     }

--- a/data/mods/Aftershock/maps/mapgen/habitats/habitat_greenhouse.json
+++ b/data/mods/Aftershock/maps/mapgen/habitats/habitat_greenhouse.json
@@ -77,7 +77,7 @@
         "í": { "item": "afs_tools_agricultural_hazardous", "chance": 90 },
         "t": { "item": "farming_tools", "chance": 60, "repeat": [ 2, 3 ] }
       },
-      "vendingmachines": { "V": { "item_group": "afs_vending_medicine", "reinforced": true } }
+      "vendingmachines": { "V": { "item_group": "afs_vending_medicine", "reinforced": true, "powered": true } }
     }
   },
   {

--- a/data/mods/Aftershock/maps/mapgen/port_augustmoon/port_augustmoon_main.json
+++ b/data/mods/Aftershock/maps/mapgen/port_augustmoon/port_augustmoon_main.json
@@ -305,9 +305,9 @@
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "terrain": { "1": "t_metal_floor", "2": "t_metal_floor", "3": "t_metal_floor" },
       "vendingmachines": {
-        "1": { "item_group": "afs_vending_false_meals", "reinforced": true },
-        "2": { "item_group": "afs_vending_ballistic_ammo", "reinforced": true },
-        "3": { "item_group": "afs_vending_medicine", "reinforced": true }
+        "1": { "item_group": "afs_vending_false_meals", "reinforced": true, "powered": true },
+        "2": { "item_group": "afs_vending_ballistic_ammo", "reinforced": true, "powered": true },
+        "3": { "item_group": "afs_vending_medicine", "reinforced": true, "powered": true }
       }
     }
   },
@@ -346,9 +346,9 @@
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "terrain": { "1": "t_metal_floor", "2": "t_metal_floor", "3": "t_metal_floor" },
       "vendingmachines": {
-        "1": { "item_group": "afs_vending_false_meals", "reinforced": true },
-        "2": { "item_group": "afs_vending_ballistic_ammo", "reinforced": true },
-        "3": { "item_group": "afs_vending_energy_ammo", "reinforced": true }
+        "1": { "item_group": "afs_vending_false_meals", "reinforced": true, "powered": true },
+        "2": { "item_group": "afs_vending_ballistic_ammo", "reinforced": true, "powered": true },
+        "3": { "item_group": "afs_vending_energy_ammo", "reinforced": true, "powered": true }
       }
     }
   },

--- a/data/mods/Aftershock/maps/mapgen/s_gas.json
+++ b/data/mods/Aftershock/maps/mapgen/s_gas.json
@@ -55,7 +55,7 @@
         { "group": "softdrugs", "x": [ 15, 18 ], "y": [ 19, 20 ], "chance": 80, "repeat": [ 0, 2 ] }
       ],
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 1, 22 ], "y": [ 1, 22 ], "density": 0.1 } ],
-      "vendingmachines": { "ñ": { "item_group": "afs_vending_false_meals", "reinforced": true } }
+      "vendingmachines": { "ñ": { "item_group": "afs_vending_false_meals", "reinforced": true, "powered": true } }
     }
   }
 ]

--- a/data/mods/Aftershock/maps/mapgen/urban_worm_farm.json
+++ b/data/mods/Aftershock/maps/mapgen/urban_worm_farm.json
@@ -53,7 +53,7 @@
         ]
       },
       "monster": { "ö": { "monster": "mon_skitterbot" } },
-      "vendingmachines": { "V": { "item_group": "afs_vending_medicine", "reinforced": true } }
+      "vendingmachines": { "V": { "item_group": "afs_vending_medicine", "reinforced": true, "powered": true } }
     }
   },
   {

--- a/doc/MAPGEN.md
+++ b/doc/MAPGEN.md
@@ -901,7 +901,8 @@ Places a vending machine (furniture) and fills it with items from an item group.
 | ---        | ---
 | item_group | (optional, string) the item group that is used to create items inside the machine. It defaults to either "vending_food" or "vending_drink" (randomly chosen).
 | reinforced | (optional, bool) setting which will make vending machine spawn as reinforced. Defaults to false.
-| lootable   | (optional, bool) setting which indicates whether this particular vending machine should have a chance to spawn ransacked (i.e. broken and with no loot inside). The chance for this is increased with each day passed after the Cataclysm. Valid only if `reinforced` is false. Defaults to false.
+| lootable   | (optional, bool) setting which indicates whether this particular vending machine should have a chance to spawn ransacked (i.e. broken and with no loot inside). The chance for this is increased with each day passed after the Cataclysm. Defaults to false.
+| powered   | (optional, bool) setting which indicates whether the machine is powered can be interacted with to buy items. Defaults to false.
 
 
 ### Place a toilet with some amount of water with "toilets"

--- a/src/map.h
+++ b/src/map.h
@@ -2061,7 +2061,7 @@ class map
         // 6 liters at 250 ml per charge
         void place_toilet( const tripoint_bub_ms &p, int charges = 6 * 4 );
         void place_vending( const tripoint_bub_ms &p, const item_group_id &type, bool reinforced = false,
-                            bool lootable = false );
+                            bool lootable = false, bool powered = false );
         // places an NPC, if static NPCs are enabled or if force is true
         character_id place_npc( const point &p, const string_id<npc_template> &type );
         void apply_faction_ownership( const point &p1, const point &p2, const faction_id &id );

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -98,8 +98,12 @@ static const furn_str_id furn_f_sign( "f_sign" );
 static const furn_str_id furn_f_table( "f_table" );
 static const furn_str_id furn_f_toilet( "f_toilet" );
 static const furn_str_id furn_f_vending_c( "f_vending_c" );
+static const furn_str_id furn_f_vending_c_off( "f_vending_c_off" );
+
 static const furn_str_id furn_f_vending_o( "f_vending_o" );
 static const furn_str_id furn_f_vending_reinforced( "f_vending_reinforced" );
+static const furn_str_id furn_f_vending_reinforced_off( "f_vending_reinforced_off" );
+
 
 static const item_group_id Item_spawn_data_ammo_rare( "ammo_rare" );
 static const item_group_id Item_spawn_data_bed( "bed" );
@@ -2172,9 +2176,11 @@ class jmapgen_vending_machine : public jmapgen_piece
         bool reinforced;
         mapgen_value<item_group_id> group_id;
         bool lootable;
+        bool powered;
         jmapgen_vending_machine( const JsonObject &jsi, const std::string_view/*context*/ ) :
             reinforced( jsi.get_bool( "reinforced", false ) )
-            , lootable( jsi.get_bool( "lootable", false ) ) {
+            , lootable( jsi.get_bool( "lootable", false ) )
+            , powered( jsi.get_bool( "powered", false ) ) {
             if( jsi.has_member( "item_group" ) ) {
                 group_id = mapgen_value<item_group_id>( jsi.get_member( "item_group" ) );
             } else {
@@ -2189,7 +2195,7 @@ class jmapgen_vending_machine : public jmapgen_piece
             if( chosen_id.is_null() ) {
                 return;
             }
-            dat.m.place_vending( r, chosen_id, reinforced, lootable );
+            dat.m.place_vending( r, chosen_id, reinforced, lootable, powered );
         }
         bool has_vehicle_collision( const mapgendata &dat, const tripoint_rel_ms &p ) const override {
             return dat.m.veh_at( tripoint_bub_ms( p.x(), p.y(), dat.zlevel() + p.z() ) ).has_value();
@@ -6637,27 +6643,34 @@ void map::place_toilet( const tripoint_bub_ms &p, int charges )
 }
 
 void map::place_vending( const tripoint_bub_ms &p, const item_group_id &type, bool reinforced,
-                         bool lootable )
+                         bool lootable, bool powered )
 {
-    if( reinforced ) {
-        furn_set( p, furn_f_vending_reinforced );
-        place_items( type, 100, p, p, false, calendar::start_of_cataclysm );
+    if ( !powered ) {
+        if( reinforced ) {
+            furn_set( p, furn_f_vending_reinforced_off );
+        } else {
+            furn_set( p, furn_f_vending_c_off );
+        }
     } else {
-        // The chance to find a non-ransacked vending machine reduces greatly with every day after the Cataclysm,
-        // unless it's hidden somewhere far away from everyone's eyes (e.g. deep in the lab)
-        if( lootable &&
-            !one_in( std::max( to_days<int>( calendar::turn - calendar::start_of_cataclysm ), 0 ) + 4 ) ) {
-            furn_set( p, furn_f_vending_o );
-            for( const tripoint_bub_ms &loc : points_in_radius( p, 1 ) ) {
-                if( one_in( 4 ) ) {
-                    spawn_item( loc, "glass_shard", rng( 1, 25 ) );
-                }
-            }
+        if( reinforced ) {
+            furn_set( p, furn_f_vending_reinforced );
         } else {
             furn_set( p, furn_f_vending_c );
-            place_items( type, 100, p, p, false, calendar::start_of_cataclysm );
         }
     }
+    // The chance to find a non-ransacked vending machine reduces greatly with every day after the Cataclysm,
+    // unless it's hidden somewhere far away from everyone's eyes (e.g. deep in the lab)
+    if( lootable &&
+        !one_in( std::max( to_days<int>( calendar::turn - calendar::start_of_cataclysm ), 0 ) + 4 ) ) {
+        bash( p.raw(), 9999 );
+        for( const tripoint &loc : points_in_radius( p.raw(), 1 ) ) {
+            if( one_in( 4 ) ) {
+                spawn_item( loc, "glass_shard", rng( 1, 25 ) );
+            }
+        }
+        } else {
+            place_items( type, 100, p, p, false, calendar::start_of_cataclysm );
+        }
 }
 
 character_id map::place_npc( const point &p, const string_id<npc_template> &type )

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -6645,7 +6645,7 @@ void map::place_toilet( const tripoint_bub_ms &p, int charges )
 void map::place_vending( const tripoint_bub_ms &p, const item_group_id &type, bool reinforced,
                          bool lootable, bool powered )
 {
-    if ( !powered ) {
+    if( !powered ) {
         if( reinforced ) {
             furn_set( p, furn_f_vending_reinforced_off );
         } else {
@@ -6668,9 +6668,9 @@ void map::place_vending( const tripoint_bub_ms &p, const item_group_id &type, bo
                 spawn_item( loc, "glass_shard", rng( 1, 25 ) );
             }
         }
-        } else {
-            place_items( type, 100, p, p, false, calendar::start_of_cataclysm );
-        }
+    } else {
+        place_items( type, 100, p, p, false, calendar::start_of_cataclysm );
+    }
 }
 
 character_id map::place_npc( const point &p, const string_id<npc_template> &type )


### PR DESCRIPTION
#### Summary
Features "Place_vending function can place unpowered machines"

#### Purpose of change
Allow the placement of vending machines while accounting for whether the structure they are placed in is powered/unpowered,

#### Describe the solution
Add a new "powered" bool that governs the placement of powered/unpowered machines.

Atm this will only add the new functionality and fix aftershock. @GuardianDll probably has a better grasp of which machines should be powered in vanilla, since they have already made this audit. All other vending machines will spawn unpowered.

#### Describe alternatives you've considered
It takes me longer to make maps in perpetuity (it already takes me a long while).

#### Testing
Visited both port agustmoon and a microlab, vending machines spawned as expected.