### PR TITLE
Switch 0.H transifex config to point to the 0.H resource

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[o:cataclysm-dda-translators:p:cataclysm-dda:r:0.H-cataclysm-dda]
+[o:cataclysm-dda-translators:p:cataclysm-dda:r:0h-cataclysm-dda]
 file_filter  = lang/po/<lang>.po
 source_file  = lang/po/cataclysm-dda.pot
 source_lang  = en

--- a/.tx/config
+++ b/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[o:cataclysm-dda-translators:p:cataclysm-dda:r:master-cataclysm-dda]
+[o:cataclysm-dda-translators:p:cataclysm-dda:r:0.H-cataclysm-dda]
 file_filter  = lang/po/<lang>.po
 source_file  = lang/po/cataclysm-dda.pot
 source_lang  = en


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
As part of getting 0.H out the door, we need to update the transifex resource this branch syncs with.
This will do nothing by itself, but I'm working on an update to the translation sync workflows to have 0.H sync properly.
Those workflow updates will live on the master branch, they don't run from the 0.H branch anyway.

#### Describe the solution
Just updates the resource to point to the existing transifex resource for 0.H.