### PR TITLE
Genericize vehicle handling for characters (no special avatar stuff)

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2273,30 +2273,35 @@ void activity_handlers::start_engines_finish( player_activity *act, Character *y
     sfx::do_vehicle_engine_sfx();
 
     if( attempted == 0 ) {
-        add_msg( m_info, _( "The %s doesn't have an engine!" ), veh->name );
+        you->add_msg_if_player( m_info, _( "The %s doesn't have an engine!" ), veh->name );
     } else if( non_muscle_attempted > 0 ) {
         //Some non-muscle engines tried to start
         if( non_muscle_attempted == non_muscle_started ) {
             //All of the non-muscle engines started
-            add_msg( n_gettext( "The %s's engine starts up.",
-                                "The %s's engines start up.", non_muscle_started ), veh->name );
+            add_msg_if_player_sees( you->pos_bub(), n_gettext( "The %s's engine starts up.",
+                                    "The %s's engines start up.", non_muscle_started ), veh->name );
         } else if( non_muscle_started > 0 ) {
             //Only some of the non-muscle engines started
-            add_msg( n_gettext( "One of the %s's engines start up.",
-                                "Some of the %s's engines start up.", non_muscle_started ), veh->name );
+            add_msg_if_player_sees( you->pos_bub(), n_gettext( "One of the %s's engines start up.",
+                                    "Some of the %s's engines start up.", non_muscle_started ), veh->name );
         } else if( non_combustion_started > 0 ) {
             //Non-combustions "engines" started
-            add_msg( _( "The %s is ready for movement." ), veh->name );
+            you->add_msg_if_player( _( "The %s is ready for movement." ), veh->name );
         } else {
             //All of the non-muscle engines failed
-            add_msg( m_bad, n_gettext( "The %s's engine fails to start.",
-                                       "The %s's engines fail to start.", non_muscle_attempted ), veh->name );
+            if( you->is_avatar() ) {
+                add_msg( m_bad, n_gettext( "The %s's engine fails to start.",
+                                           "The %s's engines fail to start.", non_muscle_attempted ), veh->name );
+            } else {
+                add_msg_if_player_sees( you->pos_bub(), n_gettext( "The %s's engine fails to start.",
+                                        "The %s's engines fail to start.", non_muscle_attempted ), veh->name );
+            }
         }
     }
 
     if( take_control && !veh->engine_on && !veh->velocity ) {
         you->controlling_vehicle = false;
-        add_msg( _( "You let go of the controls." ) );
+        you->add_msg_if_player( _( "You let go of the controls." ) );
     }
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5513,7 +5513,7 @@ void game::control_vehicle()
                 u.controlling_vehicle = true;
                 add_msg( _( "You take control of the %s." ), veh->name );
             } else {
-                veh->start_engines( true );
+                veh->start_engines( &u, true );
             }
         }
     }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -7357,7 +7357,7 @@ std::optional<int> iuse::remoteveh( Character *p, item *it, const tripoint &pos 
             g->setremoteveh( veh );
             p->add_msg_if_player( m_good, _( "You take control of the vehicle." ) );
             if( !veh->engine_on ) {
-                veh->start_engines();
+                veh->start_engines( p );
             }
         }
     } else if( choice == 1 ) {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -273,6 +273,12 @@ bool vehicle::player_in_control( const Character &p ) const
 
 bool vehicle::player_is_driving_this_veh() const
 {
+    // Unfortunate code duplication for tests
+    // Debug switch to prevent vehicles from skidding
+    // without having to place the player in them.
+    if( tags.count( "IN_CONTROL_OVERRIDE" ) ) {
+        return true;
+    }
     // Early out, nobody's driving
     if( !get_driver() ) {
         return false;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -3442,7 +3442,14 @@ bool vehicle::has_driver() const
 
 Character *vehicle::get_driver() const
 {
-    return &get_player_character();
+    // TODO: Gotta be a better way than this...
+    for( const vpart_reference &vp : get_all_parts() ) {
+        Character *occupant = vp.get_passenger();
+        if( occupant && player_in_control( *occupant ) ) {
+            return occupant;
+        }
+    }
+    return nullptr;
 }
 
 monster *vehicle::get_monster( int p ) const
@@ -3602,8 +3609,7 @@ int64_t vehicle::fuel_left( const itype_id &ftype,
 
         //if the engine in the tile is a muscle engine, and someone is ready to control this vehicle
         // TODO: Allow NPCs to power those
-        // TODO: Revise this check to driver when get_driver() can return nullptr
-        if( vp && &vp->vehicle() == this && player_is_driving_this_veh() ) {
+        if( vp && &vp->vehicle() == this && driver ) {
             const int p = avail_part_with_feature( vp->part_index(), VPFLAG_ENGINE );
             if( p >= 0 ) {
                 const vehicle_part &vp = parts[p];

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -3605,7 +3605,8 @@ int64_t vehicle::fuel_left( const itype_id &ftype,
     if( ftype == fuel_type_muscle ) {
         Character *driver = get_driver();
         if( !driver ) {
-            return fl;
+            // FIXME: Should return fl, not arbitrarily assume player
+            driver = &get_player_character();
         }
         const optional_vpart_position vp = get_map().veh_at( driver->pos_bub() );
 
@@ -4952,7 +4953,9 @@ void vehicle::consume_fuel( int load, bool idling )
     // Only process muscle power and training things when someone is actually driving.
     // Note that the vehicle can be moving even if nobody is driving it.
     if( !driver ) {
-        return;
+        // FIXME: Should return early, not arbitrarily assume player
+        // Make our pointer valid so we don't dereference nullptr and crash in the upcoming code
+        driver = &get_player_character();
     }
 
     // if engine is under load, player is actively piloting a vehicle, so train appropriate vehicle proficiency

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -273,9 +273,8 @@ bool vehicle::player_in_control( const Character &p ) const
 
 bool vehicle::player_is_driving_this_veh() const
 {
-    Character *driver = get_driver();
     // Early out, nobody's driving
-    if( !driver ) {
+    if( !get_driver() ) {
         return false;
     }
     Character &player_character = get_player_character();
@@ -3605,6 +3604,9 @@ int64_t vehicle::fuel_left( const itype_id &ftype,
     //muscle engines have infinite fuel
     if( ftype == fuel_type_muscle ) {
         Character *driver = get_driver();
+        if( !driver ) {
+            return fl;
+        }
         const optional_vpart_position vp = get_map().veh_at( driver->pos_bub() );
 
         //if the engine in the tile is a muscle engine, and someone is ready to control this vehicle

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1014,7 +1014,8 @@ class vehicle
         // stop all engines
         void stop_engines();
         // Attempt to start the vehicle's active engines
-        void start_engines( bool take_control = false, bool autodrive = false );
+        void start_engines( Character *driver = nullptr, bool take_control = false,
+                            bool autodrive = false );
 
         // Engine backfire, making a loud noise
         void backfire( const vehicle_part &vp ) const;
@@ -1395,7 +1396,6 @@ class vehicle
         Character *get_passenger( int you ) const;
         bool has_driver() const;
         // get character that is currently controlling the vehicle's motion
-        // TODO: Currently always returns player!
         Character *get_driver() const;
         // get monster on a boardable part at p
         monster *get_monster( int p ) const;

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -925,9 +925,11 @@ class vehicle
          */
         bool mod_hp( vehicle_part &pt, int qty );
 
-        // check if given player controls this vehicle
+        // check if given character controls this vehicle
         bool player_in_control( const Character &p ) const;
-        // check if player controls this vehicle remotely
+        // check if the *player* character controls this vehicle
+        bool player_is_driving_this_veh() const;
+        // check if the given character controls this vehicle remotely
         bool remote_controlled( const Character &p ) const;
 
         // initializes parts and fuel state for randomly generated vehicle and calls refresh()
@@ -1391,6 +1393,10 @@ class vehicle
         bool is_passenger( Character &c ) const;
         // get passenger at part p
         Character *get_passenger( int you ) const;
+        bool has_driver() const;
+        // get character that is currently controlling the vehicle's motion
+        // TODO: Currently always returns player!
+        Character *get_driver() const;
         // get monster on a boardable part at p
         monster *get_monster( int p ) const;
 

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -301,7 +301,6 @@ void vehicle::smart_controller_handle_turn( const std::optional<float> &k_tracti
 
     // turn on/off combustion engines when necessary
     if( !has_electric_engine ) {
-        Character &player_character = get_player_character();
         if( !discharge_forbidden_soft && is_stationary && engine_on && !autopilot_on &&
             !player_is_driving_this_veh() ) {
             stop_engines();

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -776,7 +776,7 @@ void vehicle::stop_engines()
     refresh();
 }
 
-void vehicle::start_engines( const bool take_control, const bool autodrive )
+void vehicle::start_engines( Character *driver, const bool take_control, const bool autodrive )
 {
     bool has_engine = std::any_of( engines.begin(), engines.end(), [&]( int idx ) {
         return parts[ idx ].enabled && !parts[ idx ].is_broken();
@@ -814,16 +814,14 @@ void vehicle::start_engines( const bool take_control, const bool autodrive )
         return;
     }
 
-    Character &player_character = get_player_character();
-    if( take_control && !player_character.controlling_vehicle ) {
-        player_character.controlling_vehicle = true;
-        add_msg( _( "You take control of the %s." ), name );
+    if( take_control && driver && !driver->controlling_vehicle ) {
+        driver->controlling_vehicle = true;
+        driver->add_msg_if_player( _( "You take control of the %s." ), name );
     }
-    if( !autodrive ) {
-        player_character.assign_activity( ACT_START_ENGINES, to_moves<int>( start_time ) );
-        player_character.activity.relative_placement =
-            starting_engine_position - player_character.pos_bub();
-        player_character.activity.values.push_back( take_control );
+    if( !autodrive && driver ) {
+        driver->assign_activity( ACT_START_ENGINES, to_moves<int>( start_time ) );
+        driver->activity.relative_placement = starting_engine_position - driver->pos_bub();
+        driver->activity.values.push_back( take_control );
     }
     refresh();
 }

--- a/tests/mapgen_remove_vehicles_test.cpp
+++ b/tests/mapgen_remove_vehicles_test.cpp
@@ -99,7 +99,7 @@ TEST_CASE( "mapgen_remove_vehicles" )
     veh->set_owner( get_avatar() );
     REQUIRE( here.get_vehicles().size() == 1 );
     here.board_vehicle( start_loc, &get_avatar() );
-    veh->start_engines( true );
+    veh->start_engines( &get_avatar(), true );
 
     tripoint const test_loc = get_avatar().pos();
     check_vehicle_still_works( *veh );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
![image](https://github.com/user-attachments/assets/36e15c0e-4e58-4c3c-a280-3a0298e6bdea)


#### Describe the solution
Get us closer to the future. Prep the groundwork by getting rid of a bunch of assumptions that the player is the only character that can drive.

**This does not enable NPCs to drive.**

This is just a ton of tedious work that needs to be done before NPCs can drive, and I might as well get it out of the way.

#### Describe alternatives you've considered
`player_in_control` and a few other functions could use a renaming, but that was more churn than I wanted to deal with right now

#### Testing
Did some driving around with various kinds of vehicles. Jumped into them, jumped out of them, turned them on and off and on and off. Found a bug where the player couldn't start driving anything, squashed that.

Did some autodriving too, just to be sure. No issues, plays like I expect it to. Let's see how the tests do.

#### Additional context
There should be no functional changes.