### PR TITLE
Vanilla NPCs do not rely on your bank account anymore

### DIFF
--- a/data/json/npcs/robofac/robofac_ancilla_npcs/NPC_ANCILLA_DOCTOR.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/NPC_ANCILLA_DOCTOR.json
@@ -115,14 +115,14 @@
       {
         "text": "[4 HGC, 30m] I need you to patch me up.",
         "topic": "TALK_ANCILLA_DOCTOR_AID_DONE",
-        "effect": [ { "u_spend_cash": 20000, "true_eocs": { "id": "give_aid", "effect": "give_aid" } } ],
-        "condition": { "npc_service": 20000 }
+        "effect": [ { "u_consume_item": "RobofacCoin", "count": 4 }, "give_aid" ],
+        "condition": { "u_has_items": { "item": "RobofacCoin", "count": 4 } }
       },
       {
         "text": "[8 HGC, 1h] I need you to patch my friends up.",
         "topic": "TALK_ANCILLA_DOCTOR_AID_DONE",
-        "effect": { "u_spend_cash": 40000, "true_eocs": { "id": "give_all_aid", "effect": "give_all_aid" } },
-        "condition": { "npc_service": 40000 }
+        "effect": [ { "u_consume_item": "RobofacCoin", "count": 8 }, "give_all_aid" ],
+        "condition": { "u_has_items": { "item": "RobofacCoin", "count": 8 } }
       },
       { "text": "I should be fine.", "topic": "TALK_ANCILLA_DOCTOR" }
     ]
@@ -136,25 +136,25 @@
         "text": "I was wondering if you could install a cybernetic implant…",
         "topic": "TALK_DONE",
         "effect": "bionic_install",
-        "condition": { "npc_service": 0 }
+        "condition": { "not": { "npc_has_effect": "currently_busy" } }
       },
       {
         "text": "I was wondering if you could install a cybernetic implant in my friend here…",
         "topic": "TALK_DONE",
         "effect": "bionic_install_allies",
-        "condition": { "npc_service": 0 }
+        "condition": { "not": { "npc_has_effect": "currently_busy" } }
       },
       {
         "text": "I need help removing an implant…",
         "topic": "TALK_DONE",
         "effect": "bionic_remove",
-        "condition": { "npc_service": 0 }
+        "condition": { "not": { "npc_has_effect": "currently_busy" } }
       },
       {
         "text": "I need help removing an implant from one of my friends…",
         "topic": "TALK_DONE",
         "effect": "bionic_remove_allies",
-        "condition": { "npc_service": 0 }
+        "condition": { "not": { "npc_has_effect": "currently_busy" } }
       },
       { "text": "Oh no, I was wondering if you knew where to get some.", "topic": "TALK_ANCILLA_DOCTOR_FIND_BIONICS" },
       { "text": "Never mind.", "topic": "TALK_NONE" }

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_doctor.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_doctor.json
@@ -55,7 +55,11 @@
           "clear_mission"
         ]
       },
-      { "text": "Could you help me with some bionics?", "topic": "TALK_RANCH_DOCTOR_BIONICS" },
+      {
+        "text": "Could you help me with some bionics?",
+        "topic": "TALK_RANCH_DOCTOR_BIONICS",
+        "condition": { "u_has_var": "knowledge_exodization_u_knows_exodiilore", "value": "yes" }
+      },
       { "text": "I could use your medical assistance.", "topic": "TALK_RANCH_DOCTOR_AID" },
       { "text": "…", "topic": "TALK_DONE" }
     ]
