### PR TITLE
Description fix for Bren 5.56x45mm carbine

### DIFF
--- a/data/json/items/gun/223.json
+++ b/data/json/items/gun/223.json
@@ -741,7 +741,7 @@
     "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "Bren 5.56x45mm carbine" },
-    "description": "A semi-automatic clone of the Czech Republic's standard infantry carbine, sold for civilian sport shooting and recreational use, this modular rifle makes use of the 7.62x39mm Soviet cartridge and uses proprietary magazines.",
+    "description": "A semi-automatic clone of the Czech Republic's standard infantry carbine, sold for civilian sport shooting and recreational use, this modular rifle makes use of the standard magazines of the AR-15 platform and a 5.56x45mm cartridge.",
     "variant_type": "gun",
     "variants": [
       {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
I noticed in my last run that the description text for a gun (the Bren 5.56x45mm carbine) referenced the wrong ammo type, and discovered that the text was simply not updated after being copy-pasted from a different one (the "Bren 7.62mm carbine").

#### Describe the solution
I updated the text to refer to the correct ammo type, copying some existing appropriate text from another item (the "5.56x45mm bullpup rifle").

#### Describe alternatives you've considered
I considered adjusting the Bren variants to have newly separate names (both 5.56 and 7.62 versions have the shared variant of "CZ Bren 2 carbine"), but figured a minimal edit was appropriate.

#### Testing
Built from source, spawned all versions of Bren guns, and compared to behavior in a recent experimental build.

#### Additional context
n/a