### PR TITLE
Remove flu shots from bathrooms and kitchen tongs from hardware stores

### DIFF
--- a/data/json/itemgroups/Drugs_Tobacco_Alcohol/drugs.json
+++ b/data/json/itemgroups/Drugs_Tobacco_Alcohol/drugs.json
@@ -384,7 +384,7 @@
     "id": "harddrugs",
     "items": [
       { "group": "harddrugs_residential", "prob": 133 },
-      { "item": "flu_shot", "prob": 5 },
+      { "item": "flu_shot", "prob": 5 }
     ]
   },
   {

--- a/data/json/itemgroups/Drugs_Tobacco_Alcohol/drugs.json
+++ b/data/json/itemgroups/Drugs_Tobacco_Alcohol/drugs.json
@@ -359,7 +359,7 @@
   },
   {
     "type": "item_group",
-    "id": "harddrugs",
+    "id": "harddrugs_residential",
     "items": [
       { "item": "inhaler", "prob": 14, "charges": [ 10, 100 ] },
       { "prob": 15, "group": "codeine_bottle_plastic_pill_painkiller_1_10" },
@@ -376,8 +376,15 @@
       { "prob": 3, "group": "antiparasitic_bottle_plastic_pill_prescription_1_10" },
       [ "survnote", 1 ],
       { "prob": 4, "group": "diazepam_bottle_plastic_pill_prescription_1_10" },
-      [ "flu_shot", 5 ],
       [ "syringe", 8 ]
+    ]
+  },
+    {
+    "type": "item_group",
+    "id": "harddrugs",
+    "items": [
+      { "group": "harddrugs_residential", "prob": 133 },
+      { "item": "flu_shot", "prob": 5 },
     ]
   },
   {

--- a/data/json/itemgroups/Drugs_Tobacco_Alcohol/drugs.json
+++ b/data/json/itemgroups/Drugs_Tobacco_Alcohol/drugs.json
@@ -379,13 +379,10 @@
       [ "syringe", 8 ]
     ]
   },
