### PR TITLE
Prevent negative array index for floor_cache

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -7473,7 +7473,13 @@ void map::drawsq( const catacurses::window &w, const tripoint_bub_ms &p,
 // a check to see if the lower floor needs to be rendered in tiles
 bool map::dont_draw_lower_floor( const tripoint &p ) const
 {
-    return !zlevels || p.z <= -OVERMAP_DEPTH || get_cache( p.z ).floor_cache[p.x][p.y];
+    if( !zlevels || p.z <= -OVERMAP_DEPTH ) {
+        return true;
+    } else if( !inbounds( p ) ) {
+        return false;
+    } else {
+        return get_cache( p.z ).floor_cache[p.x][p.y];
+    }
 }
 
 bool map::draw_maptile( const catacurses::window &w, const tripoint &p,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Prevent negative array index for floor_cache"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Prevents referencing `floor_cache` using out-of-bounds array indexes such as negative values and values greater than 132. Using out-of-bound indexes for this array previously caused crashes when compiled with `-D_GLIBCXX_ASSERTIONS`.

Fixes #75039 .

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

The function `map::dont_draw_lower_floor` is, for example, called from `cata_tiles::draw` with values such as `p=(0,132,0)` or `p=(-36,5,0)`. Such values can be seen when zooming out with `Z` so `draw` also handles tiles that do not fit into local bub coordinates.

Previous crash happened here:
```
#0  __pthread_kill_implementation (threadid=<optimized out>, signo=signo@entry=6, no_tid=no_tid@entry=0) at ./nptl/pthread_kill.c:44
#1  0x00007ffff787840f in __pthread_kill_internal (signo=6, threadid=<optimized out>) at ./nptl/pthread_kill.c:78
#2  0x00007ffff78294f2 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#3  0x00007ffff78124ed in __GI_abort () at ./stdlib/abort.c:79
#4  0x00007ffff7ad30be in std::__glibcxx_assert_fail(char const*, int, char const*, char const*) () from /lib/x86_64-linux-gnu/libstdc++.so.6
#5  0x00005555561d9d96 in std::array<bool, 132ul>::operator[] (__n=<optimized out>, this=<optimized out>) at /usr/include/c++/13/array:202
#6  0x00005555561dd407 in std::array<bool, 132ul>::operator[] (__n=<optimized out>, this=<optimized out>) at /usr/include/c++/13/array:200
#7  map::dont_draw_lower_floor (this=this@entry=0x5555582581a0, p=...) at src/map.cpp:7476
#8  0x0000555555b59d8f in cata_tiles::draw (this=0x5555580cd790, dest=..., center=..., width=<optimized out>, height=<optimized out>, overlay_strings=std::multimap with 0 elements, color_blocks={...}) at src/cata_tiles.cpp:1657
#9  0x00005555567f09fc in cata_cursesport::curses_drawwindow (w=...) at src/sdltiles.cpp:1317
#10 0x0000555555cfab62 in catacurses::wnoutrefresh (win_=...) at src/cursesport.cpp:189
#11 0x0000555555e9826f in game::draw (this=0x555558257c60, ui=...) at src/game.cpp:3953
#12 0x000055555695aadf in ui_adaptor::redraw_invalidated () at src/ui_manager.cpp:440
#13 0x000055555695abe3 in ui_adaptor::redraw () at src/ui_manager.cpp:345
#14 0x000055555695ac0a in ui_manager::redraw () at src/ui_manager.cpp:506
#15 0x0000555555d8a15e in do_turn () at src/do_turn.cpp:571
#16 0x0000555555781a1e in main (argc=<optimized out>, argv=<optimized out>) at src/main.cpp:873
```

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

* A bit hesitant to call `inbounds` for each tile during the `draw` call since that might have an effect on performance. It might be possible to do some smarter out-of-bounds checking?
* All of this would probably be better if we used `_ib` coordinates, which would make a bug such as this a compile-time problem instead. But that's for a future refactoring.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

0. Compiled with `-D_GLIBCXX_ASSERTIONS`.
1. Ran the steps in #75039 .
2. Can reliably reproduce the crash on `master` since this function is called with `p=(-36,5,0)`.
3. Applied these code changes. Ran the steps in #75039 again. The game no longer crashes when zooming out to max.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
