### PR TITLE
get the electric hair trimmer to only use one charge

### DIFF
--- a/data/json/items/tool/toiletries.json
+++ b/data/json/items/tool/toiletries.json
@@ -65,7 +65,7 @@
     "id": "elec_hairtrimmer",
     "type": "TOOL",
     "name": { "str": "electric hair trimmer" },
-    "description": "A pocket-sized electric trimmer made for cutting hair.  You can use it to cut your hair if it's supplied with batteries.  It requires 10 units of charge per use.",
+    "description": "A pocket-sized electric trimmer made for cutting hair.  You can use it to cut your hair if it's supplied with batteries.  It requires 1 unit of charge per use.",
     "weight": "138 g",
     "volume": "191 ml",
     "longest_side": "15 cm",
@@ -76,7 +76,7 @@
     "symbol": ";",
     "color": "yellow",
     "ammo": [ "battery" ],
-    "charges_per_use": 10,
+    "charges_per_use": 1,
     "use_action": { "type": "effect_on_conditions", "description": "Trim your hair", "effect_on_conditions": [ "barber_hair" ] },
     "pocket_data": [
       {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
The hair trimmer is absolutely unusable with the new density change. I want to make my hair bald!

#### Describe the solution
Reduce the battery to use one charge (now you can only use the trimmer for three times, assuming the battery is full)

#### Describe alternatives you've considered
Use light battery?

#### Testing
Should work.

#### Additional context
https://www.nytimes.com/wirecutter/reviews/best-hair-clippers-for-home-use/
https://www.toptenreviews.com/best-electric-hair-clippers

Many of these good-quality (cordless) trimmers last pretty decently (anyway, I do need to go to the barber for a hair cut)
