### PR TITLE
max amount of hp can't be less than 1

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2514,6 +2514,8 @@ void Character::calc_all_parts_hp( float hp_mod, float hp_adjustment, int str_ma
             new_max *= 0.8;
         }
 
+        new_max = std::max( 1, new_max );
+
         float max_hp_ratio = static_cast<float>( new_max ) /
                              static_cast<float>( part.second.get_hp_max() );
 


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Snup found that having both FLIMSY3 and GOBLIN_BUILD mutation result in hp enchantment multiplier -1, which make your max hp equal 0, and instantly kills you, which was the reason of this `npc != npc` test fails we see time to time in CI
#### Describe the solution
Truncate max hp so it can't be smaller than 1 - only max hp should be affected, not current hp
#### Testing
Compiled the game, applied both mutations - got 1 hp on all limbs
took some damage, still can die as expected