### PR TITLE
Add v2 (monocrystalline) panels to rooftop solar

### DIFF
--- a/data/json/furniture_and_terrain/furniture-appliances.json
+++ b/data/json/furniture_and_terrain/furniture-appliances.json
@@ -573,8 +573,8 @@
   {
     "type": "furniture",
     "id": "f_solar_unit",
-    "name": "mounted solar panel",
-    "description": "A set of photovoltaic power generators, which turns solar radiation into useable electricity.  While useful before the Cataclysm, they have become priceless tools, invaluable to any survivor.",
+    "name": "mounted polycrystalline solar panel",
+    "description": "A set of photovoltaic power generators, which turns solar radiation into useable electricity.  While useful before the Cataclysm, they have become priceless tools, invaluable to any survivor.  This one uses less efficient polycrystalline solar panels.",
     "symbol": "#",
     "color": "yellow",
     "move_cost_mod": 2,
@@ -589,6 +589,33 @@
       "sound_fail": "clang!",
       "items": [
         { "item": "solar_cell", "count": [ 4, 20 ] },
+        { "item": "scrap", "count": [ 12, 24 ] },
+        { "item": "amplifier", "count": [ 0, 2 ] },
+        { "item": "cable", "charges": [ 40, 60 ] },
+        { "item": "power_supply", "count": [ 0, 2 ] },
+        { "item": "scrap", "count": [ 16, 24 ] },
+        { "item": "plastic_chunk", "count": [ 4, 8 ] },
+        { "item": "steel_chunk", "count": 12 }
+      ]
+    }
+  },
+  {
+    "type": "furniture",
+    "id": "f_solar_unit_v2",
+    "copy-from": "f_solar_unit",
+    "name": "mounted monocrystalline solar panel",
+    "description": "A set of photovoltaic power generators, which turns solar radiation into useable electricity.  While useful before the Cataclysm, they have become priceless tools, invaluable to any survivor.  This one uses more efficient monocrystalline solar panels.",
+    "symbol": "#",
+    "color": "light_blue",
+    "examine_action": { "type": "appliance_convert", "furn_set": "f_null", "item": "ground_solar_panel_v2" },
+    "deconstruct": { "items": [ { "item": "ground_solar_panel_v2", "count": 1 } ] },
+    "bash": {
+      "str_min": 10,
+      "str_max": 20,
+      "sound": "whack!",
+      "sound_fail": "clang!",
+      "items": [
+        { "item": "solar_cell_v2", "count": [ 4, 20 ] },
         { "item": "scrap", "count": [ 12, 24 ] },
         { "item": "amplifier", "count": [ 0, 2 ] },
         { "item": "cable", "charges": [ 40, 60 ] },

--- a/data/json/mapgen/house/2storymodern04.json
+++ b/data/json/mapgen/house/2storymodern04.json
@@ -204,7 +204,16 @@
       ],
       "nested": {
         "2": {
-          "chunks": [ [ "residential_3x3_solar", 6 ], [ "residential_2x2_solar", 2 ], [ "residential_1x3_solar", 3 ], [ "null", 88 ] ]
+          "//": "11% chance of solar, 20% change of that solar being v2",
+          "chunks": [
+            [ "residential_3x3_solar", 12 ],
+            [ "residential_2x2_solar", 4 ],
+            [ "residential_1x3_solar", 6 ],
+            [ "residential_3x3_solar_v2", 3 ],
+            [ "residential_2x2_solar_v2", 1 ],
+            [ "residential_1x3_solar_v2", 2 ],
+            [ "null", 220 ]
+          ]
         }
       }
     }

--- a/data/json/mapgen/house/house_detatched8.json
+++ b/data/json/mapgen/house/house_detatched8.json
@@ -105,7 +105,18 @@
       ],
       "palettes": [ "roof_palette" ],
       "terrain": { ".": "t_shingle_flat_roof" },