@@ -75,16 +79,26 @@
     },
     "responses": [
       {
-        "text": "[$200, 30m] I need you to patch me up.",
+        "text": "[80 merch, 30m] I need you to patch me up.",
         "topic": "TALK_RANCH_DOCTOR_AID_DONE",
-        "effect": [ "give_aid", { "u_spend_cash": 20000 } ],
-        "condition": { "and": [ { "npc_service": 20000 }, { "npc_has_var": "dialogue_tacoma_ranch_provides_aid", "value": "yes" } ] }
+        "effect": [ { "u_consume_item": "FMCNote", "count": 80 }, "give_aid" ],
+        "condition": {
+          "and": [
+            { "u_has_items": { "item": "FMCNote", "count": 80 } },
+            { "npc_has_var": "dialogue_tacoma_ranch_provides_aid", "value": "yes" }
+          ]
+        }
       },
       {
-        "text": "[$500, 1h] I need you to patch my friends up.",
+        "text": "[200 merch, 1h] I need you to patch my friends up.",
         "topic": "TALK_RANCH_DOCTOR_AID_DONE",
-        "effect": [ "give_all_aid", { "u_spend_cash": 50000 } ],
-        "condition": { "and": [ { "npc_service": 50000 }, { "npc_has_var": "dialogue_tacoma_ranch_provides_aid", "value": "yes" } ] }
+        "effect": [ { "u_consume_item": "FMCNote", "count": 200 }, "give_all_aid" ],
+        "condition": {
+          "and": [
+            { "u_has_items": { "item": "FMCNote", "count": 200 } },
+            { "npc_has_var": "dialogue_tacoma_ranch_provides_aid", "value": "yes" }
+          ]
+        }
       },
       { "text": "Never mind.", "topic": "TALK_NONE" },
       { "text": "I've got to go…", "topic": "TALK_DONE" }
@@ -100,27 +114,35 @@
     "id": "TALK_RANCH_DOCTOR_BIONICS",
     "type": "talk_topic",
     "dynamic_line": {
-      "npc_has_var": "dialogue_tacoma_ranch_provides_bionics",
+      "npc_has_var": "dialogue_tacoma_ranch_provides_surgery",
       "value": "yes",
-      "yes": "What can I help you with?",
-      "no": "We don't have the medical equipment to do that right now."
+      "yes": "If you mean something like pacemaker, then maybe.  What's the trouble?",
+      "no": "If you mean something like pacemaker, we can't really do much without anesthesia."
     },
     "responses": [
       {
-        "text": "I was wondering if you could install a cybernetic implant…",
-        "topic": "TALK_DONE",
-        "effect": "bionic_install",
-        "condition": { "and": [ { "npc_service": 0 }, { "npc_has_var": "dialogue_tacoma_ranch_provides_bionics", "value": "yes" } ] }
+        "text": "No, i mean something, eeh, more sci-fi.  There are robo-guys in a stone castle, they say they have such technology.  They even installed something into me, look!",
+        "topic": "TALK_RANCH_DOCTOR_BIONICS_DUNNO",
+        "condition": { "u_has_bionics": "ANY" }
       },
       {
-        "text": "I need help removing an implant…",
-        "topic": "TALK_DONE",
-        "effect": "bionic_remove",
-        "condition": { "and": [ { "npc_service": 0 }, { "npc_has_var": "dialogue_tacoma_ranch_provides_bionics", "value": "yes" } ] }
+        "text": "No, i mean something, eeh, more sci-fi.  There are robo-guys in a stone castle, they say they have such technology.",
+        "topic": "TALK_RANCH_DOCTOR_BIONICS_DUNNO",
+        "condition": { "not": { "u_has_bionics": "ANY" } }
       },
       { "text": "Never mind.", "topic": "TALK_NONE" },
       { "text": "I've got to go…", "topic": "TALK_DONE" }
     ]
+  },
+  {
+    "id": "TALK_RANCH_DOCTOR_BIONICS_DUNNO",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "u_has_bionics": "ANY",
+      "yes": "Curious.  Sorry, i have no idea how it works, and i'd be afraid to even touch this parts.",
+      "no": "Are you all right?  Sci-fi bionic by robots in a stone castle?  I have some antipsychotics, if it helps."
+    },
+    "responses": [ { "text": "I've got to go…", "topic": "TALK_DONE" } ]
   },
   {
     "id": "TALK_RANCH_DOCTOR_SUPPLIES",
@@ -276,7 +298,7 @@
       "rejected": "Come back when you get a chance.  We need skilled survivors.",
       "advice": "Hospitals or clinics might have some.  Labs could have some as well.",
       "inquire": "Any progress on getting some anesthetic or parts?",
-      "success": "The scavengers found more medical equipment than I expected and with the help from the scrappers, I've been able to get most of it up and running.  I should be able to perform more operations now and could even help with some bionics if you have any.",
+      "success": "The scavengers found more medical equipment than I expected and with the help from the scrappers, I've been able to get most of it up and running.  I should be able to perform more operations now.",
       "success_lie": "What good does this do us?",
       "failure": "It was a lost cause anyways…"
     },
@@ -284,7 +306,7 @@
       "update_mapgen": [ { "om_terrain": "ranch_camp_50", "set": [ { "point": "furniture", "id": "f_anesthetic", "x": 19, "y": 19 } ] } ],
       "effect": [
         { "u_consume_item": "anesthetic", "count": 3000 },
-        { "npc_add_var": "dialogue_tacoma_ranch_provides_bionics", "value": "yes" }
+        { "npc_add_var": "dialogue_tacoma_ranch_provides_surgery", "value": "yes" }
       ]
     }
   }

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_doctor.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_doctor.json
@@ -55,11 +55,7 @@
           "clear_mission"
         ]
       },
