### PR TITLE
You can order weapons from an artisan blacksmith

### DIFF
--- a/data/json/npcs/isolated_road/isolated_road_cody_dialogue.json
+++ b/data/json/npcs/isolated_road/isolated_road_cody_dialogue.json
@@ -131,6 +131,31 @@
         "topic": "TALK_BLACKSMITH_FABRICATE"
       },
       {
+        "text": "Could you make me a weapon?",
+        "condition": {
+          "and": [
+            { "not": { "u_has_var": "dialogue_artisans_gunsmith_mentioned_quest", "value": "yes" } },
+            { "not": { "u_has_var": "dialogue_artisans_blacksmith_crafting", "value": "yes" } },
+            { "u_has_var": "dialogue_artisans_blacksmith_heard_the_deal", "value": "yes" }
+          ]
+        },
+        "topic": "TALK_BLACKSMITH_NOT_INTERESTED_FABRICATE"
+      },
+      {
+        "text": "Could you make me a weapon?",
+        "condition": {
+          "and": [
+            { "not": { "u_has_var": "dialogue_artisans_blacksmith_crafting", "value": "yes" } },
+            {
+              "//": "this variable means that you have completed quest 1 for Cody and shown Jay",
+              "u_has_var": "dialogue_artisans_gunsmith_mentioned_quest",
+              "value": "yes"
+            }
+          ]
+        },
+        "topic": "TALK_BLACKSMITH_WEAPONSMITH"
+      },
+      {
         "text": "How is my armor coming?",
         "condition": {
           "and": [
@@ -201,6 +226,16 @@
           ]
         },
         "topic": "TALK_BLACKSMITH_ARMOR_READY"
+      },
+      {
+        "text": "How is my weapon coming?",
+        "condition": {
+          "and": [
+            { "u_has_var": "dialogue_artisans_blacksmith_crafting", "value": "yes" },
+            { "u_has_var": "dialogue_artisans_u_current_project", "value": "weapon" }
+          ]
+        },
+        "topic": "TALK_BLACKSMITH_WEAPON_READY"
       },
       {
         "text": "You mentioned you'd need some special materials to make that nomad armor?",

--- a/data/json/npcs/isolated_road/isolated_road_cody_weaponsmith.json
+++ b/data/json/npcs/isolated_road/isolated_road_cody_weaponsmith.json
@@ -1,0 +1,240 @@
+[
+  {
+    "id": "EOC_blacksmith_weapon_cleanup",
+    "type": "effect_on_condition",
+    "effect": [
+      { "u_lose_var": "general_artisans_blacksmith_weapon" },
+      { "u_lose_var": "general_artisans_blacksmith_weapon_type" },
+      { "u_lose_var": "number_artisans_blacksmith_weapon_wait" },
+      { "u_lose_var": "number_artisans_blacksmith_weapon_cost" },
+      { "u_lose_var": "timer_artisans_u_waiting_on_weapon" }
+    ]
+  },
+  {
+    "id": "EOC_blacksmith_weapon_choose_type",
+    "type": "effect_on_condition",
+    "condition": { "expects_vars": [ "name", "cost", "wait" ] },
+    "effect": [
+      { "run_eocs": [ "EOC_blacksmith_weapon_cleanup" ] },
+      {
+        "set_string_var": { "context_val": "name" },
+        "target_var": { "u_val": "general_artisans_blacksmith_weapon_type" }
+      },
+      { "math": [ "u_number_artisans_blacksmith_weapon_cost", "=", "_cost" ] },
+      { "math": [ "u_number_artisans_blacksmith_weapon_wait", "=", "_wait" ] }
+    ]
+  },
+  {
+    "id": "TALK_BLACKSMITH_WEAPONSMITH",
+    "//": "this is all the dialogue related to working on weapon with Cody",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "compare_string": [ "", { "u_val": "general_artisans_blacksmith_weapon" } ],
+      "yes": {
+        "gendered_line": "Sure.  After what you've done for me, I'll forge you the finest work of art.  The price and waiting time depend on the size of the weapon in question, but it will take me a fair amount of money to buy the quality steel I need from the scavengers, and even forging a short blade will take a few days.\n\nI can also temper your weapon, but that will cost an additional 50 merch and take an additional 2 days, but I assure you, it's worth it.",
+        "relevant_genders": [ "u" ]
+      },
+      "no": "Do you still want to order your <item_name:<u_val:general_artisans_blacksmith_weapon>> or would you like to choose something else?"
+    },
+    "responses": [
+      { "text": "Forget it.", "topic": "TALK_BLACKSMITH_SERVICES" },
+      {
+        "text": "Yes, I want to order it.",
+        "condition": { "not": { "compare_string": [ "", { "u_val": "general_artisans_blacksmith_weapon" } ] } },
+        "topic": "TALK_BLACKSMITH_WEAPONSMITH_PAYMENT"
+      },
+      {
+        "text": "[200 merch, 3 days] I need a mace.",
+        "effect": { "run_eoc_with": "EOC_blacksmith_weapon_choose_type", "variables": { "name": "mace", "cost": "200", "wait": "3" } },
+        "topic": "TALK_BLACKSMITH_WEAPONSMITH_STEEL"
+      },
+      {
+        "text": "[200 merch, 3 days] I need a steelshod quarterstaff.",
+        "effect": {
+          "run_eoc_with": "EOC_blacksmith_weapon_choose_type",
+          "variables": { "name": "steel_staff", "cost": "200", "wait": "3" }
+        },
+        "topic": "TALK_BLACKSMITH_WEAPONSMITH_STEEL"
+      },
+      {
+        "text": "[250 merch, 4 days] I need a battle axe.",
+        "effect": {
+          "run_eoc_with": "EOC_blacksmith_weapon_choose_type",
+          "variables": { "name": "battleaxe", "cost": "250", "wait": "4" }
+        },
+        "topic": "TALK_BLACKSMITH_WEAPONSMITH_STEEL"
+      },
+      {
+        "text": "[250 merch, 4 days] I need a longsword.",
+        "effect": {
+          "run_eoc_with": "EOC_blacksmith_weapon_choose_type",
+          "variables": { "name": "longsword", "cost": "250", "wait": "4" }
+        },
+        "topic": "TALK_BLACKSMITH_WEAPONSMITH_STEEL"
+      },
+      {
+        "text": "[250 merch, 4 days] I need a nodachi.",
+        "effect": { "run_eoc_with": "EOC_blacksmith_weapon_choose_type", "variables": { "name": "nodachi", "cost": "250", "wait": "4" } },
+        "topic": "TALK_BLACKSMITH_WEAPONSMITH_STEEL"
+      },
+      {
+        "text": "[250 merch, 4 days] I need a zweihander.",
+        "effect": {
+          "run_eoc_with": "EOC_blacksmith_weapon_choose_type",
+          "variables": { "name": "zweihander", "cost": "250", "wait": "4" }
+        },
+        "topic": "TALK_BLACKSMITH_WEAPONSMITH_STEEL"
+      },
+      {
+        "text": "[200 merch, 3 days] I need an arming sword.",
+        "effect": {
+          "run_eoc_with": "EOC_blacksmith_weapon_choose_type",
+          "variables": { "name": "arming_sword", "cost": "200", "wait": "3" }
+        },
+        "topic": "TALK_BLACKSMITH_WEAPONSMITH_STEEL"
+      },
+      {
+        "text": "[200 merch, 3 days] I need a broadsword.",
+        "effect": {
+          "run_eoc_with": "EOC_blacksmith_weapon_choose_type",
+          "variables": { "name": "broadsword", "cost": "200", "wait": "3" }
+        },
+        "topic": "TALK_BLACKSMITH_WEAPONSMITH_STEEL"
+      },
+      {
+        "text": "[200 merch, 3 days] I need a cavalry saber.",
+        "effect": {
+          "run_eoc_with": "EOC_blacksmith_weapon_choose_type",
+          "variables": { "name": "cavalry_sabre", "cost": "200", "wait": "3" }
+        },
+        "topic": "TALK_BLACKSMITH_WEAPONSMITH_STEEL"
+      },
+      {
+        "text": "[200 merch, 3 days] I need a cutlass.",
+        "effect": { "run_eoc_with": "EOC_blacksmith_weapon_choose_type", "variables": { "name": "cutlass", "cost": "200", "wait": "3" } },
+        "topic": "TALK_BLACKSMITH_WEAPONSMITH_STEEL"
+      },
+      {
+        "text": "[200 merch, 3 days] I need a katana.",
+        "effect": { "run_eoc_with": "EOC_blacksmith_weapon_choose_type", "variables": { "name": "katana", "cost": "200", "wait": "3" } },
+        "topic": "TALK_BLACKSMITH_WEAPONSMITH_STEEL"
+      },
+      {
+        "text": "[170 merch, 3 days] I need a wakizashi.",
+        "effect": {
+          "run_eoc_with": "EOC_blacksmith_weapon_choose_type",
+          "variables": { "name": "wakizashi", "cost": "170", "wait": "3" }
+        },
+        "topic": "TALK_BLACKSMITH_WEAPONSMITH_STEEL"
+      },
+      {
+        "text": "[150 merch, 2 days] I need a kukri.",
+        "effect": { "run_eoc_with": "EOC_blacksmith_weapon_choose_type", "variables": { "name": "kukri", "cost": "150", "wait": "2" } },
+        "topic": "TALK_BLACKSMITH_WEAPONSMITH_STEEL"
+      },
+      {
+        "text": "[250 merch, 4 days] I need an estoc.",
+        "effect": { "run_eoc_with": "EOC_blacksmith_weapon_choose_type", "variables": { "name": "estoc", "cost": "250", "wait": "4" } },
+        "topic": "TALK_BLACKSMITH_WEAPONSMITH_STEEL"
+      },
+      {
+        "text": "[200 merch, 3 days] I need a rapier.",
+        "effect": { "run_eoc_with": "EOC_blacksmith_weapon_choose_type", "variables": { "name": "rapier", "cost": "200", "wait": "3" } },
+        "topic": "TALK_BLACKSMITH_WEAPONSMITH_STEEL"
+      },
+      {
+        "text": "[70 merch, 2 days] I need a trench knife.",
+        "effect": {
+          "run_eoc_with": "EOC_blacksmith_weapon_choose_type",
+          "variables": { "name": "knife_trench", "cost": "70", "wait": "2" }
+        },
+        "topic": "TALK_BLACKSMITH_WEAPONSMITH_STEEL"
+      }
+    ]
+  },
+  {
+    "id": "TALK_BLACKSMITH_WEAPONSMITH_STEEL",
+    "//": "this is all the dialogue related to working on weapon with Cody",
+    "type": "talk_topic",
+    "dynamic_line": "Okay.  What about the steel grade?  Tempering will make your weapon much more durable and a little sharper.",
+    "responses": [
+      {
+        "text": "No, high carbon steel is fine.",
+        "effect": [
+          {
+            "set_string_var": "hc_<u_val:general_artisans_blacksmith_weapon_type>",
+            "target_var": { "u_val": "general_artisans_blacksmith_weapon" },
+            "parse_tags": true
+          }
+        ],
+        "topic": "TALK_BLACKSMITH_WEAPONSMITH_PAYMENT"
+      },
+      {
+        "text": "[+50 merch, +2 days] Yes, tempered steel would be excellent.",
+        "effect": [
+          {
+            "set_string_var": "qt_<u_val:general_artisans_blacksmith_weapon_type>",
+            "target_var": { "u_val": "general_artisans_blacksmith_weapon" },
+            "parse_tags": true
+          },
+          { "math": [ "u_number_artisans_blacksmith_weapon_cost", "+=", "50" ] },
+          { "math": [ "u_number_artisans_blacksmith_weapon_wait", "+=", "2" ] }
+        ],
+        "topic": "TALK_BLACKSMITH_WEAPONSMITH_PAYMENT"
+      },
+      { "text": "Forget it.", "topic": "TALK_BLACKSMITH_SERVICES" }
+    ]
+  },
+  {
+    "id": "TALK_BLACKSMITH_WEAPONSMITH_PAYMENT",
+    "//": "this is all the dialogue related to working on weapon with Cody",
+    "type": "talk_topic",
+    "dynamic_line": "Great, so I can make your <item_name:<u_val:general_artisans_blacksmith_weapon>> for <u_val:number_artisans_blacksmith_weapon_cost> merch and in <u_val:number_artisans_blacksmith_weapon_wait> days.  Deal?",
+    "responses": [
+      {
+        "text": "[<u_val:number_artisans_blacksmith_weapon_cost> merch] Deal.  See you in <u_val:number_artisans_blacksmith_weapon_wait> days.",
+        "condition": { "u_has_items": { "item": "FMCNote", "count": { "u_val": "number_artisans_blacksmith_weapon_cost" } } },
+        "switch": true,
+        "effect": [
+          { "u_sell_item": "FMCNote", "count": { "u_val": "number_artisans_blacksmith_weapon_cost" } },
+          { "u_add_var": "dialogue_artisans_u_current_project", "value": "weapon" },
+          { "u_add_var": "dialogue_artisans_blacksmith_crafting", "value": "yes" },
+          { "math": [ "u_timer_artisans_u_waiting_on_weapon", "=", "time('now')" ] }
+        ],
+        "topic": "TALK_DONE"
+      },
+      {
+        "text": "Um… wait, I don't have that kind of money right now.",
+        "switch": true,
+        "topic": "TALK_BLACKSMITH_SERVICES"
+      },
+      { "text": "Forget it.", "topic": "TALK_BLACKSMITH_SERVICES" }
+    ]
+  },
+  {
+    "id": "TALK_BLACKSMITH_WEAPON_READY",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "math": [ "time_since(u_timer_artisans_u_waiting_on_weapon, 'unit':'days')", ">=", "u_number_artisans_blacksmith_weapon_wait" ],
+      "yes": "It's all done!  Sorry for the long wait; hopefully it's worth it.",
+      "no": "Still working on it."
+    },
+    "responses": [
+      {
+        "text": "Thanks.",
+        "condition": {
+          "math": [ "time_since(u_timer_artisans_u_waiting_on_weapon, 'unit':'days')", ">=", "u_number_artisans_blacksmith_weapon_wait" ]
+        },
+        "switch": true,
+        "effect": [
+          { "u_add_var": "dialogue_artisans_blacksmith_crafting", "value": "no" },
+          { "u_add_var": "dialogue_artisans_u_current_project", "value": "none" },
+          { "u_spawn_item": { "u_val": "general_artisans_blacksmith_weapon" } },
+          { "run_eocs": [ "EOC_blacksmith_weapon_cleanup" ] }
+        ],
+        "topic": "TALK_BLACKSMITH_SERVICES"
+      },
+      { "text": "See you when it's done.", "switch": true, "topic": "TALK_DONE" }
+    ]
+  }
+]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Cody has a new dialogue where you can order weapons"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The blacksmith could create armor for the player, but not weapons.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adds a dialogue branch similar to the armor dialogue. The assortment is based on the itemgroup of trade weapons, plus a couple of short blades to fill the niche. Price and waiting time are based on the same values ​​for the armor. Weapons are cheaper and faster to produce.
23 hours with all the necessary proficiencies and 8 skill (the blacksmith has a skill 7-10) which gives a full 3-4 days:
![sword_tempered](https://github.com/user-attachments/assets/a8287a0f-2bfe-4aaf-ac24-f11897a1febd)
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Any suggestions regarding price/time or dialogue lines are greatly appreciated.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Test world with completed quest: [Test-trimmed.tar.gz](https://github.com/user-attachments/files/16622738/Test-trimmed.tar.gz)
<details><summary>Screenshots</summary>
<p>

![wpn2](https://github.com/user-attachments/assets/139a6163-a24c-4237-9f63-8d812f944611)
![wpn3](https://github.com/user-attachments/assets/00b717bd-b4fa-4723-b600-60c8af7905a8)
![wpn6](https://github.com/user-attachments/assets/74efbf33-3c90-4230-b0fd-8552e442e1ac)
![wpn8](https://github.com/user-attachments/assets/addf71c5-382e-416c-a2e5-5ad2ac186bab)
![wpn9](https://github.com/user-attachments/assets/d927e53b-ce0e-4afe-a4a6-6790b0a3b9df)

</p>
</details> 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Buying with a wait time is used in many places, wouldn't it be nice to have a separate trade menu for this instead of using dialogs?
"u_has_var" can't check for existence of variable with any value? "math" can't be used with strings?
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
