### PR TITLE
Optimize typed coordinate conversion functions for faster Windows unsafe_get_submap_at performance

### DIFF
--- a/src/cata_inline.h
+++ b/src/cata_inline.h
@@ -1,0 +1,13 @@
+#pragma once
+#ifndef CATA_SRC_CATA_INLINE_H
+#define CATA_SRC_CATA_INLINE_H
+
+#ifndef CATA_FORCEINLINE
+#ifdef _MSC_VER
+#define CATA_FORCEINLINE __forceinline
+#else
+#define CATA_FORCEINLINE inline __attribute__((always_inline))
+#endif
+#endif
+
+#endif // CATA_SRC_CATA_INLINE_H

--- a/src/coordinates.h
+++ b/src/coordinates.h
@@ -11,6 +11,7 @@
 #include <utility>
 #include <vector>
 
+#include "cata_inline.h"
 #include "coordinate_conversions.h"
 #include "coords_fwd.h"
 #include "cuboid_rectangle.h"
@@ -115,9 +116,10 @@ class coord_point_base
         Point raw_;
 };
 
-template<typename Point, typename Subpoint, bool InBounds>
+template<typename Point, typename Subpoint>
 class coord_point_mut : public coord_point_base<Point>
 {
+    protected:
         using base = coord_point_base<Point>;
 
     public:
@@ -164,318 +166,361 @@ class coord_point_mut : public coord_point_base<Point>
         }
 };
 
