### PR TITLE
[Xedra Evolved] Add the To Bless the Sacred Weapon charm

### DIFF
--- a/data/mods/Xedra_Evolved/flags.json
+++ b/data/mods/Xedra_Evolved/flags.json
@@ -37,6 +37,6 @@
   {
     "id": "BLESSED_WEAPON",
     "type": "json_flag",
-    "info": "This weapon does extra damage against creatures of the Nether."
+    "info": "This weapon does <good>extra damage</good> against creatures of the <info>Nether</info>."
   }
 ]

--- a/data/mods/Xedra_Evolved/flags.json
+++ b/data/mods/Xedra_Evolved/flags.json
@@ -30,6 +30,11 @@
     "info": "This item can be recharged by an electrokinetic"
   },
   {
+    "id": "HEDGE_ENCHANTED",
+    "type": "json_flag",
+    "info": "This item has a <good>charm</good> on it."
+  },
+  {
     "id": "BLESSED_WEAPON",
     "type": "json_flag",
     "info": "This weapon does extra damage against creatures of the Nether."

--- a/data/mods/Xedra_Evolved/flags.json
+++ b/data/mods/Xedra_Evolved/flags.json
@@ -28,5 +28,10 @@
     "id": "ELECTROKINETIC_CHARGEABLE",
     "type": "json_flag",
     "info": "This item can be recharged by an electrokinetic"
+  },
+  {
+    "id": "BLESSED_WEAPON",
+    "type": "json_flag",
+    "info": "This weapon does extra damage against creatures of the Nether."
   }
 ]

--- a/data/mods/Xedra_Evolved/items/hedge_magic_items.json
+++ b/data/mods/Xedra_Evolved/items/hedge_magic_items.json
@@ -112,7 +112,7 @@
     "material": [ "leather", "veggy" ],
     "color": "green",
     "symbol": ",",
