### PR TITLE
Return to always treating hostile NPCs as being dangerous (for 0.I)

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4517,7 +4517,8 @@ void game::mon_info_update( )
                                       p->attitude_to( u ),
                                       npc_dist,
                                       u.controlling_vehicle ) == rule_state::BLACKLISTED ;
-            } else {
+            }
+            if( !need_processing ) {
                 need_processing = npc_dist <= iProxyDist &&
                                   p->get_attitude() == NPCATT_KILL;
             }


### PR DESCRIPTION
#### Summary
Bugfixes "Treat hostile NPCs as unsafe even if your safe mode rules don't match."

#### Purpose of change
See #65513 
After several people digging into this, it looks like the real issue is that if you even as much as initialize a safe mode manager instance by e.g. adding a single empty rule, safe mode will no longer trigger on hostile NPCs.

#### Describe the solution
This adjusts the logic so that the fallback logic of "NPCs are unsafe if they're trying to kill us" is still evaluated even if we have safe mode rules set.

#### Describe alternatives you've considered
There might be some more sophisticated option based on making safe mode more directly aware of NPC hostility, but I'm aiming for a clean bugfix.

#### Testing
I reproduced the issue by spawning a NPC who was kinda angry to start with and then provoking them so they became hostile.
Once they were hostile, safe mode triggered.
I moved away from them and added an empty safe mode rule. (just Add -> Enter)
Once I did this, safe mode no longer triggered.

After my change, I repeated this process and safe mode triggered whether there was a rule in safe mode manager or not.

#### Additional context
Looks like this happened in #43095 attempting to avoid translation overhead.  This restores the previous logic without regressing on that perf change.
Both options are arguably correct, but it seems unlikely that "ignore NPCs that are actively trying to kill me" is ever what you want.