### PR TITLE
Energy density for batteries

### DIFF
--- a/data/json/items/battery.json
+++ b/data/json/items/battery.json
@@ -14,10 +14,10 @@
     "symbol": "=",
     "color": "yellow",
     "ammo_type": [ "battery" ],
-    "capacity": 50,
+    "capacity": 3,
     "looks_like": "battery",
     "flags": [ "NO_SALVAGE", "NO_UNLOAD", "NO_RELOAD", "RECHARGE", "BATTERY_ULTRA_LIGHT" ],
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 50 } } ]
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 3 } } ]
   },
   {
     "id": "light_minus_atomic_battery_cell",
@@ -26,7 +26,7 @@
     "name": { "str": "ultra-light plutonium fuel battery", "str_pl": "ultra-light plutonium fuel batteries" },
     "description": "A battery that uses a thin plutonium-244 rod to stabilize an exotic nanocompound, designed for small size over everything else.",
     "ascii_picture": "light_minus_atomic_battery_cell",
-    "weight": "80 g",
+    "weight": "5 g",
     "volume": "1 ml",
     "price": "150 USD",
     "price_postapoc": "2 USD",
@@ -34,11 +34,11 @@
     "symbol": "=",
     "color": "green",
     "ammo_type": [ "battery" ],
-    "count": 500,
-    "capacity": 500,
+    "count": 5,
+    "capacity": 5,
     "looks_like": "battery",
     "flags": [ "NO_SALVAGE", "NO_UNLOAD", "NO_RELOAD", "LEAK_DAM", "RADIOACTIVE", "BATTERY_ULTRA_LIGHT" ],
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 500 } } ]
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 5 } } ]
   },
   {
     "id": "light_minus_disposable_cell",
@@ -47,7 +47,7 @@
     "name": { "str": "ultra-light disposable battery", "str_pl": "ultra-light disposable batteries" },
     "description": "A light battery cell designed for small size over everything else.  It retains its universal compatibility, though.  The battery's chemistry means that it has a very high capacity, but cannot be recharged.",
     "ascii_picture": "light_minus_disposable_cell",
-    "weight": "5 g",
+    "weight": "3 g",
     "volume": "1 ml",
     "price": "30 USD",
     "price_postapoc": "1 USD",
@@ -55,11 +55,11 @@
     "symbol": "=",
     "color": "yellow",
     "ammo_type": [ "battery" ],
-    "count": 100,
-    "capacity": 100,
+    "count": 2,
+    "capacity": 2,
     "looks_like": "battery",
     "flags": [ "NO_SALVAGE", "NO_UNLOAD", "NO_RELOAD", "BATTERY_ULTRA_LIGHT" ],
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 100 } } ]
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 2 } } ]
   },
   {
     "id": "light_battery_cell",
@@ -76,10 +76,10 @@
     "symbol": "=",
     "color": "yellow",
     "ammo_type": [ "battery" ],
-    "capacity": 100,
+    "capacity": 22,
     "looks_like": "battery",
     "flags": [ "NO_SALVAGE", "NO_UNLOAD", "NO_RELOAD", "RECHARGE", "BATTERY_LIGHT" ],
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 100 } } ]
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 22 } } ]
   },
   {
     "id": "light_plus_battery_cell",
@@ -96,10 +96,10 @@
     "symbol": "=",
     "color": "yellow",
     "ammo_type": [ "battery" ],
-    "capacity": 150,
+    "capacity": 33,
     "looks_like": "battery",
     "flags": [ "NO_SALVAGE", "NO_UNLOAD", "NO_RELOAD", "RECHARGE", "BATTERY_LIGHT" ],
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 150 } } ]
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 33 } } ]
   },
   {
     "id": "light_atomic_battery_cell",
@@ -116,11 +116,11 @@
     "symbol": "=",
     "color": "green",
     "ammo_type": [ "battery" ],
-    "count": 1000,
-    "capacity": 1000,
+    "count": 175,
+    "capacity": 175,
     "looks_like": "battery",
     "flags": [ "NO_SALVAGE", "NO_UNLOAD", "NO_RELOAD", "LEAK_DAM", "RADIOACTIVE", "BATTERY_LIGHT" ],
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 1000 } } ]
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 175 } } ]
   },
   {
     "id": "light_disposable_cell",
@@ -137,11 +137,11 @@
     "symbol": "=",
     "color": "yellow",
     "ammo_type": [ "battery" ],
-    "count": 300,
-    "capacity": 300,
+    "count": 45,
+    "capacity": 45,
     "looks_like": "battery",
     "flags": [ "NO_SALVAGE", "NO_UNLOAD", "NO_RELOAD", "BATTERY_LIGHT" ],
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 300 } } ]
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 45 } } ]
   },
   {
     "id": "light_dry_cell",
@@ -150,18 +150,18 @@
     "name": { "str": "light dry battery", "str_pl": "light dry batteries" },
     "description": "A light battery cell, universally compatible with all kinds of small devices.  The battery's chemistry doesn't provide high energy capacity, and it cannot be recharged.",
     "ascii_picture": "light_dry_cell",
-    "weight": "20 g",
+    "weight": "40 g",
     "volume": "35 ml",
     "price_postapoc": "1 USD",
     "material": [ "iron", "charcoal" ],
     "symbol": "=",
     "color": "yellow",
     "ammo_type": [ "battery" ],
-    "count": 100,
-    "capacity": 100,
+    "count": 5,
+    "capacity": 5,
     "looks_like": "battery",
     "flags": [ "NO_SALVAGE", "NO_UNLOAD", "NO_RELOAD", "BATTERY_LIGHT" ],
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 100 } } ]
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 5 } } ]
   },
   {
     "id": "medium_battery_cell",
@@ -178,10 +178,10 @@
     "symbol": "=",
     "color": "yellow",
     "ammo_type": [ "battery" ],
-    "capacity": 500,
+    "capacity": 444,
     "looks_like": "battery",
     "flags": [ "NO_SALVAGE", "NO_UNLOAD", "NO_RELOAD", "RECHARGE", "BATTERY_MEDIUM" ],
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 500 } } ]
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 444 } } ]
   },
   {
     "id": "medium_plus_battery_cell",
@@ -198,10 +198,10 @@
     "symbol": "=",
     "color": "yellow",
     "ammo_type": [ "battery" ],
-    "capacity": 600,
+    "capacity": 536,
     "looks_like": "battery",
     "flags": [ "NO_SALVAGE", "NO_UNLOAD", "NO_RELOAD", "RECHARGE", "BATTERY_MEDIUM" ],
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 600 } } ]
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 536 } } ]
   },
   {
     "id": "medium_atomic_battery_cell",
@@ -218,11 +218,11 @@
     "symbol": "=",
     "color": "green",
     "ammo_type": [ "battery" ],
-    "count": 5000,
-    "capacity": 5000,
+    "count": 2625,
+    "capacity": 2625,
     "looks_like": "battery",
     "flags": [ "NO_SALVAGE", "NO_UNLOAD", "NO_RELOAD", "LEAK_DAM", "RADIOACTIVE", "BATTERY_MEDIUM" ],
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 5000 } } ]
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 2625 } } ]
   },
   {
     "id": "medium_disposable_cell",
@@ -239,11 +239,11 @@
     "symbol": "=",
     "color": "yellow",
     "ammo_type": [ "battery" ],
-    "count": 1200,
-    "capacity": 1200,
+    "count": 732,
+    "capacity": 732,
     "looks_like": "battery",
     "flags": [ "NO_SALVAGE", "NO_UNLOAD", "NO_RELOAD", "BATTERY_MEDIUM" ],
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 1200 } } ]
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 732 } } ]
   },
   {
     "id": "medium_dry_cell",
@@ -259,11 +259,11 @@
     "symbol": "=",
     "color": "yellow",
     "ammo_type": [ "battery" ],
-    "count": 500,
-    "capacity": 500,
+    "count": 45,
+    "capacity": 45,
     "looks_like": "battery",
     "flags": [ "NO_SALVAGE", "NO_UNLOAD", "NO_RELOAD", "BATTERY_MEDIUM" ],
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 500 } } ]
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 45 } } ]
   },
   {
     "id": "heavy_battery_cell",
@@ -280,10 +280,10 @@
     "symbol": "=",
     "color": "yellow",
     "ammo_type": [ "battery" ],
-    "capacity": 1000,
+    "capacity": 740,
     "looks_like": "battery",
     "flags": [ "NO_SALVAGE", "NO_UNLOAD", "NO_RELOAD", "RECHARGE", "BATTERY_HEAVY" ],
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 1000 } } ]
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 740 } } ]
   },
   {
     "id": "heavy_plus_battery_cell",
@@ -300,10 +300,10 @@
     "symbol": "=",
     "color": "yellow",
     "ammo_type": [ "battery" ],
-    "capacity": 1250,
+    "capacity": 925,
     "looks_like": "battery",
     "flags": [ "NO_SALVAGE", "NO_UNLOAD", "NO_RELOAD", "RECHARGE", "BATTERY_HEAVY" ],
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 1250 } } ]
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 925 } } ]
   },
   {
     "id": "heavy_atomic_battery_cell",
@@ -320,11 +320,11 @@
     "symbol": "=",
     "color": "green",
     "ammo_type": [ "battery" ],
-    "count": 10000,
-    "capacity": 10000,
+    "count": 4800,
+    "capacity": 4800,
     "looks_like": "battery",
     "flags": [ "NO_SALVAGE", "NO_UNLOAD", "NO_RELOAD", "LEAK_DAM", "RADIOACTIVE", "BATTERY_HEAVY" ],
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 10000 } } ]
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 4800 } } ]
   },
   {
     "id": "huge_atomic_battery_cell",
@@ -361,11 +361,11 @@
     "symbol": "=",
     "color": "yellow",
     "ammo_type": [ "battery" ],
-    "count": 2500,
-    "capacity": 2500,
+    "count": 1262,
+    "capacity": 1262,
     "looks_like": "battery",
     "flags": [ "NO_SALVAGE", "NO_UNLOAD", "NO_RELOAD", "BATTERY_HEAVY" ],
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 2500 } } ]
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 1262 } } ]
   },
   {
     "id": "heavy_dry_cell",
@@ -381,10 +381,10 @@
     "symbol": "=",
     "color": "yellow",
     "ammo_type": [ "battery" ],
-    "count": 1000,
-    "capacity": 1000,
+    "count": 117,
+    "capacity": 117,
     "looks_like": "battery",
     "flags": [ "NO_SALVAGE", "NO_UNLOAD", "NO_RELOAD", "BATTERY_HEAVY" ],
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 1000 } } ]
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 117 } } ]
   }
 ]

