### PR TITLE
Avoid crash when no proficiencies in character menu

### DIFF
--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -1409,7 +1409,9 @@ static bool handle_player_display_action( Character &you, unsigned int &line,
             }
             case player_display_tab::proficiencies:
                 const std::vector<display_proficiency> profs = you.display_proficiencies();
-                show_proficiencies_window( you, profs[line].id );
+                if ( !profs.empty() ) {
+                    show_proficiencies_window( you, profs[line].id );
+                }
                 break;
         }
     } else if( action == "CHANGE_PROFESSION_NAME" ) {

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -1409,7 +1409,7 @@ static bool handle_player_display_action( Character &you, unsigned int &line,
             }
             case player_display_tab::proficiencies:
                 const std::vector<display_proficiency> profs = you.display_proficiencies();
-                if ( !profs.empty() ) {
+                if( !profs.empty() ) {
                     show_proficiencies_window( you, profs[line].id );
                 }
                 break;


### PR DESCRIPTION
#### Summary
Bugfixes "Avoid crash when the character has no proficiencies and we press enter on them inside Character menu "@"

#### Purpose of change

Yesterday I wanted to play a bit with a new random character. This character had no skills, and when I was looking inside the Character menu, I clicked enter and crashed the game.

#### Describe the solution

Minor change in the code to solve the problem

#### Testing

- Created a new character without proficiencies. Without crash in the character menu
- Add some proficiencies and click again. Works as expected

#### Additional context
![Crash](https://github.com/user-attachments/assets/22977478-6eda-43b2-9797-1d392d2fcd00)

https://github.com/user-attachments/assets/36f292c8-b8de-4754-9fdd-249c6fc09a66


