### PR TITLE
Add faster staling for issues with the Suggestion/ Discussion label.

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,6 +12,9 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
+      - name: get-time
+        run: |
+          echo "time=$(date +%I)" >> $GITHUB_ENV
       - uses: actions/stale@main
         id: stale
         with:
@@ -19,12 +22,13 @@ jobs:
           stale-pr-label: stale
           stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions. Please do not bump or comment on this issue unless you are actively working on it. Stale issues, and stale issues that are closed are still considered.'
           stale-pr-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions. Please do not bump or comment on this issue unless you are actively working on it. Stale issues, and stale issues that are closed are still considered.'
-          days-before-stale: 30
-          days-before-close: 30
+          days-before-stale: ${{ contains(fromJson('["01", "02", "03", "04", "05", "06"]'), env.time) && 30 || 15 }}
+          days-before-close: ${{ contains(fromJson('["01", "02", "03", "04", "05", "06"]'), env.time) && 30 || 15 }}
           start-date: '2020-05-07'
           operations-per-run: 110
           exempt-issue-labels: 'Accessibility,<Bug>,<Bugfix>,<Crash / Freeze>,Organization: Bounty,Good First Issue,Help Wanted,(P1 - Critical),(P2 - High),(P3 - Medium),(P4 - Low),(P5 - Long-term),(S2 - Confirmed),0.G String Freeze,0.G Feature Freeze,0.G Content Freeze'
           exempt-pr-labels: '<Bug>,<Bugfix>,<Crash / Freeze>,Organization: Bounty,Good First Issue,(P1 - Critical),(P2 - High),(P3 - Medium),(P4 - Low),(P5 - Long-term),(S2 - Confirmed),0.G String Freeze,0.G Feature Freeze,0.G Content Freeze'
+          any-of-labels: ${{ contains(fromJson('["01", "02", "03", "04", "05", "06"]'), env.time) && "" || "<Suggestion / Discussion>" }}
           exempt-all-milestones: true
           exempt-all-assignees: true
       - name: Print outputs


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Based on #75151 
This introduces faster staling for issues (or PRs, but I don't expect them to have that label) that have the "<Suggestion / Discussion>" label applied.

#### Describe the solution
Resurrecting the hour-of-the day handling from the previous alternating direction feature, I have the action process discussion issues for 6 hours and then the other issues for 6 hours. It does so by setting several of the action's parameters with the ternary operator matching against a list of hours.

#### Describe alternatives you've considered
Eh...

#### Testing
Have to run it in-repo.

#### Additional context
This is the first step in a mini-project to change how suggestion issues are used.
What I want to happen is if someone makes a kind of vague suggestion, it either results in one or more concrete issues, or is simply closed with the resolution being "well here's what was discussed" and people can read it later after its closure.