### PR TITLE
Prevent segfault when deconstructing improvised shelter

### DIFF
--- a/data/json/furniture_and_terrain/LIXA_furniture_and_terrain.json
+++ b/data/json/furniture_and_terrain/LIXA_furniture_and_terrain.json
@@ -10,7 +10,7 @@
     "light_emitted": 120,
     "looks_like": "t_carpet_green",
     "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
+    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG" ],
     "bash": {
       "str_min": 4,
       "str_max": 12,

--- a/data/json/furniture_and_terrain/terrain-manufactured.json
+++ b/data/json/furniture_and_terrain/terrain-manufactured.json
@@ -1376,6 +1376,7 @@
       "sound_fail": "whump!",
       "items": [ { "item": "rock_large", "count": [ 0, 20 ] }, { "item": "sharp_rock", "count": [ 0, 16 ] } ]
     },
+    "deconstruct": { "ter_set": "t_dirt", "items": [ { "item": "rock_large", "count": 22 } ] },
     "flags": [ "TRANSPARENT", "THIN_OBSTACLE", "SHORT", "ROUGH", "UNSTABLE", "PERMEABLE", "EASY_DECONSTRUCT" ]
   },
   {
@@ -1494,6 +1495,7 @@
       "HIDE_PLACE",
       "EASY_DECONSTRUCT"
     ],
+    "deconstruct": { "ter_set": "t_pit_shallow", "items": [ { "item": "stick", "count": 12 }, { "item": "pine_bough", "count": 24 } ] },
     "bash": {
       "str_min": 4,
       "str_max": 60,
@@ -1526,6 +1528,10 @@
       "HIDE_PLACE",
       "EASY_DECONSTRUCT"
     ],
