### PR TITLE
Neutral NPCs can now be pushed

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5598,7 +5598,8 @@ bool game::npc_menu( npc &who )
     amenu.addentry( talk, true, 't', _( "Talk" ) );
     amenu.addentry( swap_pos, obeys && !who.is_mounted() &&
                     !u.is_mounted(), 's', _( "Swap positions" ) );
-    amenu.addentry( push, (debug_mode || (!who.is_enemy() && !who.in_sleep_state())) && !who.is_mounted(), 'p', _("Push away"));
+    amenu.addentry( push, ( debug_mode || ( !who.is_enemy() && !who.in_sleep_state() ) ) &&
+                    !who.is_mounted(), 'p', _( "Push away" ) );
     amenu.addentry( examine_wounds, true, 'w', _( "Examine wounds" ) );
     amenu.addentry( examine_status, true, 'e', _( "Examine status" ) );
     amenu.addentry( use_item, true, 'i', _( "Use item on" ) );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5631,8 +5631,8 @@ bool game::npc_menu( npc &who )
             add_msg( _( "You cannot swap places while grabbing something." ) );
         }
     } else if( choice == push ) {
-        if (!obeys) {
-            if (!query_yn(_(who.name + " may be upset by this. Continue?"))) {
+        if( !obeys ) {
+            if( !query_yn( _( who.name + " may be upset by this. Continue?" ) ) ) {
                 return true;
             }
             npc_opinion &attitude = who.op_of_u;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5632,7 +5632,7 @@ bool game::npc_menu( npc &who )
         }
     } else if( choice == push ) {
         if( !obeys ) {
-            if( !query_yn( _( who.name + " may be upset by this. Continue?" ) ) ) {
+            if( !query_yn( _( "%s may be upset by this. Continue?" ), who.name ) ) {
                 return true;
             }
             npc_opinion &attitude = who.op_of_u;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5639,7 +5639,7 @@ bool game::npc_menu( npc &who )
             attitude.anger += 3;
             attitude.trust -= 3;
             attitude.value -= 1;
-            who.form_opinion(u);
+            who.form_opinion( u );
 
         }
         // TODO: Make NPCs protest when displaced onto dangerous crap

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5598,7 +5598,7 @@ bool game::npc_menu( npc &who )
     amenu.addentry( talk, true, 't', _( "Talk" ) );
     amenu.addentry( swap_pos, obeys && !who.is_mounted() &&
                     !u.is_mounted(), 's', _( "Swap positions" ) );
-    amenu.addentry( push, obeys && !who.is_mounted(), 'p', _( "Push away" ) );
+    amenu.addentry( push, (debug_mode || (!who.is_enemy() && !who.in_sleep_state())) && !who.is_mounted(), 'p', _("Push away"));
     amenu.addentry( examine_wounds, true, 'w', _( "Examine wounds" ) );
     amenu.addentry( examine_status, true, 'e', _( "Examine status" ) );
     amenu.addentry( use_item, true, 'i', _( "Use item on" ) );
@@ -5630,6 +5630,17 @@ bool game::npc_menu( npc &who )
             add_msg( _( "You cannot swap places while grabbing something." ) );
         }
     } else if( choice == push ) {
+        if (!obeys) {
+            if (!query_yn(_(who.name + " may be upset by this. Continue?"))) {
+                return true;
+            }
+            npc_opinion &attitude = who.op_of_u;
+            attitude.anger += 3;
+            attitude.trust -= 3;
+            attitude.value -= 1;
+            who.form_opinion(u);
+
+        }
         // TODO: Make NPCs protest when displaced onto dangerous crap
         tripoint oldpos = who.pos();
         who.move_away_from( u.pos(), true );


### PR DESCRIPTION
#### Summary
Content "Neutral NPCs may now be shoved."

#### Purpose of change
There are situations in the game where NPCs can block the player inside of a room. If the NPC is not obedient they cannot be pushed.

#### Describe the solution
NPCs may now be pushed, and it will change their opinion of you. Pushing them enough times will make them hostile. This is to prevent exploits. The player will be prompted and told that pushing the NPC will make them upset and asked if they wish to continue before the push occurs. Obedient NPCs can still be pushed with no cost to opinion.

#### Describe alternatives you've considered
I considered allowing swap positions with neutral characters, which won't work because it allows you to transport neutral NPCs into dangerous situations and get their gear for free. 

I also considered adding a "Walk past" option, however it requires teleporting the player and messes with the flow of time.

#### Testing
I have repeatedly spawned in NPCs and shoved the neutral ones. Friendly code has not been changed, however I also tested this with friendly NPCs.
