### PR TITLE
Restore functionality of make etags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1330,7 +1330,7 @@ ctags: $(ASTYLE_SOURCES)
 
 etags: $(ASTYLE_SOURCES)
 	etags $^
-	./tools/json_tools/cddatags.py
+	find data -name "*.json" -print0 | xargs -0 -L 50 etags --append
 
 ifneq ($(IS_WINDOWS_HOST),1)
 # Parallel astyle for posix hosts where fork and filesystem are cheap.


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
The TAGS file produced by 'make etags' has been broken since #37954 because the script invoked edits the tags file not the TAGS file. It also produces text in the wrong format for an etags file.

#### Describe the solution
Restore the previous snippet that appends the names of all the json files to the TAGS file to make etags capable of enumerating the files.

#### Describe alternatives you've considered
A more capable implementation that allows indexing json file contents would be nice, but this gets it back to working.

#### Testing
Successfully ran a big find replace regex across all the json.