### PR TITLE
[MoM] Check vitamins not powers for concentration breakers 

### DIFF
--- a/data/mods/MindOverMatter/effectoncondition/eoc_misc.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_misc.json
@@ -128,7 +128,7 @@
             { "compare_string": [ "psi_dazed_zap", { "context_val": "effect" } ] },
             { "compare_string": [ "downed", { "context_val": "effect" } ] }
           ]
-        }, 
+        },
         { "math": [ "u_vitamin('vitamin_maintained_powers')", ">=", "1" ] }
       ]
     },

--- a/data/mods/MindOverMatter/effectoncondition/eoc_misc.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_misc.json
@@ -218,7 +218,7 @@
             { "compare_string": [ "effect_psi_null", { "context_val": "effect" } ] },
             { "compare_string": [ "effect_psi_null_unbound", { "context_val": "effect" } ] }
           ]
-        }, 
+        },
         { "math": [ "u_vitamin('vitamin_maintained_powers')", ">=", "1" ] }
       ]
     },

--- a/data/mods/MindOverMatter/effectoncondition/eoc_misc.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_misc.json
@@ -106,30 +106,7 @@
             { "compare_string": [ "psi_stunned", { "context_val": "effect" } ] }
           ]
         },
-        {
-          "or": [
-            { "u_has_effect": "effect_biokin_overcome_pain" },
-            { "u_has_effect": "effect_biokin_climate_control" },
-            { "u_has_effect": "effect_biokin_hammerhand" },
-            { "u_has_effect": "effect_biokin_enhance_mobility" },
-            { "u_has_effect": "effect_clair_night_eyes" },
-            { "u_has_effect": "effect_clair_speed_reader" },
-            { "u_has_effect": "effect_electrokin_hacking_interface" },
-            { "u_has_effect": "effect_electrokin_personal_battery" },
-            { "u_has_effect": "effect_photokin_light_local" },
-            { "u_has_effect": "effect_photokin_light_barrier" },
-            { "u_has_effect": "effect_photokinetic_radio" },
-            { "u_has_effect": "effect_pyrokinetic_fire_tool" },
-            { "u_has_effect": "effect_pyrokinetic_torch_weld" },
-            { "u_has_effect": "effect_pyrokinetic_cloak" },
-            { "u_has_effect": "effect_telekinetic_strength" },
-            { "u_has_effect": "effect_telekinetic_vehicle_lift" },
-            { "u_has_effect": "effect_telekinetic_levitation" },
-            { "u_has_effect": "effect_telepathic_learning_bonus" },
-            { "u_has_effect": "effect_telepathic_morale" },
-            { "u_has_effect": "effect_vita_health" }
-          ]
-        }
+        { "math": [ "u_vitamin('vitamin_maintained_powers')", ">=", "1" ] }
       ]
     },
     "effect": [
@@ -151,31 +128,8 @@
             { "compare_string": [ "psi_dazed_zap", { "context_val": "effect" } ] },
             { "compare_string": [ "downed", { "context_val": "effect" } ] }
           ]
-        },
-        {
-          "or": [
-            { "u_has_effect": "effect_biokin_overcome_pain" },
-            { "u_has_effect": "effect_biokin_climate_control" },
-            { "u_has_effect": "effect_biokin_hammerhand" },
-            { "u_has_effect": "effect_biokin_enhance_mobility" },
-            { "u_has_effect": "effect_clair_night_eyes" },
-            { "u_has_effect": "effect_clair_speed_reader" },
-            { "u_has_effect": "effect_electrokin_hacking_interface" },
-            { "u_has_effect": "effect_electrokin_personal_battery" },
-            { "u_has_effect": "effect_photokin_light_local" },
-            { "u_has_effect": "effect_photokin_light_barrier" },
-            { "u_has_effect": "effect_photokinetic_radio" },
-            { "u_has_effect": "effect_pyrokinetic_fire_tool" },
-            { "u_has_effect": "effect_pyrokinetic_torch_weld" },
-            { "u_has_effect": "effect_pyrokinetic_cloak" },
-            { "u_has_effect": "effect_telekinetic_strength" },
-            { "u_has_effect": "effect_telekinetic_vehicle_lift" },
-            { "u_has_effect": "effect_telekinetic_levitation" },
-            { "u_has_effect": "effect_telepathic_learning_bonus" },
-            { "u_has_effect": "effect_telepathic_morale" },
-            { "u_has_effect": "effect_vita_health" }
-          ]
-        }
+        }, 
+        { "math": [ "u_vitamin('vitamin_maintained_powers')", ">=", "1" ] }
       ]
     },
     "effect": [
@@ -264,31 +218,8 @@
             { "compare_string": [ "effect_psi_null", { "context_val": "effect" } ] },
             { "compare_string": [ "effect_psi_null_unbound", { "context_val": "effect" } ] }
           ]
