### PR TITLE
Pushable neutral NPCs

### DIFF
--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -890,6 +890,7 @@ construction_id construction_menu( const bool blueprint )
             construction_group_str_id last_construction = construction_group_str_id::NULL_ID();
             if( isnew ) {
                 filter = uistate.construction_filter;
+                filter.clear();
                 tabindex = uistate.construction_tab.is_valid()
                            ? uistate.construction_tab.id().to_i() : 0;
                 if( uistate.last_construction.is_valid() ) {

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -899,6 +899,12 @@ construction_id construction_menu( const bool blueprint )
             } else if( select >= 0 && static_cast<size_t>( select ) < constructs.size() ) {
                 last_construction = constructs[select];
             }
+            else {
+                filter.clear();
+                if (uistate.last_construction.is_valid()) {
+                    last_construction = uistate.last_construction;
+                }
+            }
             category_id = construct_cat[tabindex].id;
             if( category_id == construction_category_ALL ) {
                 constructs = available;

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -901,9 +901,6 @@ construction_id construction_menu( const bool blueprint )
             }
             else {
                 filter.clear();
-                if (uistate.last_construction.is_valid()) {
-                    last_construction = uistate.last_construction;
-                }
             }
             category_id = construct_cat[tabindex].id;
             if( category_id == construction_category_ALL ) {

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -898,8 +898,7 @@ construction_id construction_menu( const bool blueprint )
                 }
             } else if( select >= 0 && static_cast<size_t>( select ) < constructs.size() ) {
                 last_construction = constructs[select];
-            }
-            else {
+            } else {
                 filter.clear();
             }
             category_id = construct_cat[tabindex].id;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5598,7 +5598,7 @@ bool game::npc_menu( npc &who )
     amenu.addentry( talk, true, 't', _( "Talk" ) );
     amenu.addentry( swap_pos, obeys && !who.is_mounted() &&
                     !u.is_mounted(), 's', _( "Swap positions" ) );
-    amenu.addentry( push, obeys && !who.is_mounted(), 'p', _( "Push away" ) );
+    amenu.addentry( push, (debug_mode || (!who.is_enemy() && !who.in_sleep_state())) && !who.is_mounted(), 'p', _("Push away"));
     amenu.addentry( examine_wounds, true, 'w', _( "Examine wounds" ) );
     amenu.addentry( examine_status, true, 'e', _( "Examine status" ) );
     amenu.addentry( use_item, true, 'i', _( "Use item on" ) );
@@ -5630,6 +5630,17 @@ bool game::npc_menu( npc &who )
             add_msg( _( "You cannot swap places while grabbing something." ) );
         }
     } else if( choice == push ) {
+        if (!obeys) {
+            if (!query_yn(_(who.name + " may be upset by this. Continue?"))) {
+                return true;
+            }
+            npc_opinion &attitude = who.op_of_u;
+            attitude.anger += 3;
+            attitude.trust -= 3;
+            attitude.value -= 1;
+            who.form_opinion(u);
+
+        }
         // TODO: Make NPCs protest when displaced onto dangerous crap
         tripoint oldpos = who.pos();
         who.move_away_from( u.pos(), true );


### PR DESCRIPTION
#### Summary
Content "Neutral NPCs may now be shoved."

#### Purpose of change
There are situations in the game where NPCs can block the player inside of a room. If the NPC is not obedient they cannot be pushed.

#### Describe the solution
NPCs may now be pushed, and it will change their opinion of you. Pushing them enough times will make them hostile. This is to prevent exploits. The player will be prompted and told that pushing the NPC will make them upset and asked if they wish to continue before the push occurs. Obedient NPCs can still be pushed with no cost to opinion.

#### Describe alternatives you've considered
I considered allowing swap positions with neutral characters, which won't work because it allows you to transport neutral NPCs into dangerous situations and get their gear for free. 

I also considered adding a "Walk past" option, however it requires teleporting the player and messes with the flow of time.

#### Testing
I have repeatedly spawned in NPCs and shoved the neutral ones. Friendly code has not been changed, however I also tested this with friendly NPCs.
