### PR TITLE
Update otherworldly measuring device power draw

### DIFF
--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -296,7 +296,7 @@
     "color": "green",
     "ammo": [ "battery" ],
     "flags": [ "WATER_BREAK" ],
-    "charges_per_use": 5000,
+    "charges_per_use": 2400,
     "use_action": [ "MEASURE_RESONANCE" ],
     "//": "Battery only, intentionally. Meant for field expeditions to other dimensions where grid power is unavailable. Too advanced for the player to make grid-useable.",
     "pocket_data": [


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Batteries changed, this item can no longer be used with *any* battery despite being intended for batteries

#### Describe the solution
Simple update. Pull the power draw down so you get about as many usages as before. A full medium plutonium battery can be used once, a heavy can be used twice.

#### Describe alternatives you've considered


#### Testing
![image](https://github.com/user-attachments/assets/b55088aa-50e0-4b8d-bc9a-0162ac90419f)

#### Additional context

