### PR TITLE
fix hwp maintenance kit item_restriction

### DIFF
--- a/data/json/items/tool/workshop.json
+++ b/data/json/items/tool/workshop.json
@@ -1075,6 +1075,8 @@
         "item_restriction": [
           "robofac_gun_ar",
           "robofac_gun_smg",
+          "robofac_gun_57",
+          "robofac_gun_46",
           "robofac_gun_dmr",
           "robofac_gun_shotgun",
           "robofac_gun_shotgun_breach",


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Someone reported you can't put all the kits into the maintenance kit container
#### Describe the solution
Add lacking guns