### PR TITLE
Prevent crash from -1 array idx when searching zones

### DIFF
--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -134,9 +134,13 @@ void uilist_impl::draw_controls()
 
     if( parent.desc_enabled ) {
         ImGui::Separator();
-        cataimgui::draw_colored_text( parent.footer_text.empty() ?
-                                      parent.entries[parent.selected].desc.c_str()
-                                      : parent.footer_text.c_str() );
+        std::string description;
+        if( !parent.footer_text.empty() ) {
+            description = parent.footer_text;
+        } else if( parent.selected >= -1 ) {
+            description = parent.entries[parent.selected].desc;
+        }
+        cataimgui::draw_colored_text( description );
     }
 }
 


### PR DESCRIPTION


<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Prevent crash from -1 array idx when searching zones"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Prevents a crash when searching for zones to add, but the search yields no results. Fixes #75738 .

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Previous crash being fixed:
```
Thread 1 "cataclysm-tiles" received signal SIGABRT, Aborted.
__pthread_kill_implementation (threadid=<optimized out>, signo=signo@entry=6, no_tid=no_tid@entry=0) at ./nptl/pthread_kill.c:44

(gdb) bt
#0  __pthread_kill_implementation (threadid=<optimized out>, signo=signo@entry=6, no_tid=no_tid@entry=0) at ./nptl/pthread_kill.c:44
#1  0x00007ffff787840f in __pthread_kill_internal (signo=6, threadid=<optimized out>) at ./nptl/pthread_kill.c:78
#2  0x00007ffff78294f2 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#3  0x00007ffff78124ed in __GI_abort () at ./stdlib/abort.c:79
#4  0x00007ffff7ad501e in std::__glibcxx_assert_fail(char const*, int, char const*, char const*) () from /lib/x86_64-linux-gnu/libstdc++.so.6
#5  0x0000555555de2639 in std::vector<uilist_entry, std::allocator<uilist_entry> >::operator[] (this=<optimized out>, __n=<optimized out>) at /usr/include/c++/14/bits/stl_vector.h:1130
#6  std::vector<uilist_entry, std::allocator<uilist_entry> >::operator[] (this=<optimized out>, __n=<optimized out>) at /usr/include/c++/14/bits/stl_vector.h:1128
#7  0x000055555699deac in uilist_impl::draw_controls (this=0x555599a181d0) at src/ui.cpp:138
#8  0x0000555555b7c312 in cataimgui::window::draw (this=0x555599a181d0) at src/cata_imgui.cpp:631
#9  cataimgui::window::draw (this=0x555599a181d0) at src/cata_imgui.cpp:600
#10 0x00005555569a2b1c in ui_adaptor::redraw_invalidated () at src/ui_manager.cpp:440
#11 0x00005555569a2bd9 in ui_adaptor::redraw () at src/ui_manager.cpp:345
#12 0x00005555569a2c00 in ui_manager::redraw () at src/ui_manager.cpp:508
#13 0x000055555699bfa4 in uilist::inputfilter (this=this@entry=0x7fffffffb9c8) at src/ui.cpp:531
#14 0x000055555699ead4 in uilist::query (this=this@entry=0x7fffffffb9c8, loop=loop@entry=true, timeout=timeout@entry=-1, allow_unfiltered_hotkeys=allow_unfiltered_hotkeys@entry=false) at src/ui.cpp:865
#15 0x0000555555c610d4 in zone_manager::query_type (this=this@entry=0x555557274060 <zone_manager::get_manager()::manager>, personal=personal@entry=false) at src/clzones.cpp:621
#16 0x0000555555ef3894 in game::zones_manager (this=this@entry=0x555558291db0) at src/game.cpp:6944
#17 0x0000555555f5d279 in game::do_regular_action (this=this@entry=0x555558291db0, act=@0x7fffffffcfec: ACTION_ZONES, player_character=..., mouse_target=std::optional [no contained value]) at src/handle_action.cpp:2438
#18 0x0000555555f60769 in game::handle_action (this=0x555558291db0) at src/handle_action.cpp:3172
#19 0x0000555555dcf14d in do_turn () at src/do_turn.cpp:579
#20 0x00005555557a1217 in main (argc=<optimized out>, argv=<optimized out>) at src/main.cpp:873
```

gdb shows that `parent.selected` was negative:
```
(gdb) frame 7
138                                           parent.entries[parent.selected].desc.c_str()
(gdb) print parent.selected
$1 = -1
(gdb) print parent.entries.size()
$2 = 63
```
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

* Could also check for whether `selected < entries.size()`, but other code handling the entries does not seem to do that anyway.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

* Can no longer reproduce the crash in #75738 .
* Also verified that uilists that use `footer_text` still works, such as the timepicker for "start of cataclysm" when creating a new char.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
