### PR TITLE
A shadow? quickfix

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -4740,10 +4740,6 @@
           { "value": "ARMOR_BASH", "add": 15 },
           { "value": "ARMOR_STAB", "add": 15 },
           { "value": "ARMOR_CUT", "add": 15 },
-          { "value": "ARMOR_HEAT", "add": 15 },
-          { "value": "ARMOR_COLD", "add": 15 },
-          { "value": "ARMOR_ELEC", "add": 15 },
-          { "value": "ARMOR_ACID", "add": 15 },
           { "value": "ARMOR_BULLET", "add": 50 }
         ]
       }

--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -4725,19 +4725,18 @@
   {
     "id": "photophobia",
     "type": "effect_type",
+    "//": "max_duration doesn't seem to work here, the effect stays forever",
     "max_duration": "5 s",
     "name": [ "photophobia" ],
-    "base_mods": { "speed_mod": [ -100 ] },
     "desc": [ "It burns!  Thankfully, this can't ever happen to you.  This is a bug if you have it." ],
     "rating": "bad",
     "show_intensity": false,
     "show_in_info": true,
-    "//": "Enchantments don't actually work for monsters! If you find that shadow is suddenly very killable, they probably got hooked up!",
     "enchantments": [
       {
         "condition": "ALWAYS",
         "values": [
-          { "value": "SPEED", "multiply": 0.5 },
+          { "value": "SPEED", "multiply": -0.5 },
           { "value": "ARMOR_BASH", "add": 15 },
           { "value": "ARMOR_STAB", "add": 15 },
           { "value": "ARMOR_CUT", "add": 15 },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Fix Shadow lieutenant speed when exposed to light"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Shadow had the speed of light
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
A quickfix. To make him not as quick
Add missing "-"
Partially fix #75279
Remove extra elemental weakness, some time ago shadow had extra elemental resistances that later got removed, presumably he was intended to loose these resistances when iluminated. I believe he was never intended to be THIS vulnerable to acid pools, electricity arcs and weak, rapid fire lasers
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Fight shadow in darkness instead. But you dont fight deamons in hell, You dont fight a priest in church. You get the idea.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Standard speed 200, 100 when iluminated. Was 300 when iluminated before.
Because echantements now seem to work on monsters, this boss is probably a lot weaker than what people are used to.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
THIS DOES NOT FIX THE ISSUE OF PHOTOPHOBIA EFFECT STAYING FOREVER ON ONCE ILLUMINATED SHADOW. Its not a big deal if you fight it with heavy duty flashlight. If you catch it with light, you probably have him photophobed for whole fight, without need to turn it off. But if for example you have only weak light source, but you suspect where this thing might be, and throw the light source at him, then he stays photophobed even after he escapes from the light.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
