### PR TITLE
Keep uilist menu items lined up with each other even if some do not have hotkeys

### DIFF
--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -61,6 +61,9 @@ void uilist_impl::on_resized()
 
 void uilist_impl::draw_controls()
 {
+    float hotkey_width =
+        ImGui::CalcTextSize( "[X]" ).x + ImGui::GetStyle().ItemSpacing.x;
+
     if( !parent.text.empty() ) {
         cataimgui::draw_colored_text( parent.text );
         ImGui::Separator();
@@ -108,6 +111,8 @@ void uilist_impl::draw_controls()
                     ImGui::SameLine( 0, 0 );
                     ImGui::Text( "%c", ']' );
                     ImGui::SameLine();
+                } else {
+                    ImGui::SetCursorPosX( hotkey_width );
                 }
                 nc_color color = ( is_selected ?
                                    parent.hilight_color :


### PR DESCRIPTION
#### Summary
Interface "Keep uilist menu items lined up with each other even if some do not have hotkeys"
#### Purpose of change

Aesthetics.

#### Testing

Easiest test is to use a bandage. In the resulting menu any limbs which are damaged have hotkeys, while those that are not are disabled and do not have hotkeys.

#### Additional context

Fixes #75695
