### PR TITLE
NPCs can use C4

### DIFF
--- a/data/json/items/tool/explosives.json
+++ b/data/json/items/tool/explosives.json
@@ -31,7 +31,8 @@
     "color": "light_gray",
     "use_action": { "type": "message", "message": "You've already set the %s's timer, you might want to get away from it." },
     "countdown_action": { "type": "explosion", "explosion": { "power": 2000 } },
-    "flags": [ "TRADER_AVOID" ]
+    "countdown_interval": "6 seconds",
+    "flags": [ "NPC_THROW_NOW" ]
   },
   {
     "id": "dynamite",

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -3404,16 +3404,24 @@ std::optional<int> iuse::granade_act( Character *, item *it, const tripoint &pos
 
 std::optional<int> iuse::c4( Character *p, item *it, const tripoint & )
 {
-    int time;
-    bool got_value = query_int( time, _( "Set the timer to how many seconds (0 to cancel)?" ) );
-    if( !got_value || time <= 0 ) {
-        p->add_msg_if_player( _( "Never mind." ) );
-        return std::nullopt;
+    int time = 0;
+    bool got_value = false;
+    if( p->is_avatar() ) {
+        got_value = query_int( time, _( "Set the timer to how many seconds (0 to cancel)?" ) );
+        if( !got_value || time <= 0 ) {
+            p->add_msg_if_player( _( "Never mind." ) );
+            return std::nullopt;
+        }
     }
     p->add_msg_if_player( n_gettext( "You set the timer to %d second.",
                                      "You set the timer to %d seconds.", time ), time );
     it->convert( itype_c4armed );
-    it->countdown_point = calendar::turn + time_duration::from_seconds( time );
+    if( got_value ) {
+        it->countdown_point = calendar::turn + time_duration::from_seconds( time );
+    } else {
+        // Uses value from the converted type (e.g. currently hardcoded c4armed)
+        it->countdown_point = calendar::turn + it->type->countdown_interval;
+    }
     it->active = true;
     return 1;
 }

--- a/src/npc_attack.cpp
+++ b/src/npc_attack.cpp
@@ -585,8 +585,10 @@ void npc_attack_activate_item::use( npc &source, const tripoint &/*location*/ ) 
     if( !source.wield( activatable_item ) ) {
         debugmsg( "%s can't wield %s it tried to activate", source.disp_name(),
                   activatable_item.display_name() );
+        return;
     }
-    source.activate_item( activatable_item );
+    // npc::wield may invalidate activatable_item's reference
+    source.activate_item( *source.get_wielded_item() );
 }
 
 bool npc_attack_activate_item::can_use( const npc &source ) const


### PR DESCRIPTION
#### Summary
Bugfixes "NPCs can use C4"

#### Purpose of change
* Fix #69677

#### Describe the solution
Similar to #75662, set a default timer and NPC C4 activations use that instead of asking the player for a time

Also had to fix two pre-existing crashes along the way... separated out into other commits.

First crash: Some absolutely bizarre reference invalidation in npc::wield which invalidates the existing `activateable_item` reference, so we just pass along a new one.

~~Second crash: The recent refactoring of npc::wont_hit_friend by @ShnitzelX2 in #75297 exposed the fact that npc_attack_throw::use was telling npc::wont_hit_friend to treat it as a gun attack. It is not a gun attack, it's throwing (right there in the namespace!). Not Shnitzel's fault, and easy enough to clean up.~~

#### Describe alternatives you've considered


#### Testing
![image](https://github.com/user-attachments/assets/309160ef-59e0-4055-8e47-810e18b94f17)


https://github.com/user-attachments/assets/329046cd-589c-41d8-b9d2-8de0bb3df7cb



#### Additional context