-    "flags": [ "ONE_PER_LAYER", "SKINTIGHT", "NO_UNLOAD", "NO_RELOAD", "MUNDANE" ],
+    "flags": [ "ONE_PER_LAYER", "SKINTIGHT", "NO_UNLOAD", "NO_RELOAD", "MUNDANE", "HEDGE_ENCHANTED" ],
     "use_action": {
       "type": "transform",
       "need_charges": 1,
@@ -138,7 +138,7 @@
     "material": [ "leather", "veggy" ],
     "color": "green",
     "symbol": ",",
-    "flags": [ "ONE_PER_LAYER", "SKINTIGHT", "NO_UNLOAD", "NO_RELOAD" ],
+    "flags": [ "ONE_PER_LAYER", "SKINTIGHT", "NO_UNLOAD", "NO_RELOAD", "HEDGE_ENCHANTED" ],
     "revert_to": "item_hedge_see_fae_necklace_done",
     "revert_msg": "Your otherworldly senses fade.",
     "relic_data": {
@@ -173,7 +173,7 @@
     "material": "wool",
     "symbol": "*",
     "color": "green_green",
-    "flags": [ "SINGLE_USE" ],
+    "flags": [ "SINGLE_USE", "HEDGE_ENCHANTED" ],
     "use_action": {
       "type": "place_trap",
       "trap": "tr_fae_snare",
@@ -196,7 +196,7 @@
     "fun": -5,
     "symbol": "q",
     "color": "blue",
-    "flags": [ "EATEN_COLD" ],
+    "flags": [ "EATEN_COLD", "HEDGE_ENCHANTED" ],
     "phase": "solid",
     "use_action": {
       "type": "effect_on_conditions",
@@ -256,7 +256,7 @@
     "name": { "str": "bearskin talisman" },
     "copy-from": "item_hedge_turn_into_bear_off",
     "description": "A heavy fur mantle attached to the skull of a bear.  When you put it on, the charm will take effect and grant you the bear's power.",
-    "extend": { "flags": [ "NO_TAKEOFF", "SKINCHANGED" ] },
+    "extend": { "flags": [ "NO_TAKEOFF", "SKINCHANGED", "HEDGE_ENCHANTED" ] },
     "use_action": {
       "type": "effect_on_conditions",
       "description": "Activate to remove the mantle and end the magic.",

--- a/data/mods/Xedra_Evolved/items/spell_learning_items/spellbooks_hedge.json
+++ b/data/mods/Xedra_Evolved/items/spell_learning_items/spellbooks_hedge.json
@@ -27,7 +27,7 @@
     "looks_like": "cookbook",
     "symbol": "?",
     "color": "brown",
-    "use_action": { "type": "learn_spell", "spells": [ "hedge_evil_eye_ward", "hedge_see_nether_eye_paste" ] }
+    "use_action": { "type": "learn_spell", "spells": [ "hedge_evil_eye_ward", "hedge_see_nether_eye_paste", "hedge_bless_steel_weapon" ] }
   },
   {
     "id": "spellbook_hedge_doctor_book",

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_fae_bans.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_fae_bans.json
@@ -368,7 +368,7 @@
         { "material": "hc_steel", "wielded_only": true },
         { "material": "ch_steel", "wielded_only": true },
         { "material": "lc_steel_chain", "wielded_only": true },
-        { "material": "mc_steel_chain", "worn_only": true },
+        { "material": "mc_steel_chain", "wielded_only": true },
         { "material": "hc_steel_chain", "wielded_only": true },
         { "material": "ch_steel_chain", "wielded_only": true }
       ],
@@ -458,7 +458,7 @@
         { "material": "hc_steel", "wielded_only": true },
         { "material": "ch_steel", "wielded_only": true },
         { "material": "lc_steel_chain", "wielded_only": true },
-        { "material": "mc_steel_chain", "worn_only": true },
+        { "material": "mc_steel_chain", "wielded_only": true },
         { "material": "hc_steel_chain", "wielded_only": true },
         { "material": "ch_steel_chain", "wielded_only": true }
       ],

--- a/data/mods/Xedra_Evolved/requirements/spell_components.json
+++ b/data/mods/Xedra_Evolved/requirements/spell_components.json
@@ -191,5 +191,11 @@
     "id": "spell_components_hedge_walk_on_water",
     "type": "requirement",
     "components": [ [ [ "alder_bark", 1 ], [ "tanbark", 1 ], [ "birchbark", 1 ], [ "willowbark", 1 ] ] ]
+  },
+  {
+    "id": "spell_components_hedge_bless_steel_weapon",
+    "type": "requirement",
+    "tools": [ [ [ "candle_lit", -1 ] ] ],
+    "components": [ [ [ "salt", 15 ] ], [ [ "wild_herbs", 30 ] ] ]
   }
 ]

--- a/data/mods/Xedra_Evolved/spells/hedge_magic_eocs.json
+++ b/data/mods/Xedra_Evolved/spells/hedge_magic_eocs.json
@@ -407,6 +407,7 @@
           "id": "EOC_HEDGE_BLESS_STEEL_WEAPON_EFFECT",
           "effect": [
             { "npc_set_flag": "BLESSED_WEAPON" },
+            { "npc_set_flag": "HEDGE_ENCHANTED" },
             {
               "u_message": "You pass the weapon through the candleflame after rubbing the mixture of salt and herbs on it while slowly reciting the words of the charm, and when you have finished you feel a sense of surety while holding it",
               "type": "good"
@@ -419,13 +420,19 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_HEDGE_BLESS_STEEL_WEAPON_ATTACKS",
+    "//": "This same EoC will account for other weapons with the BLESSED_WEAPON flag--it also requires the presence of the HEDGE_ENCHANTED flag to trigger damage removing the enchantment",
     "eoc_type": "EVENT",
     "required_event": "character_melee_attacks_monster",
     "condition": {
       "and": [
         { "u_has_wielded_with_flag": "BLESSED_WEAPON" },
         {
-          "or": [ { "npc_has_species": "NETHER" }, { "npc_has_species": "ABERRATION" }, { "npc_has_species": "NETHER_EMANATION" } ]
+          "or": [
+            { "npc_has_species": "NETHER" },
+            { "npc_has_species": "ABERRATION" },
+            { "npc_has_species": "NETHER_EMANATION" },
+            { "npc_has_species": "HORROR" }
+          ]
         }
       ]
     },
@@ -434,13 +441,14 @@
       { "u_cast_spell": { "id": "hedge_blessed_weapon_nether_damage" }, "loc": { "context_val": "nether_hellbeast" } },
       {
         "u_run_inv_eocs": "random",
-        "search_data": [ { "wielded_only": true } ],
+        "search_data": [ { "flags": [ "HEDGE_ENCHANTED" ], "wielded_only": true } ],
         "true_eocs": [
           {
             "id": "EOC_HEDGE_BLESS_STEEL_WEAPON_ATTACKS_CHECK_DAMAGE",
             "condition": { "math": [ "n_hp('ALL')", "<", "n_hp_max('bp_null') * 0.75" ] },
             "effect": [
               { "npc_unset_flag": "BLESSED_WEAPON" },
+              { "npc_unset_flag": "HEDGE_ENCHANTED" },
               { "u_message": "You no longer feel a sense of purity from your weapon", "type": "mixed" }
             ]
           }

--- a/data/mods/Xedra_Evolved/spells/hedge_magic_eocs.json
+++ b/data/mods/Xedra_Evolved/spells/hedge_magic_eocs.json
@@ -462,11 +462,11 @@
         "true_eocs": [
           {
             "id": "EOC_HEDGE_BLESS_STEEL_WEAPON_ATTACKS_CHECK_DAMAGE",
-            "condition": { "math": [ "n_hp('ALL')", "<", "n_hp_max('bp_null') * 0.75" ] },
+            "condition": { "math": [ "n_hp('ALL')", "<", "n_hp_max('bp_null') * 0.90" ] },
             "effect": [
               { "npc_unset_flag": "BLESSED_WEAPON" },
               { "npc_unset_flag": "HEDGE_ENCHANTED" },
-              { "u_message": "You no longer feel a sense of purity from your weapon", "type": "mixed" }
+              { "u_message": "You no longer feel a sense of purity from your weapon", "type": "bad" }
             ]
           }
         ]

--- a/data/mods/Xedra_Evolved/spells/hedge_magic_eocs.json
+++ b/data/mods/Xedra_Evolved/spells/hedge_magic_eocs.json
@@ -384,5 +384,68 @@
       ]
     },
     "effect": [ { "u_lose_effect": "effect_hedge_walk_on_water" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_HEDGE_BLESS_STEEL_WEAPON",
+    "effect": {
+      "u_run_inv_eocs": "random",
+      "search_data": [
+        { "material": "iron", "wielded_only": true },
+        { "material": "steel", "wielded_only": true },
+        { "material": "lc_steel", "wielded_only": true },
+        { "material": "mc_steel", "wielded_only": true },
+        { "material": "hc_steel", "wielded_only": true },
+        { "material": "ch_steel", "wielded_only": true },
+        { "material": "lc_steel_chain", "wielded_only": true },
+        { "material": "mc_steel_chain", "wielded_only": true },
+        { "material": "hc_steel_chain", "wielded_only": true },
+        { "material": "ch_steel_chain", "wielded_only": true }
+      ],
+      "true_eocs": [
+        {
+          "id": "EOC_HEDGE_BLESS_STEEL_WEAPON_EFFECT",
+          "effect": [
+            { "npc_set_flag": "BLESSED_WEAPON" },
+            {
+              "u_message": "You pass the weapon through the candleflame after rubbing the mixture of salt and herbs on it while slowly reciting the words of the charm, and when you have finished you feel a sense of surety while holding it",
+              "type": "good"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_HEDGE_BLESS_STEEL_WEAPON_ATTACKS",
+    "eoc_type": "EVENT",
+    "required_event": "character_melee_attacks_monster",
+    "condition": {
+      "and": [
+        { "u_has_wielded_with_flag": "BLESSED_WEAPON" },
+        {
+          "or": [ { "npc_has_species": "NETHER" }, { "npc_has_species": "ABERRATION" }, { "npc_has_species": "NETHER_EMANATION" } ]
+        }
+      ]
+    },
+    "effect": [
+      { "npc_location_variable": { "context_val": "nether_hellbeast" } },
+      { "u_cast_spell": { "id": "hedge_blessed_weapon_nether_damage" }, "loc": { "context_val": "nether_hellbeast" } },
+      {
+        "u_run_inv_eocs": "random",
+        "search_data": [ { "wielded_only": true } ],
+        "true_eocs": [
+          {
+            "id": "EOC_HEDGE_BLESS_STEEL_WEAPON_ATTACKS_CHECK_DAMAGE",
+            "condition": { "math": [ "n_hp('ALL')", "<", "n_hp_max('bp_null') * 0.75" ] },
+            "effect": [
+              { "npc_unset_flag": "BLESSED_WEAPON" },
+              { "u_message": "You no longer feel a sense of purity from your weapon", "type": "mixed" }
+            ]
+          }
+        ]
+      }
+    ]
   }
 ]

--- a/data/mods/Xedra_Evolved/spells/hedge_magic_eocs.json
+++ b/data/mods/Xedra_Evolved/spells/hedge_magic_eocs.json
@@ -419,26 +419,43 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_HEDGE_BLESS_STEEL_WEAPON_ATTACKS",
+    "id": "EOC_BLESSED_WEAPON_ATTACKS",
     "//": "This same EoC will account for other weapons with the BLESSED_WEAPON flag--it also requires the presence of the HEDGE_ENCHANTED flag to trigger damage removing the enchantment",
     "eoc_type": "EVENT",
     "required_event": "character_melee_attacks_monster",
-    "condition": {
-      "and": [
-        { "u_has_wielded_with_flag": "BLESSED_WEAPON" },
-        {
-          "or": [
-            { "npc_has_species": "NETHER" },
-            { "npc_has_species": "ABERRATION" },
-            { "npc_has_species": "NETHER_EMANATION" },
-            { "npc_has_species": "HORROR" }
-          ]
-        }
-      ]
-    },
+    "condition": { "u_has_wielded_with_flag": "BLESSED_WEAPON" },
     "effect": [
-      { "npc_location_variable": { "context_val": "nether_hellbeast" } },
-      { "u_cast_spell": { "id": "hedge_blessed_weapon_nether_damage" }, "loc": { "context_val": "nether_hellbeast" } },
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_BLESSED_WEAPON_ATTACKS_2",
+            "condition": {
+              "or": [
+                { "npc_has_species": "NETHER" },
+                { "npc_has_species": "ABERRATION" },
+                { "npc_has_species": "NETHER_EMANATION" },
+                { "npc_has_species": "HORROR" }
+              ]
+            },
+            "effect": [
+              { "npc_location_variable": { "context_val": "nether_hellbeast" } },
+              {
+                "u_cast_spell": { "id": "hedge_blessed_weapon_nether_damage" },
+                "loc": { "context_val": "nether_hellbeast" }
+              },
+              { "run_eocs": "EOC_HEDGE_BLESSED_WEAPON_LOSE_CHARM" }
+            ],
+            "false_effect": [ { "run_eocs": "EOC_HEDGE_BLESSED_WEAPON_LOSE_CHARM" } ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_HEDGE_BLESSED_WEAPON_LOSE_CHARM",
+    "condition": { "u_has_wielded_with_flag": "HEDGE_ENCHANTED" },
+    "effect": [
       {
         "u_run_inv_eocs": "random",
         "search_data": [ { "flags": [ "HEDGE_ENCHANTED" ], "wielded_only": true } ],

--- a/data/mods/Xedra_Evolved/spells/hedge_magic_eocs.json
+++ b/data/mods/Xedra_Evolved/spells/hedge_magic_eocs.json
@@ -423,7 +423,7 @@
     "//": "This same EoC will account for other weapons with the BLESSED_WEAPON flag--it also requires the presence of the HEDGE_ENCHANTED flag to trigger damage removing the enchantment",
     "eoc_type": "EVENT",
     "required_event": "character_melee_attacks_monster",
-    "condition": { "u_has_wielded_with_flag": "BLESSED_WEAPON" },
+    "condition": { "and": [ { "u_has_wielded_with_flag": "BLESSED_WEAPON" }, { "math": [ "_hits", "!=", "false" ] } ] },
     "effect": [
       {
         "run_eocs": [

--- a/data/mods/Xedra_Evolved/spells/hedge_magic_spells.json
+++ b/data/mods/Xedra_Evolved/spells/hedge_magic_spells.json
@@ -412,5 +412,40 @@
     "components": "spell_components_hedge_walk_on_water",
     "max_level": 1,
     "base_casting_time": 1000
+  },
+  {
+    "id": "hedge_bless_steel_weapon",
+    "type": "SPELL",
+    "name": "To Bless the Sacred Weapon",
+    "description": "Ensorcell an iron or steel weapon that you are holding so it does additional damage to unholy creatures when used in melee combat.  If the weapon is too damaged, the charm will cease to function.",
+    "message": "",
+    "flags": [ "VERBAL", "SOMATIC", "NO_FAIL", "NO_HANDS" ],
+    "valid_targets": [ "self" ],
+    "difficulty": 1,
+    "spell_class": "HEDGE_MAGIC",
+    "skill": "survival",
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_HEDGE_BLESS_STEEL_WEAPON",
+    "shape": "blast",
+    "components": "spell_components_hedge_bless_steel_weapon",
+    "max_level": 1,
+    "base_casting_time": 2880000
+  },
+  {
+    "id": "hedge_blessed_weapon_nether_damage",
+    "type": "SPELL",
+    "name": "Blessed Weapon Nether Damage",
+    "description": "This is the extra damage a blessed weapon does to Nether creatures.  It's a bug if you have it directly.",
+    "message": "",
+    "flags": [ "SILENT", "NO_EXPLOSION_SFX" ],
+    "valid_targets": [ "hostile" ],
+    "effect": "attack",
+    "shape": "blast",
+    "damage_type": "pure",
+    "min_damage": 5,
+    "max_damage": 25,
+    "min_range": 1,
+    "max_range": 1,
+    "targeted_monster_species": [ "NETHER", "ABERRATION", "NETHER_EMANATION" ]
   }
 ]

--- a/data/mods/Xedra_Evolved/spells/hedge_magic_spells.json
+++ b/data/mods/Xedra_Evolved/spells/hedge_magic_spells.json
@@ -437,7 +437,7 @@
     "name": "Blessed Weapon Nether Damage",
     "description": "This is the extra damage a blessed weapon does to Nether creatures.  It's a bug if you have it directly.",
     "message": "",
-    "flags": [ "SILENT", "NO_EXPLOSION_SFX" ],
+    "flags": [ "SILENT", "NO_EXPLOSION_SFX", "RANDOM_DAMAGE" ],
     "valid_targets": [ "hostile" ],
     "effect": "attack",
     "shape": "blast",
@@ -446,6 +446,6 @@
     "max_damage": 25,
     "min_range": 1,
     "max_range": 1,
-    "targeted_monster_species": [ "NETHER", "ABERRATION", "NETHER_EMANATION" ]
+    "targeted_monster_species": [ "NETHER", "ABERRATION", "HORROR", "NETHER_EMANATION" ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Xedra Evolved] Add the To Bless the Sacred Weapon charm"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Had this idea and wanted to see if I could get it to work, based on this passage from Robert E. Howard's _The Black Stone_

> and I read, too, of the lost, grim black cavern high in the hills where the horrified Turks hemmed a monstrous, bloated, wallowing toad-like being and slew it with flame and ancient steel blessed in old times by Muhammad, and with incantations that were old when Arabia was young. 

And I thought, what if you could use hedge magic to bless a weapon against the creatures of the Nether?

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the aforementioned charm. It takes salt, wild herbs, and a lit candle and only works on steel or iron weapons but when active, the weapon does an extra 5 to 25 damage when used against Nether creatures.  Implement a `BLESSED_WEAPON` flag, which the EoC that does the damage checks for, and a `HEDGE_ENCHANTED` flag, used so that EoCs can check for items that have hedge magic charms on them. This allows for (for example) items that just come with the `BLESSED_WEAPON` flag and always work, some kind of inherently holy blade, whereas an item with `BLESSED_WEAPON` and `HEDGE_ENCHANTED` will lose the charm if it suffers enough damage.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

![image](https://github.com/user-attachments/assets/6384af57-2dfe-4535-82c1-002c17564c15)
![image](https://github.com/user-attachments/assets/5e55c61b-22fc-4d42-ab7a-debe84bf38c1)

The charm works.
Weapon does extra damage against Nether creatures but not against non-Nether creatures.
Weapon does not do extra damage when missing.
When weapon is damaged, the charm fades.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I wanted to add the _Sefer Raziel Hamalakh_ and put this charm in there, but I'll wait until I have a couple more charms to go with it (probably protective amulets).
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
