### PR TITLE
Chain pupating zombies through ``copy-from``

### DIFF
--- a/data/json/monsters/zed-pupating.json
+++ b/data/json/monsters/zed-pupating.json
@@ -15,17 +15,14 @@
   {
     "id": "mon_zombie_crawler_pupa",
     "type": "MONSTER",
-    "name": { "str": "pupating zombie crawler" },
-    "description": "This half of a human corpse is wrapped in sticky black fibers that cover everything from the neck down.  Beneath the wrapping there is a strange rhythmic movement, grotesque to behold.",
     "copy-from": "mon_zombie_crawler_pupa_decoy",
-    "harvest": "zombie_pupating",
     "extend": {
       "special_attacks": [
         {
           "type": "spell",
           "spell_data": { "id": "small_raptor_spawn", "hit_self": true },
           "cooldown": 50,
-          "monster_message": "The pupating zombie crawler bursts, and gore-smeared winged beasts climb out of the corpse!"
+          "monster_message": "%s bursts, and gore-smeared winged beasts climb out of the corpse!"
         }
       ]
     }
@@ -47,17 +44,14 @@
   {
     "id": "mon_zombie_pupa",
     "type": "MONSTER",
-    "name": { "str": "pupating zombie" },
-    "description": "This human corpse is wrapped in sticky black fibers that cover everything from the neck down.  Beneath the wrapping there is a strange rhythmic movement, grotesque to behold.",
     "copy-from": "mon_zombie_pupa_decoy",
-    "harvest": "zombie_pupating",
     "extend": {
       "special_attacks": [
         {
           "type": "spell",
           "spell_data": { "id": "small_raptor_spawn", "hit_self": true },
           "cooldown": 50,
-          "monster_message": "The pupating zombie bursts, and gore-smeared winged beasts climb out of the corpse!"
+          "monster_message": "%s bursts, and gore-smeared winged beasts climb out of the corpse!"
         }
       ]
     }
@@ -78,17 +72,14 @@
   {
     "id": "mon_brute_pupa",
     "type": "MONSTER",
-    "name": { "str": "pupating brute" },
-    "description": "This muscular human corpse is wrapped in sticky black fibers that cover everything from the neck down.  Beneath the wrapping there is a strange rhythmic movement, grotesque to behold.",
     "copy-from": "mon_brute_pupa_decoy",
-    "harvest": "zombie_pupating",
     "extend": {
       "special_attacks": [
         {
           "type": "spell",
           "spell_data": { "id": "big_raptor_spawn", "hit_self": true },
           "cooldown": 50,
-          "monster_message": "The pupating brute bursts, and gore-smeared winged beasts climb out of the corpse!"
+          "monster_message": "%s bursts, and gore-smeared winged beasts climb out of the corpse!"
         }
       ]
     }
@@ -97,122 +88,35 @@
     "id": "mon_hulk_pupa_decoy",
     "type": "MONSTER",
     "name": { "str": "hive hulk" },
-    "//": "Not using copy_from as it messes with monster evolution.",
     "description": "The bloated torso of this gigantic corpse is wrapped in sticky black fibers.  Beneath the wrapping there is a strange rhythmic movement, grotesque to behold.",
-    "default_faction": "zombie",
-    "bodytype": "human",
-    "species": [ "ZOMBIE", "HUMAN" ],
-    "diff": 5,
-    "volume": "875000 ml",
-    "weight": "200 kg",
+    "copy-from": "mon_zombie_hulk",
     "hp": 300,
     "speed": 85,
-    "material": [ "flesh" ],
-    "symbol": "Z",
     "color": "white_magenta",
-    "scents_tracked": [ "sc_human", "sc_fetid" ],
-    "aggression": 100,
-    "morale": 100,
     "melee_skill": 4,
     "melee_dice": 3,
     "melee_dice_sides": 7,
-    "melee_damage": [ { "damage_type": "cut", "amount": 0 } ],
-    "weakpoint_sets": [ "wps_humanoid_body", "wps_humanoid_head_small" ],
-    "families": [ "prof_intro_biology", "prof_physiology", "prof_wp_zombie", "prof_wp_hulk" ],
-    "vision_day": 83,
-    "vision_night": 4,
+    "bleed_rate": 100,
     "harvest": "zombie_pupating_hulk",
     "grab_strength": 35,
-    "special_attacks": [
-      { "id": "grab" },
-      { "id": "bite_humanoid", "cooldown": 5 },
-      { "id": "scratch_humanoid" },
-      { "id": "smash", "cooldown": 30 }
-    ],
-    "death_drops": "mon_zombie_hulk_death_drops",
     "regenerates": 10,
-    "flags": [
-      "SEES",
-      "HEARS",
-      "SMELLS",
-      "STUMBLES",
-      "WARM",
-      "GRABS",
-      "BASHES",
-      "DESTROYS",
-      "POISON",
-      "NO_BREATHE",
-      "REVIVES",
-      "PUSH_MON",
-      "PUSH_VEH",
-      "SMALLSLUDGETRAIL",
-      "SLUDGEPROOF",
-      "FILTHY"
-    ],
-    "armor": { "bash": 8, "cut": 10, "bullet": 10, "electric": 6 }
+    "armor": { "bash": 8, "cut": 10, "bullet": 10, "electric": 6 },
+    "extend": { "flags": [ "SMALLSLUDGETRAIL", "SLUDGEPROOF" ] }
   },
   {
     "id": "mon_hulk_pupa",
     "type": "MONSTER",
-    "name": { "str": "hive hulk" },
-    "//": "Not using copy_from as it messes with monster evolution.",
-    "description": "The bloated torso of this gigantic corpse is wrapped in sticky black fibers.  Beneath the wrapping there is a strange rhythmic movement, grotesque to behold.",
-    "default_faction": "zombie",
-    "bodytype": "human",
-    "species": [ "ZOMBIE", "HUMAN" ],
-    "diff": 5,
-    "volume": "875000 ml",
-    "weight": "200 kg",
-    "hp": 300,
-    "speed": 85,
-    "material": [ "flesh" ],
-    "symbol": "Z",
-    "color": "white_magenta",
-    "scents_tracked": [ "sc_human", "sc_fetid" ],
-    "aggression": 100,
-    "morale": 100,
-    "melee_skill": 4,
-    "melee_dice": 3,
-    "melee_dice_sides": 7,
-    "melee_damage": [ { "damage_type": "cut", "amount": 0 } ],
-    "weakpoint_sets": [ "wps_humanoid_body", "wps_humanoid_head_small" ],
-    "families": [ "prof_intro_biology", "prof_physiology", "prof_wp_zombie", "prof_wp_hulk" ],
-    "vision_day": 83,
-    "vision_night": 4,
-    "harvest": "zombie_pupating_hulk",
-    "special_attacks": [
-      { "id": "grab" },
-      { "id": "bite_humanoid", "cooldown": 5 },
-      { "id": "scratch_humanoid" },
-      { "id": "smash", "cooldown": 30 },
-      {
-        "type": "spell",
-        "spell_data": { "id": "hive_raptor_spawn", "hit_self": true },
-        "cooldown": 30,
-        "monster_message": "The hive hulk opens its mouth, and a gore-smeared winged beast flies out of it!"
-      }
-    ],
-    "death_drops": "mon_zombie_hulk_death_drops",
-    "regenerates": 10,
-    "flags": [
-      "SEES",
-      "HEARS",
-      "SMELLS",
-      "STUMBLES",
-      "WARM",
-      "GRABS",
-      "BASHES",
-      "DESTROYS",
-      "POISON",
-      "NO_BREATHE",
-      "REVIVES",
-      "PUSH_MON",
-      "PUSH_VEH",
-      "SMALLSLUDGETRAIL",
-      "SLUDGEPROOF",
-      "FILTHY"
-    ],
-    "armor": { "bash": 8, "cut": 10, "bullet": 10, "electric": 6 }
+    "copy-from": "mon_hulk_pupa_decoy",
+    "extend": {
+      "special_attacks": [
+        {
+          "type": "spell",
+          "spell_data": { "id": "hive_raptor_spawn", "hit_self": true },
+          "cooldown": 30,
+          "monster_message": "%s opens its mouth, and a gore-smeared winged beast flies out of it!"
+        }
+      ]
+    }
   },
   {
     "id": "mon_zombie_pupa_decoy_shady",
@@ -233,8 +137,6 @@
   {
     "id": "mon_zombie_pupa_shady",
     "type": "MONSTER",
-    "name": { "str": "shady pupating zombie" },
-    "description": "An uncanny shadow envelops this creature.  You can make out the outline of what once may have been a human being, but its edges bulge rhythmically in places that are not anatomically possible for humans.",
     "copy-from": "mon_zombie_pupa_decoy",
     "extend": {
       "special_attacks": [
@@ -242,7 +144,7 @@
           "type": "spell",
           "spell_data": { "id": "shady_raptor_spawn", "hit_self": true },
           "cooldown": 50,
-          "monster_message": "The pupating zombie bursts, and shadowy winged beasts climb out of the corpse!"
+          "monster_message": "%s bursts, and shadowy winged beasts climb out of the corpse!"
         }
       ]
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I left pupating zombies out because I was under the impression they were already done this way, but the hulks were not, and the ones that were still were done pretty meh. So I am cutting down to the bare minimum.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Chained hive hulks to normal hulks. The attached comment is outdated, as both their evolution and monsters evolving into them still works as expected. This should prove no gameplay changes, except maybe slightly increasing their smash's throw strength
- Removed all excess lines from other pupating zombies
- Shortened the print messages for their spells by using ``%s``
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Spawned me 25 pupating brutes, teleported away, waited a year, they still evolved normally, but not further than the hive hulk, so evolution works as expected.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
One of the many issues found when working on #75071
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