-        },
-        {
-          "or": [
-            { "u_has_effect": "effect_biokin_overcome_pain" },
-            { "u_has_effect": "effect_biokin_climate_control" },
-            { "u_has_effect": "effect_biokin_hammerhand" },
-            { "u_has_effect": "effect_biokin_enhance_mobility" },
-            { "u_has_effect": "effect_clair_night_eyes" },
-            { "u_has_effect": "effect_clair_speed_reader" },
-            { "u_has_effect": "effect_electrokin_hacking_interface" },
-            { "u_has_effect": "effect_electrokin_personal_battery" },
-            { "u_has_effect": "effect_photokin_light_local" },
-            { "u_has_effect": "effect_photokin_light_barrier" },
-            { "u_has_effect": "effect_photokinetic_radio" },
-            { "u_has_effect": "effect_pyrokinetic_fire_tool" },
-            { "u_has_effect": "effect_pyrokinetic_torch_weld" },
-            { "u_has_effect": "effect_pyrokinetic_cloak" },
-            { "u_has_effect": "effect_telekinetic_strength" },
-            { "u_has_effect": "effect_telekinetic_vehicle_lift" },
-            { "u_has_effect": "effect_telekinetic_levitation" },
-            { "u_has_effect": "effect_telepathic_learning_bonus" },
-            { "u_has_effect": "effect_telepathic_morale" },
-            { "u_has_effect": "effect_vita_health" }
-          ]
-        }
+        }, 
+        { "math": [ "u_vitamin('vitamin_maintained_powers')", ">=", "1" ] }
       ]
     },
     "effect": [ { "run_eocs": [ "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" ] } ]

