### PR TITLE
Quick setup at start for debug worlds/characters

### DIFF
--- a/src/debug.h
+++ b/src/debug.h
@@ -285,6 +285,7 @@ extern std::unordered_set<debug_filter> enabled_filters;
 std::string filter_name( debug_filter value );
 } // namespace debugmode
 
+
 // From catch.hpp:
 // Returns true if the current process is being debugged (either
 // running under the debugger or has a debugger attached post facto).

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -434,6 +434,11 @@ class mission_debug
         static std::string describe( const mission &m );
 };
 
+// Used for quick setup
+static std::vector<trait_id> setup_traits{trait_DEBUG_BIONICS, trait_DEBUG_CLAIRVOYANCE, trait_DEBUG_CLOAK,
+           trait_DEBUG_HS, trait_DEBUG_LIGHT, trait_DEBUG_LS, trait_DEBUG_MANA, trait_DEBUG_MIND_CONTROL,
+           trait_DEBUG_NODMG, trait_DEBUG_NOTEMP, trait_DEBUG_STAMINA, trait_DEBUG_SPEED};
+
 static std::string first_word( const std::string &str )
 {
     const size_t space_pos = str.find( ' ' );
@@ -443,7 +448,7 @@ static std::string first_word( const std::string &str )
     return str.substr( 0, space_pos );
 }
 
-static bool is_debug_character()
+bool is_debug_character()
 {
     static const std::unordered_set<std::string> debug_names = {
         "Debug", "Test", "Sandbox", "Staging", "QA", "UAT"
@@ -3606,6 +3611,27 @@ static void write_global_vars()
     popup( _( "Var list written to var_list.output" ) );
 }
 
+void do_debug_quick_setup()
+{
+    if( !debug_mode ) {
+        // Turn on debug mode if not already on, but without any filters enabled (to prevent log spam).
+        // Save a few keypresses.
+        debug_mode = true;
+        debugmode::enabled_filters.clear();
+    }
+    Character &u = get_avatar();
+    normalize_body( u );
+    // Specifically only adds mutations instead of toggling them.
+    u.set_mutations( setup_traits );
+    u.remove_weapon();
+    u.clear_worn();
+    item backpack( "debug_backpack" );
+    u.wear_item( backpack );
+    for( const std::pair<const skill_id, SkillLevel> &pair : u.get_all_skills() ) {
+        u.set_skill_level( pair.first, 10 );
+    }
+}
+
 void debug()
 {
     bool debug_menu_has_hotkey = hotkey_for_action( ACTION_DEBUG,
@@ -3646,11 +3672,6 @@ void debug()
     }
 
     get_event_bus().send<event_type::uses_debug_menu>( *action );
-
-    // Used for quick setup, constructed outside the switches to reduce duplicate code
-    std::vector<trait_id> setup_traits{trait_DEBUG_BIONICS, trait_DEBUG_CLAIRVOYANCE, trait_DEBUG_CLOAK,
-                                       trait_DEBUG_HS, trait_DEBUG_LIGHT, trait_DEBUG_LS, trait_DEBUG_MANA, trait_DEBUG_MIND_CONTROL,
-                                       trait_DEBUG_NODMG, trait_DEBUG_NOTEMP, trait_DEBUG_STAMINA, trait_DEBUG_SPEED};
 
     avatar &player_character = get_avatar();
     map &here = get_map();
@@ -4100,23 +4121,7 @@ void debug()
         }
 
         case debug_menu_index::QUICK_SETUP: {
-            if( !debug_mode ) {
-                // Turn on debug mode if not already on, but without any filters enabled (to prevent log spam).
-                // Save a few keypresses.
-                debug_mode = true;
-                debugmode::enabled_filters.clear();
-            }
-            Character &u = get_avatar();
-            normalize_body( u );
-            // Specifically only adds mutations instead of toggling them.
-            u.set_mutations( setup_traits );
-            u.remove_weapon();
-            u.clear_worn();
-            item backpack( "debug_backpack" );
-            u.wear_item( backpack );
-            for( const std::pair<const skill_id, SkillLevel> &pair : u.get_all_skills() ) {
-                u.set_skill_level( pair.first, 10 );
-            }
+            do_debug_quick_setup();
             break;
         }
 

--- a/src/debug_menu.h
+++ b/src/debug_menu.h
@@ -135,6 +135,8 @@ void wishproficiency( Character *you );
 
 void debug();
 
+void do_debug_quick_setup();
+
 /* Splits a string by @param delimiter and push_back's the elements into _Container */
 template<typename Container>
 Container string_to_iterable( const std::string_view str, const std::string_view delimiter )
@@ -155,6 +157,8 @@ Container string_to_iterable( const std::string_view str, const std::string_view
 
     return res;
 }
+
+bool is_debug_character();
 
 /* Merges iterable elements into std::string with
  * @param delimiter between them

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -80,6 +80,7 @@
 #include "cursesport.h" // IWYU pragma: keep
 #include "damage.h"
 #include "debug.h"
+#include "debug_menu.h"
 #include "dependency_tree.h"
 #include "dialogue.h"
 #include "dialogue_chatbin.h"
@@ -1138,6 +1139,9 @@ bool game::start_game()
     get_event_bus().send<event_type::avatar_enters_omt>( abs_omt.raw(), cur_ter );
 
     effect_on_conditions::load_new_character( u );
+    if( debug_menu::is_debug_character() ) {
+        debug_menu::do_debug_quick_setup();
+    }
     return true;
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1141,6 +1141,7 @@ bool game::start_game()
     effect_on_conditions::load_new_character( u );
     if( debug_menu::is_debug_character() ) {
         debug_menu::do_debug_quick_setup();
+        add_msg( m_good, _( "Debug character detected.  Quick setup applied, good luck on the testing!" ) );
     }
     return true;
 }


### PR DESCRIPTION
#### Summary
Infrastructure "Quick setup at start for debug worlds/characters"

#### Purpose of change
Requested on development discord. I agree, this would be useful. So let's do it.

#### Describe the solution
If a debug character is detected on game start, it prints a log message and runs the quick setup function.

Expanded the quick setup function to also reveal current overmap.

#### Describe alternatives you've considered
A default-on option in the settings (debug tab) toggling this behavior off? There may be scenarios where quick setup is detrimental to testing, and maybe they only wanted turning off the achievements warning. Seems like a niche use case though.

#### Testing
![image](https://github.com/user-attachments/assets/e0d0b763-09cc-47ee-87b1-ada7a3ac0654)


#### Additional context
*Another* include to game.cpp? I'd like to not burden it further, but that's where we need to call the functions...
