### PR TITLE
Only attempt to dodge relatively slow projectiles

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1188,7 +1188,7 @@ void Character::consume_dodge_attempts()
     }
 }
 
-ret_val<void> Character::can_try_doge( bool ignore_dodges_left ) const
+ret_val<void> Character::can_try_dodge( bool ignore_dodges_left ) const
 {
     //If we're asleep or busy we can't dodge
     if( in_sleep_state() || has_effect( effect_narcosis ) ||
@@ -1198,7 +1198,7 @@ ret_val<void> Character::can_try_doge( bool ignore_dodges_left ) const
     }
     //If stamina is too low we can't dodge
     if( get_stamina_dodge_modifier() <= 0.11 ) {
-        add_msg_debug( debugmode::DF_MELEE, "Stamina too low to doge.  Stamina: %d", get_stamina() );
+        add_msg_debug( debugmode::DF_MELEE, "Stamina too low to dodge.  Stamina: %d", get_stamina() );
         add_msg_debug( debugmode::DF_MELEE, "Stamina dodge modifier: %f", get_stamina_dodge_modifier() );
         return ret_val<void>::make_failure( !is_npc() ? _( "Your stamina is too low to attempt to dodge." )
                                             :
@@ -1934,7 +1934,7 @@ void Character::mod_part_hp_cur( const bodypart_id &id, int set )
 
 void Character::on_try_dodge()
 {
-    ret_val<void> can_dodge = can_try_doge();
+    ret_val<void> can_dodge = can_try_dodge();
     if( !can_dodge.success() ) {
         add_msg( m_bad, can_dodge.c_str() );
         return;
@@ -1954,7 +1954,7 @@ void Character::on_dodge( Creature *source, float difficulty, float training_lev
 {
     // Make sure we're not practicing dodge in situation where we can't dodge
     // We can ignore dodges_left because it was already checked in get_dodge()
-    if( !can_try_doge( true ).success() ) {
+    if( !can_try_dodge( true ).success() ) {
         return;
     }
 

--- a/src/character.h
+++ b/src/character.h
@@ -826,7 +826,7 @@ class Character : public Creature, public visitable
         void set_dodges_left( int dodges );
         void mod_dodges_left( int mod );
         void consume_dodge_attempts();
-        ret_val<void> can_try_doge( bool ignore_dodges_left = false ) const;
+        ret_val<void> can_try_dodge( bool ignore_dodges_left = false ) const;
 
         float get_stamina_dodge_modifier() const;
 

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1238,7 +1238,10 @@ void Creature::deal_projectile_attack( Creature *source, dealt_projectile_attack
     const bool u_see_this = player_view.sees( *this );
 
     const double goodhit = accuracy_projectile_attack( attack );
-    on_try_dodge(); // There's a doge roll in accuracy_projectile_attack()
+    // We only trigger a dodge attempt if it's a relatively slow projectile.
+    if( attack.proj.speed < 20 ) {
+        on_try_dodge(); // There's a dodge roll in accuracy_projectile_attack()
+    }
 
     if( goodhit >= 1.0 && !magic ) {
         attack.missed_by = 1.0; // Arbitrary value

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1201,7 +1201,7 @@ int Character::get_spell_resist() const
 
 float Character::get_dodge() const
 {
-    if( !can_try_doge().success() ) {
+    if( !can_try_dodge().success() ) {
         return 0.0f;
     }
 


### PR DESCRIPTION
Also fix doge -> dodge typo

#### Summary
Bugfixes "Stop wasting dodge attempts on things you can't even see"

#### Purpose of change
Discord report from a weird message after a bomb went off:
![bomb-fragments-dodge-message](https://github.com/user-attachments/assets/0c538cd7-8059-4b1c-931d-bc97aada0725)
This indicates that regardless of projectile speed it's still triggering dodge attempts, which is incorrect.

#### Describe the solution
I put in a check when being targeted by a projectile to check the speed of the projectile, if it's too high to dodge naturally, we don't even attempt to dodge.

#### Describe alternatives you've considered
The way I did this means that if you have the EVASION enchantment active it will not trigger as a regular dodge either. Whether that's correct depends on what kind of evasion enchantment this is, if it's just "the magic moves you out of the way" then this is fine, but if it's "the magic makes you flinch out of the way (which would also be inconsistent with other things) it should still e.g. consume a dodge attempt.

#### Testing
Reproduced the initiating scenario by blowing up some characters with bombs with and without this.
Before the change it reported a large number of failed dodge attempts, after my change no attempts reported.
Got dogpiled by zombies, was able to get off several dodges a turn, but not as many as there were attacks.