### PR TITLE
Remove direction switching from stale action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,9 +10,6 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - name: get-time
-        run: |
-          echo "time=$(date +%I)" >> $GITHUB_ENV
       - uses: actions/stale@main
         id: stale
         with:
@@ -23,7 +20,6 @@ jobs:
           days-before-stale: 30
           days-before-close: 30
           start-date: '2020-05-07'
-          ascending: ${{ contains(fromJson('["01", "03", "05", "07", "09", "11"]'), env.time) }}
           operations-per-run: 110
           exempt-issue-labels: 'Accessibility,<Bug>,<Bugfix>,<Crash / Freeze>,Organization: Bounty,Good First Issue,Help Wanted,(P1 - Critical),(P2 - High),(P3 - Medium),(P4 - Low),(P5 - Long-term),(S2 - Confirmed),0.G String Freeze,0.G Feature Freeze,0.G Content Freeze'
           exempt-pr-labels: '<Bug>,<Bugfix>,<Crash / Freeze>,Organization: Bounty,Good First Issue,(P1 - Critical),(P2 - High),(P3 - Medium),(P4 - Low),(P5 - Long-term),(S2 - Confirmed),0.G String Freeze,0.G Feature Freeze,0.G Content Freeze'


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
The stale action has a feature where it picks up where it left off on its last invocation, but I think this hack is sabotaging it.

#### Describe the solution
Remove the weird hack, the stale action should pick up where it left off on the last invocation and proceed through the whole backlog of issues and PRs.

#### Testing
I can't test on my local repo because I don't have enough outstanding issues, just need to merge this and let it run for a few hours.