### PR TITLE
Improve invlet management for Magiclysm spell list.

### DIFF
--- a/src/inventory.h
+++ b/src/inventory.h
@@ -55,6 +55,13 @@ class invlet_wrapper : private std::string
         explicit invlet_wrapper( const char *chars ) : std::string( chars ) { }
 
         bool valid( int invlet ) const;
+
+        // Get ordinal number (first, second, third, ...) of invlet.
+        // Informs sorting order.
+        int ordinal( int invlet ) const {
+            return this->find( invlet );
+        }
+
         std::string get_allowed_chars() const {
             return *this;
         }

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2744,7 +2744,7 @@ int known_magic::get_invlet( const spell_id &sp, std::set<int> &used_invlets )
     // when spells are added or subtracted.
     // TODO: respect "Auto inventory letters" option?
     for( char &ch : inv_chars.get_allowed_chars() ) {
-        int invlet = static_cast<int>( ch );
+        int invlet = static_cast<int>( static_cast<unsigned char>( ch ) );
         if( set_invlet( sp, invlet, used_invlets ) ) {
             used_invlets.emplace( invlet );
             return invlet;

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2743,7 +2743,7 @@ int known_magic::get_invlet( const spell_id &sp, std::set<int> &used_invlets )
     // Assignment is "sticky" (permanent), to avoid invlets getting scrambled
     // when spells are added or subtracted.
     // TODO: respect "Auto inventory letters" option?
-    for( auto &ch : inv_chars.get_allowed_chars() ) {
+    for( int &ch : inv_chars.get_allowed_chars() ) {
         if( set_invlet( sp, ch, used_invlets ) ) {
             used_invlets.emplace( ch );
             return ch;

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2743,10 +2743,11 @@ int known_magic::get_invlet( const spell_id &sp, std::set<int> &used_invlets )
     // Assignment is "sticky" (permanent), to avoid invlets getting scrambled
     // when spells are added or subtracted.
     // TODO: respect "Auto inventory letters" option?
-    for( int &ch : inv_chars.get_allowed_chars() ) {
-        if( set_invlet( sp, ch, used_invlets ) ) {
-            used_invlets.emplace( ch );
-            return ch;
+    for( char &ch : inv_chars.get_allowed_chars() ) {
+        int invlet = static_cast<int>( ch );
+        if( set_invlet( sp, invlet, used_invlets ) ) {
+            used_invlets.emplace( invlet );
+            return invlet;
         }
     }
     return 0;

--- a/src/magic.h
+++ b/src/magic.h
@@ -719,13 +719,15 @@ class known_magic
         // returns false if invlet is already used
         bool set_invlet( const spell_id &sp, int invlet, const std::set<int> &used_invlets );
         void rem_invlet( const spell_id &sp );
+        // returns which invlets are already in use
+        void update_used_invlets( std::set<int> &used_invlets );
 
         void toggle_favorite( const spell_id &sp );
         bool is_favorite( const spell_id &sp );
     private:
         // gets length of longest spell name
         int get_spellname_max_width();
-        // gets invlet if assigned, or -1 if not
+        // gets invlet if assigned, or 0 if not
         int get_invlet( const spell_id &sp, std::set<int> &used_invlets );
 };
 


### PR DESCRIPTION
First, impose sensible order on spell list. Specifically, we sort by 3 dimensions:
1. favorite spells before non-favorite
2. by invlet
3. by spell name (in case no invlet; not currently possible)

Second, this change fixes some issues:
- make auto-assigned invlets "permanent" (vs scrambling letters when spells are added or subtracted)
- actually properly check if the desired invlet is actually in use (vs only checking against "reserved")

Motivation:
- addresses expected behavior; e.g., https://www.reddit.com/r/cataclysmdda/comments/oq2g3s/any_way_to_change_spell_list_order/
- might actually address Issue 50465
- might partially mitigate Issue 50018

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Better handling of spell list (sorted, bug fixes)"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Primary purpose is to sort the Magiclysm spell list.

Secondary, wider purpose is to remove some adjacent bugs / warts that testing revealed (e.g., you can assign the same letter to multiple spells), so as to end up with a more satisfactory user experience with the list.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

For sorting the list, we use 3 sort "keys", in order:
- sort favorited spells before non-favorited
- sort by invlet (using invchars.get_allowed_letters(), rather than pure alpha... because want 'a' before 'A', for example)
- sort by spell name (not actually used yet, since all spells get an invlet... but down the road, if we respect the "auto assign invlet" option, for example, this will be useful)

NOTE: I realise style guidelines discourage larger lambdas, but I think it is warranted here, because in C++ we cannot define function-with-function otherwise, and we do need much context. So I think it's warranted here, because ultimately it leads to clearer, easier to understand code.

The bug fixes are more on the trivial side.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

1. sorting could be done by constructing a "key", where we smush together key pieces of each sorting dimension, and then sort a vector of said keys (paired with spell list indices, etc)... this was initial approach, but felt hacky, was lengthier, and had a number of other draw backs. Current version is cleaner.

2. the invlet handling here feels generally brittle, especially the used_invlet tracking which essentially feels like a cache mechanism of invlets[spell_ids], and can easily get unsynchronized... the whole handling of used_invlet should likely just get encapsulated, but am trying to keep scope of this PR smallish.
In general, this code seems brittle... 

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

1. start character with many spells already known
2. bring up spell list
3. for each spell, delete binding (assign letter, but then use Backspace, or other non-allowed letter)
4. re-open spell list window, notice how spells are assigned a, b, c, d, etc... and listed in order
5. pick a spell from early on, and assign it 'z'
6. re-open spell list and confirm it is at end now
7. pick a spell from mid-pack, favorite it
8. re-open spell list and confirm it is listed at start now

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

FWIW, this is my first PR, for CDDA, or anywhere else on GitHub, so apologies up front on any fumbling anything. Suggestions welcome. Also, this PR is also a way for me to start getting familiar with CDDA code, and style, so any suggestions in this department would be welcome as well.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
