### PR TITLE
Exclude PARROT special attack from monster difficulty calculations

### DIFF
--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -377,9 +377,16 @@ void MonsterGenerator::finalize_mtypes()
                 armor_diff += dt.second;
             }
         }
+        std::unordered_set<std::string> blacklisted_specials{"PARROT", "PARROT_AT_DANGER"};
+        int special_attacks_diff = 0;
+        for( const auto &special : mon.special_attacks ) {
+            if( !blacklisted_specials.count( special.first ) ) {
+                special_attacks_diff++;
+            }
+        }
         mon.difficulty = ( mon.melee_skill + 1 ) * mon.melee_dice * ( melee_dmg_total + mon.melee_sides ) *
                          0.04 + ( mon.sk_dodge + 1 ) * armor_diff * 0.04 +
-                         ( mon.difficulty_base + mon.special_attacks.size() + 8 * mon.emit_fields.size() );
+                         ( mon.difficulty_base + special_attacks_diff + 8 * mon.emit_fields.size() );
         mon.difficulty *= ( mon.hp + mon.speed - mon.attack_cost + ( mon.morale + mon.agro ) * 0.1 ) * 0.01
                           + ( mon.vision_day + 2 * mon.vision_night ) * 0.01;
 


### PR DESCRIPTION
#### Summary
Balance "Exclude PARROT special attack from monster difficulty calculations"

#### Purpose of change
#75532 recently ran into an unintuitive part of our difficulty calculations. Adding a harmless "special attack" to the base zombie increases its difficulty, and causes related tests to fail as they expect the base zombie's difficulty to stay the same. (specifically the test is checking the "exp" gained, and the exp is always equal to the difficulty of the monster)

#### Describe the solution
Exclude those harmless special attacks from the difficulty calculation.

#### Describe alternatives you've considered
-Just change the number in the test. Bleh.
-Make the test use a test-specific monster?
-Give the base zombie a -2 difficulty modifier, to bring it back down to 4? (Apparently this doesn't work)

#### Testing
~~Whipped it up to help out a fellow contributor, haven't tested it personally. Reviewers/mergers, please be sure to check it if you get here before I find time for it.~~

Killed a mi-go without these changes, got 68 exp (mi-go had a difficulty of 68).

Killed a mi-go with these changes, got 65 exp. (The difference of 3 instead of 2 is because the value is further modified in the difficulty formula, but this proves that the changes worked as intended)

#### Additional context
This will actually reduce the difficulty of any existing monster which uses PARROT or PARROT_AT_DANGER, but I don't expect any real problems from that. Just noting it as a side effect.