### PR TITLE
Fix for Carnivores being able to eat low-calorie veggies

### DIFF
--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -465,6 +465,7 @@ std::pair<nutrients, nutrients> Character::compute_nutrient_range(
 
 int Character::nutrition_for( const item &comest ) const
 {
+    // Note: This will round down to zero for super-low-calorie foods
     return compute_effective_nutrients( comest ).kcal() / islot_comestible::kcal_per_nutr;
 }
 
@@ -901,7 +902,7 @@ ret_val<edible_rating> Character::can_eat( const item &food ) const
         return ret_val<edible_rating>::make_failure( INEDIBLE_MUTATION, _( "Ugh, you can't drink that!" ) );
     }
 
-    if( has_trait( trait_CARNIVORE ) && nutrition_for( food ) > 0 &&
+    if( has_trait( trait_CARNIVORE ) && compute_effective_nutrients( food ).kcal() > 0 &&
         food.has_any_vitamin( carnivore_blacklist ) && !food.has_flag( flag_CARNIVORE_OK ) ) {
         return ret_val<edible_rating>::make_failure( INEDIBLE_MUTATION,
                 _( "Eww.  Inedible plant stuff!" ) );


### PR DESCRIPTION
#### Summary
Bugfixes "Fix for Carnivores being able to eat low-calorie veggies"

#### Purpose of change
Veggies under ~17 calories, including pickles, accidentally slip past the code block which checks whether or not a carnivore is prohibited from eating foods.  This PR fixes that.
![menu1-pre-fix](https://github.com/user-attachments/assets/d1bee620-3ac1-4f29-a989-1081f336e111)
![menu1-post-fix](https://github.com/user-attachments/assets/d1dd7094-86e3-4347-8a5a-9c0c9ceb1ca7)

#### Describe the solution
Swapping in the method `compute_effective_nutrients()` for the method `nutrition_for()` when checking if a carnivore's meal has calories or not.  The latter currently calls the former anyway, but introduces the problem when dividing the former result as casting to an int in C++ rounds the quotient down to zero when it's too small.

A comment is also included in `nutrition_for()` warning developers of this danger.

#### Describe alternatives you've considered
On Discord, we discussed instead simply giving 1 nutrition whenever `nutrition_for()` would start with caloric food but round it down to zero.  This would still be a reasonable idea, and could safely be done even after this PR is merged, but I decided against it.  This would have the following effects:
 - Magic food: All super-low-calorie-foods would give slightly more nutrition than they should. (Like one bite of an apple, but, still.)
 - Hibernation: Super-low-calorie foods currently skip the hibernation logic entirely, but would instead show messages and contribute (very slightly) to sleepiness.
 - Food poisoning: Eating rotten super-low-calorie food currently gives 6m of food poisoning, and would instead give 6-12m.
 - Acid/fertilizer: Drinking super-low-calorie acid w/ ACIDPROOF/ACIDBLOOD, or drinking super-low-calorie fertilizer w/ THRESH_PLANT could in theory would give additional calories, but a review of the available foods suggests none are applicable anyway.

#### Testing
Built from source, and compared a carnivore's ability to eat from a menu of foods before and after the change.

#### Additional context
Thanks to @GuardianDll, @harakka and @snup. for dev help, and to @GuardianDll for tracking down this bug!