### PR TITLE
Espadrilles are not armor

### DIFF
--- a/data/json/items/armor/boots.json
+++ b/data/json/items/armor/boots.json
@@ -3370,7 +3370,6 @@
   },
   {
     "id": "espadrilles",
-    "category": "armor",
     "type": "ARMOR",
     "name": { "str_sp": "espadrilles" },
     "description": "Originating from the Pyrenees and made from a rope sole and cloth, these shoes are perfect for the hot weather, sipping Sangria and dodging tourists.",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Espadrilles were categorized as armor, when they are... Not.

#### Describe the solution
One line deletion, easy! They should now turn into normal clothing.

#### Describe alternatives you've considered

#### Testing

#### Additional context
