### PR TITLE
Allow operand number formats on g++14

### DIFF
--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2621,9 +2621,10 @@ void spellcasting_callback::display_spell_info( size_t index )
     } else if( sp.effect() == "spawn_item" ) {
         if( sp.has_flag( spell_flag::SPAWN_GROUP ) ) {
             // todo: more user-friendly presentation
-            ImGui::Text( _( "Spawn item group %1$s %2$d times" ),
-                         sp.effect_data().c_str(),
-                         sp.damage( pc ) );
+            const std::string s = string_format( _( "Spawn item group %1$s %2$d times" ),
+                                                 sp.effect_data(),
+                                                 sp.damage( pc ) );
+            ImGui::Text( "%s", s.c_str() );
         } else {
             ImGui::Text( "%s %d %s", _( "Spawn" ), sp.damage( pc ),
                          item::nname( itype_id( sp.effect_data() ), sp.damage( pc ) ).c_str() );


### PR DESCRIPTION


<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Allow operand number formats on g++14"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Allow compiling on g++14 (debian sid) without compilation errors.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Compilation fails on my rig. My compiler (see version below) gives this error when compiling. Source does not build.
```
$ g++ --version
g++ (Debian 14.2.0-1) 14.2.0
```

```
src/magic.cpp: In member function ‘void spellcasting_callback::display_spell_info(size_t)’:
src/magic.cpp:2624:24: error: ISO C++11 does not support %n$ operand number formats [-Werror=format=]
 2624 |             ImGui::Text( _( "Spawn item group %1$s %2$d times" ),
      |             ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 2625 |                          sp.effect_data().c_str(),
      |                          ~~~~~~~~~~~~~~~~~~~~~~~~~
 2626 |                          sp.damage( pc ) );
      |                          ~~~~~~~~~~~~~~~~~
```

Compiler flags used:
```
CCACHE_SLOPPINESS=pch_defines,time_macros,include_file_ctime,include_file_mtime ccache g++ -Isrc -isystem src/third-party -DRELEASE -DGIT_VERSION -DTILES -DUSE_HOME_DIR -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -D_GLIBCXX_ASSERTIONS -fstrict-flex-arrays=3 -fstack-clash-protection -fstack-protector-strong -Wl,-z,nodlopen -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -Os -Wodr -Werror -Wall -Wextra -Wformat-signedness -Wlogical-op -Wmissing-declarations -Wmissing-noreturn -Wnon-virtual-dtor -Wold-style-cast -Woverloaded-virtual -Wpedantic -Wsuggest-override -Wunused-macros -Wzero-as-null-pointer-constant -Wno-unknown-warning-option -Wno-dangling-reference -Wno-c++20-compat -Wredundant-decls -g -fsigned-char -std=c++17 -I/usr/include/SDL2 -D_REENTRANT -I/usr/include/SDL2 -I/usr/include/libpng16 -I/usr/include/x86_64-linux-gnu -I/usr/include/webp -D_REENTRANT -I/usr/include/harfbuzz -I/usr/include/freetype2 -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include/sysprof-6 -pthread -MMD -MP -Winvalid-pch -include pch/main-pch.hpp -c src/magic.cpp -o obj/tiles/magic.o
```

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Have considered perpetually carrying along a local patch that allows me to at least compile the game.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Ok so this is a bit embarrassing. I have not actually tested the functionality being changed (is it magiclysm?). What I have tested though is compiling the game, which *does not work* on `master` as of 207d942b8f using my compiler, but *works* on this branch.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

From #74341 .
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
