### PR TITLE
I can't believe it's more item disassembly changes

### DIFF
--- a/data/json/recipes/armor/legs.json
+++ b/data/json/recipes/armor/legs.json
@@ -101,7 +101,7 @@
     "book_learn": [ [ "mag_tailor", 1 ], [ "manual_tailor", 1 ] ],
     "proficiencies": [ { "proficiency": "prof_elastics", "time_multiplier": 1.25, "skill_penalty": 0.15 } ],
     "using": [ [ "tailoring_lycra_patchwork", 1 ] ],
-    "byproducts": [ [ "lycra_patch", 1 ], [ "scrap_lycra", 1 ] ]
+    "byproducts": [ [ "scrap_lycra", 1 ] ]
   },
   {
     "result": "boy_shorts",

--- a/data/json/recipes/armor/storage.json
+++ b/data/json/recipes/armor/storage.json
@@ -300,7 +300,7 @@
     "skills_required": [ "gun", 1 ],
     "time": "2 h 30 m",
     "autolearn": true,
-    "reversible": true,
+    "reversible": { "time": "7 m" },
     "using": [ [ "tailoring_canvas_patchwork", 2 ], [ "strap_small", 1 ], [ "clasps", 4 ] ],
     "proficiencies": [ { "proficiency": "prof_closures" }, { "proficiency": "prof_closures_waterproofing" } ],
     "components": [ [ [ "chestpouch", 4 ], [ "legpouch_large", 2 ] ] ]
@@ -331,7 +331,7 @@
     "difficulty": 4,
     "time": "20 m",
     "autolearn": true,
-    "reversible": true,
+    "reversible": { "time": "5 m" },
     "using": [ [ "adhesive", 1 ], [ "tailoring_leather_small", 5 ], [ "clasps", 1 ] ],
     "qualities": [ { "id": "HAMMER", "level": 1 } ],
     "components": [ [ [ "scrap", 1 ] ], [ [ "nail", 4 ], [ "bronze_nail", 4 ] ] ]

--- a/data/json/recipes/armor/torso.json
+++ b/data/json/recipes/armor/torso.json
@@ -2026,7 +2026,7 @@
     "difficulty": 3,
     "time": "6 h",
     "autolearn": true,
-    "reversible": true,
+    "reversible": { "time": "45 m" },
     "using": [ [ "tailoring_canvas_patchwork", 27 ], [ "fastener_large", 1 ] ],
     "proficiencies": [ { "proficiency": "prof_closures" }, { "proficiency": "prof_closures_waterproofing" } ]
   },
@@ -2074,7 +2074,7 @@
     "skills_required": [ "survival", 1 ],
     "time": "7 h 45 m",
     "autolearn": true,
-    "reversible": true,
+    "reversible": { "time": "45 m" },
     "using": [ [ "tailoring_fur_patchwork", 8 ], [ "fastener_large", 1 ] ],
     "proficiencies": [
       { "proficiency": "prof_closures" },
@@ -2130,7 +2130,7 @@
     "difficulty": 6,
     "time": "7 h 40 m",
     "autolearn": true,
-    "reversible": { "time": "1 h" },
+    "reversible": { "time": "45 m" },
     "book_learn": [ [ "textbook_tailor", 4 ], [ "tailor_portfolio", 4 ] ],
     "using": [ [ "tailoring_leather_patchwork", 8 ], [ "fastener_large", 1 ] ],
     "proficiencies": [
@@ -2217,7 +2217,7 @@
     "difficulty": 3,
     "time": "1 h",
     "autolearn": true,
-    "reversible": true,
+    "reversible": { "time": "45 m" },
     "using": [ [ "sewing_standard", 8 ], [ "tailoring_cotton_patchwork", 8 ] ]
   },
   {
@@ -2279,7 +2279,7 @@
     "skill_used": "tailor",
     "difficulty": 3,
     "time": "3 h 30 m",
-    "reversible": true,
+    "reversible": { "time": "10 m" },
     "book_learn": [ [ "mag_animecon", 1 ] ],
     "using": [ [ "tailoring_cotton", 8 ] ]
   },
@@ -2287,6 +2287,7 @@
     "copy-from": "maid_dress",
     "result": "maid_dress_xl",
     "type": "recipe",
+    "reversible": { "time": "15 m" },
     "using": [ [ "tailoring_cotton", 12 ] ]
   },
   {
@@ -2304,7 +2305,7 @@
     "skill_used": "tailor",
     "difficulty": 3,
     "time": "3 h",
-    "reversible": true,
+    "reversible": { "time": "7 m" },
     "book_learn": [ [ "mag_animecon", 1 ] ],
     "using": [ [ "tailoring_cotton", 6 ] ]
   },
