### PR TITLE
format `uilist` menu entries with a table

### DIFF
--- a/src/ui.h
+++ b/src/ui.h
@@ -460,6 +460,9 @@ class uilist // NOLINT(cata-xy)
     private:
         ImVec2 calculated_menu_size;
         cataimgui::bounds calculated_bounds;
+        float calculated_hotkey_width;
+        float calculated_label_width;
+        float calculated_secondary_width;
         float extra_space_left;
         float extra_space_right;
         std::vector<int> fentries;


### PR DESCRIPTION
#### Summary
Interface "format `uilist` menu entries with a table"

#### Purpose of change
This gets us better horizontal alignment of the menu entries if we ever move to a variable–width font. It also allows us to include the second label as its own column, which is currently only used by the butchery menu.

#### Testing
Butcher a corpse and check that the second column lists the duration of each possible butchery task.

#### Additional context
Fixes #75813 and #75680

![Screenshot from 2024-08-20 07-29-33](https://github.com/user-attachments/assets/0c32261f-593b-456a-ae34-9838219d06a9)

