### PR TITLE
Fix android build

### DIFF
--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -795,10 +795,7 @@ shared_ptr_fast<uilist_impl> uilist::create_or_get_ui()
 void uilist::query( bool loop, int timeout, bool allow_unfiltered_hotkeys )
 {
 #if defined(__ANDROID__)
-    bool auto_pos = w_x_setup.fun == nullptr && w_y_setup.fun == nullptr &&
-                    w_width_setup.fun == nullptr && w_height_setup.fun == nullptr;
-
-    if( get_option<bool>( "ANDROID_NATIVE_UI" ) && !entries.empty() && auto_pos ) {
+    if( get_option<bool>( "ANDROID_NATIVE_UI" ) && !entries.empty() && !desired_bounds ) {
         if( !started ) {
             calc_data();
             started = true;


### PR DESCRIPTION
#### Summary
Bugfixes "Fix android build"

#### Purpose of change

Fixes #75843

#### Describe the solution

#74341 changed some stuff around menu bounds but didn't adjust the android specific code, cause we still have nothing that actually checks that.
These are the build errors this is aiming to fix. All these variables were removed and replaced by `desired_bounds` as far as I can see. So now it just checks if there's any value in the std::optional.
```
  /home/runner/work/Cataclysm-DDA/Cataclysm-DDA/android/app/jni/src/../../../../src/ui.cpp:798:21: error: use of undeclared identifier 'w_x_setup'
      bool auto_pos = w_x_setup.fun == nullptr && w_y_setup.fun == nullptr &&
                      ^
  /home/runner/work/Cataclysm-DDA/Cataclysm-DDA/android/app/jni/src/../../../../src/ui.cpp:798:49: error: use of undeclared identifier 'w_y_setup'
      bool auto_pos = w_x_setup.fun == nullptr && w_y_setup.fun == nullptr &&
                                                  ^
  /home/runner/work/Cataclysm-DDA/Cataclysm-DDA/android/app/jni/src/../../../../src/ui.cpp:799:21: error: use of undeclared identifier 'w_width_setup'
                      w_width_setup.fun == nullptr && w_height_setup.fun == nullptr;
                      ^
  /home/runner/work/Cataclysm-DDA/Cataclysm-DDA/android/app/jni/src/../../../../src/ui.cpp:799:53: error: use of undeclared identifier 'w_height_setup'
                      w_width_setup.fun == nullptr && w_height_setup.fun == nullptr;
                                                      ^
```

#### Describe alternatives you've considered



#### Testing

I can't test this.

#### Additional context

