### PR TITLE
Active grenades don't spawn as duds

### DIFF
--- a/data/json/items/tool/explosives.json
+++ b/data/json/items/tool/explosives.json
@@ -408,6 +408,7 @@
     "color": "green",
     "use_action": { "type": "message", "message": "You've already pulled the %s's pin, try throwing it instead.", "name": "Pull pin" },
     "countdown_action": { "type": "explosion", "explosion": { "power": 240, "shrapnel": { "casing_mass": 217, "fragment_mass": 0.02 } } },
+    "countdown_interval": "5 seconds",
     "flags": [ "BOMB", "TRADER_AVOID", "DANGEROUS" ],
     "melee_damage": { "bash": 6 }
   },


### PR DESCRIPTION
#### Summary
Bugfixes "Booby trap releases a live grenade that will actually explode"

#### Purpose of change
* Fix #70854

#### Describe the solution
Andrei's post was on the money

#### Describe alternatives you've considered
Instant explosion!

#### Testing

https://github.com/user-attachments/assets/03ae3504-e036-42bb-b853-612cb617fb01



#### Additional context
