### PR TITLE
Add missing 'to' in Baton Proficiency

### DIFF
--- a/data/json/proficiencies/melee_weapons.json
+++ b/data/json/proficiencies/melee_weapons.json
@@ -181,7 +181,7 @@
     "id": "prof_batons_pro",
     "category": "prof_combat",
     "name": { "str": "Baton Proficiency" },
-    "description": "You know how strike with your baton so you get the most out of every blow.",
+    "description": "You know how to strike with your baton so you get the most out of every blow.",
     "can_learn": true,
     "default_time_multiplier": 1.5,
     "default_skill_penalty": 0.2,


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

Fix minor grammar issue

#### Describe the solution

"how strike" -> "how to strike"

#### Describe alternatives you've considered

None

#### Testing

None

#### Additional context

None
