### PR TITLE
Removes Mortar Recipe's cement recipe book requirement

### DIFF
--- a/data/json/itemgroups/supplies.json
+++ b/data/json/itemgroups/supplies.json
@@ -103,13 +103,13 @@
   {
     "id": "cement_bag",
     "type": "item_group",
-    "container-item": "bag_durasack",
+    "container-item": "bag_durasack_cement",
     "items": [ { "item": "material_cement", "count": 2800 } ]
   },
   {
     "id": "cement_bag_part",
     "type": "item_group",
-    "container-item": "bag_durasack",
+    "container-item": "bag_durasack_cement",
     "items": [ { "item": "material_cement", "count": [ 400, 2800 ] } ]
   },
   {

--- a/data/json/items/containers/containers.json
+++ b/data/json/items/containers/containers.json
@@ -149,7 +149,6 @@
   {
     "id": "bag_durasack_cement",
     "type": "GENERIC",
-    "category": "container",
     "name": { "str": "durable plastic sack, cement" },
     "looks_like": "bag_plastic",
     "description": "A large and sturdy sack, made out plastic material.  Stores cement and has instructions on how to use it to make mortar.",

--- a/data/json/items/containers/containers.json
+++ b/data/json/items/containers/containers.json
@@ -165,9 +165,7 @@
     "type": "effect_on_condition",
     "id": "EOC_CEMENT_INSTRUCTIONS",
     "condition": { "and": [ { "u_has_trait": "ILLITERATE" }, { "not": "u_driving" } ] },
-    "effect": [
-      { "u_learn_recipe": "mortar_build" }
-    ]
+    "effect": [ { "u_learn_recipe": "mortar_build" } ]
   },
   {
     "id": "bag_canvas",

--- a/data/json/items/containers/containers.json
+++ b/data/json/items/containers/containers.json
@@ -147,6 +147,29 @@
     "flags": [ "COLLAPSE_CONTENTS" ]
   },
   {
+    "id": "bag_durasack_cement",
+    "type": "GENERIC",
+    "category": "container",
+    "name": { "str": "durable plastic sack, cement" },
+    "looks_like": "bag_plastic",
+    "description": "A large and sturdy sack, made out plastic material.  Stores cement and has instructions on how to use it to make mortar.",
+    "//": "durasack woven polypropylene bags",
+    "copy-from": "bag_durasack",
+    "use_action": {
+      "type": "effect_on_conditions",
+      "description": "Instructions on what to do with the contents of the bag.",
+      "effect_on_conditions": [ "EOC_CEMENT_INSTRUCTIONS" ]
+    }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CEMENT_INSTRUCTIONS",
+    "condition": { "and": [ { "u_has_trait": "ILLITERATE" }, { "not": "u_driving" } ] },
+    "effect": [
+      { "u_learn_recipe": "mortar_build" }
+    ]
+  },
+  {
     "id": "bag_canvas",
     "type": "GENERIC",
     "category": "container",

--- a/data/json/recipes/other/parts_construction.json
+++ b/data/json/recipes/other/parts_construction.json
@@ -664,8 +664,7 @@
     "skill_used": "fabrication",
     "difficulty": 2,
     "time": "10 m",
-    "autolearn": false,
-    "book_learn": [ [ "concrete_book", 2 ] ],
+    "autolearn": true,
     "tools": [ [ [ "concrete_mix_tool", 50 ] ] ],
     "components": [ [ [ "material_cement", 50 ] ], [ [ "material_sand", 150 ] ] ]
   },

--- a/data/json/recipes/other/parts_construction.json
+++ b/data/json/recipes/other/parts_construction.json
@@ -664,7 +664,8 @@
     "skill_used": "fabrication",
     "difficulty": 2,
     "time": "10 m",
-    "autolearn": true,
+    "autolearn": false,
+    "book_learn": [ [ "concrete_book", 2 ] ],
     "tools": [ [ [ "concrete_mix_tool", 50 ] ] ],
     "components": [ [ [ "material_cement", 50 ] ], [ [ "material_sand", 150 ] ] ]
   },


### PR DESCRIPTION
#### Summary

Balance "Mortar is now an autolearned recipe"

#### Purpose of change

Fixes #74015.

#### Describe the solution

Makes Mortar into an autolearned recipe, and removes book requirement. 

#### Describe alternatives you've considered

As many commenters in #74015 agree, simply making this into an autolearned recipe is a little pathetic. I'd love to revisit this once I have more experience

#### Testing

Linting produced no errors I can tell. I can't test through Docker currently; testing welcome!!!

#### Additional context

This is my first PR! Feedback appreciated


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
