### PR TITLE
Further improve Barry Isherwood's rescue mission

### DIFF
--- a/data/json/effects_on_condition/npc_eocs/isherwood_barry_rescue_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/isherwood_barry_rescue_eocs.json
@@ -42,12 +42,16 @@
         "if": { "math": [ "isherwood_gear_status", "==", "1" ] },
         "then": {
           "mapgen_update": "nest_Isherwood_chris_swat_add",
-          "om_terrain": "rural_road",
+          "om_terrain": "isherwood_barry_rescue_field",
           "om_special": "Barry's Mi-Go Scout Tower"
         },
         "else": {
           "if": { "math": [ "isherwood_gear_status", "!=", "1" ] },
-          "then": { "mapgen_update": "nest_Isherwood_chris_add", "om_terrain": "rural_road", "om_special": "Barry's Mi-Go Scout Tower" }
+          "then": {
+            "mapgen_update": "nest_Isherwood_chris_add",
+            "om_terrain": "isherwood_barry_rescue_field",
+            "om_special": "Barry's Mi-Go Scout Tower"
+          }
         }
       }
     ]
@@ -60,12 +64,16 @@
         "if": { "and": [ { "math": [ "isherwood_lisa_coming", "==", "1" ] }, { "math": [ "isherwood_gear_status", "==", "1" ] } ] },
         "then": {
           "mapgen_update": "nest_Isherwood_lisa_swat_add",
-          "om_terrain": "rural_road",
+          "om_terrain": "isherwood_barry_rescue_field",
           "om_special": "Barry's Mi-Go Scout Tower"
         },
         "else": {
           "if": { "and": [ { "math": [ "isherwood_lisa_coming", "==", "1" ] }, { "math": [ "isherwood_gear_status", "!=", "1" ] } ] },
-          "then": { "mapgen_update": "nest_Isherwood_lisa_add", "om_terrain": "rural_road", "om_special": "Barry's Mi-Go Scout Tower" }
+          "then": {
+            "mapgen_update": "nest_Isherwood_lisa_add",
+            "om_terrain": "isherwood_barry_rescue_field",
+            "om_special": "Barry's Mi-Go Scout Tower"
+          }
         }
       }
     ]
@@ -84,7 +92,7 @@
         "then": [
           {
             "mapgen_update": "nest_Isherwood_firing_line_add",
-            "om_terrain": "rural_road",
+            "om_terrain": "isherwood_barry_rescue_field",
             "om_special": "Barry's Mi-Go Scout Tower"
           }
         ],
@@ -93,7 +101,7 @@
           "then": [
             {
               "mapgen_update": "nest_Isherwood_firing_line_swat_add",
-              "om_terrain": "rural_road",
+              "om_terrain": "isherwood_barry_rescue_field",
               "om_special": "Barry's Mi-Go Scout Tower"
             }
           ]
@@ -104,7 +112,7 @@
         "then": [
           {
             "mapgen_update": "nest_Isherwood_firing_wall_add",
-            "om_terrain": "rural_road",
+            "om_terrain": "isherwood_barry_rescue_field",
             "om_special": "Barry's Mi-Go Scout Tower"
           }
         ]
@@ -276,7 +284,7 @@
                 { "u_teleport": { "global_val": "_teleport_pos" }, "force": true },
                 {
                   "mapgen_update": "isherwood_rescue_remove_npcs",
-                  "om_terrain": "rural_road",
+                  "om_terrain": "isherwood_barry_rescue_field",
                   "om_special": "Barry's Mi-Go Scout Tower"
                 },
                 { "math": [ "currently_invading_map", "=", "0" ] },
