### PR TITLE
Enabled towing over ramps

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -6732,12 +6732,6 @@ void vehicle::do_towing_move()
         debugmsg( "tried to do towing move but towed vehicle has no towing part" );
         invalidate = true;
     }
-    if( towed_veh->global_pos3().z != global_pos3().z ) {
-        // how the hellicopter did this happen?
-        // yes, this can happen when towing over a bridge (see #47293)
-        invalidate = true;
-        add_msg( m_info, _( "A towing cable snaps off of %s." ), towed_veh->disp_name() );
-    }
     if( invalidate ) {
         invalidate_towing( true );
         return;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #75086, i.e. inability to tow vehicles over bridges.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Simply remove the block of code that detaches the tow cable when an elevation difference is detected.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
- Spawn two vehicles near a bridge.
- Hook them up with a tow cable.
- Drive the towing vehicle over the bridge.
- Verify the towed vehicle was towed both up the ramp to the bridge and down the ramp off it.

- Teleport onto the roof of a farm supply building.
- Smash the railing on one side.
- Dismantle various stuff on the roof that was in the way.
- Debug spawn two beetles, one in front of the other, and hook them up with a tow cable.
- Accelerate the towing vehicle and try to jump out of it while in motion.
- Fail to jump out before it runs off the edge of the roof.
- See the character run/roll/whatever in the forward direction from the crashed vehicle's wreck, but somehow survive.
- Teleport onto the roof.
- See the towed vehicle stand still quite some distance from the edge of the roof.
- Consider that an acceptable result. A (game) crash would not have been acceptable, while the towed vehicle following the tower over the edge would have been preferred.

- Debug spawned a beetle beside a bridge and another on it.
- Drove them into position so one was behind the other, with the tower on the bridge and the towee on the ground level.
- Hooked up a tow cable between them
- Towed up the ramp onto the bridge.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
The comment in the removed section of code indicates the author didn't think the code would actually be reached, and so would really be a fallback for "impossible" cases. @BrettDong amended the comment with a clarification that bridges (which I think were fairly recently converted from flat to having ramps by that time) would indeed be a legal case (the comment was made in conjunction with a bug fix for a crash relating to the cable snapping off from the "wrong" vehicle and the code crashing because that case wasn't handled).

In theory you'd now also be able to tow vehicles up from underground garages. I say "in theory" because I suspect there isn't enough room to align vehicles so they'd actually move up the ramp (vehicles needing to be towed typically can't be driven into a suitable position even if there is room behind the ramp).

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
