### PR TITLE
Fix dereference into an empty container

### DIFF
--- a/tests/battery_density_test.cpp
+++ b/tests/battery_density_test.cpp
@@ -96,7 +96,7 @@ static bool is_battery( const itype &type )
     // ignore items from elsewhere, including the test mod.
     if( type.has_flag( json_flag_DEBUG_ONLY ) ||
         type.src.size() > 1 ||
-        type.src.back().second.str() != std::string( "dda" ) ) {
+        ( type.src.size() == 1 && type.src.back().second.str() != std::string( "dda" ) ) ) {
         return false;
     }
     if( !!type.magazine && type.magazine->type.count( ammo_battery ) > 0 ) {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
A bad assumption on my part that itype::src was always populated by at least "dda" led to attempting to derference an empty container, causing a crash, but somehow only with LTO builds.

#### Describe the solution
Check for container population before dereferencing.

#### Testing
It's only exercised in the test, so just need the tests to run to completion.
I reproduced and tested with a LTO build locally, hopefully that makes the g++9 build happy again, requires #75576 to be merged as well or it will hit the OTHER LTO-specific breakage.