### PR TITLE
workaround for "inaccurate" healing quality

### DIFF
--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -1270,7 +1270,7 @@ bodypart_id Character::body_window( const std::string &menu_header,
         }
 
         // BANDAGE block
-        if( e.allowed && ( new_b_power > 0 || b_power > 0 ) ) {
+        if( e.allowed && ( new_b_power > 1 || b_power > 1 ) ) {
             desc += string_format( _( "Bandaged: %s" ), texitify_healing_power( b_power ) );
             if( new_b_power > 0 ) {
                 desc += string_format( " -> %s", texitify_healing_power( new_b_power ) );
@@ -1286,7 +1286,7 @@ bodypart_id Character::body_window( const std::string &menu_header,
         }
 
         // DISINFECTANT block
-        if( e.allowed && ( d_power > 0 || new_d_power > 0 ) ) {
+        if( e.allowed && ( d_power > 1 || new_d_power > 1 ) ) {
             desc += string_format( _( "Disinfected: %s" ), texitify_healing_power( d_power ) );
             if( new_d_power > 0 ) {
                 desc += string_format( " -> %s",  texitify_healing_power( new_d_power ) );

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -1199,9 +1199,9 @@ bodypart_id Character::body_window( const std::string &menu_header,
         bool bitten = has_effect( effect_bite, bp.id() );
         bool infected = has_effect( effect_infected, bp.id() );
         bool bandaged = has_effect( effect_bandaged, bp.id() );
-        const int b_power = get_effect_int( effect_bandaged, bp );
-        const int d_power = get_effect_int( effect_disinfected, bp );
-        int new_b_power = static_cast<int>( std::floor( bandage_power ) );
+        const int b_power = get_effect_int( effect_bandaged, bp ) + 1;
+        const int d_power = get_effect_int( effect_disinfected, bp ) + 1;
+        int new_b_power = static_cast<int>( std::floor( bandage_power ) + 1 );
         if( bandaged ) {
             const effect &eff = get_effect( effect_bandaged, bp );
             if( new_b_power > eff.get_max_intensity() ) {
@@ -1209,7 +1209,7 @@ bodypart_id Character::body_window( const std::string &menu_header,
             }
 
         }
-        int new_d_power = static_cast<int>( std::floor( disinfectant_power ) );
+        int new_d_power = static_cast<int>( std::floor( disinfectant_power ) + 1 );
 
         const auto &aligned_name = std::string( max_bp_name_len - utf8_width( e.name ), ' ' ) + e.name;
         std::string hp_str;

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -1199,8 +1199,8 @@ bodypart_id Character::body_window( const std::string &menu_header,
         bool bitten = has_effect( effect_bite, bp.id() );
         bool infected = has_effect( effect_infected, bp.id() );
         bool bandaged = has_effect( effect_bandaged, bp.id() );
-        const int b_power = get_effect_int( effect_bandaged, bp ) + 1;
-        const int d_power = get_effect_int( effect_disinfected, bp ) + 1;
+        const int b_power = get_effect_int( effect_bandaged, bp );
+        const int d_power = get_effect_int( effect_disinfected, bp );
         int new_b_power = static_cast<int>( std::floor( bandage_power ) + 1 );
         if( bandaged ) {
             const effect &eff = get_effect( effect_bandaged, bp );
@@ -1270,9 +1270,9 @@ bodypart_id Character::body_window( const std::string &menu_header,
         }
 
         // BANDAGE block
-        if( e.allowed && ( new_b_power > 1 || b_power > 1 ) ) {
+        if( e.allowed && ( new_b_power > 1 || b_power > 0 ) ) {
             desc += string_format( _( "Bandaged: %s" ), texitify_healing_power( b_power ) );
-            if( new_b_power > 0 ) {
+            if( new_b_power > 1 ) {
                 desc += string_format( " -> %s", texitify_healing_power( new_b_power ) );
                 if( new_b_power <= b_power ) {
                     desc += _( " (no improvement)" );
@@ -1286,9 +1286,9 @@ bodypart_id Character::body_window( const std::string &menu_header,
         }
 
         // DISINFECTANT block
-        if( e.allowed && ( d_power > 1 || new_d_power > 1 ) ) {
+        if( e.allowed && ( d_power > 0 || new_d_power > 1 ) ) {
             desc += string_format( _( "Disinfected: %s" ), texitify_healing_power( d_power ) );
-            if( new_d_power > 0 ) {
+            if( new_d_power > 1 ) {
                 desc += string_format( " -> %s",  texitify_healing_power( new_d_power ) );
                 if( new_d_power <= d_power ) {
                     desc += _( " (no improvement)" );

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -3719,19 +3719,19 @@ void heal_actor::info( const item &, std::vector<iteminfo> &dump ) const
 
     if( bandages_power > 0 ) {
         dump.emplace_back( "HEAL", _( "Base bandaging quality: " ),
-                           texitify_base_healing_power( static_cast<int>( bandages_power ) ) );
+                           texitify_base_healing_power( static_cast<int>( bandages_power ) + 1 ) );
         if( g != nullptr ) {
             dump.emplace_back( "HEAL", _( "Actual bandaging quality: " ),
-                               texitify_healing_power( get_bandaged_level( player_character ) ) );
+                               texitify_healing_power( get_bandaged_level( player_character ) + 1 ) );
         }
     }
 
     if( disinfectant_power > 0 ) {
         dump.emplace_back( "HEAL", _( "Base disinfecting quality: " ),
-                           texitify_base_healing_power( static_cast<int>( disinfectant_power ) ) );
+                           texitify_base_healing_power( static_cast<int>( disinfectant_power ) + 1 ) );
         if( g != nullptr ) {
             dump.emplace_back( "HEAL", _( "Actual disinfecting quality: " ),
-                               texitify_healing_power( get_disinfected_level( player_character ) ) );
+                               texitify_healing_power( get_disinfected_level( player_character ) + 1 ) );
         }
     }
     if( bleed > 0 ) {

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -3719,7 +3719,7 @@ void heal_actor::info( const item &, std::vector<iteminfo> &dump ) const
 
     if( bandages_power > 0 ) {
         dump.emplace_back( "HEAL", _( "Base bandaging quality: " ),
-                           texitify_base_healing_power( static_cast<int>( bandages_power ) + 1 ) );
+                           texitify_base_healing_power( static_cast<int>( bandages_power ) ) );
         if( g != nullptr ) {
             dump.emplace_back( "HEAL", _( "Actual bandaging quality: " ),
                                texitify_healing_power( get_bandaged_level( player_character ) + 1 ) );
@@ -3728,7 +3728,7 @@ void heal_actor::info( const item &, std::vector<iteminfo> &dump ) const
 
     if( disinfectant_power > 0 ) {
         dump.emplace_back( "HEAL", _( "Base disinfecting quality: " ),
-                           texitify_base_healing_power( static_cast<int>( disinfectant_power ) + 1 ) );
+                           texitify_base_healing_power( static_cast<int>( disinfectant_power ) ) );
         if( g != nullptr ) {
             dump.emplace_back( "HEAL", _( "Actual disinfecting quality: " ),
                                texitify_healing_power( get_disinfected_level( player_character ) + 1 ) );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fixes #75736 
Every time the survivor bandages, the effect's intensity is added by 1, leading to the issue above.

#### Describe the solution
Worked around the problem by making it print out the same as when the char bandages

#### Describe alternatives you've considered
I could try and prevent it from adding intensity by 1, but then I realize it's also the same in stims (e.g. black coffee's 12 stim in the JSON gives the player "Stimulants [13]" effect). Even more so, the "issue" appears way back in 0.G. The DDA src rabbit hole is so huge.

#### Testing
~~Will try and compile it later on, but just let the tests do its job first.~~
Char with 3 Health Care + Wound Care
![image](https://github.com/user-attachments/assets/7320f95d-2ac5-449e-82c2-3b25bf2ec936)
![image](https://github.com/user-attachments/assets/f2fdcbfb-f950-4267-9182-2512e0e64991)


#### Additional context
Yeah yeah I'll compile
