### PR TITLE
Cramped space doesn't prevent sleep

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -5682,10 +5682,6 @@ Character::comfort_response_t Character::base_comfort_value( const tripoint_bub_
                 }
             }
             comfort += boardable ? max_boardable_confort : -here.move_cost( p );
-
-            if( has_effect( effect_cramped_space ) ) {
-                comfort = static_cast<int>( comfort_level::impossible );
-            }
         }
         // Not in a vehicle, start checking furniture/terrain/traps at this point in decreasing order
         else if( furn_at_pos != furn_str_id::NULL_ID() ) {


### PR DESCRIPTION
#### Summary
Balance "Cramped space doesn't prevent sleep"

#### Purpose of change
Cramped space sets the comfort value to impossible (-999).

For reference, a sleeping pill addiction gives -4.

The UI doesn't give any feedback on this.
![image](https://github.com/user-attachments/assets/09a1bdb2-1c70-4f90-a393-5d22b7b33dae)


#### Describe the solution
Just remove this and keep using the vehicle part's comfort value

#### Describe alternatives you've considered
Waiting until we figure out what to do about calculating cramped space properly

#### Testing
![image](https://github.com/user-attachments/assets/555a424e-ec01-4f50-aa68-12efd672d815)


#### Additional context