@@ -2312,6 +2313,7 @@
     "copy-from": "maid_dress_short",
     "type": "recipe",
     "result": "maid_dress_short_xl",
+    "reversible": { "time": "10 m" },
     "using": [ [ "tailoring_cotton", 8 ] ]
   },
   {

--- a/data/json/recipes/recipe_deconstruction.json
+++ b/data/json/recipes/recipe_deconstruction.json
@@ -665,33 +665,33 @@
     "result": "bikini_bottom",
     "type": "uncraft",
     "time": "1 m",
-    "activity_level": "NO_EXERCISE",
-    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
-    "components": [ [ [ "sheet_lycra", 1 ] ], [ [ "thread_nomex", 5 ] ] ]
+    "activity_level": "LIGHT_EXERCISE",
+    "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ],
+    "components": [ [ [ "lycra_patch", 7 ] ], [ [ "thread_nomex", 5 ] ] ]
   },
   {
     "result": "bikini_top",
     "type": "uncraft",
-    "time": "2 m",
-    "activity_level": "NO_EXERCISE",
-    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
-    "components": [ [ [ "sheet_lycra", 1 ] ], [ [ "thread_nomex", 5 ] ], [ [ "thread", 10 ] ] ]
+    "time": "1 m",
+    "activity_level": "LIGHT_EXERCISE",
+    "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ],
+    "components": [ [ [ "lycra_patch", 7 ] ], [ [ "thread_nomex", 5 ] ], [ [ "thread", 10 ] ] ]
   },
   {
     "result": "bikini_top_fur",
     "type": "uncraft",
-    "time": "20 s",
-    "activity_level": "NO_EXERCISE",
-    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
-    "components": [ [ [ "fur", 1 ] ] ]
+    "time": "1 m",
+    "activity_level": "LIGHT_EXERCISE",
+    "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ],
+    "components": [ [ [ "fur", 4 ] ], [ [ "scrap_fur", 3 ] ], [ [ "thread", 7 ] ] ]
   },
   {
     "result": "bikini_top_leather",
     "type": "uncraft",
-    "time": "20 s",
-    "activity_level": "NO_EXERCISE",
-    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
-    "components": [ [ [ "leather", 1 ] ] ]
+    "time": "1 m",
+    "activity_level": "LIGHT_EXERCISE",
+    "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ],
+    "components": [ [ [ "leather", 7 ] ], [ [ "scrap_leather", 18 ] ], [ [ "thread", 7 ] ] ]
   },
   {
     "result": "blade",

--- a/data/json/recipes/tools/tools_electronic.json
+++ b/data/json/recipes/tools/tools_electronic.json
@@ -190,7 +190,6 @@
     "skill_used": "electronics",
     "difficulty": 4,
     "time": "30 m",
-    "reversible": true,
     "decomp_learn": 4,
     "using": [ [ "soldering_standard", 14 ] ],
     "proficiencies": [

--- a/data/json/requirements/tailoring.json
+++ b/data/json/requirements/tailoring.json
@@ -393,14 +393,14 @@
       { "id": "LEATHER_AWL", "level": 1 },
       { "id": "CUT_FINE", "level": 1 }
     ],
-    "components": [ [ [ "tanned_pelt", 1 ], [ "sheet_fur_patchwork", 1 ] ], [ [ "filament", 7, "LIST" ] ] ]
+    "components": [ [ [ "sheet_fur_patchwork", 1 ], [ "tanned_pelt", 1 ] ], [ [ "filament", 7, "LIST" ] ] ]
   },
   {
     "id": "tailoring_fur_patchwork_simple",
     "type": "requirement",
     "//": "250g per unit. Crafting fur items, per 372 g of fur; 122 g + excessive weight of material is wasted, producing fur patches as byproducts.  Time needed is usually 60 minutes per unit if hand-stitching for extra material processing time.  Used for simpler items where precision cutting is less important.",
     "qualities": [ { "id": "SEW", "level": 1 }, { "id": "CUT", "level": 1 }, { "id": "LEATHER_AWL", "level": 1 } ],
-    "components": [ [ [ "tanned_pelt", 1 ], [ "sheet_fur_patchwork", 1 ] ], [ [ "filament", 7, "LIST" ] ] ]
+    "components": [ [ [ "sheet_fur_patchwork", 1 ], [ "tanned_pelt", 1 ] ], [ [ "filament", 7, "LIST" ] ] ]
   },
   {
     "id": "tailoring_fur_small",

--- a/data/json/uncraft/armor/swimming.json
+++ b/data/json/uncraft/armor/swimming.json
@@ -1,0 +1,18 @@
+[
+  {
+    "result": "bikini_bottom_short",
+    "type": "uncraft",
+    "time": "1 m",
+    "activity_level": "LIGHT_EXERCISE",
+    "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ],
+    "components": [ [ [ "lycra_patch", 3 ] ], [ [ "thread_nomex", 3 ] ] ]
+  },
+  {
+    "result": "bikini_top_short",
+    "type": "uncraft",
+    "time": "1 m",
+    "activity_level": "LIGHT_EXERCISE",
+    "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ],
+    "components": [ [ [ "lycra_patch", 3 ] ], [ [ "thread_nomex", 3 ] ] ]
+  }
+]

--- a/data/json/uncraft/tool/electronics.json
+++ b/data/json/uncraft/tool/electronics.json
@@ -14,5 +14,21 @@
       [ [ "plastic_chunk", 2 ] ],
       [ [ "small_lcd_screen", 1 ] ]
     ]
