### PR TITLE
[Xedra Evolved] Add waterwalking hedge magic spell

### DIFF
--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -1700,6 +1700,14 @@
   },
   {
     "type": "effect_type",
+    "id": "effect_hedge_walk_on_water",
+    "name": [ "Walk Across the Flowing Waters" ],
+    "desc": [ "The waters are bearing you up." ],
+    "rating": "good",
+    "flags": [ "ITEM_WATERPROOFING", "WATERWALKING" ]
+  },
+  {
+    "type": "effect_type",
     "id": "effect_skinchanged_penalties",
     "name": [ "Skinchanged Mind" ],
     "desc": [ "You're starting to get used to being an animal.  Even enjoy it." ],

--- a/data/mods/Xedra_Evolved/itemgroups/itemgroups.json
+++ b/data/mods/Xedra_Evolved/itemgroups/itemgroups.json
@@ -397,11 +397,13 @@
     "type": "item_group",
     "subtype": "distribution",
     "entries": [
-      { "item": "spellbook_hedge_farm", "prob": 1 },
+      { "item": "spellbook_hedge_farm", "prob": 4 },
       { "item": "spellbook_hedge_ward_demons", "prob": 1 },
-      { "item": "spellbook_hedge_doctor_book", "prob": 1 },
-      { "item": "spellbook_hedge_blood_book", "prob": 1 },
-      { "item": "spellbook_hedge_ward_dreams", "prob": 1 }
+      { "item": "spellbook_hedge_doctor_book", "prob": 3 },
+      { "item": "spellbook_hedge_blood_book", "prob": 2 },
+      { "item": "spellbook_hedge_ward_dreams", "prob": 3 },
+      { "item": "spellbook_hedge_snare_changelings", "prob": 1 },
+      { "item": "spellbook_hedge_bathhouse_midnight", "prob": 1 }
     ]
   },
   {

--- a/data/mods/Xedra_Evolved/items/spell_learning_items/spellbooks_hedge.json
+++ b/data/mods/Xedra_Evolved/items/spell_learning_items/spellbooks_hedge.json
@@ -119,7 +119,7 @@
       "str": "The Bathhouse at Midnight: An Historical Survey of Magic and Divination in Russia",
       "str_pl": "copies of The Bathhouse at Midnight: An Historical Survey of Magic and Divination in Russia"
     },
-    "description": "This encyclopediac tome by W. F. Ryan concerns a wide variety of folk magic practices in pre-modern Russia, including their social context, the way that the Church had to work against folk practices like leaving items on the altar for six weeks so they would gain protective powers, the dangers of being alone in the bathhouse, ways to find and keep a husband or wife, when to throw an axe handle over your shoulder when walking into the forest, and how the government mostly suppressed magic because magical power (real or imagined) would have been a threat to secular power.  The description of some of these rituals are extremely detailed. ",
+    "description": "This encyclopediac tome by W. F. Ryan concerns a wide variety of folk magic practices in pre-modern Russia, including their social context, the way that the Church had to work against folk practices like leaving items on the altar for six weeks so they would gain protective powers, the dangers of being alone in the bathhouse, ways to find and keep a husband or wife, when to throw an axe handle over your shoulder when walking into the forest, and how the government mostly suppressed magic because magical power (real or imagined) would have been a threat to secular power.  The description of some of these rituals are extremely detailed.",
     "weight": "771 g",
     "volume": "1357 ml",
     "material": [ "paper" ],

--- a/data/mods/Xedra_Evolved/items/spell_learning_items/spellbooks_hedge.json
+++ b/data/mods/Xedra_Evolved/items/spell_learning_items/spellbooks_hedge.json
@@ -109,5 +109,26 @@
     "symbol": "?",
     "color": "white",
     "use_action": { "type": "learn_spell", "spells": [ "hedge_clairvoyance_cone" ] }
+  },
+  {
+    "id": "spellbook_hedge_bathhouse_midnight",
+    "//": "divination spells are appropriate here too",
+    "type": "BOOK",
+    "category": "manuals",
+    "name": {
+      "str": "The Bathhouse at Midnight: An Historical Survey of Magic and Divination in Russia",
+      "str_pl": "copies of The Bathhouse at Midnight: An Historical Survey of Magic and Divination in Russia"
+    },
+    "description": "This encyclopediac tome by W. F. Ryan concerns a wide variety of folk magic practices in pre-modern Russia, including their social context, the way that the Church had to work against folk practices like leaving items on the altar for six weeks so they would gain protective powers, the dangers of being alone in the bathhouse, ways to find and keep a husband or wife, when to throw an axe handle over your shoulder when walking into the forest, and how the government mostly suppressed magic because magical power (real or imagined) would have been a threat to secular power.  The description of some of these rituals are extremely detailed. ",
+    "weight": "771 g",
+    "volume": "1357 ml",
+    "material": [ "paper" ],
+    "looks_like": "paper",
+    "symbol": "?",
+    "color": "dark_gray",
+    "use_action": {
+      "type": "learn_spell",
+      "spells": [ "hedge_clairvoyance_cone", "hedge_walk_on_water", "hedge_evil_eye_ward", "hedge_cure_cold_or_flu" ]
+    }
   }
 ]

