### PR TITLE
add `always_cast_spell` ammo effect boolean

### DIFF
--- a/data/mods/Aftershock/ammo_effects.json
+++ b/data/mods/Aftershock/ammo_effects.json
@@ -49,11 +49,13 @@
   {
     "id": "ELECTRIC_CHAIN",
     "type": "ammo_effect",
+    "always_cast_spell ": true,
     "spell_data": { "id": "spell_electric_chain" }
   },
   {
     "id": "FUSION_FAN",
     "type": "ammo_effect",
+    "always_cast_spell ": true,
     "spell_data": { "id": "spell_fusion_fan" }
   },
   {

--- a/data/mods/Aftershock/ammo_effects.json
+++ b/data/mods/Aftershock/ammo_effects.json
@@ -49,13 +49,13 @@
   {
     "id": "ELECTRIC_CHAIN",
     "type": "ammo_effect",
-    "always_cast_spell ": true,
+    "always_cast_spell": true,
     "spell_data": { "id": "spell_electric_chain" }
   },
   {
     "id": "FUSION_FAN",
     "type": "ammo_effect",
-    "always_cast_spell ": true,
+    "always_cast_spell": true,
     "spell_data": { "id": "spell_fusion_fan" }
   },
   {

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -3588,6 +3588,9 @@ ammo_effects define what effect the projectile, that you shoot, would have. List
   "do_flashbang": false,     // Creates a one tile radius EMP explosion at the hit location; default false
   "do_emp_blast": false      // Creates a hardcoded flashbang explosion; default false
   "foamcrete_build": false   // Creates foamcrete fields and walls on the hit location, used in aftershock; default false
+  "spell_data": { "id": "bear_trap" } // Spell, that would be casted when projectile hits an enemy
+  "spell_data": { "id": "release_the_deltas", "hit_self": true, "min_level": 10 }, //another example
+  "always_cast_spell ": false // if spell_data is used, and this is true, spell would be casted even if projectile did not deal any damage. Default false.
 }
 ```
 

--- a/src/ammo_effect.cpp
+++ b/src/ammo_effect.cpp
@@ -94,6 +94,7 @@ void ammo_effect::load( const JsonObject &jo, const std::string_view )
     optional( jo, was_loaded, "do_emp_blast", do_emp_blast, false );
     optional( jo, was_loaded, "foamcrete_build", foamcrete_build, false );
     optional( jo, was_loaded, "spell_data", spell_data );
+    optional( jo, was_loaded, "always_cast_spell", always_cast_spell, false );
 
 
 }

--- a/src/ammo_effect.h
+++ b/src/ammo_effect.h
@@ -45,6 +45,7 @@ struct ammo_effect {
         bool do_flashbang = false;
         bool do_emp_blast = false;
         bool foamcrete_build = false;
+        bool always_cast_spell = false;
 
         field_type_id trail_field_type = fd_null.id_or( INVALID_FIELD_TYPE_ID );
         /** used during JSON loading only */

--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -521,7 +521,8 @@ dealt_projectile_attack projectile_attack( const projectile &proj_arg, const tri
 
     drop_or_embed_projectile( attack );
 
-    apply_ammo_effects( null_source ? nullptr : origin, tp, proj.proj_effects );
+    bool dealt_damage = attack.dealt_dam.total_damage() > 0;
+    apply_ammo_effects( null_source ? nullptr : origin, tp, proj.proj_effects, dealt_damage );
     const explosion_data &expl = proj.get_custom_explosion();
     if( expl.power > 0.0f ) {
         explosion_handler::explosion( null_source ? nullptr : origin, tp, proj.get_custom_explosion() );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -12561,7 +12561,7 @@ bool item::detonate( const tripoint &p, std::vector<item> &drops )
         const int rounds_exploded = rng( 1, charges_remaining / 2 );
         if( type->ammo->special_cookoff ) {
             // If it has a special effect just trigger it.
-            apply_ammo_effects( nullptr, p, type->ammo->ammo_effects );
+            apply_ammo_effects( nullptr, p, type->ammo->ammo_effects, true );
         }
         if( type->ammo->cookoff ) {
             // If ammo type can burn, then create an explosion proportional to quantity.

--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -142,7 +142,7 @@ static void foamcrete_build( const tripoint &p )
 }
 
 void apply_ammo_effects( const Creature *source, const tripoint &p,
-                         const std::set<ammo_effect_str_id> &effects )
+                         const std::set<ammo_effect_str_id> &effects, const bool dealt_damage )
 {
     map &here = get_map();
     Character &player_character = get_player_character();
@@ -188,9 +188,11 @@ void apply_ammo_effects( const Creature *source, const tripoint &p,
             }
             //cast ammo effect spells
             const spell ammo_spell = ae.spell_data.get_spell();
-            if( ammo_spell.is_valid() ) {
-                ammo_spell.cast_all_effects( *const_cast<Creature *>( source ), p );
-                ammo_spell.make_sound( p, *const_cast<Creature *>( source ) );
+            if ( ammo_spell.is_valid() ) {
+                if ( ae.always_cast_spell || dealt_damage ) {
+                    ammo_spell.cast_all_effects( *const_cast<Creature*>( source ), p );
+                    ammo_spell.make_sound( p, *const_cast<Creature*>( source ) );
+                }
             }
         }
     }

--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -188,10 +188,10 @@ void apply_ammo_effects( const Creature *source, const tripoint &p,
             }
             //cast ammo effect spells
             const spell ammo_spell = ae.spell_data.get_spell();
-            if ( ammo_spell.is_valid() ) {
-                if ( ae.always_cast_spell || dealt_damage ) {
-                    ammo_spell.cast_all_effects( *const_cast<Creature*>( source ), p );
-                    ammo_spell.make_sound( p, *const_cast<Creature*>( source ) );
+            if( ammo_spell.is_valid() ) {
+                if( ae.always_cast_spell || dealt_damage ) {
+                    ammo_spell.cast_all_effects( *const_cast<Creature *>( source ), p );
+                    ammo_spell.make_sound( p, *const_cast<Creature *>( source ) );
                 }
             }
         }

--- a/src/projectile.h
+++ b/src/projectile.h
@@ -75,7 +75,7 @@ struct dealt_projectile_attack {
 };
 
 void apply_ammo_effects( const Creature *source, const tripoint &p,
-                         const std::set<ammo_effect_str_id> &effects );
+                         const std::set<ammo_effect_str_id> &effects, const bool dealt_damage );
 int max_aoe_size( const std::set<ammo_effect_str_id> &tags );
 
 void multi_projectile_hit_message( Creature *critter, int hit_count, int damage_taken,

--- a/src/projectile.h
+++ b/src/projectile.h
@@ -75,7 +75,7 @@ struct dealt_projectile_attack {
 };
 
 void apply_ammo_effects( const Creature *source, const tripoint &p,
-                         const std::set<ammo_effect_str_id> &effects, const bool dealt_damage );
+                         const std::set<ammo_effect_str_id> &effects, bool dealt_damage );
 int max_aoe_size( const std::set<ammo_effect_str_id> &tags );
 
 void multi_projectile_hit_message( Creature *critter, int hit_count, int damage_taken,


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Attempt, albeit a bit late, to help with #75079
#### Describe the solution
Add a boolean, that allow spell to be casted if projectile didn't deal any damage, make it false by default
#### Describe alternatives you've considered
i probably could've tried to make a way for ammo_effect to run EoC directly, bypassing the spell part, but i am not familiar with how to make it
#### Testing
![GIF 22-07-2024 20-46-07](https://github.com/user-attachments/assets/be5ef059-efed-4d84-b5aa-58e2826117b4)
#### Additional context
@John-Candlebury you added an aftershock gun in #74167 that uses ammo spell, do you want me to add aforementioned boolean to that gun?
Also @Maleclypse 