### PR TITLE
[0.H backport] fix wrong speech type in hallucination message

### DIFF
--- a/data/json/effects_on_condition/npc_eocs/hallucination_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/hallucination_eocs.json
@@ -138,7 +138,7 @@
   {
     "type": "effect_on_condition",
     "id": "self_shout",
-    "effect": { "u_make_sound": "schizo_self_shout", "volume": 20, "snippet": true, "type": "speech" }
+    "effect": { "u_make_sound": "schizo_self_shout", "volume": 20, "snippet": true }
   },
   {
     "type": "effect_on_condition",


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
backport #75128, specifically the part with incorrect type of message - the rest do not exist in 0.H branch