### PR TITLE
make magiclysm/xedra evolved modded weapons useable by practice recipes

### DIFF
--- a/data/mods/Magiclysm/requirements/melee.json
+++ b/data/mods/Magiclysm/requirements/melee.json
@@ -1,0 +1,310 @@
+[
+  {
+    "id": "basic_maces",
+    "type": "requirement",
+    "//": "Any basic thing you can use as a mace.",
+    "extend": {
+      "tools": [ [ [ "bat_plus_one", -1 ], [ "bat_plus_two", -1 ], [ "bat_metal_plus_one", -1 ], [ "bat_metal_plus_two", -1 ] ] ]
+    }
+  },
+  {
+    "id": "basic_spears",
+    "type": "requirement",
+    "//": "Any given item that can be used as a spear.  Reserved for crappier things.",
+    "extend": { "tools": [ [ [ "rune_biomancer_weapon", -1 ], [ "rune_biomancer_weapon_adept", -1 ] ] ] }
+  },
+  {
+    "id": "real_maces",
+    "type": "requirement",
+    "//": "Any real, top-heavy bashing weapons with a pointy ball at the end that doesn't independantly swing (those are flails).",
+    "extend": {
+      "tools": [ [ [ "mace_plus_one", -1 ], [ "mace_plus_two", -1 ], [ "morningstar_plus_one", -1 ], [ "morningstar_plus_two", -1 ] ] ]
+    }
+  },
+  {
+    "id": "basic_great_hammers",
+    "type": "requirement",
+    "//": "Any basic thing that works like a great hammer; unga bunga.",
+    "extend": {
+      "tools": [
+        [
+          [ "sledge_plus_one", -1 ],
+          [ "sledge_plus_two", -1 ],
+          [ "sledge_heavy_plus_two", -1 ],
+          [ "sledge_heavy_plus_one", -1 ]
+        ]
+      ]
+    }
+  },
+  {
+    "id": "basic_batons",
+    "type": "requirement",
+    "//": "Any basic, easy-to-use bashing weapons.  Like police batons, sticks, or baseball bats.",
+    "extend": {
+      "tools": [
+        [
+          [ "cudgel_plus_one", -1 ],
+          [ "cudgel_plus_two", -1 ],
+          [ "q_staff_plus_one", -1 ],
+          [ "q_staff_plus_two", -1 ],
+          [ "bat_plus_one", -1 ],
+          [ "bat_plus_two", -1 ],
+          [ "bat_metal_plus_one", -1 ],
+          [ "bat_metal_plus_two", -1 ],
+          [ "rune_magus_weapon", -1 ],
+          [ "rune_magus_weapon_adept", -1 ],
+          [ "springstaff-extended", -1 ]
+        ]
+      ]
+    }
+  },
+  {
+    "id": "basic_hooks",
+    "type": "requirement",
+    "//": "Any basic thing that you can use to hook stuff in a fight.",
+    "extend": {
+      "tools": [
+        [
+          [ "sledge_plus_one", -1 ],
+          [ "sledge_plus_two", -1 ],
+          [ "sledge_heavy_plus_one", -1 ],
+          [ "sledge_heavy_plus_two", -1 ]
+        ]
+      ]
+    }
+  },
+  {
+    "id": "real_great_hammers",
+    "type": "requirement",
+    "//": "Any real great hammers.  It's got to have a big blunt end on a long pole, directly attached to it.",
+    "extend": {
+      "tools": [
+        [
+          [ "mjolnir", -1 ],
+          [ "warhammer_plus_one", -1 ],
+          [ "warhammer_plus_two", -1 ],
+          [ "lucerne_plus_one", -1 ],
+          [ "lucerne_plus_two", -1 ]
+        ]
+      ]
+    }
+  },
+  {
+    "id": "real_hooks",
+    "type": "requirement",
+    "//": "Any quality weapon designed to hook your oppenents and their gear in a fight.  Reserved for the good stuff.",
+    "extend": {
+      "tools": [
+        [
+          [ "mjolnir", -1 ],
+          [ "warhammer_plus_one", -1 ],
+          [ "warhammer_plus_two", -1 ],
+          [ "halberd_plus_one", -1 ],
+          [ "halberd_plus_two", -1 ],
+          [ "glaive_plus_one", -1 ],
+          [ "glaive_plus_two", -1 ],
+          [ "battleaxe_plus_one", -1 ],
+          [ "battleaxe_plus_two", -1 ],
+          [ "lucerne_plus_one", -1 ],
+          [ "lucerne_plus_two", -1 ],
+          [ "grim_reaper_scythe", -1 ]
+        ]
+      ]
+    }
+  },
+  {
+    "id": "real_polearms",
+    "type": "requirement",
+    "//": "Any real, top-heavy cutting weapons with a long pole and a blade on the end, designed to swing side-to-side.  Think like a sword with a really long handle.",
+    "extend": { "tools": [ [ [ "halberd_plus_one", -1 ], [ "halberd_plus_two", -1 ] ] ] }
+  },
+  {
+    "id": "real_spears",
+    "type": "requirement",
+    "//": "Any weapon that features a long pole with a pointed tip at the end.  Reserved for quality weapons.",
+    "extend": {
+      "tools": [
+        [
+          [ "gungnir", -1 ],
+          [ "wolfsbane", -1 ],
+          [ "spear_steel_plus_one", -1 ],
+          [ "spear_steel_plus_two", -1 ],
+          [ "qiang_plus_one", -1 ],
+          [ "qiang_plus_two", -1 ],
+          [ "glaive_plus_one", -1 ],
+          [ "glaive_plus_two", -1 ],
+          [ "naginata_plus_one", -1 ],
+          [ "naginata_plus_two", -1 ],
+          [ "pike_plus_one", -1 ],
+          [ "pike_plus_two", -1 ],
+          [ "lucerne_plus_one", -1 ],
+          [ "lucerne_plus_two", -1 ]
+        ]
+      ]
+    }
+  },
+  {
+    "id": "real_thrusting_swords",
+    "type": "requirement",
+    "//": "Any real, quality weapon designed to be used in a thrusting fashion.  Needs to be a sword, not a spear.  This includes fencing weaponry.",
+    "extend": {
+      "tools": [
+        [
+          [ "gram", -1 ],
+          [ "jian_plus_one", -1 ],
+          [ "jian_plus_two", -1 ],
+          [ "estoc_plus_one", -1 ],
+          [ "estoc_plus_two", -1 ],
+          [ "broadsword_plus_one", -1 ],
+          [ "broadsword_plus_two", -1 ],
+          [ "cavalry_sabre_plus_one", -1 ],
+          [ "cavalry_sabre_plus_two", -1 ],
+          [ "rapier_plus_one", -1 ],
+          [ "rapier_plus_two", -1 ]
+        ]
+      ]
+    }
+  },
+  {
+    "id": "real_quarterstaves",
+    "type": "requirement",
+    "//": "Any real, pole-like weapons designed for bashing and smashing.  Reserved for quality items.",
+    "extend": {
+      "tools": [
+        [
+          [ "laevateinn", -1 ],
+          [ "q_staff_plus_one", -1 ],
+          [ "q_staff_plus_two", -1 ],
+          [ "i_staff_plus_one", -1 ],
+          [ "i_staff_plus_two", -1 ],
+          [ "rune_magus_weapon", -1 ],
+          [ "rune_magus_weapon_adept", -1 ]
+        ]
+      ]
+    }
+  },
+  {
+    "id": "basic_knives",
+    "type": "requirement",
+    "//": "Any small close-range stabbing weapons.  Not explicity designed for combat.",
+    "extend": { "tools": [ [ [ "rune_animist_weapon", -1 ], [ "rune_animist_weapon_adept", -1 ] ] ] }
+  },
+  {
+    "id": "real_knives",
+    "type": "requirement",
+    "//": "Any real, small weapons meant to stab someone at close range; larger shivs basically.",
+    "extend": {
+      "tools": [
+        [
+          [ "orich_knife_combat", -1 ],
+          [ "knife_combat_plus_one", -1 ],
+          [ "knife_combat_plus_two", -1 ],
+          [ "knife_rambo_plus_one", -1 ],
+          [ "knife_rambo_plus_two", -1 ],
+          [ "knife_trench_plus_one", -1 ],
+          [ "knife_trench_plus_two", -1 ],
+          [ "kris_plus_one", -1 ],
+          [ "kris_plus_two", -1 ],
+          [ "kukri_plus_one", -1 ],
+          [ "kukri_plus_two", -1 ],
+          [ "tanto_plus_one", -1 ],
+          [ "tanto_plus_two", -1 ]
+        ]
+      ]
+    }
+  },
+  {
+    "id": "real_short_swords",
+    "type": "requirement",
+    "//": "Any real, edged short swords you could practice with, like broadswords.  I reckon that anything with a straight, sharp point to it that primarily swings side-to-side can qualify.",
+    "extend": {
+      "tools": [
+        [
+          [ "khopesh_plus_one", -1 ],
+          [ "khopesh_plus_two", -1 ],
+          [ "sword_xiphos_plus_one", -1 ],
+          [ "sword_xiphos_plus_two", -1 ]
+        ]
+      ]
+    }
+  },
+  {
+    "id": "real_medium_swords",
+    "type": "requirement",
+    "//": "Any real, edged medium swords you could practice with, like cavalry sabres.  This is any sword that is bigger than a short sword, but shorter than a long sword.",
+    "extend": {
+      "tools": [
+        [
+          [ "gram", -1 ],
+          [ "jian_plus_one", -1 ],
+          [ "jian_plus_two", -1 ],
+          [ "scimitar_plus_one", -1 ],
+          [ "scimitar_plus_two", -1 ],
+          [ "arming_sword_plus_one", -1 ],
+          [ "arming_sword_plus_two", -1 ],
+          [ "broadsword_plus_one", -1 ],
+          [ "broadsword_plus_two", -1 ],
+          [ "cavalry_sabre_plus_one", -1 ],
+          [ "cavalry_sabre_plus_two", -1 ],
+          [ "cutlass_plus_one", -1 ],
+          [ "cutlass_plus_two", -1 ],
+          [ "wakizashi_plus_one", -1 ],
+          [ "wakizashi_plus_two", -1 ],
+          [ "dao_plus_one", -1 ],
+          [ "dao_plus_two", -1 ],
+          [ "rune_kelvinist_weapon", -1 ],
+          [ "rune_kelvinist_ice_adept_weapon", -1 ]
+        ]
+      ]
+    }
+  },
+  {
+    "id": "real_long_swords",
+    "type": "requirement",
+    "//": "Any real, edged long swords you could practice with, like katanas, longswords, etc.  I reckon that anything with a straight, sharp point to it that primarily swings side-to-side can qualify.",
+    "extend": {
+      "tools": [
+        [
+          [ "orich_longsword", -1 ],
+          [ "longsword_mithril", -1 ],
+          [ "longsword_plus_one", -1 ],
+          [ "longsword_plus_two", -1 ],
+          [ "katana_plus_one", -1 ],
+          [ "katana_plus_two", -1 ]
+        ]
+      ]
+    }
+  },
+  {
+    "id": "real_great_swords",
+    "type": "requirement",
+    "//": "Any real, edged, big swords you could practice with, like zweihanders, greatswords, or the Dragonslayer, etc.  I reckon that anything with a straight, sharp point to it that primarily swings side-to-side, and is large enough to require a normal human to use two hands can qualify.",
+    "extend": {
+      "tools": [
+        [ [ "nodachi_plus_one", -1 ], [ "nodachi_plus_two", -1 ], [ "zweihander_plus_one", -1 ], [ "zweihander_plus_two", -1 ] ]
+      ]
+    }
+  },
+  {
+    "id": "real_axes",
+    "type": "requirement",
+    "//": "Any real, cutting weapons that can be used like an axe; large, heavy head with two sharp sides on a pole.",
+    "extend": { "tools": [ [ [ "rune_stormshaper_weapon", -1 ], [ "rune_stormshaper_weapon_adept", -1 ] ] ] }
+  },
+  {
+    "id": "real_great_axes",
+    "type": "requirement",
+    "//": "Any real, cutting weapons that can be used like an axe; large, heavy head with two sharp sides on a pole.",
+    "extend": {
+      "tools": [
+        [
+          [ "orich_fire_ax", -1 ],
+          [ "battleaxe_plus_one", -1 ],
+          [ "battleaxe_plus_two", -1 ],
+          [ "fire_ax_plus_one", -1 ],
+          [ "fire_ax_plus_two", -1 ]
+        ]
+      ]
+    }
+  }
+]

