### PR TITLE
[WIP] Make Crowd Crush reflect irl

### DIFF
--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -335,7 +335,7 @@ void suffer::while_grabbed( Character &you )
     int impassable_ter = 0;
     for( auto&& dest : here.points_in_radius( you.pos(), 2, 0 ) ) { // *NOPAD*
         const monster *const mon = creatures.creature_at<monster>( dest );
-        if( mon && mon->has_flag( mon_flag_GROUP_BASH ) && !helpermon.is_hallucination() ) {
+        if( mon && mon->has_flag( mon_flag_GROUP_BASH ) && !mon.is_hallucination() ) {
             crowd++;
             add_msg_debug( debugmode::DF_CHARACTER, "Crowd pressure check: monster %s found, crowd size %d",
                            mon->name(), crowd );

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -333,9 +333,9 @@ void suffer::while_grabbed( Character &you )
     creature_tracker &creatures = get_creature_tracker();
     int crowd = 0;
     int impassable_ter = 0;
-    for( auto&& dest : here.points_in_radius( you.pos(), 1, 0 ) ) { // *NOPAD*
+    for( auto&& dest : here.points_in_radius( you.pos(), 2, 0 ) ) { // *NOPAD*
         const monster *const mon = creatures.creature_at<monster>( dest );
-        if( mon && mon->has_flag( mon_flag_GROUP_BASH ) ) {
+        if( mon && mon->has_flag( mon_flag_GROUP_BASH ) && !helpermon.is_hallucination() ) {
             crowd++;
             add_msg_debug( debugmode::DF_CHARACTER, "Crowd pressure check: monster %s found, crowd size %d",
                            mon->name(), crowd );
@@ -345,8 +345,8 @@ void suffer::while_grabbed( Character &you )
         }
     }
 
-    // if we aren't near two monsters with GROUP_BASH we won't suffocate
-    if( crowd < 2 ) {
+    // if we aren't near four monsters with GROUP_BASH we won't suffocate
+    if( crowd < 6 ) {
         return;
     }
     // Getting crushed against the wall counts as a monster
@@ -355,14 +355,14 @@ void suffer::while_grabbed( Character &you )
         crowd += impassable_ter;
     }
 
-    if( crowd == 2 ) {
+    if( crowd == 6 ) {
         // only a chance to lose breath at low grab chance, none with only a single zombie
         you.oxygen -= rng( 0, 1 );
-    } else if( crowd <= 4 ) {
-        you.oxygen -= 1;
-    } else if( crowd <= 6 ) {
-        you.oxygen -= rng( 1, 2 );
     } else if( crowd <= 8 ) {
+        you.oxygen -= 1;
+    } else if( crowd <= 10 ) {
+        you.oxygen -= rng( 1, 2 );
+    } else if( crowd <= 12 ) {
         you.oxygen -= 2;
     }
 

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -335,7 +335,7 @@ void suffer::while_grabbed( Character &you )
     int impassable_ter = 0;
     for( auto&& dest : here.points_in_radius( you.pos(), 2, 0 ) ) { // *NOPAD*
         const monster *const mon = creatures.creature_at<monster>( dest );
-        if( mon && mon->has_flag( mon_flag_GROUP_BASH ) && !mon.is_hallucination() ) {
+        if( mon && mon->has_flag( mon_flag_GROUP_BASH ) && !mon->is_hallucination() ) {
             crowd++;
             add_msg_debug( debugmode::DF_CHARACTER, "Crowd pressure check: monster %s found, crowd size %d",
                            mon->name(), crowd );


### PR DESCRIPTION
Update suffer.cpp

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Crowd Crush mechanic tuning"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
This mechanic is designed to reflect crowd crush.  Crowd crush should not happen with two things grabbing you, however zombies behind the zombies grabbing you attempting to get in to grab you  should also be counted as they'll add to the crush.  What this should do is make it harder for a couple of lone zombies wandering nearby to start crushing you but easier for hordes that catch you to begin crushing you.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
This now checks 2 out from the pc and also attempts to make it so that hallucinations cannot assist in crushing you.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Making an issue spelling out my ideal jsonized system that uses a points based approach with each monster being worth a set number of points compared to how big they are vs the size of the player and with truly huge monsters having the ability to smother/crush the player with a special grab style attack instead of requiring other monsters/walls nearby.  
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
