### PR TITLE
Enchantments can affect monster luminance

### DIFF
--- a/doc/MAGIC.md
+++ b/doc/MAGIC.md
@@ -957,6 +957,7 @@ Character status value  | Description
 `ARMOR_STAB`            | 
 `REGEN_HP`              | Affects the rate the monster recovers hp.
 `SPEED`                 | Affects the base speed of the monster.
+`LUMINATION`            | Affects monster luminance
 
 ### Enchantment value examples
 

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -508,8 +508,10 @@ void map::generate_lightmap( const int zlev )
             // TODO: [lightmap] Attach natural light brightness to creatures
             // TODO: [lightmap] Allow creatures to have light attacks (i.e.: eyebot)
             // TODO: [lightmap] Allow creatures to have facing and arc lights
-            if( critter.type->luminance > 0 ) {
-                apply_light_source( mp, critter.type->luminance );
+            float critter_luminance = critter.calculate_by_enchantment( critter.type->luminance,
+                                      enchant_vals::mod::LUMINATION, true );
+            if( critter_luminance > 0 ) {
+                apply_light_source( mp, critter_luminance );
             }
         }
     }

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -324,7 +324,8 @@ bool enchantment::is_monster_relevant() const
             pair_values.first == enchant_vals::mod::ARMOR_HEAT ||
             pair_values.first == enchant_vals::mod::ARMOR_STAB ||
             pair_values.first == enchant_vals::mod::REGEN_HP ||
-            pair_values.first == enchant_vals::mod::SPEED ) {
+            pair_values.first == enchant_vals::mod::SPEED ||
+            pair_values.first == enchant_vals::mod::LUMINATION ) {
             return true;
         }
     }
@@ -343,7 +344,8 @@ bool enchantment::is_monster_relevant() const
             pair_values.first == enchant_vals::mod::ARMOR_HEAT ||
             pair_values.first == enchant_vals::mod::ARMOR_STAB ||
             pair_values.first == enchant_vals::mod::REGEN_HP ||
-            pair_values.first == enchant_vals::mod::SPEED ) {
+            pair_values.first == enchant_vals::mod::SPEED ||
+            pair_values.first == enchant_vals::mod::LUMINATION ) {
             return true;
         }
     }


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Another request from discord
#### Describe the solution
LUMINATION enchantment now can affect monsters
#### Testing
```
  {
    "type": "effect_on_condition",
    "id": "EOC_TEST_APPLY_EFFECT",
    "eoc_type": "EVENT",
    "required_event": "character_melee_attacks_monster",
    "effect": [ { "npc_add_effect": "effect_test_test", "duration": 9999 }, { "u_message": "Applied lumination" } ]
  },
  {
    "id": "effect_test_test",
    "type": "effect_type",
    "name": [ "AAAAA" ],
    "desc": [ "AAAAA." ],
    "rating": "good",
    "show_intensity": true,
    "enchantments": [ { "values": [ { "value": "LUMINATION", "add": 40 } ] } ]
  }
```
![image](https://github.com/user-attachments/assets/d8fddcf8-a2e3-4ea2-ab76-1d7040e69bee)
#### Additional context
@Standing-Storm 