### PR TITLE
overmap granularity audit: Industrial buildings

### DIFF
--- a/data/json/overmap/overmap_terrain/overmap_terrain_industrial.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_industrial.json
@@ -3,7 +3,7 @@
     "type": "overmap_terrain",
     "id": [ "public_works_NE", "public_works_NW", "public_works_SE" ],
     "name": "public works",
-    "vision_levels": "city_building",
+    "vision_levels": "industrial_building",
     "sym": "w",
     "color": "light_gray",
     "see_cost": "high",
@@ -38,7 +38,7 @@
     "name": "serving area interface",
     "sym": "0",
     "color": "i_magenta",
-    "vision_levels": "isolated_building",
+    "vision_levels": "isolated_electronics",
     "see_cost": "spaced_high"
   },
   {
@@ -56,7 +56,7 @@
     "name": "small power substation",
     "sym": "H",
     "color": "light_cyan",
-    "vision_levels": "isolated_building",
+    "vision_levels": "isolated_electronics",
     "see_cost": "spaced_high"
   },
   {
@@ -65,14 +65,14 @@
     "name": "small power substation roof",
     "sym": "H",
     "color": "light_cyan",
-    "vision_levels": "isolated_building",
+    "vision_levels": "isolated_electronics",
     "see_cost": "none"
   },
   {
     "type": "overmap_terrain",
     "id": [ "pwr_large_entrance", "pwr_large_2", "pwr_large_3", "pwr_large_4" ],
     "name": "large power substation",
-    "vision_levels": "isolated_building",
+    "vision_levels": "isolated_electronics",
     "sym": "H",
     "color": "cyan",
     "see_cost": "spaced_high"
@@ -91,6 +91,7 @@
     "id": "warehouse",
     "copy-from": "generic_city_building",
     "name": "small warehouse",
+    "vision_levels": "warehouse",
     "sym": "w",
     "color": "light_blue"
   },
@@ -99,6 +100,7 @@
     "id": "warehouse_roof",
     "copy-from": "generic_city_building",
     "name": "small warehouse roof",
+    "vision_levels": "warehouse",
     "sym": "w",
     "color": "light_blue"
   },
@@ -107,6 +109,7 @@
     "id": [ "small_storage_units", "small_storage_units_1" ],
     "copy-from": "generic_city_building",
     "name": "small storage units",
+    "vision_levels": "warehouse",
     "sym": "#",
     "color": "i_yellow"
   },
@@ -115,6 +118,7 @@
     "id": [ "small_storage_units_roof", "small_storage_units_roof_1" ],
     "copy-from": "generic_city_building",
     "name": "small storage units roof",
+    "vision_levels": "warehouse",
     "sym": "#",
     "color": "i_yellow"
   },
@@ -123,6 +127,7 @@
     "id": [ "lumberyard_0_0", "lumberyard_0_1", "lumberyard_1_0", "lumberyard_1_1" ],
     "copy-from": "generic_city_building",
     "name": "lumberyard",
+    "vision_levels": "industrial_building",
     "sym": "L",
     "color": "i_green",
     "spawns": { "group": "GROUP_WASP_FORAGER", "population": [ 1, 3 ], "chance": 10 },
@@ -133,6 +138,7 @@
     "id": [ "lumberyard_0_0_roof", "lumberyard_0_1_roof", "lumberyard_1_0_roof", "lumberyard_1_1_roof" ],
     "copy-from": "generic_city_building",
     "name": "lumberyard",
+    "vision_levels": "industrial_building",
     "sym": "L",
     "color": "i_green"
   },
@@ -140,7 +146,7 @@
     "type": "overmap_terrain",
     "id": [ "lumbermill_0_0", "lumbermill_0_1", "lumbermill_1_0", "lumbermill_1_1" ],
     "copy-from": "generic_city_building_no_sidewalk",
-    "vision_levels": "isolated_building",
+    "vision_levels": "industrial_building",
     "name": "lumbermill",
     "sym": "L",
     "color": "i_green",
@@ -171,6 +177,7 @@
     "id": [ "construction_site", "house_vacant", "house_vacant1", "house_vacant2", "house_vacant3" ],
     "name": "construction site",
     "copy-from": "generic_city_building",
+    "vision_levels": "industrial_building",
     "sym": "x",
     "color": "i_light_gray",
     "extend": { "flags": [ "SOURCE_CONSTRUCTION", "SOURCE_FABRICATION" ] }
@@ -180,6 +187,7 @@
     "id": [ "abandonedwarehouse", "abandonedwarehouse_1", "abandonedwarehouse_2", "abandonedwarehouse_3", "abandonedwarehouse_4" ],
     "copy-from": "generic_city_building",
     "name": "abandoned warehouse",
+    "vision_levels": "warehouse",
     "sym": "w",
     "color": "brown"
   },
@@ -194,6 +202,7 @@
     ],
     "copy-from": "generic_city_building",
     "name": "abandoned warehouse roof",
