### PR TITLE
Fix cottage cheese w/ savory veg also requiring fruit

### DIFF
--- a/data/json/items/comestibles/dairy.json
+++ b/data/json/items/comestibles/dairy.json
@@ -289,8 +289,8 @@
     "description": "Unaged curdled milk and whey, made by draining cheese rather than pressing like cheese curds.  The retained whey keeps the curds loose and soft, giving a somewhat soupy texture to this lower calorie variety of cheese.  By adding savory vegetables to it you've made what might be a full meal.",
     "price": "4 USD 85 cent",
     "price_postapoc": "1 USD 75 cent",
-    "calories": 475,
-    "vitamins": [ [ "calcium", 32 ], [ "iron", 8 ] ],
+    "calories": 332,
+    "vitamins": [ [ "calcium", 32 ], [ "vitC", 13 ] ],
     "fun": 2
   },
   {

--- a/data/json/recipes/food/dairy_products.json
+++ b/data/json/recipes/food/dairy_products.json
@@ -119,7 +119,6 @@
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [
       [ [ "cottage_cheese", 1 ] ],
-      [ [ "sweet_fruit", 1, "LIST" ] ],
       [ [ "onion", 1 ] ],
       [
         [ "bell_pepper", 1 ],


### PR DESCRIPTION


#### Summary
None

#### Purpose of change
Looks like the food recipe "cottage cheese with savory vegetables" includes fruit as a result of being copy-pasted from "cottage cheese with fruit", when it shouldn't.  The "fruit" recipe is better in every way and requires a subset of the ingredients of this recipe.
![Screenshot 2024-08-11 234931](https://github.com/user-attachments/assets/9c3340eb-4327-4a2c-b6b5-cf4298d7cf56)
![Screenshot 2024-08-11 234942](https://github.com/user-attachments/assets/a8ccfe77-e11b-4e8f-b030-ea86f9331358)

#### Describe the solution
Removed the fruit requirement from "cottage cheese w/ savory vegetables".

#### Describe alternatives you've considered
n/a

#### Testing
Confirmed recipe looks more appropriate after change.

#### Additional context
![Screenshot 2024-08-11 235622](https://github.com/user-attachments/assets/d8eb3005-7c73-4860-b862-b0c8ba483d0d)