### PR TITLE
Ruin propane supply

### DIFF
--- a/data/json/itemgroups/SUS/domestic.json
+++ b/data/json/itemgroups/SUS/domestic.json
@@ -535,12 +535,10 @@
       { "collection": [ { "item": "charcoal", "prob": 70 }, { "item": "char_smoker", "prob": 100 } ], "prob": 5 },
       {
         "collection": [
-          { "item": "small_propane_tank", "prob": 70, "count": [ 1, 3 ], "charges": [ 1000, 3000 ] },
-          { "item": "medium_propane_tank", "prob": 85, "count": [ 1, 2 ], "charges": [ 2000, 15000 ] },
-          { "item": "large_propane_tank", "prob": 25, "charges": [ 2000, 60000 ] },
+          { "item": "small_propane_tank", "prob": 70, "count": [ 1, 2 ], "charges": [ 1000, 3000 ] },
           { "item": "propane_cooker", "prob": 80 }
         ],
-        "prob": 12
+        "prob": 1
       },
       { "item": "can_sealer", "prob": 2 },
       { "item": "oil_press_manual", "prob": 2 },
@@ -688,7 +686,6 @@
     "type": "item_group",
     "//": "SUS item groups are collections that contain a reasonable realistic distribution of items that might spawn in a given storage furniture.",
     "//2": "This group is for an oven that might have some pots and pans in the warming drawer.",
-    "//3": "added propane spawns here, even if it's not technically a gas oven, it *does* have a pilot light in it.",
     "subtype": "collection",
     "entries": [
       {
@@ -739,13 +736,6 @@
           { "item": "dutch_oven", "prob": 5 }
         ],
         "prob": 50
-      },
-      {
-        "distribution": [
-          { "item": "medium_propane_tank", "prob": 40, "count": [ 1, 2 ], "charges": [ 2000, 15000 ] },
-          { "item": "large_propane_tank", "prob": 60, "charges": [ 2000, 60000 ] }
-        ],
-        "prob": 15
       }
     ]
   },

--- a/data/json/itemgroups/SUS/garage.json
+++ b/data/json/itemgroups/SUS/garage.json
@@ -23,23 +23,7 @@
             ],
             "prob": 25
           },
-          { "item": "welder" },
-          {
-            "collection": [
-              { "item": "propane_torch" },
-              { "item": "medium_propane_tank", "count": [ 0, 1 ], "prob": 95, "charges": [ 0, 15000 ] },
-              { "item": "small_propane_tank", "count": [ 1, 2 ], "prob": 95, "charges": [ 0, 3000 ] },
-              { "item": "medium_propane_tank", "count": [ 0, 1 ], "prob": 95, "charges": 15000 },
-              { "item": "small_propane_tank", "count": [ 1, 2 ], "prob": 95, "charges": 3000 },
-              {
-                "distribution": [
-                  { "item": "brazing_rod_bronze", "prob": 100, "charges": [ 1000, 2000 ] },
-                  { "item": "brazing_rod_alloy", "prob": 70, "charges": [ 500, 1500 ] }
-                ]
-              }
-            ],
-            "prob": 15
-          }
+          { "item": "welder" }
         ]
       },
       { "distribution": [ { "item": "welding_mask", "prob": 70 }, { "item": "goggles_welding", "prob": 70 } ] },


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Propane tanks appearing inside electric ovens came up in discussion.
I tracked it down to an addition that was trying to provide better propane supply (laudible) but used tome rather questionable rationales...

#### Describe the solution
Reign in the propane tank spawns.
This removes them entirely from ovens and welding gear set pieces, and reduces the camping stove that spawns in kitchen cupboards to spawning with small tanks.

#### Describe alternatives you've considered
If you're going to add propane tank spawns to domestic item groups, put a propane grill on porches and decks attached to houses, that's super common in the US.