+    "vision_levels": "warehouse",
     "sym": "w",
     "color": "brown"
   },
@@ -208,6 +217,7 @@
     ],
     "copy-from": "generic_city_building",
     "name": "storage units",
+    "vision_levels": "warehouse",
     "sym": "#",
     "color": "i_yellow"
   },
@@ -222,6 +232,7 @@
     ],
     "copy-from": "generic_city_building",
     "name": "storage units roof",
+    "vision_levels": "warehouse",
     "sym": "#",
     "color": "i_yellow"
   },
@@ -284,7 +295,7 @@
       "steel_mill_4_3_3"
     ],
     "copy-from": "generic_city_building_no_sidewalk",
-    "vision_levels": "large_building",
+    "vision_levels": "large_industrial_building",
     "name": "steel mill",
     "sym": "S",
     "color": "dark_gray"
@@ -330,7 +341,7 @@
     "name": "light industry",
     "sym": "I",
     "color": "light_blue",
-    "vision_levels": "isolated_building",
+    "vision_levels": "industrial_building",
     "see_cost": "high",
     "extras": "build",
     "mondensity": 2
@@ -338,7 +349,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "mine_entrance", "mine_entrance_loading_zone" ],
-    "vision_levels": "isolated_building",
+    "vision_levels": "industrial_building",
     "name": "mine entrance",
     "sym": "M",
     "color": "magenta",
@@ -457,7 +468,7 @@
     "name": "light industry",
     "sym": "I",
     "color": "light_blue",
-    "vision_levels": "isolated_building",
+    "vision_levels": "industrial_building",
     "see_cost": "high",
     "extras": "build",
     "mondensity": 2

--- a/data/json/overmap/vision_levels.json
+++ b/data/json/overmap/vision_levels.json
@@ -47,6 +47,36 @@
     ]
   },
   {
+    "id": "isolated_electronics",
+    "//": "appliances, machineries visible outside",
+    "type": "oter_vision",
+    "levels": [
+      { "name": "appliances", "sym": "&", "color": "light_gray" },
+      { "name": "deployed appliances", "sym": "A", "color": "light_gray" },
+      { "name": "deployed appliances", "sym": "A", "color": "light_gray" }
+    ]
+  },
+  {
+    "id": "industrial_building",
+    "//": "an industrial building that is neither a warehouse, nor having appliances installed",
+    "type": "oter_vision",
+    "levels": [
+      { "name": "building", "sym": "^", "color": "light_gray" },
+      { "name": "industrial building", "sym": "i", "color": "light_gray" },
+      { "name": "industrial building", "sym": "i", "color": "light_gray" }
+    ]
+  },
+  {
+    "id": "warehouse",
+    "//": "a warehouse or similar",
+    "type": "oter_vision",
+    "levels": [
+      { "name": "building", "sym": "^", "color": "light_gray" },
+      { "name": "warehouse", "sym": "w", "color": "light_gray" },
+      { "name": "warehouse", "sym": "w", "color": "light_gray" }
+    ]
+  },
+  {
     "id": "island",
     "//": "any island",
     "type": "oter_vision",
@@ -168,6 +198,16 @@
       { "name": "city", "color": "light_gray", "sym": "#" },
       { "name": "large building", "color": "i_light_gray", "sym": "+" },
       { "name": "large building", "color": "i_light_gray", "sym": "+" }
+    ]
+  },
+  {
+    "id": "large_industrial_building",
+    "//": "a large industrial building (at least 2x2 overmap tiles)",
+    "type": "oter_vision",
+    "levels": [
+      { "name": "large industrial building", "color": "i_white", "sym": "^" },
+      { "name": "large industrial building", "color": "i_white", "sym": "^" },
+      { "name": "large industrial building", "color": "i_white", "sym": "^" }
     ]
   },
   {


### PR DESCRIPTION
#### Summary
Content "more OM granularity vision levels for industrial buildings"

#### Purpose of change
A warehouse is def not the same as a residental house when a person looks from afar.

#### Describe the solution
Features some more vision levels:
- `warehouse` for obviously, warehouses/storages
- `isolated_electronics` for buildings that deploys electronic thingy
- `industrial_building` (and the large one) for neither of above

#### Describe alternatives you've considered
None

#### Testing
OG overmap:
![image](https://github.com/user-attachments/assets/ca386622-ae71-4e17-b566-9817a6012a42)
vague level:
![image](https://github.com/user-attachments/assets/18f6c268-1664-428a-ba23-4ec722f555c4)
outlines/details:
![image](https://github.com/user-attachments/assets/d8acba09-b3a4-40a7-8c75-4c3a699cfbe4)
Additional images:
![image](https://github.com/user-attachments/assets/a62663a5-9e75-42ec-85b5-d8ab3c5c8bbd)
![image](https://github.com/user-attachments/assets/face2284-b3ba-4bbc-a276-cf3e654cfca7)


#### Additional context
Had to go for the default colorscheme for now, ImGui is currently anti-light mode

Sequel of my previous PR.
