### PR TITLE
fix NPCs spawning hallucinations, that player can see

### DIFF
--- a/data/json/effects_on_condition/npc_eocs/hallucination_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/hallucination_eocs.json
@@ -138,7 +138,7 @@
   {
     "type": "effect_on_condition",
     "id": "self_shout",
-    "effect": { "u_make_sound": "schizo_self_shout", "volume": 20, "snippet": true, "type": "speech" }
+    "effect": { "u_make_sound": "schizo_self_shout", "volume": 20, "snippet": true }
   },
   {
     "type": "effect_on_condition",

--- a/data/json/effects_on_condition/npc_eocs/hallucination_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/hallucination_eocs.json
@@ -176,7 +176,8 @@
     "id": "creature_hallucinations",
     "//TODO": "ideally checks is the tile visible, and then spawns hallu where player can't see it",
     "//": "If monsters are nearby, 3/4 chance to spawn some hallucinations of random monsters nearby and run again half the time, 1/4 chance to spawn some of YOUR_FEARS. If not, spawns some of YOUR_FEARS",
-    "condition": { "and": [ { "math": [ "rand(3)", "<", "3" ] }, { "math": [ "u_monsters_nearby()", ">", "0" ] } ] },
+    "//2": "avatar check to prevent NPCs from spawning hallucinations, that player can see",
+    "condition": { "and": [ { "math": [ "rand(3)", "<", "3" ] }, { "math": [ "u_monsters_nearby()", ">", "0" ] }, "u_is_avatar" ] },
     "effect": [
       {
         "u_spawn_monster": "",
@@ -192,6 +193,7 @@
     "type": "effect_on_condition",
     "id": "creature_hallucinations_fears",
     "//TODO": "ideally checks is the tile visible, and then spawns hallu where player can't see it",
+    "condition": "u_is_avatar",
     "effect": {
       "u_spawn_monster": "GROUP_YOUR_FEARS",
       "group": true,


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
I heard rumors that NPCs can spawn hallucinatons, visible by player. not good
#### Describe the solution
Add `u_is_avatar` check so only avatar can see said hallucinations
#### Testing
Hard to test because there is no bugreport with save file with this bug
UPD: was told dino dave always has psychosis, debug moved it afar, waited for a while, confirmed it's his work with hallucinations; applied fix, waited again - no hallucination now