### PR TITLE
Show tileset id along with debug overmap info

### DIFF
--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -1081,6 +1081,7 @@ nc_color oter_t::get_color( om_vision_level vision, const bool from_land_use_cod
 
 std::string oter_t::get_tileset_id( om_vision_level vision ) const
 {
+    // If this changes, be sure to change the debug display on the overmap ui to not strip the prefix!
     if( type->vision_levels->viewed( vision ) != nullptr ) {
         return string_format( "vl#%s$%s", type->vision_levels.str(), io::enum_to_string( vision ) );
     }

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1060,6 +1060,9 @@ static void draw_om_sidebar(
                    oter.get_rotation() );
         mvwprintz( wbar, point( 1, ++lines ), c_white,
                    "oter_type: %s", oter.get_type_id().str() );
+        // tileset ids come with a prefix that must be stripped
+        mvwprintz( wbar, point( 1, ++lines ), c_white,
+                   "tileset id: '%s'", oter.get_tileset_id( center_vision ).substr( 3 ) );
         std::vector<oter_id> predecessors = overmap_buffer.predecessors( center );
         if( !predecessors.empty() ) {
             mvwprintz( wbar, point( 1, ++lines ), c_white, "predecessors:" );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
https://github.com/CleverRaven/Cataclysm-DDA/pull/75236#issuecomment-2256800013

#### Describe the solution
Add the tileset id to the debug information provided.

#### Describe alternatives you've considered
I don't understand the other problem "current implementation ignoring overmap objects and use only first sprite of the object set". Could you elaborate @vetall812 ?

#### Testing
Debug teleport on the overmap, and look around at tiles:
![image](https://github.com/user-attachments/assets/932656c4-4c84-4fd8-888a-3974898a3e73)
