### PR TITLE
Defer checking death effect validity until finalize function.

### DIFF
--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -408,6 +408,8 @@ void MonsterGenerator::finalize_mtypes()
         build_behavior_tree( mon );
         finalize_pathfinding_settings( mon );
 
+        mon.mdeath_effect.has_effect = mon.mdeath_effect.sp.is_valid();
+
         mon.weakpoints.clear();
         for( const weakpoints_id &wpset : mon.weakpoints_deferred ) {
             mon.weakpoints.add_from_set( wpset, true );
@@ -1812,7 +1814,6 @@ void monster_death_effect::load( const JsonObject &jo )
 {
     optional( jo, was_loaded, "message", death_message, to_translation( "The %s dies!" ) );
     optional( jo, was_loaded, "effect", sp );
-    has_effect = sp.is_valid();
     optional( jo, was_loaded, "corpse_type", corpse_type, mdeath_type::NORMAL );
     optional( jo, was_loaded, "eoc", eoc );
 }


### PR DESCRIPTION
This can cause death effects with dependencies fail to load

#### Summary
None

#### Purpose of change
Fixes #75332
As reported, death effects can be subject to load ordering failure based on the effect having dependencies on other json entities.
This should make them load-order independent.

#### Describe the solution
This defers checking if a death effect is present and valid until the finalize step, at which point all of its dependencies should have been resolved.

#### Testing
Reproduced the issue with the upstream PR, after this fix the death effect fires and has its intended effects.