### PR TITLE
[Magiclysm] Signpost a way(denarius) to get to the forge of wonders

### DIFF
--- a/data/mods/Magiclysm/items/currency.json
+++ b/data/mods/Magiclysm/items/currency.json
@@ -13,6 +13,44 @@
     "color": "light_gray",
     "symbol": "$",
     "flags": [ "COIN_SHAPED" ],
-    "material": [ "mithril_metal" ]
+    "material": [ "mithril_metal" ],
+    "use_action": {
+      "type": "effect_on_conditions",
+      "description": "Further deface the coin",
+      "effect_on_conditions": [
+        {
+          "id": "EOC_REVEAL_ROUTE_TO_FORGE_OF_WONDERS",
+          "//": "We must start our search from a road, otherwise the route reveal will fail. For whatever reason.",
+          "condition": { "u_near_om_location": "road" },
+          "effect": [
+            {
+              "u_location_variable": { "context_val": "forge_location" },
+              "target_params": { "om_terrain": "forge_3B", "search_range": 2000, "z": 0 }
+            },
+            { "reveal_map": { "context_val": "forge_location" }, "radius": 4 },
+            {
+              "u_location_variable": { "context_val": "current_location_nearest_road" },
+              "target_params": { "om_terrain": "road", "search_range": 3, "z": 0 }
+            },
+            {
+              "u_message": "You scratch your nails against the coin like so many before you, and feel Valzain's tears.  He longingly cries for somewhere that is not here, and now you know where.",
+              "type": "good"
+            },
+            {
+              "reveal_route": { "context_val": "current_location_nearest_road" },
+              "target_var": { "context_val": "forge_location" },
+              "radius": 0,
+              "road_only": false
+            }
+          ],
+          "false_effect": [
+            {
+              "u_message": "You rub the scratches on the coin, but leave no mark.  Oh, would-be traveller, how can you wear upon his visage like the wagon wheels upon the roads?",
+              "type": "mixed"
+            }
+          ]
+        }
+      ]
+    }
   }
 ]


### PR DESCRIPTION
#### Summary
Content "Signpost a way(denarius) to get to the forge of wonders"

#### Purpose of change
The forge of wonders was made globally unique, but there's still no way to reliably find it.

#### Describe the solution
Thanks to Guardian's work to expose this the reveal and reveal route functions to EOCs, we can just write an EOC for it.

#### Describe alternatives you've considered
My original iteration had it firing on game start with this message:
`{ "u_message": "When the troubles began, you felt something… new.  You're not sure what it is, but you're sure you know how to get there.  Somehow.", "type": "mixed" },`

#### Testing
Works properly when used on the roads, gives ~~magical~~ prose hints when not on the roads as desired.

#### Additional context
Will not function properly without #75836 due to oter id matching (there is no *spawned* terrain with the id of `road`, it always spawns with a connection suffix)
