### PR TITLE
Random NPC classes can define weighted chance of spawning

### DIFF
--- a/doc/NPCs.md
+++ b/doc/NPCs.md
@@ -35,6 +35,7 @@ Format:
   "name": { "str": "Example NPC" },                                        // Mandatory, display name for this class.
   "job_description": "I'm helping you learn the game.",                    // Mandatory
   "common": false,                                                         // Optional, defaults true. Whether or not this class can appear via random generation. Randomly generated NPCs will have skills, proficiencies, and bionics applied to them as a default new player character would.
+  "common_spawn_weight": 1.5,                                              // Optional (float), default 1.0 . For classes with common, this is how often they spawn. Higher numbers spawn more often.
   "sells_belongings": false,                                               // Optional. See [Shopkeeper NPC configuration](#shopkeeper-npc-configuration)
   "bonus_str": { "rng": [ -4, 0 ] },                                       // Optional. Modifies stat by the given value. This example shows a random distribution between -4 and 0.
   "bonus_dex": 100,                                                        // Optional. This example always adds exactly 100 to the stat.

--- a/src/npc_class.h
+++ b/src/npc_class.h
@@ -75,6 +75,7 @@ class npc_class
         translation job_description;
 
         bool common = true;
+        double common_spawn_weight = 1;
 
         distribution bonus_str;
         distribution bonus_dex;


### PR DESCRIPTION
#### Summary
Infrastructure "Random NPC classes can define weighted chance of spawning, relative to other random NPC classes"

#### Purpose of change
Multiple contributors requested this feature on the development discord. It makes sense - not every randomly spawnable class should be just as common as each other.

#### Describe the solution
Add a weighting variable, put the classes in a weighted list, pick from the list. Uses existing RNG functions - nothing new or fancy here. Existing classes without this variable defined will all have the same weight - 1.0, and will work exactly the same as before. If no weights are added, then the weight of each is 1.0, and the chances for a particular NPC class to roll is exactly the same as before.

#### Describe alternatives you've considered
Full support for conditions and math, so that the chance could be dynamic based on post-cataclysm time or other variables 😈 

...That's a lot more effort though.

#### Testing
Game correctly errors when weighting is defined but class cannot spawn
![image](https://github.com/user-attachments/assets/ca3338fa-10a4-442b-8322-0fe1c6e4ccd9)

Locally set the "Operator" class to 500 weight. Spawned about 10 NPCs after starting a new game. Got one doctor, the rest were operators. Quite the difference.

#### Additional context