--- a/data/mods/MindOverMatter/effectoncondition/eoc_on_power_use_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_on_power_use_events.json
@@ -541,13 +541,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_POWER_MAINTENANCE_PLUS_ONE",
-    "condition": {
-      "math": [
-        "u_vitamin('vitamin_maintained_powers')",
-        ">=",
-        "( u_val('intelligence') / 4) + (u_bonus_concentration_powers) + (concentration_trait_bonuses())"
-      ]
-    },
+    "condition": { "math": [ "u_vitamin('vitamin_maintained_powers')", ">=", "concentration_calculations()" ] },
     "effect": [
       {
         "u_message": "It's taking you a lot of concentration to maintain your powers.  You're not sure you'll be able to do it for very long.",
@@ -561,13 +555,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_POWER_MAINTENANCE_MINUS_ONE",
-    "condition": {
-      "math": [
-        "u_vitamin('vitamin_maintained_powers')",
-        "==",
-        "( u_val('intelligence') / 4) + (u_bonus_concentration_powers) + (concentration_trait_bonuses()) + 1"
-      ]
-    },
+    "condition": { "math": [ "u_vitamin('vitamin_maintained_powers')", "==", "concentration_calculations() + 1" ] },
     "effect": [
       { "u_message": "As you stop concentrating, your mind clears a bit.  It's easier to think now.", "type": "good" },
       { "u_lose_effect": "effect_psi_intense_concentration" },
@@ -580,22 +568,9 @@
     "id": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK",
     "condition": {
       "and": [
+        { "math": [ "u_vitamin('vitamin_maintained_powers')", ">", "concentration_calculations()" ] },
         {
-          "math": [
-            "u_vitamin('vitamin_maintained_powers')",
-            ">",
-            "( u_val('intelligence') / 4) + (u_bonus_concentration_powers) + (concentration_trait_bonuses())"
-          ]
-        },
-        {
-          "x_in_y_chance": {
-            "x": {
-              "math": [
-                "((u_vitamin('vitamin_maintained_powers')) / (( u_val('intelligence') / 4) + (u_bonus_concentration_powers) + (concentration_trait_bonuses()))) * 5"
-              ]
-            },
-            "y": 100
-          }
+          "x_in_y_chance": { "x": { "math": [ "(u_vitamin('vitamin_maintained_powers') / max(concentration_calculations(),1)) * 5" ] }, "y": 100 }
         }
       ]
     },
@@ -606,7 +581,7 @@
         "math": [
           "u_vitamin('vitamin_psionic_drain')",
           "+=",
-          "rng( 3,8 ) * (u_vitamin('vitamin_maintained_powers')) / (( u_val('intelligence') / 4) + (u_bonus_concentration_powers) + (concentration_trait_bonuses()))"
+          "rng( 3,8 ) * (u_vitamin('vitamin_maintained_powers')) / concentration_calculations()"
         ]
       },
       {
@@ -691,13 +666,7 @@
     "condition": {
       "and": [
         { "test_eoc": "EOC_CONDITION_SPELLCASTING_FINISH_TRAIT_AND_SCHOOL_LIST" },
-        {
-          "math": [
-            "u_vitamin('vitamin_maintained_powers')",
-            ">=",
-            "( u_val('intelligence') / 4) + u_bonus_concentration_powers + concentration_trait_bonuses()"
-          ]
-        }
+        { "math": [ "u_vitamin('vitamin_maintained_powers')", ">=", "concentration_calculations()" ] }
       ]
     },
     "effect": [ { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" } ]

--- a/data/mods/MindOverMatter/effectoncondition/eoc_on_power_use_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_on_power_use_events.json
@@ -692,7 +692,11 @@
       "and": [
         { "test_eoc": "EOC_CONDITION_SPELLCASTING_FINISH_TRAIT_AND_SCHOOL_LIST" },
         {
-          "math": [ "u_vitamin('vitamin_maintained_powers')", ">=", "( u_val('intelligence') / 4) + (u_bonus_concentration_powers)" ]
+          "math": [
+            "u_vitamin('vitamin_maintained_powers')",
+            ">=",
+            "( u_val('intelligence') / 4) + u_bonus_concentration_powers + concentration_trait_bonuses()"
+          ]
         }
       ]
     },

--- a/data/mods/MindOverMatter/jmath.json
+++ b/data/mods/MindOverMatter/jmath.json
@@ -55,6 +55,12 @@
   },
   {
     "type": "jmath_function",
+    "id": "concentration_calculations",
+    "num_args": 0,
+    "return": "(u_val('intelligence') / 4) + u_bonus_concentration_powers + concentration_trait_bonuses()"
+  },
+  {
+    "type": "jmath_function",
     "id": "contemplation_factor",
     "num_args": 1,
     "//": "This equates to about 500 XP per hour of contemplation when at minimum focus",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Check vitamins not powers for concentration breakers "
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Noticed that for things like being dazed or set on fire, the EoCs were checking a small subset of specific power effects before rolling to maintain concentration. It's better and more comprehensive to check the concentration vitamin directly. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Remove list of powers, check vitamin. 

Also add a jmath statement to handle all concentration checks and bonuses and route the existing EoCs through it for ease of later maintenance.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Ran back and forth. Winded broke concentration sometimes, but not all the time.

Waited with powers above limit. Limit broke eventually, but not immediately.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

A lot  of combat buffs were not being checked for in the concentration breaking EoCs, so getting thrown, slipping, being set on fire, being boomered, etc are going to be much more dangerous now. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