+    "deconstruct": {
+      "ter_set": "t_pit_shallow",
+      "items": [ { "item": "stick", "count": 12 }, { "item": "pine_bough", "count": 24 }, { "item": "withered", "count": 80 } ]
+    },
     "bash": {
       "str_min": 4,
       "str_max": 60,

--- a/data/mods/Megafauna/furniture_and_terrain/terrain-manufactured.json
+++ b/data/mods/Megafauna/furniture_and_terrain/terrain-manufactured.json
@@ -12,7 +12,7 @@
     "floor_bedding_warmth": 800,
     "comfort": 1,
     "connect_groups": "INDOORFLOOR",
-    "flags": [ "CONTAINER", "FLAMMABLE_ASH", "REDUCE_SCENT", "INDOORS", "MOUNTABLE", "HIDE_PLACE", "EASY_DECONSTRUCT", "NO_SIGHT" ],
+    "flags": [ "CONTAINER", "FLAMMABLE_ASH", "REDUCE_SCENT", "INDOORS", "MOUNTABLE", "HIDE_PLACE", "NO_SIGHT" ],
     "bash": {
       "str_min": 4,
       "str_max": 60,

--- a/data/mods/Xedra_Evolved/furniture_and_terrain/terrain-flora.json
+++ b/data/mods/Xedra_Evolved/furniture_and_terrain/terrain-flora.json
@@ -411,17 +411,7 @@
     "coverage": 80,
     "floor_bedding_warmth": 2000,
     "comfort": 3,
-    "flags": [
-      "TRANSPARENT",
-      "CONTAINER",
-      "FLAMMABLE_ASH",
-      "THIN_OBSTACLE",
-      "REDUCE_SCENT",
-      "INDOORS",
-      "MOUNTABLE",
-      "HIDE_PLACE",
-      "EASY_DECONSTRUCT"
-    ],
+    "flags": [ "TRANSPARENT", "CONTAINER", "FLAMMABLE_ASH", "THIN_OBSTACLE", "REDUCE_SCENT", "INDOORS", "MOUNTABLE", "HIDE_PLACE" ],
     "bash": {
       "str_min": 12,
       "str_max": 60,

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -2045,8 +2045,12 @@ void construct::do_turn_deconstruct( const tripoint_bub_ms &p, Character &who )
 
         auto deconstruct_items = []( const item_group_id & drop_group ) {
             std::string ret;
+            const Item_spawn_data *spawn_data = item_group::spawn_data_from_group( drop_group );
+            if( spawn_data == nullptr ) {
+                return ret;
+            }
             const std::map<const itype *, std::pair<int, int>> deconstruct_items =
-                        item_group::spawn_data_from_group( drop_group )->every_item_min_max();
+                        spawn_data->every_item_min_max();
             for( const auto &deconstruct_item : deconstruct_items ) {
                 const int &min = deconstruct_item.second.first;
                 const int &max = deconstruct_item.second.second;

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -1039,6 +1039,10 @@ void ter_t::check() const
             debugmsg( "ter %s has invalid emission %s set", id.c_str(), e.str().c_str() );
         }
     }
+    if( has_flag( ter_furn_flag::TFLAG_EASY_DECONSTRUCT ) && !deconstruct.can_do ) {
+        debugmsg( "ter %s has EASY_DECONSTRUCT flag but cannot be deconstructed",
+                  id.c_str(), deconstruct.drop_group.c_str() );
+    }
 }
 
 furn_t::furn_t() : open( furn_str_id::NULL_ID() ), close( furn_str_id::NULL_ID() ) {}


### PR DESCRIPTION


<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Prevent segfault when deconstructing improvised shelter"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fixes #75525 .

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Previous segfault happened when trying to display the list of items that deconstruction would yield, but this terrain has no `deconstruct` json.

This commit also adds a check with `debugmsg` for future such cases during the game startup validation. It also fixes other terrains that had the same problem (`t_improvised_shelter_filled`, `t_rockyobstacle` and `t_carpet_concrete_green_olight`).

Previous crash being fixed:
```
Thread 1 "cataclysm-tiles" received signal SIGSEGV, Segmentation fault.
0x0000555555cb9602 in operator() (drop_group=..., __closure=<optimized out>) at src/construction.cpp:2049
2049                            item_group::spawn_data_from_group( drop_group )->every_item_min_max();
(gdb) bt
 #0  0x0000555555cb9602 in operator() (drop_group=..., __closure=<optimized out>) at src/construction.cpp:2049
 #1  0x0000555555cb9af2 in construct::do_turn_deconstruct (p=..., who=...) at src/construction.cpp:2086
 #2  0x0000555555a32fad in activity_handlers::build_do_turn (act=0x5555583e4338, you=0x5555583e3c70) at src/activity_handlers.cpp:3424
 #3  0x0000555555a6b7de in std::function<void(player_activity*, Character*)>::operator() (this=<optimized out>, __args#0=<optimized out>, __args#0@entry=0x5555583e4338, __args#1=<optimized out>, __args#1@entry=0x5555583e3c70) at /usr/include/c++/14/bits/std_function.h:591
 #4  0x0000555555a69647 in activity_type::call_do_turn (this=<optimized out>, act=act@entry=0x5555583e4338, you=you@entry=0x5555583e3c70) at src/activity_type.cpp:160
 #5  0x00005555566d3a1c in player_activity::do_turn (this=0x5555583e4338, you=...) at src/player_activity.cpp:320
 #6  0x0000555555dcef82 in do_turn () at src/do_turn.cpp:592
 #7  0x00005555557a1217 in main (argc=<optimized out>, argv=<optimized out>) at src/main.cpp:873
```

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Considered just removing the `EASY_DECONSTRUCT` flag from the improvised shelters, but that would have been too easy.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Can no longer reproduce the segfault in #75525 . The improvised shelter can now be simple-deconstructed:

![snapshot4](https://github.com/user-attachments/assets/f9d5866a-451c-4726-bd11-6a986c46b479)
![snapshot5](https://github.com/user-attachments/assets/d5deb04d-0401-4485-b6e2-851ddb303426)


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
