### PR TITLE
more sophisticated logic and details in the sunset/sunrise morale

### DIFF
--- a/data/json/effects_on_condition/misc_effect_on_condition.json
+++ b/data/json/effects_on_condition/misc_effect_on_condition.json
@@ -278,13 +278,58 @@
     "run_for_npcs": true,
     "condition": { "and": [ "u_is_outside", "u_can_see" ] },
     "effect": [
-      { "u_message": "The sunrise always makes you a feel a little bit better." },
       {
-        "u_add_morale": "morale_sunrise",
-        "bonus": 10,
-        "max_bonus": 10,
-        "duration": "120 minutes",
-        "decay_start": "60 minutes"
+        "if": { "or": [ { "is_weather": "sunny" }, { "is_weather": "clear" } ] },
+        "then": [
+          {
+            "if": { "and": [ { "u_has_trait": "SPIRITUAL" }, { "x_in_y_chance": { "x": 1, "y": 2 } } ] },
+            "then": [
+              { "u_message": "You can feel God's doing in this very beautiful sunrise." },
+              {
+                "u_add_morale": "morale_sunrise",
+                "bonus": 15,
+                "max_bonus": 15,
+                "duration": "120 minutes",
+                "decay_start": "60 minutes"
+              }
+            ],
+            "else": [
+              {
+                "if": { "x_in_y_chance": { "x": 1, "y": 5 } },
+                "then": [
+                  { "u_message": "The sunrise is especially beautiful today." },
+                  {
+                    "u_add_morale": "morale_sunrise",
+                    "bonus": 15,
+                    "max_bonus": 15,
+                    "duration": "120 minutes",
+                    "decay_start": "60 minutes"
+                  }
+                ],
+                "else": [
+                  { "u_message": "The sunrise always makes you a feel a little bit better." },
+                  {
+                    "u_add_morale": "morale_sunrise",
+                    "bonus": 10,
+                    "max_bonus": 10,
+                    "duration": "120 minutes",
+                    "decay_start": "60 minutes"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "else": [
+          { "u_message": "The sunrise is hidden behind clouds, but it is still a bright, new day." },
+          {
+            "u_add_morale": "morale_sunrise",
+            "bonus": 5,
+            "max_bonus": 5,
+            "duration": "60 minutes",
+            "decay_start": "30 minutes"
+          }
+        ]
       }
     ]
   },
@@ -296,13 +341,58 @@
     "run_for_npcs": true,
     "condition": { "and": [ "u_is_outside", "u_can_see" ] },
     "effect": [
-      { "u_message": "The sunset always makes you a feel a little bit better." },
       {
-        "u_add_morale": "morale_sunset",
-        "bonus": 10,
-        "max_bonus": 10,
-        "duration": "120 minutes",
-        "decay_start": "60 minutes"
+        "if": { "or": [ { "is_weather": "sunny" }, { "is_weather": "clear" } ] },
+        "then": [
+          {
+            "if": { "and": [ { "u_has_trait": "SPIRITUAL" }, { "x_in_y_chance": { "x": 1, "y": 2 } } ] },
+            "then": [
+              { "u_message": "You can feel God's doing in this very beautiful sunset." },
+              {
+                "u_add_morale": "morale_sunset",
+                "bonus": 15,
+                "max_bonus": 15,
+                "duration": "120 minutes",
+                "decay_start": "60 minutes"
+              }
+            ],
+            "else": [
+              {
+                "if": { "x_in_y_chance": { "x": 1, "y": 5 } },
+                "then": [
+                  { "u_message": "The sunset is especially beautiful today." },
+                  {
+                    "u_add_morale": "morale_sunset",
+                    "bonus": 15,
+                    "max_bonus": 15,
+                    "duration": "120 minutes",
+                    "decay_start": "60 minutes"
+                  }
+                ],
+                "else": [
+                  { "u_message": "The sunset always makes you a feel a little bit better." },
+                  {
+                    "u_add_morale": "morale_sunset",
+                    "bonus": 10,
+                    "max_bonus": 10,
+                    "duration": "120 minutes",
+                    "decay_start": "60 minutes"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "else": [
+          { "u_message": "The sunset is hidden behind clouds, but you can still see the pretty amber hue." },
+          {
+            "u_add_morale": "morale_sunset",
+            "bonus": 5,
+            "max_bonus": 5,
+            "duration": "60 minutes",
+            "decay_start": "30 minutes"
+          }
+        ]
       }
     ]
   }

--- a/data/json/effects_on_condition/misc_effect_on_condition.json
+++ b/data/json/effects_on_condition/misc_effect_on_condition.json
@@ -284,7 +284,7 @@
           {
             "if": { "and": [ { "u_has_trait": "SPIRITUAL" }, { "x_in_y_chance": { "x": 1, "y": 2 } } ] },
             "then": [
-              { "u_message": "You can feel God's doing in this very beautiful sunrise." },
+              { "u_message": "As you gaze upon the sunrise, you feel enraptured by its ethereal beauty.", "type": "good" },
               {
                 "u_add_morale": "morale_sunrise",
                 "bonus": 15,
@@ -297,7 +297,7 @@
               {
                 "if": { "x_in_y_chance": { "x": 1, "y": 5 } },
                 "then": [
-                  { "u_message": "The sunrise is especially beautiful today." },
+                  { "u_message": "The sunrise is especially beautiful today.", "type": "good" },
                   {
                     "u_add_morale": "morale_sunrise",
                     "bonus": 15,
@@ -307,7 +307,7 @@
                   }
                 ],
                 "else": [
-                  { "u_message": "The sunrise always makes you a feel a little bit better." },
+                  { "u_message": "The sunrise always makes you a feel a little bit better.", "type": "good" },
                   {
                     "u_add_morale": "morale_sunrise",
                     "bonus": 10,
@@ -321,7 +321,7 @@
           }
         ],
         "else": [
-          { "u_message": "The sunrise is hidden behind clouds, but it is still a bright, new day." },
+          { "u_message": "The sunrise is hidden behind clouds, but it is still a bright, new day.", "type": "good" },
           {
             "u_add_morale": "morale_sunrise",
             "bonus": 5,
@@ -347,7 +347,7 @@
           {
             "if": { "and": [ { "u_has_trait": "SPIRITUAL" }, { "x_in_y_chance": { "x": 1, "y": 2 } } ] },
             "then": [
-              { "u_message": "You can feel God's doing in this very beautiful sunset." },
+              { "u_message": "As you gaze upon the sunset, you feel enraptured by its ethereal beauty.", "type": "good" },
               {
                 "u_add_morale": "morale_sunset",
                 "bonus": 15,
@@ -360,7 +360,7 @@
               {
                 "if": { "x_in_y_chance": { "x": 1, "y": 5 } },
                 "then": [
-                  { "u_message": "The sunset is especially beautiful today." },
+                  { "u_message": "The sunset is especially beautiful today.", "type": "good" },
                   {
                     "u_add_morale": "morale_sunset",
                     "bonus": 15,
@@ -370,7 +370,7 @@
                   }
                 ],
                 "else": [
-                  { "u_message": "The sunset always makes you a feel a little bit better." },
+                  { "u_message": "The sunset always makes you a feel a little bit better.", "type": "good" },
                   {
                     "u_add_morale": "morale_sunset",
                     "bonus": 10,
@@ -384,7 +384,7 @@
           }
         ],
         "else": [
-          { "u_message": "The sunset is hidden behind clouds, but you can still see the pretty amber hue." },
+          { "u_message": "The sunset is hidden behind clouds, but you can still see the pretty amber hue.", "type": "good" },
           {
             "u_add_morale": "morale_sunset",
             "bonus": 5,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "More detailed sunset/sunrise morale based on actual weather and traits"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

Saw this new thing, immediately had the desire to flesh it out. Here we go.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

- Takes weather into account. Is it sunny or clear?
  - Sunny/clear
    - Check if spiritual:
      - Character has a high chance (50%) of getting an increased morale (15 vs the normal 10) from the sunrise/sunset.
    - Otherwise high chance (80%) for a normal buff. 20% chance to see an exceptionally beautiful sunrise/sunset and get 15 vs the normal 10 of morale.
  - Everything else
    - Character gets only 5 morale which also decays much faster.
#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Also considering portal storms and making these give debuffs instead, the likes of "You look up an expect a sunset, but instead you see a twisted, eerie celestial body.". I already nested enough ifs for today. Plus we already have sun-related stuff in the portal eocs anyways.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

![image](https://github.com/user-attachments/assets/e0a867b4-1dea-4d9a-a39a-96121b54c241)

While I tested this and am reasonably confident this will not cause errors, be extra vigilant when reviewing as this is my most complex EOC yet.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
