### PR TITLE
Warn on new character in existing world (0.H)

### DIFF
--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -942,6 +942,13 @@ bool main_menu::new_character_tab()
                 if( world == nullptr ) {
                     continue;
                 }
+                if( !world->world_saves.empty() ) {
+                    if( !query_yn(
+                            _( "Many game features will not work correctly with multiple characters in the same world. Create a new character anyway?" ) ) ) {
+                        return false;
+                    }
+                }
+
                 world_generator->set_active_world( world );
                 try {
                     g->setup();
@@ -979,6 +986,12 @@ bool main_menu::new_character_tab()
         WORLD *world = world_generator->pick_world( !is_play_now, is_play_now );
         if( world == nullptr ) {
             return false;
+        }
+        if( !world->world_saves.empty() ) {
+            if( !query_yn(
+                    _( "Many game features will not work correctly with multiple characters in the same world. Create a new character anyway?" ) ) ) {
+                return false;
+            }
         }
         world_generator->set_active_world( world );
         try {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fixes #67750 
Supporting multiple characters independently in the same world is not supported per-se, so we pop up a warning that things might break.

#### Describe the solution
This just pops up a message informing the user that this might break things.

#### Describe alternatives you've considered
I was trying to get this working so that this prompt would be permanently dismissable by setting an option in case the user doesn't care, but ran into weird issues with the option being cleared after I set it, possibly related to the code running either right before or right after we call world_generator->set_active_world( world );

This patch attempts to do so, but as I said I couldn't get it to work:
```
diff --git a/src/main_menu.cpp b/src/main_menu.cpp
index 2c6e976aeba..9157b451ead 100644
--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -898,6 +898,9 @@ bool main_menu::opening_screen()
 bool main_menu::new_character_tab()
 {
     avatar &pc = get_avatar();
+    const bool force_uc = get_option<bool>( "FORCE_CAPITAL_YN" );
+    const auto &allow_key = force_uc ? input_context::disallow_lower_case_or_non_modified_letters
+                            : input_context::allow_all_keys;
     // Preset character templates
     if( sel2 == 1 ) {
         if( templates.empty() ) {
@@ -942,11 +945,30 @@ bool main_menu::new_character_tab()
                 if( world == nullptr ) {
                     continue;
                 }
-                if( !world->world_saves.empty() ) {
-                    if( !query_yn(
-                            _( "Many game features will not work correctly with multiple characters in the same world. Create a new character anyway?" ) ) ) {
+                if( !world->world_saves.empty() &&
+                    get_option<bool>( "WARN_ABOUT_MULTI_PLAYER_WORLD" ) ) {
+                    const std::string &action = query_popup()
+                                                .preferred_keyboard_mode( keyboard_mode::keycode )
+                                                .context( "YES_NO_STOP_ASKING" )
+                                                .message( force_uc && !is_keycode_mode_supported() ?
+                                                          pgettext( "warn_about_player_multi_world",
+                                                                  "%s (Case Sensitive)" ) :
+                                                          pgettext( "warn_about_player_multi_world",
+                                                                  "%s" ),
+                                                          _( "Many game features will not work correctly with multiple characters in the same world. Create a new character anyway?" ) )
+                                                .option( "YES", allow_key )
+                                                .option( "NO", allow_key )
+                                                .option( "STOP_ASKING", allow_key )
+                                                .query()
+                                                .action;
+
+                    if( action == "NO" ) {
                         return false;
                     }
+                    if( action == "STOP_ASKING" ) {
+                        get_options().get_option( "WARN_ABOUT_MULTI_PLAYER_WORLD" ).setValue( "false" );
+                        get_options().save();
+                    }
                 }
 
                 world_generator->set_active_world( world );
@@ -987,13 +1009,34 @@ bool main_menu::new_character_tab()
         if( world == nullptr ) {
             return false;
         }
-        if( !world->world_saves.empty() ) {
-            if( !query_yn(
-                    _( "Many game features will not work correctly with multiple characters in the same world. Create a new character anyway?" ) ) ) {
+        world_generator->set_active_world( world );
+        if( !world->world_saves.empty() &&
+            get_option<bool>( "WARN_ABOUT_MULTI_PLAYER_WORLD" ) ) {
+            const std::string &action = query_popup()
+                                        .preferred_keyboard_mode( keyboard_mode::keycode )
+                                        .context( "YES_NO_STOP_ASKING" )
+                                        .message( force_uc && !is_keycode_mode_supported() ?
+                                                  pgettext( "warn_about_player_multi_world",
+                                                          "%s (Case Sensitive)" ) :
+                                                  pgettext( "warn_about_player_multi_world", "%s" ),
+                                                  _( "Many game features will not work correctly with multiple characters in the same world. Create a new character anyway?" ) )
+                                        .option( "YES", allow_key )
+                                        .option( "NO", allow_key )
+                                        .option( "STOP_ASKING", allow_key )
+                                        .query()
+                                        .action;
+
+            if( action == "NO" ) {
                 return false;
             }
+            if( action == "STOP_ASKING" ) {
+                get_options().get_option( "WARN_ABOUT_MULTI_PLAYER_WORLD" ).setValue( "false" );
+                get_options().save();
+                if( get_option<bool>( "WARN_ABOUT_MULTI_PLAYER_WORLD" ) ) {
+                    debugmsg( "Well that sucks it's still true" );
+                }
+            }
         }
-        world_generator->set_active_world( world );
         try {
             g->setup();
         } catch( const std::exception &err ) {
new file mode 100644
index 00000000000..a797c1ac806
--- /dev/null
+++ b/data/core/ui_flags.json
@@ -0,0 +1,9 @@
+[
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "WARN_ABOUT_MULTI_PLAYER_WORLD",
+    "info": "Flag to persistently remember if user has said not to warn about multi-player worlds.",
+    "stype": "bool",
+    "value": true
+  }
+]
```

#### Testing
Created a new character in an empty exiting world, no popup.
Created a new character in a world with characters already in it, popup displayed, if I select no it exits back to the main menu.