### PR TITLE
Added validation of mapgen weight

### DIFF
--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -761,6 +761,14 @@ load_mapgen_function( const JsonObject &jio, const std::string &id_base, const p
                       const point &total )
 {
     dbl_or_var weight = get_dbl_or_var( jio, "weight", false,  1000 );
+    if( weight.min.is_constant() && ( weight.min.constant() < 0 ||
+                                      weight.min.constant() >= 2147483648 ) ) {
+        jio.throw_error_at( "weight", "min value out of bounds (0 - max int)" );
+    }
+    if( weight.pair && weight.max.is_constant() && ( weight.max.constant() < 0 ||
+            weight.max.constant() >= 2147483648 ) ) {
+        jio.throw_error_at( "weight", "max value out of bounds (0 - max int)" );
+    }
 
     if( jio.get_bool( "disabled", false ) ) {
         jio.allow_omitted_members();

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -762,11 +762,11 @@ load_mapgen_function( const JsonObject &jio, const std::string &id_base, const p
 {
     dbl_or_var weight = get_dbl_or_var( jio, "weight", false,  1000 );
     if( weight.min.is_constant() && ( weight.min.constant() < 0 ||
-                                      weight.min.constant() >= 2147483648 ) ) {
+                                      weight.min.constant() >= INT_MAX ) ) {
         jio.throw_error_at( "weight", "min value out of bounds (0 - max int)" );
     }
     if( weight.pair && weight.max.is_constant() && ( weight.max.constant() < 0 ||
-            weight.max.constant() >= 2147483648 ) ) {
+            weight.max.constant() >= INT_MAX ) ) {
         jio.throw_error_at( "weight", "max value out of bounds (0 - max int)" );
     }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #75741, i.e. too high mapgen weights resulting in it being ignored.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add validation of weight parameters when parsing the JSON.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Tackle validation of other JSON parsing. Scope creep...

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Result of loading world created according to the bug report description:
 DEBUG    : Error: Json error: data/mods/desert_region/mapgen/waterbody.json:20:14: <color_white><color_cyan>min value out of bounds (0 - 20,000,000)</color>

    ],
    "//": "Weight should be removed if/when lake_shore and river (or their weights) are unhardcoded",
<color_light_red>    "weight": 100000000000,
</color>
            <color_cyan>▲▲▲</color>
    "object": {
      "fill_ter": "t_mudcrack",
</color>


 FUNCTION : load_game
 FILE     : C:\Cataclysm-DDA\src\main_menu.cpp
 LINE     : 1103
 VERSION  : 0.G-11455-g8bbef0c5d2-dirty

When the offending entry had its weight adjusted no report was produced and the save loaded normally.

Verified that nothing blows up with the 20 million limit (there might have been existing extreme weights).

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
- Note that I don't know WHY it fails. A large double number is converted to an int in the convoluted code mess, and that resulting number isn't > 0. However, preventing such numbers from being used should solve the problem.
- There are lots of other places were weights are use. Consider that to be out of scope.
- It's weird to parse double but then cast the values to int. Don't understand why a double is used at all.
- There are lots of places were int64 are parsed and then cast to ints. Again, that's out of scope.
- Decided on 20 million as the max limit to be reasonably sure you won't accidentally add yet another variant of something and then have things go weird. Note that I don't actually know how the weights are processed, but guess they're tallied up, in which case lots of large weights could push you over the limit. Anyway, 20 million should be more than enough for any real usage (trying to provide a huge number to drown out a base version is really a different issue: there's probably a need to have a way to reduce be base version's weight to 0 for mods). Again, out of scope.
- Encountered the error report in debug.log after the one produced by this PR, but only when the error is reported, not when the game is loaded normally:
13:48:31.401 ERROR : C:\Cataclysm-DDA\src\flexbuffer_json.cpp:347 [error_skipped_members] (json-error)
Json error: data/json/monsters/bird.json:193:17: <color_white><color_cyan>Invalid or misplaced field name "copy-from" in JSON data</color>

    "id": "mon_chickadee_chick",

    "type": "MONSTER",

<color_light_red>    "copy-from": "mon_generic_chick_tiny",
</color>
               <color_cyan>▲▲▲</color>
    "upgrades": { "age_grow": 7, "into": "mon_chickadee" }
  },
</color>
Providing it here in case it might be a genuine error that somehow is suppressed normally. The base assumption is that this is a result of the error report disrupting the parsing somehow, though.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