--- a/data/mods/TEST_DATA/known_bad_density.json
+++ b/data/mods/TEST_DATA/known_bad_density.json
@@ -35,7 +35,6 @@
       "small_lcd_screen",
       "biscuit",
       "koji",
-      "light_minus_disposable_cell",
       "fire_piston",
       "broken_c4_hack",
       "oatmeal_deluxe",

--- a/tests/battery_density_test.cpp
+++ b/tests/battery_density_test.cpp
@@ -1,0 +1,132 @@
+#include "cata_catch.h"
+#include "item_factory.h"
+#include "itype.h"
+
+static const ammotype ammo_battery( "battery" );
+static const flag_id json_flag_DEBUG_ONLY( "DEBUG_ONLY" );
+
+struct battery_chemistry_family {
+    float max_energy_density_kj_kg;
+    float max_energy_density_kj_l;
+};
+
+// NOLINTBEGIN(cata-static-string_id-constants)
+static const std::map<itype_id, std::string> battery_to_chemistry = {
+    {itype_id( "light_minus_battery_cell" ), "LiON"},
+    {itype_id( "light_battery_cell" ), "LiON"},
+    {itype_id( "light_plus_battery_cell" ), "LiON"},
+    {itype_id( "medium_battery_cell" ), "LiON"},
+    {itype_id( "medium_plus_battery_cell" ), "LiON"},
+    {itype_id( "heavy_battery_cell" ), "LiON"},
+    {itype_id( "heavy_plus_battery_cell" ), "LiON"},
+    {itype_id( "folding_solar_panel_deployed" ), "LiON"},
+    {itype_id( "folding_solar_panel_v2_deployed" ), "LiON"},
+
+    {itype_id( "light_minus_atomic_battery_cell" ), "atomic"},
+    {itype_id( "light_atomic_battery_cell" ), "atomic"},
+    {itype_id( "medium_atomic_battery_cell" ), "atomic"},
+    {itype_id( "heavy_atomic_battery_cell" ), "atomic"},
+    {itype_id( "huge_atomic_battery_cell" ), "atomic"},
+
+    {itype_id( "light_minus_disposable_cell" ), "Lithium-Manganese"},
+    {itype_id( "light_disposable_cell" ), "Lithium-Manganese"},
+    {itype_id( "medium_disposable_cell" ), "Lithium-Manganese"},
+    {itype_id( "heavy_disposable_cell" ), "Lithium-Manganese"},
+
+    {itype_id( "light_dry_cell" ), "Zinc-Carbon"},
+    {itype_id( "medium_dry_cell" ), "Zinc-Carbon"},
+    {itype_id( "heavy_dry_cell" ), "Zinc-Carbon"},
+
+    {itype_id( "battery_car" ), "Lead-acid"},
+    {itype_id( "battery_motorbike" ), "Lead-acid"},
+    {itype_id( "battery_motorbike_small" ), "Lead-acid"},
+
+    // These are in a seperate group because the car batteries might
+    // end up being switched to something different.
+    {itype_id( "large_storage_battery" ), "LiON"},
+    {itype_id( "medium_storage_battery" ), "LiON"},
+    {itype_id( "small_storage_battery" ), "LiON"},
+    {itype_id( "storage_battery" ), "LiON"}
+};
+// NOLINTEND(cata-static-string_id-constants)
+
+
+// LiON or LiPO is tough to actually nail down because there are so many different chemistries and everything is flooded with marketing.
+// https://en.wikipedia.org/wiki/Energy_density_Extended_Reference_Table
+// At the end of the day I compared with several actual 18650 cells which ended up agreeing with the table at Energy_density_Extended_Reference_Table instead of some of the more extreme values I found elsewhere.
+// https://www.batteryjunction.com/batteries/li-ion-rechargeable/samsung-inr18650-25r
+
+// There is potential to add hyper-premium batteries for e.g. laptops and small high-powered electric devices based on these figures.
+// https://en.wikipedia.org/wiki/Lithium-ion_battery
+// Specific energy  100–265 W⋅h/kg (360–950 kJ/kg)
+// Energy density   250–693 W⋅h/L (900–2,490 J/cm3)
+
+// Atomic cell energy density is based on theoretical solid state battery density from
+// https://en.wikipedia.org/wiki/Solid-state_battery
+// i.e. "Thin film type: 300–900 Wh/kg (490–1,470 kJ/lb) Bulk type: 250–500 Wh/kg (410–820 kJ/lb)"
+
+// Lithium–Manganese, which I'm using for "consumer-grade disposable batteries" sourced from
+// https://en.wikipedia.org/wiki/Energy_density_Extended_Reference_Table
+
+// Zinc-manganese (alkaline), which I'm using for "consumer grade disposable battery" based on
+// https://en.wikipedia.org/wiki/Energy_density_Extended_Reference_Table
+
+// Zinc-Carbon, which I'm using for "player craftable disposable battery" based on
+// https://en.wikipedia.org/wiki/Energy_density_Extended_Reference_Table
+
+// Lead-acid specific Energy and specific density calculated from a typical exemplar at
+// https://www.amazon.com/ACDelco-48AGM-Professional-Automotive-Battery/dp/B008FWCLHU/
+// With primary statistics of:
+// dimensions: 7.5"D x 11.9"W x 7.6"H = Volume 11.1153455 liters
+// Weight: 45.5 pounds = 20.63845 kg
+// Capacity: 70 Amp-Hours x 12V = 3024 kJ
+// This also roughly agrees with https://en.wikipedia.org/wiki/Energy_density_Extended_Reference_Table
+static const std::map<std::string, battery_chemistry_family> chemistries = {
+    {std::string( "LiON" ), { 740.0, 3330.0 }},
+    {std::string( "atomic" ), { 3000.0, 5000.0 }},
+    {std::string( "Lithium-Manganese" ), { 1010.0, 2090.0}},
+    {std::string( "Alkaline" ), { 600.0, 1430.0}},
+    {std::string( "Zinc-Carbon" ), { 130.0, 331.0}},
+    {std::string( "Lead-acid" ), { 180, 360 }}
+};
+
+static bool is_battery( const itype &type )
+{
+    // We're only making assertions about the "dda" mod,
+    // ignore items from elsewhere, including the test mod.
+    if( type.has_flag( json_flag_DEBUG_ONLY ) ||
+        type.src.size() > 1 ||
+        type.src.back().second.str() != std::string( "dda" ) ) {
+        return false;
+    }
+    if( !!type.magazine && type.magazine->type.count( ammo_battery ) > 0 ) {
+        return true;
+    }
+    return false;
+}
+
+TEST_CASE( "battery_density_check" )
+{
+    for( const itype *id : item_controller->find( is_battery ) ) {
+        auto chemistry_name = battery_to_chemistry.find( id->get_id() );
+        battery_chemistry_family chemistry;
+        if( chemistry_name == battery_to_chemistry.end() ) {
+            WARN( "Didn't find a battery chemistry for " << id->get_id().str().c_str() <<
+                  ", assuming Alkaline." );
+            chemistry = chemistries.at( "Alkaline" );
+        } else {
+            chemistry = chemistries.at( chemistry_name->second );
+        }
+        float capacity_in_kj = id->magazine ? id->magazine->capacity : id->tool->max_charges;
+        float weight_in_kg = units::to_kilogram( id->weight );
+        float volume_in_L = units::to_liter( id->volume );
+        INFO( id->get_id().str().c_str() );
+        CAPTURE( capacity_in_kj );
+        CAPTURE( weight_in_kg );
+        CAPTURE( volume_in_L );
+        INFO( "Capacity should be: " << std::min( chemistry.max_energy_density_kj_kg * weight_in_kg,
+                chemistry.max_energy_density_kj_l * volume_in_L ) << " kJ" );
+        CHECK( capacity_in_kj / weight_in_kg <= chemistry.max_energy_density_kj_kg );
+        CHECK( capacity_in_kj / volume_in_L <= chemistry.max_energy_density_kj_l );
+    }
+}

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -905,7 +905,7 @@ TEST_CASE( "tools_use_charge_to_craft", "[crafting][charge]" )
                 CHECK( get_remaining_charges( "hotplate" ) == 0 );
                 CHECK( get_remaining_charges( "soldering_iron_portable" ) == 0 );
                 // vacuum molding takes 4 charges