-      "nested": { "1": { "chunks": [ [ "residential_1x2_solar", 6 ], [ "residential_2x2_solar", 4 ], [ "null", 88 ] ] } }
+      "nested": {
+        "1": {
+          "//": "11% chance for solar, 20% chance it's v2",
+          "chunks": [
+            [ "residential_1x2_solar", 12 ],
+            [ "residential_2x2_solar", 8 ],
+            [ "residential_1x2_solar_v2", 3 ],
+            [ "residential_2x2_solar_v2", 2 ],
+            [ "null", 220 ]
+          ]
+        }
+      }
     }
   },
   {

--- a/data/json/mapgen/lmoe.json
+++ b/data/json/mapgen/lmoe.json
@@ -72,7 +72,16 @@
       "palettes": [ "bunker_ext" ],
       "place_nested": [
         {
-          "chunks": [ [ "residential_1x2_solar", 3 ], [ "residential_2x2_solar", 1 ], [ "residential_1x3_solar", 2 ], [ "null", 94 ] ],
+          "//": "6% chance of solar, 20% chance it's v2",
+          "chunks": [
+            [ "residential_1x2_solar", 12 ],
+            [ "residential_2x2_solar", 4 ],
+            [ "residential_1x3_solar", 8 ],
+            [ "residential_1x2_solar_v2", 3 ],
+            [ "residential_2x2_solar_v2", 1 ],
+            [ "residential_1x3_solar_v2", 2 ],
+            [ "null", 470 ]
+          ],
           "x": 11,
           "y": 10
         }

--- a/data/json/mapgen/nested/nested_chunks_roof.json
+++ b/data/json/mapgen/nested/nested_chunks_roof.json
@@ -567,5 +567,41 @@
     "method": "json",
     "nested_mapgen_id": "industrial_1x1_solar",
     "object": { "mapgensize": [ 1, 1 ], "place_furniture": [ { "furn": "f_solar_unit", "x": 0, "y": 0 } ] }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "residential_2x2_solar_v2",
+    "object": { "mapgensize": [ 2, 2 ], "place_furniture": [ { "furn": "f_solar_unit_v2", "x": [ 0, 1 ], "y": [ 0, 1 ] } ] }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "residential_1x2_solar_v2",
+    "object": { "mapgensize": [ 2, 2 ], "place_furniture": [ { "furn": "f_solar_unit_v2", "x": 0, "y": [ 0, 1 ] } ] }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "residential_1x3_solar_v2",
+    "object": { "mapgensize": [ 3, 3 ], "place_furniture": [ { "furn": "f_solar_unit_v2", "x": 0, "y": [ 0, 2 ] } ] }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "residential_3x3_solar_v2",
+    "object": { "mapgensize": [ 3, 3 ], "place_furniture": [ { "furn": "f_solar_unit_v2", "x": [ 0, 2 ], "y": [ 0, 2 ] } ] }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "industrial_1x5_solar_v2",
+    "object": { "mapgensize": [ 5, 5 ], "place_furniture": [ { "furn": "f_solar_unit_v2", "x": [ 0, 4 ], "y": 0 } ] }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "industrial_1x1_solar_v2",
+    "object": { "mapgensize": [ 1, 1 ], "place_furniture": [ { "furn": "f_solar_unit_v2", "x": 0, "y": 0 } ] }
   }
 ]

--- a/data/json/mapgen_palettes/roof_palette.json
+++ b/data/json/mapgen_palettes/roof_palette.json
@@ -56,9 +56,18 @@
     "liquids": { "Я": { "liquid": "water_clean", "amount": [ 0, 300 ] } },
     "nested": {
       "1": {
-        "chunks": [ [ "residential_1x2_solar", 6 ], [ "residential_2x2_solar", 2 ], [ "residential_1x3_solar", 3 ], [ "null", 88 ] ]
+        "//": "11% chance of solar, 20% chance it's v2",
+        "chunks": [
+          [ "residential_1x2_solar", 24 ],
+          [ "residential_2x2_solar", 8 ],
+          [ "residential_1x3_solar", 12 ],
+          [ "residential_1x2_solar_v2", 6 ],
+          [ "residential_2x2_solar_v2", 2 ],
+          [ "residential_1x3_solar_v2", 3 ],
+          [ "null", 440 ]
+        ]
       },
-      "2": { "chunks": [ "industrial_1x1_solar" ] },
+      "2": { "chunks": [ [ "industrial_1x1_solar", 4 ], [ "industrial_1x1_solar_v2", 1 ] ] },
       "5": { "chunks": [ [ "null", 90 ], [ "roof_1x1_birdnest", 10 ] ] },
       "-": { "chunks": [ [ "null", 1000 ], [ "roof_1x1_birdnest", 5 ] ] }
     },


### PR DESCRIPTION

#### Summary
Content "v2 solar panels now spawn in the world more frequently"

#### Purpose of change
https://github.com/CleverRaven/Cataclysm-DDA/pull/75227#issuecomment-2251234221

Monosilicon panels don't appear anywhere but on a car. From data on solar added in Massachusetts and monosilicon panel production as a percent of solar production, we can get some numbers for how frequently they should occur.

| Year  |  Solar Added (MW) | Monosilicon (%) | Added Monosilicon (MW) |
|-------|-------------------|-----------------|------------------------|
| 2011  | 42.65             | 25              | 10.66                  |
| 2012  | 134.5             | 25              | 33.63                  |
| 2013  | 226.94            | 25              | 56.74                  |
| 2014  | 269.11            | 25              | 67.28                  |
| 2015  | 286.53            | 25              | 71.63                  |
| 2016  | 394               | 25              | 98.5                   |
| 2017  | 571               | 35              | 199.85                 |
| 2018  | 370               | 45              | 166.5                  |
| 2019  | 237               | 65              | 154.05                 |
| Total | 2531.73           | -               | 858.83                 |

858.83/2531.73 = 34% high-efficiency monosilicon panels

Production Percent from https://www.ise.fraunhofer.de/content/dam/ise/de/documents/publications/studies/Photovoltaics-Report.pdf
Solar Added from https://www.mass.gov/info-details/renewable-energy-snapshot#installed-solar-capacity-in-massachusetts-

#### Describe the solution
Add v2 solar panel nests, and make them spawn at the places the other solar nests spawn with 20% chance. 20% is fairly stingy, but the data to get a rate is pretty terrible.

#### Testing
Teleport around to roofs. Find monocrystalline panels.
