### PR TITLE
Fewer submap inbounds checks by using `_ib` coords

### DIFF
--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -668,7 +668,8 @@ void editmap::draw_main_ui_overlay()
             std::map<tripoint_bub_ms, std::tuple<mtype_id, int, bool, Creature::Attitude>> spawns;
             for( int x = 0; x < 2; x++ ) {
                 for( int y = 0; y < 2; y++ ) {
-                    submap *sm = tmpmap.get_submap_at_grid( { x, y, target.z()} );
+                    const tripoint_bub_sm_ib submap_pos{ x, y, target.z() };
+                    submap *sm = tmpmap.get_submap_at_grid( submap_pos );
                     if( sm ) {
                         const tripoint_bub_ms sm_origin = origin_p + tripoint( x * SEEX, y * SEEY, target.z() );
                         for( const spawn_point &sp : sm->spawns ) {
@@ -1879,7 +1880,7 @@ void editmap::mapgen_preview( const real_coords &tc, uilist &gmenu )
         } else if( gpmenu.ret == 1 ) {
             tmpmap.rotate( 1 );
         } else if( gpmenu.ret == 2 ) {
-            const point_rel_sm target_sub( target.x() / SEEX, target.y() / SEEY );
+            const point_bub_sm target_sub( target.x() / SEEX, target.y() / SEEY );
 
             here.set_transparency_cache_dirty( target.z() );
             here.set_outside_cache_dirty( target.z() );
@@ -1894,8 +1895,8 @@ void editmap::mapgen_preview( const real_coords &tc, uilist &gmenu )
                     for( int z = -OVERMAP_DEPTH; z <= OVERMAP_HEIGHT; z++ ) {
                         // Apply previewed mapgen to map. Since this is a function for testing, we try avoid triggering
                         // functions that would alter the results
-                        const tripoint_rel_sm dest_pos = target_sub + tripoint( x, y, z );
-                        const tripoint_rel_sm src_pos = tripoint_rel_sm{ x, y, z };
+                        const tripoint_bub_sm dest_pos = target_sub + tripoint( x, y, z );
+                        const tripoint_bub_sm_ib src_pos = tripoint_bub_sm_ib{ x, y, z };
 
                         submap *destsm = here.get_submap_at_grid( dest_pos );
                         submap *srcsm = tmpmap.get_submap_at_grid( src_pos );
@@ -1921,7 +1922,7 @@ void editmap::mapgen_preview( const real_coords &tc, uilist &gmenu )
             // Since we cleared the vehicle cache of the whole z-level (not just the generate map), we add it back here
             for( int x = 0; x < here.getmapsize(); x++ ) {
                 for( int y = 0; y < here.getmapsize(); y++ ) {
-                    const tripoint_rel_sm dest_pos = tripoint_rel_sm( x, y, target.z() );
+                    const tripoint_bub_sm_ib dest_pos = tripoint_bub_sm_ib( x, y, target.z() );
                     const submap *destsm = here.get_submap_at_grid( dest_pos );
                     if( destsm == nullptr ) {
                         debugmsg( "Tried to update vehicle cache at (%d,%d,%d) but the submap is not loaded", dest_pos.x(),
@@ -1968,7 +1969,8 @@ vehicle *editmap::mapgen_veh_query( const tripoint_abs_omt &omt_tgt )
     std::vector<vehicle *> possible_vehicles;
     for( int x = 0; x < 2; x++ ) {
         for( int y = 0; y < 2; y++ ) {
-            submap *destsm = target_bay.get_submap_at_grid( { x, y, target.z()} );
+            const tripoint_bub_sm_ib submap_pos{ x, y, target.z() };
+            submap *destsm = target_bay.get_submap_at_grid( submap_pos );
             if( destsm == nullptr ) {
                 debugmsg( "Tried to get vehicles at (%d,%d,%d) but the submap is not loaded", x, y, target.z() );
                 continue;
@@ -2005,7 +2007,8 @@ bool editmap::mapgen_veh_destroy( const tripoint_abs_omt &omt_tgt, vehicle *car_
     target_bay.load( omt_tgt, false );
     for( int x = 0; x < 2; x++ ) {
         for( int y = 0; y < 2; y++ ) {
-            submap *destsm = target_bay.get_submap_at_grid( { x, y, target.z()} );
+            const tripoint_bub_sm_ib submap_pos{ x, y, target.z() };
+            submap *destsm = target_bay.get_submap_at_grid( submap_pos );
             if( destsm == nullptr ) {
                 debugmsg( "Tried to destroy vehicle at (%d,%d,%d) but the submap is not loaded", x, y, target.z() );
                 continue;

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -114,7 +114,8 @@ bool map::build_transparency_cache( const int zlev )
     // Traverse the submaps in order
     for( int smx = 0; smx < my_MAPSIZE; ++smx ) {
         for( int smy = 0; smy < my_MAPSIZE; ++smy ) {
-            const submap *cur_submap = get_submap_at_grid( {smx, smy, zlev} );
+            const tripoint_bub_sm_ib submap_pos{ smx, smy, zlev };
+            const submap *cur_submap = get_submap_at_grid( submap_pos );
             if( cur_submap == nullptr ) {
                 debugmsg( "Tried to build transparency cache at (%d,%d,%d) but the submap is not loaded", smx, smy,
                           zlev );
@@ -435,7 +436,8 @@ void map::generate_lightmap( const int zlev )
     // Traverse the submaps in order
     for( int smx = 0; smx < my_MAPSIZE; ++smx ) {
         for( int smy = 0; smy < my_MAPSIZE; ++smy ) {
-            const submap *cur_submap = get_submap_at_grid( { smx, smy, zlev } );
+            const tripoint_bub_sm_ib submap_pos{ smx, smy, zlev };
+            const submap *cur_submap = get_submap_at_grid( submap_pos );
             if( cur_submap == nullptr ) {
                 debugmsg( "Tried to generate lightmap at (%d,%d,%d) but the submap is not loaded", smx, smy, zlev );
                 continue;

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -169,7 +169,8 @@ void map::process_fields()
         for( int x = 0; x < my_MAPSIZE; x++ ) {
             for( int y = 0; y < my_MAPSIZE; y++ ) {
                 if( field_cache[ x + y * MAPSIZE ] ) {
-                    submap *const current_submap = get_submap_at_grid( { x, y, z } );
+                    const tripoint_bub_sm_ib submap_pos{ x, y, z };
+                    submap *const current_submap = get_submap_at_grid( submap_pos );
                     if( current_submap == nullptr ) {
                         debugmsg( "Tried to process field at (%d,%d,%d) but the submap is not loaded", x, y, z );
                         continue;

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -150,12 +150,13 @@ void map::check_submap_active_item_consistency()
     for( int z = -OVERMAP_DEPTH; z < OVERMAP_HEIGHT; ++z ) {
         for( int x = 0; x < MAPSIZE; ++x ) {
             for( int y = 0; y < MAPSIZE; ++y ) {
-                tripoint_rel_sm p( x, y, z );
+                const tripoint_bub_sm p( x, y, z );
+                const tripoint_abs_sm p_abs = p.raw() + abs_sub.xy();
                 submap *s = get_submap_at_grid( p );
                 REQUIRE( s != nullptr );
                 bool submap_has_active_items = !s->active_items.empty();
-                bool cache_has_active_items = submaps_with_active_items.count( p + abs_sub.xy() ) != 0;
-                CAPTURE( abs_sub.xy(), p, p + abs_sub.xy() );
+                bool cache_has_active_items = submaps_with_active_items.count( p_abs ) != 0;
+                CAPTURE( abs_sub.xy(), p, p_abs );
                 CHECK( submap_has_active_items == cache_has_active_items );
             }
         }


### PR DESCRIPTION

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Performance "Fewer submap inbounds checks by using _ib coords"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Improve performance by removing inbounds-checks when we have already checked before that a point is inbound.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

The main intention of this commit is to remove the inbounds check from `map::get_nonant` by forcing the caller to supply an already-inbounds-checked tripoint using an `_ib` type. But in order to do that, two other changes are required (in this commit):

1. Change submap coordinates from `tripoint_rel_sm`->`tripoint_bub_sm`.
2. Update calls to `get_submap_at_grid` to specify whether the point is already inbounds-checked or not.

These two changes are described below:

#### 1. Change to `tripoint_bub_sm`

So, we want to use one of the `_ib` types.

Coordinates to specify a position for a submap used `tripoint_rel_sm` before this commit. But `_rel_sm` has no inbounds `_ib` type. It shouldn't. Saying that a relative coordinate is inbounds doesn't make sense - it only makes sense if we also specify another point to where it is relative to. One such point is the bubble reference.

This commit therefore changes coordinates that specify a submap so that they instead use `tripoint_bub_sm`. This is in fact a stronger statement about the coordinate type - now we're saying that the coordinate is relative to the bubble. Before, when using `tripoint_rel_sm`, the type did not explicitly state what it was relative to (but before, it was always implicitly relative to the bubble anyway).

`_bub_sm` also has an `_ib` type, so this commit uses `tripoint_bub_sm_ib` to specify coordinates for submaps where we've already inbounds-checked it before.

#### 2. Update calls to `get_submap_at_grid`

The method `get_submap_at_grid` takes a submap coordinate and returns the submap. In some of the places where we call this method, we can be sure that the point is in fact inbounds, for example:

* When having called `inbounds()` just before, such as in `map::get_submap_at( const tripoint & )`: https://github.com/CleverRaven/Cataclysm-DDA/blob/a0579c0134dccd83ea91792b6989dd95edf10492/src/map.h#L2369-L2372

* When iterating xy between `0` and `my_MAPSIZE`, for example `map::generate` : https://github.com/CleverRaven/Cataclysm-DDA/blob/a0579c0134dccd83ea91792b6989dd95edf10492/src/mapgen.cpp#L236-L239

This commit therefore updates the places where it is obvious that the point is already bounds-checked so that `get_submap_at_grid` or `get_nonant` is called with `tripoint_bub_sm_ib` (inbound).

The other overloaded version of `get_submap_at_grid` that takes `tripoint_bub_sm` still does inbounds checking.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

More ideas (not implemented in this branch):
* We could add a method `bool map::inbounds(tripoint_bub_NN p, tripoint_bub_NN_ib &p_ib)` that assigns to `p_ib` if the point is in fact inbounds. That way, we could guard creation of inbound coords so that it's only the map itself that may create them.
* Iteration of all submaps is currently done like `for( int x = 0; x < getmapsize(); x++ )` . Instead, we could change this to a map method that returns `tripoint_range<>` of inbound coords with some `_ib` type. This could guard creation of inbound coords closer to the map's responsibility.
* In some places we use `const` points as parameters, and in some places we use `const &` references as parameters. I think I read on some other PR what these tripoints are so small that they'd fit in a single register so that it would actually be preferable to *not* use references? Specifically, should it be `get_nonant( const tripoint_bub_sm_ib &gridp )` (with reference) or `get_nonant( const tripoint_bub_sm_ib gridp )` (without reference)?
* This commit also prepares us for making similar changes for mapsquare coords (`tripoint_bub_ms_ib`) and not only submaps (`tripoint_bub_sm_ib`) if we want.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

* Have played on this branch using my savegame for at least 2 hours, including exploring new areas, combat and base management. Works. ✓
* Have explicitly tested map editing since some of the changed files were about that. Works. ✓

I honestly expected a larger performance increase from this, but I guess the most benefit will be for mapsquare `bub_ms` coords (later).

Before:
![before](https://github.com/user-attachments/assets/12789840-8b17-477d-85b0-1cc04ac26b21)

After:
![after](https://github.com/user-attachments/assets/2cc0ee4a-9422-4bad-a2ba-ee864b66ff52)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

It's important that we verify that all compilers and all tests pass before merging this.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
