### PR TITLE
Leather Body Armor Coverage fix

### DIFF
--- a/data/json/items/armor/suits_protection.json
+++ b/data/json/items/armor/suits_protection.json
@@ -23,7 +23,7 @@
         "material": [ { "type": "leather", "covered_by_mat": 100, "thickness": 6.5 } ]
       },
       { "covers": [ "arm_l", "arm_r" ], "coverage": 90, "encumbrance": 18 },
-      { "covers": [ "leg_l", "leg_r" ], "coverage": 85, "encumbrance": 18 }
+      { "covers": [ "leg_l", "leg_r" ], "coverage": 95, "encumbrance": 18 }
     ],
     "warmth": 20,
     "material_thickness": 6,
@@ -249,7 +249,7 @@
         "material": [ { "type": "leather", "covered_by_mat": 100, "thickness": 4.5 } ]
       },
       { "covers": [ "arm_l", "arm_r" ], "coverage": 90, "encumbrance": 14 },
-      { "covers": [ "leg_l", "leg_r" ], "coverage": 85, "encumbrance": 14 }
+      { "covers": [ "leg_l", "leg_r" ], "coverage": 95, "encumbrance": 14 }
     ],
     "warmth": 25,
     "material_thickness": 4,
@@ -998,7 +998,7 @@
       },
       {
         "covers": [ "leg_l", "leg_r" ],
-        "coverage": 85,
+        "coverage": 95,
         "encumbrance": 22,
         "material": [
           { "type": "leather", "covered_by_mat": 100, "thickness": 4 },
@@ -1008,7 +1008,7 @@
       },
       {
         "covers": [ "leg_l", "leg_r" ],
-        "coverage": 85,
+        "coverage": 95,
         "encumbrance": 0,
         "material": [ { "type": "leather", "covered_by_mat": 100, "thickness": 4 } ],
         "specifically_covers": [ "leg_hip_l", "leg_hip_r", "leg_knee_l", "leg_knee_r" ]


### PR DESCRIPTION
#### Summary
Bugfixes "Adjust the leg coverage of the leather suits to be in line with its components"

#### Purpose of change
The Leather Body Armor is an item made of the Leather Leg/Arm guards and the Leather Cuirass, but the leg coverage was different, less than the component, the leg guards, the armor does not cut their components so there is no reason for this discrepancy and material disappearance.

#### Describe the solution
Adjust the coverage values of the body armor (And its upgrades) to be in line with the leg guards.

#### Describe alternatives you've considered
None at all!

#### Testing
None.

#### Additional context

