### PR TITLE
Wasp changes

### DIFF
--- a/data/json/monster_special_attacks/monster_gun.json
+++ b/data/json/monster_special_attacks/monster_gun.json
@@ -307,5 +307,35 @@
     "range": 100,
     "dispersion": 1000,
     "ranged_damage": { "damage_type": "stab", "amount": 30 }
+  },
+  {
+    "id": "wasp_shoot",
+    "type": "GUN",
+    "copy-from": "fake_item",
+    "name": { "str": "organic shoot" },
+    "description": "Fake gun that shoot organic and almost solidified matter",
+    "flags": [ "PSEUDO", "NEVER_JAMS", "NO_TURRET" ],
+    "ammo_effects": [ "NO_DAMAGE_SCALING", "NO_PENETRATE_OBSTACLES" ],
+    "material": [ "flesh" ],
+    "skill": "rifle",
+    "durability": 10,
+    "range": 35,
+    "dispersion": 4800,
+    "ranged_damage": { "damage_type": "bash", "amount": 6 }
+  },
+  {
+    "id": "wasp_power_shoot",
+    "type": "GUN",
+    "copy-from": "fake_item",
+    "name": { "str": "organic shoot" },
+    "description": "Fake gun that shoot organic and solidified matter",
+    "flags": [ "PSEUDO", "NEVER_JAMS", "NO_TURRET" ],
+    "ammo_effects": [ "NO_DAMAGE_SCALING", "NO_PENETRATE_OBSTACLES" ],
+    "material": [ "flesh" ],
+    "skill": "rifle",
+    "durability": 10,
+    "range": 45,
+    "dispersion": 4800,
+    "ranged_damage": { "damage_type": "bash", "amount": 20 }
   }
 ]

