### PR TITLE
fungal infected ferals have lower speed

### DIFF
--- a/data/json/monsters/feral_humans.json
+++ b/data/json/monsters/feral_humans.json
@@ -174,6 +174,7 @@
     "id": "mon_feral_human_pipe_fungal_infected",
     "type": "MONSTER",
     "copy-from": "mon_feral_human_pipe",
+    "speed": 90,
     "upgrades": { "age_grow": 4, "into": "mon_feral_human_pipe_fungal_corpse" },
     "burn_into": "mon_starer_pipe",
     "extend": { "flags": [ "NO_FUNG_DMG" ], "species": [ "FUNGUS" ] }
@@ -182,6 +183,7 @@
     "id": "mon_feral_human_crowbar_fungal_infected",
     "type": "MONSTER",
     "copy-from": "mon_feral_human_crowbar",
+    "speed": 90,
     "upgrades": { "age_grow": 4, "into": "mon_feral_human_crowbar_fungal_corpse" },
     "burn_into": "mon_starer_crowbar",
     "extend": { "flags": [ "NO_FUNG_DMG" ], "species": [ "FUNGUS" ] }
@@ -190,6 +192,7 @@
     "id": "mon_feral_human_axe_fungal_infected",
     "type": "MONSTER",
     "copy-from": "mon_feral_human_axe",
+    "speed": 90,
     "upgrades": { "age_grow": 4, "into": "mon_feral_human_axe_fungal_corpse" },
     "burn_into": "mon_starer_axe",
     "extend": { "flags": [ "NO_FUNG_DMG" ], "species": [ "FUNGUS" ] }
@@ -563,6 +566,7 @@
     "id": "mon_feral_cop_fungal_infected",
     "type": "MONSTER",
     "copy-from": "mon_feral_cop",
+    "speed": 85,
     "description": "A maddened and crazed police officer infected by the fungus.  Their body armor is overgrown with fungal matter.  Though obviously in pain they don't seem any less keen to batter you to death with their baton.",
     "extend": { "flags": [ "NO_FUNG_DMG" ], "species": [ "FUNGUS" ] }
   },


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
The ferals still breathe, can still feel pain (albeit crazed), yet they can still retain their speed after getting infected by fungus?

#### Describe the solution
Reduced fungal infected ferals' speed by 10%

#### Describe alternatives you've considered
None

#### Testing
Should work

#### Additional context
NONE
