### PR TITLE
Grant additional permissions to stale action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: '30 * * * *'
 permissions:
+  context: write
   issues: write
   pull-requests: write
 jobs:


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
This is required to allow stateful operation as per https://github.com/actions/stale/issues/1090

#### Describe the solution
Add the permission.

#### Additional context
Error message from https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/10049921109/job/27776859646
`Github API rate remaining: 4790; reset at: Mon Jul 22 2024 23:58:37 GMT+0000 (Coordinated Universal Time)
state: persisting info about 222 issue(s)
/usr/bin/tar --posix -cf cache.tzst --exclude cache.tzst -P -C /home/runner/work/Cataclysm-DDA/Cataclysm-DDA --files-from manifest.txt --use-compress-program zstdmt
Failed to save: Unable to reserve cache with key _state, another job may be creating this cache. More details: Cache already exists. Scope: refs/heads/master, Key: _state, Version: fa41d75081481069cfb6b92a5f83a94c6e06ef3ab2e6b762649ac5f86f46153f`