### PR TITLE
prevent spam of healing messages from WEAKNESS_TO_WATER

### DIFF
--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -1937,8 +1937,8 @@ void Character::drench( int saturation, const body_part_set &flags, bool ignore_
 
     if( enchantment_cache->modify_value( enchant_vals::mod::WEAKNESS_TO_WATER, 0 ) > 0 ) {
         add_msg_if_player( m_bad, _( "You feel the water burning your skin." ) );
-    } else if( enchantment_cache->modify_value( enchant_vals::mod::WEAKNESS_TO_WATER, 0 ) < 0 ) {
-        add_msg_if_player( m_bad, _( "You feel the water runs on your skin, making you feel better." ) );
+    } else if( enchantment_cache->modify_value( enchant_vals::mod::WEAKNESS_TO_WATER, 0 ) < 0 && one_in( 30 ) ) {
+        add_msg_if_player( m_good, _( "You feel the water runs on your skin, making you feel better." ) );
     }
 
     // Remove onfire effect

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -1937,7 +1937,8 @@ void Character::drench( int saturation, const body_part_set &flags, bool ignore_
 
     if( enchantment_cache->modify_value( enchant_vals::mod::WEAKNESS_TO_WATER, 0 ) > 0 ) {
         add_msg_if_player( m_bad, _( "You feel the water burning your skin." ) );
-    } else if( enchantment_cache->modify_value( enchant_vals::mod::WEAKNESS_TO_WATER, 0 ) < 0 && one_in( 300 ) ) {
+    } else if( enchantment_cache->modify_value( enchant_vals::mod::WEAKNESS_TO_WATER, 0 ) < 0 &&
+               one_in( 300 ) ) {
         add_msg_if_player( m_good, _( "You feel the water runs on your skin, making you feel better." ) );
     }
 

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -1937,7 +1937,7 @@ void Character::drench( int saturation, const body_part_set &flags, bool ignore_
 
     if( enchantment_cache->modify_value( enchant_vals::mod::WEAKNESS_TO_WATER, 0 ) > 0 ) {
         add_msg_if_player( m_bad, _( "You feel the water burning your skin." ) );
-    } else if( enchantment_cache->modify_value( enchant_vals::mod::WEAKNESS_TO_WATER, 0 ) < 0 && one_in( 30 ) ) {
+    } else if( enchantment_cache->modify_value( enchant_vals::mod::WEAKNESS_TO_WATER, 0 ) < 0 && one_in( 300 ) ) {
         add_msg_if_player( m_good, _( "You feel the water runs on your skin, making you feel better." ) );
     }
 


### PR DESCRIPTION
#### Summary
None
#### Describe the solution
Make healing message of weakness to water green
Make healing message appear with 1/300 chance (once per 5 minutes)
#### Additional context
![Screenshot_20240806_180040](https://github.com/user-attachments/assets/fadbe687-7907-44a6-96f5-fe4e1c5d315c)