-      {
-        "text": "Could you help me with some bionics?",
-        "topic": "TALK_RANCH_DOCTOR_BIONICS",
-        "condition": { "u_has_var": "knowledge_exodization_u_knows_exodiilore", "value": "yes" }
-      },
+      { "text": "Could you help me with some bionics?", "topic": "TALK_RANCH_DOCTOR_BIONICS" },
       { "text": "I could use your medical assistance.", "topic": "TALK_RANCH_DOCTOR_AID" },
       { "text": "…", "topic": "TALK_DONE" }
     ]
@@ -114,35 +110,27 @@
     "id": "TALK_RANCH_DOCTOR_BIONICS",
     "type": "talk_topic",
     "dynamic_line": {
-      "npc_has_var": "dialogue_tacoma_ranch_provides_surgery",
+      "npc_has_var": "dialogue_tacoma_ranch_provides_bionics",
       "value": "yes",
-      "yes": "If you mean something like pacemaker, then maybe.  What's the trouble?",
-      "no": "If you mean something like pacemaker, we can't really do much without anesthesia."
+      "yes": "What can I help you with?",
+      "no": "We don't have the medical equipment to do that right now."
     },
     "responses": [
       {
-        "text": "No, i mean something, eeh, more sci-fi.  There are robo-guys in a stone castle, they say they have such technology.  They even installed something into me, look!",
-        "topic": "TALK_RANCH_DOCTOR_BIONICS_DUNNO",
-        "condition": { "u_has_bionics": "ANY" }
+        "text": "I was wondering if you could install a cybernetic implant…",
+        "topic": "TALK_DONE",
+        "effect": "bionic_install",
+        "condition": { "and": [ { "npc_service": 0 }, { "npc_has_var": "dialogue_tacoma_ranch_provides_bionics", "value": "yes" } ] }
       },
       {
-        "text": "No, i mean something, eeh, more sci-fi.  There are robo-guys in a stone castle, they say they have such technology.",
-        "topic": "TALK_RANCH_DOCTOR_BIONICS_DUNNO",
-        "condition": { "not": { "u_has_bionics": "ANY" } }
+        "text": "I need help removing an implant…",
+        "topic": "TALK_DONE",
+        "effect": "bionic_remove",
+        "condition": { "and": [ { "npc_service": 0 }, { "npc_has_var": "dialogue_tacoma_ranch_provides_bionics", "value": "yes" } ] }
       },
       { "text": "Never mind.", "topic": "TALK_NONE" },
       { "text": "I've got to go…", "topic": "TALK_DONE" }
     ]
-  },
-  {
-    "id": "TALK_RANCH_DOCTOR_BIONICS_DUNNO",
-    "type": "talk_topic",
-    "dynamic_line": {
-      "u_has_bionics": "ANY",
-      "yes": "Curious.  Sorry, i have no idea how it works, and i'd be afraid to even touch this parts.",
-      "no": "Are you all right?  Sci-fi bionic by robots in a stone castle?  I have some antipsychotics, if it helps."
-    },
-    "responses": [ { "text": "I've got to go…", "topic": "TALK_DONE" } ]
   },
   {
     "id": "TALK_RANCH_DOCTOR_SUPPLIES",
@@ -298,7 +286,7 @@
       "rejected": "Come back when you get a chance.  We need skilled survivors.",
       "advice": "Hospitals or clinics might have some.  Labs could have some as well.",
       "inquire": "Any progress on getting some anesthetic or parts?",
-      "success": "The scavengers found more medical equipment than I expected and with the help from the scrappers, I've been able to get most of it up and running.  I should be able to perform more operations now.",
+      "success": "The scavengers found more medical equipment than I expected and with the help from the scrappers, I've been able to get most of it up and running.  I should be able to perform more operations now and could even help with some bionics if you have any.",
       "success_lie": "What good does this do us?",
       "failure": "It was a lost cause anyways…"
     },
