### PR TITLE
Yet more item disassembly adjustments

### DIFF
--- a/data/json/recipes/armor/head.json
+++ b/data/json/recipes/armor/head.json
@@ -10,7 +10,7 @@
     "skills_required": [ "survival", 1 ],
     "time": "1 h",
     "autolearn": true,
-    "reversible": true,
+    "reversible": { "time": "10 m" },
     "using": [ [ "tailoring_cotton_patchwork", 2 ] ]
   },
   {
@@ -21,7 +21,7 @@
     "subcategory": "CSC_ARMOR_HEAD",
     "skill_used": "tailor",
     "time": "30 m",
-    "reversible": true,
+    "reversible": { "time": "10 m" },
     "autolearn": true,
     "using": [ [ "tailoring_cotton_patchwork_simple", 1 ] ]
   },
@@ -33,7 +33,7 @@
     "subcategory": "CSC_ARMOR_HEAD",
     "skill_used": "tailor",
     "time": "30 m",
-    "reversible": true,
+    "reversible": { "time": "10 m" },
     "autolearn": true,
     "using": [ [ "tailoring_cotton_patchwork_simple", 1 ] ]
   },
@@ -47,7 +47,7 @@
     "difficulty": 2,
     "time": "90 m",
     "autolearn": true,
-    "reversible": true,
+    "reversible": { "time": "30 m" },
     "using": [ [ "tailoring_felt_small", 6 ] ]
   },
   {

--- a/data/json/recipes/armor/storage.json
+++ b/data/json/recipes/armor/storage.json
@@ -198,6 +198,8 @@
     "difficulty": 4,
     "time": "6 h",
     "autolearn": true,
+    "reversible": true,
+    "//": "Item disassembly based on reversible craft and manually defined uncraft integration. Read ITEM_DISASSEMBLY.mb for more info.",
     "using": [
       [ "tailoring_nylon_patchwork", 10 ],
       [ "fastener_small", 1 ],
@@ -855,6 +857,8 @@
     "skills_required": [ [ "gun", 1 ], [ "launcher", 1 ] ],
     "time": "3 h",
     "autolearn": true,
+    "reversible": true,
+    "//": "Item disassembly based on reversible craft and manually defined uncraft integration. Read ITEM_DISASSEMBLY.mb for more info.",
     "using": [
       [ "tailoring_nylon_patchwork", 1 ],
       [ "fastener_small", 1 ],
@@ -1266,7 +1270,8 @@
     "time": "8 h 30 m",
     "autolearn": false,
     "book_learn": [ [ "manual_gun", 2 ] ],
-    "reversible": { "time": "10 m" },
+    "reversible": true,
+    "//": "Item disassembly based on reversible craft and manually defined uncraft integration. Read ITEM_DISASSEMBLY.mb for more info.",
     "using": [ [ "tailoring_nylon_patchwork", 6 ], [ "fastener_small", 2 ] ],
     "proficiencies": [ { "proficiency": "prof_closures" }, { "proficiency": "prof_closures_waterproofing" } ],
     "components": [ [ [ "strap_small", 2, "LIST" ] ], [ [ "clasps", 2, "LIST" ] ] ]

--- a/data/json/recipes/armor/torso.json
+++ b/data/json/recipes/armor/torso.json
@@ -1760,7 +1760,7 @@
     "difficulty": 5,
     "time": "9 h",
     "autolearn": true,
-    "reversible": true,
+    "reversible": { "time": "50 m" },
     "using": [ [ "tailoring_felt_patchwork", 36 ], [ "fastener_large", 1 ] ],
     "proficiencies": [ { "proficiency": "prof_closures" } ]
   },
@@ -1788,7 +1788,7 @@
     "skill_used": "tailor",
     "difficulty": 4,
     "time": "2 h",
-    "reversible": true,
+    "reversible": { "time": "35 m" },
     "autolearn": true,
     "using": [ [ "tailoring_felt_patchwork", 18 ] ]
   },

--- a/data/json/recipes/tools/tool.json
+++ b/data/json/recipes/tools/tool.json
@@ -551,7 +551,6 @@
     "difficulty": 5,
     "skills_required": [ "mechanics", 3 ],
     "time": "300 m",
-    "reversible": true,
     "book_learn": [ [ "manual_mechanics", 3 ], [ "manual_fabrication", 5 ], [ "textbook_fabrication", 5 ] ],
     "using": [ [ "blacksmithing_standard", 20 ], [ "steel_standard", 5 ] ],
     "proficiencies": [
@@ -572,7 +571,6 @@
     "difficulty": 2,
     "skills_required": [ "mechanics", 1 ],
     "time": "100 m",
-    "reversible": true,
     "book_learn": [ [ "manual_mechanics", 1 ], [ "manual_fabrication", 2 ], [ "textbook_fabrication", 2 ] ],
     "qualities": [ { "id": "SAW_M", "level": 1 }, { "id": "SCREW", "level": 1 }, { "id": "WRENCH", "level": 1 } ],
     "components": [ [ [ "pipe", 4 ] ], [ [ "scrap", 2 ] ] ]
@@ -587,7 +585,6 @@
     "difficulty": 3,
     "skills_required": [ "mechanics", 2 ],
     "time": "200 m",
-    "reversible": true,
     "//": "50cm weld",
     "book_learn": [ [ "manual_mechanics", 2 ], [ "manual_fabrication", 3 ], [ "textbook_fabrication", 3 ] ],
     "using": [ [ "welding_standard", 50 ] ],

--- a/data/json/recipes/tools/tool.json
+++ b/data/json/recipes/tools/tool.json
@@ -830,8 +830,9 @@
     "difficulty": 4,
     "time": "30 m",
     "reversible": true,
+    "//1": "Item disassembly based on reversible craft and manually defined uncraft integration. Read ITEM_DISASSEMBLY.mb for more info.",
     "autolearn": true,
-    "//": "50cm weld",
+    "//2": "50cm weld",
     "using": [ [ "welding_standard", 50 ], [ "blacksmithing_standard", 14 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },

--- a/data/json/uncraft/armor/storage.json
+++ b/data/json/uncraft/armor/storage.json
@@ -41,8 +41,6 @@
     "result": "dry_bag",
     "type": "uncraft",
     "activity_level": "LIGHT_EXERCISE",
-    "skill_used": "tailor",
-    "difficulty": 3,
     "time": "35 m",
     "qualities": [ { "id": "FABRIC_CUT", "level": 1 }, { "id": "CUT", "level": 2 } ],
     "components": [ [ [ "sheet_lycra_patchwork", 18 ] ], [ [ "button_plastic", 1 ] ], [ [ "plastic_sheet_small", 9 ] ] ]
@@ -51,8 +49,6 @@
     "result": "dry_bag_large",
     "type": "uncraft",
     "activity_level": "LIGHT_EXERCISE",
-    "skill_used": "tailor",
-    "difficulty": 3,
     "time": "35 m",
     "qualities": [ { "id": "FABRIC_CUT", "level": 1 }, { "id": "CUT", "level": 2 } ],
     "components": [ [ [ "sheet_lycra_patchwork", 9 ] ], [ [ "button_plastic", 1 ] ], [ [ "plastic_sheet_small", 38 ] ] ]
@@ -61,10 +57,24 @@
     "result": "gas_mask_pouch",
     "type": "uncraft",
     "activity_level": "LIGHT_EXERCISE",
-    "skill_used": "tailor",
-    "difficulty": 1,
-    "time": "2 m 30 s",
+    "time": "10 m",
     "qualities": [ { "id": "FABRIC_CUT", "level": 1 }, { "id": "CUT", "level": 2 } ],
-    "components": [ [ [ "strap_cotton", 1 ] ], [ [ "snapfastener_steel", 2 ] ], [ [ "sheet_nylon", 3 ] ], [ [ "nylon", 11 ] ] ]
+    "components": [ [ [ "strap_cotton", 2 ] ], [ [ "snapfastener_steel", 10 ] ], [ [ "sheet_nylon", 6 ] ], [ [ "thread", 30 ] ] ]
+  },
+  {
+    "result": "grenade_pouch",
+    "type": "uncraft",
+    "activity_level": "LIGHT_EXERCISE",
+    "time": "10 m",
+    "qualities": [ { "id": "FABRIC_CUT", "level": 1 }, { "id": "CUT", "level": 2 } ],
+    "components": [ [ [ "strap_cotton", 1 ] ], [ [ "snapfastener_steel", 5 ] ], [ [ "sheet_nylon", 1 ] ], [ [ "thread", 5 ] ] ]
+  },
+  {
+    "result": "dump_pouch",
+    "type": "uncraft",
+    "activity_level": "LIGHT_EXERCISE",
+    "time": "15 m",
+    "qualities": [ { "id": "FABRIC_CUT", "level": 1 }, { "id": "CUT", "level": 2 } ],
+    "components": [ [ [ "strap_cotton", 1 ] ], [ [ "snapfastener_steel", 5 ] ], [ [ "sheet_nylon", 10 ] ], [ [ "thread", 50 ] ] ]
   }
 ]

--- a/data/json/uncraft/containers/generic.json
+++ b/data/json/uncraft/containers/generic.json
@@ -34,5 +34,29 @@
     "time": "5 s",
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [ [ [ "aluminum_foil", 37 ] ], [ [ "plastic_sheet_small", 1 ] ] ]
+  },
+  {
+    "result": "stirling_kit_box",
+    "type": "uncraft",
+    "activity_level": "LIGHT_EXERCISE",
+    "time": "4 m",
+    "qualities": [ { "id": "CUT", "level": 2 } ],
+    "components": [ [ [ "cardboard", 40 ] ] ]
+  },
+  {
+    "result": "robot_kit_box",
+    "type": "uncraft",
+    "activity_level": "LIGHT_EXERCISE",
+    "time": "4 m",
+    "qualities": [ { "id": "CUT", "level": 2 } ],
+    "components": [ [ [ "cardboard", 40 ] ] ]
+  },
+  {
+    "result": "bottle_glass_seasoning_small",
+    "type": "uncraft",
+    "activity_level": "LIGHT_EXERCISE",
+    "time": "1 s",
+    "components": [ [ [ "glass_shard", 2 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   }
 ]

--- a/data/json/uncraft/tool/cooking.json
+++ b/data/json/uncraft/tool/cooking.json
@@ -6,5 +6,13 @@
     "time": "5 m",
     "qualities": [ { "id": "HAMMER", "level": 2 } ],
     "components": [ [ [ "material_aluminium_ingot", 2 ] ] ]
+  },
+  {
+    "result": "can_sealer",
+    "type": "uncraft",
+    "activity_level": "MODERATE_EXERCISE",
+    "time": "20 m",
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 2 } ],
+    "components": [ [ [ "simple_crank", 1 ] ], [ [ "scrap", 8 ] ], [ [ "steel_chunk", 4 ] ], [ [ "steel_lump", 2 ] ] ]
   }
 ]

