### PR TITLE
Isolation Protocol:  Add roguelike style health regen and pain reduction

### DIFF
--- a/data/mods/Isolation-Protocol/EOC/balance_eoc.json
+++ b/data/mods/Isolation-Protocol/EOC/balance_eoc.json
@@ -1,0 +1,26 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "ISO_REGEN_CLOCK",
+    "recurrence": "15 seconds",
+    "global": true,
+    "condition": { "math": [ "u_monsters_nearby('radius': 10, 'attitude': 'hostile')", "==", "0" ] },
+    "effect": [
+      { "math": [ "u_hp('torso')", "+=", "2" ] },
+      { "math": [ "u_hp('head')", "+=", "2" ] },
+      { "math": [ "u_hp('arm_l')", "+=", "2" ] },
+      { "math": [ "u_hp('arm_r')", "+=", "2" ] },
+      { "math": [ "u_hp('leg_l')", "+=", "2" ] },
+      { "math": [ "u_hp('leg_r')", "+=", "2" ] },
+      { "math": [ "u_pain()", "-=", "4" ] }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "ISO_PAIN_CEILING",
+    "eoc_type": "EVENT",
+    "required_event": "character_takes_damage",
+    "condition": { "math": [ "u_pain()", ">", "40" ] },
+    "effect": [ { "math": [ "u_pain()", "=", "40" ] } ]
+  }
+]

--- a/data/mods/Isolation-Protocol/Player/Perks/enchantments.json
+++ b/data/mods/Isolation-Protocol/Player/Perks/enchantments.json
@@ -7,6 +7,12 @@
   },
   {
     "type": "enchantment",
+    "id": "iso_pain_adjust",
+    "condition": "ALWAYS",
+    "values": [ { "value": "PAIN", "multiply": { "math": [ "u_pain() > 40 ? -1 : -0.4" ] } } ]
+  },
+  {
+    "type": "enchantment",
     "id": "iso_ench_deliverator",
     "condition": "ALWAYS",
     "name": { "str": "The Deliverator" },

--- a/data/mods/Isolation-Protocol/Player/traits.json
+++ b/data/mods/Isolation-Protocol/Player/traits.json
@@ -5,7 +5,7 @@
     "name": "Lab Diver",
     "points": 0,
     "description": "Secret anchor point trait for gameplay enchantments.  Mod will break if you purify this trait.",
-    "enchantments": [ "iso_ranged_adjust" ],
+    "enchantments": [ "iso_ranged_adjust", "iso_pain_adjust" ],
     "starting_trait": false,
     "player_display": false,
     "purifiable": false,

--- a/data/mods/Isolation-Protocol/ui.json
+++ b/data/mods/Isolation-Protocol/ui.json
@@ -37,7 +37,7 @@
   {
     "id": "iso_danger",
     "type": "widget",
-    "label": "Ambient normality:",
+    "label": "Ambient normality",
     "style": "text",
     "clauses": [
       {
@@ -65,7 +65,7 @@
         "text": "Distorted",
         "color": "dark_gray",
         "condition": {
-          "and": [ { "math": [ "u_ISO_CURRENT_LEVEL_DANGER", ">=", "15" ] }, { "math": [ "u_ISO_CURRENT_LEVEL_DANGER", "<", "15" ] } ]
+          "and": [ { "math": [ "u_ISO_CURRENT_LEVEL_DANGER", ">=", "15" ] }, { "math": [ "u_ISO_CURRENT_LEVEL_DANGER", "<", "20" ] } ]
         }
       },
       {
@@ -73,7 +73,7 @@
         "text": "Unstable",
         "color": "magenta",
         "condition": {
-          "and": [ { "math": [ "u_ISO_CURRENT_LEVEL_DANGER", ">=", "20" ] }, { "math": [ "u_ISO_CURRENT_LEVEL_DANGER", "<", "20" ] } ]
+          "and": [ { "math": [ "u_ISO_CURRENT_LEVEL_DANGER", ">=", "20" ] }, { "math": [ "u_ISO_CURRENT_LEVEL_DANGER", "<", "25" ] } ]
         }
       },
       {


### PR DESCRIPTION
#### Summary
Mods "Isolation Protocol: Add roguelike style health regen and pain reduction"


#### Purpose of change

I noticed while playtesting the new lab shape that changes to the overall balancing of the game in the past year made completing two lab levels back to back factually impossible with the starting characters.  Which isnt really the intended experience at all.

#### Describe the solution

In classic roguelike fashion, every 15 seconds the player regenerates 2 hp on all bodyparts and looses 4 pain if there are no enemies in a 10 tile radius.  Pain has also been capped to a maximum of 40.

All powered with enchantments and recurring EOCs. 

#### Testing
Made sure the pain cap applied and the regen worked properly.

#### Additional context

Some of the lab variants are still likely impossible to complete, especially the electric plant and flesh raptor ones. The latter might need some adjutment in vanilla the former probably wants something custom to the mod.