-    {
+  {
     "type": "item_group",
     "id": "harddrugs",
-    "items": [
-      { "group": "harddrugs_residential", "prob": 133 },
-      { "item": "flu_shot", "prob": 5 }
-    ]
+    "items": [ { "group": "harddrugs_residential", "prob": 133 }, { "item": "flu_shot", "prob": 5 } ]
   },
   {
     "type": "item_group",

--- a/data/json/itemgroups/Locations_MapExtras/mansion.json
+++ b/data/json/itemgroups/Locations_MapExtras/mansion.json
@@ -313,7 +313,7 @@
     "id": "dresser_shabby",
     "type": "item_group",
     "subtype": "collection",
-    "groups": [ [ "harddrugs", 10 ], [ "clothing_shabby", 70 ], [ "clothing_shabby", 50 ], [ "clothing_shabby", 40 ] ]
+    "groups": [ [ "harddrugs_residential", 10 ], [ "clothing_shabby", 70 ], [ "clothing_shabby", 50 ], [ "clothing_shabby", 40 ] ]
   },
   {
     "id": "dresser_fancy",
@@ -1325,7 +1325,7 @@
       { "item": "sewing_kit", "prob": 10, "charges": [ 0, -1 ] },
       [ "mag_beauty", 10 ],
       [ "mag_glam", 10 ],
-      { "group": "harddrugs", "prob": 5 },
+      { "harddrugs_residential": "harddrugs", "prob": 5 },
       [ "hairbrush", 30 ],
       [ "comb_pocket", 15 ],
       [ "curler_hair", 10 ],

--- a/data/json/itemgroups/Locations_MapExtras/mansion.json
+++ b/data/json/itemgroups/Locations_MapExtras/mansion.json
@@ -1325,7 +1325,7 @@
       { "item": "sewing_kit", "prob": 10, "charges": [ 0, -1 ] },
       [ "mag_beauty", 10 ],
       [ "mag_glam", 10 ],
-      { "harddrugs_residential": "harddrugs", "prob": 5 },
+      { "group": "harddrugs_residential", "prob": 5 },
       [ "hairbrush", 30 ],
       [ "comb_pocket", 15 ],
       [ "curler_hair", 10 ],

--- a/data/json/itemgroups/collections_domestic.json
+++ b/data/json/itemgroups/collections_domestic.json
@@ -282,7 +282,7 @@
       { "prob": 5, "group": "antihistamine_bottle_plastic_pill_supplement_1_30" },
       { "item": "nyquil", "prob": 5, "charges": [ 1, 5 ] },
       { "group": "mansion_guns", "prob": 3 },
-      { "group": "harddrugs", "prob": 1 },
+      { "group": "harddrugs_residential", "prob": 1 },
       { "group": "wallets", "prob": 10 },
       [ "ankle_wallet_pouch", 1 ],
       [ "joint", 1 ],

--- a/data/json/itemgroups/tools.json
+++ b/data/json/itemgroups/tools.json
@@ -195,7 +195,6 @@
       [ "jerrycan_big", 10 ],
       { "item": "char_smoker", "prob": 5, "charges": [ 0, 300 ] },
       { "item": "dehydrator", "prob": 5 },
-      [ "tongs", 1 ],
       [ "tourist_table", 1 ],
       [ "vac_mold", 10 ],
       [ "polycarbonate_sheet", 50 ],

--- a/data/json/mapgen_palettes/basement.json
+++ b/data/json/mapgen_palettes/basement.json
@@ -180,7 +180,7 @@
       "t": { "item": "SUS_toilet", "chance": 10, "repeat": [ 1, 3 ] },
       "v": [
         { "item": "art", "chance": 5 },
-        { "item": "harddrugs", "chance": 10, "repeat": [ 1, 2 ] },
+        { "item": "harddrugs_residential", "chance": 10, "repeat": [ 1, 2 ] },
         { "item": "maps", "chance": 2 },
         { "item": "guns_pistol_common", "chance": 50, "ammo": 90, "magazine": 100 },
         { "item": "gemstones", "chance": 30, "repeat": [ 1, 2 ] }
@@ -195,7 +195,7 @@
         { "item": "SUS_hair_drawer", "chance": 50 },
         { "item": "SUS_bathroom_cabinet", "chance": 50 },
         { "item": "softdrugs", "chance": 20, "repeat": [ 1, 2 ] },
-        { "item": "harddrugs", "chance": 2 }
+        { "item": "harddrugs_residential", "chance": 2 }
       ],
       "9": { "item": "shower", "chance": 30, "repeat": [ 1, 2 ] },
       "Z": { "item": "laundry", "chance": 100 },
@@ -257,7 +257,7 @@
       "t": { "item": "SUS_toilet", "chance": 10, "repeat": [ 1, 3 ] },
       "v": [
         { "item": "art", "chance": 5 },
-        { "item": "harddrugs", "chance": 10, "repeat": [ 1, 2 ] },
+        { "item": "harddrugs_residential", "chance": 10, "repeat": [ 1, 2 ] },
         { "item": "maps", "chance": 2 },
         { "item": "guns_pistol_common", "chance": 50, "ammo": 90, "magazine": 100 },
         { "item": "gemstones", "chance": 30, "repeat": [ 1, 2 ] }
@@ -272,7 +272,7 @@
         { "item": "SUS_hair_drawer", "chance": 50 },
         { "item": "SUS_bathroom_cabinet", "chance": 50 },
         { "item": "softdrugs", "chance": 20, "repeat": [ 1, 2 ] },
-        { "item": "harddrugs", "chance": 2 }
+        { "item": "harddrugs_residential", "chance": 2 }
       ],
       "9": { "item": "shower", "chance": 30, "repeat": [ 1, 2 ] },
       "Z": { "item": "laundry", "chance": 100 },

--- a/data/json/mapgen_palettes/cabin.json
+++ b/data/json/mapgen_palettes/cabin.json
@@ -147,7 +147,7 @@
         { "item": "SUS_hair_drawer", "chance": 30 },
         { "item": "SUS_bathroom_cabinet", "chance": 30 },
         { "item": "SUS_bathroom_medicine", "chance": 20 },
-        { "item": "harddrugs", "chance": 2 }
+        { "item": "harddrugs_residential", "chance": 2 }
       ],
       "t": { "item": "dining", "chance": 30, "repeat": [ 1, 2 ] },
       "U": { "item": "camping", "chance": 30, "repeat": [ 1, 4 ] },

--- a/data/json/mapgen_palettes/house_general_abandoned.json
+++ b/data/json/mapgen_palettes/house_general_abandoned.json
@@ -192,7 +192,7 @@
       "v": [
         { "item": "art", "chance": 5 },
         { "item": "home_display_case", "chance": 30 },
-        { "item": "harddrugs", "chance": 10, "repeat": [ 1, 2 ] },
+        { "item": "harddrugs_residential", "chance": 10, "repeat": [ 1, 2 ] },
         { "item": "maps", "chance": 2 },
         { "item": "guns_pistol_common", "chance": 50, "ammo": 90, "magazine": 100 },
         { "item": "gemstones", "chance": 30, "repeat": [ 1, 2 ] }
@@ -205,7 +205,7 @@
       "3": [ { "item": "SUS_utensils", "chance": 3 }, { "item": "SUS_knife_drawer", "chance": 3 } ],
       "4": { "item": "SUS_junk_drawer", "chance": 6 },
       "5": { "item": "SUS_kitchen_sink", "chance": 5 },
-      "8": [ { "item": "SUS_bathroom_medicine", "chance": 1 }, { "item": "harddrugs", "chance": 5 } ],
+      "8": [ { "item": "SUS_bathroom_medicine", "chance": 1 }, { "item": "harddrugs_residential", "chance": 5 } ],
       "@": { "item": "bed", "chance": 5 },
       "Z": { "item": "laundry", "chance": 10 },
       "W": { "item": "laundry", "chance": 10 }

--- a/data/json/mapgen_palettes/house_general_palette.json
+++ b/data/json/mapgen_palettes/house_general_palette.json
@@ -250,7 +250,7 @@
         { "item": "art", "chance": 5 },
         { "item": "art_all", "chance": 10 },
         { "item": "home_display_case", "chance": 30 },
-        { "item": "harddrugs", "chance": 10, "repeat": [ 1, 2 ] },
+        { "item": "harddrugs_residential", "chance": 10, "repeat": [ 1, 2 ] },
         { "item": "maps", "chance": 2 },
         { "item": "guns_pistol_common", "chance": 25, "ammo": 90, "magazine": 100 },
         { "item": "gemstones", "chance": 30, "repeat": [ 1, 2 ] }
@@ -307,7 +307,7 @@
         { "item": "SUS_hair_drawer", "chance": 30 },
         { "item": "SUS_bathroom_cabinet", "chance": 30 },
         { "item": "SUS_bathroom_medicine", "chance": 40 },
-        { "item": "harddrugs", "chance": 2 }
+        { "item": "harddrugs_residential", "chance": 2 }
       ],
       "9": { "item": "shower", "chance": 30, "repeat": [ 1, 2 ] },
       "@": { "item": "bed", "chance": 50 },
@@ -627,7 +627,7 @@
         { "item": "SUS_hair_drawer", "chance": 30 },
         { "item": "SUS_bathroom_cabinet", "chance": 30 },
         { "item": "SUS_bathroom_medicine", "chance": 40 },
-        { "item": "harddrugs", "chance": 2 }
+        { "item": "harddrugs_residential", "chance": 2 }
       ],
       "9": { "item": "shower", "chance": 33, "repeat": [ 2, 4 ] },
       "@": [ { "item": "bed", "chance": 50 }, { "item": "laundry", "chance": 20 } ],
