### PR TITLE
fix m4_cqbr spawning in the wild

### DIFF
--- a/data/json/items/gun/223.json
+++ b/data/json/items/gun/223.json
@@ -348,7 +348,7 @@
         "id": "m4_cqbr",
         "name": { "str": "Mk 18 CQBR carbine" },
         "description": "This is a shorter M4 carbine with a 10.3 inch barrel, intended for confined spaces and close quarters battle situations.",
-        "weight": 1
+        "weight": 0
       }
     ],
     "to_hit": -1,


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
fix #75372
#### Describe the solution
Because the bug happens when the game assing `Mk 18 CQBR` variant of `modular_m4_carbine` ignoring the gunmod installed on a gun, the solution is to remove ability for `Mk 18 CQBR` to spawn in the world, so it can be spawned only via `m4_cqbr` itemgroup
#### Describe alternatives you've considered
Conditional name and description depending on gunmod installed?