### PR TITLE
Add apiaries to the farm generation

### DIFF
--- a/data/json/mapgen/farm.json
+++ b/data/json/mapgen/farm.json
@@ -580,5 +580,92 @@
       ],
       "palettes": [ "roof_palette" ]
     }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": [ [ "farm_1_apiary" ] ],
+    "//": "Apiary",
+    "weight": 250,
+    "object": {
+      "fill_ter": "t_dirt",
+      "rows": [
+        "                        ",
+        "                        ",
+        "     FFFFFFFFFFFFFFFFFF ",
+        "     F         ,      F ",
+        "     F ⬡⬡  ⬡⬡  ⬡⬡  ⬡⬡ F ",
+        ",,,  F ⬡⬡  ⬡⬡  ⬡⬡  ⬡⬡ F ",
+        ",,,,,g,,,,,     ,,    F ",
+        "  ,,,g,,,,   ,        F ",
+        "     F ⬡⬡  ⬡⬡  ⬡⬡  ⬡⬡ F ",
+        "   , F ⬡⬡  ⬡⬡  ⬡⬡  ⬡⬡ F ",
+        "     F               ,F ",
+        "    ,FFFFFFFFFFFFFFFFFF ",
+        "     ,,                 ",
+        "           ,      ##### ",
+        "               , ♦#r♠♥# ",
+        "                ,,+___# ",
+        "                  ##### ",
+        "                        ",
+        " FFFFFFFFFFFFFFFFFFFFFF ",
+        " F                    F ",
+        " F  DDDDDDDDDDDDDDDD  F ",
+        " F                    F ",
+        " F  DDDDDDDDDDDDDDDD  F ",
+        " F                    F "
+      ],
+      "terrain": { "⬡": [ [ "t_apiary", 5 ], [ "t_apiary_empty", 95 ] ] },
+      "items": {
+        "♠": [
+          { "item": "hive", "chance": 50, "repeat": [ 2, 4 ] },
+          { "item": "home_hw", "chance": 50 },
+          { "item": "tools_common", "chance": 50 }
+        ],
+        "r": { "item": "honey_market_stall", "repeat": [ 4, 12 ] }
+      },
+      "furniture": { "♥": "f_machinery_light", "♠": "f_locker", "♦": "f_woodchips" },
+      "sealed_item": { "D": { "item": { "item": "seed_corn" }, "furniture": "f_plant_seedling", "chance": 70 } },
+      "palettes": [ "farm" ],
+      "place_monster": [
+        { "group": "GROUP_BEEKEEPER", "x": [ 6, 21 ], "y": [ 3, 10 ], "pack_size": 1, "chance": 10 },
+        { "group": "GROUP_BEE", "x": [ 6, 21 ], "y": [ 3, 10 ], "pack_size": [ 2, 4 ], "chance": 20 }
+      ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": [ [ "farm_1_apiary_roof" ] ],
+    "weight": 250,
+    "object": {
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                  ..... ",
+        "                  ...=. ",
+        "                  ..... ",
+        "                  ..... ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        "
+      ],
+      "palettes": [ "roof_palette" ]
+    }
   }
 ]

--- a/data/json/overmap/overmap_mutable/farm_mutable.json
+++ b/data/json/overmap/overmap_mutable/farm_mutable.json
@@ -77,6 +77,8 @@
       "farm_1_coop_roof": { "overmap": "farm_1_coop_roof_north" },
       "farm_1_greenhouse": { "overmap": "farm_1_greenhouse_north", "south": "house_to_extension" },
       "farm_1_greenhouse_roof": { "overmap": "farm_1_greenhouse_roof_north" },
+      "farm_1_apiary": { "overmap": "farm_1_apiary_north", "south": "house_to_extension" },
+      "farm_1_apiary_roof": { "overmap": "farm_1_apiary_roof_north" },
       "farm_2": { "overmap": "farm_2_north", "connections": { "north": { "connection": "local_road" } } },
       "farm_2_roof": { "overmap": "farm_2_roof_north" },
       "farm_3": { "overmap": "farm_3_north" },
@@ -361,6 +363,11 @@
         {
           "name": "ext_greenhouse",
           "chunk": [ { "overmap": "farm_1_greenhouse", "pos": [ 0, 0, 0 ] }, { "overmap": "farm_1_greenhouse_roof", "pos": [ 0, 0, 1 ] } ],
+          "weight": 1
+        },
+        {
+          "name": "ext_apiary",
+          "chunk": [ { "overmap": "farm_1_apiary", "pos": [ 0, 0, 0 ] }, { "overmap": "farm_1_apiary_roof", "pos": [ 0, 0, 1 ] } ],
           "weight": 1
         }
       ],

--- a/data/json/overmap/overmap_terrain/overmap_terrain_agricultural.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_agricultural.json
@@ -637,6 +637,22 @@
   },
   {
     "type": "overmap_terrain",
+    "id": [ "farm_1_apiary" ],
+    "copy-from": "generic_rural_building",
+    "name": "apiary",
+    "sym": "h",
+    "color": "yellow"
+  },
+  {
+    "type": "overmap_terrain",
+    "id": [ "farm_1_apiary_roof" ],
+    "copy-from": "generic_rural_building",
+    "name": "apiary roof",
+    "sym": "h",
+    "color": "yellow"
+  },
+  {
+    "type": "overmap_terrain",
     "id": "horse_farm_isherwood_9_roof",
     "copy-from": "farm_horse_greenhouse_roof",
     "extras": ""


### PR DESCRIPTION
#### Summary
Content "Added apiary overmap tile to farm generation"

#### Purpose of change

Adds an apiary (bee yard) to the overmap generation in farm areas. Area has a small chance for spawning oversized bees or a scarred zombie. First time adding stuff to the game, please let me know if this needs balance tweaks or other changes!

![image](https://github.com/user-attachments/assets/719d64cb-4e61-4853-836d-4d4ff40f9eb0)
![image](https://github.com/user-attachments/assets/8a71fc64-f8c0-4140-b48b-68bfd757f05d)
[![image](https://github.com/user-attachments/assets/814a4098-f5d5-4d88-ad3a-08824be5719f)](https://commons.wikimedia.org/wiki/File:Apiary-bee_yard-_Ohio_2006.JPG)


#### Describe the solution

Adds an overmap tile `farm_1_apiary` (based on `farm_1_greenhouse`) which if generated spawns a handful of beehives and a shed with some tools.

