### PR TITLE
Items inside integrated armor are not deleted if mutation is removed

### DIFF
--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -1172,6 +1172,9 @@ std::list<item> outfit::remove_worn_items_with( const std::function<bool( item &
     std::list<item> result;
     for( auto iter = worn.begin(); iter != worn.end(); ) {
         if( filter( *iter ) ) {
+            if( iter->can_unload() ) {
+                iter->spill_contents( guy );
+            }
             iter->on_takeoff( guy );
             result.splice( result.begin(), worn, iter++ );
         } else {


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
When integrated mutation is removed, it's content is lost forever. Not anymore
#### Describe the solution
Add check, that would spill items on the ground if said mutation would be removed
#### Testing
Before changes
![image](https://github.com/user-attachments/assets/de7e881b-b2d9-48b4-b5c2-770213c80272)
After changes
![image](https://github.com/user-attachments/assets/721dec1d-5765-40e6-ba8e-28b969c34d7c)
#### Additional context
@Standing-Storm 