@@ -746,7 +746,7 @@
         { "item": "SUS_hair_drawer", "chance": 30 },
         { "item": "SUS_bathroom_cabinet", "chance": 30 },
         { "item": "SUS_bathroom_medicine", "chance": 40 },
-        { "item": "harddrugs", "chance": 2 }
+        { "item": "harddrugs_residential", "chance": 2 }
       ],
       "9": { "item": "shower", "chance": 33, "repeat": [ 2, 4 ] },
       "@": [ { "item": "bed", "chance": 50 }, { "item": "laundry", "chance": 20 } ],

--- a/data/json/mapgen_palettes/house_w_palette.json
+++ b/data/json/mapgen_palettes/house_w_palette.json
@@ -196,7 +196,7 @@
       "j": [
         { "item": "softdrugs", "chance": 45, "repeat": [ 1, 3 ] },
         { "item": "cleaning", "chance": 30, "repeat": [ 1, 2 ] },
-        { "item": "harddrugs", "chance": 5 }
+        { "item": "harddrugs_residential", "chance": 5 }
       ],
       "T": { "item": "shower", "chance": 30, "repeat": [ 1, 2 ] },
       "n": { "item": "SUS_kitchen_sink", "chance": 10, "repeat": [ 1, 2 ] },

--- a/data/json/mapgen_palettes/lodge_palette.json
+++ b/data/json/mapgen_palettes/lodge_palette.json
@@ -131,7 +131,7 @@
         { "item": "SUS_dresser_mens", "chance": 50, "repeat": [ 1, 4 ] },
         { "item": "SUS_dresser_womens", "chance": 50, "repeat": [ 1, 4 ] }
       ],
