### PR TITLE
Remove inaccessible valhallist-related content

### DIFF
--- a/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_talk.json
+++ b/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_talk.json
@@ -177,13 +177,7 @@
         "text": "Are you interested in any chemical supplies?",
         "topic": "TALK_EVAC_MERCHANT_DEAL_NEGOTIATE_CHEM",
         "condition": { "u_has_mission": "MISSION_CABIN_CHEMIST_SET_TRADE_ROUTE" }
-      },
-      {
-        "text": "Are you interested in any household goods?",
-        "topic": "TALK_EVAC_MERCHANT_DEAL_NEGOTIATE_MISC",
-        "condition": { "u_has_mission": "MISSION_VALHALLISTS_SET_TRADE_ROUTE" }
-      },
-      { "text": "Actually, I need to head out.", "topic": "TALK_DONE" }
+      }
     ]
   },
   {
@@ -348,18 +342,6 @@
     "responses": [
       {
         "text": "Well, how about 300 merch for 10 liters of…",
-        "effect": { "u_spawn_item": "trade_writ" },
-        "topic": "TALK_DONE"
-      }
-    ]
-  },
-  {
-    "id": "TALK_EVAC_MERCHANT_DEAL_NEGOTIATE_MISC",
-    "type": "talk_topic",
-    "dynamic_line": "We are running a bit short on toilet paper, soap, toothpaste…  What's the offer?",
-    "responses": [
-      {
-        "text": "Well, how about 200 merch for 75 pounds of…",
         "effect": { "u_spawn_item": "trade_writ" },
         "topic": "TALK_DONE"
       }

--- a/data/mods/innawood/npcs/classes.json
+++ b/data/mods/innawood/npcs/classes.json
@@ -38,18 +38,5 @@
       { "skill": "rifle", "bonus": { "rng": [ 0, 3 ] } },
       { "skill": "archery", "bonus": { "rng": [ 0, 3 ] } }
     ]
-  },
-  {
-    "type": "npc_class",
-    "id": "NC_SLAVE",
-    "name": { "str": "Slave" },
-    "job_description": "I've had very bad luck recently.",
-    "traits": [ { "group": "BG_survival_story_EVACUEE" }, { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
-    "carry_override": "naked_prisoner",
-    "weapon_override": "naked_prisoner",
-    "//": "Override to erase worn_override so they'll get a full selection of random innawoods NPC clothes (without having to define a new item group)",
-    "skills": [
-      { "skill": "ALL", "level": { "mul": [ { "one_in": 3 }, { "sum": [ { "dice": [ 4, 2 ] }, { "rng": [ -4, -1 ] } ] } ] } }
-    ]
   }
 ]


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Valhallists were fully removed in #71705 but some references stuck around

#### Describe the solution
Remove remaining references, including the NC_Slave override I added to innawoods

#### Describe alternatives you've considered
Validation for `u_has_mission` that the mission is actually an existing type?

#### Testing
Compiles, loads

#### Additional context
I'm not actually sure removing NPC classes like this won't produce errors but the class was already removed from vanilla in the same way.