### PR TITLE
Change time and skill penalty of Q&T, romove word "repatedly"

### DIFF
--- a/data/json/proficiencies/metalwork.json
+++ b/data/json/proficiencies/metalwork.json
@@ -133,10 +133,10 @@
     "id": "prof_quenching",
     "category": "prof_smithing",
     "name": { "str": "Quenching & Tempering" },
-    "description": "Quenching involves repeatedly heating the steel, quenching it in water, then tempering it to create extremely tough metal.",
+    "description": "Quenching involves heating the steel, quenching it in water, then tempering it to create extremely tough metal.",
     "can_learn": true,
-    "default_time_multiplier": 3,
-    "default_skill_penalty": 0.25,
+    "default_time_multiplier": 1.5,
+    "default_skill_penalty": 1,
     "time_to_learn": "20 h"
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Small changes to Quenching and tempering proficiency"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I worked five years as bladesmith. When my characters reach the moment of blacksmithing, I tend to notice details and differences between game and real life. Quenching is the most critical moment in making a high quality blade or armor. Its one of the last steps, and any mistake can lead to catastrophic faliure. If youre not experienced at this, you are not doing this longer than a mastersmith would do it, but chance of faliure is much, MUCH higher. Baisicaly, there are three outcomes:
1. Everything went fine
2. Hardening effect of quench didnt occur or you got a small bending that can be fixed (minor faliure)
3. Blade cracked/melted/bended beyond repair/carbon in steel burned (cathastophic faliure)

There is no situation where "everything went fine but you did it 3x times slower cuz youre new"
There is one situation where "you did your job slower because you had to repeat some steps", and that comes from mistakes caused by high skill requirements.

About tempering, you can temper it too little and it breaks in first use, or temper it too much, and loose all hardening effect. These all are effects of what game calls "faliures"
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Change default time penalty for missing Q&T proficiency from x3 to x1,5.
Change skill penalty form 0,25 to 1. 
Remove word "repeatedly" from descrieption. Idealy, you Q&T only once.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Make skill penalty even higher, like 2 or 2,5. But none other proficiences have it this high.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
For high skill and int character that had all other proficiences minor faliure chance went from about 2,5% to 7,5%. when trying to make tempered steel armor. For lower skilled character that was mising some more proficiences it went from 20% m.f.c. to 70%. I was hoping for some higher increase in cathastophic faliure chance, but oh well, i guess thats how the system works.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
To achieve perfect quench you need to have good, uniform steel and know its properties, be able to heat it up to right temperature at right peace and keep it for specific time depending on material and thickness of quenchaed item. Temperature needs to be even, and its best done in protective, non-oxygen atmosphere, best done in special furnance that is made just for heating for quenching, that can hold the whole object (they get big when you heat a big blade or curiass). Best furnances for this purpose are electric or gass powered. Then you do the quench in water or oil or salted water or moving air, depending on the material. In case of water,oil etc. it should be heated up. to specific temperature too, usually arround 60 deg. C

Did I mention that big, long blades should to be quenched vertically, because they can bend under their own mass if they were held horizontaly when red hot? You could try to support it with some wire etc., but if on double edged blade one edge is quenched earlier than the other, this can cause bend and make one edge harder than other
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
