### PR TITLE
Allow cephalopods to gain the ability to eat, sleep underwater

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -8958,9 +8958,9 @@
     "points": 1,
     "vitamin_cost": 60,
     "description": "Falling asleep underwater is easy for you, and you spend less time asleep when you rest there.  You can also eat underwater, though you can't drink.",
-    "prereqs": [ "SEESLEEP", "FROG_EYES" ],
-    "category": [ "FISH", "BATRACHIAN" ],
-    "threshreq": [ "THRESH_FISH", "THRESH_BATRACHIAN" ]
+    "prereqs": [ "SEESLEEP", "FROG_EYES", "GILLS_CEPH" ],
+    "category": [ "FISH", "BATRACHIAN", "CEPHALOPOD" ],
+    "threshreq": [ "THRESH_FISH", "THRESH_BATRACHIAN", "THRESH_CEPHALOPOD" ]
   },
   {
     "type": "mutation",


### PR DESCRIPTION
#### Summary
Features "Allow cephalopods to gain the ability to eat, sleep underwater"

#### Purpose of change

I thought it was strange that fish mutants and frog mutants could eat underwater but a cephalopod mutant could not. I didn't really care about sleeping.

#### Describe the solution

This modifies the Aqueos Sleeper trait to also be in the Cephalopod mutation tree, requiring the threshold and the Cephalopod Gills mutation.

#### Describe alternatives you've considered

I considered requiring the Cephalopod Eyes mutation instead. I don't understand why this mutation requires the eye mutations and not the breathing underwater mutations.

#### Testing

I tested loading a game to make sure there were no JSON errors.
I tested using the debug menu to grant the mutation to a character with the THRESH_CEPHALOPOD and GILLS_CEPH mutations.

#### Additional context

If merged, will data/mods/extra_mut_scen/mutation_scenarios.json need to be updated as well?