### PR TITLE
Make overheating of mech lasers negligible unless "salvaged"

### DIFF
--- a/data/json/items/gun/ups.json
+++ b/data/json/items/gun/ups.json
@@ -47,7 +47,7 @@
     "type": "GUN",
     "reload_noise_volume": 20,
     "name": { "str": "CMES laser cannon" },
-    "description": "The integral weapon system for the CMES exoskeleton mech-suit, a rotating-barrel actively-cooled rapid-fire laser system.",
+    "description": "The integral weapon system for the CMES exoskeleton mech-suit, a rotating-barrel rapid-fire laser system.  Advanced heat management systems in its parent mech-suit negate virtually all overheating issues, allowing for sustained fire.",
     "weight": "39500 g",
     "volume": "11 L",
     "price": "95 kUSD",
@@ -69,8 +69,8 @@
     "ammo_effects": [ "LASER", "PLASMA_BUBBLE", "IGNITE" ],
     "flags": [ "NO_UNLOAD", "NEVER_JAMS", "NO_UNWIELD", "NO_SALVAGE", "NO_REPAIR", "UNBREAKABLE_MELEE", "NON_FOULING", "USE_UPS" ],
     "overheat_threshold": 200,
-    "cooling_value": 2,
-    "heat_per_shot": 6,
+    "heat_per_shot": 3,
+    "cooling_value": 50,
     "faults": [ "fault_overheat_melting", "fault_overheat_safety" ],
     "melee_damage": { "bash": 8 }
   },
@@ -79,7 +79,7 @@
     "type": "GUN",
     "reload_noise_volume": 2,
     "name": { "str": "RMES marksman system" },
-    "description": "The integral weapon system for the RMES exoskeleton mech-suit, a quiet and accurate marksman laser rifle.",
+    "description": "The integral weapon system for the RMES exoskeleton mech-suit, a quiet and accurate marksman laser rifle.  Advanced heat management systems in its parent mech-suit negate virtually all overheating issues, allowing for sustained fire.",
     "weight": "12500 g",
     "volume": "5500 ml",
     "price": "95 kUSD",
@@ -109,8 +109,8 @@
       "USE_UPS"
     ],
     "overheat_threshold": 100,
-    "cooling_value": 2,
-    "heat_per_shot": 17,
+    "heat_per_shot": 10,
+    "cooling_value": 50,
     "faults": [ "fault_overheat_melting", "fault_overheat_safety" ],
     "melee_damage": { "bash": 6 }
   },
@@ -219,9 +219,12 @@
     "looks_like": "m134",
     "type": "GUN",
     "name": { "str": "salvaged CMES laser cannon" },
-    "description": "This gatling-laser has been stripped from its CMES mech-suit and is far too heavy to use on its own.  You will need to deploy it or mount it to a vehicle, but it could be devastating if you have deep battery reserves.",
+    "description": "This gatling-laser has been stripped from its CMES mech-suit and is far too heavy to use on its own.  You will need to deploy it or mount it to a vehicle, but it could be devastating if you have deep battery reserves.  Without access to the heat management systems of the mech-suit it came from, it is dangerous to put it under too much stress.",
     "valid_mod_locations": [ [ "emitter", 1 ], [ "lens", 1 ], [ "sling", 1 ] ],
     "extend": { "flags": [ "MOUNTED_GUN" ] },
+    "heat_per_shot": 6,
+    "durability": 7,
+    "cooling_value": 2,
     "delete": { "flags": [ "UNBREAKABLE_MELEE", "NO_REPAIR", "NO_SALVAGE", "NO_UNWIELD" ] }
   },
   {
@@ -230,8 +233,11 @@
     "looks_like": "m107a1",
     "type": "GUN",
     "name": { "str": "salvaged RMES marksman laser" },
-    "description": "Formerly belonging to an RMES mech-suit, this powerful long-range laser rifle was never designed for human hands.  You might be able to make it work if you deployed it or mounted it to a vehicle, though, and its long range and potency could be pretty handy if you can keep it powered.",
+    "description": "Formerly belonging to an RMES mech-suit, this powerful long-range laser rifle was never designed for human hands.  You will need to deploy it or mount it to a vehicle, but its long range and potency could be pretty handy if you can keep it powered.  Without access to the heat management systems of the mech-suit it came from, it is dangerous to put it under too much stress.",
     "valid_mod_locations": [ [ "emitter", 1 ], [ "lens", 1 ], [ "sling", 1 ] ],
+    "heat_per_shot": 17,
+    "durability": 7,
+    "cooling_value": 2,
     "extend": { "flags": [ "MOUNTED_GUN" ] },
     "delete": { "flags": [ "UNBREAKABLE_MELEE", "NO_REPAIR", "NO_SALVAGE", "NO_UNWIELD" ] }
   }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "mech-lasers that are still part of the suit virtually never overheat; if salvaged overheating becomes a severe issue"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #74818
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
The idea is that since a mechsuit is a big, heavy, inconvenient and power hungry war machine, it has some kind of sophisticated cooling system to mostly prevent its laser weapon from overheating. This is a "lore reason" to sidestep the aforementioned exploit. Dramatically lowered the weapon heat gain and dramatically raised the weapon cooling amount. You should basically never see them overheat.
If you "salvage" the lasers (take them from the "corpse" of the mech via disassembly) the version you get is far more prone to overheating, because it no longer has access to the (extremely heavy) components which inextricably link it to the mech it came from. As a result I also lowered the durability from 8 to 7, so it can experience catastrophic failures (it was never designed to be used this way, suffice to say the warranty is probably void) rather than simply shutting down for a bit to cycle heat.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Remove heatgain entirely from the mounted (nonsalvaged) versions. I like that it's still "there" but the numbers are such that it can be ignored, it's a fun little bit of trivia for code diving that it actually does still overheat, just not by much.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
