### PR TITLE
allow map_cursor to be made from abs pos

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6988,7 +6988,7 @@ void longsalvage_activity_actor::finish( player_activity &act, Character &who )
         // Check first and only if possible attempt it with player char
         // This suppresses warnings unless it is an item the player wears
         if( actor->valid_to_cut_up( nullptr, it ) ) {
-            item_location item_loc( map_cursor( who.pos_bub() ), &it );
+            item_location item_loc( map_cursor( who.get_location() ), &it );
             actor->try_to_cut_up( who, *salvage_tool, item_loc );
             return;
         }

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -3532,7 +3532,7 @@ int get_auto_consume_moves( Character &you, const bool food )
             }
         } else {
             for( item &it : here.i_at( here.bub_from_abs( loc ) ) ) {
-                item_location i_loc( map_cursor( here.bub_from_abs( loc ) ), &it );
+                item_location i_loc( map_cursor( loc ), &it );
                 visit_item_contents( i_loc, visit );
             }
         }

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -334,7 +334,8 @@ item_location Character::i_add( item it, bool /* should_stack */, const item *av
     if( added == item_location::nowhere ) {
         if( !allow_wield || !wield( it ) ) {
             if( allow_drop ) {
-                return item_location( map_cursor( pos_bub() ), &get_map().add_item_or_charges( pos_bub(), it ) );
+                return item_location( map_cursor( get_location() ), &get_map().add_item_or_charges( pos_bub(),
+                                      it ) );
             } else {
                 return added;
             }
@@ -368,7 +369,7 @@ item_location Character::i_add( item it, int &copies_remaining,
         }
         if( allow_drop && copies_remaining > 0 ) {
             item map_added = get_map().add_item_or_charges( pos_bub(), it, copies_remaining );
-            added = added ? added : item_location( map_cursor( pos_bub() ), &map_added );
+            added = added ? added : item_location( map_cursor( get_location() ), &map_added );
         }
     }
     return added;
@@ -394,7 +395,8 @@ ret_val<item_location> Character::i_add_or_fill( item &it, bool should_stack, co
         if( new_charge >= 1 ) {
             if( !allow_wield || !wield( it ) ) {
                 if( allow_drop ) {
-                    loc = item_location( map_cursor( pos_bub() ), &get_map().add_item_or_charges( pos_bub(), it ) );
+                    loc = item_location( map_cursor( get_location() ), &get_map().add_item_or_charges( pos_bub(),
+                                         it ) );
                 }
             } else {
                 loc = item_location( *this, &weapon );

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -2414,6 +2414,7 @@ bool Character::craft_consume_tools( item &craft, int multiplier, bool start_cra
                         craft.set_tools_to_continue( false );
                         return false;
                     }
+                    break;
                 case usage_from::none:
                 case usage_from::cancel:
                 case usage_from::num_usages_from:
@@ -2744,7 +2745,7 @@ void Character::disassemble_all( bool one_pass )
     bool found_any = false;
     std::vector<item_location> to_disassemble;
     for( item &it : get_map().i_at( pos_bub() ) ) {
-        to_disassemble.emplace_back( map_cursor( pos_bub() ), &it );
+        to_disassemble.emplace_back( map_cursor( get_location() ), &it );
     }
     for( item_location &it_loc : to_disassemble ) {
         // Prevent disassembling an in process disassembly because it could have been created by a previous iteration of this loop

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -9614,7 +9614,7 @@ void game::butcher()
                 case MULTIBUTCHER:
                     butcher_submenu( corpses );
                     for( map_stack::iterator &it : corpses ) {
-                        u.activity.targets.emplace_back( map_cursor( u.pos_bub() ), &*it );
+                        u.activity.targets.emplace_back( map_cursor( u.get_location() ), &*it );
                     }
                     break;
                 case MULTIDISASSEMBLE_ONE:
@@ -9630,13 +9630,13 @@ void game::butcher()
             break;
         case BUTCHER_CORPSE: {
             butcher_submenu( corpses, indexer_index );
-            u.activity.targets.emplace_back( map_cursor( u.pos_bub() ), &*corpses[indexer_index] );
+            u.activity.targets.emplace_back( map_cursor( u.get_location() ), &*corpses[indexer_index] );
         }
         break;
         case BUTCHER_DISASSEMBLE: {
             // Pick index of first item in the disassembly stack
             item *const target = &*disassembly_stacks[indexer_index].first;
-            u.disassemble( item_location( map_cursor( u.pos_bub() ), target ), true );
+            u.disassemble( item_location( map_cursor( u.get_location() ), target ), true );
         }
         break;
         case BUTCHER_SALVAGE: {
@@ -9645,7 +9645,7 @@ void game::butcher()
             } else {
                 // Pick index of first item in the salvage stack
                 item *const target = &*salvage_stacks[indexer_index].first;
-                item_location item_loc( map_cursor( u.pos_bub() ), target );
+                item_location item_loc( map_cursor( u.get_location() ), target );
                 salvage_iuse->try_to_cut_up( u, *salvage_tool, item_loc );
             }
         }
@@ -10846,7 +10846,7 @@ point game::place_player( const tripoint &dest_loc, bool quick )
             if( !corpses.empty() ) {
                 u.assign_activity( ACT_BUTCHER, 0, true );
                 for( item *it : corpses ) {
-                    u.activity.targets.emplace_back( map_cursor( u.pos_bub() ), it );
+                    u.activity.targets.emplace_back( map_cursor( u.get_location() ), it );
                 }
             }
         } else if( pulp_butcher == "pulp" || pulp_butcher == "pulp_adjacent" ||

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -842,7 +842,7 @@ void item_location::deserialize( const JsonObject &obj )
         obj.read( "parent", parent );
         if( !parent.ptr->valid() ) {
             debugmsg( "parent location does not point to valid item" );
-            ptr.reset( new impl::item_on_map( map_cursor( tripoint_bub_ms( pos ) ), idx ) ); // drop on ground
+            ptr.reset( new impl::item_on_map( map_cursor( parent.pos_bub() ), idx ) ); // drop on ground
             return;
         }
         const std::list<item *> parent_contents = parent->all_items_top();

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -2404,6 +2404,7 @@ std::optional<int> iuse::pack_item( Character *p, item *it, const tripoint & )
     if( !p ) {
         debugmsg( "%s called action pack_item that requires character but no character is present",
                   it->typeId().str() );
+        return std::nullopt;
     }
     if( p->cant_do_underwater() ) {
         return std::nullopt;

--- a/src/map_selector.cpp
+++ b/src/map_selector.cpp
@@ -5,6 +5,7 @@
 #include <optional>
 #include <vector>
 
+#include "coordinate_constants.h"
 #include "game_constants.h"
 #include "map.h"
 #include "map_iterator.h"
@@ -114,7 +115,10 @@ std::optional<tripoint_bub_ms> random_point( const tripoint_range<tripoint_bub_m
 }
 
 map_cursor::map_cursor( const tripoint_bub_ms &pos ) : pos_abs_( g ? get_map().getglobal(
-                pos ) : tripoint_abs_ms( tripoint_zero ) ), pos_bub_( g ? tripoint_bub_ms( tripoint_zero ) : pos ) { }
+                pos ) : tripoint_abs_ms( tripoint_zero ) ), pos_bub_( g ? tripoint_bub_ms_zero : pos ) { }
+
+map_cursor::map_cursor( const tripoint_abs_ms &pos ) : pos_abs_( pos ),
+    pos_bub_( tripoint_bub_ms_zero ) { }
 
 tripoint_bub_ms map_cursor::pos() const
 {

--- a/src/map_selector.h
+++ b/src/map_selector.h
@@ -21,6 +21,8 @@ class map_cursor : public visitable
 
     public:
         explicit map_cursor( const tripoint_bub_ms &pos );
+        // Marginally faster than the previous operation if you have the absolute coordinates at hand.
+        explicit map_cursor( const tripoint_abs_ms &pos );
         tripoint_bub_ms pos() const;
 
         // inherited from visitable

--- a/tests/harvest_test.cpp
+++ b/tests/harvest_test.cpp
@@ -41,7 +41,7 @@ static void butcher_mon( const mtype_id &monid, const activity_id &actid, int *c
         cow.die( nullptr );
         u.move_to( cow.get_location() );
         player_activity act( actid, 0, true );
-        act.targets.emplace_back( map_cursor( u.pos_bub() ), &*here.i_at( cow_loc ).begin() );
+        act.targets.emplace_back( map_cursor( u.get_location() ), &*here.i_at( cow_loc ).begin() );
         while( !act.is_null() ) {
             activity_handlers::butcher_finish( &act, &u );
         }

--- a/tests/invlet_test.cpp
+++ b/tests/invlet_test.cpp
@@ -253,11 +253,11 @@ static void pick_up_from_feet( Character &you, const std::string &id )
     map_stack items = get_map().i_at( you.pos() );
     size_t size_before = items.size();
 
-    item *found = retrieve_item( map_cursor( you.pos_bub() ), id );
+    item *found = retrieve_item( map_cursor( you.get_location() ), id );
     REQUIRE( found );
 
     you.set_moves( 100 );
-    const std::vector<item_location> target_items = { item_location( map_cursor( you.pos_bub() ), found ) };
+    const std::vector<item_location> target_items = { item_location( map_cursor( you.get_location() ), found ) };
     you.assign_activity( pickup_activity_actor( target_items, { 0 }, you.pos_bub(), false ) );
     you.activity.do_turn( you );
 
@@ -269,7 +269,7 @@ static void wear_from_feet( Character &you, const std::string &id )
     map_stack items = get_map().i_at( you.pos_bub() );
     size_t size_before = items.size();
 
-    item *found = retrieve_item( map_cursor( you.pos_bub() ), id );
+    item *found = retrieve_item( map_cursor( you.get_location() ), id );
     REQUIRE( found );
 
     you.wear_item( *found, false );
@@ -283,7 +283,7 @@ static void wield_from_feet( Character &you, const std::string &id )
     map_stack items = get_map().i_at( you.pos_bub() );
     size_t size_before = items.size();
 
-    item *found = retrieve_item( map_cursor( you.pos_bub() ), id );
+    item *found = retrieve_item( map_cursor( you.get_location() ), id );
     REQUIRE( found );
 
     you.wield( *found );
@@ -322,7 +322,7 @@ static item &item_at( Character &you, const std::string &id, const inventory_loc
 {
     switch( loc ) {
         case GROUND: {
-            item *found = retrieve_item( map_cursor( you.pos_bub() ), id );
+            item *found = retrieve_item( map_cursor( you.get_location() ), id );
             REQUIRE( found );
             return *found;
         }

--- a/tests/item_pickup_test.cpp
+++ b/tests/item_pickup_test.cpp
@@ -172,7 +172,7 @@ TEST_CASE( "pickup_m4_with_a_rope_in_a_hiking_backpack", "[pickup][container]" )
 
         WHEN( "they pick up the M4" ) {
             // Get item_location for m4 on the map
-            item_location m4_loc( map_cursor( they.pos_bub() ), &m4a1 );
+            item_location m4_loc( map_cursor( they.get_location() ), &m4a1 );
             const drop_locations &thing = { std::make_pair( m4_loc, 1 ) };
             CHECK_FALSE( backpack.has_item( m4a1 ) );
             // Now pick up the M4

--- a/tests/item_pocket_test.cpp
+++ b/tests/item_pocket_test.cpp
@@ -1829,12 +1829,14 @@ static void test_pickup_autoinsert_sub_sub( bool autopickup, bool wear, bool sof
     Character &u = get_player_character();
     clear_map();
     clear_character( u, true );
-    item_location cont1( map_cursor( u.pos_bub() ), &m.add_item_or_charges( u.pos_bub(),
+    item_location cont1( map_cursor( u.get_location() ), &m.add_item_or_charges( u.pos_bub(),
                          cont_nest_rigid ) );
-    item_location cont2( map_cursor( u.pos_bub() ), &m.add_item_or_charges( u.pos_bub(),
+    item_location cont2( map_cursor( u.get_location() ), &m.add_item_or_charges( u.pos_bub(),
                          cont_nest_soft ) );
-    item_location obj1( map_cursor( u.pos_bub() ), &m.add_item_or_charges( u.pos_bub(), rigid_obj ) );
-    item_location obj2( map_cursor( u.pos_bub() ), &m.add_item_or_charges( u.pos_bub(), soft_obj ) );
+    item_location obj1( map_cursor( u.get_location() ), &m.add_item_or_charges( u.pos_bub(),
+                        rigid_obj ) );
+    item_location obj2( map_cursor( u.get_location() ), &m.add_item_or_charges( u.pos_bub(),
+                        soft_obj ) );
     pickup_activity_actor act_actor( { obj1, obj2 }, { 1, 1 }, u.pos_bub(), autopickup );
     u.assign_activity( act_actor );
 
@@ -2061,7 +2063,7 @@ static void test_pickup_autoinsert_sub_sub( bool autopickup, bool wear, bool sof
         item_location c = give_item_to_char( u, soft_nested ? cont2 : cont1 );
         WHEN( "item stack too large to fit in top-level container" ) {
             stack.charges = 300;
-            item_location obj3( map_cursor( u.pos_bub() ), &m.add_item_or_charges( u.pos_bub(), stack ) );
+            item_location obj3( map_cursor( u.get_location() ), &m.add_item_or_charges( u.pos_bub(), stack ) );
             REQUIRE( obj3->charges == 300 );
             u.cancel_activity();
             pickup_activity_actor new_actor( { obj3 }, { 300 }, u.pos_bub(), autopickup );
@@ -2092,7 +2094,7 @@ static void test_pickup_autoinsert_sub_sub( bool autopickup, bool wear, bool sof
         }
         WHEN( "item stack too large to fit in top-level container" ) {
             stack.charges = 300;
-            item_location obj3( map_cursor( u.pos_bub() ), &m.add_item_or_charges( u.pos_bub(), stack ) );
+            item_location obj3( map_cursor( u.get_location() ), &m.add_item_or_charges( u.pos_bub(), stack ) );
             REQUIRE( obj3->charges == 300 );
             u.cancel_activity();
             pickup_activity_actor new_actor( { obj3 }, { 300 }, u.pos_bub(), autopickup );
@@ -2124,7 +2126,7 @@ static void test_pickup_autoinsert_sub_sub( bool autopickup, bool wear, bool sof
         obj2.remove_item();
         WHEN( "item stack too large to fit in top-level container" ) {
             stack.charges = 300;
-            item_location obj3( map_cursor( u.pos_bub() ), &m.add_item_or_charges( u.pos_bub(), stack ) );
+            item_location obj3( map_cursor( u.get_location() ), &m.add_item_or_charges( u.pos_bub(), stack ) );
             REQUIRE( obj3->charges == 300 );
             u.cancel_activity();
             pickup_activity_actor new_actor( { obj3 }, { 300 }, u.pos_bub(), autopickup );
@@ -2256,7 +2258,7 @@ TEST_CASE( "multipocket_liquid_transfer_test", "[pocket][item][liquid]" )
     item cont_suit( "test_robofac_armor_rig" );
 
     // Place a container at the character's feet
-    item_location jug_w_water( map_cursor( u.pos_bub() ), &m.add_item_or_charges( u.pos_bub(),
+    item_location jug_w_water( map_cursor( u.get_location() ), &m.add_item_or_charges( u.pos_bub(),
                                cont_jug ) );
 
     GIVEN( "character wearing a multipocket liquid container" ) {

--- a/tests/iuse_actor_test.cpp
+++ b/tests/iuse_actor_test.cpp
@@ -151,7 +151,7 @@ static void cut_up_yields( const std::string &target )
 
     units::mass cut_up_target_mass = cut_up_target.weight();
     item &spawned_item = here.add_item_or_charges( guy.pos_bub(), cut_up_target );
-    item_location item_loc( map_cursor( guy.pos_bub() ), &spawned_item );
+    item_location item_loc( map_cursor( guy.get_location() ), &spawned_item );
 
     REQUIRE( smallest_yield_mass <= cut_up_target_mass );
 

--- a/tests/unseal_and_spill_test.cpp
+++ b/tests/unseal_and_spill_test.cpp
@@ -454,7 +454,7 @@ void test_scenario::run()
         }
         case container_location::ground: {
             item &added = here.add_item( guy.pos_bub(), it );
-            it_loc = item_location( map_cursor( guy.pos_bub() ), &added );
+            it_loc = item_location( map_cursor( guy.get_location() ), &added );
             break;
         }
         default: {
@@ -862,7 +862,7 @@ void test_scenario::run()
         REQUIRE( !it_loc );
     }
     INFO( "checking ground items" );
-    match( map_cursor( guy.pos_bub() ), here.i_at( guy.pos_bub() ), ground );
+    match( map_cursor( guy.get_location() ), here.i_at( guy.pos_bub() ), ground );
     INFO( "checking vehicle items" );
     std::optional<vpart_reference> vp = here.veh_at( guy.pos_bub() )
                                         .part_with_feature( vpart_bitflags::VPFLAG_CARGO, true );

--- a/tests/visitable_remove_test.cpp
+++ b/tests/visitable_remove_test.cpp
@@ -327,7 +327,7 @@ TEST_CASE( "visitable_remove", "[visitable]" )
         REQUIRE( our + adj == count );
 
         map_selector sel( p.pos_bub(), 1 );
-        map_cursor cur( p.pos_bub() );
+        map_cursor cur( p.get_location() );
 
         REQUIRE( count_items( sel, container_id ) == count );
         REQUIRE( count_items( sel, liquid_id ) == count );

--- a/tests/wield_times_test.cpp
+++ b/tests/wield_times_test.cpp
@@ -49,7 +49,7 @@ static void wield_check_from_ground( avatar &guy, const itype_id &item_name,
 {
     item &spawned_item = get_map().add_item_or_charges( guy.pos_bub(), item( item_name, calendar::turn,
                          1 ) );
-    item_location item_loc( map_cursor( guy.pos_bub() ), &spawned_item );
+    item_location item_loc( map_cursor( guy.get_location() ), &spawned_item );
     CHECK( item_loc.obtain_cost( guy ) == Approx( expected_moves ).epsilon( 0.1f ) );
 }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Allow map_cursor to be created from an absolute position in addition to a bubble one.
Given that it's stored as an absolute position internally (except for the weirdo case which may or may not exist), it makes sense to allow it to be stored directly.
Also silenced a couple of trivial compiler warnings as a by-catch.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add another creation operation and convert the usages where an absolute position was converted into a bubble one to use the new operation instead.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Add operation to extract the absolute position, but there don't seem to be much use for it.
- Address the compiler warning about game.cpp operation rate_action_eat, line 1901 which is clearly incorrect, as a check whether a value differs from either if two constants is always going to be true. The compiler suggests || should be &&, which seems reasonable. However, I don't know that's what's intended.
- Get rid of the weirdo logic to handle usage of map_cursor prior to the existence of a valid "g" pointer. However, while I haven't seen anything clearly requiring it, I cannot rule out that there actually are cases where this is needed.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Load a save with a driving car and drive until it hit stuff. There should be no functional changes.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
