### PR TITLE
Make scripted unique NPC spawns unavailable as random spawns

### DIFF
--- a/data/json/encounters/randec_independent_travelers.json
+++ b/data/json/encounters/randec_independent_travelers.json
@@ -94,7 +94,7 @@
     "method": "json",
     "update_mapgen_id": "nest_RandEnc_campervan_traveler_remove",
     "object": {
-      "remove_npcs": [ { "class": "FM_caravan_merchant_random", "x": [ 0, 23 ], "y": [ 0, 23 ] } ],
+      "remove_npcs": [ { "class": "traveler_camper_van", "x": [ 0, 23 ], "y": [ 0, 23 ] } ],
       "remove_vehicles": [ { "vehicles": [ "traveler_van_motorhome" ], "x": [ 0, 23 ], "y": [ 0, 23 ] } ]
     }
   }

--- a/data/json/npcs/random_encounters/camper_van_traveler.json
+++ b/data/json/npcs/random_encounters/camper_van_traveler.json
@@ -2,7 +2,7 @@
   {
     "type": "npc",
     "id": "traveler_camper_van",
-    "class": "NC_SCAVENGER",
+    "class": "NC_CAMPER_VAN_TRAVELER",
     "attitude": 0,
     "mission": 3,
     "chat": "TALK_NPC_CAMPER_VAN_TRAVELER",
@@ -14,6 +14,7 @@
     "name": { "str": "Scavenger" },
     "job_description": "I'm just trying to survive.",
     "traits": [ { "group": "BG_survival_story_EVACUEE" }, { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
+    "common": false,
     "shopkeeper_price_rules": [
       { "category": "food", "premium": 2.5 },
       { "item": "gasoline", "premium": 2.5 },

--- a/data/json/npcs/random_encounters/free_merchant_caravans.json
+++ b/data/json/npcs/random_encounters/free_merchant_caravans.json
@@ -37,6 +37,7 @@
     "id": "NC_CARAVAN_MERCHANT",
     "name": { "str": "Trader" },
     "job_description": "I'm collecting gear and selling it.",
+    "common": false,
     "traits": [
       { "group": "BG_survival_story_EVACUEE" },
       { "group": "NPC_starting_traits" },
@@ -53,6 +54,7 @@
     "id": "NC_CARAVAN_GUARD",
     "name": { "str": "Bounty Hunter" },
     "job_description": "I'm a killer for hire.",
+    "common": false,
     "traits": [
       { "group": "BG_survival_story_POLICE" },
       { "group": "NPC_starting_traits" },


### PR DESCRIPTION
#### Summary
Bugfixes "Make scripted unique NPC spawns unavailable as random spawns"

#### Purpose of change
More fixes from just trying to fix one bug. When randomly spawning NPCs, I found some that would not move. Why? Because they were unique NPCs, and had the RETURN_TO_START_POS trait. That's fine, but then they shouldn't be available as random spawns.

#### Describe the solution
Make them not `common` (disable them from random spawning, their scripted spawns still function as before)

The camper spawn by @MNG-cataclysm appears to be seriously bugged. The class introduced in that PR was unused, and the mapgen removal aims at `FM_caravan_merchant_random`, not the NPC that actually spawns with the camper van. 

I was unable to get the camper to spawn at all, so I'm unsure if there are further problems, but I am confident in my changes to it regardless.

#### Describe alternatives you've considered
Auditing all the NPC classes. Not today, that's for sure

#### Testing


#### Additional context
