### PR TITLE
Fixes the condition for Hub-01 to repair salvaged exoskeletons

### DIFF
--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_prototypes.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_prototypes.json
@@ -206,10 +206,9 @@
       {
         "text": "I salvaged this combat exoskeleton.  Do you think you could repair it?",
         "condition": {
-          "or": [
-            { "u_has_var": "dialogue_hub_rnd_u_current_project", "value": "phase_immersion_suit" },
-            { "u_has_var": "dialogue_hub_rnd_u_current_project", "value": "rm13_armor" },
-            { "u_has_var": "dialogue_hub_rnd_u_current_project", "value": "combat_exoskeleton_light_salvaged" }
+          "and": [
+            { "u_has_items": { "item": "combat_exoskeleton_light_salvaged", "count": 1 } },
+            { "not": { "u_has_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" } }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_EXOSKELETON_REPAIR"


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Something got mixed up just before #74962 was merged. This prevented the option to have salvaged exo skeletons repaired from showing up. 

#### Describe the solution

Restore the original condition for the repair dialog to show up.

#### Describe alternatives you've considered

Opening an issue I guess?

#### Testing

Took my salvaged exo skeleton to Hub-01, saw that no repair options showed up under "prototypes".
Applied this fix, tried again and was able to hand the exo in for repairs.

#### Additional context
