### PR TITLE
Add Flathub download button and Flatpak manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ Ncurses and tiles versions are available in the [official repos](https://tracker
 
 #### Flathub
 
-[![Download from Flathub](https://flathub.org/assets/badges/flathub-badge-en.png)](https://flathub.org/apps/org.cataclysmdda.CataclysmDDA)
+<a href="https://flathub.org/apps/org.cataclysmdda.CataclysmDDA">
+    <img src="https://flathub.org/assets/badges/flathub-badge-en.png" alt="Download from Flathub" width="200"/>
+</a>
 
 ## Compile
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Ncurses and tiles versions are available in the [official repos](https://tracker
 
 `sudo apt install cataclysm-dda-curses cataclysm-dda-sdl`
 
+#### Flathub
+
+[![Download from Flathub](https://flathub.org/assets/badges/flathub-badge-en.png)](https://flathub.org/apps/org.cataclysmdda.CataclysmDDA)
+
 ## Compile
 
 Please read [COMPILING.md](doc/COMPILING/COMPILING.md) - it covers general information and more specific recipes for Linux, OS X, Windows and BSD. See [COMPILER_SUPPORT.md](doc/COMPILING/COMPILER_SUPPORT.md) for details on which compilers we support. And you can always dig for more information in [doc/](https://github.com/CleverRaven/Cataclysm-DDA/tree/master/doc).

--- a/README.md
+++ b/README.md
@@ -45,9 +45,7 @@ Ncurses and tiles versions are available in the [official repos](https://tracker
 
 #### Flathub
 
-<a href="https://flathub.org/apps/org.cataclysmdda.CataclysmDDA">
-    <img src="https://flathub.org/assets/badges/flathub-badge-en.png" alt="Download from Flathub" width="200"/>
-</a>
+[Download from Flathub](https://flathub.org/apps/org.cataclysmdda.CataclysmDDA)
 
 ## Compile
 

--- a/org.cataclysmdda.CataclysmDDA.yml
+++ b/org.cataclysmdda.CataclysmDDA.yml
@@ -1,0 +1,33 @@
+id: "org.cataclysmdda.CataclysmDDA"
+runtime: "org.freedesktop.Platform"
+runtime-version: '23.08'
+sdk: org.freedesktop.Sdk
+command: cataclysm-tiles
+finish-args: 
+  - --socket=pulseaudio
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
+  - --device=dri
+
+modules:
+  - name: cataclysm-tiles
+    buildsystem: simple
+    build-options:
+      env:
+        MAKE_ARGS: "PREFIX=/app LANGUAGES=all USE_XDG_DIR=1 TILES=1 SOUND=1 RELEASE=1 RUNTESTS=0 ASTYLE=0 LINTJSON=0"
+    build-commands:
+      - sed -i "/#WARNINGS = -w/c WARNINGS = -w" Makefile
+      - make -j $FLATPAK_BUILDER_N_JOBS $MAKE_ARGS
+      - make $MAKE_ARGS localization
+      - make $MAKE_ARGS install
+      - install -Dm644 data/xdg/org.cataclysmdda.CataclysmDDA.svg /app/share/icons/hicolor/scalable/apps/org.cataclysmdda.CataclysmDDA.svg
+      - install -Dm755 data/xdg/org.cataclysmdda.CataclysmDDA.desktop /app/share/applications/org.cataclysmdda.CataclysmDDA.desktop
+      - install -Dm644 org.cataclysmdda.CataclysmDDA.appdata.xml /app/share/metainfo/org.cataclysmdda.CataclysmDDA.appdata.xml
+    sources:
+      - type: git
+        url: https://github.com/CleverRaven/Cataclysm-DDA.git
+        commit: "3a1e04656d51c79af87b5505b1b3c37867378cce"
+      - type: file
+        url: https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/dedfc2e5310b505a9728098d1b59777cb8b1e861/data/xdg/org.cataclysmdda.CataclysmDDA.appdata.xml
+        sha256: ca7bf1a3a0598729440aaae73111ffa3992121fa19f0e36d988eee22055db29e


### PR DESCRIPTION
#### Summary
Infrastructure "Add Flathub download button and Flatpak manifest"

#### Purpose of change

To make it easier for users to download the game via Flathub, I have added a download button that directs users to the Flathub page. Additionally, I included a Flatpak manifest (yaml) in the repository to facilitate the building and distribution of the game via Flatpak.

#### Describe the solution

- Added a "Download on Flathub" button in README.md.
- Created a Flatpak manifest (yaml) file and added it to the repository, allowing the game to be easily packaged and distributed via Flatpak.

#### Describe alternatives you've considered

I considered creating a separate repository specifically for the Flatpak version of the game, but ultimately decided to submit it to Flathub to leverage its existing infrastructure and reach a wider audience.

#### Testing

- Verified that the Flathub download button correctly links to the Flathub page.
- Tested the Flatpak manifest by building the package locally to ensure it works as expected.

#### Additional context

N/A