--- a/data/mods/Xedra_Evolved/requirements/melee.json
+++ b/data/mods/Xedra_Evolved/requirements/melee.json
@@ -1,0 +1,145 @@
+[
+  {
+    "id": "real_knives",
+    "type": "requirement",
+    "//": "Any real, small weapons meant to stab someone at close range; larger shivs basically.",
+    "extend": {
+      "tools": [
+        [
+          [ "glass_knife", -1 ],
+          [ "dreamdross_knife", -1 ],
+          [ "dreamforged_knife_combat", -1 ],
+          [ "dreamforged_kris", -1 ],
+          [ "dreamforged_kukri", -1 ],
+          [ "dreamforged_tanto", -1 ],
+          [ "moons_tears_knife_baselard", -1 ]
+        ]
+      ]
+    }
+  },
+  {
+    "id": "real_quarterstaves",
+    "type": "requirement",
+    "//": "Any real, pole-like weapons designed for bashing and smashing.  Reserved for quality items.",
+    "extend": { "tools": [ [ [ "dreamdross_bo", -1 ], [ "dreamforged_q_staff", -1 ], [ "dreamforged_q_staff_exp", -1 ] ] ] }
+  },
+  {
+    "id": "real_great_hammers",
+    "type": "requirement",
+    "//": "Any real great hammers.  It's got to have a big blunt end on a long pole, directly attached to it.",
+    "extend": { "tools": [ [ [ "dreamforged_warhammer", -1 ], [ "dreamforged_lucerne", -1 ] ] ] }
+  },
+  {
+    "id": "real_polearms",
+    "type": "requirement",
+    "//": "Any real, top-heavy cutting weapons with a long pole and a blade on the end, designed to swing side-to-side.  Think like a sword with a really long handle.",
+    "extend": {
+      "tools": [
+        [
+          [ "dreamforged_halberd", -1 ],
+          [ "dreamforged_glaive", -1 ],
+          [ "dreamforged_glaive_healing", -1 ],
+          [ "dreamforged_naginata", -1 ],
+          [ "dreamforged_lucerne", -1 ]
+        ]
+      ]
+    }
+  },
+  {
+    "id": "real_hooks",
+    "type": "requirement",
+    "//": "Any quality weapon designed to hook your oppenents and their gear in a fight.  Reserved for the good stuff.",
+    "extend": {
+      "tools": [
+        [
+          [ "dreamforged_warhammer", -1 ],
+          [ "dreamforged_halberd", -1 ],
+          [ "dreamforged_glaive", -1 ],
+          [ "dreamforged_glaive_healing", -1 ],
+          [ "dreamforged_battleaxe", -1 ],
+          [ "dreamforged_lucerne", -1 ]
+        ]
+      ]
+    }
+  },
+  {
+    "id": "real_spears",
+    "type": "requirement",
+    "//": "Any weapon that features a long pole with a pointed tip at the end.  Reserved for quality weapons.",
+    "extend": { "tools": [ [ [ "dreamforged_spear", -1 ] ] ] }
+  },
+  {
+    "id": "real_maces",
+    "type": "requirement",
+    "//": "Any real, top-heavy bashing weapons with a pointy ball at the end that doesn't independantly swing (those are flails).",
+    "extend": {
+      "tools": [ [ [ "redcap_club", -1 ], [ "dreamdross_club", -1 ], [ "dreamforged_mace", -1 ], [ "dreamforged_morningstar", -1 ] ] ]
+    }
+  },
+  {
+    "id": "real_short_swords",
+    "type": "requirement",
+    "//": "Any real, edged short swords you could practice with, like broadswords.  I reckon that anything with a straight, sharp point to it that primarily swings side-to-side can qualify.",
+    "extend": { "tools": [ [ [ "dreamforged_khopesh", -1 ] ] ] }
+  },
+  {
+    "id": "real_medium_swords",
+    "type": "requirement",
+    "//": "Any real, edged medium swords you could practice with, like cavalry sabres.  This is any sword that is bigger than a short sword, but shorter than a long sword.",
+    "extend": {
+      "tools": [
+        [
+          [ "pooka_gladius", -1 ],
+          [ "dreamforged_arming_sword", -1 ],
+          [ "dreamforged_broadsword", -1 ],
+          [ "dreamforged_tsurugi_speed", -1 ]
+        ]
+      ]
+    }
+  },
+  {
+    "id": "real_long_swords",
+    "type": "requirement",
+    "//": "Any real, edged long swords you could practice with, like katanas, longswords, etc.  I reckon that anything with a straight, sharp point to it that primarily swings side-to-side can qualify.",
+    "extend": {
+      "tools": [
+        [
+          [ "mirror_march_estoc", -1 ],
+          [ "winter_lord_estoc", -1 ],
+          [ "dreamforged_longsword", -1 ],
+          [ "dreamforged_katana", -1 ],
+          [ "dreamforged_wakizashi", -1 ]
+        ]
+      ]
+    }
+  },
+  {
+    "id": "real_great_swords",
+    "type": "requirement",
+    "//": "Any real, edged, big swords you could practice with, like zweihanders, greatswords, or the Dragonslayer, etc.  I reckon that anything with a straight, sharp point to it that primarily swings side-to-side, and is large enough to require a normal human to use two hands can qualify.",
+    "extend": { "tools": [ [ [ "dreamforged_nodachi", -1 ], [ "dreamforged_zweihander", -1 ] ] ] }
+  },
+  {
+    "id": "real_thrusting_swords",
+    "type": "requirement",
+    "//": "Any real, quality weapon designed to be used in a thrusting fashion.  Needs to be a sword, not a spear.  This includes fencing weaponry.",
+    "extend": {
+      "tools": [
+        [
+          [ "mirror_march_estoc", -1 ],
+          [ "winter_lord_estoc", -1 ],
+          [ "dreamforged_estoc", -1 ],
+          [ "dreamforged_broadsword", -1 ],
+          [ "dreamforged_tsurugi_speed", -1 ],
+          [ "dreamforged_rapier", -1 ]
+        ]
+      ]
+    }
+  },
+  {
+    "id": "real_great_axes",
+    "type": "requirement",
+    "//": "Any real, cutting weapons that can be used like an axe; large, heavy head with two sharp sides on a pole.",
+    "extend": { "tools": [ [ [ "dreamforged_battleaxe", -1 ] ] ] }
+  }
+]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "make magiclysm/xedra evolved weapons useable by practice recipes"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #69968 
Fixes some modded items like not being able to be used for training.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Painstakingly extending the requirements to the mods and adding all the weapons to them.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
make melee weapons use the same system as guns
use weapon_category, but its too broad
somehow make copy_from also add the item to the requirement
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Gave myself Quarterstaff, quarterstaff +1 and dreamforged quarterstaff. all 3 can be used to practice melee (beginner)
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Ive only done Magiclysm and xedra evolved weapons, other mods are untouched and need to get the same treatment.
This system is not very scaleable, we implement a system that also lets lets you inherit the training recipes from copy_from.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