-template<typename Point, typename Subpoint>
-class coord_point_mut< Point, Subpoint, true> : public coord_point_base<Point>
+template<typename Point, origin Origin, scale Scale>
+class coord_point_ob : public
+    coord_point_mut<Point, coord_point_ob<point, Origin, Scale>>
 {
-        using base = coord_point_base<Point>;
+        using base = coord_point_mut<Point, coord_point_ob<point, Origin, Scale>>;
 
     public:
-        // Default constructed point is always inbounds.
-        constexpr coord_point_mut() = default;
-
-        // TODO: move the const accessors into base when cata-unsequenced-calls is fixed.
-        constexpr const Point &raw() const {
-            return this->raw_;
-        }
-
-        constexpr auto x() const {
-            return raw().x;
-        }
-        constexpr auto y() const {
-            return raw().y;
-        }
-        constexpr auto z() const {
-            return raw().z;
-        }
-
-    protected:
-        // Hide the constructors so they are not used by accident.
-        //
-        // Use make_unchecked instead.
-        explicit constexpr coord_point_mut( const Point &p ) : base( p ) {}
-        template <typename T>
-        constexpr coord_point_mut( const Subpoint &p, T z ) : base( p.raw(), z ) {}
-        template<typename T>
-        constexpr coord_point_mut( T x, T y ) : base( x, y ) {}
-        template<typename T>
-        constexpr coord_point_mut( T x, T y, T z ) : base( x, y, z ) {}
-};
-
-template<typename Point, origin Origin, scale Scale, bool InBounds>
-class coord_point : public
-    coord_point_mut<Point, coord_point<point, Origin, Scale, InBounds>, InBounds>
-{
-        using base = coord_point_mut<Point, coord_point<point, Origin, Scale, InBounds>, InBounds>;
         using base::base;
 
-    public:
         static constexpr int dimension = Point::dimension;
 
-        using this_as_tripoint_ob = coord_point<tripoint, Origin, Scale>;
-        using this_as_point = coord_point<point, Origin, Scale, InBounds>;
-        using this_as_ob = coord_point<Point, Origin, Scale>;
+        static constexpr bool is_inbounds = false;
+        using this_as_tripoint = coord_point_ob<tripoint, Origin, Scale>;
+        using this_as_point = coord_point_ob<point, Origin, Scale>;
+        using this_as_ob = coord_point_ob<Point, Origin, Scale>;
+        using this_as_tripoint_ob = coord_point_ob<tripoint, Origin, Scale>;
 
-        // Explicit functions to construct inbounds versions without doing any
-        // bounds checking. Only use these with a very good reason, when you
-        // are completely sure the result will be inbounds.
         template <typename T>
-        static constexpr coord_point make_unchecked( T x, T y ) {
-            return coord_point( x, y );
+        static constexpr coord_point_ob make_unchecked( T x, T y ) {
+            return coord_point_ob( x, y );
         }
         template <typename T>
-        static constexpr coord_point make_unchecked( T x, T y, T z ) {
-            return coord_point( x, y, z );
+        static constexpr coord_point_ob make_unchecked( T x, T y, T z ) {
+            return coord_point_ob( x, y, z );
         }
-        static constexpr coord_point make_unchecked( const this_as_ob &other ) {
-            return coord_point( other.raw() );
+        static constexpr coord_point_ob make_unchecked( const base &other ) {
+            return coord_point_ob( other );
         }
-        static constexpr coord_point make_unchecked( const Point &other ) {
-            return coord_point( other );
-        }
-        template <typename T>
-        static constexpr coord_point make_unchecked( const this_as_point &other, T z ) {
-            return coord_point( other, z );
+        static constexpr coord_point_ob make_unchecked( const Point &other ) {
+            return coord_point_ob( other );
         }
         template <typename T>
-        static constexpr coord_point make_unchecked( const point &other, T z ) {
-            return coord_point( other.x, other.y, z );
+        static constexpr coord_point_ob make_unchecked( const this_as_point &other, T z ) {
+            return coord_point_ob( other, z );
         }
-
-        // Allow implicit conversions from inbounds to out of bounds.
-        // NOLINTNEXTLINE(google-explicit-constructor)
-        operator this_as_ob() const {
-            return this_as_ob( this->raw() );
+        template <typename T>
+        static constexpr coord_point_ob make_unchecked( const point &other, T z ) {
+            return coord_point_ob( other.x, other.y, z );
         }
 
         constexpr auto xy() const {
-            return this_as_point::make_unchecked( this->raw().xy() );
+            return this_as_point( this->raw().xy() );
         }
 
-        friend inline this_as_ob operator+( const coord_point &l, const point &r ) {
+        friend inline this_as_ob operator+( const coord_point_ob &l, const point &r ) {
             return this_as_ob( l.raw() + r );
         }
 
-        friend inline this_as_tripoint_ob operator+( const coord_point &l, const tripoint &r ) {
+        friend inline this_as_tripoint_ob operator+( const coord_point_ob &l, const tripoint &r ) {
             return this_as_tripoint_ob( l.raw() + r );
         }
 
-        friend inline this_as_ob operator+( const point &l, const coord_point &r ) {
+        friend inline this_as_ob operator+( const point &l, const coord_point_ob &r ) {
             return this_as_ob( l + r.raw() );
         }
 
-        friend inline this_as_tripoint_ob operator+( const tripoint &l, const coord_point &r ) {
+        friend inline this_as_tripoint_ob operator+( const tripoint &l, const coord_point_ob &r ) {
             return this_as_tripoint_ob( l + r.raw() );
         }
 
-        friend inline this_as_ob operator-( const coord_point &l, const point &r ) {
+        friend inline this_as_ob operator-( const coord_point_ob &l, const point &r ) {
             return this_as_ob( l.raw() - r );
         }
 
-        friend inline this_as_tripoint_ob operator-( const coord_point &l, const tripoint &r ) {
+        friend inline this_as_tripoint_ob operator-( const coord_point_ob &l, const tripoint &r ) {
             return this_as_tripoint_ob( l.raw() - r );
         }
 };
 
 template<typename Point, origin Origin, scale Scale>
-constexpr inline coord_point<Point, Origin, Scale> &operator+=( coord_point<Point, Origin, Scale>
-        &me, const coord_point<Point, origin::relative, Scale> &r )
+class coord_point_ib : public coord_point_ob<Point, Origin, Scale>
+{
+        using base = coord_point_ob<Point, Origin, Scale>;
+        using base::base;
+
+    public:
+        static constexpr bool is_inbounds = true;
+        using this_as_tripoint = coord_point_ib<tripoint, Origin, Scale>;
+        using this_as_point = coord_point_ib<point, Origin, Scale>;
+        using this_as_tripoint_ob = coord_point_ob<tripoint, Origin, Scale>;
+        using this_as_ob = base;
+
+        // Explicit functions to construct inbounds versions without doing any
+        // bounds checking. Only use these with a very good reason, when you
+        // are completely sure the result will be inbounds.
+        template <typename T>
+        static constexpr coord_point_ib make_unchecked( T x, T y ) {
+            return coord_point_ib( x, y );
+        }
+        template <typename T>
+        static constexpr coord_point_ib make_unchecked( T x, T y, T z ) {
+            return coord_point_ib( x, y, z );
+        }
+        static constexpr coord_point_ib make_unchecked( const base &other ) {
+            return coord_point_ib( other );
+        }
+        static constexpr coord_point_ib make_unchecked( const Point &other ) {
+            return coord_point_ib( other );
+        }
+        template <typename T>
+        static constexpr coord_point_ib make_unchecked( const this_as_point &other, T z ) {
+            return coord_point_ib( other, z );
+        }
+        template <typename T>
+        static constexpr coord_point_ib make_unchecked( const point &other, T z ) {
+            return coord_point_ib( other.x, other.y, z );
+        }
+
+        // Allow implicit conversions from inbounds to out of bounds.
+        // NOLINTNEXTLINE(google-explicit-constructor)
+        operator const this_as_ob &() const {
+            return *this;
+        }
+
+        const this_as_ob &as_ob() const {
+            return *this;
+        }
+
+        constexpr auto xy() const {
+            return this_as_point::make_unchecked( this->raw().xy() );
+        }
+};
+
+template<typename Point, origin Origin, scale Scale>
+constexpr inline coord_point_ob<Point, Origin, Scale> &operator+=
+( coord_point_ob<Point, Origin, Scale>
+  &me, const coord_point_ob<Point, origin::relative, Scale> &r )
 {
     me.raw() += r.raw();
     return me;
 }
 
 template<typename Point, origin Origin, scale Scale>
-constexpr inline coord_point<Point, Origin, Scale> &operator-=( coord_point<Point, Origin, Scale>
-        &me, const coord_point<Point, origin::relative, Scale> &r )
+constexpr inline coord_point_ob<Point, Origin, Scale> &operator-=
+( coord_point_ob<Point, Origin, Scale>
+  &me, const coord_point_ob<Point, origin::relative, Scale> &r )
 {
     me.raw() -= r.raw();
     return me;
 }
 
 template<typename Point, origin Origin, scale Scale>
-constexpr inline coord_point<Point, Origin, Scale> &operator+=( coord_point<Point, Origin, Scale>
-        &me, const point &r )
+constexpr inline coord_point_ob<Point, Origin, Scale> &operator+=
+( coord_point_ob<Point, Origin, Scale>
+  &me, const point &r )
 {
     me.raw() += r;
     return me;
 }
 
 template<typename Point, origin Origin, scale Scale>
-constexpr inline coord_point<Point, Origin, Scale> &operator-=( coord_point<Point, Origin, Scale>
-        &me, const point &r )
+constexpr inline coord_point_ob<Point, Origin, Scale> &operator-=
+( coord_point_ob<Point, Origin, Scale>
+  &me, const point &r )
 {
     me.raw() -= r;
     return me;
 }
 
 template<typename Point, origin Origin, scale Scale>
-constexpr inline coord_point<Point, Origin, Scale> &operator+=( coord_point<Point, Origin, Scale>
-        &me, const tripoint &r )
+constexpr inline coord_point_ob<Point, Origin, Scale> &operator+=
+( coord_point_ob<Point, Origin, Scale>
+  &me, const tripoint &r )
 {
     me.raw() += r;
     return me;
 }
 
 template<typename Point, origin Origin, scale Scale>
-constexpr inline coord_point<Point, Origin, Scale> &operator-=( coord_point<Point, Origin, Scale>
-        &me, const tripoint &r )
+constexpr inline coord_point_ob<Point, Origin, Scale> &operator-=
+( coord_point_ob<Point, Origin, Scale>
+  &me, const tripoint &r )
 {
     me.raw() -= r;
     return me;
 }
 
-template<typename Point, origin Origin, scale Scale, bool LhsInBounds, bool RhsInBounds>
-constexpr inline bool operator==( const coord_point<Point, Origin, Scale, LhsInBounds> &l,
-                                  const coord_point<Point, Origin, Scale, RhsInBounds> &r )
+template<typename Point, origin Origin, scale Scale>
+constexpr inline bool operator==( const coord_point_ob<Point, Origin, Scale> &l,
+                                  const coord_point_ob<Point, Origin, Scale> &r )
 {
     return l.raw() == r.raw();
 }
 
-template<typename Point, origin Origin, scale Scale, bool LhsInBounds, bool RhsInBounds>
-constexpr inline bool operator!=( const coord_point<Point, Origin, Scale, LhsInBounds> &l,
-                                  const coord_point<Point, Origin, Scale, RhsInBounds> &r )
+template<typename Point, origin Origin, scale Scale>
+constexpr inline bool operator!=( const coord_point_ob<Point, Origin, Scale> &l,
+                                  const coord_point_ob<Point, Origin, Scale> &r )
 {
     return l.raw() != r.raw();
 }
 
-template<typename Point, origin Origin, scale Scale, bool LhsInBounds, bool RhsInBounds>
-constexpr inline bool operator<( const coord_point<Point, Origin, Scale, LhsInBounds> &l,
-                                 const coord_point<Point, Origin, Scale, RhsInBounds> &r )
+template<typename Point, origin Origin, scale Scale>
+constexpr inline bool operator<( const coord_point_ob<Point, Origin, Scale> &l,
+                                 const coord_point_ob<Point, Origin, Scale> &r )
 {
     return l.raw() < r.raw();
 }
 
-template<typename PointL, typename PointR, origin OriginL, scale Scale, bool InBounds>
+template<typename PointL, typename PointR, origin OriginL, scale Scale>
 constexpr inline auto operator+(
-    const coord_point<PointL, OriginL, Scale, InBounds> &l,
-    const coord_point<PointR, origin::relative, Scale> &r )
+    const coord_point_ob<PointL, OriginL, Scale> &l,
+    const coord_point_ob<PointR, origin::relative, Scale> &r )
 {
     using PointResult = decltype( PointL() + PointR() );
-    return coord_point<PointResult, OriginL, Scale>( l.raw() + r.raw() );
+    return coord_point_ob<PointResult, OriginL, Scale>( l.raw() + r.raw() );
 }
 
-template < typename PointL, typename PointR, origin OriginR, scale Scale, bool InBounds,
+template < typename PointL, typename PointR, origin OriginR, scale Scale,
            // enable_if to prevent ambiguity with above when both args are
            // relative
            typename = std::enable_if_t < OriginR != origin::relative >>
 constexpr inline auto operator+(
-    const coord_point<PointL, origin::relative, Scale> &l,
-    const coord_point<PointR, OriginR, Scale, InBounds> &r )
+    const coord_point_ob<PointL, origin::relative, Scale> &l,
+    const coord_point_ob<PointR, OriginR, Scale> &r )
 {
     using PointResult = decltype( PointL() + PointR() );
-    return coord_point<PointResult, OriginR, Scale>( l.raw() + r.raw() );
+    return coord_point_ob<PointResult, OriginR, Scale>( l.raw() + r.raw() );
 }
 
-template<typename PointL, typename PointR, origin OriginL, scale Scale, bool InBounds>
+template<typename PointL, typename PointR, origin OriginL, scale Scale>
 constexpr inline auto operator-(
-    const coord_point<PointL, OriginL, Scale, InBounds> &l,
-    const coord_point<PointR, origin::relative, Scale> &r )
+    const coord_point_ob<PointL, OriginL, Scale> &l,
+    const coord_point_ob<PointR, origin::relative, Scale> &r )
 {
     using PointResult = decltype( PointL() + PointR() );
-    return coord_point<PointResult, OriginL, Scale>( l.raw() - r.raw() );
+    return coord_point_ob<PointResult, OriginL, Scale>( l.raw() - r.raw() );
 }
 
-template < typename PointL, typename PointR, origin Origin, scale Scale, bool LhsInBounds,
-           bool RhsInBounds,
+template < typename PointL, typename PointR, origin Origin, scale Scale,
            // enable_if to prevent ambiguity with above when both args are
            // relative
            typename = std::enable_if_t < Origin != origin::relative >>
 constexpr inline auto operator-(
-    const coord_point<PointL, Origin, Scale, LhsInBounds> &l,
-    const coord_point<PointR, Origin, Scale, RhsInBounds> &r )
+    const coord_point_ob<PointL, Origin, Scale> &l,
+    const coord_point_ob<PointR, Origin, Scale> &r )
 {
     using PointResult = decltype( PointL() + PointR() );
-    return coord_point<PointResult, origin::relative, Scale>( l.raw() - r.raw() );
+    return coord_point_ob<PointResult, origin::relative, Scale>( l.raw() - r.raw() );
 }
 
 // Only relative points can be multiplied by a constant
 template<typename Point, scale Scale>
-constexpr inline coord_point<Point, origin::relative, Scale> operator*(
-    int l, const coord_point<Point, origin::relative, Scale> &r )
+constexpr inline coord_point_ob<Point, origin::relative, Scale> operator*(
+    int l, const coord_point_ob<Point, origin::relative, Scale> &r )
 {
-    return coord_point<Point, origin::relative, Scale>( l * r.raw() );
+    return coord_point_ob<Point, origin::relative, Scale>( l * r.raw() );
 }
 
 template<typename Point, scale Scale>
-constexpr inline coord_point<Point, origin::relative, Scale> operator*(
-    const coord_point<Point, origin::relative, Scale> &r, int l )
+constexpr inline coord_point_ob<Point, origin::relative, Scale> operator*(
+    const coord_point_ob<Point, origin::relative, Scale> &r, int l )
 {
-    return coord_point<Point, origin::relative, Scale>( r.raw() * l );
+    return coord_point_ob<Point, origin::relative, Scale>( r.raw() * l );
 }
 
-template<typename Point, origin Origin, scale Scale, bool InBounds>
+template<typename Point, origin Origin, scale Scale>
 inline std::ostream &operator<<( std::ostream &os,
-                                 const coord_point<Point, Origin, Scale, InBounds> &p )
+                                 const coord_point_ob<Point, Origin, Scale> &p )
 {
     return os << p.raw();
 }
 
-template <typename Point, origin Origin, scale Scale, bool LhsInBounds, bool RhsInBounds>
-constexpr inline coord_point < Point, Origin, Scale, LhsInBounds &&RhsInBounds >
-coord_min( const coord_point<Point, Origin, Scale, LhsInBounds> &l,
-           const coord_point<Point, Origin, Scale, RhsInBounds> &r )
+template <typename Point, origin Origin, scale Scale>
+constexpr inline coord_point < Point, Origin, Scale>
+coord_min( const coord_point_ob<Point, Origin, Scale> &l,
+           const coord_point_ob<Point, Origin, Scale> &r )
 {
-    return coord_point < Point, Origin, Scale, LhsInBounds &&
-           RhsInBounds >::make_unchecked( std::min( l.x(), r.x() ), std::min( l.y(), r.y() ), std::min( l.z(),
-                                          r.z() ) );
+    return coord_point < Point, Origin, Scale >::make_unchecked( std::min( l.x(), r.x() ),
+            std::min( l.y(), r.y() ), std::min( l.z(),
+                    r.z() ) );
 }
 
-template <typename Point, origin Origin, scale Scale, bool LhsInBounds, bool RhsInBounds>
-constexpr inline coord_point < Point, Origin, Scale, LhsInBounds &&RhsInBounds >
-coord_max( const coord_point<Point, Origin, Scale, LhsInBounds> &l,
-           const coord_point<Point, Origin, Scale, RhsInBounds> &r )
+template <typename Point, origin Origin, scale Scale>
+constexpr inline coord_point < Point, Origin, Scale >
+coord_max( const coord_point_ob<Point, Origin, Scale> &l,
+           const coord_point_ob<Point, Origin, Scale> &r )
 {
-    return coord_point < Point, Origin, Scale, LhsInBounds &&
-           RhsInBounds >::make_unchecked( std::max( l.x(), r.x() ), std::max( l.y(), r.y() ), std::max( l.z(),
-                                          r.z() ) );
+    return coord_point < Point, Origin, Scale >::make_unchecked( std::max( l.x(), r.x() ),
+            std::max( l.y(), r.y() ), std::max( l.z(),
+                    r.z() ) );
 }
 
-template<int ScaleUp, int ScaleDown, scale ResultScale, bool InBounds>
+// Min and max of inbounds points results in an inbounds point.
+
+template <typename Point, origin Origin, scale Scale>
+constexpr inline coord_point_ib < Point, Origin, Scale>
+coord_min( const coord_point_ib<Point, Origin, Scale> &l,
+           const coord_point_ib<Point, Origin, Scale> &r )
+{
+    return coord_point_ib < Point, Origin, Scale >::make_unchecked( std::min( l.x(), r.x() ),
+            std::min( l.y(), r.y() ), std::min( l.z(),
+                    r.z() ) );
+}
+
+template <typename Point, origin Origin, scale Scale>
+constexpr inline coord_point_ib < Point, Origin, Scale >
+coord_max( const coord_point_ib<Point, Origin, Scale> &l,
+           const coord_point_ib<Point, Origin, Scale> &r )
+{
+    return coord_point_ib < Point, Origin, Scale >::make_unchecked( std::max( l.x(), r.x() ),
+            std::max( l.y(), r.y() ), std::max( l.z(),
+                    r.z() ) );
+}
+
+template<int ScaleUp, int ScaleDown, scale ResultScale>
 struct project_to_impl;
 
-template<int ScaleUp, scale ResultScale, bool InBounds>
-struct project_to_impl<ScaleUp, 0, ResultScale, InBounds> {
-    template<typename Point, origin Origin, scale SourceScale>
-    coord_point<Point, Origin, ResultScale, InBounds> operator()(
-        const coord_point<Point, Origin, SourceScale, InBounds> &src ) {
+template<int ScaleUp, scale ResultScale>
+struct project_to_impl<ScaleUp, 0, ResultScale> {
+    template<template<class, origin, scale> class coord, typename Point, origin Origin, scale SourceScale>
+    coord<Point, Origin, ResultScale> CATA_FORCEINLINE operator()(
+        const coord<Point, Origin, SourceScale> src ) {
         // Inbounds points are guaranteed to be inbounds after scaling up.
         //
         // e.g. point_bub_sm_ib scaled up to point_bub_ms_ib points to the top
         // left of the submap, which is still inbounds.
-        return coord_point<Point, Origin, ResultScale, InBounds>::make_unchecked( multiply_xy( src.raw(),
+        return coord<Point, Origin, ResultScale>::make_unchecked( multiply_xy( src.raw(),
                 ScaleUp ) );
     }
 };
 
 template<int ScaleDown, scale ResultScale>
-struct project_to_impl<0, ScaleDown, ResultScale, false> {
+struct project_to_impl<0, ScaleDown, ResultScale> {
     template<typename Point, origin Origin, scale SourceScale>
-    coord_point<Point, Origin, ResultScale> operator()(
-        const coord_point<Point, Origin, SourceScale> &src ) {
-        return coord_point<Point, Origin, ResultScale>(
+    coord_point_ob<Point, Origin, ResultScale> CATA_FORCEINLINE operator()(
+        const coord_point_ob<Point, Origin, SourceScale> src ) {
+        return coord_point_ob<Point, Origin, ResultScale>(
                    divide_xy_round_to_minus_infinity( src.raw(), ScaleDown ) );
     }
-};
 
-template<int ScaleDown, scale ResultScale>
-struct project_to_impl<0, ScaleDown, ResultScale, true> {
     template<typename Point, origin Origin, scale SourceScale>
-    coord_point<Point, Origin, ResultScale, true> operator()(
-        const coord_point<Point, Origin, SourceScale, true> &src ) {
+    coord_point_ib<Point, Origin, ResultScale> CATA_FORCEINLINE operator()(
+        const coord_point_ib<Point, Origin, SourceScale> src ) {
         // Inbounds points are guaranteed to be inbounds after scaling down.
         //
         // They are also guaranteed to be >= 0, so we can use a more effecient method of scaling.
-        return coord_point<Point, Origin, ResultScale, true>::make_unchecked(
+        return coord_point_ib<Point, Origin, ResultScale>::make_unchecked(
                    divide_xy_round_to_minus_infinity_non_negative( src.raw(), ScaleDown ) );
     }
 };
 
-template<scale ResultScale, typename Point, origin Origin, scale SourceScale, bool InBounds>
-inline auto project_to( const coord_point<Point, Origin, SourceScale, InBounds> &src )
+template<scale ResultScale, typename Point, origin Origin, scale SourceScale>
+CATA_FORCEINLINE auto project_to( const coord_point_ob<Point, Origin, SourceScale> src )
 {
     constexpr int scale_down = map_squares_per( ResultScale ) / map_squares_per( SourceScale );
     constexpr int scale_up = map_squares_per( SourceScale ) / map_squares_per( ResultScale );
-    return project_to_impl<scale_up, scale_down, ResultScale, InBounds>()( src );
+    return project_to_impl<scale_up, scale_down, ResultScale>()( src );
+}
+
+template<scale ResultScale, typename Point, origin Origin, scale SourceScale>
+CATA_FORCEINLINE auto project_to( const coord_point_ib<Point, Origin, SourceScale> src )
+{
+    constexpr int scale_down = map_squares_per( ResultScale ) / map_squares_per( SourceScale );
+    constexpr int scale_up = map_squares_per( SourceScale ) / map_squares_per( ResultScale );
+    return project_to_impl<scale_up, scale_down, ResultScale>()( src );
 }
 
 // Resolves the remainer type for project_remain. In most cases the result shares
@@ -486,27 +531,37 @@ inline auto project_to( const coord_point<Point, Origin, SourceScale, InBounds> 
 // do this for origin::reality_bubble
 template<typename Point, origin RemainderOrigin, scale SourceScale, bool InBounds>
 struct remainder_inbounds {
-    using type = coord_point<Point, RemainderOrigin, SourceScale, InBounds>;
+    using type =
+        std::conditional_t<InBounds, coord_point_ib<Point, RemainderOrigin, SourceScale>, coord_point_ob<Point, RemainderOrigin, SourceScale>>;
 };
 
 // *_sm_ms are always inbounds as remainder.
 template<typename Point, bool InBounds>
 struct remainder_inbounds<Point, origin::submap, scale::map_square, InBounds> {
-    using type = coord_point<Point, origin::submap, scale::map_square, true>;
+    using type = coord_point_ib<Point, origin::submap, scale::map_square>;
 };
 
 template<typename Point, origin RemainderOrigin, scale SourceScale, bool InBounds>
 using remainder_inbounds_t = typename
                              remainder_inbounds<Point, RemainderOrigin, SourceScale, InBounds>::type;
 
+template<typename Point, origin QuotientOrigin, scale SourceScale, bool InBounds>
+using quotient_type_t =
+    std::conditional_t<InBounds, coord_point_ib<Point, QuotientOrigin, SourceScale>, coord_point_ob<Point, QuotientOrigin, SourceScale>>;
+
 template<origin Origin, scale CoarseScale, scale FineScale, bool InBounds>
 struct quotient_remainder_helper {
     constexpr static origin RemainderOrigin = origin_from_scale( CoarseScale );
-    using quotient_type = coord_point<point, Origin, CoarseScale, InBounds>;
-    using quotient_type_tripoint = coord_point<tripoint, Origin, CoarseScale, InBounds>;
+    using quotient_type = quotient_type_t<point, Origin, CoarseScale, InBounds>;
+    using quotient_type_tripoint = quotient_type_t<tripoint, Origin, CoarseScale, InBounds>;
+    using quotient_type_ob = quotient_type_t<point, Origin, CoarseScale, false>;
+    using quotient_type_tripoint_ob = quotient_type_t<tripoint, Origin, CoarseScale, false>;
     using remainder_type = remainder_inbounds_t<point, RemainderOrigin, FineScale, InBounds>;
     using remainder_type_tripoint =
         remainder_inbounds_t<tripoint, RemainderOrigin, FineScale, InBounds>;
+    using remainder_type_ob = remainder_inbounds_t<point, RemainderOrigin, FineScale, false>;
+    using remainder_type_tripoint_ob =
+        remainder_inbounds_t<tripoint, RemainderOrigin, FineScale, false>;
 };
 
 template<origin Origin, scale CoarseScale, scale FineScale, bool InBounds>
@@ -530,8 +585,12 @@ struct quotient_remainder_tripoint {
     using helper = quotient_remainder_helper<Origin, CoarseScale, FineScale, InBounds>;
     using quotient_type = typename helper::quotient_type;
     using quotient_type_tripoint = typename helper::quotient_type_tripoint;
+    using quotient_type_ob = typename helper::quotient_type_ob;
+    using quotient_type_tripoint_ob = typename helper::quotient_type_tripoint_ob;
     using remainder_type = typename helper::remainder_type;
     using remainder_type_tripoint = typename helper::remainder_type_tripoint;
+    using remainder_type_ob = typename helper::remainder_type_ob;
+    using remainder_type_tripoint_ob = typename helper::remainder_type_tripoint_ob;
 
     // Annoyingly, for the conversion operators below to work correctly, we
     // need to have point and tripoint version of both quotient and remainder
@@ -555,6 +614,36 @@ struct quotient_remainder_tripoint {
     operator std::tuple<quotient_type &, remainder_type_tripoint &>() {
         return std::tie( quotient, remainder_tripoint );
     }
+
+    // Additional conversions that allow converting _ib results to _ob outputs.
+    // The template trickery is to avoid ambiguous overloads
+
+    template < typename quotient_tripoint_ob = quotient_type_tripoint_ob,
+               std::enable_if_t < !std::is_same_v<quotient_type_tripoint, quotient_tripoint_ob >> * = nullptr >
+    // NOLINTNEXTLINE(google-explicit-constructor)
+    operator std::tuple<quotient_type_tripoint_ob &, remainder_type &>() {
+        return std::tie( static_cast<quotient_type_tripoint_ob &>( quotient_tripoint ), remainder );
+    }
+    template < typename quotient_ob = quotient_type_ob,
+               std::enable_if_t < !std::is_same_v<quotient_type, quotient_ob >> * = nullptr >
+    // NOLINTNEXTLINE(google-explicit-constructor)
+    operator std::tuple<quotient_ob &, remainder_type_tripoint &>() {
+        return std::tie( static_cast<quotient_ob &>( quotient ), remainder_tripoint );
+    }
+
+    template < typename remainder_ob = remainder_type_ob,
+               std::enable_if_t < !std::is_same_v<remainder_type, remainder_ob >> * = nullptr >
+    // NOLINTNEXTLINE(google-explicit-constructor)
+    operator std::tuple<quotient_type_tripoint &, remainder_ob &>() {
+        return std::tie( quotient_tripoint, static_cast<remainder_ob &>( remainder ) );
+    }
+    template < typename remainder_tripoint_ob = remainder_type_tripoint_ob,
+               std::enable_if_t < !std::is_same_v<remainder_type_tripoint, remainder_tripoint_ob >> * = nullptr >
+    // NOLINTNEXTLINE(google-explicit-constructor)
+    operator std::tuple<quotient_type &, remainder_tripoint_ob &>() {
+        return std::tie( quotient, static_cast<remainder_tripoint_ob &>( remainder_tripoint ) );
+    }
+
 };
 
 // project_remain returns a helper struct, intended to be used with std::tie
@@ -576,9 +665,10 @@ struct quotient_remainder_tripoint {
 //  point_abs_om quotient;
 //  tripoint_om_sm remainder;
 //  std::tie( quotient, remainder ) = project_remain<coords::om>( val );
-template<scale ResultScale, origin Origin, scale SourceScale, bool InBounds>
-inline quotient_remainder_point<Origin, ResultScale, SourceScale, InBounds> project_remain(
-    const coord_point<point, Origin, SourceScale, InBounds> &src )
+template<scale ResultScale, origin Origin, scale SourceScale, template<class, origin, scale> class coord, bool InBounds = coord<point, Origin, SourceScale>::is_inbounds>
+CATA_FORCEINLINE quotient_remainder_point<Origin, ResultScale, SourceScale, InBounds>
+project_remain(
+    const coord<point, Origin, SourceScale> src )
 {
     constexpr int ScaleDown = map_squares_per( ResultScale ) / map_squares_per( SourceScale );
     static_assert( ScaleDown > 0, "You can only project to coarser coordinate systems" );
@@ -591,9 +681,10 @@ inline quotient_remainder_point<Origin, ResultScale, SourceScale, InBounds> proj
     return { quotient, remainder };
 }
 
-template<scale ResultScale, origin Origin, scale SourceScale, bool InBounds>
-inline quotient_remainder_tripoint<Origin, ResultScale, SourceScale, InBounds> project_remain(
-    const coord_point<tripoint, Origin, SourceScale, InBounds> &src )
+template<scale ResultScale, origin Origin, scale SourceScale, template<class, origin, scale> class coord, bool InBounds = coord<tripoint, Origin, SourceScale>::is_inbounds>
+CATA_FORCEINLINE quotient_remainder_tripoint<Origin, ResultScale, SourceScale, InBounds>
+project_remain(
+    const coord<tripoint, Origin, SourceScale> src )
 {
     using qrp = quotient_remainder_tripoint<Origin, ResultScale, SourceScale, InBounds>;
     using quotient_type_tripoint = typename qrp::quotient_type_tripoint;
@@ -606,44 +697,55 @@ inline quotient_remainder_tripoint<Origin, ResultScale, SourceScale, InBounds> p
 }
 
 template<typename PointL, typename PointR, origin CoarseOrigin, scale CoarseScale,
-         origin FineOrigin, scale FineScale, bool CoarseInBounds, bool FineInBounds>
+         origin FineOrigin, scale FineScale>
 inline auto project_combine(
-    const coord_point<PointL, CoarseOrigin, CoarseScale, CoarseInBounds> &coarse,
-    const coord_point<PointR, FineOrigin, FineScale, FineInBounds> &fine )
+    const coord_point_ob<PointL, CoarseOrigin, CoarseScale> &coarse,
+    const coord_point_ob<PointR, FineOrigin, FineScale> &fine )
 {
     static_assert( origin_from_scale( CoarseScale ) == FineOrigin,
                    "given point types are not compatible for combination" );
     static_assert( PointL::dimension != 3 || PointR::dimension != 3,
                    "two tripoints should not be combined; it's unclear how to handle z" );
     using PointResult = decltype( PointL() + PointR() );
-    const coord_point<PointL, CoarseOrigin, FineScale> refined_coarse =
+    const coord_point_ob<PointL, CoarseOrigin, FineScale> refined_coarse =
         project_to<FineScale>( coarse );
-    return coord_point < PointResult, CoarseOrigin, FineScale, CoarseInBounds &&
-           FineInBounds >::make_unchecked( refined_coarse.raw() + fine.raw() );
+    return coord_point < PointResult, CoarseOrigin, FineScale >::make_unchecked(
+               refined_coarse.raw() + fine.raw() );
 }
 
-template<scale FineScale, origin Origin, scale CoarseScale, bool InBounds>
-inline auto project_bounds( const coord_point<point, Origin, CoarseScale, InBounds> &coarse )
+template<typename PointL, typename PointR, origin CoarseOrigin, scale CoarseScale,
+         origin FineOrigin, scale FineScale>
+inline auto project_combine(
+    const coord_point_ib<PointL, CoarseOrigin, CoarseScale> &coarse,
+    const coord_point_ib<PointR, FineOrigin, FineScale> &fine )
+{
+    using PointResult = decltype( PointL() + PointR() );
+    return coord_point_ib<PointResult, CoarseOrigin, FineScale>::make_unchecked( project_combine(
+                coarse.as_ob(), fine.as_ob() ).raw() );
+}
+
+template<scale FineScale, origin Origin, scale CoarseScale>
+inline auto project_bounds( const coord_point_ob<point, Origin, CoarseScale> &coarse )
 {
     constexpr point one( 1, 1 ); // NOLINT(cata-use-named-point-constants)
-    return half_open_rectangle<coord_point<point, Origin, FineScale>>(
+    return half_open_rectangle<coord_point_ob<point, Origin, FineScale>>(
                project_to<FineScale>( coarse ), project_to<FineScale>( coarse + one ) );
 }
 
-template<scale FineScale, origin Origin, scale CoarseScale, bool InBounds>
-inline auto project_bounds( const coord_point<tripoint, Origin, CoarseScale, InBounds> &coarse )
+template<scale FineScale, origin Origin, scale CoarseScale>
+inline auto project_bounds( const coord_point_ob<tripoint, Origin, CoarseScale> &coarse )
 {
     constexpr point one( 1, 1 ); // NOLINT(cata-use-named-point-constants)
-    return half_open_cuboid<coord_point<tripoint, Origin, FineScale>>(
+    return half_open_cuboid<coord_point_ob<tripoint, Origin, FineScale>>(
                project_to<FineScale>( coarse ), project_to<FineScale>( coarse + one ) );
 }
 
 } // namespace coords
 
-template<typename Point, coords::origin Origin, coords::scale Scale, bool InBounds>
+template<typename Point, coords::origin Origin, coords::scale Scale>
 // NOLINTNEXTLINE(cert-dcl58-cpp)
-struct std::hash<coords::coord_point<Point, Origin, Scale, InBounds>> {
-    std::size_t operator()( const coords::coord_point<Point, Origin, Scale, InBounds> &p ) const {
+struct std::hash<coords::coord_point_ob<Point, Origin, Scale>> {
+    std::size_t operator()( const coords::coord_point_ob<Point, Origin, Scale> &p ) const {
         const hash<Point> h{};
         return h( p.raw() );
     }
@@ -676,89 +778,127 @@ point_bub_ms rebase_bub( point_omt_ms p );
 tripoint_bub_ms rebase_bub( tripoint_omt_ms p );
 tripoint_omt_ms rebase_omt( tripoint_bub_ms p );
 
-template<typename Point, coords::origin Origin, coords::scale Scale, bool LhsInBounds, bool RhsInBounds>
-inline int square_dist( const coords::coord_point<Point, Origin, Scale, LhsInBounds> &loc1,
-                        const coords::coord_point<Point, Origin, Scale, RhsInBounds> &loc2 )
+template<typename Point, coords::origin Origin, coords::scale Scale>
+inline int square_dist( const coords::coord_point_ob<Point, Origin, Scale> &loc1,
+                        const coords::coord_point_ob<Point, Origin, Scale> &loc2 )
 {
     return square_dist( loc1.raw(), loc2.raw() );
 }
 
-template<typename Point, coords::origin Origin, coords::scale Scale, bool LhsInBounds, bool RhsInBounds>
-inline int trig_dist( const coords::coord_point<Point, Origin, Scale, LhsInBounds> &loc1,
-                      const coords::coord_point<Point, Origin, Scale, RhsInBounds> &loc2 )
+template<typename Point, coords::origin Origin, coords::scale Scale>
+inline int trig_dist( const coords::coord_point_ob<Point, Origin, Scale> &loc1,
+                      const coords::coord_point_ob<Point, Origin, Scale> &loc2 )
 {
     return trig_dist( loc1.raw(), loc2.raw() );
 }
 
-template<typename Point, coords::origin Origin, coords::scale Scale, bool LhsInBounds, bool RhsInBounds>
-inline int rl_dist( const coords::coord_point<Point, Origin, Scale, LhsInBounds> &loc1,
-                    const coords::coord_point<Point, Origin, Scale, RhsInBounds> &loc2 )
+template<typename Point, coords::origin Origin, coords::scale Scale>
+inline int rl_dist( const coords::coord_point_ob<Point, Origin, Scale> &loc1,
+                    const coords::coord_point_ob<Point, Origin, Scale> &loc2 )
 {
     return rl_dist( loc1.raw(), loc2.raw() );
 }
 
-template<typename Point, coords::origin Origin, coords::scale Scale, bool LhsInBounds, bool RhsInBounds>
-inline int manhattan_dist( const coords::coord_point<Point, Origin, Scale, LhsInBounds> &loc1,
-                           const coords::coord_point<Point, Origin, Scale, RhsInBounds> &loc2 )
+template<typename Point, coords::origin Origin, coords::scale Scale>
+inline int manhattan_dist( const coords::coord_point_ob<Point, Origin, Scale> &loc1,
+                           const coords::coord_point_ob<Point, Origin, Scale> &loc2 )
 {
     return manhattan_dist( loc1.raw(), loc2.raw() );
 }
 
-template<typename Point, coords::origin Origin, coords::scale Scale, bool LhsInBounds, bool RhsInBounds>
-inline int octile_dist( const coords::coord_point<Point, Origin, Scale, LhsInBounds> &loc1,
-                        const coords::coord_point<Point, Origin, Scale, RhsInBounds> &loc2, int multiplier = 1 )
+template<typename Point, coords::origin Origin, coords::scale Scale>
+inline int octile_dist( const coords::coord_point_ob<Point, Origin, Scale> &loc1,
+                        const coords::coord_point_ob<Point, Origin, Scale> &loc2, int multiplier = 1 )
 {
     return octile_dist( loc1.raw(), loc2.raw(), multiplier );
 }
 
-template<typename Point, coords::origin Origin, coords::scale Scale, bool LhsInBounds, bool RhsInBounds>
-direction direction_from( const coords::coord_point<Point, Origin, Scale, LhsInBounds> &loc1,
-                          const coords::coord_point<Point, Origin, Scale, RhsInBounds> &loc2 )
+template<typename Point, coords::origin Origin, coords::scale Scale>
+direction direction_from( const coords::coord_point_ob<Point, Origin, Scale> &loc1,
+                          const coords::coord_point_ob<Point, Origin, Scale> &loc2 )
 {
     return direction_from( loc1.raw(), loc2.raw() );
 }
 
-template<typename Point, coords::origin Origin, coords::scale Scale, bool LhsInBounds, bool RhsInBounds,
-         std::enable_if_t<std::is_same_v<Point, point>, int> = 0>
-std::vector < coords::coord_point < Point, Origin, Scale, LhsInBounds && RhsInBounds >>
-        line_to( const coords::coord_point<Point, Origin, Scale, LhsInBounds> &loc1,
-                 const coords::coord_point<Point, Origin, Scale, RhsInBounds> &loc2,
+template<typename Point, coords::origin Origin, coords::scale Scale, std::enable_if_t<std::is_same_v<Point, point>, int> = 0>
+std::vector < coords::coord_point < Point, Origin, Scale >>
+        line_to( const coords::coord_point_ob<Point, Origin, Scale> &loc1,
+                 const coords::coord_point_ob<Point, Origin, Scale> &loc2,
                  const int t = 0 )
 {
     std::vector<Point> raw_result = line_to( loc1.raw(), loc2.raw(), t );
-    std::vector < coords::coord_point < Point, Origin, Scale, LhsInBounds &&RhsInBounds >> result;
+    std::vector < coords::coord_point < Point, Origin, Scale >> result;
     std::transform( raw_result.begin(), raw_result.end(), std::back_inserter( result ),
     []( const Point & p ) {
-        return coords::coord_point < Point, Origin, Scale, LhsInBounds &&
-               RhsInBounds >::make_unchecked( p );
+        return coords::coord_point < Point, Origin, Scale >::make_unchecked( p );
     } );
     return result;
 }
 
-template<typename Tripoint, coords::origin Origin, coords::scale Scale, bool LhsInBounds, bool RhsInBounds,
+template<typename Point, coords::origin Origin, coords::scale Scale, std::enable_if_t<std::is_same_v<Point, point>, int> = 0>
+std::vector < coords::coord_point_ib < Point, Origin, Scale >>
+        line_to( const coords::coord_point_ib<Point, Origin, Scale> &loc1,
+                 const coords::coord_point_ib<Point, Origin, Scale> &loc2,
+                 const int t = 0 )
+{
+    std::vector<Point> raw_result = line_to( loc1.raw(), loc2.raw(), t );
+    std::vector < coords::coord_point_ib < Point, Origin, Scale >> result;
+    std::transform( raw_result.begin(), raw_result.end(), std::back_inserter( result ),
+    []( const Point & p ) {
+        return coords::coord_point_ib < Point, Origin, Scale >::make_unchecked( p );
+    } );
+    return result;
+}
+
+template<typename Tripoint, coords::origin Origin, coords::scale Scale,
          std::enable_if_t<std::is_same_v<Tripoint, tripoint>, int> = 0>
-std::vector < coords::coord_point < Tripoint, Origin, Scale, LhsInBounds && RhsInBounds >>
-        line_to( const coords::coord_point<Tripoint, Origin, Scale, LhsInBounds> &loc1,
-                 const coords::coord_point<Tripoint, Origin, Scale, RhsInBounds> &loc2,
+std::vector < coords::coord_point < Tripoint, Origin, Scale >>
+        line_to( const coords::coord_point_ob<Tripoint, Origin, Scale> &loc1,
+                 const coords::coord_point_ob<Tripoint, Origin, Scale> &loc2,
                  const int t = 0, const int t2 = 0 )
 {
     std::vector<Tripoint> raw_result = line_to( loc1.raw(), loc2.raw(), t, t2 );
-    std::vector < coords::coord_point < Tripoint, Origin, Scale, LhsInBounds &&RhsInBounds >> result;
+    std::vector < coords::coord_point < Tripoint, Origin, Scale>> result;
     std::transform( raw_result.begin(), raw_result.end(), std::back_inserter( result ),
     []( const Tripoint & p ) {
-        return coords::coord_point < Tripoint, Origin, Scale, LhsInBounds &&
-               RhsInBounds >::make_unchecked( p );
+        return coords::coord_point < Tripoint, Origin, Scale >::make_unchecked( p );
     } );
     return result;
 }
 
-template<typename Point, coords::origin Origin, coords::scale Scale, bool LhsInBounds, bool RhsInBounds>
-coords::coord_point < Point, Origin, Scale, LhsInBounds &&RhsInBounds >
-midpoint( const coords::coord_point<Point, Origin, Scale, LhsInBounds> &loc1,
-          const coords::coord_point<Point, Origin, Scale, RhsInBounds> &loc2 )
+template<typename Tripoint, coords::origin Origin, coords::scale Scale,
+         std::enable_if_t<std::is_same_v<Tripoint, tripoint>, int> = 0>
+std::vector < coords::coord_point_ib < Tripoint, Origin, Scale>>
+        line_to( const coords::coord_point_ib<Tripoint, Origin, Scale> &loc1,
+                 const coords::coord_point_ib<Tripoint, Origin, Scale> &loc2,
+                 const int t = 0, const int t2 = 0 )
 {
-    return coords::coord_point < Point, Origin, Scale, LhsInBounds &&
-           RhsInBounds >::make_unchecked( ( loc1.raw() + loc2.raw() ) / 2 );
+    std::vector<Tripoint> raw_result = line_to( loc1.raw(), loc2.raw(), t, t2 );
+    std::vector < coords::coord_point_ib < Tripoint, Origin, Scale >> result;
+    std::transform( raw_result.begin(), raw_result.end(), std::back_inserter( result ),
+    []( const Tripoint & p ) {
+        return coords::coord_point_ib < Tripoint, Origin, Scale >::make_unchecked( p );
+    } );
+    return result;
+}
+
+
+template<typename Point, coords::origin Origin, coords::scale Scale>
+coords::coord_point < Point, Origin, Scale >
+midpoint( const coords::coord_point_ob<Point, Origin, Scale> &loc1,
+          const coords::coord_point_ob<Point, Origin, Scale> &loc2 )
+{
+    return coords::coord_point < Point, Origin, Scale >::make_unchecked( (
+                loc1.raw() + loc2.raw() ) / 2 );
+}
+
+template<typename Point, coords::origin Origin, coords::scale Scale>
+coords::coord_point_ib < Point, Origin, Scale >
+midpoint( const coords::coord_point_ib<Point, Origin, Scale> &loc1,
+          const coords::coord_point_ib<Point, Origin, Scale> &loc2 )
+{
+    return coords::coord_point_ib < Point, Origin, Scale >::make_unchecked( (
+                loc1.raw() + loc2.raw() ) / 2 );
 }
 
 template<typename Point>
@@ -788,22 +928,30 @@ Tripoint midpoint( const half_open_cuboid<Tripoint> &box )
 }
 
 template<typename Point, coords::origin Origin, coords::scale Scale>
-std::vector<coords::coord_point<Point, Origin, Scale>>
-        closest_points_first( const coords::coord_point<Point, Origin, Scale> &loc,
+std::vector<coords::coord_point_ob<Point, Origin, Scale>>
+        closest_points_first( const coords::coord_point_ob<Point, Origin, Scale> &loc,
                               int min_dist, int max_dist )
 {
     std::vector<Point> raw_result = closest_points_first( loc.raw(), min_dist, max_dist );
-    std::vector<coords::coord_point<Point, Origin, Scale>> result;
+    std::vector<coords::coord_point_ob<Point, Origin, Scale>> result;
     result.reserve( raw_result.size() );
     std::transform( raw_result.begin(), raw_result.end(), std::back_inserter( result ),
     []( const Point & p ) {
-        return coords::coord_point<Point, Origin, Scale>( p );
+        return coords::coord_point_ob<Point, Origin, Scale>( p );
     } );
     return result;
 }
-template<typename Point, coords::origin Origin, coords::scale Scale, bool InBounds>
-std::vector<coords::coord_point<Point, Origin, Scale>>
-        closest_points_first( const coords::coord_point<Point, Origin, Scale, InBounds> &loc,
+template<typename Point, coords::origin Origin, coords::scale Scale>
+std::vector<coords::coord_point_ob<Point, Origin, Scale>>
+        closest_points_first( const coords::coord_point_ob<Point, Origin, Scale> &loc,
+                              int max_dist )
+{
+    return closest_points_first( loc, 0, max_dist );
+}
+
+template<typename Point, coords::origin Origin, coords::scale Scale>
+std::vector<coords::coord_point_ib<Point, Origin, Scale>>
+        closest_points_first( const coords::coord_point_ib<Point, Origin, Scale> &loc,
                               int max_dist )
 {
     return closest_points_first( loc, 0, max_dist );

--- a/src/coords_fwd.h
+++ b/src/coords_fwd.h
@@ -2,6 +2,8 @@
 #ifndef CATA_SRC_COORDS_FWD_H
 #define CATA_SRC_COORDS_FWD_H
 
+#include <type_traits>
+
 struct point;
 struct tripoint;
 
@@ -32,8 +34,15 @@ constexpr scale omt = scale::overmap_terrain;
 constexpr scale seg = scale::segment;
 constexpr scale om = scale::overmap;
 
+template<typename Point, origin Origin, scale Scale>
+class coord_point_ob;
+
+template<typename Point, origin Origin, scale Scale>
+class coord_point_ib;
+
 template<typename Point, origin Origin, scale Scale, bool InBounds = false>
-class coord_point;
+using coord_point =
+    std::conditional_t<InBounds, coord_point_ib<Point, Origin, Scale>, coord_point_ob<Point, Origin, Scale>>;
 
 } // namespace coords
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1805,7 +1805,7 @@ furn_id map::furn( const tripoint &p ) const
     return furn( tripoint_bub_ms( p ) );
 }
 
-furn_id map::furn( const tripoint_bub_ms &p ) const
+furn_id map::furn( const tripoint_bub_ms p ) const
 {
     if( !inbounds( p ) ) {
         return furn_str_id::NULL_ID();
@@ -2000,7 +2000,7 @@ std::string map::furnname( const tripoint_bub_ms &p )
  * retained for high performance comparisons, save/load, and gradual transition
  * to string terrain.id
  */
-ter_id map::ter( const tripoint &p ) const
+ter_id map::ter( const tripoint p ) const
 {
     if( !inbounds( p ) ) {
         return ter_str_id::NULL_ID().id();

--- a/src/map.h
+++ b/src/map.h
@@ -965,7 +965,7 @@ class map
         }
         // TODO: fix point types (remove the first overload)
         furn_id furn( const tripoint &p ) const;
-        furn_id furn( const tripoint_bub_ms &p ) const;
+        furn_id furn( tripoint_bub_ms p ) const;
         // TODO: Get rid of untyped overload.
         furn_id furn( const point_bub_ms &p ) const {
             return furn( tripoint_bub_ms( p, abs_sub.z() ) );
@@ -1010,7 +1010,7 @@ class map
 
         // Terrain
         // TODO: fix point types (remove the first overload)
-        ter_id ter( const tripoint &p ) const;
+        ter_id ter( tripoint p ) const;
         ter_id ter( const tripoint_bub_ms &p ) const;
         // TODO: Get rid of untyped overload.
         ter_id ter( const point &p ) const {
@@ -2399,11 +2399,9 @@ class map
             offset_p.y = p.y % SEEY;
             return unsafe_get_submap_at( p );
         }
-        submap *unsafe_get_submap_at( const tripoint_bub_ms &p, point_sm_ms &offset_p ) {
+        submap *unsafe_get_submap_at( const tripoint_bub_ms p, point_sm_ms &offset_p ) {
             tripoint_bub_sm sm;
-            point_sm_ms_ib l;
-            std::tie( sm, l ) = project_remain<coords::sm>( p );
-            offset_p = point_sm_ms( l );
+            std::tie( sm, offset_p ) = project_remain<coords::sm>( p );
             return unsafe_get_submap_at( p );
         }
         // TODO: fix point types (remove the first overload)
@@ -2413,11 +2411,9 @@ class map
             return unsafe_get_submap_at( p );
         }
         const submap *unsafe_get_submap_at(
-            const tripoint_bub_ms &p, point_sm_ms &offset_p ) const {
+            const tripoint_bub_ms p, point_sm_ms &offset_p ) const {
             tripoint_bub_sm sm;
-            point_sm_ms_ib l;
-            std::tie( sm, l ) = project_remain<coords::sm>( p );
-            offset_p = point_sm_ms( l );
+            std::tie( sm, offset_p ) = project_remain<coords::sm>( p );
             return unsafe_get_submap_at( p );
         }
         // TODO: Get rid of untyped overload

--- a/src/mdarray.h
+++ b/src/mdarray.h
@@ -16,14 +16,14 @@ namespace cata
 template<typename Point>
 struct mdarray_default_size_impl;
 
-template<typename Point, coords::scale Scale, bool InBounds>
-struct mdarray_default_size_impl<coords::coord_point<Point, coords::origin::reality_bubble, Scale, InBounds>> {
+template<template<class, coords::origin, coords::scale> class coord_point, typename Point, coords::scale Scale>
+struct mdarray_default_size_impl<coord_point<Point, coords::origin::reality_bubble, Scale>> {
     static constexpr size_t value = MAPSIZE_X / map_squares_per( Scale );
     static_assert( MAPSIZE_X % map_squares_per( Scale ) == 0, "Scale must be smaller than map" );
 };
 
-template<typename Point, coords::origin Origin, coords::scale Scale, bool InBounds>
-struct mdarray_default_size_impl<coords::coord_point<Point, Origin, Scale, InBounds>> {
+template<template<class, coords::origin, coords::scale> class coord_point, typename Point, coords::origin Origin, coords::scale Scale>
+struct mdarray_default_size_impl<coord_point<Point, Origin, Scale>> {
     static constexpr coords::scale outer_scale = coords::scale_from_origin( Origin );
     static constexpr size_t value = map_squares_per( outer_scale ) / map_squares_per( Scale );
     static_assert( value > 0, "Scale must be smaller origin" );

--- a/src/omdata.h
+++ b/src/omdata.h
@@ -77,7 +77,7 @@ std::string name( type dir );
 point rotate( const point &p, type dir );
 tripoint rotate( const tripoint &p, type dir );
 template<typename Point, coords::scale Scale>
-auto rotate( const coords::coord_point<Point, coords::origin::relative, Scale> &p, type dir )
+auto rotate( const coords::coord_point_ob<Point, coords::origin::relative, Scale> &p, type dir )
 -> coords::coord_point<Point, coords::origin::relative, Scale>
 {
     return coords::coord_point<Point, coords::origin::relative, Scale> { rotate( p.raw(), dir ) };

--- a/tests/coordinate_test.cpp
+++ b/tests/coordinate_test.cpp
@@ -18,13 +18,12 @@ static_assert( tripoint_abs_omt::dimension == 3 );
 
 // Out of bounds coords can be implicitly constructed from inbounds ones. This is used
 // to ensure a return type is NOT an inbounds one, before it can be converted.
-template <typename Point, coords::origin Origin, coords::scale Scale, bool InBounds>
-coords::coord_point<Point, Origin, Scale, InBounds> assert_not_ib( const
-        coords::coord_point<Point, Origin, Scale, InBounds> &p )
-{
-    static_assert( !InBounds );
-    return p;
-}
+#define assert_not_ib(p) \
+    (([](auto&& _p) { \
+        using _t = decltype(_p); \
+        static_assert(!std::decay_t<_t>::is_inbounds); \
+        return std::forward<_t>(_p); } \
+     )(p))
 
 TEST_CASE( "coordinate_strings", "[point][coords][nogame]" )
 {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Performance "Optimize typed coordinate conversion functions for widespread savings"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I accidentally left a performance profiling run open for a couple hours. Interestingly, I noticed that what should be a basic math function, `project_coord`, was top of the list in self CPU at a shockingly high % of total cpu. This tickled my performance hotspot spidey sense so I went digging.

There's a variety of things going on but the basic point is the compiler was not inlining `project_coord` which by design is supposed to be inlined to take advantage of dead code stripping because the struct has more members than usually needed. This meant wasted computation in a very, very, hot code path.

The net win is `map::ter` is about 33% faster, `map::furn` is 25% faster, many other things called less often probably have similar wins. `map::ter` in particular is called in the render codepath so that makes everything just a bit snappier.

There were, unfortunately, no measurable wins with clang-cl. The generated code was identical (and fairly optimal) before/after my changes.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

- Force the compiler to inline the function with compiler specific annotations.
- Optimize the class hierarchy so that 'in bounds' points are a subclass of 'out of bounds' points (really, not-validated-in-bounds points). This allows for taking a const ob& from an ib point, a free operation, instead of a conversion/copy. In turn this allows directly returning the result of project_coord out of get_submap_unsafe
- Other tweaks to reduce the generated asm size, like taking points by value as arguments. Tripoints fit in an SSE register, and the compiler would not optimize some of these functions more without passing by value (a const ref can still be changed by the caller or through a called function, after all).  

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

- Being happy with slow less optimized code.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Hacked up `map_bounds_checking` test to run 100 times in a loop. Instrumented it enough times to get 3 results within noise of each other, before & after.

<img width="1276" alt="image" src="https://github.com/user-attachments/assets/a16e576f-8af4-4c81-9c08-590e6cea3971">

I also hand expanded the template code into `unsafe_get_submap_at` to strip all the dead code manually and the generated assembly was functionally identical.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

There's nontrivial bulk added by two conditionals because at the bottom of the math stack are calls to `divide_xy_round_to_minus_infinity`. If we can get the inputs to be `_ib` points, then the math instead uses `divide_xy_round_to_minus_infinity_non_negative` which is branch free and reduces the asm from 54 lines to 35 lines and no conditional jumps. That's a longer term and harder effort though, and my immediate attempts to do this did not get any significant wins off the bat.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
