### PR TITLE
Mutinous NPCs no longer follower your rules

### DIFF
--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1581,6 +1581,7 @@ void npc::mutiny()
     my_fac->trusts_u -= 5;
     g->remove_npc_follower( getID() );
     set_fac( faction_amf );
+    rules = npc_follower_rules(); // Mutinous NPCs no longer follower your rules
     job.clear_all_priorities();
     if( assigned_camp ) {
         assigned_camp = std::nullopt;


### PR DESCRIPTION
#### Summary
Bugfixes "Mutinous NPCs no longer follower your rules"

#### Purpose of change
While trying to fix crashes for #75668 I found some functions which suggested that NPCs would check their rules without considering if they were a follower or not

#### Describe the solution
As a safety measure, reset the NPC's rules to default after mutiny. Just in case the player gave them some rules like "Don't use guns", they should no longer care about those instructions. They want to shoot the player, if the player told them 5 seconds ago "Don't shoot me!", that no longer matters to them.

The rules are *defaulted* instead of *cleared*, because the default is what they would get if they were a randomly spawned NPC (e.g. had never met the player).

#### Describe alternatives you've considered
Manually auditing every single rules check in the NPC files

#### Testing
Only that it compiles. Uses the same defaulting behavior as I used in #74854 so it's essentially already been tested.

#### Additional context