--- a/data/json/monstergroups/bugs.json
+++ b/data/json/monstergroups/bugs.json
@@ -179,7 +179,7 @@
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
       {
-        "monster": "mon_wasp_reforced",
+        "monster": "mon_wasp_reinforced",
         "weight": 100,
         "starts": "180 hours",
         "pack_size": [ 2, 6 ],
@@ -421,7 +421,7 @@
     "monsters": [
       { "monster": "mon_wasp_small_kamikaze", "weight": 15 },
       { "monster": "mon_wasp_gunner", "weight": 100 },
-      { "monster": "mon_wasp_reforced", "weight": 100 },
+      { "monster": "mon_wasp_reinforced", "weight": 100 },
       { "monster": "mon_wasp", "weight": 20 },
       { "monster": "mon_wasp_pitiful", "weight": 5 }
     ]

--- a/data/json/monstergroups/bugs.json
+++ b/data/json/monstergroups/bugs.json
@@ -163,55 +163,39 @@
     "name": "GROUP_WASP_NEST",
     "type": "monstergroup",
     "monsters": [
-      { "monster": "mon_wasp_small", "weight": 500, "ends": "180 hours", "conditions": [ "SPRING", "SUMMER", "AUTUMN" ] },
+      { "monster": "mon_wasp_small", "weight": 100, "conditions": [ "SPRING", "SUMMER", "AUTUMN" ] },
       {
         "monster": "mon_wasp_small",
-        "weight": 500,
-        "starts": "180 hours",
-        "ends": "540 hours",
         "pack_size": [ 2, 4 ],
+        "starts": "96 hours",
+        "weight": 50,
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
       {
-        "monster": "mon_wasp_small_guard",
-        "weight": 500,
-        "ends": "180 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_wasp_small_guard",
-        "weight": 500,
+        "monster": "mon_wasp_gunner",
+        "weight": 100,
         "starts": "180 hours",
-        "ends": "540 hours",
-        "pack_size": [ 2, 4 ],
+        "pack_size": [ 2, 5 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
       {
-        "monster": "mon_wasp",
-        "weight": 500,
+        "monster": "mon_wasp_reforced",
+        "weight": 100,
         "starts": "180 hours",
-        "ends": "540 hours",
+        "pack_size": [ 2, 6 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
       {
-        "monster": "mon_wasp",
-        "weight": 500,
-        "starts": "540 hours",
-        "pack_size": [ 2, 4 ],
+        "monster": "mon_wasp_small_kamikaze",
+        "weight": 100,
+        "starts": "90 hours",
+        "pack_size": [ 1, 3 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
       {
-        "monster": "mon_wasp_guard",
-        "weight": 500,
-        "starts": "180 hours",
-        "ends": "540 hours",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      {
-        "monster": "mon_wasp_guard",
-        "weight": 500,
-        "starts": "540 hours",
-        "pack_size": [ 2, 4 ],
+        "monster": "mon_wasp_pitiful",
+        "weight": 10,
+        "starts": "90 hours",
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       }
     ]
@@ -430,5 +414,16 @@
     "type": "monstergroup",
     "name": "GROUP_SPIDER_MOM_SUMMON",
     "monsters": [ { "monster": "mon_spider_cellar_small", "weight": 67 }, { "monster": "mon_spider_cellar_giant_s", "weight": 33 } ]
+  },
+  {
+    "name": "GROUP_WASP_UPGRADE",
+    "type": "monstergroup",
+    "monsters": [
+      { "monster": "mon_wasp_small_kamikaze", "weight": 15 },
+      { "monster": "mon_wasp_gunner", "weight": 100 },
+      { "monster": "mon_wasp_reforced", "weight": 100 },
+      { "monster": "mon_wasp", "weight": 20 },
+      { "monster": "mon_wasp_pitiful", "weight": 5 }
+    ]
   }
 ]

--- a/data/json/monsters/insect_spider.json
+++ b/data/json/monsters/insect_spider.json
@@ -1839,7 +1839,7 @@
     "dissect": "dissect_insect_sample_single",
     "anger_triggers": [ "FRIEND_ATTACKED", "PLAYER_CLOSE", "PLAYER_WEAK", "HOSTILE_SEEN" ],
     "fear_triggers": [ "HURT", "FIRE" ],
-    "upgrades": { "age_grow": 30, "into": "mon_wasp" },
+    "upgrades": { "half_life": 15, "into_group": "GROUP_WASP_UPGRADE" },
     "zombify_into": "mon_meat_cocoon_tiny",
     "fungalize_into": "mon_wasp_small_fungus",
     "flags": [
@@ -2009,6 +2009,138 @@
     "fungalize_into": "mon_wasp_mega_fungus",
     "delete": { "flags": [ "HARDTOSHOOT", "FLIES" ] },
     "armor": { "bash": 8, "cut": 30, "stab": 18, "bullet": 22, "electric": 4 }
+  },
+  {
+    "type": "MONSTER",
+    "id": "mon_wasp_small_kamikaze",
+    "copy-from": "mon_wasp_small",
+    "looks_like": "",
+    "name": "kamikaze wasp",
+    "description": "A huge wasp, almost half your size, with bright yellow markings on her jet-black carapace. Bloated and with problems flying. Deformed and pity, something is off with this wasp.",
+    "dodge": 2,
+    "proportional": { "hp": 0.3, "speed": 0.6, "volume": 1.3, "weight": 1.5 },
+    "death_function": { "effect": { "id": "death_sludge_mega", "hit_self": true }, "corpse_type": "NO_CORPSE", "message": "The %s explodes!" }
+  },
+  {
+    "type": "MONSTER",
+    "id": "mon_wasp_gunner",
+    "copy-from": "mon_wasp_small",
+    "name": "gunner wasp",
+    "description": "A huge wasp the size of a large cat with bright yellow markings on her jet-black carapace. Where the string should be, there's a weird looking hole, with a black sustance dropping",
+    "proportional": { "hp": 1.1, "volume": 1.1, "speed": 0.9, "weight": 1.1 },
+    "relative": { "dodge": -1, "diff": 2, "vision_day": 1, "vision_night": 1 },
+    "extend": { "flags": [ "HIT_AND_RUN" ] },
+    "special_attacks": [
+      {
+        "type": "gun",
+        "gun_type": "wasp_shoot",
+        "description": "The wasp launch a dense liquid from the abdomen",
+        "ranges": [ [ 2, 9, "DEFAULT" ] ]
+      }
+    ],
+    "upgrades": { "half_life": 40, "into": "mon_wasp_sniper" }
+  },
+  {
+    "type": "MONSTER",
+    "id": "mon_wasp_sniper",
+    "copy-from": "mon_wasp",
+    "name": "sniper wasp",
+    "description": "A huge wasp the size of a large cat with bright yellow markings on her jet-black carapace. Where the string should be, there's a weird-looking hole with a black substance dropping.",
+    "proportional": { "hp": 1.2, "speed": 0.8, "volume": 1.2, "weight": 1.2 },
+    "relative": { "dodge": -1, "vision_day": 2, "vision_night": 2, "diff": 3 },
+    "extend": { "flags": [ "HIT_AND_RUN" ] },
+    "special_attacks": [
+      {
+        "type": "gun",
+        "gun_type": "wasp_shoot",
+        "description": "The wasp launch a dense liquid from the abdomen",
+        "ranges": [ [ 2, 12, "DEFAULT" ] ]
+      }
+    ],
+    "upgrades": { "half_life": 45, "into": "mon_wasp_torret" }
+  },
+  {
+    "type": "MONSTER",
+    "id": "mon_wasp_torret",
+    "copy-from": "mon_wasp",
+    "name": "torret wasp",
+    "looks_like": "",
+    "description": "A deformed and gigant wasp-like mass with the capacity to shoot at large distances some sort of liquid",
+    "dodge": 0,
+    "diff": 20,
+    "proportional": { "hp": 1.5, "speed": 0.8, "volume": 1.8, "weight": 1.8 },
+    "relative": { "vision_day": 4, "vision_night": 4 },
+    "extend": { "flags": [ "IMMOBILE" ] },
+    "delete": { "weakpoint_sets": [ "wps_arthropod_flying" ], "flags": [ "FLIES" ], "families": [ "prof_wp_flying" ] },
+    "special_attacks": [
+      {
+        "type": "gun",
+        "gun_type": "wasp_power_shoot",
+        "description": "The wasp launch a solidified and black piece of matter from the abdomen",
+        "ranges": [ [ 1, 15, "DEFAULT" ] ]
+      }
+    ]
+  },
+  {
+    "type": "MONSTER",
+    "id": "mon_wasp_reforced",
+    "copy-from": "mon_wasp",
+    "name": "reforced wasp",
+    "looks_like": "",
+    "description": "A gigantic wasp worker. Wings fused to the back and an extremely hard body. Have no ability to fly and crawl, defending the other wasps like a guardian dog.",
+    "dodge": 3,
+    "melee_skill": 8,
+    "melee_dice": 3,
+    "melee_dice_sides": 8,
+    "proportional": { "hp": 1.4, "speed": 0.8, "volume": 1.1, "weight": 1.6 },
+    "relative": { "armor": { "bash": 3, "cut": 3, "stab": 3, "bullet": 3 } },
+    "special_attacks": [ { "id": "grab" }, { "id": "bite_grab" } ],
+    "delete": { "weakpoint_sets": [ "wps_arthropod_flying" ], "flags": [ "FLIES" ], "families": [ "prof_wp_flying" ] },
+    "extend": { "weakpoint_sets": [ "wps_arthropod_beetle" ] },
+    "upgrades": { "half_life": 45, "into": "mon_wasp_juggernaut" }
+  },
+  {
+    "type": "MONSTER",
+    "id": "mon_wasp_juggernaut",
+    "copy-from": "mon_wasp_reforced",
+    "name": "juggernaut wasp",
+    "looks_like": "",
+    "species": [ "INSECT" ],
+    "description": "A gigantic wasp worker. Wings fused to the back and an extremely hard body. It's even difficult to imagine this being moving, but it does. And fast",
+    "melee_dice_sides": 10,
+    "proportional": { "hp": 1.5, "volume": 1.3, "weight": 1.8 },
+    "relative": { "armor": { "bash": 5, "cut": 5, "stab": 5, "bullet": 5 } }
+  },
+  {
+    "type": "MONSTER",
+    "id": "mon_wasp_pitiful",
+    "copy-from": "mon_wasp",
+    "name": "pitiful wasp",
+    "looks_like": "",
+    "species": [ "INSECT" ],
+    "description": "A gigantic wasp worker. Something was wrong with his evolution, converting this wasp into a parody of himself. Lame, without any agility, moves on the ground. Mandibles deformed, wings without mobility, and a deformed body without the capacity to move enough, this wasp has been descarted and damned to die alone.",
+    "delete": { "weakpoint_sets": [ "wps_arthropod_flying" ], "families": [ "prof_wp_flying" ] },
+    "proportional": { "hp": 0.7, "volume": 1.2, "weight": 1.15 },
+    "relative": { "armor": { "bash": 5, "cut": 5, "stab": 5, "bullet": 5 } },
+    "speed": 30,
+    "aggression": -10,
+    "morale": 25,
+    "aggro_character": false,
+    "melee_skill": 3,
+    "melee_dice": 1,
+    "melee_dice_sides": 3,
+    "special_attacks": [ [ "EAT_CARRION", 100 ], [ "EAT_FOOD", 100 ] ],
+    "dodge": 0,
+    "bleed_rate": 120,
+    "vision_day": 10,
+    "vision_night": 4,
+    "stomach_size": 350,
+    "flags": [ "SEES", "HEARS", "CANPLAY", "PATH_AVOID_FIRE", "EATS", "SMALL_HIDER", "STUMBLES" ],
+    "petfood": {
+      "food": [ "CATFOOD", "CATTLEFOOD", "DOGFOOD" ],
+      "feed": "Your wasp, it's eating paintfully, but...happy?",
+      "pet": "You pet your wasp. The touch is something between sticky and hard."
+    }
   },
   {
     "id": "mon_dermatik_larva",

--- a/data/json/monsters/insect_spider.json
+++ b/data/json/monsters/insect_spider.json
@@ -2083,9 +2083,9 @@
   },
   {
     "type": "MONSTER",
-    "id": "mon_wasp_reforced",
+    "id": "mon_wasp_reinforced",
     "copy-from": "mon_wasp",
-    "name": "reforced wasp",
+    "name": "reinforced wasp",
     "looks_like": "",
     "description": "A gigantic wasp worker. Wings fused to the back and an extremely hard body. Have no ability to fly and crawl, defending the other wasps like a guardian dog.",
     "dodge": 3,
@@ -2102,7 +2102,7 @@
   {
     "type": "MONSTER",
     "id": "mon_wasp_juggernaut",
-    "copy-from": "mon_wasp_reforced",
+    "copy-from": "mon_wasp_reinforced",
     "name": "juggernaut wasp",
     "looks_like": "",
     "species": [ "INSECT" ],


### PR DESCRIPTION

#### Purpose of change

The wasps are an old friend of every CDDA player, but few changes have been introduced since time ago. I wanted to introduce new variations in the way these monsters work together and fight


#### Describe the solution

New types of wasp evolved from the "small" wasp

- Close combat : Reforced and juggernaut wasp

Heavier and without the capacity to fly, converting the wings into some form of natural armor. The task in combat is to run to the enemy and block their path by biting and grabbing the attacker.

- Attack at distance: Gunner, Snipper, and Torret Wasps

Giving up the speed to fly, they evolved to be better defenders of the hive, shooting a black, solidified liquid from the abdomen. With every evolution, they are slower and more deformed, ending as an unnatural mass whose only purpose is to guard and shoot.

- Special type: Kamikaze wasp

A bloated wasp with a substance similar to sludge. Can make the escape difficult and make the prey vulnerable to range attacks.

- A new pet: Pitiful wasp

Something was wrong with the evolution of this wasp. The best you can do for this deformed monster is end his suffering. The second best? Give him some food and obtain a new friend.

#### Describe the alternatives you've considered

I like the idea of making the wasp evolve to work better in a team and defend the nest. I think that can fit with the core of CDDA, but it can be implemented in a mod too.

Other things I consider changing:

The wasps with attacks at a distance are difficult to kill and have a high rate of fire and damage. Maybe reduce it.
I'm not sure the evolution rate is balanced with the difficulty expected as the small wasps evolve into more challenging types.
Names and descriptions can be improved.
I wanted to make the pitiful wasp milkable, but I decided not to introduce this possibility.

#### Testing

A manual test using a wasp nest and summoning the wasps one by one

#### Additional context

![Captura de pantalla 2024-07-22 213352](https://github.com/user-attachments/assets/bdafdd2d-3fc3-41d2-9862-bf816d1c5c8f)
![Captura de pantalla 2024-07-22 213812](https://github.com/user-attachments/assets/2a4cb883-467d-4778-af78-d8677fc5c7a0)
![Captura de pantalla 2024-07-22 214503](https://github.com/user-attachments/assets/8cd8af7d-3778-41e8-8628-3e981b4bd0b7)

