### PR TITLE
Support for multiple randomized field sprite variants

### DIFF
--- a/doc/TILESET.md
+++ b/doc/TILESET.md
@@ -514,7 +514,7 @@ This entry sets it so that the f_desk furniture if it contains either a pen or a
 
 `"layer": 100` this defines the order the sprites will draw in. 1 drawing first 100 drawing last (so 100 ends up on top). This only works for items, Fields are instead drawn in the order they are stacked on the tile.
 
-`"sprite": [{"id": "desk_pen_1", "weight": 2}, {"id": "desk_pen_2", "weight": 2}]` an array of the possible sprites that can display. For items multiple sprites can be provided with specific weights and will be selected at random.
+`"sprite": [{"id": "desk_pen_1", "weight": 2}, {"id": "desk_pen_2", "weight": 2}]` an array of the possible sprites that can display. Multiple sprites can be provided with specific weights and will be selected at random for each item.
 
 `"offset_x": 16`, `"offset_y": -48` optional sprite offset.
 
@@ -524,7 +524,7 @@ This entry sets it so that the f_desk furniture if it contains either a pen or a
 
 `"field": "fd_fire"` the field id. (only supported in field_variants)
 
-`"sprite": [{"id": "desk_fd_fire", "weight": 1}]` A field can have at most one sprite.
+`"sprite": [{"id": "desk_fd_fire", "weight": 1}]` an array of the possible sprites that can display. Multiple sprites can be provided with specific weights and will be selected at random based on map position.
 
 `"offset_x": 16`, `"offset_y": -48` optional sprite offset.
 

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -149,6 +149,11 @@ pixel_minimap_mode pixel_minimap_mode_from_string( const std::string &mode )
     return pixel_minimap_mode::solid;
 }
 
+auto simple_point_hash = []( const auto &p )
+{
+    return p.x + p.y * 65536;
+};
+
 } // namespace
 
 static int msgtype_to_tilecolor( const game_message_type type, const bool bOldMsg )
@@ -2773,10 +2778,6 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEG
         }
     }
 
-    auto simple_point_hash = []( const auto & p ) {
-        return p.x + p.y * 65536;
-    };
-
     // seed the PRNG to get a reproducible random int
     // TODO: faster solution here
     unsigned int seed = 0;
@@ -3649,8 +3650,8 @@ bool cata_tiles::draw_field_or_item( const tripoint &p, const lit_level ll, int 
                         if( fld.id().str() == layer_var.id ) {
 
                             // get the sprite to draw
-                            // roll should be based on the maptile seed to keep visuals consistent
-                            int roll = 1;
+                            // roll is based on the maptile seed to keep visuals consistent
+                            int roll = simple_point_hash( p ) % layer_var.total_weight;
                             std::string sprite_to_draw;
                             for( const auto &sprite_list : layer_var.sprite ) {
                                 roll = roll - sprite_list.second;
@@ -3677,8 +3678,8 @@ bool cata_tiles::draw_field_or_item( const tripoint &p, const lit_level ll, int 
                             if( fld.id().str() == layer_var.id ) {
 
                                 // get the sprite to draw
-                                // roll should be based on the maptile seed to keep visuals consistent
-                                int roll = 1;
+                                // roll is based on the maptile seed to keep visuals consistent
+                                int roll = simple_point_hash( p ) % layer_var.total_weight;
                                 std::string sprite_to_draw;
                                 for( const auto &sprite_list : layer_var.sprite ) {
                                     roll = roll - sprite_list.second;
@@ -3766,7 +3767,7 @@ bool cata_tiles::draw_field_or_item( const tripoint &p, const lit_level ll, int 
                             const bool layer_nv = nv_goggles_activated;
 
                             // get the sprite to draw
-                            // roll should be based on the maptile seed to keep visuals consistent
+                            // roll is based on the item seed to keep visuals consistent
                             int roll = i.seed % layer_var.total_weight;
                             std::string sprite_to_draw;
                             for( const auto &sprite_list : layer_var.sprite ) {
@@ -3811,7 +3812,7 @@ bool cata_tiles::draw_field_or_item( const tripoint &p, const lit_level ll, int 
                                 const bool layer_nv = nv_goggles_activated;
 
                                 // get the sprite to draw
-                                // roll should be based on the maptile seed to keep visuals consistent
+                                // roll is based on the item seed to keep visuals consistent
                                 int roll = i.seed % layer_var.total_weight;
                                 std::string sprite_to_draw;
                                 for( const auto &sprite_list : layer_var.sprite ) {


### PR DESCRIPTION
#### Summary
Infrastructure "Added support for multiple randomized field sprite variants"

#### Purpose of change
The JSON required for terrain-aware sprites for fields in layering.json previously demanded the use of a sprite array with weights, despite our only supporting one sprite at a time and ignoring the weights. This change makes the field syntax make sense, by introducing support for supporting multiple field sprites and actually using those weight values.

#### Describe the solution
As the code for terrain-aware item and field variants is pretty much identical, all that was needed here was updating the random seed used for field sprite position (it was previously hardcoded to "1").  An existing comment suggested that the best way to do this would be to use map position.  To do that, I found and re-used an existing method ("simple_point_hash") in the same file for getting a quick seed based on map position, which required moving that method to a slightly higher scope.

I also updated the four comments describing the seed used for the item/field variants, and the documentation for this feature (TILESET.md).

#### Describe alternatives you've considered
Changing the JSON syntax did cross my mind, but it seemed unwise as we wouldn't want to invalidate all the existing layering.json.

I also considered copying the internals of "simple_point_hash" (a single line) rather than pulling it out into a different scope, but abstracting out a function seemed worth the small additional risk.

#### Testing
Since no existing layering.json file currently uses multiple field sprites, I set up the layering.json for Ultica such that the firebarrel smoke field sprite uses the current smoke with weight 2, and also fungal haze with weight 2, and updated the tileset.

![Screenshot 2024-08-12 212239](https://github.com/user-attachments/assets/b4fa4bcc-2383-4b82-8c50-89de39455153)

I then debugged in ten firebarrels and lit them all up to produce smoke. Before the code changes in the PR, every field simply used the fungal haze every time, as 1 (hardcoded) % 2 (existing weight) = 1 (second item in an array).

![Screenshot 2024-08-12 175053](https://github.com/user-attachments/assets/a1cd08cd-9084-4402-9da6-ed679a298c4e)

But after the change, half of the barrels used the other animated spriteset, as expected.

![Screenshot 2024-08-12 214019](https://github.com/user-attachments/assets/d72050f9-6e5e-4ac4-a82e-853757e44105)

#### Additional context
While I'm aware that this is not a highly requested feature, it does make the variant system significantly cleaner, and I see no downside.