@@ -299,6 +307,7 @@
     "condition": {
       "and": [
         { "u_has_mission": "MISSION_ISHERWOOD_CHRIS_1" },
+        { "not": { "u_has_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" } },
         {
           "and": [
             { "not": { "u_near_om_location": "barry_mi-go_scout_tower_1", "range": 2 } },
@@ -324,7 +333,7 @@
               { "u_teleport": { "global_val": "_teleport_pos" }, "force": true },
               {
                 "mapgen_update": "isherwood_rescue_remove_npcs",
-                "om_terrain": "rural_road",
+                "om_terrain": "isherwood_barry_rescue_field",
                 "om_special": "Barry's Mi-Go Scout Tower"
               }
             ]
@@ -372,7 +381,7 @@
       },
       {
         "if": { "math": [ "isherwood_family_coming", "==", "1" ] },
-        "then": { "mapgen_update": "isherwood_rescue_remove_npcs", "om_terrain": "rural_road" }
+        "then": { "mapgen_update": "isherwood_rescue_remove_npcs", "om_terrain": "isherwood_barry_rescue_field" }
       },
       {
         "mapgen_update": "isherwood_rescue_remove_npcs",
@@ -449,7 +458,7 @@
         "if": { "math": [ "isherwood_family_coming", "==", "1" ] },
         "then": [
           { "set_string_var": "blames_themselves", "target_var": { "global_val": "isherwood_barry_death_opinion" } },
-          { "mapgen_update": "isherwood_rescue_remove_npcs", "om_terrain": "rural_road" },
+          { "mapgen_update": "isherwood_rescue_remove_npcs", "om_terrain": "isherwood_barry_rescue_field" },
           {
             "u_location_variable": { "global_val": "isherwood_mission_sucess_return_map" },
             "target_params": { "om_terrain": "horse_farm_isherwood_13", "search_range": 500, "z": 0 },

--- a/data/json/effects_on_condition/npc_eocs/isherwood_barry_rescue_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/isherwood_barry_rescue_eocs.json
@@ -138,17 +138,20 @@
     "required_event": "avatar_enters_omt",
     "condition": {
       "and": [
-        { "not": { "math": [ "isherwood_barry_rescued", "==", "1" ] } },
+        { "math": [ "isherwood_barry_rescued", "!=", "1" ] },
+        { "math": [ "isherwood_family_coming", "!=", "1" ] },
         { "u_has_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" },
         { "u_near_om_location": "horse_farm_isherwood_13", "range": 30 }
       ]
     },
+    "deactivate_condition": { "math": [ "isherwood_barry_rescued", "==", "1" ] },
     "effect": [
       {
         "u_message": "Barry raises a hand to signal you to stop.  \"This is it.  Thank you so much.  I can't believe I'm here, alive.  It almost feels like I'm dreaming, like it can't be real.\"  He stares at you, his eyes glistening.  \"Whoever you are, thank you.  I'm going to head the rest of the way now and catch up to my family.  Come by and talk to me later when I've had a moment to rest.\"",
         "type": "good",
         "popup": true
       },
+      { "u_lose_var": "u_dont_know_about_farm", "type": "general", "context": "knowledge" },
       {
         "if": { "u_has_mission": "MISSION_ISHERWOOD_CHRIS_1" },
         "then": [
@@ -170,49 +173,83 @@
                 ]
               }
             ],
-            "unique_ids": [ "BARRY_MISSION", "CHRIS_MISSION", "LISA_MISSION" ]
+            "unique_ids": [ "CHRIS_MISSION", "LISA_MISSION" ]
           }
-        ],
-        "else": {
-          "u_run_npc_eocs": [
-            {
-              "id": "EOC_BARRY_ONLY_LEAVE",
-              "effect": [
-                {
-                  "u_location_variable": { "global_val": "invasion_map" },
-                  "target_params": { "om_terrain": "horse_farm_isherwood_13", "search_range": 500, "z": 0 }
-                },
-                { "u_teleport": { "global_val": "invasion_map" }, "force": true },
-                {
-                  "mapgen_update": "remove_barry_and_company",
-                  "om_terrain": "horse_farm_isherwood_13",
-                  "om_special": "Isherwood Farm Mutable"
-                }
-              ]
-            }
-          ],
-          "unique_ids": [ "BARRY_MISSION" ]
-        }
+        ]
+      },
+      {
+        "if": {
+          "and": [
+            { "not": { "u_has_mission": "MISSION_ISHERWOOD_CHRIS_1" } },
+            { "not": { "u_has_mission": "MISSION_ISHERWOOD_BARRY_RETURN_TO_FARM" } }
+          ]
+        },
+        "then": [
+          { "assign_mission": "MISSION_ISHERWOOD_BARRY_RETURN_TO_FARM" },
+          { "finish_mission": "MISSION_ISHERWOOD_BARRY_RETURN_TO_FARM", "success": true }
+        ]
       },
       {
         "if": { "u_has_mission": "MISSION_ISHERWOOD_CHRIS_1" },
-        "then": [ { "finish_mission": "MISSION_ISHERWOOD_CHRIS_1", "success": true } ],
-        "else": {
-          "if": { "u_has_mission": "MISSION_ISHERWOOD_BARRY_RETURN_TO_FARM" },
-          "then": [ { "finish_mission": "MISSION_ISHERWOOD_BARRY_RETURN_TO_FARM", "success": true } ],
-          "else": {
-            "if": {
-              "and": [
-                { "not": { "u_has_mission": "MISSION_ISHERWOOD_CHRIS_1" } },
-                { "not": { "u_has_mission": "MISSION_ISHERWOOD_BARRY_RETURN_TO_FARM" } }
-              ]
-            },
-            "then": [
-              { "assign_mission": "MISSION_ISHERWOOD_BARRY_RETURN_TO_FARM" },
-              { "finish_mission": "MISSION_ISHERWOOD_BARRY_RETURN_TO_FARM", "success": true }
+        "then": [ { "finish_mission": "MISSION_ISHERWOOD_CHRIS_1", "success": true } ]
+      },
+      {
+        "if": { "u_has_mission": "MISSION_ISHERWOOD_BARRY_RETURN_TO_FARM" },
+        "then": [ { "finish_mission": "MISSION_ISHERWOOD_BARRY_RETURN_TO_FARM", "success": true } ]
+      },
+      {
+        "u_run_npc_eocs": [
+          {
+            "id": "EOC_BARRY_TRAVEL_HOME",
+            "effect": [
+              {
+                "u_set_goal": {
+                  "om_terrain": "horse_farm_isherwood_14",
+                  "om_special": "Isherwood Farm Mutable",
+                  "reveal_radius": 0,
+                  "search_range": 500
+                }
+              }
             ]
           }
-        }
+        ],
+        "unique_ids": [ "BARRY_MISSION" ]
+      },
+      { "math": [ "barry_travelling_home", "=", "1" ] }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_BARRY_CHECK_IF_HOME",
+    "recurrence": 100,
+    "condition": { "math": [ "barry_travelling_home", "==", "1" ] },
+    "deactivate_condition": { "math": [ "barry_travelling_home", "==", "2" ] },
+    "effect": [
+      {
+        "u_run_npc_eocs": [
+          {
+            "id": "EOC_BARRY_CHECK_IF_HOME_TRUE_EFFECT",
+            "condition": { "u_near_om_location": "horse_farm_isherwood_14", "range": 0 },
+            "effect": [
+              {
+                "u_location_variable": { "global_val": "barry_return_home_map" },
+                "target_params": { "om_terrain": "horse_farm_isherwood_13", "om_special": "Isherwood Farm Mutable", "search_range": 500, "z": 0 },
+                "furniture": "f_sofa",
+                "target_max_radius": 30,
+                "min_radius": 0,
+                "max_radius": 0
+              },
+              { "u_teleport": { "global_val": "barry_return_home_map" }, "force": true },
+              {
+                "queue_eocs": { "id": "EOC_BARRY_CHECK_IF_HOME_DEACTIVATE", "effect": { "math": [ "barry_travelling_home", "=", "2" ] } },
+                "time_in_future": 25
+              },
+              { "u_spawn_item": "NC_Isherwood_Barry_equip", "use_item_group": true, "force_equip": true },
+              { "u_spawn_item": "3006", "count": [ 8, 16 ] }
+            ]
+          }
+        ],
+        "unique_ids": [ "BARRY_MISSION" ]
       }
     ]
   },
@@ -221,6 +258,7 @@
     "id": "isherwood_mission_large_damage_retreat",
     "recurrence": 1,
     "condition": { "math": [ "currently_invading_map", "==", "1" ] },
+    "deactivate_condition": { "math": [ "isherwood_barry_rescued", "==", "1" ] },
     "effect": [
       {
         "if": { "math": [ "isherwood_family_coming", "==", "1" ] },
@@ -257,6 +295,7 @@
     "global": true,
     "eoc_type": "EVENT",
     "required_event": "avatar_moves",
+    "deactivate_condition": { "math": [ "isherwood_barry_rescued", "==", "1" ] },
     "condition": {
       "and": [
         { "u_has_mission": "MISSION_ISHERWOOD_CHRIS_1" },
@@ -298,7 +337,7 @@
       {
         "u_location_variable": { "global_val": "isherwood_mission_sucess_return_map" },
         "target_params": { "om_terrain": "horse_farm_isherwood_13", "search_range": 500, "z": 0 },
-        "furniture": "f_sofa",
+        "furniture": "f_chair",
         "target_max_radius": 30,
         "min_radius": 0,
         "max_radius": 0
@@ -357,7 +396,7 @@
       {
         "u_location_variable": { "global_val": "isherwood_mission_sucess_return_map" },
         "target_params": { "om_terrain": "horse_farm_isherwood_13", "search_range": 500, "z": 0 },
-        "furniture": "f_sofa",
+        "furniture": "f_chair",
         "target_max_radius": 30,
         "min_radius": 0,
         "max_radius": 0
@@ -371,6 +410,7 @@
     "global": true,
     "eoc_type": "EVENT",
     "required_event": "avatar_moves",
+    "deactivate_condition": { "math": [ "isherwood_barry_rescued", "==", "1" ] },
     "condition": {
       "and": [
         { "u_has_mission": "MISSION_ISHERWOOD_CHRIS_1" },
@@ -413,7 +453,7 @@
           {
             "u_location_variable": { "global_val": "isherwood_mission_sucess_return_map" },
             "target_params": { "om_terrain": "horse_farm_isherwood_13", "search_range": 500, "z": 0 },
-            "furniture": "f_sofa",
+            "furniture": "f_chair",
             "target_max_radius": 30,
             "min_radius": 0,
             "max_radius": 0

--- a/data/json/mapgen/basic/field.json
+++ b/data/json/mapgen/basic/field.json
@@ -2,7 +2,7 @@
   {
     "type": "mapgen",
     "method": "json",
-    "om_terrain": [ "field" ],
+    "om_terrain": [ "field", "isherwood_barry_rescue_field" ],
     "object": {
       "fill_ter": "t_region_groundcover",
       "rows": [

--- a/data/json/mapgen/nested/isherwood_mission_nested.json
+++ b/data/json/mapgen/nested/isherwood_mission_nested.json
@@ -167,8 +167,7 @@
         { "class": "isherwood_luke_swat_copy", "x": [ 0, 23 ], "y": [ 0, 23 ] },
         { "class": "isherwood_jesse_swat_copy", "x": [ 0, 23 ], "y": [ 0, 23 ] },
         { "class": "isherwood_chris_swat_copy", "x": [ 0, 23 ], "y": [ 0, 23 ] },
-        { "class": "isherwood_lisa_swat_copy", "x": [ 0, 23 ], "y": [ 0, 23 ] },
-        { "class": "isherwood_barry", "x": [ 0, 23 ], "y": [ 0, 23 ] }
+        { "class": "isherwood_lisa_swat_copy", "x": [ 0, 23 ], "y": [ 0, 23 ] }
       ],
       "remove_vehicles": [ { "vehicles": [ "extended_pickup" ], "x": [ 0, 23 ], "y": [ 0, 23 ] } ]
     }
@@ -179,7 +178,6 @@
     "method": "json",
     "object": {
       "remove_npcs": [
-        { "class": "isherwood_barry", "x": [ 0, 23 ], "y": [ 0, 23 ] },
         { "class": "isherwood_chris_copy", "x": [ 0, 23 ], "y": [ 0, 23 ] },
         { "class": "isherwood_lisa_copy", "x": [ 0, 23 ], "y": [ 0, 23 ] },
         { "class": "isherwood_chris_swat_copy", "x": [ 0, 23 ], "y": [ 0, 23 ] },

--- a/data/json/npcs/isherwood_farm/Isherwood_Rescue_NPC_Duplicates.json
+++ b/data/json/npcs/isherwood_farm/Isherwood_Rescue_NPC_Duplicates.json
@@ -4,12 +4,23 @@
     "id": "TALK_ISHERWOOD_FAMILY_DUPLICATES",
     "dynamic_line": {
       "follower_present": "NC_ISHERWOOD_BARRY",
-      "no": [
-        "What's up?  Change of plans?",
-        "Everything OK?",
-        "Not really a good time for a chat.",
-        "I can't believe this is happening."
-      ],
+      "no": {
+        "u_has_var": "barry_following",
+        "type": "general",
+        "context": "meeting",
+        "value": "yes",
+        "no": [
+          "What's up?  Change of plans?",
+          "Everything OK?",
+          "Not really a good time for a chat.",
+          "I can't believe this is happening."
+        ],
+        "yes": [
+          { "gendered_line": "Barry!  Oh my god, you found him!", "relevant_genders": [ "u" ] },
+          "Barry!  You're okay!",
+          "Oh god, oh thank god.  Let's get Barry out of here."
+        ]
+      },
       "yes": [
         { "gendered_line": "Barry!  Oh my god, you found him!", "relevant_genders": [ "u" ] },
         "Barry!  You're okay!",
@@ -28,18 +39,38 @@
         "effect": [
           { "u_lose_var": "barry_following", "type": "general", "context": "meeting" },
           { "u_add_var": "u_saved_barry", "type": "general", "context": "meeting", "value": "yes" },
-          { "u_spawn_item": "hsurvivor_jumpsuit", "count": 1 },
           { "finish_mission": "MISSION_ISHERWOOD_CHRIS_1", "success": true },
           { "mapgen_update": "isherwood_rescue_remove_npcs", "om_terrain": "rural_road" },
+          { "math": [ "barry_travelling_home", "=", "1" ] },
+          {
+            "u_run_npc_eocs": [
+              {
+                "id": "EOC_BARRY_TELEPORT_HOME",
+                "effect": [
+                  {
+                    "u_location_variable": { "global_val": "barry_return_home_map" },
+                    "target_params": { "om_terrain": "horse_farm_isherwood_14", "om_special": "Isherwood Farm Mutable", "search_range": 500, "z": 0 },
+                    "terrain": "t_dirt",
+                    "target_max_radius": 30,
+                    "min_radius": 0,
+                    "max_radius": 0
+                  },
+                  { "u_teleport": { "global_val": "barry_return_home_map" } }
+                ]
+              }
+            ],
+            "unique_ids": [ "BARRY_MISSION" ]
+          },
           {
             "u_location_variable": { "global_val": "isherwood_mission_sucess_return_map" },
             "target_params": { "om_terrain": "horse_farm_isherwood_13", "search_range": 500, "z": 0 },
-            "furniture": "f_sofa",
+            "furniture": "f_chair",
             "target_max_radius": 30,
             "min_radius": 0,
             "max_radius": 0
           },
-          { "u_teleport": { "global_val": "isherwood_mission_sucess_return_map" }, "force": true }
+          { "u_teleport": { "global_val": "isherwood_mission_sucess_return_map" }, "force": true },
+          { "u_spawn_item": "hsurvivor_jumpsuit", "count": 1 }
         ],
         "topic": "TALK_DONE"
       },

--- a/data/json/npcs/isherwood_farm/Isherwood_Rescue_NPC_Duplicates.json
+++ b/data/json/npcs/isherwood_farm/Isherwood_Rescue_NPC_Duplicates.json
@@ -40,7 +40,7 @@
           { "u_lose_var": "barry_following", "type": "general", "context": "meeting" },
           { "u_add_var": "u_saved_barry", "type": "general", "context": "meeting", "value": "yes" },
           { "finish_mission": "MISSION_ISHERWOOD_CHRIS_1", "success": true },
-          { "mapgen_update": "isherwood_rescue_remove_npcs", "om_terrain": "rural_road" },
+          { "mapgen_update": "isherwood_rescue_remove_npcs", "om_terrain": "isherwood_barry_rescue_field" },
           { "math": [ "barry_travelling_home", "=", "1" ] },
           {
             "u_run_npc_eocs": [

--- a/data/json/npcs/isherwood_farm/NPC_Barry_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Barry_Isherwood.json
@@ -10,7 +10,6 @@
     "attitude": 0,
     "mission": 7,
     "chat": "TALK_ISHERWOOD_BARRY_RESCUE",
-    "mission_offered": "MISSION_ISHERWOOD_BARRY_1",
     "faction": "isherwood_family",
     "death_eocs": [ "EOC_BARRY_ISHERWOOD_DIE" ]
   },
@@ -36,6 +35,26 @@
     "worn_override": "naked_prisoner",
     "carry_override": "naked_prisoner",
     "weapon_override": "naked_prisoner"
+  },
+  {
+    "type": "item_group",
+    "id": "NC_Isherwood_Barry_equip",
+    "//": "This is given to him upon returning home, rather than at spawn.",
+    "subtype": "collection",
+    "entries": [
+      { "item": "backpack_leather" },
+      { "item": "jacket_flannel" },
+      { "item": "ammo_pouch" },
+      { "item": "boxer_shorts" },
+      { "item": "tshirt" },
+      { "item": "pants_cargo" },
+      { "item": "leather_belt" },
+      { "item": "gloves_fingerless" },
+      { "item": "cowboy_hat" },
+      { "item": "boots" },
+      { "item": "socks" },
+      { "item": "browning_blr", "charges": 4, "contents-group": "NC_ISHERWOOD_rifle_mods" }
+    ]
   },
   {
     "type": "talk_topic",
@@ -71,12 +90,24 @@
         "condition": { "u_has_mission": "MISSION_ISHERWOOD_CHRIS_1" }
       },
       {
+        "text": "Okay then, your family's outside.  Let me go get them.",
+        "condition": { "u_has_mission": "MISSION_ISHERWOOD_CHRIS_1" },
+        "effect": [
+          { "u_add_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" },
+          { "math": [ "u_timer_barry_rescue", "=", "time('now')" ] },
+          { "npc_first_topic": "TALK_ISHERWOOD_BARRY" }
+        ],
+        "topic": "TALK_DONE"
+      },
+      {
         "text": "Let's go.",
+        "condition": { "not": { "u_has_mission": "MISSION_ISHERWOOD_CHRIS_1" } },
         "effect": [
           "follow_only",
           { "u_add_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" },
           { "math": [ "u_timer_barry_rescue", "=", "time('now')" ] },
-          { "npc_first_topic": "TALK_ISHERWOOD_BARRY" }
+          { "npc_first_topic": "TALK_ISHERWOOD_BARRY" },
+          { "assign_mission": "MISSION_ISHERWOOD_BARRY_RETURN_TO_FARM" }
         ],
         "topic": "TALK_DONE"
       },
@@ -90,12 +121,12 @@
     "dynamic_line": "*gulps.  \"I sure as hell am.  Did my family send you?  Please, we gotta go.  There are more of those things.  They're everywhere.\"",
     "responses": [
       {
-        "text": "Yeah, they did.  Let's go.",
+        "text": "Yeah, they did, I'll go get them.",
         "effect": [
-          "follow_only",
           { "u_add_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" },
           { "math": [ "u_timer_barry_rescue", "=", "time('now')" ] },
-          { "npc_first_topic": "TALK_ISHERWOOD_BARRY" }
+          { "npc_first_topic": "TALK_ISHERWOOD_BARRY" },
+          { "assign_mission": "MISSION_ISHERWOOD_BARRY_RETURN_TO_FARM" }
         ],
         "topic": "TALK_DONE"
       },
@@ -109,22 +140,48 @@
     "dynamic_line": "*switches, abruptly, to pure white-hot rage.  \"DOES THIS LOOK LIKE A TIME FOR FUCKING QUESTIONS?\"  He stops, shaking, and returns to how he was before.  \"I'm sorry.  I'm so sorry.  Oh god, I'm sorry.  I need to get out of here.\"",
     "responses": [
       {
-        "text": "Okay, me too.  Let's go.",
+        "text": "Okay, me too, let's go.",
+        "condition": { "not": { "u_has_mission": "MISSION_ISHERWOOD_CHRIS_1" } },
         "effect": [
           "follow_only",
           { "u_add_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" },
           { "math": [ "u_timer_barry_rescue", "=", "time('now')" ] },
-          { "npc_first_topic": "TALK_ISHERWOOD_BARRY" }
+          { "npc_first_topic": "TALK_ISHERWOOD_BARRY" },
+          { "assign_mission": "MISSION_ISHERWOOD_BARRY_RETURN_TO_FARM" }
         ],
         "topic": "TALK_DONE"
       },
       {
         "text": "All right, we're leaving, but you better not test me again.",
+        "condition": { "not": { "u_has_mission": "MISSION_ISHERWOOD_CHRIS_1" } },
         "effect": [
           "follow_only",
           { "u_add_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" },
           { "math": [ "u_timer_barry_rescue", "=", "time('now')" ] },
-          { "npc_first_topic": "TALK_ISHERWOOD_BARRY" }
+          { "npc_first_topic": "TALK_ISHERWOOD_BARRY" },
+          { "assign_mission": "MISSION_ISHERWOOD_BARRY_RETURN_TO_FARM" }
+        ],
+        "topic": "TALK_DONE"
+      },
+      {
+        "text": "Okay, me too. I'll go get your family.",
+        "condition": { "u_has_mission": "MISSION_ISHERWOOD_CHRIS_1" },
+        "effect": [
+          { "u_add_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" },
+          { "math": [ "u_timer_barry_rescue", "=", "time('now')" ] },
+          { "npc_first_topic": "TALK_ISHERWOOD_BARRY" },
+          { "assign_mission": "MISSION_ISHERWOOD_BARRY_RETURN_TO_FARM" }
+        ],
+        "topic": "TALK_DONE"
+      },
+      {
+        "text": "All right, we're leaving, but you better not test me again.  I'll be back with your family.",
+        "condition": { "u_has_mission": "MISSION_ISHERWOOD_CHRIS_1" },
+        "effect": [
+          { "u_add_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" },
+          { "math": [ "u_timer_barry_rescue", "=", "time('now')" ] },
+          { "npc_first_topic": "TALK_ISHERWOOD_BARRY" },
+          { "assign_mission": "MISSION_ISHERWOOD_BARRY_RETURN_TO_FARM" }
         ],
         "topic": "TALK_DONE"
       },
@@ -143,14 +200,14 @@
         "effect": { "u_add_var": "u_dont_know_about_farm", "type": "general", "context": "knowledge", "value": "yes" }
       },
       {
-        "text": "That shouldn't take long, your family's outside waiting.",
+        "text": "That shouldn't take long, your family's outside waiting.  I'll be back with them.",
         "topic": "TALK_DONE",
         "condition": { "u_has_mission": "MISSION_ISHERWOOD_CHRIS_1" },
         "effect": [
-          "follow_only",
           { "u_add_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" },
           { "math": [ "u_timer_barry_rescue", "=", "time('now')" ] },
-          { "npc_first_topic": "TALK_ISHERWOOD_BARRY" }
+          { "npc_first_topic": "TALK_ISHERWOOD_BARRY" },
+          { "assign_mission": "MISSION_ISHERWOOD_BARRY_RETURN_TO_FARM" }
         ]
       }
     ]
@@ -233,6 +290,24 @@
         "condition": {
           "and": [
             { "u_has_var": "u_dont_know_about_farm", "type": "general", "context": "knowledge", "value": "yes" },
+            { "not": { "u_has_mission": "MISSION_ISHERWOOD_BARRY_RETURN_TO_FARM" } },
+            {
+              "and": [
+                { "not": { "npc_near_om_location": "barry_mi-go_scout_tower_1", "range": 3 } },
+                { "not": { "npc_near_om_location": "barry_mi-go_scout_tower_2", "range": 3 } },
+                { "not": { "npc_near_om_location": "barry_mi-go_scout_tower_3", "range": 3 } },
+                { "not": { "npc_near_om_location": "barry_mi-go_scout_tower_4", "range": 3 } }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "text": "I've thought about it some more, and I'd like to have the directions to your farm.",
+        "topic": "TALK_ISHERWOOD_BARRY_TOWER_farm_directions",
+        "condition": {
+          "and": [
+            { "u_has_var": "u_thinking_about_farm", "type": "general", "context": "knowledge", "value": "yes" },
             { "not": { "u_has_mission": "MISSION_ISHERWOOD_BARRY_RETURN_TO_FARM" } },
             {
               "and": [
@@ -363,7 +438,7 @@
     "dynamic_line": "*shivers, though the room is warm, and moves his mouth wordlessly for a few seconds.  \"It's hard to remember details.  The air in that place messes with your brain, makes it all feel like some kind of dream.  Makes it so you can't fight back.  Not that I could have anyway.\"  He stares into space for a moment, then swallows hard.  \"They cut into me, over and over.  I don't think they took anything out.  They just opened me up, poked around.  I was awake for all of it, as awake as for anything else.  Sometimes I felt pain, other times they did something to me so I could feel it but it didn't hurt.  There were big, pale ones that did the cutting.\"  His voice gets increasingly detached as he speaks, and his shaking grows worse.  You're not sure it would be wise for him to go further.",
     "speaker_effect": { "sentinel": "barry_PTSD1", "effect": { "math": [ "barry_PTSD_freakouts", "+=", "1" ] } },
     "responses": [
-      { "text": "[Let him continue.]", "topic": "TALK_ISHERWOOD_BARRY_TOWER_fresh3" },
+      { "text": "(Let him continue)", "topic": "TALK_ISHERWOOD_BARRY_TOWER_fresh3" },
       { "text": "That's enough for now, Barry.", "topic": "TALK_ISHERWOOD_BARRY_TOWER_fresh_stop" },
       { "text": "On second thought, I think you should recover more.", "topic": "TALK_DONE" }
     ]
@@ -372,7 +447,7 @@
     "type": "talk_topic",
     "id": "TALK_ISHERWOOD_BARRY_TOWER_fresh3",
     "dynamic_line": "*shudders, looking like he might vomit.  \"What did they want?  Why me?  Every time, they'd put me back together again, seal it up and make it look almost like nothing happened.\"  He yanks up his shirt to show the scars.  \"But I know what happened, it was REAL, goddammit!\"  He drops the shirt, bends forward, and dry heaves for a few seconds.  Wordless, he hides his face in his hands, and stops responding.",
-    "responses": [ { "text": "[Leave.]", "topic": "TALK_DONE" } ]
+    "responses": [ { "text": "(Leave)", "topic": "TALK_DONE" } ]
   },
   {
     "type": "talk_topic",
@@ -403,7 +478,7 @@
     "speaker_effect": { "effect": { "u_add_var": "u_knows_barry_family_story", "value": "yes" } },
     "responses": [
       {
-        "text": "[PER 9] Was your choice in partners part of the problem with your father?",
+        "text": "[PERCEPTION] Was your choice in partners part of the problem with your father?",
         "topic": "TALK_ISHERWOOD_BARRY_TOWER_family3",
         "condition": { "u_has_perception": 9 }
       },
@@ -431,13 +506,22 @@
     "type": "talk_topic",
     "id": "TALK_ISHERWOOD_BARRY_TOWER_farm",
     "dynamic_line": "Oh, yeah, now I remember.  That farm I was talking about is where I live, almost the whole Isherwood family lives there, including me.  I just wanted to get back home as fast as possible so I can see everyone again, and so everyone knows that I'm okay.",
+    "speaker_effect": {
+      "sentinel": "u_learned_about_farm",
+      "effect": [ { "u_lose_var": "u_dont_know_about_farm", "type": "general", "context": "knowledge" } ]
+    },
     "responses": [
       { "text": "Can you give me some directions to it?", "topic": "TALK_ISHERWOOD_BARRY_TOWER_farm_directions" },
       {
         "text": "That's pretty cool.  I'd like to ask you about something else.",
-        "topic": "TALK_ISHERWOOD_BARRY_askback"
+        "topic": "TALK_ISHERWOOD_BARRY_askback",
+        "effect": { "u_add_var": "u_thinking_about_farm", "type": "general", "context": "knowledge", "value": "yes" }
       },
-      { "text": "I'm going to head out.", "topic": "TALK_DONE" }
+      {
+        "text": "I'm going to head out.",
+        "topic": "TALK_DONE",
+        "effect": { "u_add_var": "u_thinking_about_farm", "type": "general", "context": "knowledge", "value": "yes" }
+      }
     ]
   },
   {
@@ -450,10 +534,14 @@
         "topic": "TALK_DONE",
         "effect": [
           { "assign_mission": "MISSION_ISHERWOOD_BARRY_RETURN_TO_FARM" },
-          { "u_lose_var": "u_dont_know_about_farm", "type": "general", "context": "knowledge" }
+          { "u_lose_var": "u_thinking_about_farm", "type": "general", "context": "knowledge" }
         ]
       },
-      { "text": "I'd like to think about it some more.", "topic": "TALK_DONE" }
+      {
+        "text": "I'd like to think about it some more.",
+        "topic": "TALK_DONE",
+        "effect": { "u_add_var": "u_thinking_about_farm", "type": "general", "context": "knowledge", "value": "yes" }
+      }
     ]
   },
   {
@@ -472,7 +560,7 @@
         "search_range": 240
       }
     },
-    "end": { "effect": [ { "math": [ "isherwood_barry_rescued", "=", "1" ] } ] },
+    "end": { "effect": [ "stop_following", { "math": [ "isherwood_barry_rescued", "=", "1" ] } ] },
     "origins": [ "ORIGIN_SECONDARY" ],
     "//": "Dialogue is handled externally.",
     "dialogue": {

--- a/data/json/npcs/isherwood_farm/NPC_Barry_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Barry_Isherwood.json
@@ -438,7 +438,7 @@
     "dynamic_line": "*shivers, though the room is warm, and moves his mouth wordlessly for a few seconds.  \"It's hard to remember details.  The air in that place messes with your brain, makes it all feel like some kind of dream.  Makes it so you can't fight back.  Not that I could have anyway.\"  He stares into space for a moment, then swallows hard.  \"They cut into me, over and over.  I don't think they took anything out.  They just opened me up, poked around.  I was awake for all of it, as awake as for anything else.  Sometimes I felt pain, other times they did something to me so I could feel it but it didn't hurt.  There were big, pale ones that did the cutting.\"  His voice gets increasingly detached as he speaks, and his shaking grows worse.  You're not sure it would be wise for him to go further.",
     "speaker_effect": { "sentinel": "barry_PTSD1", "effect": { "math": [ "barry_PTSD_freakouts", "+=", "1" ] } },
     "responses": [
-      { "text": "(Let him continue)", "topic": "TALK_ISHERWOOD_BARRY_TOWER_fresh3" },
+      { "text": "[Let him continue.]", "topic": "TALK_ISHERWOOD_BARRY_TOWER_fresh3" },
       { "text": "That's enough for now, Barry.", "topic": "TALK_ISHERWOOD_BARRY_TOWER_fresh_stop" },
       { "text": "On second thought, I think you should recover more.", "topic": "TALK_DONE" }
     ]
@@ -447,7 +447,7 @@
     "type": "talk_topic",
     "id": "TALK_ISHERWOOD_BARRY_TOWER_fresh3",
     "dynamic_line": "*shudders, looking like he might vomit.  \"What did they want?  Why me?  Every time, they'd put me back together again, seal it up and make it look almost like nothing happened.\"  He yanks up his shirt to show the scars.  \"But I know what happened, it was REAL, goddammit!\"  He drops the shirt, bends forward, and dry heaves for a few seconds.  Wordless, he hides his face in his hands, and stops responding.",
-    "responses": [ { "text": "(Leave)", "topic": "TALK_DONE" } ]
+    "responses": [ { "text": "[Leave.]", "topic": "TALK_DONE" } ]
   },
   {
     "type": "talk_topic",
@@ -478,7 +478,7 @@
     "speaker_effect": { "effect": { "u_add_var": "u_knows_barry_family_story", "value": "yes" } },
     "responses": [
       {
-        "text": "[PERCEPTION] Was your choice in partners part of the problem with your father?",
+        "text": "[PER 9] Was your choice in partners part of the problem with your father?",
         "topic": "TALK_ISHERWOOD_BARRY_TOWER_family3",
         "condition": { "u_has_perception": 9 }
       },

--- a/data/json/npcs/isherwood_farm/NPC_Barry_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Barry_Isherwood.json
@@ -164,7 +164,7 @@
         "topic": "TALK_DONE"
       },
       {
-        "text": "Okay, me too. I'll go get your family.",
+        "text": "Okay, me too.  I'll go get your family.",
         "condition": { "u_has_mission": "MISSION_ISHERWOOD_CHRIS_1" },
         "effect": [
           { "u_add_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" },

--- a/data/json/npcs/isherwood_farm/NPC_Barry_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Barry_Isherwood.json
@@ -122,7 +122,19 @@
     "responses": [
       {
         "text": "Yeah, they did, I'll go get them.",
+        "condition": { "math": [ "isherwood_family_coming", "==", "1" ] },
         "effect": [
+          { "u_add_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" },
+          { "math": [ "u_timer_barry_rescue", "=", "time('now')" ] },
+          { "npc_first_topic": "TALK_ISHERWOOD_BARRY" }
+        ],
+        "topic": "TALK_DONE"
+      },
+      {
+        "text": "Yeah, Chris did, we're taking you home.",
+        "condition": { "math": [ "isherwood_family_coming", "!=", "1" ] },
+        "effect": [
+          "follow_only",
           { "u_add_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" },
           { "math": [ "u_timer_barry_rescue", "=", "time('now')" ] },
           { "npc_first_topic": "TALK_ISHERWOOD_BARRY" },
@@ -141,7 +153,7 @@
     "responses": [
       {
         "text": "Okay, me too, let's go.",
-        "condition": { "not": { "u_has_mission": "MISSION_ISHERWOOD_CHRIS_1" } },
+        "condition": { "math": [ "isherwood_family_coming", "!=", "1" ] },
         "effect": [
           "follow_only",
           { "u_add_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" },
@@ -153,7 +165,7 @@
       },
       {
         "text": "All right, we're leaving, but you better not test me again.",
-        "condition": { "not": { "u_has_mission": "MISSION_ISHERWOOD_CHRIS_1" } },
+        "condition": { "math": [ "isherwood_family_coming", "!=", "1" ] },
         "effect": [
           "follow_only",
           { "u_add_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" },
@@ -165,23 +177,21 @@
       },
       {
         "text": "Okay, me too.  I'll go get your family.",
-        "condition": { "u_has_mission": "MISSION_ISHERWOOD_CHRIS_1" },
+        "condition": { "math": [ "isherwood_family_coming", "==", "1" ] },
         "effect": [
           { "u_add_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" },
           { "math": [ "u_timer_barry_rescue", "=", "time('now')" ] },
-          { "npc_first_topic": "TALK_ISHERWOOD_BARRY" },
-          { "assign_mission": "MISSION_ISHERWOOD_BARRY_RETURN_TO_FARM" }
+          { "npc_first_topic": "TALK_ISHERWOOD_BARRY" }
         ],
         "topic": "TALK_DONE"
       },
       {
         "text": "All right, we're leaving, but you better not test me again.  I'll be back with your family.",
-        "condition": { "u_has_mission": "MISSION_ISHERWOOD_CHRIS_1" },
+        "condition": { "math": [ "isherwood_family_coming", "==", "1" ] },
         "effect": [
           { "u_add_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" },
           { "math": [ "u_timer_barry_rescue", "=", "time('now')" ] },
-          { "npc_first_topic": "TALK_ISHERWOOD_BARRY" },
-          { "assign_mission": "MISSION_ISHERWOOD_BARRY_RETURN_TO_FARM" }
+          { "npc_first_topic": "TALK_ISHERWOOD_BARRY" }
         ],
         "topic": "TALK_DONE"
       },
@@ -202,8 +212,19 @@
       {
         "text": "That shouldn't take long, your family's outside waiting.  I'll be back with them.",
         "topic": "TALK_DONE",
-        "condition": { "u_has_mission": "MISSION_ISHERWOOD_CHRIS_1" },
+        "condition": { "math": [ "isherwood_family_coming", "==", "1" ] },
         "effect": [
+          { "u_add_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" },
+          { "math": [ "u_timer_barry_rescue", "=", "time('now')" ] },
+          { "npc_first_topic": "TALK_ISHERWOOD_BARRY" }
+        ]
+      },
+      {
+        "text": "That shouldn't take long, I brought some of your family with me.  Let's get you home.",
+        "topic": "TALK_DONE",
+        "condition": { "and": [ { "math": [ "isherwood_family_coming", "!=", "1" ] }, { "u_has_mission": "MISSION_ISHERWOOD_CHRIS_1" } ] },
+        "effect": [
+          "follow_only",
           { "u_add_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" },
           { "math": [ "u_timer_barry_rescue", "=", "time('now')" ] },
           { "npc_first_topic": "TALK_ISHERWOOD_BARRY" },

--- a/data/json/npcs/isherwood_farm/NPC_Carlos_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Carlos_Isherwood.json
@@ -354,7 +354,7 @@
         "reveal_radius": 1,
         "random": true,
         "search_range": 20,
-        "min_distance": 8
+        "min_distance": 2
       },
       "update_mapgen": { "place_npcs": [ { "class": "isherwood_chris", "x": 8, "y": 17, "target": true } ] }
     },

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -5455,13 +5455,20 @@
       { "point": [ 0, 0, 1 ], "overmap": "barry_mi-go_scout_tower_2_north" },
       { "point": [ 0, 0, 2 ], "overmap": "barry_mi-go_scout_tower_3_north" },
       { "point": [ 0, 0, 3 ], "overmap": "barry_mi-go_scout_tower_4_north" },
-      { "point": [ 0, 1, 0 ], "overmap": "rural_road_ns" }
+      { "point": [ 0, 1, 0 ], "overmap": "isherwood_barry_rescue_field" },
+      { "point": [ 1, 1, 0 ], "overmap": "field" },
+      { "point": [ -1, 1, 0 ], "overmap": "field" },
+      { "point": [ 1, 0, 0 ], "overmap": "field" },
+      { "point": [ -1, 0, 0 ], "overmap": "field" },
+      { "point": [ 0, -1, 0 ], "overmap": "field" },
+      { "point": [ 1, -1, 0 ], "overmap": "field" },
+      { "point": [ -1, -1, 0 ], "overmap": "field" }
     ],
     "locations": [ "wilderness" ],
     "city_distance": [ 5, -1 ],
     "city_sizes": [ 0, 20 ],
     "occurrences": [ 70, 100 ],
-    "connections": [ { "point": [ 0, 2, 0 ], "terrain": "road", "connection": "local_road" } ],
+    "connections": [ { "point": [ -2, 2, 0 ], "terrain": "road", "connection": "local_road" } ],
     "flags": [ "MI-GO", "WILDERNESS", "GLOBALLY_UNIQUE" ],
     "eoc": { "id": "EOC_ISHERWOOD_MIGO_SPAWN_EXCEPTIONS", "condition": { "not": { "mod_is_loaded": "innawood" } } },
     "spawns": { "group": "GROUP_MI-GO_CAMP_OM", "population": [ 2, 5 ], "radius": [ 2, 30 ] }

--- a/data/json/overmap/overmap_terrain/overmap_terrain_hardcoded.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_hardcoded.json
@@ -10,7 +10,7 @@
   },
   {
     "type": "overmap_terrain",
-    "id": "field",
+    "id": [ "field", "isherwood_barry_rescue_field" ],
     "copy-from": "generic_open_land",
     "name": "field",
     "sym": ".",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Further improve Barry Isherwood's rescue mission."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Followup PR to #75044, keep adding more stuff to Barry's rescue quest.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
This PR makes a few changes pertaining to the mission:
1. Barry can now independently travel back home when he gets to an area that he recognizes. This will complete the quest he gives to take you home, and results in him traveling back the Isherwood's horse farm. He will then receive a fresh set of Isherwood-centric equipment and hang out in the house with Lisa, where the player can talk to him.
2. Parts of the rescue quest with the family have been reworked to accommodate this travel pattern. Instead of Barry becoming one of your temporary followers, you will instead be prompted to go outside and inform the family that you found him. This will then teleport him to the horse farm and chain into the regular EOCs that give him equipment and place him. (This is primarily due to a bug I couldn't solve where Barry wouldn't stop following you when teleported back, but this circumvents that).
3. I redid some of the mapgen for the unique tower, so that it's now in a clearing and sits alongside a road. This makes it look more natural and doesn't stick out by having a road lead to it.
4. The player now has the choice to postpone accepting Barry's return quest if found naturally, rather than going through the Isherwood's channels. This was a simple dialogue change.
5. I added deactivate conditions to recurring mission EOCs related to the Isherwood's, so these EOCs won't take up more processing space after they're no longer needed. I also changed Carlos's minimum range on placing Chris at the cabin to 2 instead of 8, as I encountered a situation where the cabin spawned too close, and thus failed to place Chris at that location, breaking the quest chain at the start because you couldn't talk to him. Additionally, I removed an old mission definition that Barry was supposed to offer, since that mission was deleted and replaced with this new one. It threw errors during gameplay.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not changing the minimum search distance for Chris's second mission.
Still having Barry follow you out of the tower when the family is present, even though I couldn't get that to work.
Preferably, I would like to have Barry simply path to a specific spot on Lisa's farm house, rather than having him go to the lot beside it and then teleport in. However, current `u_set_goal` pathing only allows the selection of whole overmap tiles, and not the fine-tuned specifics (aka. selection down to a single specific tile) that `u_teleport` supports.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
So far, everything works great.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
There's so much more that could be done with the aftereffects of Barry being rescued, such as how characters react or potential missions Barry might ask of you, but I think that I should leave that to someone more experienced with Isherwood social dynamics.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
