### PR TITLE
No Summoned Undead corpse

### DIFF
--- a/data/mods/Magiclysm/Spells/animist.json
+++ b/data/mods/Magiclysm/Spells/animist.json
@@ -123,7 +123,7 @@
     "max_range": 3,
     "min_aoe": 2,
     "max_aoe": 2,
-    "flags": [ "SILENT", "NO_EXPLOSION_SFX" ],
+    "flags": [ "SILENT", "NO_EXPLOSION_SFX", "NO_CORPSE_QUIET" ],
     "min_duration": { "math": [ "summoning_proficiency_bonus_calculate(36000, 30)" ] },
     "max_duration": { "math": [ "summoning_proficiency_bonus_calculate(1080000, 30)" ] },
     "duration_increment": { "math": [ "summoning_proficiency_bonus_calculate(36000, 0.034)" ] }
@@ -268,7 +268,7 @@
     "max_range": 3,
     "min_aoe": 2,
     "max_aoe": 2,
-    "flags": [ "SILENT", "NO_EXPLOSION_SFX" ],
+    "flags": [ "SILENT", "NO_EXPLOSION_SFX", "NO_CORPSE_QUIET" ],
     "min_duration": { "math": [ "summoning_proficiency_bonus_calculate(36000, 30)" ] },
     "max_duration": { "math": [ "summoning_proficiency_bonus_calculate(1080000, 30)" ] },
     "duration_increment": { "math": [ "summoning_proficiency_bonus_calculate(36000, 0.034)" ] }


### PR DESCRIPTION
#### Summary
Mods "No Summoned Undead corpse"
#### Purpose of change

Summoned Undead are supposed to be ethereal summons, so them leaving corpses seems to be unintended behaviour.

#### Describe the solution

adds "NO_CORPSE_QUIET" flag to abstract summoned zombies

#### Describe alternatives you've considered

#### Testing

summoned an undead, let it run out, observed no corpse