--- a/data/json/uncraft/tool/workshop.json
+++ b/data/json/uncraft/tool/workshop.json
@@ -22,5 +22,29 @@
     "time": "5 m",
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 2 } ],
     "components": [ [ [ "steel_chunk", 1 ] ], [ [ "scrap", 1 ] ] ]
+  },
+  {
+    "result": "jack",
+    "type": "uncraft",
+    "activity_level": "MODERATE_EXERCISE",
+    "time": "20 m",
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 2 } ],
+    "components": [ [ [ "steel_lump", 5 ] ] ]
+  },
+  {
+    "result": "jack_makeshift",
+    "type": "uncraft",
+    "activity_level": "MODERATE_EXERCISE",
+    "time": "15 m",
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 2 } ],
+    "components": [ [ [ "pipe", 4 ] ], [ [ "scrap", 2 ] ] ]
+  },
+  {
+    "result": "jack_small",
+    "type": "uncraft",
+    "activity_level": "MODERATE_EXERCISE",
+    "time": "15 m",
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 2 } ],
+    "components": [ [ [ "pipe", 4 ] ], [ [ "scrap", 2 ] ] ]
   }
 ]

--- a/data/json/uncraft/tool/workshop.json
+++ b/data/json/uncraft/tool/workshop.json
@@ -8,6 +8,14 @@
     "components": [ [ [ "scrap", 8 ] ] ]
   },
   {
+    "result": "wrench_small",
+    "type": "uncraft",
+    "activity_level": "MODERATE_EXERCISE",
+    "time": "2 m",
+    "qualities": [ { "id": "HAMMER", "level": 2 } ],
+    "components": [ [ [ "scrap", 2 ] ] ]
+  },
+  {
     "result": "tin_snips",
     "type": "uncraft",
     "activity_level": "MODERATE_EXERCISE",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
 - Switched from jacks being reversible to being uncrafts, so that they don't need an anvil to disassemble
 - Switched from the can sealer being reversible to being an uncraft/reversion integration, so that it doesn't need an anvil to disassemble but remembers components used to craft it
 - Fixed the uncraft/reversion integration for the gas mask pouch so that it doesn't lose a shitload of resources for wild spawned ones, and takes 10 minutes instead
 - Added an uncraft/reversion integration disassembly for grenade pouches and dump pouches
 - Added uncrafts for STEM kit box, robot kit box, small adjustable wrench, and small glass seasoning bottle
 - Removed skill and difficulty from some uncrafts that were just cutting out parts of storage bags
 - Manually defined reversible craft times for balaclava, headscarf, bandana, wool berret, peacoat, and poncho
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Double tested the uncraft/reversion integration works as intended and by golly it do
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
