### PR TITLE
Prevent segfault if repair item disappears

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2471,6 +2471,12 @@ void repair_item_finish( player_activity *act, Character *you, bool no_menu )
     // Valid Repeat choice and target, attempt repair.
     if( repeat != repeat_type::INIT && act->targets.size() >= 2 ) {
         item_location &fix_location = act->targets[1];
+        if( !fix_location ) {
+            // The item could disappear for various reasons: moved by follower, burned up, eaten by a grue, etc.
+            you->add_msg_if_player( m_warning, _( "You can no longer find the item to repair." ) );
+            act->set_to_null();
+            return;
+        }
 
         // Remember our level: we want to stop retrying on level up
         const int old_level = you->get_skill_level( actor->used_skill );


### PR DESCRIPTION

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Prevent segfault if repair item disappears"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Prevents segfault that could previously occur if the item being repaired was invalidated. Fixes #75113 .


<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

The target item being repaired could get invalidated for various reasons, such as a follower moving it via zone sorting, the item could burn up in a fire, etc.

Previous segfault that this commit attempts to prevent:
```
 #0  0x0000555555ef9057 in item::is_null (this=this@entry=0x0) at src/item.cpp:943
 #1  0x000055555602322c in repair_item_actor::can_repair_target (this=this@entry=0x555560003e80, pl=..., fix=..., print_msg=print_msg@entry=true, check_consumed_available=check_consumed_available@entry=true) at src/iuse_actor.cpp:2920
 #2  0x00005555560243c2 in repair_item_actor::repair (this=this@entry=0x555560003e80, pl=..., tool=..., fix=..., refit_only=refit_only@entry=false) at src/iuse_actor.cpp:3106
 #3  0x00005555559d5b55 in repair_item_finish (act=0x5555580cdf58, you=0x5555580cd890, no_menu=false) at src/activity_handlers.cpp:2477
 #4  0x0000555555a00f52 in std::function<void (player_activity*, Character*)>::operator()(player_activity*, Character*) const (this=<optimized out>, __args#0=<optimized out>, __args#0@entry=0x5555580cdf58, __args#1=<optimized out>, __args#1@entry=0x5555580cd890) at /usr/include/c++/13/bits/std_function.h:591
 #5  0x00005555559ff229 in activity_type::call_finish (this=<optimized out>, act=act@entry=0x5555580cdf58, you=you@entry=0x5555580cd890) at src/activity_type.cpp:168
 #6  0x00005555564e368b in player_activity::do_turn (this=0x5555580cdf58, you=...) at src/player_activity.cpp:393
 #7  0x0000555555cec856 in do_turn () at src/do_turn.cpp:532
 #8  0x0000555555776e74 in main (argc=<optimized out>, argv=<optimized out>) at src/main.cpp:873
```

Instead, this commit adds a message shown to the player if the target item is no longer valid for whatever reason.


<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Performed the steps in #75113 . Can no longer reproduce the segfault on this branch. Instead, the new msg is shown:
![snapshot2](https://github.com/user-attachments/assets/d5ff61dd-544c-4fea-8b18-9a0e19743465)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
