### PR TITLE
Expose instability to json

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -1205,6 +1205,11 @@
     "//": "This mutation does not count toward thresholds at all."
   },
   {
+    "id": "ROBUST_GENETIC",
+    "type": "json_flag",
+    "//": "Applies robust genetic bonus - mutations give only 1 unit of instability for all traits instead of 1 unit for your current tree, and 2 for any outer tree."
+  },
+  {
     "id": "HIDDEN_HALLU",
     "type": "json_flag",
     "craft_inherit": true,

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -1261,6 +1261,7 @@
     "vitamin_cost": 260,
     "description": "Your genome has rapidly adapted to the Cataclysm and can handle the strain of mutation better.  Taking different kinds of mutagen won't result in more defective mutations than normal.",
     "starting_trait": true,
+    "flags": [ "ROBUST_GENETIC" ],
     "cancels": [ "CHAOTIC_BAD", "RESTRICTED" ],
     "category": [ "FISH", "SLIME", "MEDICAL", "PLANT" ]
   },

--- a/doc/MAGIC.md
+++ b/doc/MAGIC.md
@@ -856,8 +856,9 @@ Character status value  | Description
 `METABOLISM`            | Multiplier for `metabolic_rate_base`, which respond for default bmi rate; Formula for basic bmi is `metabolic_rate_base * ( (weight_in_kg / 10 ) + (6.25 * height) - (5 * age) + 5 )`; Since it's a percent, using `multiply` is recommended; Since metabolism is directly connected to weariness, at this moment decreasing it makes you more weary the less metabolism you have; zero metabolism (`multiply: -1`) is handled separately, and makes you never wear
 `MOD_HEALTH`            | If this is anything other than zero (which it defaults to) you will to mod your health to a max/min of `MOD_HEALTH_CAP` every half hour.
 `MOD_HEALTH_CAP`        | If this is anything other than zero (which it defaults to) you will cap your `MOD_HEALTH` gain/loss at this every half hour.
-`MOTION_VISION_RANGE`  | Reveals all monsters as a red `?` within the specified radius.
+`MOTION_VISION_RANGE`   | Reveals all monsters as a red `?` within the specified radius.
 `MOVE_COST`             | 
+`MUT_INSTABILITY_MOD`   | Modifies your instability score, which affect the chance to get bad mutation (scales with amount of good mutations you have, capping at 67%, check `Character::roll_bad_mutation` for more information). `add: 1` would be equal of having 1 good mutation more, increasing the chance to get bad mutation, `add: -1` would be like you have one good mutation less, decreasing the chance to get bad mutation.
 `MOVECOST_FLATGROUND_MOD`| How many moves you spend to move 1 tile on flat ground; shown in UI
 `MOVECOST_OBSTACLE_MOD` | How many moves you spend to move 1 tile, if this tile has a movecost more than 105 moves; not shown in UI
 `MOVECOST_SWIM_MOD`     | How many moves you spend to move 1 tile in water; not shown in UI

--- a/doc/MAGIC.md
+++ b/doc/MAGIC.md
@@ -858,7 +858,7 @@ Character status value  | Description
 `MOD_HEALTH_CAP`        | If this is anything other than zero (which it defaults to) you will cap your `MOD_HEALTH` gain/loss at this every half hour.
 `MOTION_VISION_RANGE`   | Reveals all monsters as a red `?` within the specified radius.
 `MOVE_COST`             | 
-`MUT_INSTABILITY_MOD`   | Modifies your instability score, which affect the chance to get bad mutation (scales with amount of good mutations you have, capping at 67%, check `Character::roll_bad_mutation` for more information). `add: 1` would be equal of having 1 good mutation more, increasing the chance to get bad mutation, `add: -1` would be like you have one good mutation less, decreasing the chance to get bad mutation.
+`MUT_INSTABILITY_MOD`   | Modifies your instability score, which affects the chance to get bad mutation (scales with amount of good mutations you have, capping at 67%, check `Character::roll_bad_mutation` for more information). `add: 1` would be equal to having 1 good mutation more, increasing the chance to get bad mutation, `add: -1` would be like you have one good mutation less, decreasing the chance to get bad mutation.
 `MOVECOST_FLATGROUND_MOD`| How many moves you spend to move 1 tile on flat ground; shown in UI
 `MOVECOST_OBSTACLE_MOD` | How many moves you spend to move 1 tile, if this tile has a movecost more than 105 moves; not shown in UI
 `MOVECOST_SWIM_MOD`     | How many moves you spend to move 1 tile in water; not shown in UI

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -75,6 +75,7 @@ namespace io
             case enchant_vals::mod::MAX_HP: return "MAX_HP";
             case enchant_vals::mod::REGEN_HP: return "REGEN_HP";
             case enchant_vals::mod::REGEN_HP_AWAKE: return "REGEN_HP_AWAKE";
