### PR TITLE
Moved Magiclysm validation to Basic Build

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -92,6 +92,7 @@ jobs:
             pch: 1
             archive-success: basic-build
             dont_skip_data_only_changes: 1
+            mods: --mods=magiclysm
             title: Basic Build and Test (Clang 10, Ubuntu, Curses)
             # ~190MB in a clean build
             # ~30MB compressed
@@ -141,7 +142,6 @@ jobs:
             pch: 1
             sanitize: address
             cxxflags: --gcc-toolchain=/opt/mock-gcc-11
-            mods: --mods=magiclysm
             dont_skip_data_only_changes: 1
             title: Clang 12, Ubuntu, Tiles, ASan
             # ~390MB in a clean build

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -92,7 +92,7 @@ jobs:
             pch: 1
             archive-success: basic-build
             dont_skip_data_only_changes: 1
-            mods: --mods=magiclysm
+            mods: --mods=magiclysm,
             title: Basic Build and Test (Clang 10, Ubuntu, Curses)
             # ~190MB in a clean build
             # ~30MB compressed

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -92,7 +92,7 @@ jobs:
             pch: 1
             archive-success: basic-build
             dont_skip_data_only_changes: 1
-            mods: --mods=magiclysm,
+            mods: --mods=magiclysm
             title: Basic Build and Test (Clang 10, Ubuntu, Curses)
             # ~190MB in a clean build
             # ~30MB compressed


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
In #74597 I noticed the magiclysm checks were happening way down the list in the alternate compiler builds, this is supposed to be happening in Basic Build.

#### Describe the solution
Moved --mods=magiclysm to the Basic Build entry.

#### Additional Context
This needs to be rebased on top of #75131 to pass Basic Build.