### PR TITLE
let hospitalized humans revive as zed crawlers

### DIFF
--- a/data/json/monsters/civilians.json
+++ b/data/json/monsters/civilians.json
@@ -120,6 +120,7 @@
     "//": "So they are not perpetually fleeing despite lying in a hospital bed",
     "morale": 0,
     "upgrades": { "into": "mon_zombie_crawler" },
+    "zombify_into": "mon_zombie_crawler",
     "delete": { "flags": [ "SEES", "HEARS" ] },
     "copy-from": "mon_civilian_stationary"
   },


### PR DESCRIPTION
#### Summary
Balance "let hospitalized humans revive as zed crawlers"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Ain't no way a person under life support + immobile can get "upgraded" as a normal zombie.

#### Describe the solution
Revive them as crawlers, just like their upgrade line

#### Describe alternatives you've considered
Add zombie to revive groups?

#### Testing
Should work.

#### Additional context
NONE

