### PR TITLE
Prevent segfault when target of firstaid_activity_actor disappears

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6648,6 +6648,11 @@ void firstaid_activity_actor::finish( player_activity &act, Character &who )
     static const std::string iuse_name_string( "heal" );
 
     item_location it = act.targets.front();
+    if( !it ) {
+        debugmsg( "Lost tool used for healing" );
+        act.set_to_null();
+        return;
+    }
     item *used_tool = it->get_usable_item( iuse_name_string );
     if( used_tool == nullptr ) {
         debugmsg( "Lost tool used for healing" );


### PR DESCRIPTION


<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Prevent segfault when target of firstaid_activity_actor disappears"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Prevents segfault when performing `firstaid_activity_actor` but the bandage tool disappeared. Fixes #75309 .

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Backtrace of fixed segfault:
```
Thread 1 "cataclysm-tiles" received signal SIGSEGV, Segmentation fault.
(gdb) bt
 #0  0x0000555555ece5a4 in item::get_usable_item_helper<item> (use_name="heal", self=...) at src/item.cpp:11584
 #1  item::get_usable_item (this=0x0, use_name="heal") at src/item.cpp:11606
 #2  0x000055555599c6bf in firstaid_activity_actor::finish (this=0x55559b583f20, act=..., who=...) at src/activity_actor.cpp:6651
 #3  0x00005555564d8c6b in player_activity::do_turn (this=0x555558108218, you=...) at src/player_activity.cpp:391
 #4  0x0000555555ce3fa6 in do_turn () at src/do_turn.cpp:532
 #5  0x000055555577511a in main (argc=<optimized out>, argv=<optimized out>) at src/main.cpp:873
```

An example where this happened was when the bandage was inside a spillable container (clay canning pot), that spilled its contents when starting the activity. Spiling the clay canning pot invalidates the `item_location`. Backtrace of when the clay canning pot was spilled:
```
 #0  item_pocket::get_name (this=0x555557fa7540) at src/item_pocket.cpp:2117
 #1  item_pocket::handle_liquid_or_spill (this=this@entry=0x555557fa7540, guy=..., avoid=0x555557fa8060) at src/item_pocket.cpp:806
 #2  0x0000555555a6aa60 in avatar_action::use_item (you=..., loc=..., method="heal") at src/avatar_action.cpp:1212
 #3  0x0000555555a6dda7 in avatar_action::eat_or_use (you=..., loc=...) at src/avatar_action.cpp:988
 #4  0x0000555555e3e1c5 in game::do_regular_action (this=this@entry=0x555557f94a60, act=@0x7fffffffd1b0: ACTION_EAT, player_character=..., mouse_target=std::optional [no contained value]) at src/handle_action.cpp:2479
 #5  0x0000555555e41260 in game::handle_action (this=0x555557f94a60) at src/handle_action.cpp:3176
 #6  0x0000555555ce422f in do_turn () at /usr/include/c++/13/bits/unique_ptr.h:199
 #7  0x000055555577511a in main (argc=<optimized out>, argv=<optimized out>) at src/main.cpp:873
```

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Having the bandages inside the clay canning pot like that should not be possible since the clay canning pot is a spillable container, but apparently it is, and that's possibly a separate issue. Wielding the clay canning pot should be ok, since that wouldnt spill it, but having it inside the inventory like that causes the issue. Maybe autopickup placed them inside the spillable container? It's possibly a separate issue to prevent this in the first place. 

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

When performing the steps in #75309 , the segfault can longer be reproduced. Instead, it shows the debugmsg "Lost tool used for healing".

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
