### PR TITLE
Remove bloated comments from translation files, part 2

### DIFF
--- a/lang/string_extractor/parsers/furniture.py
+++ b/lang/string_extractor/parsers/furniture.py
@@ -13,12 +13,10 @@ def parse_furniture(json, origin):
     if "bash" in json:
         if "sound" in json["bash"]:
             write_text(json["bash"]["sound"], origin,
-                       comment="Bashing sound of furniture \"{}\"".
-                       format(name))
+                       comment="Bashing sound")
         if "sound_fail" in json["bash"]:
             write_text(json["bash"]["sound_fail"], origin,
-                       comment="Bashing failed sound of furniture \"{}\""
-                       .format(name))
+                       comment="Bashing failed sound")
     if "examine_action" in json:
         parse_examine_action(json["examine_action"], origin,
                              "furniture \"{}\"".format(name))

--- a/lang/string_extractor/parsers/material.py
+++ b/lang/string_extractor/parsers/material.py
@@ -8,13 +8,13 @@ def parse_material(json, origin):
 
     if "bash_dmg_verb" in json:
         write_text(json["bash_dmg_verb"], origin,
-                   comment="Bash damage verb of material {}".format(name))
+                   comment="Bash damage verb of material")
 
     if "cut_dmg_verb" in json:
         write_text(json["cut_dmg_verb"], origin,
-                   comment="Cut damage verb of material {}".format(name))
+                   comment="Cut damage verb of material")
 
     if "dmg_adj" in json:
         for i in range(4):
             write_text(json["dmg_adj"][i], origin,
-                       comment="Damage adjective of material {}".format(name))
+                       comment="Damage adjective of material")

--- a/lang/string_extractor/parsers/monster_attack.py
+++ b/lang/string_extractor/parsers/monster_attack.py
@@ -11,8 +11,4 @@ def parse_monster_attack(json, origin):
         "no_dmg_msg_npc",
     ]:
         if key in json:
-            write_text(
-                json[key],
-                origin,
-                comment='Monster attack "{}" message'.format(json["id"]),
-            )
+            write_text(json[key], origin, comment="Monster attack message")

