### PR TITLE
Allow ebooks in read command

### DIFF
--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -131,7 +131,8 @@ static item_location inv_internal( Character &u, const inventory_selector_preset
                                    const std::string &title, int radius,
                                    const std::string &none_message,
                                    const std::string &hint = std::string(),
-                                   item_location container = item_location() )
+                                   item_location container = item_location(),
+                                   bool add_ebooks = false )
 {
     inventory_pick_selector inv_s( u, preset );
 
@@ -156,6 +157,9 @@ static item_location inv_internal( Character &u, const inventory_selector_preset
         // Default behavior.
         inv_s.add_character_items( u );
         inv_s.add_nearby_items( radius );
+        if( add_ebooks ) {
+            inv_s.add_character_ebooks( u );
+        }
     }
 
     if( u.has_activity( consuming ) ) {
@@ -1560,7 +1564,8 @@ item_location game_menus::inv::read( Character &you )
 {
     const std::string msg = you.is_avatar() ? _( "You have nothing to read." ) :
                             string_format( _( "%s has nothing to read." ), you.disp_name() );
-    return inv_internal( you, read_inventory_preset( you ), _( "Read" ), 1, msg );
+    return inv_internal( you, read_inventory_preset( you ), _( "Read" ), 1, msg, "", item_location(),
+                         true );
 }
 
 item_location game_menus::inv::ebookread( Character &you, item_location &ereader )

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -2097,6 +2097,13 @@ void inventory_selector::add_character_items( Character &character )
     }
 }
 
+void inventory_selector::add_character_ebooks( Character &character )
+{
+    for( item_location &ereader : character.all_items_loc() ) {
+        add_contained_ebooks( ereader );
+    }
+}
+
 void inventory_selector::add_map_items( const tripoint &target )
 {
     map &here = get_map();

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -615,6 +615,7 @@ class inventory_selector
         void add_contained_gunmods( Character &you, item &gun );
         void add_contained_ebooks( item_location &container );
         void add_character_items( Character &character );
+        void add_character_ebooks( Character &character );
         void add_map_items( const tripoint &target );
         void add_vehicle_items( const tripoint &target );
         void add_nearby_items( int radius = 1 );


### PR DESCRIPTION
#### Summary

Interface "Allow ebooks in read command"

#### Purpose of change

Show all stored ebooks from player inventory (not nearby items) in "read" menu, so there is no need to call read ebook iuse function

#### Testing

Have a ebook with some books stored, try to read and see ebooks available for selection in the reading menu.

#### Additional context

Reading directly from nearby ebooks looks like a more invasive change.