### PR TITLE
fix wont_hit_friend causing segfault

### DIFF
--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2712,6 +2712,10 @@ int npc::confident_throw_range( const item &thrown, Creature *target ) const
 // Index defaults to -1, i.e., wielded weapon
 bool npc::wont_hit_friend( const tripoint &tar, const item &it, bool throwing ) const
 {
+    if( !throwing && it.is_gun() && it.empty() ) {
+        return true;    // Prevent calling nullptr ammo_data
+    }
+
     if( throwing && rl_dist( pos(), tar ) == 1 ) {
         return true;    // If we're *really* sure that our aim is dead-on
     }


### PR DESCRIPTION
#### Summary
Bugfixes "`npc::wont_hit_friend` causing segfault"

#### Purpose of change
Fix https://github.com/CleverRaven/Cataclysm-DDA/issues/75707

#### Describe the solution
Prevent calling nullptr ammo_data.

#### Describe alternatives you've considered

#### Testing
Bandit firing a crossbow no longer causes segfault.

#### Additional context