### PR TITLE
Invalidate weight carried cache when multidrop

### DIFF
--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -436,6 +436,8 @@ std::vector<item_location> drop_on_map( Character &you, item_drop_reason reason,
     }
 
     you.recoil = MAX_RECOIL;
+    you.invalidate_weight_carried_cache();
+
     return items_dropped;
 }
 


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fix #75489
#### Describe the solution
Add cache invalidation
#### Describe alternatives you've considered
~~make `execute()` accept character as parameter, and invalidate it within the `execute()` itself? i am a bit less confident in doing it for myself~~
#### Testing
![GIF 10-08-2024 13-56-39](https://github.com/user-attachments/assets/a238ea01-0ad4-450f-9250-a7c3886e9cdb)