### PR TITLE
Fix spellcast adjustment not working

### DIFF
--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -975,20 +975,20 @@ int spell::duration( const Creature &caster ) const
 {
     dialogue d( get_talker_for( caster ), nullptr );
     const int leveled_duration = min_leveled_duration( caster );
-    float duration;
-
+    int return_value;
     if( has_flag( spell_flag::RANDOM_DURATION ) ) {
-        return rng( std::min( leveled_duration, static_cast<int>( type->max_duration.evaluate( d ) ) ),
-                    std::max( leveled_duration,
-                              static_cast<int>( type->max_duration.evaluate( d ) ) ) );
+        return_value = rng( std::min( leveled_duration,
+                                      static_cast<int>( type->max_duration.evaluate( d ) ) ),
+                            std::max( leveled_duration,
+                                      static_cast<int>( type->max_duration.evaluate( d ) ) ) );
     } else {
         if( type->max_duration.evaluate( d ) >= type->min_duration.evaluate( d ) ) {
-            return std::min( leveled_duration, static_cast<int>( type->max_duration.evaluate( d ) ) );
+            return_value = std::min( leveled_duration, static_cast<int>( type->max_duration.evaluate( d ) ) );
         } else {
-            return std::max( leveled_duration, static_cast<int>( type->max_duration.evaluate( d ) ) );
+            return_value = std::max( leveled_duration, static_cast<int>( type->max_duration.evaluate( d ) ) );
         }
     }
-    return std::max( duration * temp_duration_multiplyer, 0.0f );
+    return std::max( return_value * temp_duration_multiplyer, 0.0f );
 }
 
 std::string spell::duration_string( const Creature &caster ) const


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Spellcast adjustment didn't apply it's effect
#### Describe the solution
Tweak code so it actually works
#### Testing
```json
  {
    "type": "effect_on_condition",
    "id": "EOC_metamagic_extend",
    "eoc_type": "EVENT",
    "required_event": "opens_spellbook",
    "effect": [
      { "math": [ "u_spellcasting_adjustment('duration', 'flag_blacklist': 'PERMANENT_ALL_LEVELS' )", "=", "10.0" ] },
      { "math": [ "u_spellcasting_adjustment('cost', 'flag_blacklist': 'PERMANENT_ALL_LEVELS' )", "=", "0.5" ] }
    ]
  },
```
with this eoc, all spells always have 10 times bigger duration than before
(i lost the screenshots with in game tests :( )