### PR TITLE
Withdrawals are distracting

### DIFF
--- a/src/activity_type.cpp
+++ b/src/activity_type.cpp
@@ -79,6 +79,7 @@ std::string enum_to_string<distraction_type>( distraction_type data )
         case distraction_type::temperature: return "temperature";
         case distraction_type::mutation: return "mutation";
         case distraction_type::oxygen: return "oxygen";
+        case distraction_type::withdrawal: return "withdrawal";
         // *INDENT-ON*
         default:
             cata_fatal( "Invalid distraction_type in enum_to_string" );

--- a/src/distraction_manager.cpp
+++ b/src/distraction_manager.cpp
@@ -40,6 +40,7 @@ static const std::vector<configurable_distraction> &get_configurable_distraction
         {&uistate.distraction_temperature,     translate_marker( "Temperature" ),                  translate_marker( "This distraction will interrupt your activity when your temperature is very high or very low." )},
         {&uistate.distraction_mutation,        translate_marker( "Mutation" ),                     translate_marker( "This distraction will interrupt your activity when you gain or lose a mutation." )},
         {&uistate.distraction_oxygen,          translate_marker( "Asphyxiation" ),                 translate_marker( "This distraction will interrupt your activity when you can't breathe." )},
+        {&uistate.distraction_withdrawal,      translate_marker( "Withdrawals" ),                  translate_marker( "This distraction will interrupt your activity when you have withdrawals." )},
     };
     return configurable_distractions;
 }

--- a/src/distraction_manager.cpp
+++ b/src/distraction_manager.cpp
@@ -40,7 +40,7 @@ static const std::vector<configurable_distraction> &get_configurable_distraction
         {&uistate.distraction_temperature,     translate_marker( "Temperature" ),                  translate_marker( "This distraction will interrupt your activity when your temperature is very high or very low." )},
         {&uistate.distraction_mutation,        translate_marker( "Mutation" ),                     translate_marker( "This distraction will interrupt your activity when you gain or lose a mutation." )},
         {&uistate.distraction_oxygen,          translate_marker( "Asphyxiation" ),                 translate_marker( "This distraction will interrupt your activity when you can't breathe." )},
-        {&uistate.distraction_withdrawal,      translate_marker( "Withdrawals" ),                  translate_marker( "This distraction will interrupt your activity when you have withdrawals." )},
+        {&uistate.distraction_withdrawal,      translate_marker( "Withdrawal" ),                  translate_marker( "This distraction will interrupt your activity when you have withdrawals." )},
     };
     return configurable_distractions;
 }

--- a/src/enums.h
+++ b/src/enums.h
@@ -335,6 +335,7 @@ enum class distraction_type : int {
     temperature,
     mutation,
     oxygen,
+    withdrawal,
     last,
 };
 

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -393,6 +393,9 @@ void suffer::from_addictions( Character &you )
     for( addiction &cur_addiction : you.addictions ) {
         if( cur_addiction.sated <= 0_turns &&
             cur_addiction.intensity >= MIN_ADDICTION_LEVEL ) {
+            if( uistate.distraction_withdrawal && !you.is_npc() ) {
+            g->cancel_activity_or_ignore_query( distraction_type::withdrawal, _( "You start having withdrawals!" ) );
+            }
             cur_addiction.run_effect( you );
         }
         cur_addiction.sated -= 1_turns;

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -394,7 +394,8 @@ void suffer::from_addictions( Character &you )
         if( cur_addiction.sated <= 0_turns &&
             cur_addiction.intensity >= MIN_ADDICTION_LEVEL ) {
             if( uistate.distraction_withdrawal && !you.is_npc() ) {
-            g->cancel_activity_or_ignore_query( distraction_type::withdrawal, _( "You start having withdrawals!" ) );
+                g->cancel_activity_or_ignore_query( distraction_type::withdrawal,
+                                                    _( "You start having withdrawals!" ) );
             }
             cur_addiction.run_effect( you );
         }

--- a/src/uistate.h
+++ b/src/uistate.h
@@ -156,6 +156,7 @@ class uistatedata
         bool distraction_temperature = true;
         bool distraction_mutation = true;
         bool distraction_oxygen = true;
+        bool distraction_withdrawal = true;
         bool numpad_navigation = false;
 
         // V Menu Stuff


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Addiction withdrawals are a toggleable distraction"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Addictions have been annoying because withdrawals can reduce your stats while working on some long-term task, infinitely extending the task as you suffer more withdrawals while trying to complete it. The addiction system in game asks you to satsfy it but doesnt stop you from passing out trying to practice some activity. Despite causing distracting pain, there has been no distraction to interrupt or notify you. Unlike asthma etc.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Now, you can enable/disable withdrawals as a distraction, meaning they will stop your activity before your character gets horrible withdrawal symptoms, giving you a means to address them. RPing a junkie has never been easier! If the distraction messages get annoying, you can ignore them or toggle them off in the distractions menu. Fixes Issue #75195

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Auto-consuming drugs, which i'm still working on.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested in basic build, seems to work great.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