--- a/lang/string_extractor/parsers/terrain.py
+++ b/lang/string_extractor/parsers/terrain.py
@@ -13,11 +13,10 @@ def parse_terrain(json, origin):
     if "bash" in json:
         if "sound" in json["bash"]:
             write_text(json["bash"]["sound"], origin,
-                       comment="Bashing sound of terrain \"{}\"".format(name))
+                       comment="Bashing sound")
         if "sound_fail" in json["bash"]:
             write_text(json["bash"]["sound_fail"], origin,
-                       comment="Bashing failed sound of terrain \"{}\""
-                       .format(name))
+                       comment="Bashing failed sound")
     if "boltcut" in json:
         if "message" in json["boltcut"]:
             write_text(json["boltcut"]["message"], origin,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Another cleanup of bloated comments, possibly the last one.

<details><summary>Details</summary>
<p>

```
#. ~ Monster attack "feral_weapon_pipe" message
#. ~ Monster attack "feral_weapon_crowbar" message
#. ~ Monster attack "feral_weapon_PR24" message
#. ~ Monster attack "feral_weapon_stick" message
#. ~ Monster attack "feral_weapon_axe" message
#. ~ Monster attack "feral_weapon_shotgun_melee" message
#. ~ Monster attack "feral_weapon_broom" message
#. ~ Monster attack "feral_weapon_knife_chef" message
#. ~ Monster attack "feral_weapon_candlestick" message
#. ~ Monster attack "feral_weapon_rapier" message
#. ~ Monster attack "feral_weapon_rapier_fake" message
#. ~ Monster attack "feral_weapon_battleaxe" message
#. ~ Monster attack "feral_weapon_mace" message
#. ~ Monster attack "feral_weapon_wrench_large" message
#. ~ Monster attack "feral_weapon_lug_wrench" message
#. ~ Monster attack "feral_weapon_mop_folded" message
#. ~ Monster attack "feral_weapon_crash_axe" message
#. ~ Monster attack "feral_weapon_knife_combat" message
#. ~ Monster attack "feral_weapon_knife_combat_low_skill" message
#. ~ Monster attack "feral_weapon_hammer" message
#. ~ Monster attack "feral_weapon_shovel" message
#. ~ Monster attack "feral_weapon_makeshift_machete" message
#. ~ Monster attack "feral_weapon_scalpel" message
#. ~ Monster attack "feral_weapon_feral_m9" message
#. ~ Monster attack "feral_weapon_heavy_flashlight" message
#. ~ Monster attack "feral_weapon_m18" message
#. ~ Monster attack "feral_weapon_feral_militia_gun" message
#. ~ Monster attack "feral_weapon_baton-extended" message
#. ~ Monster attack "feral_weapon_mace_pipe" message
#. ~ Monster attack "party_rocker_pipe" message
#. ~ Monster attack "party_rocker_bottle" message
#. ~ Monster attack "goblin_cudgel_attack" message
#. ~ Monster attack "goblin_boss_attack" message
#. ~ Monster attack "bugbear_combat_machete" message
#. ~ Monster attack "bugbear_combat_machete_rapid_strike" message
#. ~ Monster attack "bugbear_stalker_attack" message
#. ~ Monster attack "ogre_weapon_club" message
#. ~ Monster attack "orc_combat_machete" message
#. ~ Monster attack "orc_combat_machete_rapid_strike" message
#. ~ Monster attack "orc_blood_pipe_attack" message
#: data/json/monster_special_attacks/feral_weapon_attacks.json
#: data/mods/CrazyCataclysm/crazy_attacks.json
#: data/mods/Magiclysm/monsters/goblin.json
#: data/mods/Magiclysm/monsters/ogre.json
#: data/mods/Magiclysm/monsters/orcs.json
#, c-format
msgid "%1$s tries to hit you, but you dodge!"
msgstr ""

#. ~ Damage adjective of material Aluminum
#. ~ Damage adjective of material Brass
#. ~ Damage adjective of material Bronze
#. ~ Damage adjective of material Thessalonian Bronze
#. ~ Damage adjective of material Budget Steel
#. ~ Damage adjective of material Copper
#. ~ Damage adjective of material Egg
#. ~ Damage adjective of material Gold
#. ~ Damage adjective of material Cast iron
#. ~ Bash damage verb of material Junk Food
#. ~ Bash damage verb of material Bread
#. ~ Damage adjective of material Lead
#. ~ Damage adjective of material Silver
#. ~ Damage adjective of material Platinum
#. ~ Damage adjective of material Low Carbon Steel
#. ~ Damage adjective of material Medium Carbon Steel
#. ~ Damage adjective of material High Carbon Steel
#. ~ Damage adjective of material Case Hardened Carbon Steel
#. ~ Damage adjective of material Tempered Carbon Steel
#. ~ Damage adjective of material Budget Steel Chain
#. ~ Damage adjective of material Low Carbon Steel Chain
#. ~ Damage adjective of material Medium Carbon Steel Chain
#. ~ Damage adjective of material High Carbon Steel Chain
#. ~ Damage adjective of material Case Hardened Carbon Steel Chain
#. ~ Damage adjective of material Tempered Carbon Steel Chain
#. ~ Damage adjective of material Steel
#. ~ Damage adjective of material Energetic Nanocompound
#. ~ Damage adjective of material Uranium cell
#. ~ Damage adjective of material Pressurized Hydrogen
#. ~ Damage adjective of material Superalloy
#. ~ Damage adjective of material Layered Carbide
#. ~ Damage adjective of material Strange Metal
#. ~ Damage adjective of material Tin
#. ~ Bash damage verb of material Processed Food
#. ~ Bash damage verb of material Cheese
#. ~ Bash damage verb of material Ice Cream
#. ~ Damage adjective of material Zinc
#. ~ Damage adjective of material Carbon Lattice
#. ~ Damage adjective of material Titanium
#. ~ Damage adjective of material Vacuum-cast Carbide
#. ~ Damage adjective of material Carbide ThermoWeave(c)
#. ~ Damage adjective of material Orichalcum
#. ~ Damage adjective of material Mithril
#. ~ Damage adjective of material Moon Tears
#. ~ Damage adjective of material Moon Tears Fine Chain
#. ~ Damage adjective of material Dreamdross
#. ~ Damage adjective of material Forged Dreams
#. ~ Damage adjective of material Flesh Roots
#: data/json/materials.json data/mods/Aftershock/items/materials.json
#: data/mods/BlazeIndustries/items/materials.json
#: data/mods/Magiclysm/materials.json data/mods/Xedra_Evolved/material.json
msgid "smashed"
msgstr ""
```

</p>
</details> 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Merge comments into a single one for sounds, for damage to materials and for monster attacks.

```
#. ~ Monster attack message
#: data/json/monster_special_attacks/feral_weapon_attacks.json
#: data/mods/CrazyCataclysm/crazy_attacks.json
#, c-format
msgid "%1$s hits your %2$s with a pipe!"
msgstr ""

#. ~ Bash damage verb of material
#. ~ Cut damage verb of material
#. ~ Damage adjective of material
#: data/json/materials.json data/mods/Magiclysm/materials.json
#: data/mods/MindOverMatter/materials.json
#: data/mods/My_Sweet_Cataclysm/sweet_materials.json
msgid "damaged"
msgstr ""

#. ~ Bashing sound
#. ~ Bashing failed sound
#: data/json/furniture_and_terrain/LIXA_furniture_and_terrain.json
....blah blah blah
msgid "crunch!"
msgstr ""
```

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Translations are extracted without errors.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Some strings are used as verbs and as adjectives. I think it's not enough to just specify the context in the parser, you need to change the material.cpp. Which I don't really want to do, especially considering that adjectives are not used by default.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
