### PR TITLE
[MoM] Switch armor overrides to armor extensions

### DIFF
--- a/data/mods/MindOverMatter/monsters/monster_overrides.json
+++ b/data/mods/MindOverMatter/monsters/monster_overrides.json
@@ -332,8 +332,7 @@
     "copy-from": "mon_shoggoth",
     "type": "MONSTER",
     "regeneration_modifiers": [ [ "effect_vitakin_hurt", -25 ] ],
-    "extend": { "flags": [ "TEEP_IMMUNE" ] },
-    "armor": { "bash": 10, "cut": 30, "bullet": 24, "electric": 4, "psi_telekinetic_damage": 20 }
+    "extend": { "flags": [ "TEEP_IMMUNE" ], "armor": { "psi_telekinetic_damage": 20 } }
   },
   {
     "id": "mon_fleshy_shambler",
@@ -387,15 +386,13 @@
     "id": "mon_flaming_eye",
     "copy-from": "mon_flaming_eye",
     "type": "MONSTER",
-    "extend": { "flags": [ "TEEP_IMMUNE" ] },
-    "armor": { "bash": 4, "psi_telekinetic_damage": 20 }
+    "extend": { "flags": [ "TEEP_IMMUNE" ], "armor": { "psi_telekinetic_damage": 20 } }
   },
   {
     "id": "mon_flying_polyp",
     "copy-from": "mon_flying_polyp",
     "type": "MONSTER",
-    "extend": { "flags": [ "TEEP_IMMUNE" ] },
-    "armor": { "bash": 8, "electric": 3, "psi_telekinetic_damage": 15 }
+    "extend": { "flags": [ "TEEP_IMMUNE" ], "armor": { "psi_telekinetic_damage": 15 } }
   },
   {
     "id": "mon_headless_dog_thing",
@@ -407,17 +404,22 @@
     "id": "mon_hound_tindalos",
     "copy-from": "mon_hound_tindalos",
     "type": "MONSTER",
-    "extend": { "flags": [ "TEEP_IMMUNE", "TELEPORT_IMMUNE" ] },
-    "attack_effs": [ { "id": "effect_teleporting_lock", "duration": [ 5, 60 ], "chance": 50 } ],
-    "armor": { "cut": 50, "bullet": 40, "electric": 1, "psi_telekinetic_damage": 50 }
+    "extend": { "flags": [ "TEEP_IMMUNE", "TELEPORT_IMMUNE" ], "armor": { "psi_telekinetic_damage": 50 } },
+    "attack_effs": [ { "id": "effect_teleporting_lock", "duration": [ 5, 60 ], "chance": 50 } ]
   },
   {
     "id": "mon_hound_tindalos_afterimage",
     "copy-from": "mon_hound_tindalos_afterimage",
     "type": "MONSTER",
-    "extend": { "flags": [ "TEEP_IMMUNE", "TELEPORT_IMMUNE" ] },
-    "attack_effs": [ { "id": "effect_teleporting_lock", "duration": [ 5, 60 ], "chance": 50 } ],
-    "armor": { "cut": 50, "bullet": 40, "electric": 1, "psi_telekinetic_damage": 50 }
+    "extend": { "flags": [ "TEEP_IMMUNE", "TELEPORT_IMMUNE" ], "armor": { "psi_telekinetic_damage": 50 } },
+    "attack_effs": [ { "id": "effect_teleporting_lock", "duration": [ 5, 60 ], "chance": 50 } ]
+  },
+  {
+    "id": "mon_tindalos",
+    "copy-from": "mon_tindalos",
+    "type": "MONSTER",
+    "extend": { "flags": [ "TEEP_IMMUNE", "TELEPORT_IMMUNE" ], "armor": { "psi_telekinetic_damage": 50 } },
+    "attack_effs": [ { "id": "effect_teleporting_lock", "duration": [ 5, 60 ], "chance": 50 } ]
   },
   {
     "id": "mon_hunting_horror",
@@ -495,7 +497,7 @@
     "id": "mon_teke_mouse",
     "copy-from": "mon_teke_mouse",
     "type": "MONSTER",
-    "armor": { "bash": 15, "cut": 3, "bullet": 26, "psi_telekinetic_damage": 25 }
+    "extend": { "armor": { "psi_telekinetic_damage": 25 } }
   },
   {
     "id": "mon_fungaloid_tower",
@@ -525,181 +527,181 @@
     "id": "mon_fungal_hedgerow",
     "copy-from": "mon_fungal_hedgerow",
     "type": "MONSTER",
-    "armor": { "bash": 10, "cut": 10, "bullet": 8, "electric": 4, "psi_telepathic_damage": 15 }
+    "extend": { "armor": { "psi_telepathic_damage": 15 } }
   },
   {
     "id": "mon_fungal_blossom",
     "copy-from": "mon_fungal_blossom",
     "type": "MONSTER",
-    "armor": { "bash": 4, "cut": 4, "bullet": 3, "electric": 4, "psi_telepathic_damage": 10 }
+    "extend": { "armor": { "psi_telepathic_damage": 10 } }
   },
   {
     "id": "mon_fungal_tendril",
     "copy-from": "mon_fungal_tendril",
     "type": "MONSTER",
-    "armor": { "bash": 10, "cut": 4, "bullet": 3, "electric": 4, "psi_telepathic_damage": 10 }
+    "extend": { "armor": { "psi_telepathic_damage": 10 } }
   },
   {
     "id": "mon_fungaloid",
     "copy-from": "mon_fungaloid",
     "type": "MONSTER",
-    "armor": { "bash": 10, "cut": 4, "bullet": 3, "electric": 4, "psi_telepathic_damage": 20 }
+    "extend": { "armor": { "psi_telepathic_damage": 20 } }
   },
   {
     "id": "mon_fungaloid_young",
     "copy-from": "mon_fungaloid_young",
     "type": "MONSTER",
-    "armor": { "bash": 4, "cut": 4, "bullet": 3, "electric": 3, "psi_telepathic_damage": 15 }
+    "extend": { "armor": { "psi_telepathic_damage": 15 } }
   },
   {
     "id": "mon_fungaloid_shambler",
     "copy-from": "mon_fungaloid_shambler",
     "type": "MONSTER",
-    "armor": { "bash": 4, "cut": 10, "stab": 20, "acid": 3, "bullet": 20, "electric": 3, "psi_telepathic_damage": 30 }
+    "extend": { "armor": { "psi_telepathic_damage": 30 } }
   },
   {
     "id": "mon_ant_fungus",
     "copy-from": "mon_ant_fungus",
     "type": "MONSTER",
-    "armor": { "bash": 1, "cut": 1, "bullet": 1, "electric": 2, "psi_telepathic_damage": 4 }
+    "extend": { "armor": { "psi_telepathic_damage": 4 } }
   },
   {
     "id": "mon_zombie_child_fungus",
     "copy-from": "mon_zombie_child_fungus",
     "type": "MONSTER",
-    "armor": { "electric": 3, "psi_telepathic_damage": 4 }
+    "extend": { "armor": { "psi_telepathic_damage": 4 } }
   },
   {
     "id": "mon_zombie_fungus",
     "copy-from": "mon_zombie_fungus",
     "type": "MONSTER",
-    "armor": { "bash": 3, "electric": 5, "psi_telepathic_damage": 6 }
+    "extend": { "armor": { "psi_telepathic_damage": 6 } }
   },
   {
     "id": "mon_fungal_raptor",
     "copy-from": "mon_fungal_raptor",
     "type": "MONSTER",
-    "armor": { "psi_telepathic_damage": 2 }
+    "extend": { "armor": { "psi_telepathic_damage": 2 } }
   },
   {
     "id": "mon_boomer_fungus",
     "copy-from": "mon_boomer_fungus",
     "type": "MONSTER",
-    "armor": { "bash": 2, "electric": 4, "psi_telepathic_damage": 3 }
+    "extend": { "armor": { "psi_telepathic_damage": 3 } }
   },
   {
     "id": "mon_fungal_wretch",
     "copy-from": "mon_fungal_wretch",
     "type": "MONSTER",
-    "armor": { "electric": 1, "psi_telepathic_damage": 4 }
+    "extend": { "armor": { "psi_telepathic_damage": 4 } }
   },
   {
     "id": "mon_spider_fungus",
     "copy-from": "mon_spider_fungus",
     "type": "MONSTER",
-    "armor": { "bash": 2, "cut": 6, "bullet": 5, "electric": 2, "psi_telepathic_damage": 2 }
+    "extend": { "armor": { "psi_telepathic_damage": 2 } }
   },
   {
     "id": "mon_skeleton_hulk_fungus",
     "copy-from": "mon_skeleton_hulk_fungus",
     "type": "MONSTER",
-    "armor": { "bash": 20, "cut": 45, "bullet": 36, "electric": 8, "psi_telepathic_damage": 50 }
+    "extend": { "armor": { "psi_telepathic_damage": 50 } }
   },
   {
     "id": "mon_skeleton_brute_fungus",
     "copy-from": "mon_skeleton_brute_fungus",
     "type": "MONSTER",
-    "armor": { "bash": 0, "electric": 5, "psi_telepathic_damage": 4 }
+    "extend": { "armor": { "psi_telepathic_damage": 4 } }
   },
   {
     "id": "mon_skeleton_fungus",
     "copy-from": "mon_skeleton_fungus",
     "type": "MONSTER",
-    "armor": { "bash": 0, "electric": 5, "psi_telepathic_damage": 2 }
+    "extend": { "armor": { "psi_telepathic_damage": 2 } }
   },
   {
     "id": "mon_zombie_gasbag_fungus",
     "copy-from": "mon_zombie_gasbag_fungus",
     "type": "MONSTER",
-    "armor": { "electric": 4, "psi_telepathic_damage": 1 }
+    "extend": { "armor": { "psi_telepathic_damage": 1 } }
   },
   {
     "id": "mon_feral_cop_fungal_infected",
     "copy-from": "mon_feral_cop_fungal_infected",
     "type": "MONSTER",
-    "armor": { "bash": 8, "cut": 12, "stab": 9, "bullet": 14, "electric": 2, "psi_telepathic_damage": 10 }
+    "extend": { "armor": { "psi_telepathic_damage": 10 } }
   },
   {
     "id": "mon_feral_human_axe_fungal_infected",
     "copy-from": "mon_feral_human_axe_fungal_infected",
     "type": "MONSTER",
-    "armor": { "psi_telepathic_damage": 8 }
+    "extend": { "armor": { "psi_telepathic_damage": 8 } }
   },
   {
     "id": "mon_feral_human_axe_fungal_corpse",
     "copy-from": "mon_feral_human_axe_fungal_corpse",
     "type": "MONSTER",
-    "armor": { "psi_telepathic_damage": 8 }
+    "extend": { "armor": { "psi_telepathic_damage": 8 } }
   },
   {
     "id": "mon_feral_human_pipe_fungal_infected",
     "copy-from": "mon_feral_human_pipe_fungal_infected",
     "type": "MONSTER",
-    "armor": { "psi_telepathic_damage": 8 }
+    "extend": { "armor": { "psi_telepathic_damage": 8 } }
   },
   {
     "id": "mon_feral_human_pipe_fungal_corpse",
     "copy-from": "mon_feral_human_pipe_fungal_corpse",
     "type": "MONSTER",
-    "armor": { "psi_telepathic_damage": 8 }
+    "extend": { "armor": { "psi_telepathic_damage": 8 } }
   },
   {
     "id": "mon_feral_human_crowbar_fungal_infected",
     "copy-from": "mon_feral_human_crowbar_fungal_infected",
     "type": "MONSTER",
-    "armor": { "psi_telepathic_damage": 8 }
+    "extend": { "armor": { "psi_telepathic_damage": 8 } }
   },
   {
     "id": "mon_feral_human_crowbar_fungal_corpse",
     "copy-from": "mon_feral_human_crowbar_fungal_corpse",
     "type": "MONSTER",
-    "armor": { "psi_telepathic_damage": 8 }
+    "extend": { "armor": { "psi_telepathic_damage": 8 } }
   },
   {
     "id": "mon_mi_go",
     "copy-from": "mon_mi_go",
     "type": "MONSTER",
-    "armor": { "bash": 4, "cut": 12, "bullet": 10, "electric": 2, "psi_telepathic_damage": 25 }
+    "extend": { "armor": { "psi_telepathic_damage": 25 } }
   },
   {
     "id": "mon_mi_go_scout",
     "copy-from": "mon_mi_go_scout",
     "type": "MONSTER",
-    "armor": { "bash": 4, "cut": 5, "bullet": 4, "electric": 2, "psi_telepathic_damage": 25 }
+    "extend": { "armor": { "psi_telepathic_damage": 25 } }
   },
   {
     "id": "mon_mi_go_guard",
     "copy-from": "mon_mi_go_guard",
     "type": "MONSTER",
-    "armor": { "bash": 17, "cut": 22, "bullet": 18, "electric": 4, "psi_telepathic_damage": 70 }
+    "extend": { "armor": { "psi_telepathic_damage": 70 } }
   },
   {
     "id": "mon_mi_go_slaver",
     "copy-from": "mon_mi_go_slaver",
     "type": "MONSTER",
-    "armor": { "bash": 4, "cut": 12, "bullet": 10, "electric": 3, "psi_telepathic_damage": 35 }
+    "extend": { "armor": { "psi_telepathic_damage": 35 } }
   },
   {
     "id": "mon_mi_go_surgeon",
     "copy-from": "mon_mi_go_surgeon",
     "type": "MONSTER",
-    "armor": { "bash": 5, "cut": 13, "bullet": 10, "electric": 3, "psi_telepathic_damage": 32 }
+    "extend": { "armor": { "psi_telepathic_damage": 32 } }
   },
   {
     "id": "mon_mi_go_myrmidon",
     "copy-from": "mon_mi_go_myrmidon",
     "type": "MONSTER",
-    "armor": { "bash": 19, "cut": 27, "bullet": 22, "electric": 6, "psi_telepathic_damage": 120 }
+    "extend": { "armor": { "psi_telepathic_damage": 120 } }
   },
   {
     "id": "mon_yrax_delta",
@@ -722,6 +724,12 @@
   {
     "id": "mon_yrax_sphenocorona",
     "copy-from": "mon_yrax_sphenocorona",
+    "type": "MONSTER",
+    "species": [ "ROBOT", "YRAX_CONSTRUCT" ]
+  },
+  {
+    "id": "mon_yrax_triakis",
+    "copy-from": "mon_yrax_triakis",
     "type": "MONSTER",
     "species": [ "ROBOT", "YRAX_CONSTRUCT" ]
   }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Switch armor overrides to armor extensions"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

When I originally added telekinetic/telepathic armor to various monsters, it was not possible to extend armor during copy-from. Now it is, so I should do that for future compatibility.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Extend the armor.

Also add telekinetic armor to the star-crowned hound and give the `YRAX_CONSTRUCT` species to the Yrax Triakis so it's immune to Electrokinesis, since the Yrax directly tap the strong nuclear force to power their robots and then invoke Yog-Sothoth as a reference frame to make all locations co-terminous and thus reduce data travel times to 0. Or something. Anyway, they don't use electricity. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
