### PR TITLE
Fix wield

### DIFF
--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -503,7 +503,7 @@ VisitResponse map_cursor::visit_items(
     if( get_map().inbounds( pos() ) ) {
         return visit_items_internal( &get_map(), this, pos(), func );
     } else {
-        tinymap here;
+        tinymap here; // Tinymap is sufficient. Only looking at single location, so no Z level need.
         // pos returns the pos_bub location of the target relative to the reality bubble
         // even though the location isn't actually inside of it. Thus, we're loading a map
         // around that location to do our work.

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -467,10 +467,9 @@ const
     return inv->visit_items( func );
 }
 
-static VisitResponse visit_items_internal( map *here, const map_cursor *cur,
+static VisitResponse visit_items_internal( map *here,
         const tripoint_bub_ms p, const std::function<VisitResponse( item *, item * )> &func )
 {
-
     // check furniture pseudo items
     if( here->furn( p ) != furn_str_id::NULL_ID() ) {
         itype_id it_id = here->furn( p )->crafting_pseudo_item;
@@ -501,7 +500,7 @@ VisitResponse map_cursor::visit_items(
     const std::function<VisitResponse( item *, item * )> &func ) const
 {
     if( get_map().inbounds( pos() ) ) {
-        return visit_items_internal( &get_map(), this, pos(), func );
+        return visit_items_internal( &get_map(), pos(), func );
     } else {
         tinymap here; // Tinymap is sufficient. Only looking at single location, so no Z level need.
         // pos returns the pos_bub location of the target relative to the reality bubble
@@ -510,7 +509,7 @@ VisitResponse map_cursor::visit_items(
         tripoint_abs_ms abs_pos = get_map().getglobal( pos() );
         here.load( project_to<coords::omt>( abs_pos ), false );
         tripoint_omt_ms p = tripoint_omt_ms( here.getlocal( abs_pos ) );
-        visit_items_internal( here.cast_to_map(), this, rebase_bub( p ), func );
+        visit_items_internal( here.cast_to_map(), rebase_bub( p ), func );
     }
 }
 

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -467,21 +467,13 @@ const
     return inv->visit_items( func );
 }
 
-/** @relates visitable */
-VisitResponse map_cursor::visit_items(
-    const std::function<VisitResponse( item *, item * )> &func ) const
+static VisitResponse visit_items_internal( map *here, const map_cursor *cur,
+        const tripoint_bub_ms p, const std::function<VisitResponse( item *, item * )> &func )
 {
-    smallmap here;  // tinymap would work as well, as we're only looking at a single position.
-    // pos returns the pos_bub location of the target relative to the reality bubble
-    // even if the location isn't actually inside of it. Thus, we're loading a map
-    // around that location to do our work.
-    tripoint_abs_ms abs_pos = get_map().getglobal( pos() );
-    here.load( project_to<coords::omt>( abs_pos ), false );
-    tripoint_omt_ms p = tripoint_omt_ms( here.getlocal( abs_pos ) );
 
     // check furniture pseudo items
-    if( here.furn( p ) != furn_str_id::NULL_ID() ) {
-        itype_id it_id = here.furn( p )->crafting_pseudo_item;
+    if( here->furn( p ) != furn_str_id::NULL_ID() ) {
+        itype_id it_id = here->furn( p )->crafting_pseudo_item;
         if( it_id.is_valid() ) {
             item it( it_id );
             if( visit_internal( func, &it ) == VisitResponse::ABORT ) {
@@ -491,17 +483,35 @@ VisitResponse map_cursor::visit_items(
     }
 
     // skip inaccessible items
-    if( here.has_flag( ter_furn_flag::TFLAG_SEALED, p.raw() ) &&
-        !here.has_flag( ter_furn_flag::TFLAG_LIQUIDCONT, p.raw() ) ) {
+    if( here->has_flag( ter_furn_flag::TFLAG_SEALED, p ) &&
+        !here->has_flag( ter_furn_flag::TFLAG_LIQUIDCONT, p ) ) {
         return VisitResponse::NEXT;
     }
 
-    for( item &e : here.i_at( p.raw() ) ) {
+    for( item &e : here->i_at( p ) ) {
         if( visit_internal( func, &e ) == VisitResponse::ABORT ) {
             return VisitResponse::ABORT;
         }
     }
     return VisitResponse::NEXT;
+}
+
+/** @relates visitable */
+VisitResponse map_cursor::visit_items(
+    const std::function<VisitResponse( item *, item * )> &func ) const
+{
+    if( get_map().inbounds( pos() ) ) {
+        return visit_items_internal( &get_map(), this, pos(), func );
+    } else {
+        tinymap here;
+        // pos returns the pos_bub location of the target relative to the reality bubble
+        // even though the location isn't actually inside of it. Thus, we're loading a map
+        // around that location to do our work.
+        tripoint_abs_ms abs_pos = get_map().getglobal( pos() );
+        here.load( project_to<coords::omt>( abs_pos ), false );
+        tripoint_omt_ms p = tripoint_omt_ms( here.getlocal( abs_pos ) );
+        visit_items_internal( here.cast_to_map(), this, rebase_bub( p ), func );
+    }
 }
 
 /** @relates visitable */

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -509,7 +509,7 @@ VisitResponse map_cursor::visit_items(
         tripoint_abs_ms abs_pos = get_map().getglobal( pos() );
         here.load( project_to<coords::omt>( abs_pos ), false );
         tripoint_omt_ms p = tripoint_omt_ms( here.getlocal( abs_pos ) );
-        visit_items_internal( here.cast_to_map(), rebase_bub( p ), func );
+        return visit_items_internal( here.cast_to_map(), rebase_bub( p ), func );
     }
 }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #75098, and #75085 i.e. slowdown due to excessive map loading.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Changed the code to load a map only if an item_location position is outside of the reality bubble.
This is achieved by:
- Moving the bulk of the code to a helper function that takes a map and map relative position as a parameter.
- checking if the position is in bounds.
- Call the helper with the normal reality bubble map when in bounds (should be the vast majority of cases).
- Perform the required coordinate juggling and creation of a map containing the location otherwise, and then call the helper function with the map and calculated relative position.
- Also changed smallmap to the faster tinymap in case there are more oddballs than just item_location save loading that uses item_locations referencing items outside of the reality bubble.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Rewriting item_locations to at least provide operations to get the absolute coordinate stored inside so we don't have to convert it to reality bubble coordinates and then convert those back to absolute, before converting them to target map relative positions. Probably a useful improvement, but also probably out of scope for this PR.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
- Tested wielding and unwielding first with the updated code and then reverted back to the original one. Didn't really see a difference, but there might have been a slight hesitation with the original code on wielding.
- Walked to a flatbed truck and examined it in the same sessions as above. The modified code seems "normal" while the old code seemed a bit sluggish.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
The casting of the map and coordinates seem weird to the uninitiated. However tinymaps are actually just maps with different sizes, and the code knows that and works accordingly. In fact, almost all tinymap operations are skins on top of map ones. Similarly, the coordinate casting is the same thing tinymap operations do to call the actual map implementation. The difference between bub and omt coordinates are really the expectations of the users, as they're really just the offset from the top left corner.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