-                CHECK( get_remaining_charges( "UPS_off" ) == 282 );
+                CHECK( get_remaining_charges( "UPS_off" ) == 207 );
             }
         }
 

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -506,7 +506,7 @@ TEST_CASE( "EOC_math_item", "[eoc][math_parser]" )
     REQUIRE( globvars.get_global_value( "npctalk_var_key_charge_count" ).empty() );
     CHECK( effect_on_condition_EOC_math_item_count->activate( d ) );
     CHECK( globvars.get_global_value( "npctalk_var_key_item_count" ) == "2" );
-    CHECK( globvars.get_global_value( "npctalk_var_key_charge_count" ) == "300" );
+    CHECK( globvars.get_global_value( "npctalk_var_key_charge_count" ) == "66" );
 }
 
 TEST_CASE( "EOC_math_proficiency", "[eoc][math_parser]" )

--- a/tests/vehicle_interact_test.cpp
+++ b/tests/vehicle_interact_test.cpp
@@ -114,7 +114,7 @@ TEST_CASE( "repair_vehicle_part", "[vehicle]" )
         tools.emplace_back( "hammer" );
         tools.insert( tools.end(), 5, item( "steel_chunk" ) );
         tools.insert( tools.end(), 50, item( "welding_wire_steel" ) );
