### PR TITLE
Homullus alchemy

### DIFF
--- a/data/mods/Xedra_Evolved/items/alchemy.json
+++ b/data/mods/Xedra_Evolved/items/alchemy.json
@@ -482,7 +482,7 @@
     "type": "COMESTIBLE",
     "comestible_type": "MED",
     "name": { "str_sp": "Imbuement of Parchment" },
-    "description": "Faewild and Dreamdross ground to dust.  With the remains of the fair, and united with a dollop of fae, and human blood.  The resulting mixture will eventually dissolve into what almost looks like liquid porcelain.",
+    "description": "While looking in a mirror Faewild and Dreamdross were ground to dust.  With the remains of the fair, and united with a dollop of fae, and human blood.  The resulting mixture will eventually dissolve into what almost looks like liquid porcelain.",
     "weight": "50 g",
     "volume": "2 ml",
     "price": "150 cent",

--- a/data/mods/Xedra_Evolved/items/alchemy.json
+++ b/data/mods/Xedra_Evolved/items/alchemy.json
@@ -482,7 +482,7 @@
     "type": "COMESTIBLE",
     "comestible_type": "MED",
     "name": { "str_sp": "Imbuement of Parchment" },
-    "description": ".",
+    "description": "Faewild and Dreamdross ground to dust.  With the remains of the fair, and united with a dollop of fae, and human blood.  The resulting mixture will eventually dissolve into what almost looks like liquid porcelain.",
     "weight": "50 g",
     "volume": "2 ml",
     "price": "150 cent",

--- a/data/mods/Xedra_Evolved/recipes/alchemy.json
+++ b/data/mods/Xedra_Evolved/recipes/alchemy.json
@@ -424,5 +424,26 @@
       [ [ "batrachian_sample", 1 ], [ "rabbit_sample", 1 ] ],
       [ [ "water", 2 ] ]
     ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "result": "doll_imbuement",
+    "category": "CC_XEDRA",
+    "subcategory": "CSC_XEDRA_ALCHEMY",
+    "skill_used": "deduction",
+    "skills_required": [ [ "deduction", 5 ], [ "spellcraft", 5 ] ],
+    "difficulty": 3,
+    "time": "55 m",
+    "flags": [ "SECRET" ],
+    "tools": [ [ [ "mirror", -1 ] ], [ [ "mortar_pestle", -1 ] ] ],
+    "components": [
+      [ [ "blood", 1 ] ],
+      [ [ "fae_blood", 1 ] ],
+      [ [ "life_extension_potion", 1 ] ],
+      [ [ "homullus_sample", 5 ] ],
+      [ [ "faewild", 55 ] ],
+      [ [ "scrap_dreamdross", 55 ] ]
+    ]
   }
 ]


### PR DESCRIPTION
#### Summary

Mods "Illuminated Alchemy Perk uses"

#### Purpose of change

Currently, the Illuminated Alchemy perk cycles through a couple recipes that do not exist, and then tells you that you know all recipes the perk allows you to learn.

#### Describe the solution

Introducing a recipe to make the "Imbuement of Parchment" (the transformation item for becoming a Homullus).
The tools for this are a **mortar and pestle** (to grind the ingredients) and a **mirror** (to create something in your image).
The ingredients are:
- 1 human blood
- 1 fae blood
- 1 life extension potion (also learned from alchemy perks)
- 5 homullus samples
- 55 faewild dust
- 55 scrap dreamdross

The idea is to have the human blood, the fae blood, the samples of the mutation tree, the faewild dust and the scrap dreamdross be the uniting ingredients all imbuements will share at the end. For Homullus I wanted the faewild dust and dreamdross to have "symmetric" numbers, so they have the 5 from the samples, but twice. The other imbuements will have different numbers for those - probably less. (5 also returns in the deduction skill, and spellcraft skill required, as well as the craft taking 55min).
And other than the life extension potion, the mirror will also change. For example to a source of fire for the imbuement of the flames. I don't know yet, what the life extension potion could be exchanged for, but it should be something you learned from alchemy.

(oh also: I added a description to the imbuement of parchment to reflect its creation method)

#### Describe alternatives you've considered

- wildly more and/or more difficult to acquire materials
- adding a talking doll either as ingredient or tool (that uses charges? 👀)
- less homullus samples required
- more homullus samples required
- adding a blood draw kit to the tools required to encourage the blood being your own
- not having the recipe require deduction 5, and spellcraft 5

#### Testing

started a game, got the perk, and crafted the recipe (it's currently guaranteed to get gotten, since it's the only recipe on that alchemy level)


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
