### PR TITLE
turn off debug symbols on g++-9 test

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -115,6 +115,7 @@ jobs:
 
           - compiler: g++-9
             os: ubuntu-latest
+            release: 1
             cmake: 0
             tiles: 0
             sound: 0


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
#73240 turned on debug symbols on all CI tests; most of the time it works fine, but gcc 9 is very prone to end with `fatal error: write: No space left on device`
#### Describe the solution
Make gcc 9 not throw debug symbols to fix it
#### Additional context
![image](https://github.com/user-attachments/assets/e5831a3c-abf7-4728-a6a3-683e199091ad)