### PR TITLE
Add itemgroup field that activate spawned item

### DIFF
--- a/doc/ITEM_SPAWN.md
+++ b/doc/ITEM_SPAWN.md
@@ -97,6 +97,7 @@ Each entry can have more values (shown above as `...`).  They allow further prop
 "container-group": "<group-id>",
 "entry-wrapper": "<item-id>",
 "sealed": <boolean>
+"active": <boolean>
 "custom-flags": <array of string>,
 "variant": <string>
 "artifact": <object>
@@ -111,6 +112,8 @@ Each entry can have more values (shown above as `...`).  They allow further prop
 `charges`: Setting only min and not max will make the game calculate the max charges based on container or ammo/magazine capacity. Setting max too high will decrease it to the maximum capacity. Not setting min will set it to 0 when max is set.
 
 `sealed`: If true, a container will be sealed when the item spawns.  Default is `true`.
+
+`active`: If true, item would be spawned activated.  Be sure to use active versions of item, like `flashlight_on` instead of `flashlight`.  Default is `false`
 
 `custom-flags`: An array of flags that will be applied to this item.
 

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -5035,6 +5035,9 @@ void Item_factory::add_entry( Item_group &ig, const JsonObject &obj, const std::
         modifier.sealed = obj.get_bool( "sealed" );
         use_modifier = true;
     }
+    if( obj.has_member( "active" ) ) {
+        sptr->active = obj.get_bool( "active" );
+    }
     std::vector<std::string> custom_flags;
     use_modifier |= load_string( custom_flags, obj, "custom-flags" );
     modifier.custom_flags.clear();

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -230,6 +230,9 @@ item Single_item_creator::create_single_without_container( const time_point &bir
     if( one_in( 3 ) && tmp.has_flag( flag_VARSIZE ) ) {
         tmp.set_flag( flag_FIT );
     }
+
+    tmp.active = active;
+
     if( components_items ) {
         for( itype_id component_id : *components_items ) {
             if( !component_id.is_valid() ) {

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -231,7 +231,9 @@ item Single_item_creator::create_single_without_container( const time_point &bir
         tmp.set_flag( flag_FIT );
     }
 
-    tmp.active = active;
+    if( active.has_value() ) {
+        tmp.active = *active;
+    }
 
     if( components_items ) {
         for( itype_id component_id : *components_items ) {

--- a/src/item_group.h
+++ b/src/item_group.h
@@ -205,7 +205,7 @@ class Item_spawn_data
          */
         std::optional<std::vector<itype_id>> components_items;
         bool sealed = true;
-        bool active = false;
+        std::optional<bool> active = false;
 
         struct relic_generator {
             relic_procgen_data::generation_rules rules;

--- a/src/item_group.h
+++ b/src/item_group.h
@@ -205,7 +205,7 @@ class Item_spawn_data
          */
         std::optional<std::vector<itype_id>> components_items;
         bool sealed = true;
-        std::optional<bool> active = false;
+        std::optional<bool> active = std::nullptr;
 
         struct relic_generator {
             relic_procgen_data::generation_rules rules;

--- a/src/item_group.h
+++ b/src/item_group.h
@@ -205,7 +205,7 @@ class Item_spawn_data
          */
         std::optional<std::vector<itype_id>> components_items;
         bool sealed = true;
-        std::optional<bool> active = std::nullptr;
+        std::optional<bool> active = std::nullopt;
 
         struct relic_generator {
             relic_procgen_data::generation_rules rules;

--- a/src/item_group.h
+++ b/src/item_group.h
@@ -205,6 +205,7 @@ class Item_spawn_data
          */
         std::optional<std::vector<itype_id>> components_items;
         bool sealed = true;
+        bool active = false;
 
         struct relic_generator {
             relic_procgen_data::generation_rules rules;


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
~~Technically fixes  #75627, but i will make a way for EoC to activate item also, so no closing~~ just now i found `u_activate` and `npc_activate` do exist already
#### Describe the solution
Add a field for itemgroups, so they can spawn activated items
#### Testing
Spawned active grenade
```json
  {
    "id": "TEEEEEST",
    "type": "item_group",
    "subtype": "distribution",
    "entries": [ { "item": "grenade_act", "prob": 100, "active": true } ]
  },
```
It didn't work, because of #70854, should be covered by #75662

Spawned gasbomb_act, exploded the second it spawned in the world

Spawned active flashlights, was off, because of lack of battery
Added battery, still off, because battery spawns empty
Added charges to batteries, finally flashlight spawned active and emitted light around
#### Additional context
@Karol1223 it is not what you asked, but it is what you need