### PR TITLE
Add Maximize build space action to build job

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -238,6 +238,10 @@ jobs:
         SKIP: ${{ ( github.event.pull_request.draft == true && matrix.title != 'Basic Build and Test (Clang 10, Ubuntu, Curses)' ) || ( matrix.dont_skip_data_only_changes == 0 && needs.skip-duplicates.outputs.should_skip_code == 'true' ) || ( matrix.dont_skip_data_only_changes != 0 && needs.skip-duplicates-mods.outputs.should_skip_data == 'true' ) }}
         SKIP_TESTS: ${{ needs.matrix-variables.outputs.skip_tests }}
     steps:
+    - name: Maximize build space
+      uses: AdityaGarg8/remove-unwanted-software@v4.1
+      with:
+        remove-android: 'true'
     - name: checkout repository
       if: ${{ env.SKIP == 'false' }}
       uses: actions/checkout@v4

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -239,7 +239,7 @@ jobs:
         SKIP_TESTS: ${{ needs.matrix-variables.outputs.skip_tests }}
     steps:
     - name: Maximize build space
-      if: ${{startsWith(matrix.os, 'ubuntu-')}}
+      if: ${{ runner.os == 'Linux' }}
       uses: AdityaGarg8/remove-unwanted-software@v4.1
       with:
         remove-android: 'true'

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -239,6 +239,7 @@ jobs:
         SKIP_TESTS: ${{ needs.matrix-variables.outputs.skip_tests }}
     steps:
     - name: Maximize build space
+      if: ${{startsWith(matrix.os, 'ubuntu-')}}
       uses: AdityaGarg8/remove-unwanted-software@v4.1
       with:
         remove-android: 'true'


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
The LTO build is failong due to disk space exhaustion.

#### Describe the solution
Add this action to the build job https://github.com/marketplace/actions/maximize-build-disk-space-only-remove-unwanted-software

#### Describe alternatives you've considered
In #75572 I am instead removing debug symbols from the LTO build.

#### Testing
Need to just see if this runs in a reasonable amount of time and if it un-breaks the LTO build.