### PR TITLE
Update construction.cpp

### DIFF
--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -890,6 +890,7 @@ construction_id construction_menu( const bool blueprint )
             construction_group_str_id last_construction = construction_group_str_id::NULL_ID();
             if( isnew ) {
                 filter = uistate.construction_filter;
+                filter.clear();
                 tabindex = uistate.construction_tab.is_valid()
                            ? uistate.construction_tab.id().to_i() : 0;
                 if( uistate.last_construction.is_valid() ) {


### PR DESCRIPTION
#### Summary
Interface "Construction menu filter resets on close"

#### Purpose of change
When you have a filter in the crafting menu it resets on close. When you have a filter in the construction menu it is maintained and the user has to backspace their filter. This is a UI inconsistency that messes with muscle memory.

#### Describe the solution
I only added 1 line so that the filter is reset when the UI menu is instanced.

#### Describe alternatives you've considered

An alternative would be to maintain this behavior in the crafting menu along with the ability to press the 'del' key to backspace all of the characters at once. 

#### Testing

In the game I loaded in, opened the construction menu, and it resets the filter on open as expected.