-        test_repair( tools, false, true );
+        test_repair( tools, false, false );
     }
     SECTION( "welder_missing_goggles" ) {
         std::vector<item> tools;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fixes #75336
Vehicle batteries seem to be fine, but a lot of portable batteries were egregiously to energy dense.

#### Describe the solution
Added an energy density test that asserts energy and specific densities for batteries based on battery chemistry and fixed the outliers (as you can see a lot of them were waaaay off).
This excludes test and debug batteries, and batteries from mods other than dda.

#### Describe alternatives you've considered
LiON in particular is tricky, there is hypothetically some room in there for more rare/premium battery cells to be found somewhere, so that door is open, but I don't have any intention of adding it. FYI this is like a 15% extra bump to capacity, not something crazy.
I checked adding tools to this as well, but it turns out they were all passing anyway and once I pivoted to making different assertions about different battery types it would have required a huge list mapping tools to battery type, so no thanks.

#### Testing
Tests continue to pass.
As commented after I first posted this, some items might have issues with their largest loadable battery being too low capacity to operate them, I'll see what I can do about that, but it's possible some items will be squeezed out of existence since they only ever worked because our battery capacities were broken.

#### Additional Context
This broke sticking a UPS in a welder and using it to repair your vehicle, as the heavy plus battery a UPS defaults to no longer has 1000kJ of capacity.  This was a ridiculous and practically broken thing to do in the first place so that's fine.
We might want to follow up and remove the UPS-mod from the welder and actually turn it to a real ~~boy~~ welding cart instead of the weird gamey hand tool it's been since OG Cataclysm, but I don't want to scope creep this PR.
If you have a fully charged car battery you can use that to run a welder to do 10x repairs, that's a still kinda silly option but better than using portable tool power packs for it, which is pretty much what the heavy battery packs represent.

The power requirement for the gunsmith kit is kind of weird in the first place, if your gun is *damaged* you aren't soldering it back into pristine shape, ideally guns would get faults like having their sights misaligned or furniture broken, which would be more flexibly fixable, but on the other hand representing what happens to your gun when you're in melee is a pretty low priority.
Likewise if we're talking damage from firing, that should also be gun faults, and likewise fixable with repairing or replacing gun components, not waving a soldering iron over it and sacrificing some power and solder to the gun gods.

As for the power armor, use an atomic battery, they have significantly more capacity, that's the whole point of them.