+            case enchant_vals::mod::MUT_INSTABILITY_MOD: return "MUT_INSTABILITY_MOD";
             case enchant_vals::mod::HUNGER: return "HUNGER";
             case enchant_vals::mod::THIRST: return "THIRST";
             case enchant_vals::mod::SLEEPINESS: return "SLEEPINESS";

--- a/src/magic_enchantment.h
+++ b/src/magic_enchantment.h
@@ -48,6 +48,7 @@ enum class mod : int {
     REGEN_STAMINA,
     FAT_TO_MAX_HP,
     CARDIO_MULTIPLIER,
+    MUT_INSTABILITY_MOD,
     MAX_HP,        // for all limbs! use with caution
     REGEN_HP,
     REGEN_HP_AWAKE,

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -205,6 +205,8 @@ int Character::get_instability_per_category( const mutation_category_id &categ )
             }
         }
     }
+    mut_count = enchantment_cache->modify_value( enchant_vals::mod::MUT_INSTABILITY_MOD, mut_count );
+    mut_count = std::max( mut_count, 0 );
     return mut_count;
 }
 

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -54,6 +54,7 @@ static const itype_id itype_fake_burrowing( "fake_burrowing" );
 static const json_character_flag json_flag_CHLOROMORPH( "CHLOROMORPH" );
 static const json_character_flag json_flag_HUGE( "HUGE" );
 static const json_character_flag json_flag_LARGE( "LARGE" );
+static const json_character_flag json_flag_ROBUST_GENETIC( "ROBUST_GENETIC" );
 static const json_character_flag json_flag_ROOTS2( "ROOTS2" );
 static const json_character_flag json_flag_ROOTS3( "ROOTS3" );
 static const json_character_flag json_flag_SHAPESHIFT_SIZE_HUGE( "SHAPESHIFT_SIZE_HUGE" );
@@ -84,7 +85,6 @@ static const trait_id trait_M_BLOOM( "M_BLOOM" );
 static const trait_id trait_M_FERTILE( "M_FERTILE" );
 static const trait_id trait_M_PROVENANCE( "M_PROVENANCE" );
 static const trait_id trait_NAUSEA( "NAUSEA" );
-static const trait_id trait_ROBUST( "ROBUST" );
 static const trait_id trait_SLIMESPAWNER( "SLIMESPAWNER" );
 static const trait_id trait_SNAIL_TRAIL( "SNAIL_TRAIL" );
 static const trait_id trait_TREE_COMMUNION( "TREE_COMMUNION" );
@@ -180,7 +180,7 @@ bool Character::has_base_trait( const trait_id &b ) const
 int Character::get_instability_per_category( const mutation_category_id &categ ) const
 {
     int mut_count = 0;
-    bool robust = has_trait( trait_ROBUST );
+    bool robust = has_flag( json_flag_ROBUST_GENETIC );
     // For each and every trait we have...
     for( const trait_id &mut : get_mutations() ) {
         // only count muts that have 0 or more points, aren't a threshold, have a category, and aren't a base trait.


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Json power
#### Describe the solution
Make `ROBUST_GENETIC` check the flag
Add enchantment, that modifies the result of get_instability_per_category
#### Testing
without test mutation applied
![image](https://github.com/user-attachments/assets/9a0db08e-5799-417c-be73-464ad49e7251)
next second, with test mutation applied
![image](https://github.com/user-attachments/assets/85a48a77-4086-4c6b-8c13-2e94942f55bd)
#### Additional context
![image](https://github.com/user-attachments/assets/99e5f968-ea00-436f-8334-323a29daa46f)
Would be funny if psionic mutation counted as very bad mutations for instability purposes 