### PR TITLE
Recruit civilians and ferals, civilians upgrade into ferals

### DIFF
--- a/data/json/monsters/civilians.json
+++ b/data/json/monsters/civilians.json
@@ -73,6 +73,7 @@
       "subtype": "collection",
       "items": [ { "group": "mon_zombie_cop_death_drops", "prob": 100 }, { "item": "glock_22", "prob": 100, "charges": [ 0, 6 ] } ]
     },
+    "upgrades": { "into": "mon_feral_cop" },
     "zombify_into": "mon_zombie_cop",
     "extend": { "flags": [ "DROPS_AMMO", "WIELDED_WEAPON" ] },
     "starting_ammo": { "40fmj": 10 },
@@ -137,12 +138,9 @@
     "name": "GROUP_CIVILIANS_UPGRADE",
     "type": "monstergroup",
     "monsters": [
-      { "monster": "mon_zombie", "weight": 264, "cost_multiplier": 0 },
-      { "monster": "mon_zombie_fat", "weight": 266, "cost_multiplier": 0 },
-      { "monster": "mon_zombie_tough", "weight": 100, "cost_multiplier": 0 },
-      { "monster": "mon_zombie_crawler", "weight": 66, "cost_multiplier": 0 },
-      { "monster": "mon_zombie_brainless", "weight": 30, "cost_multiplier": 0 },
-      { "group": "GROUP_FERAL", "weight": 180, "cost_multiplier": 0 }
+      { "monster": "mon_feral_human_pipe", "weight": 240, "cost_multiplier": 0 },
+      { "monster": "mon_feral_sapien_spear", "weight": 20, "cost_multiplier": 0 },
+      { "group": "GROUP_FERAL", "weight": 4, "cost_multiplier": 0 }
     ]
   },
   {

--- a/data/json/monsters/feral_humans.json
+++ b/data/json/monsters/feral_humans.json
@@ -21,6 +21,7 @@
     "melee_dice": 1,
     "melee_dice_sides": 6,
     "weakpoint_sets": [ "wps_humanoid_body" ],
+    "chat_topics": [ "TALK_FERAL_HUMAN" ],
     "families": [ "prof_intro_biology", "prof_physiology" ],
     "dodge": 1,
     "harvest": "human",

--- a/data/json/npcs/civilians/civilians.json
+++ b/data/json/npcs/civilians/civilians.json
@@ -4,8 +4,21 @@
     "id": "TALK_CIVILIAN_PANIC",
     "dynamic_line": "&You see this crazed fellows eyes darting around anxiously, always anticipating impending doom.  Every now and then you can even hear them whimper in fear.  Although they do not seem aggressive, they definitely are out of their mind.",
     "responses": [
+      { "text": "Follow me if you want to live!",
+        "condition": { 
+            "and": [ { "not": {"npc_has_effect": "asked_to_follow"} },{ "not": {"npc_has_effect": "pet"} } ]
+        },
+        "trial": { "type": "PERSUADE", "difficulty": 10 },
+        "success": { "topic": "TALK_CIVILIAN_PANIC_EVAC2", "effect": [ { "npc_add_effect": "pet", "duration": "PERMANENT" }, {"math": [ "n_val('friendly')", "=", "-1" ] } ] },
+        "failure": { "topic": "TALK_CIVILIAN_PANIC_EVAC", "effect": [{ "npc_add_effect": "asked_to_follow", "duration": 4000 }] }
+      },
       { "text": "You need to get to safety!", "topic": "TALK_CIVILIAN_PANIC_EVAC" },
-      { "text": "[Awkwardly distance yourself.]", "topic": "TALK_DONE" }
+      { "text": "[Awkwardly distance yourself.]", "topic": "TALK_DONE",
+        "condition": {"math": [ "n_val('friendly')", "!=", "-1" ] }
+      },
+      { "text": "[Lead the way.]", "topic": "TALK_DONE",
+        "condition": {"math": [ "n_val('friendly')", "==", "-1" ] }
+      }
     ]
   },
   {
@@ -16,6 +29,12 @@
   },
   {
     "type": "talk_topic",
+    "id": "TALK_CIVILIAN_PANIC_EVAC2",
+    "dynamic_line": "&Still trembling, they nod and move towards you.",
+    "responses": [ { "text": "[Lead the way.]", "topic": "TALK_DONE" } ]
+  },
+  {
+    "type": "talk_topic",
     "id": "TALK_CIVILIAN_FIGHTER",
     "dynamic_line": [
       "I'm gonna kill all these <swear> things!",
@@ -23,8 +42,35 @@
       "I'M INVINCIBLE!"
     ],
     "responses": [
-      { "text": "Are you crazy?  Get out of here!", "topic": "TALK_CIVILIAN_FIGHTER_EVAC" },
-      { "text": "[Leave them to their futile fight.]", "topic": "TALK_DONE" }
+      { "text": "Come join me! Together we are stronger!",
+        "condition": { 
+            "and": [ { "not": {"npc_has_effect": "asked_to_follow"} },{ "not": {"npc_has_effect": "pet"} } ]
+        },
+        "trial": { "type": "PERSUADE", "difficulty": 10 },
+        "success": { "topic": "TALK_CIVILIAN_FIGHTER_EVAC3", "effect": [ { "npc_add_effect": "pet", "duration": "PERMANENT" }, {"math": [ "n_val('friendly')", "=", "-1" ] } ] },
+        "failure": { "topic": "TALK_CIVILIAN_FIGHTER_EVAC2", "effect": [{ "npc_add_effect": "asked_to_follow", "duration": 4000 }] }
+      },
+      { "text": "Are you crazy?  Get out of here!", "topic": "TALK_CIVILIAN_FIGHTER_EVAC",
+        "condition": {"math": [ "n_val('friendly')", "!=", "-1" ] }
+      },
+      { "text": "[Leave them to their futile fight.]", "topic": "TALK_DONE",
+        "condition": {"math": [ "n_val('friendly')", "!=", "-1" ] }
+      },
+      { "text": "Fight!", "topic": "TALK_FERAL_HUMAN_EVAC3",
+        "condition": {"math": [ "n_val('friendly')", "==", "-1" ] },
+        "effect": [ {"math": [ "n_val('anger')", "=", "1000" ] }, {"math": [ "n_val('morale')", "=", "1000" ] } ]
+      },
+      { "text": "Calm down <dumb> <name_b>!", "topic": "TALK_FERAL_HUMAN_EVAC4",
+        "condition": {"math": [ "n_val('friendly')", "==", "-1" ] },
+        "effect": {"math": [ "n_val('anger')", "=", "-1000" ] }
+      },
+      { "text": "Run!", "topic": "TALK_FERAL_HUMAN_EVAC4",
+        "condition": {"math": [ "n_val('friendly')", "==", "-1" ] },
+        "effect": {"math": [ "n_val('morale')", "=", "-1000" ] }
+      },
+      { "text": "[Lead the way.]", "topic": "TALK_DONE",
+        "condition": {"math": [ "n_val('friendly')", "==", "-1" ] }
+      }
     ]
   },
   {
@@ -35,12 +81,69 @@
   },
   {
     "type": "talk_topic",
+    "id": "TALK_CIVILIAN_FIGHTER_EVAC2",
+    "dynamic_line": [ "I don't need your <swear> help! Get out of here <name_b>!" ],
+    "responses": [ { "text": "[Leave them to their futile fight.]", "topic": "TALK_DONE" } ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_CIVILIAN_FIGHTER_EVAC3",
+    "dynamic_line": [ "Alright! Lets go!" ],
+    "responses": [ { "text": "[Lead the way.]", "topic": "TALK_DONE" } ]
+  },
+  {
+    "type": "talk_topic",
     "id": "TALK_CIVILIAN_OFFICER",
     "dynamic_line": [
       "Stand aside citizen, I'll handle this!",
       "Don't worry, I'm with the police<punc>",
       "&The officer scans the area, looking for trouble.  They have a dangerous glint in their eyes."
     ],
+    "responses": [
+      { "text": "I need your help over here! <keep_up>",
+        "condition": { 
+            "and": [ { "not": {"npc_has_effect": "asked_to_follow"} },{ "not": {"npc_has_effect": "pet"} } ]
+        },
+        "trial": { "type": "PERSUADE", "difficulty": 10 },
+        "success": { "topic": "TALK_CIVILIAN_OFFICER_EVAC", "effect": [ { "npc_add_effect": "pet", "duration": "PERMANENT" }, {"math": [ "n_val('friendly')", "=", "-1" ] } ] },
+        "failure": { "topic": "TALK_CIVILIAN_OFFICER_EVAC2", "effect": [{ "npc_add_effect": "asked_to_follow", "duration": 4000 }] }
+      },
+      { "text": "[Back away.]", "topic": "TALK_DONE",
+        "condition": {"math": [ "n_val('friendly')", "!=", "-1" ] }
+      },
+      { "text": "Fight!", "topic": "TALK_CIVILIAN_OFFICER_EVAC3",
+        "condition": {"math": [ "n_val('friendly')", "==", "-1" ] },
+        "effect": [ {"math": [ "n_val('anger')", "=", "1000" ] }, {"math": [ "n_val('morale')", "=", "1000" ] } ]
+      },
+      { "text": "Put your <swear> weapon down!", "topic": "TALK_CIVILIAN_OFFICER_EVAC3",
+        "condition": {"math": [ "n_val('friendly')", "==", "-1" ] },
+        "effect": {"math": [ "n_val('anger')", "=", "-1000" ] }
+      },
+      { "text": "Run!", "topic": "TALK_CIVILIAN_OFFICER_EVAC3",
+        "condition": {"math": [ "n_val('friendly')", "==", "-1" ] },
+        "effect": {"math": [ "n_val('morale')", "=", "-1000" ] }
+      },
+      { "text": "[Lead the way.]", "topic": "TALK_DONE",
+        "condition": {"math": [ "n_val('friendly')", "==", "-1" ] }
+      }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_CIVILIAN_OFFICER_EVAC",
+    "dynamic_line": [ "<okay><punc> lead the way <name_g>!" ],
+    "responses": [ { "text": "[Back away.]", "topic": "TALK_DONE" } ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_CIVILIAN_OFFICER_EVAC2",
+    "dynamic_line": [ "Stay close for now<punc> I have to secure the perimeter." ],
+    "responses": [ { "text": "[Back away.]", "topic": "TALK_DONE" } ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_CIVILIAN_OFFICER_EVAC3",
+    "dynamic_line": [ "<okay><punc>" ],
     "responses": [ { "text": "[Back away.]", "topic": "TALK_DONE" } ]
   },
   {
@@ -57,11 +160,36 @@
   },
   {
     "type": "talk_topic",
+    "id": "TALK_CIVILIAN_PARENT_EVAC2",
+    "dynamic_line": "&They seem to ignore you and continue crying out.",
+    "responses": [ { "text": "[Let them keep on searching.]", "topic": "TALK_DONE" } ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_CIVILIAN_PARENT_EVAC3",
+    "dynamic_line": [ "I'm coming!", "We have to hurry!", "Show me!" ],
+    "responses": [ { "text": "[Lead the way.]", "topic": "TALK_DONE" } ]
+  },
+  {
+    "type": "talk_topic",
     "id": "TALK_CIVILIAN_PARENT",
     "dynamic_line": [ "Have you seen my child?", "I am not leaving without my little one!", "Where is my kid?" ],
     "responses": [
-      { "text": "Your child is likely dead by now and you should get to safety!", "topic": "TALK_CIVILIAN_PARENT_EVAC" },
-      { "text": "[Let them keep on searching.]", "topic": "TALK_DONE" }
+      { "text": "Hey <name_g>! I think your kid is this way! Follow me!",
+        "condition": { 
+            "and": [ { "not": {"npc_has_effect": "asked_to_follow"} },{ "not": {"npc_has_effect": "pet"} } ]
+        },
+        "trial": { "type": "PERSUADE", "difficulty": 10 },
+        "success": { "topic": "TALK_CIVILIAN_PARENT_EVAC3", "effect": [ { "npc_add_effect": "pet", "duration": "PERMANENT" }, {"math": [ "n_val('friendly')", "=", "-1" ] } ] },
+        "failure": { "topic": "TALK_CIVILIAN_PARENT_EVAC2", "effect": [{ "npc_add_effect": "asked_to_follow", "duration": 4000 }] }
+      },
+      { "text": "Your child is probably a <zombie> by now! Give it up!", "topic": "TALK_CIVILIAN_PARENT_EVAC" },
+      { "text": "[Let them keep on searching.]", "topic": "TALK_DONE",
+        "condition": {"math": [ "n_val('friendly')", "!=", "-1" ] }
+      },
+      { "text": "[Lead the way.]", "topic": "TALK_DONE",
+        "condition": {"math": [ "n_val('friendly')", "==", "-1" ] }
+      }
     ]
   }
 ]

--- a/data/json/npcs/feral_humans/feral_humans.json
+++ b/data/json/npcs/feral_humans/feral_humans.json
@@ -1,0 +1,60 @@
+[
+  {
+    "type": "talk_topic",
+    "id": "TALK_FERAL_HUMAN",
+    "dynamic_line": [
+      "&They leer at you intensely while gripping their weapon.",
+      "&They stomp and growl.",
+      "&They swing their weapon menacingly and make strange gestures.",
+      "&They point their finger at you and swing their weapon around."
+    ],
+    "responses": [
+      { "text": "[Try to pacify them.]",
+        "condition": { 
+            "and": [ { "not": {"npc_has_effect": "asked_to_follow"} },{ "not": {"npc_has_effect": "pet"} } ]
+        },
+        "trial": { "type": "PERSUADE", "difficulty": -20 },
+        "success": { "topic": "TALK_FERAL_HUMAN_EVAC", "effect": [ { "npc_add_effect": "pet", "duration": "PERMANENT" }, {"math": [ "n_val('friendly')", "=", "-1" ] } ] },
+        "failure": { "topic": "TALK_FERAL_HUMAN_EVAC2", "effect": [{ "npc_add_effect": "asked_to_follow", "duration": 4000 }] }
+      },
+      { "text": "[Rouse them up.]", "topic": "TALK_FERAL_HUMAN_EVAC3",
+        "condition": {"math": [ "n_val('friendly')", "==", "-1" ] },
+        "effect": {"math": [ "n_val('anger')", "=", "1000" ] }
+      },
+      { "text": "[Calm them down.]", "topic": "TALK_FERAL_HUMAN_EVAC4",
+        "condition": {"math": [ "n_val('friendly')", "==", "-1" ] },
+        "effect": {"math": [ "n_val('anger')", "=", "-1000" ] }
+      },
+      { "text": "[This is hopeless.]", "topic": "TALK_DONE",
+        "condition": {"math": [ "n_val('friendly')", "!=", "-1" ] }
+      },
+      { "text": "[Lead the way.]", "topic": "TALK_DONE",
+        "condition": {"math": [ "n_val('friendly')", "==", "-1" ] }
+      }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_FERAL_HUMAN_EVAC",
+    "dynamic_line": "&Whatever you did seems to have worked! At least for now<punc>",
+    "responses": [ { "text": "[Lead the way.]", "topic": "TALK_DONE" } ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_FERAL_HUMAN_EVAC2",
+    "dynamic_line": "&It's no good. They ignore you completely.",
+    "responses": [ { "text": "[This is hopeless.]", "topic": "TALK_DONE" } ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_FERAL_HUMAN_EVAC3",
+    "dynamic_line": "&They raise their weapon and grin!",
+    "responses": [ { "text": "[Lead the way.]", "topic": "TALK_DONE" } ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_FERAL_HUMAN_EVAC4",
+    "dynamic_line": "&They lower their weapon and scowl...",
+    "responses": [ { "text": "[Lead the way.]", "topic": "TALK_DONE" } ]
+  }
+]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Recruit civilians and ferals, civilians upgrade into ferals instead of zombies"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

So the idea is you can already talk to the random scared people running around the world. But they are stupid and don't really do much. They just seem to exist for flavor during the start of the game. They jump to their deaths and you can't do nothing about it. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Now you can attempt to recruit them. I also changed it so they upgrade into feral people instead of zombies so you don't end up with friendly zombies. According to the lore these guys are apparently similar to ferals so I think this makes more sense than spontaneous zombification anyway. Existing ferals can be recruited in a similar way but have a very difficult social roll.

Just talk to the civilian or feral and choose the persuasion option. A roll is done based on your social skill in order to befriend them. You can order around friendly futile fighters, overconfident officers, and ferals to fight or run if needed. You can also attach bags to your civilians and ferals like pets.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
If the feral aspect of this doesn't work I think allowing for civilians to follow you would still be good. I would just have to find a way to keep them from upgrading into zombies. Ideally I want to make it so they can be rehabilitated into survivor npcs once they are brought to safety. I heard you could do something like this with broken cyborgs. This is a similar idea.

If there is no way to work it in I might consider offering it as a mod.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Tested it on my computer. Ran a few games and lead the guys around. Checked how they interact with each other and how they upgrade in debug mode.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
![panic](https://github.com/user-attachments/assets/88fef74c-e342-4539-acd5-22b05f4038ef)
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
