### PR TITLE
[Xedra Evolved] Add werewolf start scenario

### DIFF
--- a/data/mods/Xedra_Evolved/eocs/shapeshifter_eocs.json
+++ b/data/mods/Xedra_Evolved/eocs/shapeshifter_eocs.json
@@ -1,0 +1,133 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_WEREWOLF_WOLF_FORM_activated",
+    "condition": { "not": { "u_has_trait": "WEREWOLF_HYBRID_FORM_TRAITS" } },
+    "effect": [
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_WEREWOLF_WOLF_FORM_activated_2",
+            "//": "Reusing VAMPIRE_WOLF_FORM_TRAITS because it works fine for being a wolf.",
+            "condition": { "not": { "u_has_trait": "VAMPIRE_WOLF_FORM_TRAITS" } },
+            "effect": [
+              {
+                "run_eocs": [
+                  {
+                    "id": "EOC_WEREWOLF_WOLF_FORM_activated_3",
+                    "condition": { "math": [ "u_val('mana')", ">=", "50" ] },
+                    "effect": [
+                      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+                      { "math": [ "u_transformed_mana", "=", "u_val('mana') - 50" ] },
+                      { "u_add_trait": "VAMPIRE_WOLF_FORM_TRAITS" },
+                      {
+                        "u_message": "Your body shifts and you fall on all fours as fur sprouts from your skin and your mouth and teeth lengthen.",
+                        "type": "good"
+                      }
+                    ],
+                    "false_effect": [
+                      { "u_message": "You don't have enough mana to transform into a wolf.", "type": "bad" },
+                      { "queue_eocs": "EOC_WEREWOLF_WOLF_FORM_deactivated_future", "time_in_future": 0 }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "false_effect": [
+              {
+                "run_eocs": [
+                  {
+                    "id": "EOC_WEREWOLF_WOLF_FORM_deactivated",
+                    "condition": { "u_has_trait": "VAMPIRE_WOLF_FORM_TRAITS" },
+                    "effect": [
+                      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+                      {
+                        "u_message": "Your body shifts and contracts and you return to your humanoid form.",
+                        "type": "neutral"
+                      },
+                      { "u_lose_trait": "VAMPIRE_WOLF_FORM_TRAITS" },
+                      { "math": [ "u_val('mana')", "=", "u_transformed_mana" ] }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "false_effect": [ { "run_eocs": "EOC_WEREWOLF_WOLF_FORM_activated_2" }, { "u_deactivate_trait": "WEREWOLF_HYBRID_FORM" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_WEREWOLF_WOLF_FORM_deactivated_future",
+    "//": "This is necessary because calling u_deactivate_trait from within the trait EoC to deactivate that trait does not work",
+    "effect": { "u_deactivate_trait": "WEREWOLF_ANIMAL_FORM" }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_WEREWOLF_HYBRID_FORM_activated",
+    "condition": { "not": { "u_has_trait": "VAMPIRE_WOLF_FORM_TRAITS" } },
+    "effect": [
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_WEREWOLF_HYBRID_FORM_activated_2",
+            "condition": { "not": { "u_has_trait": "WEREWOLF_HYBRID_FORM_TRAITS" } },
+            "effect": [
+              {
+                "run_eocs": [
+                  {
+                    "id": "EOC_WEREWOLF_HYBRID_FORM_activated_3",
+                    "condition": { "math": [ "u_val('mana')", ">=", "50" ] },
+                    "effect": [
+                      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+                      { "math": [ "u_transformed_mana", "=", "u_val('mana') - 50" ] },
+                      { "math": [ "u_calories()", "*=", "3" ] },
+                      { "u_add_trait": "WEREWOLF_HYBRID_FORM_TRAITS" },
+                      {
+                        "u_message": "Your body shifts and grows as enormous fangs and claws erupt from your skin and your mouth lengthens into a muzzle.",
+                        "type": "good"
+                      }
+                    ],
+                    "false_effect": [
+                      { "u_message": "You don't have enough mana to transform into your war form.", "type": "bad" },
+                      { "queue_eocs": "EOC_WEREWOLF_HYBRID_FORM_deactivated_future", "time_in_future": 0 }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "false_effect": [
+              {
+                "run_eocs": [
+                  {
+                    "id": "EOC_WEREWOLF_HYBRID_FORM_deactivated",
+                    "condition": { "u_has_trait": "WEREWOLF_HYBRID_FORM_TRAITS" },
+                    "effect": [
+                      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+                      {
+                        "u_message": "Your body shifts and contracts and you return to your humanoid form.",
+                        "type": "neutral"
+                      },
+                      { "u_lose_trait": "WEREWOLF_HYBRID_FORM_TRAITS" },
+                      { "math": [ "u_val('mana')", "=", "u_transformed_mana" ] },
+                      { "math": [ "u_calories()", "/=", "3" ] }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "false_effect": [ { "run_eocs": "EOC_WEREWOLF_HYBRID_FORM_activated_2" }, { "u_deactivate_trait": "WEREWOLF_ANIMAL_FORM" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_WEREWOLF_HYBRID_FORM_deactivated_future",
+    "//": "This is necessary because calling u_deactivate_trait from within the trait EoC to deactivate that trait does not work",
+    "effect": { "u_deactivate_trait": "WEREWOLF_ANIMAL_FORM" }
+  }
+]

--- a/data/mods/Xedra_Evolved/eocs/shapeshifter_eocs.json
+++ b/data/mods/Xedra_Evolved/eocs/shapeshifter_eocs.json
@@ -20,6 +20,7 @@
                       { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
                       { "math": [ "u_transformed_mana", "=", "u_val('mana') - 50" ] },
                       { "u_add_trait": "VAMPIRE_WOLF_FORM_TRAITS" },
+                      { "u_add_trait": "CARNIVORE" },
                       {
                         "u_message": "Your body shifts and you fall on all fours as fur sprouts from your skin and your mouth and teeth lengthen.",
                         "type": "good"
@@ -46,6 +47,7 @@
                         "type": "neutral"
                       },
                       { "u_lose_trait": "VAMPIRE_WOLF_FORM_TRAITS" },
+                      { "u_lose_trait": "CARNIVORE" },
                       { "math": [ "u_val('mana')", "=", "u_transformed_mana" ] }
                     ]
                   }
@@ -56,7 +58,7 @@
         ]
       }
     ],
-    "false_effect": [ { "run_eocs": "EOC_WEREWOLF_WOLF_FORM_activated_2" }, { "u_deactivate_trait": "WEREWOLF_HYBRID_FORM" } ]
+    "false_effect": [ { "u_deactivate_trait": "WEREWOLF_HYBRID_FORM" }, { "run_eocs": "EOC_WEREWOLF_WOLF_FORM_activated_2" } ]
   },
   {
     "type": "effect_on_condition",
@@ -85,6 +87,7 @@
                       { "math": [ "u_transformed_mana", "=", "u_val('mana') - 50" ] },
                       { "math": [ "u_calories()", "*=", "3" ] },
                       { "u_add_trait": "WEREWOLF_HYBRID_FORM_TRAITS" },
+                      { "u_add_trait": "CARNIVORE" },
                       {
                         "u_message": "Your body shifts and grows as enormous fangs and claws erupt from your skin and your mouth lengthens into a muzzle.",
                         "type": "good"
@@ -111,6 +114,7 @@
                         "type": "neutral"
                       },
                       { "u_lose_trait": "WEREWOLF_HYBRID_FORM_TRAITS" },
+                      { "u_lose_trait": "CARNIVORE" },
                       { "math": [ "u_val('mana')", "=", "u_transformed_mana" ] },
                       { "math": [ "u_calories()", "/=", "3" ] }
                     ]
@@ -122,7 +126,7 @@
         ]
       }
     ],
-    "false_effect": [ { "run_eocs": "EOC_WEREWOLF_HYBRID_FORM_activated_2" }, { "u_deactivate_trait": "WEREWOLF_ANIMAL_FORM" } ]
+    "false_effect": [ { "u_deactivate_trait": "WEREWOLF_ANIMAL_FORM" }, { "run_eocs": "EOC_WEREWOLF_HYBRID_FORM_activated_2" } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/Xedra_Evolved/items/armor/integrated.json
+++ b/data/mods/Xedra_Evolved/items/armor/integrated.json
@@ -802,5 +802,59 @@
     "flags": [ "INTEGRATED", "REBREATHER", "UNBREAKABLE", "PERSONAL", "NO_SALVAGE", "TRADER_AVOID" ],
     "environmental_protection": 15,
     "armor": [ { "encumbrance": 0, "coverage": 100, "covers": [ "mouth" ] } ]
+  },
+  {
+    "id": "integrated_claws_werewolf",
+    "type": "ARMOR",
+    "category": "armor",
+    "name": { "str_sp": "werewolf claws" },
+    "description": "You have massive claws on your end of your furry fingers.",
+    "weight": "100 g",
+    "volume": "250 ml",
+    "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 6 ] ],
+    "price": "0 cent",
+    "price_postapoc": "0 cent",
+    "material": [ "chitin" ],
+    "symbol": ";",
+    "color": "dark_gray",
+    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "OUTER", "PADDED", "NO_SALVAGE" ],
+    "armor": [
+      {
+        "material": [ { "type": "chitin", "covered_by_mat": 100, "thickness": 3 } ],
+        "covers": [ "hand_l", "hand_r" ],
+        "specifically_covers": [ "hand_fingers_l", "hand_fingers_r" ],
+        "coverage": 20,
+        "encumbrance": 3
+      }
+    ],
+    "melee_damage": { "cut": 20 }
+  },
+  {
+    "id": "integrated_werewolf_teeth",
+    "type": "ARMOR",
+    "category": "armor",
+    "name": { "str_sp": "werewolf teeth" },
+    "description": "A mouth full of vicious sharp teeth, almost twice as large as a wolf's.",
+    "weight": "50 g",
+    "volume": "100 ml",
+    "price": "0 cent",
+    "price_postapoc": "0 cent",
+    "material": [ "bone" ],
+    "symbol": ",",
+    "color": "white",
+    "warmth": 5,
+    "qualities": [ [ "CUT", 2 ], [ "BUTCHER", 4 ] ],
+    "techniques": [ "FANGS_BITE", "FANGS_BITE_NATURAL", "FANGS_BITE_CRIT" ],
+    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "PERSONAL", "PADDED", "PROVIDES_TECHNIQUES" ],
+    "armor": [
+      {
+        "material": [ { "type": "bone", "covered_by_mat": 100, "thickness": 3.2 } ],
+        "covers": [ "mouth" ],
+        "specifically_covers": [ "mouth_lips" ],
+        "coverage": 100,
+        "encumbrance": 0
+      }
+    ],
+    "melee_damage": { "stab": 18 }
   }
 ]

--- a/data/mods/Xedra_Evolved/items/armor/integrated.json
+++ b/data/mods/Xedra_Evolved/items/armor/integrated.json
@@ -817,6 +817,7 @@
     "material": [ "chitin" ],
     "symbol": ";",
     "color": "dark_gray",
+    "techniques": [ "CLAWS_SHAPESHIFTER", "CLAWS_SHAPESHIFTER_RENDING", "CLAWS_SHAPESHIFTER_CRIT" ],
     "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "OUTER", "PADDED", "NO_SALVAGE" ],
     "armor": [
       {
@@ -844,7 +845,7 @@
     "color": "white",
     "warmth": 5,
     "qualities": [ [ "CUT", 2 ], [ "BUTCHER", 4 ] ],
-    "techniques": [ "FANGS_BITE", "FANGS_BITE_NATURAL", "FANGS_BITE_CRIT" ],
+    "techniques": [ "FANGS_BITE_SHAPESHIFTER", "FANGS_BITE_SHAPESHIFTER_CRIT" ],
     "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "PERSONAL", "PADDED", "PROVIDES_TECHNIQUES" ],
     "armor": [
       {
@@ -855,6 +856,6 @@
         "encumbrance": 0
       }
     ],
-    "melee_damage": { "stab": 18 }
+    "melee_damage": { "stab": 15 }
   }
 ]

--- a/data/mods/Xedra_Evolved/items/armor/integrated.json
+++ b/data/mods/Xedra_Evolved/items/armor/integrated.json
@@ -828,7 +828,7 @@
         "encumbrance": 3
       }
     ],
-    "melee_damage": { "cut": 20 }
+    "melee_damage": { "cut": 16 }
   },
   {
     "id": "integrated_werewolf_teeth",
@@ -856,6 +856,6 @@
         "encumbrance": 0
       }
     ],
-    "melee_damage": { "stab": 15 }
+    "melee_damage": { "stab": 13 }
   }
 ]

--- a/data/mods/Xedra_Evolved/martial_arts/shapeshifter.json
+++ b/data/mods/Xedra_Evolved/martial_arts/shapeshifter.json
@@ -1,0 +1,102 @@
+[
+  {
+    "type": "technique",
+    "id": "CLAWS_SHAPESHIFTER",
+    "name": "Claw Slash",
+    "melee_allowed": true,
+    "messages": [ "You deliver a slash to %s with your claws", "<npcname> delivers a slash to %s with their claws!" ],
+    "unarmed_allowed": true,
+    "weighting": 1,
+    "reach_ok": false,
+    "miss_recovery": true,
+    "attack_vectors": [ "vector_punch" ],
+    "flat_bonuses": [
+      { "stat": "damage", "type": "cut", "scaling-stat": "unarmed", "scale": 1.0 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "str", "scale": 0.75 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "unarmed", "scale": 0.06 },
+      { "stat": "movecost", "scaling-stat": "melee", "scale": -1.25 },
+      { "stat": "movecost", "scaling-stat": "dex", "scale": -0.5 }
+    ]
+  },
+  {
+    "type": "technique",
+    "id": "CLAWS_SHAPESHIFTER_RENDING",
+    "name": "Claw Rending Slash",
+    "melee_allowed": true,
+    "messages": [ "You slash %s, tearing open bleeding wounds.", "<npcname> slashes %s, tearing open bleeding wounds." ],
+    "unarmed_allowed": true,
+    "weighting": -2,
+    "crit_ok": true,
+    "reach_ok": false,
+    "miss_recovery": true,
+    "attack_vectors": [ "vector_punch" ],
+    "tech_effects": [ { "id": "bleed", "chance": 100, "duration": 600, "on_damage": true, "message": "%s is bleeding!" } ],
+    "flat_bonuses": [
+      { "stat": "damage", "type": "cut", "scaling-stat": "unarmed", "scale": 1.0 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "str", "scale": 0.75 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "unarmed", "scale": 0.06 },
+      { "stat": "movecost", "scaling-stat": "melee", "scale": -1.25 },
+      { "stat": "movecost", "scaling-stat": "dex", "scale": -0.5 }
+    ]
+  },
+  {
+    "type": "technique",
+    "id": "CLAWS_SHAPESHIFTER_CRIT",
+    "name": "Critical Claw Slash",
+    "melee_allowed": true,
+    "messages": [ "You deliver a wicked slash to %s with your claws", "<npcname> delivers a wicked slash to %s with their claws!" ],
+    "unarmed_allowed": true,
+    "reach_ok": false,
+    "crit_tec": true,
+    "miss_recovery": true,
+    "attack_vectors": [ "vector_punch" ],
+    "flat_bonuses": [
+      { "stat": "damage", "type": "cut", "scaling-stat": "unarmed", "scale": 4.4 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "str", "scale": 0.75 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "unarmed", "scale": 0.24 },
+      { "stat": "arpen", "type": "bash", "scaling-stat": "unarmed", "scale": 1 },
+      { "stat": "arpen", "type": "cut", "scaling-stat": "unarmed", "scale": 1 },
+      { "stat": "movecost", "scaling-stat": "melee", "scale": -1.25 },
+      { "stat": "movecost", "scaling-stat": "dex", "scale": -0.5 }
+    ]
+  },
+  {
+    "type": "technique",
+    "id": "FANGS_BITE_SHAPESHIFTER",
+    "//": "Separate to avoid Natural Stance requirement",
+    "name": "Fang Bite",
+    "melee_allowed": true,
+    "messages": [ "You bite %s", "<npcname> bites %s!" ],
+    "unarmed_allowed": true,
+    "weighting": -3,
+    "reach_ok": false,
+    "attack_vectors": [ "vector_bite" ],
+    "flat_bonuses": [
+      { "stat": "damage", "type": "stab", "scaling-stat": "unarmed", "scale": 1.0 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "str", "scale": 0.75 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "unarmed", "scale": 0.06 },
+      { "stat": "movecost", "scaling-stat": "melee", "scale": -1.25 },
+      { "stat": "movecost", "scaling-stat": "dex", "scale": -0.5 }
+    ]
+  },
+  {
+    "type": "technique",
+    "id": "FANGS_BITE_SHAPESHIFTER_CRIT",
+    "name": "Critical Fang Bite",
+    "melee_allowed": true,
+    "messages": [ "You deliver a wicked bite to %s", "<npcname> delivers a wicked bite to %s!" ],
+    "unarmed_allowed": true,
+    "reach_ok": false,
+    "crit_tec": true,
+    "attack_vectors": [ "vector_bite" ],
+    "flat_bonuses": [
+      { "stat": "damage", "type": "stab", "scaling-stat": "unarmed", "scale": 4.4 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "str", "scale": 0.75 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "unarmed", "scale": 0.24 },
+      { "stat": "arpen", "type": "bash", "scaling-stat": "unarmed", "scale": 1 },
+      { "stat": "arpen", "type": "stab", "scaling-stat": "unarmed", "scale": 1 },
+      { "stat": "movecost", "scaling-stat": "melee", "scale": -1.25 },
+      { "stat": "movecost", "scaling-stat": "dex", "scale": -0.5 }
+    ]
+  }
+]

--- a/data/mods/Xedra_Evolved/mutations/shapeshifters.json
+++ b/data/mods/Xedra_Evolved/mutations/shapeshifters.json
@@ -94,10 +94,11 @@
           { "value": "MELEE_DAMAGE", "multiply": 0.33 },
           { "value": "CRAFTING_SPEED_MULTIPLIER", "multiply": -0.8 },
           { "value": "STAMINA_REGEN_MOD", "add": 0.2 },
-          { "value": "MELEE_STAMINA_CONSUMPTION", "multiply": -0.33 }
+          { "value": "MELEE_STAMINA_CONSUMPTION", "multiply": -0.33 },
+          { "value": "SOCIAL_PERSUADE", "add": -50 },
+          { "value": "SOCIAL_INTIMIDATE", "add": 40 }
         ],
-        "mutations": [ "MUZZLE", "TAIL_FLUFFY", "PAWS", "LUPINE_FUR", "LUPINE_EARS", "PERSISTENCE_HUNTER2", "PRED3" ],
-        "skills": [ { "value": "unarmed", "add": 4 } ]
+        "mutations": [ "MUZZLE", "TAIL_FLUFFY", "PAWS", "LUPINE_FUR", "LUPINE_EARS", "PERSISTENCE_HUNTER2", "PRED3" ]
       },
       {
         "condition": "ALWAYS",

--- a/data/mods/Xedra_Evolved/mutations/shapeshifters.json
+++ b/data/mods/Xedra_Evolved/mutations/shapeshifters.json
@@ -75,6 +75,8 @@
     "name": { "str": "Werewolf Hybrid Form" },
     "points": 99,
     "description": "You are a hybrid of wolf and human.  This provides the actual effects of werewolf hybrid form.  Should not be player-visible",
+    "visibility": 30,
+    "ugliness": 30,
     "valid": false,
     "starting_trait": false,
     "purifiable": false,

--- a/data/mods/Xedra_Evolved/mutations/shapeshifters.json
+++ b/data/mods/Xedra_Evolved/mutations/shapeshifters.json
@@ -91,7 +91,6 @@
           { "value": "DEXTERITY", "add": 2 },
           { "value": "STRENGTH", "add": 6 },
           { "value": "NIGHT_VIS", "add": 8 },
-          { "value": "MELEE_DAMAGE", "multiply": 0.33 },
           { "value": "CRAFTING_SPEED_MULTIPLIER", "multiply": -0.8 },
           { "value": "STAMINA_REGEN_MOD", "add": 0.2 },
           { "value": "MELEE_STAMINA_CONSUMPTION", "multiply": -0.33 },

--- a/data/mods/Xedra_Evolved/mutations/shapeshifters.json
+++ b/data/mods/Xedra_Evolved/mutations/shapeshifters.json
@@ -90,8 +90,9 @@
           { "value": "STRENGTH", "add": 6 },
           { "value": "NIGHT_VIS", "add": 8 },
           { "value": "MELEE_DAMAGE", "multiply": 0.33 },
-          { "value": "CRAFTING_SPEED_MULTIPLIER", "multiply": -1000 },
-          { "value": "STAMINA_REGEN_MOD", "add": 0.2 }
+          { "value": "CRAFTING_SPEED_MULTIPLIER", "multiply": -0.8 },
+          { "value": "STAMINA_REGEN_MOD", "add": 0.2 },
+          { "value": "MELEE_STAMINA_CONSUMPTION", "multiply": -0.33 }
         ],
         "mutations": [ "MUZZLE", "TAIL_FLUFFY", "PAWS", "LUPINE_FUR", "LUPINE_EARS", "PERSISTENCE_HUNTER2", "PRED3" ],
         "skills": [ { "value": "unarmed", "add": 4 } ]
@@ -105,12 +106,15 @@
           { "value": "DODGE_CHANCE", "add": 4 }
         ]
       },
-      { "condition": "ALWAYS", "values": [ { "value": "HEARING_MULT", "multiply": 0.25 } ] },
+      {
+        "condition": { "and": [ { "not": "is_day" }, { "math": [ "moon_phase() == 4" ] } ] },
+        "values": [ { "value": "DEXTERITY", "add": 2 }, { "value": "STRENGTH", "add": 2 }, { "value": "SPEED", "multiply": 0.05 } ]
+      },
       {
         "intermittent_activation": {
           "effects": [
             {
-              "frequency": "10 seconds",
+              "frequency": "6 seconds",
               "spell_effects": [ { "id": "goblin_fruit_regeneration_spell" }, { "id": "shapeshifter_remove_pain_spell" } ]
             }
           ]

--- a/data/mods/Xedra_Evolved/mutations/shapeshifters.json
+++ b/data/mods/Xedra_Evolved/mutations/shapeshifters.json
@@ -1,0 +1,124 @@
+[
+  {
+    "type": "mutation",
+    "id": "NATIVE_SHAPESHIFTER",
+    "name": { "str": "Natural Shapeshifter" },
+    "points": 0,
+    "description": "You were born a shapeshifter, and after your gifts manifested themselves, you gained other benefits as well.  Even in human form, you heal a little faster than normal and your broken bones heal straight and true.",
+    "starting_trait": false,
+    "purifiable": false,
+    "valid": false,
+    "vitamin_rates": [
+      [ "mutagen", 1 ],
+      [ "mutagen_alpha", 1 ],
+      [ "mutagen_batrachian", 1 ],
+      [ "mutagen_beast", 1 ],
+      [ "mutagen_bird", 1 ],
+      [ "mutagen_cattle", 1 ],
+      [ "mutagen_cephalopod", 1 ],
+      [ "mutagen_chimera", 1 ],
+      [ "mutagen_crustacean", 1 ],
+      [ "mutagen_elfa", 1 ],
+      [ "mutagen_feline", 1 ],
+      [ "mutagen_fish", 1 ],
+      [ "mutagen_gastropod", 1 ],
+      [ "mutagen_human", 1 ],
+      [ "mutagen_insect", 1 ],
+      [ "mutagen_lizard", 1 ],
+      [ "mutagen_lupine", 1 ],
+      [ "mutagen_medical", 1 ],
+      [ "mutagen_mouse", 1 ],
+      [ "mutagen_plant", 1 ],
+      [ "mutagen_raptor", 1 ],
+      [ "mutagen_rabbit", 1 ],
+      [ "mutagen_rat", 1 ],
+      [ "mutagen_slime", 1 ],
+      [ "mutagen_spider", 1 ],
+      [ "mutagen_troglobite", 1 ],
+      [ "mutagen_ursine", 1 ]
+    ],
+    "no_cbm_on_bp": [ "torso", "head", "eyes", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+    "flags": [ "MEND_ALL" ],
+    "enchantments": [ { "values": [ { "value": "REGEN_HP", "multiply": 0.25 }, { "value": "REGEN_HP_AWAKE", "multiply": 0.1 } ] } ]
+  },
+  {
+    "type": "mutation",
+    "id": "WEREWOLF_ANIMAL_FORM",
+    "name": { "str": "Lupine Form" },
+    "points": 0,
+    "description": "You can transform yourself into a wolf and run through the forests.",
+    "starting_trait": false,
+    "purifiable": false,
+    "valid": false,
+    "active": true,
+    "activated_is_setup": true,
+    "activated_eocs": [ "EOC_WEREWOLF_WOLF_FORM_activated" ],
+    "deactivated_eocs": [ "EOC_WEREWOLF_WOLF_FORM_deactivated" ]
+  },
+  {
+    "type": "mutation",
+    "id": "WEREWOLF_HYBRID_FORM",
+    "name": { "str": "War Form" },
+    "points": 0,
+    "description": "You can transform yourself into a wolf-human hybrid and rip your enemies to shreds.",
+    "starting_trait": false,
+    "purifiable": false,
+    "valid": false,
+    "active": true,
+    "activated_is_setup": true,
+    "activated_eocs": [ "EOC_WEREWOLF_HYBRID_FORM_activated" ],
+    "deactivated_eocs": [ "EOC_WEREWOLF_HYBRID_FORM_deactivated" ]
+  },
+  {
+    "type": "mutation",
+    "id": "WEREWOLF_HYBRID_FORM_TRAITS",
+    "name": { "str": "Werewolf Hybrid Form" },
+    "points": 99,
+    "description": "You are a hybrid of wolf and human.  This provides the actual effects of werewolf hybrid form.  Should not be player-visible",
+    "valid": false,
+    "starting_trait": false,
+    "purifiable": false,
+    "player_display": false,
+    "//": "The second enchantment takes into account the effects of the mutations added by the first enchantment, whose own enchantments do not transfer over due to bug #74994.  If that bug is fixed, it can be deleted.",
+    "enchantments": [
+      {
+        "condition": "ALWAYS",
+        "values": [
+          { "value": "SPEED", "multiply": 0.2 },
+          { "value": "RANGE", "multiply": -1 },
+          { "value": "DEXTERITY", "add": 2 },
+          { "value": "STRENGTH", "add": 6 },
+          { "value": "NIGHT_VIS", "add": 8 },
+          { "value": "MELEE_DAMAGE", "multiply": 0.33 },
+          { "value": "CRAFTING_SPEED_MULTIPLIER", "multiply": -1000 },
+          { "value": "STAMINA_REGEN_MOD", "add": 0.2 }
+        ],
+        "mutations": [ "MUZZLE", "TAIL_FLUFFY", "PAWS", "LUPINE_FUR", "LUPINE_EARS", "PERSISTENCE_HUNTER2", "PRED3" ],
+        "skills": [ { "value": "unarmed", "add": 4 } ]
+      },
+      {
+        "condition": "ALWAYS",
+        "values": [
+          { "value": "STAMINA_REGEN_MOD", "add": 0.2 },
+          { "value": "HEARING_MULT", "multiply": 0.75 },
+          { "value": "COMBAT_CATCHUP", "multiply": 2 },
+          { "value": "DODGE_CHANCE", "add": 4 }
+        ]
+      },
+      { "condition": "ALWAYS", "values": [ { "value": "HEARING_MULT", "multiply": 0.25 } ] },
+      {
+        "intermittent_activation": {
+          "effects": [
+            {
+              "frequency": "10 seconds",
+              "spell_effects": [ { "id": "goblin_fruit_regeneration_spell" }, { "id": "shapeshifter_remove_pain_spell" } ]
+            }
+          ]
+        }
+      }
+    ],
+    "flags": [ "NO_SPELLCASTING", "PRED3", "TOUGH_FEET", "TEMPORARY_SHAPESHIFT", "SHAPESHIFT_SIZE_HUGE" ],
+    "override_look": { "id": "mon_loup_garou", "tile_category": "monster" },
+    "integrated_armor": [ "integrated_claws_werewolf", "integrated_werewolf_teeth", "integrated_lupine_fur" ]
+  }
+]

--- a/data/mods/Xedra_Evolved/scenario.json
+++ b/data/mods/Xedra_Evolved/scenario.json
@@ -49,7 +49,7 @@
   {
     "type": "scenario",
     "id": "werewolf_native_born",
-    "name": "Werewolf, Native-born",
+    "name": "Werewolf, Natural-born",
     "flags": [ "LONE_START" ],
     "points": 0,
     "description": "You had no idea what was going on the first time it happened, when you woke up with mud on your bare feet and a sour taste in your mouth, but you were soon found.  The People of the Moon, they called themselves, and they said you were one of them.  A werewolf.  You lived out in the wilderness for a while but didn't entirely abandon human civilization, and when the Cataclysm yet you ignored the evacuation warnings and struck it out on their own.  Maybe some of the People are still out there.",
@@ -64,7 +64,7 @@
       "sloc_forest",
       "sloc_field"
     ],
-    "forced_traits": [ "NATIVE_SHAPESHIFTER", "WEREWOLF_ANIMAL_FORM", "WEREWOLF_WAR_FORM" ]
+    "forced_traits": [ "NATIVE_SHAPESHIFTER", "WEREWOLF_ANIMAL_FORM", "WEREWOLF_HYBRID_FORM" ]
   },
   {
     "type": "scenario",

--- a/data/mods/Xedra_Evolved/scenario.json
+++ b/data/mods/Xedra_Evolved/scenario.json
@@ -48,6 +48,26 @@
   },
   {
     "type": "scenario",
+    "id": "werewolf_native_born",
+    "name": "Werewolf, Native-born",
+    "flags": [ "LONE_START" ],
+    "points": 0,
+    "description": "You had no idea what was going on the first time it happened, when you woke up with mud on your bare feet and a sour taste in your mouth, but you were soon found.  The People of the Moon, they called themselves, and they said you were one of them.  A werewolf.  You lived out in the wilderness for a while but didn't entirely abandon human civilization, and when the Cataclysm yet you ignored the evacuation warnings and struck it out on their own.  Maybe some of the People are still out there.",
+    "start_name": "Alone",
+    "allowed_locs": [
+      "sloc_shelter_vandalized_a",
+      "sloc_shelter_vandalized_b",
+      "sloc_shelter_vandalized_c",
+      "sloc_hermit_shack",
+      "sloc_cabin",
+      "sloc_house_boarded",
+      "sloc_forest",
+      "sloc_field"
+    ],
+    "forced_traits": [ "NATIVE_SHAPESHIFTER", "WEREWOLF_ANIMAL_FORM", "WEREWOLF_WAR_FORM" ]
+  },
+  {
+    "type": "scenario",
     "id": "once_bitten",
     "name": "Once Bitten",
     "points": 0,

--- a/data/mods/Xedra_Evolved/spells/shapeshifter.json
+++ b/data/mods/Xedra_Evolved/spells/shapeshifter.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "shapeshifter_remove_pain_spell",
+    "type": "SPELL",
+    "name": "Shapeshifter reduce pain spell",
+    "description": "This reduces pain for shapeshifters as their wounds regenerate.  You should never see it.",
+    "valid_targets": [ "self" ],
+    "min_damage": 1,
+    "max_damage": 1,
+    "effect": "recover_energy",
+    "effect_str": "PAIN",
+    "shape": "blast",
+    "energy_source": "STAMINA",
+    "flags": [ "SILENT", "PAIN_NORESIST" ]
+  }
+]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Xedra Evolved] Add werewolf start scenario"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Talked about this a bit with Maleclypse and playable shapeshifters are in the design docs. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the "Werewolf, Natural-born" scenario (so you can pick a variety of different professions). Natural-Born here is to leave open the possibility of a "Werewolf, Accursed" scenario where you have to transform and kill people during the full moon.

These are urban fantasy werewolves, so they have a normal wolf form and a hybrid war form. In human and wolf form they heal slightly faster and don't need splints but otherwise have only the normal advantages of human (or wolf) form. In war form they're an almost three meter tall human-wolf killing machine with enormous teeth and claws who regenerate crippling wounds in minutes. War form has a very high Visibility and Ugliness rating, so trying to interact with humans in it is a futile endeavor. 

I've used mana as a resource to control shapeshifting because it's as good a resource as any and every character has it. If JSONized mana is implemented we can implement another resource for it. 

Werewolves will not mutate if they take mutagen and they cannot have CBMs installed. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

The mechanics of shifting all work, as does the scenario.  

Werewolves are very powerful in close combat in their war forms, but they're not invincible. You can't just dive in and hold tab and expect to win.  You're a wolf--do hit and run attacks, back away to take advantage of your regeneration, and then strike. Powerful enough melee combatants (hulks) can still provide a big challenge,  at least until you have some experience under your belt.

Your claws and fangs scale highly with your Unarmed skill, so if you want to start out as an effective werewolf combatant, take some levels in Unarmed. 

One disadvantage: it looks like `mon_loup_garou` does not have coverage in all tilesets, so hybrid form has no sprite.

Spawning some NPCs in war form:

![Untitled](https://github.com/user-attachments/assets/757b5931-108c-43b0-9c80-711996e5fdfb)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

At the moment, shapeshifted characters still get the benefit of their armor. This is a problem I haven't solved yet. 

Once there are werewolf NPCs out there, we can give this scenario the mission, "Find the survivors of the People.,"

Are there werebears, wereravens, weresharks, etc?

Maybe.  Maybe. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
