### PR TITLE
Allow CVD machine to coat iron weapons

### DIFF
--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -203,6 +203,7 @@ static const material_id material_bone( "bone" );
 static const material_id material_cac2powder( "cac2powder" );
 static const material_id material_ch_steel( "ch_steel" );
 static const material_id material_hc_steel( "hc_steel" );
+static const material_id material_iron( "iron" );
 static const material_id material_lc_steel( "lc_steel" );
 static const material_id material_mc_steel( "mc_steel" );
 static const material_id material_qt_steel( "qt_steel" );
@@ -348,7 +349,8 @@ void iexamine::cvdmachine( Character &you, const tripoint & )
                !e.has_flag( flag_DIAMOND ) && !e.has_flag( flag_NO_CVD ) &&
                ( e.made_of( material_steel ) || e.made_of( material_ch_steel ) ||
                  e.made_of( material_hc_steel ) || e.made_of( material_lc_steel ) ||
-                 e.made_of( material_mc_steel ) || e.made_of( material_qt_steel ) );
+                 e.made_of( material_mc_steel ) || e.made_of( material_qt_steel ) ||
+                 e.made_of( material_iron ) );
     }, _( "Apply diamond coating" ), 1, _( "You don't have a suitable item to coat with diamond" ) );
 
     if( !loc ) {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fixes #56678.

#### Describe the solution
Simply added iron to the list of allowable materials used in the chain of || statements in `iexamine::cvdmachine`.

#### Describe alternatives you've considered
I researched other materials, as mentioned in the linked issue, and decided not to use them.  Aluminum, bronze, and copper seem incompatible with the CVD diamond process.  Budget steel miiight work, but I assume it was intentionally left out of the list when the other steel variants were added, and it seems like it'd do more harm than good to include it here.

#### Testing
Built from source, spawned in a CVD machine console and confirmed that a selection of weapons worked as expected, including a full-iron baselard.

#### Additional context
![Screenshot 2024-08-04 121419](https://github.com/user-attachments/assets/43f75ade-584a-4999-b838-13f09e12ec21)