### PR TITLE
make uilist menus render their footer text/item descriptions with color

### DIFF
--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -129,8 +129,9 @@ void uilist_impl::draw_controls()
 
     if( parent.desc_enabled ) {
         ImGui::Separator();
-        ImGui::TextWrapped( "%s", parent.footer_text.empty() ? parent.entries[parent.selected].desc.c_str()
-                            : parent.footer_text.c_str() );
+        cataimgui::draw_colored_text( parent.footer_text.empty() ?
+                                      parent.entries[parent.selected].desc.c_str()
+                                      : parent.footer_text.c_str() );
     }
 }
 


### PR DESCRIPTION
#### Summary
Interface "make uilist menus render their footer text/item descriptions with color"

#### Purpose of change

Makes the uilist menus render their footer text/item descriptions with color, if they happen to use color tags. This fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/75673

#### Testing

The easiest place to see it is the would care menu you get when you consume a bandage or some antiseptic.