### PR TITLE
Fix linux experimental build toolchain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,17 +219,15 @@ jobs:
         if: runner.os == 'Linux' && matrix.mxe == 'none' && matrix.android == 'none' && !matrix.wasm
         run: |
           sudo apt-get update
-          sudo apt-get install libsdl2-dev
+          sudo apt-get install libsdl2-dev libncursesw5-dev libsdl2-ttf-dev libsdl2-image-dev libsdl2-mixer-dev libpulse-dev ccache gettext parallel
           git clone https://github.com/libsdl-org/SDL.git --branch release-2.0.20 --depth 1
           cd SDL
           mkdir build
           cd build
-          ../configure
+          ../configure --prefix=/usr
           make -j$((`nproc`+0))
           sudo make install
           cp ../LICENSE.txt ${{ github.workspace }}/LICENSE-SDL.txt
-          sudo apt-get install libncursesw5-dev libsdl2-ttf-dev libsdl2-image-dev \
-            libsdl2-mixer-dev libpulse-dev ccache gettext parallel
       - name: Install Emscripten (WebAssembly)
         if: matrix.wasm
         uses: mymindstorm/setup-emsdk@v13

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,15 +219,17 @@ jobs:
         if: runner.os == 'Linux' && matrix.mxe == 'none' && matrix.android == 'none' && !matrix.wasm
         run: |
           sudo apt-get update
-          sudo apt-get install libsdl2-dev libncursesw5-dev libsdl2-ttf-dev libsdl2-image-dev libsdl2-mixer-dev libpulse-dev ccache gettext parallel
+          sudo apt-get install libsdl2-dev
           git clone https://github.com/libsdl-org/SDL.git --branch release-2.0.20 --depth 1
           cd SDL
           mkdir build
           cd build
-          ../configure --prefix=/usr
+          ../configure
           make -j$((`nproc`+0))
           sudo make install
           cp ../LICENSE.txt ${{ github.workspace }}/LICENSE-SDL.txt
+          sudo apt-get install libncursesw5-dev libsdl2-ttf-dev libsdl2-image-dev \
+            libsdl2-mixer-dev libpulse-dev ccache gettext parallel
       - name: Install Emscripten (WebAssembly)
         if: matrix.wasm
         uses: mymindstorm/setup-emsdk@v13

--- a/Makefile
+++ b/Makefile
@@ -717,33 +717,6 @@ endif
 
 PKG_CONFIG = $(CROSS)pkg-config
 
-ifeq ($(SOUND), 1)
-  ifneq ($(TILES),1)
-    $(error "SOUND=1 only works with TILES=1")
-  endif
-  ifeq ($(NATIVE),osx)
-    ifndef FRAMEWORK # libsdl build
-      ifeq ($(MACPORTS), 1)
-        LDFLAGS += -lSDL2_mixer -lvorbisfile -lvorbis -logg
-      else # homebrew
-        CXXFLAGS += $(shell $(PKG_CONFIG) --cflags SDL2_mixer)
-        LDFLAGS += $(shell $(PKG_CONFIG) --libs SDL2_mixer)
-        LDFLAGS += -lvorbisfile -lvorbis -logg
-      endif
-    endif
-  else # not osx
-    CXXFLAGS += $(shell $(PKG_CONFIG) --cflags SDL2_mixer)
-    LDFLAGS += $(shell $(PKG_CONFIG) --libs SDL2_mixer)
-    LDFLAGS += -lpthread
-  endif
-
-  ifeq ($(MSYS2),1)
-    LDFLAGS += -lmpg123 -lshlwapi -lvorbisfile -lvorbis -logg -lflac
-  endif
-
-  CXXFLAGS += -DSDL_SOUND
-endif
-
 ifeq ($(SDL), 1)
   TILES = 1
 endif
@@ -778,7 +751,8 @@ ifeq ($(TILES), 1)
       endif
     endif
   else ifneq ($(NATIVE),emscripten)
-    CXXFLAGS += $(shell $(PKG_CONFIG) --cflags sdl2 SDL2_image SDL2_ttf)
+    CXXFLAGS += $(shell $(PKG_CONFIG) --cflags sdl2)
+    CXXFLAGS += $(shell $(PKG_CONFIG) --cflags SDL2_image SDL2_ttf)
 
     ifeq ($(STATIC), 1)
       LDFLAGS += $(shell $(PKG_CONFIG) sdl2 --static --libs)
@@ -788,9 +762,6 @@ ifeq ($(TILES), 1)
 
     LDFLAGS += -lSDL2_ttf -lSDL2_image
 
-    # We don't use SDL_main -- we have proper main()/WinMain()
-    CXXFLAGS := $(filter-out -Dmain=SDL_main,$(CXXFLAGS))
-    LDFLAGS := $(filter-out -lSDL2main,$(LDFLAGS))
   endif
 
   DEFINES += -DTILES
@@ -859,6 +830,37 @@ else
     CXXFLAGS += -DNCURSES_INTERNALS
   endif
 endif # TILES
+
+ifeq ($(SOUND), 1)
+  ifneq ($(TILES),1)
+    $(error "SOUND=1 only works with TILES=1")
+  endif
+  ifeq ($(NATIVE),osx)
+    ifndef FRAMEWORK # libsdl build
+      ifeq ($(MACPORTS), 1)
+        LDFLAGS += -lSDL2_mixer -lvorbisfile -lvorbis -logg
+      else # homebrew
+        CXXFLAGS += $(shell $(PKG_CONFIG) --cflags SDL2_mixer)
+        LDFLAGS += $(shell $(PKG_CONFIG) --libs SDL2_mixer)
+        LDFLAGS += -lvorbisfile -lvorbis -logg
+      endif
+    endif
+  else # not osx
+    CXXFLAGS += $(shell $(PKG_CONFIG) --cflags SDL2_mixer)
+    LDFLAGS += $(shell $(PKG_CONFIG) --libs SDL2_mixer)
+    LDFLAGS += -lpthread
+  endif
+
+  ifeq ($(MSYS2),1)
+    LDFLAGS += -lmpg123 -lshlwapi -lvorbisfile -lvorbis -logg -lflac
+  endif
+
+  CXXFLAGS += -DSDL_SOUND
+endif
+
+# We don't use SDL_main -- we have proper main()/WinMain()
+CXXFLAGS := $(filter-out -Dmain=SDL_main,$(CXXFLAGS))
+LDFLAGS := $(filter-out -lSDL2main,$(LDFLAGS))
 
 ifeq ($(BSD), 1)
   # BSDs have backtrace() and friends in a separate library


### PR DESCRIPTION
#### Summary
Build "Fixed linux experimental build automation issues caused by SDL dependencies"

#### Purpose of change

Resolves #74858 by implementing the patches mentioned therein by @andrei8l. I am unable to confirm if this also resolves Android builds as mentioned in the comments of the issue report at hand.

#### Describe the solution

Adjusts the Makefile to explicitly order SDL and dependencies so as to prevent the wrong version of SDL being included by the build system.

#### Describe alternatives you've considered

My brain is very smooth especially with regards to complicated build scripts and github action workflows, I just integrated the code given in the issue to see if it'd make the errors go away. A discussion with context is available [on the discord server](https://canary.discord.com/channels/598523535169945603/598523535169945607/1264255275896934471).

#### Testing

Repository was forked, changes were made and pushed to master on said fork. A successful experimental build was performed and can be seen here: https://github.com/MisfitMaid/Cataclysm-DDA-actionstest/actions/runs/10022428809