@@ -306,7 +294,7 @@
       "update_mapgen": [ { "om_terrain": "ranch_camp_50", "set": [ { "point": "furniture", "id": "f_anesthetic", "x": 19, "y": 19 } ] } ],
       "effect": [
         { "u_consume_item": "anesthetic", "count": 3000 },
-        { "npc_add_var": "dialogue_tacoma_ranch_provides_surgery", "value": "yes" }
+        { "npc_add_var": "dialogue_tacoma_ranch_provides_bionics", "value": "yes" }
       ]
     }
   }

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_nurse.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_nurse.json
@@ -89,16 +89,16 @@
     },
     "responses": [
       {
-        "text": "[$100, 15m] I need you to patch me up.",
+        "text": "[40 merch, 15m] I need you to patch me up.",
         "topic": "TALK_RANCH_NURSE_AID_DONE",
-        "effect": [ { "u_spend_cash": 10000, "true_eocs": { "id": "EOC_lesser_give_aid", "effect": "lesser_give_aid" } } ],
-        "condition": { "npc_service": 10000 }
+        "effect": [ { "u_consume_item": "FMCNote", "count": 40 }, "lesser_give_aid" ],
+        "condition": { "u_has_items": { "item": "FMCNote", "count": 40 } }
       },
       {
-        "text": "[$250, 30h] I need you to patch my friends up.",
+        "text": "[100 merch, 30m] I need you to patch my friends up.",
         "topic": "TALK_RANCH_NURSE_AID_DONE",
-        "effect": { "u_spend_cash": 25000, "true_eocs": { "id": "EOC_lesser_give_all_aid", "effect": "lesser_give_all_aid" } },
-        "condition": { "npc_service": 25000 }
+        "effect": [ { "u_consume_item": "FMCNote", "count": 100 }, "lesser_give_all_aid" ],
+        "condition": { "u_has_items": { "item": "FMCNote", "count": 100 } }
       },
       { "text": "I should be fine.", "topic": "TALK_RANCH_NURSE" }
     ]

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_woodcutter1.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_woodcutter1.json
@@ -50,12 +50,12 @@
     },
     "responses": [
       {
-        "text": "[$2000, 1d] 10 logs",
+        "text": "[800 merch, 1d] 10 logs",
         "topic": "TALK_DONE",
         "effect": [
+          { "u_consume_item": "FMCNote", "count": 800 },
           {
-            "u_spend_cash": 200000,
-            "true_eocs": {
+            "run_eocs": {
               "id": "EOC_10_logs",
               "effect": [
                 { "mapgen_update": "tacoma_commune_woodcutter_10_logs", "om_terrain": "ranch_camp_67" },
@@ -65,15 +65,15 @@
             }
           }
         ],
-        "condition": { "npc_service": 200000 }
+        "condition": { "u_has_items": { "item": "FMCNote", "count": 800 } }
       },
       {
-        "text": "[$12000, 7d] 100 logs",
+        "text": "[4800 merch, 7d] 100 logs",
         "topic": "TALK_DONE",
         "effect": [
+          { "u_consume_item": "FMCNote", "count": 4800 },
           {
-            "u_spend_cash": 1200000,
-            "true_eocs": {
+            "run_eocs": {
               "id": "EOC_100_logs",
               "effect": [
                 { "mapgen_update": "tacoma_commune_woodcutter_100_logs", "om_terrain": "ranch_camp_67" },
@@ -83,7 +83,7 @@
             }
           }
         ],
-        "condition": { "npc_service": 1200000 }
+        "condition": { "u_has_items": { "item": "FMCNote", "count": 4800 } }
       },
       { "text": "Maybe later.", "topic": "TALK_RANCH_WOODCUTTER", "condition": "npc_available" },
       { "text": "I'll be back later.", "topic": "TALK_RANCH_WOODCUTTER" }

--- a/data/mods/Aftershock/npcs/Augustmoon_Salvors/augustmoon_doctor.json
+++ b/data/mods/Aftershock/npcs/Augustmoon_Salvors/augustmoon_doctor.json
@@ -83,13 +83,13 @@
     },
     "responses": [
       {
-        "text": "[4 HGC, 30m] I need you to patch me up.",
+        "text": "[1200$, 30m] I need you to patch me up.",
         "topic": "TALK_MERCURIAL_DOCTOR_AID_DONE",
         "effect": [ { "u_spend_cash": 120000, "true_eocs": { "id": "give_a_aid", "effect": "give_aid" } } ],
         "condition": { "npc_service": 120000 }
       },
       {
-        "text": "[8 HGC, 1h] I need you to patch my friends up.",
+        "text": "[2400$, 1h] I need you to patch my friends up.",
         "topic": "TALK_MERCURIAL_DOCTOR_AID_DONE",
         "effect": { "u_spend_cash": 240000, "true_eocs": { "id": "give_a_all_aid", "effect": "give_all_aid" } },
         "condition": { "npc_service": 240000 }


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fix #75433
#### Describe the solution
Repalce all instances of manipulation with cash (aka your bank account) and `npc_service` with `u_has_items` and `u_consume_item`
~~After some lore discussion, remove tacoma ability to install/uninstall bionic, and make custom bionic dialogue to reflect that they have no idea about bionic at all~~ moved to #75463
#### Testing
![image](https://github.com/user-attachments/assets/bafc03ce-1af3-4b39-a40a-bcce9099eacc)
#### Additional context
augustmoon is intentionally left unchanged because aftershock uses bank account; just fixed them not using $, but HGC in message