### PR TITLE
remove purification tablet from clean water recipe

### DIFF
--- a/data/json/recipes/recipe_food.json
+++ b/data/json/recipes/recipe_food.json
@@ -82,7 +82,7 @@
     "//2": "https://blackblum.com/pages/charcoal-water-filter",
     "//3": "50g of charcoal for 1 liter of water = 12.5g of charcoal per u of water.  1u charcoal weighs 1.04g, so making it 12:1",
     "autolearn": true,
-    "tools": [ [ [ "water_purifier", 14 ], [ "pur_tablets", 1 ], [ "char_purifier", 12 ], [ "char_purifier_clay", 12 ] ] ],
+    "tools": [ [ [ "water_purifier", 14 ], [ "char_purifier", 12 ], [ "char_purifier_clay", 12 ] ] ],
     "components": [ [ [ "water", 1 ] ] ]
   },
   {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
It's impossible to use purification tablets to craft "clean water" nowadays. I noticed about that on [Reddit](https://www.reddit.com/r/cataclysmdda/comments/1ern2at/comment/lhzut87/)

#### Describe the solution
Removed it from "tools"

#### Describe alternatives you've considered
Add some additional recipes for clean water w/ tablets to further clean it? Nah, that's too silly (normal "water" are mostly drinkable now)

#### Testing
Should work.

#### Additional context
Remember folks, boil your water!
