### PR TITLE
Tweak boiled bandages

### DIFF
--- a/data/json/recipes/other/medical.json
+++ b/data/json/recipes/other/medical.json
@@ -77,10 +77,10 @@
     "autolearn": true,
     "qualities": [ { "id": "BOIL", "level": 1 } ],
     "tools": [ [ [ "water_boiling_heat", 4, "LIST" ] ] ],
-    "//": "3 units of water + 114g of cotton, bandages will soak up some of the water but the rest should be potable",
+    "//": "3 units of water + 114g of cotton, bandages will soak up some of the water but the rest should be returned",
     "result_mult": 9,
     "components": [ [ [ "bandages_makeshift", 9 ] ], [ [ "water_clean", 3 ], [ "water", 3 ] ] ],
-    "byproducts": [ [ "water_clean", 2 ] ]
+    "byproducts": [ [ "water", 2 ] ]
   },
   {
     "result": "adhesive_bandages",

--- a/data/json/recipes/other/medical.json
+++ b/data/json/recipes/other/medical.json
@@ -79,7 +79,7 @@
     "tools": [ [ [ "water_boiling_heat", 4, "LIST" ] ] ],
     "//": "3 units of water + 114g of cotton, bandages will soak up some of the water but the rest should be returned",
     "result_mult": 9,
-    "components": [ [ [ "bandages_makeshift", 9 ] ], [ [ "water_clean", 3 ], [ "water", 3 ] ] ],
+    "components": [ [ [ "bandages_makeshift", 9 ] ], [ [ "water_clean", 3 ] ] ],
     "byproducts": [ [ "water", 2 ] ]
   },
   {


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fix #73333
Fix #75606
#### Describe the solution
Replaced clean water from byproducts of boiled bandages to generic water - can't boil rags and then get potable water
Removed generic water from ingredients of boiled bandages - can't disinfect anything in dirty water