### PR TITLE
draw_colored_text should “draw” an empty line if given an empty string

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -433,13 +433,14 @@ void cataimgui::draw_colored_text( std::string const &text, nc_color &color,
 void cataimgui::draw_colored_text( std::string const &text,
                                    float wrap_width, bool *is_selected, bool *is_focused, bool *is_hovered )
 {
+    if( text.empty() ) {
+        ImGui::NewLine();
+        return;
+    }
+
     ImGui::PushID( text.c_str() );
     int startColorStackCount = GImGui->ColorStack.Size;
     ImGuiID itemId = GImGui->CurrentWindow->IDStack.back();
-
-    if( text.empty() ) {
-        ImGui::NewLine( );
-    }
 
     size_t chars_per_line = size_t( wrap_width );
     if( chars_per_line == 0 ) {

--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -436,6 +436,11 @@ void cataimgui::draw_colored_text( std::string const &text,
     ImGui::PushID( text.c_str() );
     int startColorStackCount = GImGui->ColorStack.Size;
     ImGuiID itemId = GImGui->CurrentWindow->IDStack.back();
+
+    if( text.empty() ) {
+        ImGui::NewLine( );
+    }
+
     size_t chars_per_line = size_t( wrap_width );
     if( chars_per_line == 0 ) {
         chars_per_line = SIZE_MAX;


### PR DESCRIPTION
#### Summary
Interface "draw_colored_text should “draw” an empty line if given an empty string"
#### Purpose of change

It needs to be consistent and always end with the cursor on a new line.

#### Additional context

Fixes #75685
