### PR TITLE
also add actions:write permission to actions/stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: '30 * * * *'
 permissions:
+  actions: write
   contents: write
   issues: write
   pull-requests: write


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
This is needed for cache handling with the current version. They have an issue open at https://github.com/actions/stale/issues/1133 about it.

#### Describe the solution
Add the permission.

#### Describe alternatives you've considered
Reportedly we could lock actions/stale to version 8 instead.
It's possible it's just getting confused because the current cache file was created by a manually invoked run of the action?

#### Additional context
It looks like either the stale action or the cache infrastructure (not clear which) is using the action definition as part of a checksum for ownership of the state file, and if it's different it can't delete the cache without these additional permissions.