### PR TITLE
Protein Bar containers

### DIFF
--- a/data/json/itemgroups/SUS/evac_shelter.json
+++ b/data/json/itemgroups/SUS/evac_shelter.json
@@ -78,7 +78,7 @@
             "prob": 30
           },
           { "item": "water_clean", "count": [ 6, 12 ], "prob": 20 },
-          { "item": "protein_bar_evac", "count": [ 20, 24 ], "container-item": "bag_plastic", "prob": 60 },
+          { "item": "protein_bar_evac", "count": [ 20, 24 ], "container-item": "box_small", "on_overflow": "spill", "prob": 60 },
           {
             "collection": [
               { "item": "extinguisher", "prob": 70, "charges": 100 },
@@ -139,7 +139,7 @@
             ],
             "prob": 50
           },
-          { "item": "protein_bar_evac", "count": [ 1, 23 ], "container-item": "bag_plastic", "prob": 60 },
+          { "item": "protein_bar_evac", "count": [ 1, 23 ], "container-item": "box_small", "on_overflow": "spill", "prob": 60 },
           {
             "collection": [
               { "item": "extinguisher", "prob": 50, "charges": 100 },

--- a/data/json/itemgroups/SUS/evac_shelter.json
+++ b/data/json/itemgroups/SUS/evac_shelter.json
@@ -78,7 +78,7 @@
             "prob": 30
           },
           { "item": "water_clean", "count": [ 6, 12 ], "prob": 20 },
-          { "item": "protein_bar_evac", "count": [ 20, 24 ], "prob": 60 },
+          { "item": "protein_bar_evac", "count": [ 20, 24 ], "container-item": "bag_plastic", "prob": 60 },
           {
             "collection": [
               { "item": "extinguisher", "prob": 70, "charges": 100 },
@@ -139,7 +139,7 @@
             ],
             "prob": 50
           },
-          { "item": "protein_bar_evac", "count": [ 1, 23 ], "prob": 60 },
+          { "item": "protein_bar_evac", "count": [ 1, 23 ], "container-item": "bag_plastic", "prob": 60 },
           {
             "collection": [
               { "item": "extinguisher", "prob": 50, "charges": 100 },

--- a/data/json/itemgroups/SUS/evac_shelter.json
+++ b/data/json/itemgroups/SUS/evac_shelter.json
@@ -78,7 +78,13 @@
             "prob": 30
           },
           { "item": "water_clean", "count": [ 6, 12 ], "prob": 20 },
-          { "item": "protein_bar_evac", "count": [ 20, 24 ], "container-item": "box_small", "on_overflow": "spill", "prob": 60 },
+          {
+            "collection": [
+              { "item": "protein_bar_evac", "count": 12, "container-item": "box_small" },
+              { "item": "protein_bar_evac", "count": [ 8, 12 ], "container-item": "box_small" }
+            ],
+            "prob": 60
+          },
           {
             "collection": [
               { "item": "extinguisher", "prob": 70, "charges": 100 },
@@ -139,7 +145,13 @@
             ],
             "prob": 50
           },
-          { "item": "protein_bar_evac", "count": [ 1, 23 ], "container-item": "box_small", "on_overflow": "spill", "prob": 60 },
+          {
+            "collection": [
+              { "item": "protein_bar_evac", "count": [ 1, 12 ], "container-item": "box_small" },
+              { "item": "protein_bar_evac", "count": [ 0, 11 ], "container-item": "box_small" }
+            ],
+            "prob": 60
+          },
           {
             "collection": [
               { "item": "extinguisher", "prob": 50, "charges": 100 },

--- a/data/json/items/comestibles/protein.json
+++ b/data/json/items/comestibles/protein.json
@@ -61,7 +61,7 @@
     "//": "Inspired by, but not based on, a true story",
     "description": "SoyPelusa ran a highly successful crowdfunding campaign for their signature protein bar, dubbed \"DaiZoom.\"\n\nA person can live on one of these bars, three times a day, presumably forever.  After backers received their product, a single flaw was found: most consumers found starvation preferable to the flavor.  Warehouses of the product went unsold as the company went bankrupt, providing the perfect opportunity for FEMA to scoop them up and stock the evac shelters.\n\nNow, you hold a piece of famous crowdfunding history in your hands.  How exciting.",
     "weight": "150 g",
-    "volume": "223 ml",
+    "volume": "175 ml",
     "price": "5 USD",
     "price_postapoc": "50 cent",
     "flags": [ "EDIBLE_FROZEN" ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Spawn a plastic bag to contain large pile of protein bars"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Now that containers exist, it makes very little sense for all these bars to be left loose in a cabinet as if someone put them all in one at a time.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Shrink the size of a protein bar from 223 ml to 175 ml, and spawn two `box_small` which together can hold up to 24 bars.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Leave protein bars at 223 ml and use a single `box_medium` which would be absurdly big; or use a single 6L plastic bag which would be just the right size but makes less sense than two small boxes.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