+  },
+  {
+    "result": "two_way_radio",
+    "type": "uncraft",
+    "activity_level": "LIGHT_EXERCISE",
+    "skill_used": "electronics",
+    "time": "20 m",
+    "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "CUT", "level": 1 } ],
+    "components": [
+      [ [ "amplifier", 1 ] ],
+      [ [ "transponder", 1 ] ],
+      [ [ "receiver", 1 ] ],
+      [ [ "antenna", 1 ] ],
+      [ [ "scrap_aluminum", 5 ] ],
+      [ [ "cable", 10 ] ]
+    ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
The following items had their reversion times specified:
- chest rig
- axe ring
- all sleeveless trenchcoats (leather trenchcoat had the time lowered to match the rest)
- sleeveless tunic
- all french maid dresses

Other changes regarding disassembly:
- Two-way radio is no longer disassembled via reversion, instead it got a manual uncraft similar to the handheld console so that it doesn't need a soldering iron to take apart
- The uncrafts for all bikini items were completely reworked to not generate mass, or not to lose an absurd amount of mass
- Short biniki top and bottom got a new uncraft each

Other changes not regarding disassembly
- The recipe to craft a bikini bottom no longer gives a lycra patch as a byproduct, as it generated mass
- The requirement group for fur sewing had its components switched around - this should not change anything for crafting, but might affect reversible crafts, making the mapgen-spawned versions of those items no longer produce pelts upon disassembly
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
