### PR TITLE
Prevent div by zero crash in mana widget

### DIFF
--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -1306,7 +1306,7 @@ nc_color widget::value_color( int value )
     // Get range of values from min to max
     const int var_range = _var_max - _var_min;
 
-    if( ! _breaks.empty() ) {
+    if( var_range > 0 && ! _breaks.empty() ) {
         const int value_offset = ( 100 * ( value - _var_min ) ) / var_range;
         for( int i = 0; i < color_max; i++ ) {
             if( value_offset < _breaks[i] ) {


### PR DESCRIPTION

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Prevent div by zero crash in mana widget"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Prevents division by zero crash when displaying widgets with defined break levels.

Fixes #75566 . Fixes #72474 .

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Example of where previous crash from div-by-zero happened:
* Provided save used the `zenfs_thick_sidebar`, which includes widget `zenfs_mana_bar_14_no_label` that defines break levels.
* When running the provided save, mana value is usually at `v=201` with `min=0` `max=201`.
* Those values are computed by `known_magic::max_mana` where internal values are `bionic_penalty=999` `mana_base=1000` `int_bonus=200`.
* But when int falls (because of tiredness), then `known_magic::max_mana` will return `0` because `int_bonus=-100`.
* This leads to `_var_max=0` in `widget::value_color` and thus `var_range=0` which causes the div by zero.

Backtrace of previous crash being fixed:
```
Thread 1 "cataclysm-tiles" received signal SIGFPE, Arithmetic exception.
0x0000555556a9c54e in widget::value_color (this=this@entry=0x7fffffffb8d8, value=value@entry=201) at src/widget.cpp:1310
1310            const int value_offset = ( 100 * ( value - _var_min ) ) / var_range;

(gdb) bt
 #0  0x0000555556a9c54e in widget::value_color (this=this@entry=0x7fffffffb8d8, value=value@entry=201) at src/widget.cpp:1310
 #1  0x0000555556aa37dc in widget::color_value_string[abi:cxx11](int, int) (this=this@entry=0x7fffffffb8d8, value=201, width_max=width_max@entry=14) at src/widget.cpp:1262
 #2  0x0000555556aa38ca in widget::show[abi:cxx11](avatar const&, unsigned int) (this=this@entry=0x7fffffffb8d8, ava=..., max_width=max_width@entry=14) at src/widget.cpp:890
 #3  0x0000555556aa497f in widget::layout[abi:cxx11](avatar const&, unsigned int, int, bool) (this=this@entry=0x7fffffffb8d8, ava=..., max_width=<optimized out>, label_width=label_width@entry=0, skip_pad=false) at src/widget.cpp:1834
 #4  0x0000555556aa42c2 in widget::layout[abi:cxx11](avatar const&, unsigned int, int, bool) (this=this@entry=0x7fffffffbe88, ava=..., max_width=<optimized out>, label_width=label_width@entry=9, skip_pad=false) at src/widget.cpp:1794
 #5  0x0000555556aa3cfa in widget::layout[abi:cxx11](avatar const&, unsigned int, int, bool) (this=this@entry=0x7fffffffc438, ava=..., max_width=<optimized out>, label_width=label_width@entry=0, skip_pad=false) at src/widget.cpp:1724
 #6  0x0000555556aa42c2 in widget::layout[abi:cxx11](avatar const&, unsigned int, int, bool) (this=this@entry=0x7fffffffc9e8, ava=..., max_width=<optimized out>, label_width=label_width@entry=0, skip_pad=false) at src/widget.cpp:1794
 #7  0x0000555556aa42c2 in widget::layout[abi:cxx11](avatar const&, unsigned int, int, bool) (this=this@entry=0x555562c47160, ava=..., max_width=<optimized out>, max_width@entry=64, label_width=<optimized out>, skip_pad=skip_pad@entry=false) at src/widget.cpp:1794
 #8  0x0000555556aa5222 in custom_draw_func (args=...) at src/widget.cpp:970
 #9  0x0000555555ec4360 in std::function<int(draw_args const&)>::operator() (this=0x555597eb1780, __args#0=...) at /usr/include/c++/14/bits/std_function.h:591
 #10 game::draw_panels (this=this@entry=0x55555827ef50, force_draw=force_draw@entry=true) at src/game.cpp:4007
 #11 0x0000555555eed1ac in game::draw (this=0x55555827ef50, ui=...) at src/game.cpp:3961
 #12 0x00005555569a962c in ui_adaptor::redraw_invalidated () at src/ui_manager.cpp:440
 #13 0x00005555569a96e9 in ui_adaptor::redraw () at src/ui_manager.cpp:345
 #14 0x00005555569a9710 in ui_manager::redraw () at src/ui_manager.cpp:506
 #15 0x0000555555dd0850 in do_turn () at src/do_turn.cpp:712
 #16 0x00005555557a138d in main (argc=<optimized out>, argv=<optimized out>) at src/main.cpp:873

(gdb) print var_range
$1 = 0
(gdb) print value
$2 = 201
(gdb) print _var_min
$3 = 0
(gdb) print _var_max
$4 = 0
```
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

* Can reliably reproduce the div-by-zero using the save (and config) in #75566 . On this branch, the crash can no longer be reproduced.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Other conditionals in this method are already checking `var_range > 0`.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