--- a/data/mods/Xedra_Evolved/requirements/spell_components.json
+++ b/data/mods/Xedra_Evolved/requirements/spell_components.json
@@ -186,5 +186,10 @@
     "type": "requirement",
     "qualities": [ { "id": "SEW", "level": 2 } ],
     "components": [ [ [ "skull_bear", 1 ] ], [ [ "animal_blood", 5 ] ], [ [ "raw_fur", 20 ] ], [ [ "sinew", 25 ] ] ]
+  },
+  {
+    "id": "spell_components_hedge_walk_on_water",
+    "type": "requirement",
+    "components": [ [ [ "alder_bark", 1 ], [ "tanbark", 1 ], [ "birchbark", 1 ], [ "willowbark", 1 ] ] ]
   }
 ]

--- a/data/mods/Xedra_Evolved/spells/hedge_magic_eocs.json
+++ b/data/mods/Xedra_Evolved/spells/hedge_magic_eocs.json
@@ -349,27 +349,27 @@
     "id": "EOC_HEDGE_WALK_ON_WATER_CONTINUANCE",
     "eoc_type": "EVENT",
     "required_event": "avatar_moves",
-    "condition": { "u_is_on_terrain_with_flag": "SWIMMABLE" },
+    "condition": { "u_has_effect": "effect_hedge_walk_on_water" },
     "effect": [
       {
         "run_eocs": [
           {
             "id": "EOC_HEDGE_WALK_ON_WATER_CONTINUANCE_2",
-            "condition": { "u_has_effect": "effect_hedge_walk_on_water" },
+            "condition": { "u_is_on_terrain_with_flag": "SWIMMABLE" },
             "effect": [
               {
                 "if": { "math": [ "u_effect_duration('effect_hedge_walk_on_water')", "<=", "2" ] },
                 "then": [ { "u_add_effect": "effect_hedge_walk_on_water", "duration": 2 } ],
                 "else": [ { "u_add_effect": "effect_hedge_walk_on_water", "duration": 1 } ]
               }
+            ],
+            "false_effect": [
+              { "u_message": "As you step on solid ground again, the charm fades.", "type": "neutral" },
+              { "u_lose_effect": "effect_hedge_walk_on_water" }
             ]
           }
         ]
       }
-    ],
-    "false_effect": [
-      { "u_message": "As you step on solid ground again, the charm fades.", "type": "neutral" },
-      { "u_lose_effect": "effect_hedge_walk_on_water" }
     ]
   },
   {

--- a/data/mods/Xedra_Evolved/spells/hedge_magic_eocs.json
+++ b/data/mods/Xedra_Evolved/spells/hedge_magic_eocs.json
@@ -380,7 +380,7 @@
     "condition": {
       "and": [
         { "u_has_effect": "effect_hedge_walk_on_water" },
-        { "compare_string": [ "walk", { "context_val": "movement_mode" } ] }
+        { "compare_string": [ "run", { "context_val": "movement_mode" } ] }
       ]
     },
     "effect": [ { "u_lose_effect": "effect_hedge_walk_on_water" } ]

--- a/data/mods/Xedra_Evolved/spells/hedge_magic_eocs.json
+++ b/data/mods/Xedra_Evolved/spells/hedge_magic_eocs.json
@@ -330,5 +330,46 @@
       { "u_consume_item": "item_hedge_turn_into_bear", "count": 1 },
       { "u_spawn_item": "item_hedge_turn_into_bear_off", "suppress_message": true }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_HEDGE_WALK_ON_WATER",
+    "condition": { "u_is_on_terrain_with_flag": "SWIMMABLE" },
+    "effect": [
+      {
+        "u_message": "You drop the bark on the water and recite the words of the charm, and as you take your first step, the water feels firm under your feet.",
+        "type": "good"
+      },
+      { "u_add_effect": "effect_hedge_walk_on_water", "duration": 1 }
+    ],
+    "false_effect": [ { "u_message": "You must be standing on water or the charm will have no effect.", "type": "bad" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_HEDGE_WALK_ON_WATER_CONTINUANCE",
+    "eoc_type": "EVENT",
+    "required_event": "avatar_moves",
+    "condition": { "u_is_on_terrain_with_flag": "SWIMMABLE" },
+    "effect": [
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_HEDGE_WALK_ON_WATER_CONTINUANCE_2",
+            "condition": { "u_has_effect": "effect_hedge_walk_on_water" },
+            "effect": [
+              {
+                "if": { "math": [ "u_effect_duration('effect_hedge_walk_on_water')", "<=", "2" ] },
+                "then": [ { "u_add_effect": "effect_hedge_walk_on_water", "duration": 2 } ],
+                "else": [ { "u_add_effect": "effect_hedge_walk_on_water", "duration": 1 } ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "false_effect": [
+      { "u_message": "As you step on solid ground again, the charm fades.", "type": "neutral" },
+      { "u_lose_effect": "effect_hedge_walk_on_water" }
+    ]
   }
 ]

--- a/data/mods/Xedra_Evolved/spells/hedge_magic_eocs.json
+++ b/data/mods/Xedra_Evolved/spells/hedge_magic_eocs.json
@@ -371,5 +371,18 @@
       { "u_message": "As you step on solid ground again, the charm fades.", "type": "neutral" },
       { "u_lose_effect": "effect_hedge_walk_on_water" }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_HEDGE_WALK_ON_WATER_RUNNING_CANCEL",
+    "eoc_type": "EVENT",
+    "required_event": "avatar_moves",
+    "condition": {
+      "and": [
+        { "u_has_effect": "effect_hedge_walk_on_water" },
+        { "compare_string": [ "walk", { "context_val": "movement_mode" } ] }
+      ]
+    },
+    "effect": [ { "u_lose_effect": "effect_hedge_walk_on_water" } ]
   }
 ]

--- a/data/mods/Xedra_Evolved/spells/hedge_magic_spells.json
+++ b/data/mods/Xedra_Evolved/spells/hedge_magic_spells.json
@@ -399,7 +399,7 @@
     "id": "hedge_walk_on_water",
     "type": "SPELL",
     "name": "To Walk Across the Flowing Waters",
-    "description": "While standing with your feet in the water, recite this charm to have the water bear you up.  You must keep moving at a steady pace, without running or stopping for more than a few moments, or the charm will fade. ",
+    "description": "While standing with your feet in the water, recite this charm to have the water bear you up.  You must keep moving at a steady pace, without running or stopping for more than a few moments, or the charm will fade.",
     "message": "",
     "flags": [ "VERBAL", "SOMATIC", "NO_FAIL" ],
     "valid_targets": [ "self" ],

--- a/data/mods/Xedra_Evolved/spells/hedge_magic_spells.json
+++ b/data/mods/Xedra_Evolved/spells/hedge_magic_spells.json
@@ -393,8 +393,24 @@
     "shape": "blast",
     "components": "spell_components_hedge_turn_into_bear",
     "max_level": 1,
-    "min_damage": 1,
-    "max_damage": 1,
     "base_casting_time": 720000
+  },
+  {
+    "id": "hedge_walk_on_water",
+    "type": "SPELL",
+    "name": "To Walk Across the Flowing Waters",
+    "description": "While standing with your feet in the water, recite this charm to have the water bear you up.  You must keep moving at a steady pace, without running or stopping for more than a few moments, or the charm will fade. ",
+    "message": "",
+    "flags": [ "VERBAL", "SOMATIC", "NO_FAIL" ],
+    "valid_targets": [ "self" ],
+    "difficulty": 1,
+    "spell_class": "HEDGE_MAGIC",
+    "skill": "survival",
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_HEDGE_WALK_ON_WATER",
+    "shape": "blast",
+    "components": "spell_components_hedge_walk_on_water",
+    "max_level": 1,
+    "base_casting_time": 1000
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Xedra Evolved] Add waterwalking hedge magic spell"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Adding more waterwalking.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the aforementioned charm. It requires dropping some bark on the water while standing on the water and reciting the charm, and then as long as you keep moving you can keep walking on the water. Standing still for too long, or running, will cancel the effect and dump you in the water the next step you take.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Book appears, teaches you the charm, and the charm works. Duration is short and accounts for the higher cost of diagonal movement. Standing still too long or running ends the charm.

There's some wonkiness due to the classic "effects only start working the turn after they're applied (and stop the turn after they end)," but it otherwise works. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

_The Bathhouse at Midnight_ is a great book if you can find a copy. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
