### PR TITLE
Fixed map generate bug

### DIFF
--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -240,10 +240,10 @@ void map::generate( const tripoint_abs_omt &p, const time_point &when, bool save
             for( int gridz = -OVERMAP_DEPTH; gridz <= OVERMAP_HEIGHT; gridz++ ) {
                 const tripoint_rel_sm pos( gridx, gridy, gridz );
                 const size_t grid_pos = get_nonant( pos );
-                const std::vector<bool>::iterator iter = generated.begin() + grid_pos;
-                generated.emplace( iter, MAPBUFFER.submap_exists( p_sm_base.xy() + pos ) );
+                // For some reason 'emplace' doesn't work. emplacing data later overwrote data...
+                generated[grid_pos] = MAPBUFFER.submap_exists( p_sm_base.xy() + pos );
 
-                if( !generated.at( grid_pos ) || save_results ) {
+                if( !generated.at( grid_pos ) || !save_results ) {
                     setsubmap( grid_pos, new submap() );
 
                     // Generate uniform submaps immediately and cheaply.
@@ -281,6 +281,7 @@ void map::generate( const tripoint_abs_omt &p, const time_point &when, bool save
             for( int gridy = 0; gridy <= 1; gridy++ ) {
                 const tripoint_rel_sm pos( gridx, gridy, gridz );
                 const size_t grid_pos = get_nonant( pos );
+
                 if( ( !generated.at( grid_pos ) || !save_results ) &&
                     !getsubmap( grid_pos )->is_uniform() &&
                     uniform_terrain( overmap_buffer.ter( { p.xy(), gridz } ) ) == t_null.id() ) {
@@ -309,7 +310,7 @@ void map::generate( const tripoint_abs_omt &p, const time_point &when, bool save
                                  !generated.at( get_nonant( { point_rel_sm_south, p_sm.z() } ) );
 
         mapgendata dat( { p.xy(), gridz}, *this, density, when, nullptr );
-        if( ( !save_results || any_missing ) &&
+        if( ( any_missing || !save_results ) &&
             uniform_terrain( overmap_buffer.ter( { p.xy(), gridz } ) ) == t_null.id() ) {
             draw_map( dat );
         }
@@ -328,7 +329,7 @@ void map::generate( const tripoint_abs_omt &p, const time_point &when, bool save
             }
         }
 
-        if( !save_results || any_missing ) {
+        if( any_missing || !save_results ) {
 
             // At some point, we should add region information so we can grab the appropriate extras
             map_extras &this_ex = region_settings_map["default"].region_extras[terrain_type->get_extras()];

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -100,10 +100,8 @@ static const furn_str_id furn_f_toilet( "f_toilet" );
 static const furn_str_id furn_f_vending_c( "f_vending_c" );
 static const furn_str_id furn_f_vending_c_off( "f_vending_c_off" );
 
-static const furn_str_id furn_f_vending_o( "f_vending_o" );
 static const furn_str_id furn_f_vending_reinforced( "f_vending_reinforced" );
 static const furn_str_id furn_f_vending_reinforced_off( "f_vending_reinforced_off" );
-
 
 static const item_group_id Item_spawn_data_ammo_rare( "ammo_rare" );
 static const item_group_id Item_spawn_data_bed( "bed" );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #75265, fix #75262, fix #75256, fix #75258, i.e. map featured generated again when they should remain unchanged, including generation of duplicate NPCs.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Restore a lost negation (lost when optimizing the code). This is what caused the re-generation and duplicate characters.
- Tracked down a bizarre failure of .emplace to work properly, where placement at at least one other index cleared one set earlier. This led to a crash on loading of my save after fixing the "real" bug. Replaced emplace with old school indexing (which the style enforcer probably will scream about).
- Swapped a couple of boolean checks around for a negligible performance gain: normal game play should be the optimal path, with editmap stuff being allowed to cost more.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
- Before fixing the bugs:
  - Walked to a car and drove to a Mr Lapin (a lot of them have been generated all over the place), saw him in a single instance (I've not visited his place before), verified via the overmap (only a single character listed for that tile).
  - Drove away a bit and noted a levitating wasp nest roof (which is what causes the shadow in one bug report), and saved when 10 or so overmap tiles away from Mr. Lapin.
  - Loaded the save and drove to Mr. Lapin, and found two copies of him.
- After fixing the bugs:
  - Repeating the above, without finding any levitating wasp nest roof (or any nest at all, for that matter). When returning to Mr. Lapin he hadn't been duplicated (again, verified it via the overmap).

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I don't like the 'emplace' failure one bit.
I tracked it down using debug output to debug.log, and that showed that generate emplace at begin+52 was set to true and there was indeed a submap at the corresponding coordinates.
However, 11 iterations later, when the data for grid_pos 21 was emplaced, the data at grid_pos 52 was suddenly false (grid_pos 21 corresponds to pos (1, 0, -10), so it's the start of the next stack).

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
