### PR TITLE
Bugfix for Vehicles Incorrectly Displacing Water Creatures

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -7804,6 +7804,25 @@ const std::set<tripoint> &vehicle::get_points( const bool force_refresh, const b
     return occupied_points;
 }
 
+void vehicle::part_project_points( const tripoint &dp )
+{
+    std::set<tripoint> projected_points;
+    for( int p = 0; p < part_count(); p++ ) {
+        vehicle_part &vp = parts.at( p );
+        if( vp.removed || !vp.is_real_or_active_fake() ) {
+            continue;
+        }
+
+        const vpart_info &info = vp.info();
+        if( !vp.is_fake && info.location != part_location_structure && !info.has_flag( VPFLAG_ROTOR ) ) {
+            continue;
+        }
+        // Coordinates of where part will go due to movement (dx/dy/dz)
+        //  and turning (precalc[1])
+        vp.next_pos = tripoint_bub_ms( global_pos3() + dp + vp.precalc[1] );
+    }
+}
+
 std::list<item> vehicle::use_charges( const vpart_position &vp, const itype_id &type,
                                       int &quantity, const std::function<bool( const item & )> &filter, bool in_tools )
 {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -7823,6 +7823,17 @@ void vehicle::part_project_points( const tripoint &dp )
     }
 }
 
+std::set<tripoint_bub_ms> vehicle::get_projected_part_points() const
+{
+    std::set<tripoint_bub_ms> projected_points;
+
+    for( int p = 0; p < part_count(); p++ ) {
+        const vehicle_part &vp = parts.at( p );
+        projected_points.insert( vp.next_pos );
+    }
+    return projected_points;
+}
+
 std::list<item> vehicle::use_charges( const vpart_position &vp, const itype_id &type,
                                       int &quantity, const std::function<bool( const item & )> &filter, bool in_tools )
 {

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -452,7 +452,7 @@ struct vehicle_part {
         std::array<tripoint, 2> precalc = { { tripoint( -1, -1, 0 ), tripoint( -1, -1, 0 ) } };
 
         /** temporarily held projected position */
-        tripoint_bub_ms next_pos = tripoint_bub_ms( -1, -1, 0 );
+        tripoint_bub_ms next_pos = tripoint_bub_ms( -1, -1, 0 ); // NOLINT(cata-serialize)
 
         /** current part health with range [0,durability] */
         int hp() const;
@@ -1967,6 +1967,9 @@ class vehicle
 
         // calculate the new projected points for all vehicle parts to move to
         void part_project_points( const tripoint &dp );
+
+        // get all vehicle parts' projected points
+        std::set<tripoint_bub_ms> get_projected_part_points() const;
 
         /**
         * Consumes specified charges (or fewer) from the vehicle part

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -451,6 +451,9 @@ struct vehicle_part {
         // NOLINTNEXTLINE(cata-use-named-point-constants)
         std::array<tripoint, 2> precalc = { { tripoint( -1, -1, 0 ), tripoint( -1, -1, 0 ) } };
 
+        /** temporarily held projected position */
+        tripoint_bub_ms next_pos = tripoint_bub_ms( -1, -1, 0 );
+
         /** current part health with range [0,durability] */
         int hp() const;
 
@@ -1961,6 +1964,9 @@ class vehicle
 
         // Update the set of occupied points and return a reference to it
         const std::set<tripoint> &get_points( bool force_refresh = false, bool no_fake = false ) const;
+
+        // calculate the new projected points for all vehicle parts to move to
+        void part_project_points( const tripoint &dp );
 
         /**
         * Consumes specified charges (or fewer) from the vehicle part

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -891,6 +891,7 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
         if( here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, critter->pos_bub() ) ) {
             tripoint end_pos = critter->pos();
             tripoint start_pos;
+            const std::set<tripoint_bub_ms> projected_points = get_projected_part_points();
             const units::angle angle =
                 move.dir() + ( coll_velocity > 0 ? 0_degrees : 180_degrees ) + 45_degrees *
                 ( parts[part].mount.x > pivot_point().x ? -1 : 1 );
@@ -898,7 +899,8 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
             // push the animal out of way until it's no longer in our vehicle and not in
             // anyone else's position
             while( get_creature_tracker().creature_at( end_pos, true ) ||
-                   cur_points.find( end_pos ) != cur_points.end() ) {
+                   cur_points.find( end_pos ) != cur_points.end() ||
+                   projected_points.find( tripoint_bub_ms( end_pos ) ) != projected_points.end() ) {
                 start_pos = end_pos;
                 calc_ray_end( angle, 2, start_pos, end_pos );
             }

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -891,7 +891,8 @@ veh_collision vehicle::part_collision( int part, const tripoint &p,
             tripoint end_pos = critter->pos();
             tripoint start_pos;
             const units::angle angle =
-                move.dir() + 45_degrees * ( parts[part].mount.x > pivot_point().x ? -1 : 1 );
+                move.dir() + ( coll_velocity > 0 ? 0_degrees : 180_degrees ) + 45_degrees *
+                ( parts[part].mount.x > pivot_point().x ? -1 : 1 );
             const std::set<tripoint> &cur_points = get_points( true );
             // push the animal out of way until it's no longer in our vehicle and not in
             // anyone else's position

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -740,6 +740,7 @@ bool vehicle::collision( std::vector<veh_collision> &colls,
     const int sign_before = sgn( velocity_before );
     bool empty = true;
     map &here = get_map();
+    part_project_points( dp );
     for( int p = 0; p < part_count(); p++ ) {
         const vehicle_part &vp = parts.at( p );
         if( vp.removed || !vp.is_real_or_active_fake() ) {
@@ -753,7 +754,7 @@ bool vehicle::collision( std::vector<veh_collision> &colls,
         empty = false;
         // Coordinates of where part will go due to movement (dx/dy/dz)
         //  and turning (precalc[1])
-        const tripoint dsp = global_pos3() + dp + vp.precalc[1];
+        const tripoint dsp = vp.next_pos.raw();
         veh_collision coll = part_collision( p, dsp, just_detect, bash_floor );
         if( coll.type == veh_coll_nothing && info.has_flag( VPFLAG_ROTOR ) ) {
             size_t radius = static_cast<size_t>( std::round( info.rotor_info->rotor_diameter / 2.0f ) );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "vehicles incorrectly displacing water creatures"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

- Fixes #47093

When you hit a creature on the water with a vehicle, displacing the creature did not check for the vehicle's future position. If the creature happened to get put there (in the worst-case scenario, the tile where the player gets moved to), you'd get the bug displayed in the video in #47093. Another example: a 45 degree turn left into an adjacent monster like this 

![fishturn](https://github.com/user-attachments/assets/36953f0f-22d7-4696-a682-a4e27ab03236)
would also cause the same bug.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

- Extract projected vehicle part positions from the vehicle part collision loop, so they're all precalculated for every individual VP
- Adds a function to get those positions
- implement into water creature collision code
- water creature collision accounts for velocity for good measure

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
I thought about using a different displacement function instead of set_pos() (e.g. fling_creature() or knockback() ), but that isn't particularly realistic and would be obnoxious when driving through a school of fish. Increasing the distance water creatures are displaced would also work but would look goofy.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
- all tests passed locally
- made sure the test case from #47093 was resolved, along with the test case I found
- drove into a large group of water creatures and pushed them around for a bit
- made sure a vehicle could drive normally

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Out of curiosity, I tried my sharp turn test case as shown above on land, and there were instances where the monster hit got knocked to the other side of the car anywhere from 3-6 times. As far as I can tell, though, monsters can't force you out of the vehicle on land if you hit them wrong. 

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
