### PR TITLE
EoC funciton to allow checking/setting trait purifiability in gametime

### DIFF
--- a/data/mods/TEST_DATA/EOC.json
+++ b/data/mods/TEST_DATA/EOC.json
@@ -1,6 +1,22 @@
 [
   {
     "type": "effect_on_condition",
+    "id": "EOC_TEST_PURIFIABILITY_FALSE",
+    "effect": [
+      { "u_set_trait_purifiability": "purifiability_first", "purifiable": false },
+      { "u_set_trait_purifiability": "purifiability_second", "purifiable": false }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_TEST_PURIFIABILITY_TRUE",
+    "effect": [
+      { "u_set_trait_purifiability": "purifiability_first", "purifiable": true },
+      { "u_set_trait_purifiability": "purifiability_second", "purifiable": true }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_teleport_test",
     "//": "shifts the character down and to the right",
     "global": true,

--- a/data/mods/TEST_DATA/mutations.json
+++ b/data/mods/TEST_DATA/mutations.json
@@ -383,6 +383,24 @@
   },
   {
     "type": "mutation",
+    "id": "purifiability_first",
+    "name": { "str": "Tests setting purifiability via EOCs" },
+    "points": 1,
+    "valid": true,
+    "purifiable": true,
+    "description": "Tests setting purifiability via EOCs - purifiable by default, can be flipped in gametime"
+  },
+  {
+    "type": "mutation",
+    "id": "purifiability_second",
+    "name": { "str": "Tests setting purifiability via EOCs" },
+    "points": 1,
+    "valid": true,
+    "purifiable": false,
+    "description": "Tests setting purifiability via EOCs - nonpurifiable by default, can't be flipped in gametime"
+  },
+  {
+    "type": "mutation",
     "id": "TEST_REMOVAL_0",
     "name": { "str": "Removal test zeroth (non-purifiable)" },
     "points": 1,

--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -383,6 +383,24 @@ Checks do alpha talker has `FEATHERS` mutation
 { "u_has_trait": "FEATHERS" }
 ```
 
+### `u_is_trait_purifiable`, `npc_is_trait_purifiable`
+- type: string or [variable object](##variable-object)
+- return true if the checked trait is purifiable for the alpha or beta talker
+- non-purifiability is either set globally in the trait definition or per-character via `u/npc_set_trait_purifiability`
+
+#### Valid talkers:
+
+| Avatar | Character | NPC | Monster |  Furniture | Item |
+| ------ | --------- | --------- | ---- | ------- | --- | 
+| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ |
+
+#### Examples
+Checks if the `FEATHERS` trait is purifiable for the character (returns true as per the trait definition unless another effect set the trait non-purifiable for the target)
+```json
+{ "u_is_trait_purifiable": "FEATHERS" }
+```
+
+
 ### `u_has_martial_art`, `npc_has_martial_art`
 - type: string or [variable object](##variable-object)
 - return true if alpha or beta talker has some martial art
@@ -2371,6 +2389,23 @@ Mutate towards Tail Stub (removing any incompatibilities) using the category set
         "category": { "u_val": "upcoming_mutation_category", },
         "use_vitamins": true
       },
+```
+
+#### `u_set_trait_purifiability`, `npc_set_trait_purifiability`
+
+If you have the given trait it will be added to /removed from your list of non-purifiable traits, overriding `purifiable: true` in the given trait's definition.
+
+| Syntax | Optionality | Value  | Info |
+| --- | --- | --- | --- | 
+| "u/npc_set_trait_purifiablility" | **mandatory** | string or [variable object](##variable-object) | id of the trait to change
+| "purifiable" | **mandatory** | bool | `true` adds the trait to the unpurifiable trait list, `false` removes it |
+
+```json
+{
+  "u_set_trait_purifiability": "BEAK",   // Trait ID to change
+  "purifiable": false   // Turns the trait unpurifiable for the talker
+}
+
 ```
 
 #### `u_add_effect`, `npc_add_effect`

--- a/src/character.h
+++ b/src/character.h
@@ -3948,6 +3948,8 @@ class Character : public Creature, public visitable
          * Contains mutation ids of the base traits.
          */
         std::unordered_set<trait_id> my_traits;
+        // Mutations that have been turned unpurifiable via EoC
+        std::unordered_set<trait_id> my_intrinsic_mutations;
         /**
          * Pointers to mutation branches in @ref my_mutations.
          */

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -609,6 +609,15 @@ conditional_t::func f_has_trait( const JsonObject &jo, std::string_view member, 
     };
 }
 
+conditional_t::func f_is_trait_purifiable( const JsonObject &jo, std::string_view member,
+        bool is_npc )
+{
+    str_or_var trait_to_check = get_str_or_var( jo.get_member( member ), member, true );
+    return [trait_to_check, is_npc]( dialogue const & d ) {
+        return d.actor( is_npc )->is_trait_purifiable( trait_id( trait_to_check.evaluate( d ) ) );
+    };
+}
+
 conditional_t::func f_has_visible_trait( const JsonObject &jo, std::string_view member,
         bool is_npc )
 {
@@ -2415,6 +2424,7 @@ std::vector<condition_parser>
 parsers = {
     {"u_has_any_trait", "npc_has_any_trait", jarg::array, &conditional_fun::f_has_any_trait },
     {"u_has_trait", "npc_has_trait", jarg::member, &conditional_fun::f_has_trait },
+    { "u_is_trait_purifiable", "npc_is_trait_purifiable", jarg::member, &conditional_fun::f_is_trait_purifiable},
     {"u_has_visible_trait", "npc_has_visible_trait", jarg::member, &conditional_fun::f_has_visible_trait },
     {"u_has_martial_art", "npc_has_martial_art", jarg::member, &conditional_fun::f_has_martial_art },
     {"u_using_martial_art", "npc_using_martial_art", jarg::member, &conditional_fun::f_using_martial_art },

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1989,6 +1989,10 @@ std::unordered_set<trait_id> Character::get_same_type_traits( const trait_id &fl
 
 bool Character::purifiable( const trait_id &flag ) const
 {
+    if( my_intrinsic_mutations.count( flag ) > 0 ) {
+        return false;
+    }
+    // If we haven't set the trait unpurifiable in gametime check its definition
     return flag->purifiable;
 }
 

--- a/src/mutation_ui.cpp
+++ b/src/mutation_ui.cpp
@@ -343,7 +343,12 @@ void avatar::power_mutations()
 
         if( menu_mode == mutation_menu_mode::examining && examine_id.has_value() ) {
             werase( w_description );
-            std::vector<std::string> desc = foldstring( mutation_desc( examine_id.value() ), WIDTH - 2 );
+            std::string description = mutation_desc( examine_id.value() );
+            if( !purifiable( examine_id.value() ) ) {
+                description +=
+                    _( "\n<color_yellow>This trait is an intrinsic part of you now, purifier won't be able to remove it.</color>" );
+            }
+            std::vector<std::string> desc = foldstring( description, WIDTH - 2 );
             const int winh = catacurses::getmaxy( w_description );
             const bool do_scroll = desc.size() > static_cast<unsigned>( std::abs( winh ) );
             const int fline = do_scroll ? examine_pos % ( desc.size() + 1 - winh ) : 0;

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -3092,6 +3092,17 @@ talk_effect_fun_t::func f_mutate_towards( const JsonObject &jo, std::string_view
     };
 }
 
+talk_effect_fun_t::func f_set_trait_purifiability( const JsonObject &jo, std::string_view member,
+        const std::string_view, bool is_npc )
+{
+    str_or_var trait = get_str_or_var( jo.get_member( member ), member, true, "" );
+    const bool purifiable = jo.get_bool( "purifiable", true );
+
+    return [is_npc, trait, purifiable]( dialogue const & d ) {
+        d.actor( is_npc )->set_trait_purifiability( trait_id( trait.evaluate( d ) ), purifiable );
+    };
+}
+
 talk_effect_fun_t::func f_add_bionic( const JsonObject &jo, std::string_view member,
                                       const std::string_view, bool is_npc )
 {
@@ -6493,6 +6504,7 @@ parsers = {
     { "u_mutate", "npc_mutate", jarg::member | jarg::array, &talk_effect_fun::f_mutate },
     { "u_mutate_category", "npc_mutate_category", jarg::member, &talk_effect_fun::f_mutate_category },
     { "u_mutate_towards", "npc_mutate_towards", jarg::member, &talk_effect_fun::f_mutate_towards},
+    { "u_set_trait_purifiability", "npc_set_trait_purifiability", jarg::member, &talk_effect_fun::f_set_trait_purifiability},
     { "u_learn_martial_art", "npc_learn_martial_art", jarg::member, &talk_effect_fun::f_learn_martial_art },
     { "u_forget_martial_art", "npc_forget_martial_art", jarg::member, &talk_effect_fun::f_forget_martial_art },
     { "u_location_variable", "npc_location_variable", jarg::object, &talk_effect_fun::f_location_variable },

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -629,14 +629,20 @@ static void draw_traits_tab( ui_adaptor &ui, const catacurses::window &w_traits,
     wnoutrefresh( w_traits );
 }
 
-static void draw_traits_info( const catacurses::window &w_info, const unsigned line,
+static void draw_traits_info( const catacurses::window &w_info, const Character &you,
+                              const unsigned line,
                               const std::vector<trait_and_var> &traitslist, const unsigned info_line )
 {
     werase( w_info );
     if( line < traitslist.size() ) {
         const trait_and_var &cur = traitslist[line];
+        std::string trait_desc = cur.desc();
+        if( !you.purifiable( cur.trait ) ) {
+            trait_desc +=
+                _( "\n<color_yellow>This trait is an intrinsic part of you now, purifier won't be able to remove it.</color>" );
+        }
         const std::string desc =
-            string_format( "%s: %s", colorize( cur.name(), cur.trait->get_display_color() ), cur.desc() );
+            string_format( "%s: %s", colorize( cur.name(), cur.trait->get_display_color() ), trait_desc );
         draw_x_info( w_info, desc, info_line );
     }
     wnoutrefresh( w_info );
@@ -1054,7 +1060,7 @@ static void draw_info_window( const catacurses::window &w_info, const Character 
             draw_skills_info( w_info, you, line, skillslist, info_line );
             break;
         case player_display_tab::traits:
-            draw_traits_info( w_info, line, traitslist, info_line );
+            draw_traits_info( w_info, you, line, traitslist, info_line );
             break;
         case player_display_tab::bionics:
             draw_bionics_info( w_info, line, bionicslist, info_line );

--- a/src/talker.h
+++ b/src/talker.h
@@ -225,6 +225,9 @@ class talker
         virtual bool has_trait( const trait_id & ) const {
             return false;
         }
+        virtual bool is_trait_purifiable( const trait_id & ) const {
+            return false;
+        }
         virtual bool has_recipe( const recipe_id & ) const {
             return false;
         }
@@ -240,6 +243,7 @@ class talker
         virtual void unset_mutation( const trait_id & ) {}
         virtual void activate_mutation( const trait_id & ) {}
         virtual void deactivate_mutation( const trait_id & ) {}
+        virtual void set_trait_purifiability( const trait_id &, const bool purifiable ) {}
         virtual void set_sleepiness( int ) {};
         virtual bool has_flag( const json_character_flag & ) const {
             return false;

--- a/src/talker.h
+++ b/src/talker.h
@@ -243,7 +243,7 @@ class talker
         virtual void unset_mutation( const trait_id & ) {}
         virtual void activate_mutation( const trait_id & ) {}
         virtual void deactivate_mutation( const trait_id & ) {}
-        virtual void set_trait_purifiability( const trait_id &, const bool purifiable ) {}
+        virtual void set_trait_purifiability( const trait_id &, const bool & ) {}
         virtual void set_sleepiness( int ) {};
         virtual bool has_flag( const json_character_flag & ) const {
             return false;

--- a/src/talker_character.cpp
+++ b/src/talker_character.cpp
@@ -262,7 +262,7 @@ void talker_character::mutate_towards( const trait_id &trait, const mutation_cat
     me_chr->mutate_towards( trait, mut_cat, nullptr, use_vitamins );
 }
 
-void talker_character::set_trait_purifiability( const trait_id &trait, const bool purifiable )
+void talker_character::set_trait_purifiability( const trait_id &trait, const bool &purifiable )
 {
     // If we want to set it non-purifiable and we didn't already do that and we really do have the trait
     if( me_chr->has_trait( trait ) ) {

--- a/src/talker_character.cpp
+++ b/src/talker_character.cpp
@@ -215,6 +215,11 @@ bool talker_character_const::has_trait( const trait_id &trait_to_check ) const
     return me_chr_const->has_trait( trait_to_check );
 }
 
+bool talker_character_const::is_trait_purifiable( const trait_id &trait_to_check ) const
+{
+    return me_chr_const->purifiable( trait_to_check );
+}
+
 bool talker_character_const::has_recipe( const recipe_id &recipe_to_check ) const
 {
     return me_chr_const->knows_recipe( &*recipe_to_check );
@@ -255,6 +260,22 @@ void talker_character::mutate_towards( const trait_id &trait, const mutation_cat
                                        const bool &use_vitamins )
 {
     me_chr->mutate_towards( trait, mut_cat, nullptr, use_vitamins );
+}
+
+void talker_character::set_trait_purifiability( const trait_id &trait, const bool purifiable )
+{
+    // If we want to set it non-purifiable and we didn't already do that and we really do have the trait
+    if( me_chr->has_trait( trait ) ) {
+        if( !purifiable && !me_chr->my_intrinsic_mutations.count( trait ) ) {
+            me_chr->my_intrinsic_mutations.insert( trait );
+            add_msg_debug( debugmode::DF_MUTATION, "Setting trait %s unpurifiable", trait.c_str() );
+        };
+        // If we want to set it purifiable
+        if( purifiable && me_chr->my_intrinsic_mutations.count( trait ) ) {
+            me_chr->my_intrinsic_mutations.erase( trait );
+            add_msg_debug( debugmode::DF_MUTATION, "Setting trait %s purifiable", trait.c_str() );
+        }
+    }
 }
 
 void talker_character::set_mutation( const trait_id &new_trait, const mutation_variant *variant )

--- a/src/talker_character.h
+++ b/src/talker_character.h
@@ -246,7 +246,7 @@ class talker_character: public talker_cloner<talker_character, talker_character_
         void mutate_category( const mutation_category_id &mut_cat, const bool &use_vitamins ) override;
         void mutate_towards( const trait_id &trait, const mutation_category_id &mut_cat,
                              const bool &use_vitamins ) override;
-        void set_trait_purifiability( const trait_id &trait, const bool &purifiable );
+        void set_trait_purifiability( const trait_id &trait, const bool &purifiable ) override;
         void set_mutation( const trait_id &new_trait, const mutation_variant * = nullptr ) override;
         void unset_mutation( const trait_id &old_trait ) override;
         void activate_mutation( const trait_id &trait ) override;

--- a/src/talker_character.h
+++ b/src/talker_character.h
@@ -88,6 +88,7 @@ class talker_character_const: public talker_cloner<talker_character_const>
         int mana_cur() const override;
         int mana_max() const override;
         bool has_trait( const trait_id &trait_to_check ) const override;
+        bool is_trait_purifiable( const trait_id &trait_to_check ) const override;
         bool has_recipe( const recipe_id &recipe_to_check ) const override;
         bool has_flag( const json_character_flag &trait_flag_to_check ) const override;
         bool has_species( const species_id &species ) const override;
@@ -245,6 +246,7 @@ class talker_character: public talker_cloner<talker_character, talker_character_
         void mutate_category( const mutation_category_id &mut_cat, const bool &use_vitamins ) override;
         void mutate_towards( const trait_id &trait, const mutation_category_id &mut_cat,
                              const bool &use_vitamins ) override;
+        void set_trait_purifiability( const trait_id &trait, const bool purifiable );
         void set_mutation( const trait_id &new_trait, const mutation_variant * = nullptr ) override;
         void unset_mutation( const trait_id &old_trait ) override;
         void activate_mutation( const trait_id &trait ) override;

--- a/src/talker_character.h
+++ b/src/talker_character.h
@@ -246,7 +246,7 @@ class talker_character: public talker_cloner<talker_character, talker_character_
         void mutate_category( const mutation_category_id &mut_cat, const bool &use_vitamins ) override;
         void mutate_towards( const trait_id &trait, const mutation_category_id &mut_cat,
                              const bool &use_vitamins ) override;
-        void set_trait_purifiability( const trait_id &trait, const bool purifiable );
+        void set_trait_purifiability( const trait_id &trait, const bool &purifiable );
         void set_mutation( const trait_id &new_trait, const mutation_variant * = nullptr ) override;
         void unset_mutation( const trait_id &old_trait ) override;
         void activate_mutation( const trait_id &trait ) override;

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -82,11 +82,11 @@ effect_on_condition_EOC_meta_test_talker_type( "EOC_meta_test_talker_type" );
 static const effect_on_condition_id
 effect_on_condition_EOC_mon_nearby_test( "EOC_mon_nearby_test" );
 static const effect_on_condition_id effect_on_condition_EOC_mutator_test( "EOC_mutator_test" );
-static const effect_on_condition_id effect_on_condition_EOC_options_tests( "EOC_options_tests" );
 static const effect_on_condition_id
 effect_on_condition_EOC_TEST_PURIFIABILITY_FALSE( "EOC_TEST_PURIFIABILITY_FALSE" );
 static const effect_on_condition_id
 effect_on_condition_EOC_TEST_PURIFIABILITY_TRUE( "EOC_TEST_PURIFIABILITY_TRUE" );
+static const effect_on_condition_id effect_on_condition_EOC_options_tests( "EOC_options_tests" );
 static const effect_on_condition_id effect_on_condition_EOC_recipe_test_1( "EOC_recipe_test_1" );
 static const effect_on_condition_id effect_on_condition_EOC_recipe_test_2( "EOC_recipe_test_2" );
 static const effect_on_condition_id

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -16,6 +16,10 @@ static const activity_id ACT_ADD_VARIABLE_DURING( "ACT_ADD_VARIABLE_DURING" );
 static const activity_id ACT_GENERIC_EOC( "ACT_GENERIC_EOC" );
 
 static const effect_on_condition_id
+effect_on_condition_EOC_TEST_PURIFIABILITY_FALSE( "EOC_TEST_PURIFIABILITY_FALSE" );
+static const effect_on_condition_id
+effect_on_condition_EOC_TEST_PURIFIABILITY_TRUE( "EOC_TEST_PURIFIABILITY_TRUE" );
+static const effect_on_condition_id
 effect_on_condition_EOC_TEST_TRANSFORM_LINE( "EOC_TEST_TRANSFORM_LINE" );
 static const effect_on_condition_id
 effect_on_condition_EOC_TEST_TRANSFORM_RADIUS( "EOC_TEST_TRANSFORM_RADIUS" );
@@ -82,10 +86,6 @@ effect_on_condition_EOC_meta_test_talker_type( "EOC_meta_test_talker_type" );
 static const effect_on_condition_id
 effect_on_condition_EOC_mon_nearby_test( "EOC_mon_nearby_test" );
 static const effect_on_condition_id effect_on_condition_EOC_mutator_test( "EOC_mutator_test" );
-static const effect_on_condition_id
-effect_on_condition_EOC_TEST_PURIFIABILITY_FALSE( "EOC_TEST_PURIFIABILITY_FALSE" );
-static const effect_on_condition_id
-effect_on_condition_EOC_TEST_PURIFIABILITY_TRUE( "EOC_TEST_PURIFIABILITY_TRUE" );
 static const effect_on_condition_id effect_on_condition_EOC_options_tests( "EOC_options_tests" );
 static const effect_on_condition_id effect_on_condition_EOC_recipe_test_1( "EOC_recipe_test_1" );
 static const effect_on_condition_id effect_on_condition_EOC_recipe_test_2( "EOC_recipe_test_2" );

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -83,6 +83,10 @@ static const effect_on_condition_id
 effect_on_condition_EOC_mon_nearby_test( "EOC_mon_nearby_test" );
 static const effect_on_condition_id effect_on_condition_EOC_mutator_test( "EOC_mutator_test" );
 static const effect_on_condition_id effect_on_condition_EOC_options_tests( "EOC_options_tests" );
+static const effect_on_condition_id
+effect_on_condition_EOC_TEST_PURIFIABILITY_FALSE( "EOC_TEST_PURIFIABILITY_FALSE" );
+static const effect_on_condition_id
+effect_on_condition_EOC_TEST_PURIFIABILITY_TRUE( "EOC_TEST_PURIFIABILITY_TRUE" );
 static const effect_on_condition_id effect_on_condition_EOC_recipe_test_1( "EOC_recipe_test_1" );
 static const effect_on_condition_id effect_on_condition_EOC_recipe_test_2( "EOC_recipe_test_2" );
 static const effect_on_condition_id
@@ -142,6 +146,8 @@ static const ter_str_id ter_t_grass( "t_grass" );
 
 static const trait_id trait_process_mutation( "process_mutation" );
 static const trait_id trait_process_mutation_two( "process_mutation_two" );
+static const trait_id trait_purifiability_first( "purifiability_first" );
+static const trait_id trait_purifiability_second( "purifiability_second" );
 
 namespace
 {
@@ -600,6 +606,33 @@ TEST_CASE( "EOC_mutation_test", "[eoc][mutations]" )
     CHECK( std::stod( globvars.get_global_value( "npctalk_var_test_val" ) ) == Approx(
                1 ) );
     CHECK( globvars.get_global_value( "npctalk_var_context_test" ) == "process_mutation" );
+}
+
+TEST_CASE( "EOC_purifiability", "[eoc][mutations]" )
+{
+    clear_avatar();
+    clear_map();
+    avatar &me = get_avatar();
+
+    // Gain both traits
+    me.toggle_trait( trait_purifiability_first );
+    me.toggle_trait( trait_purifiability_second );
+    // Check assumptions
+    REQUIRE( me.purifiable( trait_purifiability_first ) );
+    REQUIRE( !me.purifiable( trait_purifiability_second ) );
+
+    dialogue d( get_talker_for( get_avatar() ), std::make_unique<talker>() );
+    // Try to set both traits to non-purifiable
+    REQUIRE( effect_on_condition_EOC_TEST_PURIFIABILITY_FALSE->activate( d ) );
+    // Neither are purifiable
+    CHECK( !me.purifiable( trait_purifiability_first ) );
+    CHECK( !me.purifiable( trait_purifiability_second ) );
+
+    // Try to set both traits purifiable
+    REQUIRE( effect_on_condition_EOC_TEST_PURIFIABILITY_TRUE->activate( d ) );
+    // The by default non-purifiable trait stays non-purifiable, the other resets
+    CHECK( me.purifiable( trait_purifiability_first ) );
+    CHECK( !me.purifiable( trait_purifiability_second ) );
 }
 
 TEST_CASE( "EOC_monsters_nearby", "[eoc][math_parser]" )


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Dynamic trait purifiability"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
Trait purifiability is completely immutable in gametime, which means a relatively simple progression step e.g. ("Your beak is now just a part of you") would require duplicate trait definitions with the purifiability set to false.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
- Added a trait list `my_intrinsic_traits` to `Character`
- Expanded the purifiability check to respect the intrinsic trait list overriding purifiability
- Added a colored info line to both the mutation and @ menu indicating which trait is non-purifiable (both for by definition sticky traits and dynamic ones) - that should spare you some hhg rounds
- Added an EoC function to add/remove a trait to this list
- Added a condition for `is_trait_purifiable`
- Added some unit tests checking that everything works

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
Move the system over completely (ie. purifiability is not checked in the trait definition at all, on gaining a non-purifiable trait the id gets added to the intrinsic trait list). Would be cleaner, but it would require some form of savegame migration to update in-progress characters.
#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
Added an eoc to flip a trait, when it was non-purifiable purifier could not remove it and the descriptions were updated with the snippets. When flipping back it could be removed and the snippet was gone.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
Would you believe it, tangentially part of limb stuff.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
