### PR TITLE
Dial down the amount of charges for beginner practice recipe

### DIFF
--- a/data/json/recipes/practice/computers.json
+++ b/data/json/recipes/practice/computers.json
@@ -12,7 +12,7 @@
     "practice_data": { "min_difficulty": 0, "max_difficulty": 1, "skill_limit": 2 },
     "autolearn": [ [ "computer", 1 ] ],
     "book_learn": [ [ "mag_computer", 0 ], [ "howto_computer", 0 ] ],
-    "tools": [ [ [ "laptop", 50 ], [ "eink_tablet_pc", 20 ], [ "smart_phone", 20 ] ] ],
+    "tools": [ [ [ "laptop", 50 ], [ "eink_tablet_pc", 1 ], [ "smart_phone", 5 ] ] ],
     "flags": [ "BLIND_EASY" ]
   },
   {

--- a/data/json/recipes/practice/computers.json
+++ b/data/json/recipes/practice/computers.json
@@ -12,7 +12,7 @@
     "practice_data": { "min_difficulty": 0, "max_difficulty": 1, "skill_limit": 2 },
     "autolearn": [ [ "computer", 1 ] ],
     "book_learn": [ [ "mag_computer", 0 ], [ "howto_computer", 0 ] ],
-    "tools": [ [ [ "laptop", 50 ], [ "eink_tablet_pc", 1 ], [ "smart_phone", 5 ] ] ],
+    "tools": [ [ [ "laptop", 10 ], [ "eink_tablet_pc", 1 ], [ "smart_phone", 5 ] ] ],
     "flags": [ "BLIND_EASY" ]
   },
   {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
From https://github.com/CleverRaven/Cataclysm-DDA/pull/75557#issuecomment-2279105308, I find the amount of charges required to perform simple tasks (prob just swiping, scrolling, reading random stuffs) w/o internet connection for smartphone & the e-ink tablet PC is just too much

#### Describe the solution
Reduce the charges:
- Smartphones now only cost 5 charge per hour (more than 8 hrs)
- e-ink tablet PCs now only cost 1 charge (22-44 hours, and I take the Kindle as reference)

#### Describe alternatives you've considered
Leave the woefully unrealistic charges as-is & letting people complaining how annoying is the change.

#### Testing
Should work.

#### Additional context
See my comment there, with additional link:
https://www.reddit.com/r/kindle/comments/ykwnwk/how_long_does_your_kindle_battery_last_and_how/
https://www.quora.com/Is-it-okay-for-my-new-Kindle-Paperwhite-11th-generation-battery-to-go-from-100-to-92-in-less-than-day
