### PR TITLE
Make aim game toolkit recipes use 5 energy instead of 50

### DIFF
--- a/data/json/recipes/practice/ranged.json
+++ b/data/json/recipes/practice/ranged.json
@@ -230,7 +230,7 @@
     "time": "1 h",
     "practice_data": { "min_difficulty": 0, "max_difficulty": 2, "skill_limit": 3 },
     "autolearn": [ [ "pistol", 0 ] ],
-    "tools": [ [ [ "aim_game", 50 ] ] ],
+    "tools": [ [ [ "aim_game", 5 ] ] ],
     "qualities": [ { "id": "PISTOL", "level": 1 } ]
   },
   {
@@ -246,7 +246,7 @@
     "time": "1 h",
     "practice_data": { "min_difficulty": 0, "max_difficulty": 2, "skill_limit": 3 },
     "autolearn": [ [ "rifle", 0 ] ],
-    "tools": [ [ [ "aim_game", 50 ] ] ],
+    "tools": [ [ [ "aim_game", 5 ] ] ],
     "qualities": [ { "id": "RIFLE", "level": 1 } ]
   },
   {
@@ -262,7 +262,7 @@
     "time": "1 h",
     "practice_data": { "min_difficulty": 0, "max_difficulty": 2, "skill_limit": 3 },
     "autolearn": [ [ "shotgun", 0 ] ],
-    "tools": [ [ [ "aim_game", 50 ] ] ],
+    "tools": [ [ [ "aim_game", 5 ] ] ],
     "qualities": [ { "id": "SHOTGUN", "level": 1 } ]
   },
   {
@@ -278,7 +278,7 @@
     "time": "1 h",
     "practice_data": { "min_difficulty": 0, "max_difficulty": 2, "skill_limit": 3 },
     "autolearn": [ [ "smg", 0 ] ],
-    "tools": [ [ [ "aim_game", 50 ] ] ],
+    "tools": [ [ [ "aim_game", 5 ] ] ],
     "qualities": [ { "id": "SMG", "level": 1 } ]
   },
   {


### PR DESCRIPTION
#### Summary
Balance "Make aim game toolkit use less power"

#### Purpose of change

https://github.com/CleverRaven/Cataclysm-DDA/pull/75361 has nerfed battery density, which makes aim game toolkit item unusable (as it is impossible to get 50 charges with any of small battery). 

#### Describe the solution

Scale the power requirement back to ~6 uses on a single use light battery.

#### Describe alternatives you've considered

What should be energy usage? 3-4 hours on a rechargable battery and 5-6 hours on a AA battery should be OK.

#### Testing

Checked that recipies ingame use 5 energy instead of 50.

#### Additional context


