### PR TITLE
Vision granularity audit: Military (or just FEMA Camps)

### DIFF
--- a/data/json/overmap/overmap_terrain/overmap_terrain_military.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_military.json
@@ -24,7 +24,7 @@
       "fema_roof",
       "fema_1_3_roof"
     ],
-    "vision_levels": "isolated_building",
+    "vision_levels": "isolated_camp",
     "name": "FEMA camp",
     "sym": "F",
     "color": "i_blue",
@@ -36,7 +36,7 @@
     "type": "overmap_terrain",
     "id": [ "FEMA_tlc", "FEMA_te", "FEMA_trc", "FEMA_le", "FEMA_mid", "FEMA_re", "FEMA_blc", "FEMA_brc" ],
     "name": "FEMA refugee camp",
-    "vision_levels": "isolated_building",
+    "vision_levels": "isolated_camp",
     "sym": "F",
     "color": "i_blue",
     "extras": "build",

--- a/data/json/overmap/vision_levels.json
+++ b/data/json/overmap/vision_levels.json
@@ -37,6 +37,16 @@
     "levels": [ { "name": "tower", "sym": "0", "color": "light_gray" }, { "name": "tower", "sym": "0", "color": "light_gray" } ]
   },
   {
+    "id": "isolated_camp",
+    "//": "If there's a tent, it's a camp",
+    "type": "oter_vision",
+    "levels": [
+      { "name": "tent", "sym": ";", "color": "light_gray", "looks_like": "campsite" },
+      { "name": "camp", "sym": "+", "color": "light_gray", "looks_like": "campsite" },
+      { "name": "camp", "sym": "+", "color": "light_gray", "looks_like": "campsite" }
+    ]
+  },
+  {
     "id": "island",
     "//": "any island",
     "type": "oter_vision",


### PR DESCRIPTION
#### Summary
Content "Add more vision level (at least for FEMA camps, for now)"

#### Purpose of change
I find it strange how a building with multiple tents is treated the same as a concrete building.

#### Describe the solution
Added a new overmap terrain vision called `isolated_camp` (sure, there are body sites there, but mostly the thing that stands out most are tents)

#### Describe alternatives you've considered
Leave it as is

#### Testing
Tested w/ a FEMA refugee camp:
![image](https://github.com/user-attachments/assets/a8f5ac97-d965-4958-8ffd-55b9e5760af9)
![image](https://github.com/user-attachments/assets/4df1d126-8dcc-40cb-9d8c-3408db47e418)

#### Additional context
I'll do more later on, this is just the beginning