### PR TITLE
don't build with debug symbols on lto

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -124,7 +124,6 @@ jobs:
             libbacktrace: 1
             native: linux64
             pch: 1
-            cxxflags: -gsplit-dwarf
             title: GCC 9, Curses, LTO
             # ~850MB in a clean build
             # ~370MB compressed
@@ -230,6 +229,7 @@ jobs:
         LTO: ${{ matrix.lto }}
         LIBBACKTRACE: ${{ matrix.libbacktrace }}
         RELEASE: 1
+        DEBUG_SYMBOLS: ${{ ! matrix.lto }}
         ARCHIVE_SUCCESS: ${{ matrix.archive-success }}
         CCACHE_LIMIT: ${{ matrix.ccache_limit }}
         CCACHE_FILECLONE: true

--- a/build-scripts/gha_compile_only.sh
+++ b/build-scripts/gha_compile_only.sh
@@ -64,7 +64,7 @@ then
         ..
     make -j$num_jobs
 else
-    make -j "$num_jobs" CCACHE=1 CROSS="$CROSS_COMPILATION" LINTJSON=0 FRAMEWORK=1 UNIVERSAL_BINARY=1 DEBUG_SYMBOLS=1
+    make -j "$num_jobs" CCACHE=1 CROSS="$CROSS_COMPILATION" LINTJSON=0 FRAMEWORK=1 UNIVERSAL_BINARY=1
 
     # For CI on macOS, patch the test binary so it can find SDL2 libraries.
     if [[ ! -z "$OS" && "$OS" = "macos-12" ]]


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Lto job was exhausting disk space, and I strongly suspect it's due to debug symbols.

#### Describe the solution
Set debug_symbol manually based on lto flag instead of setting it unconditionally in gha_compile_only.sh

#### Describe alternatives you've considered
I tried to set up -gsplit-dwarf, but that's not supported with g++ 9.
You could maybe delete intermediate files (.o after completing the game build and before building the test exe? No idea if that would save enough. 
Can also try to just prune the worker disk before we start building. There's a Helper for this I ran across ac while back,  but this is much simpler. 

#### Testing
Check that all the builds except the LTO build supply -g, and that the lto build completes.