### PR TITLE
optimized map::generate a bit

### DIFF
--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -119,6 +119,21 @@ submap *mapbuffer::lookup_submap( const tripoint_abs_sm &p )
     return iter->second.get();
 }
 
+bool mapbuffer::submap_exists( const tripoint_abs_sm &p )
+{
+    const auto iter = submaps.find( p );
+    if( iter == submaps.end() ) {
+        try {
+            return unserialize_submaps( p );
+        } catch( const std::exception &err ) {
+            debugmsg( "Failed to load submap %s: %s", p.to_string(), err.what() );
+        }
+        return false;
+    }
+
+    return true;
+}
+
 void mapbuffer::save( bool delete_after_save )
 {
     assure_dir_exist( PATH_INFO::world_base_save_path() + "/maps" );

--- a/src/mapbuffer.h
+++ b/src/mapbuffer.h
@@ -62,6 +62,9 @@ class mapbuffer
          * submap object, don't delete it on your own.
          */
         submap *lookup_submap( const tripoint_abs_sm &p );
+        // Cheaper version of the above for when you only care about whether the
+        // submap exists or not.
+        bool submap_exists( const tripoint_abs_sm &p );
 
     private:
         using submap_map_t = std::map<tripoint_abs_sm, std::unique_ptr<submap>>;

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -237,7 +237,7 @@ void map::generate( const tripoint_abs_omt &p, const time_point &when, bool save
                 const tripoint_rel_sm pos( gridx, gridy, gridz );
                 const size_t grid_pos = get_nonant( pos );
                 const std::vector<bool>::iterator iter = generated.begin() + grid_pos;
-                generated.emplace( iter, MAPBUFFER.lookup_submap( p_sm_base.xy() + pos ) != nullptr );
+                generated.emplace( iter, MAPBUFFER.submap_exists( p_sm_base.xy() + pos ) );
 
                 if( !generated.at( grid_pos ) || save_results ) {
                     setsubmap( grid_pos, new submap() );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Improve performance of map::generate. This was triggered by #75166, but I don't consider this to solve that report.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Replace repeated calls to MAPBUFFER.lookup_submap to see if it exists with a single check to a new submap_exists operation and then store the results in a vector that's then used for the subsequent existence checks.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Waiting for more expert opinions on what to improve.
- Trying to see if anything can be done about map::is_main_cleanup_queued as that operation seems to use 5.28% of the CPU used in the last testing run (for the same reason lookup_submap costs a lot, i.e. a large number of calls). Out of scope for this PR.
- Restructure map::loadn code and usage to take the 3D nature of maps into account by loading vertical stacks of maps rather than one level at a time (when the maps support Z levels, of course), and possible also the fact that you don't load a single submap stack, but 4, 11, 21, or a full map's worth, and you ought to be able to gain some synergy by loading all of the stacks from a generated/loaded omt without reevaluating whether you need to generate/load it for every stack. Note such a change doesn't really relate to the recently introduced mapgen 3D support, as maps (and thus their loading) have been 3D for a long time before that change. Out of scope for this PR.
Edit: Tried it and didn't it to work properly (light isn't set properly), but nevertheless, a performance test showed no significant performance change compared to the master code, presumably because juggling vectors to store state gobbles up the gains made elsewhere. Abandoning this as a failure.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Bumbling running of the VS profiler before and after modifying the code.
The results seemed to indicate a drop of the overall CPU consumption of map::generate from 15.17% of the CPU budget before the change to 5.28% after. An intermediate run after the changes to generate but before the addition to mapbuffer gave a result that was somewhere in between these two values.
Running the game by teleporting straight to the east to the edge of the revealed map (guaranteeing it hasn't been generated), starting recording and then keep moving east by keeping the movement key pressed until safe mode reported a monster showed it still hesitates at times (and I think it's probably on OMT boundaries). I can't say if the effect is smaller. I'd probably need a slower computer for that.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
It's quite possible the variability in results from different runs is high enough to make single measurements rather pointless.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
