### PR TITLE
better debugmsg of multiple attacks of the same type

### DIFF
--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -1497,10 +1497,8 @@ void mtype::add_special_attack( const JsonObject &obj, const std::string &src )
         if( iter != special_attacks_names.end() ) {
             special_attacks_names.erase( iter );
         }
-        if( test_mode ) {
-            debugmsg( "%s specifies more than one attack of (sub)type %s, ignoring all but the last",
-                      id.c_str(), new_attack->id.c_str() );
-        }
+        debugmsg( "%s specifies more than one attack of (sub)type %s, ignoring all but the last.  Add different `id`s to each attack of this type to prevent this.",
+                  id.c_str(), new_attack->id.c_str() );
     }
 
     special_attacks.emplace( new_attack->id, new_attack );


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
There are zero reasons the game should not mention that your multiple attacks of the same type are erased to one, especially when we show this information when running CI
#### Describe the solution
Remove `test_mode` check, explain how to resolve the error
#### Testing
CI