### PR TITLE
One z level counts as 4 meters for distance calculations

### DIFF
--- a/src/line.cpp
+++ b/src/line.cpp
@@ -1035,7 +1035,7 @@ FastDistanceApproximation trig_dist_fast( const tripoint_bub_ms &loc1, const tri
     return FastDistanceApproximation(
                ( loc1.x() - loc2.x() ) * ( loc1.x() - loc2.x() ) +
                ( loc1.y() - loc2.y() ) * ( loc1.y() - loc2.y() ) +
-               ( loc1.z() - loc2.z() ) * ( loc1.z() - loc2.z() ) );
+               ( ( loc1.z() - loc2.z() ) * 4 ) * ( ( loc1.z() - loc2.z() ) * 4 ) );
 }
 
 FastDistanceApproximation square_dist_fast( const tripoint_bub_ms &loc1,

--- a/src/line.h
+++ b/src/line.h
@@ -175,7 +175,7 @@ inline float trig_dist( const tripoint &loc1, const tripoint &loc2 )
 {
     return std::sqrt( static_cast<double>( ( loc1.x - loc2.x ) * ( loc1.x - loc2.x ) ) +
                       ( ( loc1.y - loc2.y ) * ( loc1.y - loc2.y ) ) +
-                      ( ( loc1.z - loc2.z ) * ( loc1.z - loc2.z ) ) );
+                      ( ( ( loc1.z - loc2.z ) * 4 ) * ( ( loc1.z - loc2.z ) * 4 ) ) );
 }
 float trig_dist( const tripoint_bub_ms &loc1, const tripoint_bub_ms &loc2 );
 inline float trig_dist( const point &loc1, const point &loc2 )
@@ -188,7 +188,7 @@ float trig_dist( const point_bub_ms &loc1, const point_bub_ms &loc2 );
 inline int square_dist( const tripoint &loc1, const tripoint &loc2 )
 {
     const tripoint d = ( loc1 - loc2 ).abs();
-    return std::max( { d.x, d.y, d.z } );
+    return std::max( { d.x, d.y, d.z * 4 } );
 }
 inline int square_dist( const point &loc1, const point &loc2 )
 {

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -3372,13 +3372,26 @@ void target_ui::update_status()
     }
 }
 
-int target_ui::dist_fn( const tripoint_bub_ms &p )
+int get_zlevel_modifiers( const tripoint &src, const tripoint &dst )
 {
+    map const &here = get_map();
+    // standing on downstair attacking down
+    if( here.has_flag( ter_furn_flag::TFLAG_GOES_DOWN, src )  && src.xy() == dst.xy() &&
+        src.z - dst.z == 1 ) {
+        return -2;
+    };
+    // standing on upstair attacking up
+    if( here.has_flag( ter_furn_flag::TFLAG_GOES_UP, src )  && src.xy() == dst.xy() &&
+        src.z - dst.z == -1 ) {
+        return -2;
+    };
+    return 0;
+}
 
-    add_msg( m_warning, string_format( "point 1: %s", src.to_string() ) );
-    add_msg( m_warning, string_format( "point 2: %s", p.to_string() ) );
-
-    return static_cast<int>( std::round( rl_dist_exact( src, p ) ) );
+int target_ui::dist_fn( const tripoint &p )
+{
+    int z_adj = get_zlevel_modifiers( src, p );
+    return std::round( rl_dist_exact( src, p ) + z_adj );
 }
 
 void target_ui::set_last_target()

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -3378,12 +3378,12 @@ int get_zlevel_modifiers( const tripoint &src, const tripoint &dst )
     // standing on downstair attacking down
     if( here.has_flag( ter_furn_flag::TFLAG_GOES_DOWN, src )  && src.xy() == dst.xy() &&
         src.z - dst.z == 1 ) {
-        return -2;
+        return -3;
     };
     // standing on upstair attacking up
     if( here.has_flag( ter_furn_flag::TFLAG_GOES_UP, src )  && src.xy() == dst.xy() &&
         src.z - dst.z == -1 ) {
-        return -2;
+        return -3;
     };
     return 0;
 }

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -3140,15 +3140,6 @@ bool target_ui::set_cursor_pos( const tripoint_bub_ms &new_pos )
                         break;
                     }
                 }
