### PR TITLE
No filter on construction menu

### DIFF
--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -890,6 +890,7 @@ construction_id construction_menu( const bool blueprint )
             construction_group_str_id last_construction = construction_group_str_id::NULL_ID();
             if( isnew ) {
                 filter = uistate.construction_filter;
+                filter.clear();
                 tabindex = uistate.construction_tab.is_valid()
                            ? uistate.construction_tab.id().to_i() : 0;
                 if( uistate.last_construction.is_valid() ) {

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -899,6 +899,12 @@ construction_id construction_menu( const bool blueprint )
             } else if( select >= 0 && static_cast<size_t>( select ) < constructs.size() ) {
                 last_construction = constructs[select];
             }
+            else {
+                filter.clear();
+                if (uistate.last_construction.is_valid()) {
+                    last_construction = uistate.last_construction;
+                }
+            }
             category_id = construct_cat[tabindex].id;
             if( category_id == construction_category_ALL ) {
                 constructs = available;

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -901,9 +901,6 @@ construction_id construction_menu( const bool blueprint )
             }
             else {
                 filter.clear();
-                if (uistate.last_construction.is_valid()) {
-                    last_construction = uistate.last_construction;
-                }
             }
             category_id = construct_cat[tabindex].id;
             if( category_id == construction_category_ALL ) {

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -898,8 +898,7 @@ construction_id construction_menu( const bool blueprint )
                 }
             } else if( select >= 0 && static_cast<size_t>( select ) < constructs.size() ) {
                 last_construction = constructs[select];
-            }
-            else {
+            } else {
                 filter.clear();
             }
             category_id = construct_cat[tabindex].id;


### PR DESCRIPTION
#### Summary
Interface "The filter is reset when you open the construction menu" 

#### Purpose of change
Construction and crafting are some of the most frequently used interfaces, yet closing the construction screen does not clear your filter, while the crafting screen does clear your filter. This feels awkward for the user's muscle-memory because they do not behave the same way. Currently you have to manually backspace your most recent query to search for something else.

#### Describe the solution
My solution simply clears the filter when you are opening up the construction menu and it is not the first time. I placed it in a place where if you have crafted something previously, the menu should auto-move to your most recently constructed thing but with no filter.

#### Describe alternatives you've considered
I have considered letting the 'del' key fully clear out the active filter in all filters, or a changeable option for this behavior. I think that those solutions are a bit over-kill for the current problem.

#### Testing
I have spawned into a game with a hammer and screwdriver and started deconstructing stuff. As expected, next time I press * I am given the construction menu with my cursor already on "deconstruct furniture" but without a filter applied, allowing me to easily type out my next desired task.
