### PR TITLE
Fix fatigue sfx id

### DIFF
--- a/doc/SOUNDPACKS.md
+++ b/doc/SOUNDPACKS.md
@@ -225,7 +225,7 @@ Example: if `plmove|t_grass_long` is defined it will be played before default `p
 
 ### Fatigue
 
-* `plmove sleepiness_m_low|sleepiness_m_med|sleepiness_m_high|sleepiness_f_low|sleepiness_f_med|sleepiness_f_high`
+* `plmove fatigue_m_low|fatigue_m_med|fatigue_m_high|fatigue_f_low|fatigue_f_med|fatigue_f_high`
 
 ### Player hurt
 

--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -207,7 +207,7 @@ bool cleanup_at_end()
     sfx::fade_audio_group( sfx::group::weather, 300 );
     sfx::fade_audio_group( sfx::group::time_of_day, 300 );
     sfx::fade_audio_group( sfx::group::context_themes, 300 );
-    sfx::fade_audio_group( sfx::group::sleepiness, 300 );
+    sfx::fade_audio_group( sfx::group::low_stamina, 300 );
 
     zone_manager::get_manager().clear();
 
@@ -750,7 +750,7 @@ bool do_turn()
     sfx::do_danger_music();
     sfx::do_vehicle_engine_sfx();
     sfx::do_vehicle_exterior_engine_sfx();
-    sfx::do_sleepiness();
+    sfx::do_low_stamina_sfx();
 
     // reset player noise
     u.volume = 0;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2909,7 +2909,7 @@ void game::bury_screen() const
     sfx::fade_audio_group( sfx::group::weather, 2000 );
     sfx::fade_audio_group( sfx::group::time_of_day, 2000 );
     sfx::fade_audio_group( sfx::group::context_themes, 2000 );
-    sfx::fade_audio_group( sfx::group::sleepiness, 2000 );
+    sfx::fade_audio_group( sfx::group::low_stamina, 2000 );
 }
 
 void game::death_screen()

--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -329,7 +329,7 @@ bool init_sound()
                                static_cast<int>( sfx::group::context_themes ) );
             Mix_GroupChannels( static_cast<int>( sfx::channel::stamina_75 ),
                                static_cast<int>( sfx::channel::stamina_35 ),
-                               static_cast<int>( sfx::group::sleepiness ) );
+                               static_cast<int>( sfx::group::low_stamina ) );
 
             sound_init_success = true;
         } else {

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -1633,7 +1633,7 @@ void sfx::do_danger_music()
     prev_hostiles = hostiles;
 }
 
-void sfx::do_sleepiness()
+void sfx::do_low_stamina_sfx()
 {
     if( test_mode ) {
         return;
@@ -1648,48 +1648,48 @@ void sfx::do_sleepiness()
     16: Stamina 50%
     17: Stamina 25%*/
     if( player_character.get_stamina() >= player_character.get_stamina_max() * .75 ) {
-        fade_audio_group( group::sleepiness, 2000 );
+        fade_audio_group( group::low_stamina, 2000 );
         return;
     } else if( player_character.get_stamina() <= player_character.get_stamina_max() * .74 &&
                player_character.get_stamina() >= player_character.get_stamina_max() * .5 &&
                player_character.male && !is_channel_playing( channel::stamina_75 ) ) {
-        fade_audio_group( group::sleepiness, 1000 );
-        play_ambient_variant_sound( "plmove", "sleepiness_m_low", seas_str, indoors,
+        fade_audio_group( group::low_stamina, 1000 );
+        play_ambient_variant_sound( "plmove", "fatigue_m_low", seas_str, indoors,
                                     night, 100, channel::stamina_75, 1000 );
         return;
     } else if( player_character.get_stamina() <= player_character.get_stamina_max() * .49 &&
                player_character.get_stamina() >= player_character.get_stamina_max() * .25 &&
                player_character.male && !is_channel_playing( channel::stamina_50 ) ) {
-        fade_audio_group( group::sleepiness, 1000 );
-        play_ambient_variant_sound( "plmove", "sleepiness_m_med", seas_str, indoors,
+        fade_audio_group( group::low_stamina, 1000 );
+        play_ambient_variant_sound( "plmove", "fatigue_m_med", seas_str, indoors,
                                     night, 100, channel::stamina_50, 1000 );
         return;
     } else if( player_character.get_stamina() <= player_character.get_stamina_max() * .24 &&
                player_character.get_stamina() >= 0 && player_character.male &&
                !is_channel_playing( channel::stamina_35 ) ) {
-        fade_audio_group( group::sleepiness, 1000 );
-        play_ambient_variant_sound( "plmove", "sleepiness_m_high", seas_str, indoors,
+        fade_audio_group( group::low_stamina, 1000 );
+        play_ambient_variant_sound( "plmove", "fatigue_m_high", seas_str, indoors,
                                     night, 100, channel::stamina_35, 1000 );
         return;
     } else if( player_character.get_stamina() <= player_character.get_stamina_max() * .74 &&
                player_character.get_stamina() >= player_character.get_stamina_max() * .5 &&
                !player_character.male && !is_channel_playing( channel::stamina_75 ) ) {
-        fade_audio_group( group::sleepiness, 1000 );
-        play_ambient_variant_sound( "plmove", "sleepiness_f_low", seas_str, indoors,
+        fade_audio_group( group::low_stamina, 1000 );
+        play_ambient_variant_sound( "plmove", "fatigue_f_low", seas_str, indoors,
                                     night, 100, channel::stamina_75, 1000 );
         return;
     } else if( player_character.get_stamina() <= player_character.get_stamina_max() * .49 &&
                player_character.get_stamina() >= player_character.get_stamina_max() * .25 &&
                !player_character.male && !is_channel_playing( channel::stamina_50 ) ) {
-        fade_audio_group( group::sleepiness, 1000 );
-        play_ambient_variant_sound( "plmove", "sleepiness_f_med", seas_str, indoors,
+        fade_audio_group( group::low_stamina, 1000 );
+        play_ambient_variant_sound( "plmove", "fatigue_f_med", seas_str, indoors,
                                     night, 100, channel::stamina_50, 1000 );
         return;
     } else if( player_character.get_stamina() <= player_character.get_stamina_max() * .24 &&
                player_character.get_stamina() >= 0 && !player_character.male &&
                !is_channel_playing( channel::stamina_35 ) ) {
-        fade_audio_group( group::sleepiness, 1000 );
-        play_ambient_variant_sound( "plmove", "sleepiness_f_high", seas_str, indoors,
+        fade_audio_group( group::low_stamina, 1000 );
+        play_ambient_variant_sound( "plmove", "fatigue_f_high", seas_str, indoors,
                                     night, 100, channel::stamina_35, 1000 );
         return;
     }
@@ -2037,7 +2037,7 @@ bool sfx::has_variant_sound( const std::string &, const std::string & )
 void sfx::stop_sound_effect_fade( channel, int ) { }
 void sfx::stop_sound_effect_timed( channel, int ) { }
 void sfx::do_player_death_hurt( const Character &, bool ) { }
-void sfx::do_sleepiness() { }
+void sfx::do_low_stamina_sfx() { }
 void sfx::do_obstacle( const std::string & ) { }
 void sfx::play_variant_sound( const std::string &, const std::string &, const std::string &,
                               const std::optional<bool> &, const std::optional<bool> &, int ) { }

--- a/src/sounds.h
+++ b/src/sounds.h
@@ -144,7 +144,7 @@ enum class group : int {
     weather = 1,    //SFX related to weather
     time_of_day,    //SFX related to time of day
     context_themes, //SFX related to context themes
-    sleepiness         //SFX related to sleepiness
+    low_stamina         //SFX related to low_stamina
 };
 
 void load_sound_effects( const JsonObject &jsobj );
@@ -196,7 +196,7 @@ void stop_sound_effect_fade( channel channel, int duration );
 void stop_sound_effect_timed( channel channel, int time );
 int set_channel_volume( channel channel, int volume );
 void do_player_death_hurt( const Character &target, bool death );
-void do_sleepiness();
+void do_low_stamina_sfx();
 // @param obst should be string id of obstacle terrain or vehicle part
 void do_obstacle( const std::string &obst = "" );
 } // namespace sfx


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Out of Breath sounds not playing"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fixes #73038

#72708 renamed fatigue to sleepiness, but the sfx ids for being low on stamina was also called fatigue, and now it's called sleepiness, but it's actually a low stamina sfx and not a sleepiness sfx

#### Describe the solution

- revert the change to the id, it's a sfx id it's kinda hidden, and changing it broke every soundpack that have this sfx
- rename the enum to low_stamina : this doesn't affect external thigns and makes more sense
- same with do_fatigue that became do_sleepiness and now becomes `do_low_stamina_sfx` so now it's actually clear

#### Describe alternatives you've considered

- rename the sfx id to `low_stamina`

#### Testing

- Compile without error
 
I never managed to get sound working when compiling from source so I can't test that the sound works again, but this is a straight revert to the previous id it should work

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