-
-                // FIXME: due to a bug in map::find_clear_path (#39693),
-                //        returned trajectory is invalid in some cases.
-                //        This bandaid stops us from exceeding range,
-                //        but does not fix the issue.
-                if( dist_fn( valid_pos ) > range ) {
-                    debugmsg( "Exceeded allowed range!" );
-                    valid_pos = src;
-                }
             }
         } else {
             tripoint_rel_ms delta = valid_pos - src;
@@ -3383,6 +3374,10 @@ void target_ui::update_status()
 
 int target_ui::dist_fn( const tripoint_bub_ms &p )
 {
+
+    add_msg( m_warning, string_format( "point 1: %s", src.to_string() ) );
+    add_msg( m_warning, string_format( "point 2: %s", p.to_string() ) );
+
     return static_cast<int>( std::round( rl_dist_exact( src, p ) ) );
 }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

THIS IS DEEPLY WIP AND NOT TESTED TO ANY SIGNIFICANT DEGREE. I'm just putting this draft up so it stays on my todo list. Initially this is just to explore what the implementation should look like, what the impact is and how many things it potentially breaks.

#### Summary
Features "One z level counts as 4 meters for distance calculations"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
There's a variety of weirdness resulting from z levels only counting as 1m even though our design assumption is they're 4m (except when not), including but not limited to using relatively pokey sticks of various lengths to reliably attack things from roofs. Yeet that. Special accomodation needs to be done for fighting on stairs where we assume you to be somewhere mid way on the tile, and for monsters to do the same if they have reach attack-range attacks that make any sense to be used on stairs. Otherwise this will stay extremely MVP, or it'll be thrown in the bin if the MVP approach doesn't work.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- [x] Multiply the z coordinate values by 4 in trig_dist and friends
- [x] Add special casing for player attack code so that attacking up/down stairs counts as 1 distance
  - [ ] Both ranged and melee
  - [ ] Add special casing for monster attack code for same
- [ ] Ensure zombies will be able to do their bump attack up/down from stairs
- [ ] Add explicit tests for the special casing
- [ ] Fix distance tests and add new test assertions for new behavior expectations
- [ ] Prune current attack tests where they don't make sense any more
- [ ] Make sure nothing changes anywhere visibility wise
- [x] Add some funni diagrams to this PR to demonstrate rationale (thanks Kevin)
- [ ] Check if #65266 is easy to get rid of while I'm here
- [ ] Stairs should be 4m long, figure out if that's in scope here
- [ ] check how this interacts with https://github.com/CleverRaven/Cataclysm-DDA/blob/66cc38eb5d65fa53d52fc8100918eee4d26c0d5f/src/sounds.cpp#L245

Out of scope for this PR
* standing on top of furniture, terrain and vehicles of varying height in general
  * I don't want to bring terrain flags or any of that nonsense into trig_dist because it's just used for point to point distance calcs in a very general way and most of the time we don't care if there's a table or stairs or a bush there or not. We don't really have good flags for this anyway since sometimes  terrain and furniture uses flags for things and sometimes move cost. We don't actually know the whether something is standable-on or at what height, just passability.
* Effects of mob height
* Effects of player height
* Stances
* Crawling zombies
* Stair/ladder distinction

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Poking at stuff up and down stairs in a test save.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
![image](https://github.com/user-attachments/assets/017d9738-3609-45e8-b394-440427a32eeb)

https://discord.com/channels/598523535169945603/598523535169945607/1307791071308284084
![image](https://github.com/user-attachments/assets/d504a11b-eab4-47aa-b609-be9cd3257684)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
