### PR TITLE
[Xedra Evolved] Turn activated learn-recipe Paraclesian traits into Passive ones

### DIFF
--- a/data/mods/Xedra_Evolved/mutations/paraclesians/salamander_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/salamander_eocs.json
@@ -140,7 +140,7 @@
     "effect": [
       { "u_learn_recipe": "lamp_oil_from_water" },
       {
-        "u_message": "From the fiery depths of your spirit, knowledge of how to turn various other water into strong alcohol fills your mind.",
+        "u_message": "From the fiery depths of your spirit, knowledge of how to turn various other water into lamp oil fills your mind.",
         "type": "good"
       }
     ]

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/salamander_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/salamander_eocs.json
@@ -120,14 +120,30 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_SALAMANDER_WATER_TO_BOOZE",
-    "condition": { "u_has_trait": "SALAMANDER_WATER_TO_BOOZE" },
-    "effect": [ { "u_learn_recipe": "mixed_alcohol_strong_from_water" } ]
+    "required_event": "gains_mutation",
+    "eoc_type": "EVENT",
+    "condition": { "compare_string": [ "SALAMANDER_WATER_TO_BOOZE", { "context_val": "trait" } ] },
+    "effect": [
+      { "u_learn_recipe": "mixed_alcohol_strong_from_water" },
+      {
+        "u_message": "From the fiery depths of your spirit, knowledge of how to turn various other water into strong alcohol fills your mind.",
+        "type": "good"
+      }
+    ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_SALAMANDER_WATER_TO_FUEL",
-    "condition": { "u_has_trait": "SALAMANDER_WATER_TO_FUEL" },
-    "effect": [ { "u_learn_recipe": "lamp_oil_from_water" } ]
+    "required_event": "gains_mutation",
+    "eoc_type": "EVENT",
+    "condition": { "compare_string": [ "SALAMANDER_WATER_TO_FUEL", { "context_val": "trait" } ] },
+    "effect": [
+      { "u_learn_recipe": "lamp_oil_from_water" },
+      {
+        "u_message": "From the fiery depths of your spirit, knowledge of how to turn various other water into strong alcohol fills your mind.",
+        "type": "good"
+      }
+    ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/salamander_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/salamander_mutations.json
@@ -210,11 +210,9 @@
     "points": 0,
     "visibility": 0,
     "ugliness": 0,
-    "description": "Upon gaining this ability the Salamander can activate this trait to learn how to convert water into very strong alcohol.",
+    "description": "Upon gaining this ability the Salamander learns how to convert water into very strong alcohol.",
     "prereqs": [ "SALAMANDER_EYES" ],
-    "category": [ "SALAMANDER" ],
-    "active": true,
-    "activated_eocs": [ "EOC_SALAMANDER_WATER_TO_BOOZE" ]
+    "category": [ "SALAMANDER" ]
   },
   {
     "type": "mutation",
@@ -223,11 +221,9 @@
     "points": 6,
     "visibility": 0,
     "ugliness": 0,
-    "description": "Upon gaining this ability the Salamander can activate this trait to learn how to convert water directly into fuel.  This is an intensely draining activity.",
+    "description": "Upon gaining this ability the Salamander learn how to convert water directly into fuel.  This is an intensely draining activity.",
     "prereqs": [ "SALAMANDER_WATER_TO_BOOZE" ],
-    "category": [ "SALAMANDER" ],
-    "active": true,
-    "activated_eocs": [ "EOC_SALAMANDER_WATER_TO_FUEL" ]
+    "category": [ "SALAMANDER" ]
   },
   {
     "type": "mutation",

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/undine_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/undine_eocs.json
@@ -96,40 +96,46 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_SALTWATER_TO_FRESHWATER",
-    "condition": { "u_has_trait": "SALTWATER_TO_FRESHWATER" },
+    "id": "EOC_UNDINE_LEARN_SALTWATER_TO_FRESHWATER",
+    "eoc_type": "EVENT",
+    "required_event": "gains_mutation",
+    "condition": { "compare_string": [ "SALTWATER_TO_FRESHWATER", { "context_val": "trait" } ] },
     "effect": [
+      { "u_learn_recipe": "salt_water_from_water" },
+      { "u_learn_recipe": "water_from_salt_water" },
       {
-        "u_roll_remainder": [ "salt_water_from_water", "water_from_salt_water" ],
-        "type": "recipe",
-        "true_eocs": [ "EOC_SUCCESFUL_ROLL_REMAINDER_ELEMENTAL_RECIPE" ],
-        "false_eocs": [ "EOC_COMPLETED_ROLL_REMAINDER_ELEMENTAL_RECIPE" ]
+        "u_message": "Drawn from some atavistic well, knowledge of how to turn fresh water into salt water, and vice versa, fills your mind.",
+        "type": "good"
       }
     ]
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_FOUL_WATER",
-    "condition": { "u_has_trait": "FOUL_WATER" },
+    "id": "EOC_UNDINE_LEARN_FOUL_WATER",
+    "required_event": "gains_mutation",
+    "eoc_type": "EVENT",
+    "condition": { "compare_string": [ "FOUL_WATER", { "context_val": "trait" } ] },
     "effect": [
+      { "u_learn_recipe": "water_from_water_clean" },
+      { "u_learn_recipe": "water_clean_from_water" },
       {
-        "u_roll_remainder": [ "water_from_water_clean", "water_clean_from_water" ],
-        "type": "recipe",
-        "true_eocs": [ "EOC_SUCCESFUL_ROLL_REMAINDER_ELEMENTAL_RECIPE" ],
-        "false_eocs": [ "EOC_COMPLETED_ROLL_REMAINDER_ELEMENTAL_RECIPE" ]
+        "u_message": "Drawn from some atavistic well, knowledge of how to turn foul water into clean, pure water, and vice versa, fills your mind.",
+        "type": "good"
       }
     ]
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_LIQUID_TO_WATER",
-    "condition": { "u_has_trait": "LIQUID_TO_WATER" },
+    "id": "EOC_UNDINE_LEARN_LIQUID_TO_WATER",
+    "required_event": "gains_mutation",
+    "eoc_type": "EVENT",
+    "condition": { "compare_string": [ "LIQUID_TO_WATER", { "context_val": "trait" } ] },
     "effect": [
+      { "u_learn_recipe": "water_from_liquid" },
+      { "u_learn_recipe": "water_clean_from_water" },
       {
-        "u_roll_remainder": [ "water_from_liquid" ],
-        "type": "recipe",
-        "true_eocs": [ "EOC_SUCCESFUL_ROLL_REMAINDER_ELEMENTAL_RECIPE" ],
-        "false_eocs": [ "EOC_COMPLETED_ROLL_REMAINDER_ELEMENTAL_RECIPE" ]
+        "u_message": "Drawn from some atavistic well, knowledge of how to turn various other liquids directly into water fills your mind.",
+        "type": "good"
       }
     ]
   },

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/undine_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/undine_mutations.json
@@ -126,14 +126,12 @@
   {
     "type": "mutation",
     "id": "SALTWATER_TO_FRESHWATER",
-    "name": { "str": "Saltwater to Freshwater" },
+    "name": { "str": "One Foot in the River and One in the Sea" },
     "points": 0,
     "visibility": 0,
     "ugliness": 0,
-    "description": "Upon gaining this ability the Undine can activate this trait to learn how to convert salt water into freshwater and vice versa.",
-    "category": [ "UNDINE" ],
-    "active": true,
-    "activated_eocs": [ "EOC_SALTWATER_TO_FRESHWATER" ]
+    "description": "Upon gaining this ability the Undine learns how to convert salt water into freshwater and vice versa.",
+    "category": [ "UNDINE" ]
   },
   {
     "type": "mutation",
@@ -149,26 +147,22 @@
   {
     "type": "mutation",
     "id": "FOUL_WATER",
-    "name": { "str": "Foul Water" },
+    "name": { "str": "Cleansing the Poison Well" },
     "points": 0,
     "visibility": 0,
     "ugliness": 0,
-    "description": "Upon gaining this ability the Undine can activate this trait to gain the ability to foul water, making it murky and possibly infested.  Conversely, the Undine can also cleanse water that is not already clean.",
-    "category": [ "UNDINE" ],
-    "active": true,
-    "activated_eocs": [ "EOC_FOUL_WATER" ]
+    "description": "Upon gaining this ability the Undine learns how to foul water, making it murky and possibly infested.  Conversely, the Undine can also cleanse water that is not already clean.",
+    "category": [ "UNDINE" ]
   },
   {
     "type": "mutation",
     "id": "LIQUID_TO_WATER",
-    "name": { "str": "Various liquids to Freshwater" },
+    "name": { "str": "Return to Primordial Waters" },
     "points": 0,
     "visibility": 0,
     "ugliness": 0,
-    "description": "Upon gaining this ability the Undine can activate this trait to gain the ability to convert various liquids into freshwater.",
-    "category": [ "UNDINE" ],
-    "active": true,
-    "activated_eocs": [ "EOC_LIQUID_TO_WATER" ]
+    "description": "Upon gaining this ability the Undine learns how to convert various liquids into freshwater.",
+    "category": [ "UNDINE" ]
   },
   {
     "type": "mutation",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Xedra Evolved] Turn activated learn-recipe Paraclesian traits into Passive ones"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change


Some of the Paraclesian fae (Undine mostly, but also Salamander) have activated traits that teach you recipes. These are a little weird because you activate them once, maybe twice, and then never again, but they sit in your Active Mutations list forever. Fortunately, the `gains_mutation` event EoC can be used to make them passive and replicate this functionality.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Change the Undine traits Saltwater to Freshwater (renamed "One Foot in the River and One in the Sea"), Foul Water (renamed "Cleansing the Poison Well"), and Various liquids to Water (renamed "Return to Primordial Waters") to passive traits. Set up Event EoCs that teach the recipes when you gain those traits instead.

Do the same for the Salamander traits Burning Water and Fire From Water.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

![Untitled](https://github.com/user-attachments/assets/74c524be-f5e6-4c14-b927-45bd4d67122f)

(pre-name change)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
