### PR TITLE
Show variant tiles for overmap vision levels

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2826,6 +2826,7 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEG
         break;
         case TILE_CATEGORY::OVERMAP_WEATHER:
         case TILE_CATEGORY::OVERMAP_TERRAIN:
+        case TILE_CATEGORY::OVERMAP_VISION_LEVEL:
         case TILE_CATEGORY::MAP_EXTRA:
             seed = simple_point_hash( pos );
             break;


### PR DESCRIPTION

#### Summary
None

#### Purpose of change
Solves one of the problems in https://github.com/CleverRaven/Cataclysm-DDA/issues/75454

I left the new tile category out of the random seed generation, so only the first tile of the possible variants was ever used for overmap vision level tiles.


#### Describe the solution
Add the new tile category to random seed generation.

#### Testing
@vetall812 Lent me their tileset, and I could use it to verify that it worked:
![image](https://github.com/user-attachments/assets/475b1f62-6d17-4ebf-a584-bc9a7afac1c7)