-      "F": [ { "item": "SUS_fridge", "chance": 35 }, { "item": "harddrugs", "chance": 40, "repeat": [ 1, 3 ] } ],
+      "F": [ { "item": "SUS_fridge", "chance": 35 }, { "item": "harddrugs_residential", "chance": 40, "repeat": [ 1, 3 ] } ],
       "h": { "item": "shower", "chance": 20 },
       "O": { "item": "livingroom", "chance": 20 }
     }

--- a/data/json/mapgen_palettes/lumberyard.json
+++ b/data/json/mapgen_palettes/lumberyard.json
@@ -63,7 +63,7 @@
       "l": { "item": "clothing_work_set", "chance": 40 },
       "L": [ { "item": "hardware", "chance": 35 }, { "item": "mechanics", "chance": 15 } ],
       "r": { "item": "tools_tree_cutting", "chance": 70, "repeat": [ 1, 3 ] },
-      "m": [ { "item": "softdrugs", "chance": 40 }, { "item": "harddrugs", "chance": 40 } ]
+      "m": [ { "item": "softdrugs", "chance": 40 }, { "item": "harddrugs_residential", "chance": 40 } ]
     },
     "item": { "O": { "item": "2x4", "repeat": [ 2, 20 ] }, ",": { "item": "splinter", "chance": 10, "repeat": [ 1, 5 ] } },
     "vendingmachines": { "D": { "item_group": "vending_drink", "lootable": true }, "F": { "item_group": "vending_food", "lootable": true } }

--- a/data/json/mapgen_palettes/nuclear_plant_palette.json
+++ b/data/json/mapgen_palettes/nuclear_plant_palette.json
@@ -145,7 +145,7 @@
         { "item": "rad_gear", "chance": 10, "repeat": [ 1, 2 ] },
         { "item": "used_1st_aid", "chance": 5 },
         { "item": "softdrugs", "chance": 3 },
-        { "item": "harddrugs", "chance": 2 },
+        { "item": "harddrugs_residential", "chance": 2 },
         { "item": "drugs_rare", "chance": 1 }
       ],
       "L": [


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Minor itemgroup weirdness I found on my most freshly made savefile
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Split ``harddrugs`` into the old ID (which should present identically ingame) and ``harddrugs_residential`` which is identical but with the flu shot removed. Replaced the old ID with new ones in all non-medical related mapgen palettes and itemgroups. Which is... all but the hospital itemgroup and the modular lab palettes. Yeah vaccines are now rarer
- Removed the kitchen tongs from hardware stores, they seemed to be there with the old assumption that they were metalworking tongs. Wanted to remove them from sewage groups as well, but those groups seem to include some chemical stuff as well so maybe they fit there?
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- I initially also wanted to get rid of raw lobster chunks laying on campground tables without any plates or anything like that but that's a more complex issue than what I'm willing to tackle right now. Odds are campgrounds might be too trigger happy with what itemgroups they use? Because the itemgroups seem to make sense
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I also should look at what the hell is going on in some zombie drops. Ain't nobody carrying an autoclave or an industrial compressor on their back.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
