### PR TITLE
remove mutations by radiations option

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2820,13 +2820,6 @@ void options_manager::add_options_world_default()
 
     add_empty_line();
 
-    add( "RAD_MUTATION", "world_default", to_translation( "Mutations by radiation" ),
-         to_translation( "If true, radiation causes the player to mutate." ),
-         true
-       );
-
-    add_empty_line();
-
     add( "CHARACTER_POINT_POOLS", "world_default", to_translation( "Character point pools" ),
          to_translation( "Allowed point pools for character generation." ),
     { { "any", to_translation( "Any" ) }, { "multi_pool", to_translation( "Legacy Multipool" ) }, { "story_teller", to_translation( "Survivor" ) } },

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -1173,7 +1173,7 @@ void suffer::from_radiation( Character &you )
         // 200 rads = 100 / 10000 = 1 / 100
         // 1000 rads = 900 / 10000 = 9 / 100 = 10% !!!
         // 2000 rads = 2000 / 10000 = 1 / 5 = 20% !!!
-        if( get_option<bool>( "RAD_MUTATION" ) && rng( 100, 10000 ) < you.get_rad() ) {
+        if( rng( 100, 10000 ) < you.get_rad() ) {
             get_event_bus().send<event_type::character_radioactively_mutates>( you.getID() );
         }
         if( you.get_rad() > 50 && rng( 1, 3000 ) < you.get_rad() &&


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Getting yourself ridiculously high radiation (in order to get mutated in the first place) is something one fucks around and find out, not really something on accident.

#### Describe the solution
Remove the option

#### Describe alternatives you've considered
None

#### Testing
Will try and compile later, but mostly, should work.

#### Additional context
I'm quite surprised this option hasn't been looked over during the "Option removal spree" period.
