### PR TITLE
[Xedra Evolved] Add Homullus must wake up near humans fae ban + eating restrictions

### DIFF
--- a/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_mutations.json
@@ -487,7 +487,7 @@
     "id": "HOMULLUS_EAT_DEMIHUMANS",
     "name": { "str": "The Top of the Food Chain" },
     "points": 5,
-    "description": "Humanity are omnivores in the most literal sense.  You can eat anything not human without any moral qualms.",
+    "description": "Humanity are omnivores in the most literal sense.  You can eat anything not human without any moral qualms.  However, the food that pre-Cataclysm humanity would slowly poison themselves with is anathema to you, and you will eat only good-tasting food unless you are starving.",
     "types": [ "DIET" ],
     "prereqs": [ "HOMULLUS_THE_HUNTER", "HOMULLUS_THE_HUNTER2" ],
     "category": [ "HOMULLUS" ],

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_fae_bans.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_fae_bans.json
@@ -70,7 +70,7 @@
     "type": "effect_on_condition",
     "id": "EOC_ARVORE_FAE_BAN_SLEPT_IN_CITY",
     "eoc_type": "EVENT",
-    "required_event": "character_wakes_up",
+    "required_event": "character_s_up",
     "condition": {
       "and": [
         { "u_has_trait": "THRESH_ARVORE" },
@@ -87,7 +87,7 @@
       { "queue_eocs": "EOC_PARACLESIAN_BROKE_FAE_BAN_PAIN", "time_in_future": 1 },
       { "math": [ "u_val('sleepiness')", "+=", "150" ] },
       {
-        "u_message": "You awaken with a groggy head, blinking bleary eyes.  Sleeping near the remnants of civilization away from the bounty of nature, your sleep was not as restful as it should have been.",
+        "u_message": "You an with a groggy head, blinking bleary eyes.  Sleeping near the remnants of civilization away from the bounty of nature, your sleep was not as restful as it should have been.",
         "type": "bad"
       }
     ]
@@ -96,7 +96,7 @@
     "type": "effect_on_condition",
     "id": "EOC_IERDE_FAE_BAN_DIDNT_SLEEP_UNDERGROUND",
     "eoc_type": "EVENT",
-    "required_event": "character_wakes_up",
+    "required_event": "character_s_up",
     "condition": {
       "and": [
         { "u_has_trait": "THRESH_IERDE" },
@@ -126,7 +126,7 @@
       { "queue_eocs": "EOC_PARACLESIAN_BROKE_FAE_BAN_PAIN", "time_in_future": 1 },
       { "math": [ "u_val('sleepiness')", "+=", "150" ] },
       {
-        "u_message": "You awaken in pain, your muscles stiff, your body groaning in protest.  Away from the depths of the living earth, your sleep was not as restful as it should have been.",
+        "u_message": "You an in pain, your muscles stiff, your body groaning in protest.  Away from the depths of the living earth, your sleep was not as restful as it should have been.",
         "type": "bad"
       }
     ]
@@ -198,6 +198,44 @@
       }
     ]
   },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_HOMULLUS_FAE_BAN_DIDNT_SLEEP_NEAR_HUMANS",
+    "eoc_type": "EVENT",
+    "required_event": "character_wakes_up",
+    "condition": {
+      "and": [
+        {
+          "or": [
+            { "and": [ { "u_has_trait": "HOMULLUS_BACKSTAGE" }, { "u_has_trait": "HOMULLUS_REGEN_STAMINA" } ] },
+            { "u_has_trait": "THRESH_HOMULLUS" }
+          ]
+        },
+        { "math": [ "(u_characters_nearby('radius': 45, 'attitude': 'any')", "==", "0" ] }
+      ]
+    },
+    "effect": [
+      { "run_eocs": "EOC_PARACLESIAN_BROKE_FAE_BAN" },
+      {
+        "u_message": "You awaken with a start as a terrible feeling of crushing loneliness grips you.  You were meant to live in close contat with humans, not wake up to an empty home.",
+        "type": "bad"
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_HOMULLUS_FAE_BAN_PICKY_EATER",
+    "eoc_type": "EVENT",
+    "required_event": "gains_mutation",
+    "//": "Automatically gain the Picky Eater trait when gaining the Top of the Food Chain trait",
+    "condition": {
+      "and": [
+        { "compare_string": [ "HOMULLUS_EAT_DEMIHUMANS", { "context_val": "trait" } ] },
+        { "u_has_trait": "HOMULLUS" } }
+      ]
+    },
+    "effect": [ { "u_add_trait": "PICKYEATER" } ]
+  },
   {
     "type": "effect_on_condition",
     "id": "EOC_SALAMANDER_FAE_BAN_GET_WET",

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_fae_bans.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_fae_bans.json
@@ -217,7 +217,7 @@
     "effect": [
       { "run_eocs": "EOC_PARACLESIAN_BROKE_FAE_BAN" },
       {
-        "u_message": "You awaken with a start as a terrible feeling of crushing loneliness grips you.  You were meant to live in close contat with humans, not wake up to an empty home.",
+        "u_message": "You awaken with a start as a terrible feeling of crushing loneliness grips you.  You were meant to live in close contact with humans, not wake up to an empty home.",
         "type": "bad"
       }
     ]

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_fae_bans.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_fae_bans.json
@@ -126,7 +126,7 @@
       { "queue_eocs": "EOC_PARACLESIAN_BROKE_FAE_BAN_PAIN", "time_in_future": 1 },
       { "math": [ "u_val('sleepiness')", "+=", "150" ] },
       {
-        "u_message": "You an in pain, your muscles stiff, your body groaning in protest.  Away from the depths of the living earth, your sleep was not as restful as it should have been.",
+        "u_message": "You awaken in pain, your muscles stiff, your body groaning in protest.  Away from the depths of the living earth, your sleep was not as restful as it should have been.",
         "type": "bad"
       }
     ]

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_fae_bans.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_fae_bans.json
@@ -70,7 +70,7 @@
     "type": "effect_on_condition",
     "id": "EOC_ARVORE_FAE_BAN_SLEPT_IN_CITY",
     "eoc_type": "EVENT",
-    "required_event": "character_s_up",
+    "required_event": "character_wakes_up",
     "condition": {
       "and": [
         { "u_has_trait": "THRESH_ARVORE" },
@@ -87,7 +87,7 @@
       { "queue_eocs": "EOC_PARACLESIAN_BROKE_FAE_BAN_PAIN", "time_in_future": 1 },
       { "math": [ "u_val('sleepiness')", "+=", "150" ] },
       {
-        "u_message": "You an with a groggy head, blinking bleary eyes.  Sleeping near the remnants of civilization away from the bounty of nature, your sleep was not as restful as it should have been.",
+        "u_message": "You awaken with a groggy head, blinking bleary eyes.  Sleeping near the remnants of civilization away from the bounty of nature, your sleep was not as restful as it should have been.",
         "type": "bad"
       }
     ]
@@ -96,7 +96,7 @@
     "type": "effect_on_condition",
     "id": "EOC_IERDE_FAE_BAN_DIDNT_SLEEP_UNDERGROUND",
     "eoc_type": "EVENT",
-    "required_event": "character_s_up",
+    "required_event": "character_wakes_up",
     "condition": {
       "and": [
         { "u_has_trait": "THRESH_IERDE" },
@@ -200,42 +200,39 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_HOMULLUS_FAE_BAN_DIDNT_SLEEP_NEAR_HUMANS",
-    "eoc_type": "EVENT",
-    "required_event": "character_wakes_up",
-    "condition": {
-      "and": [
-        {
-          "or": [
-            { "and": [ { "u_has_trait": "HOMULLUS_BACKSTAGE" }, { "u_has_trait": "HOMULLUS_REGEN_STAMINA" } ] },
-            { "u_has_trait": "THRESH_HOMULLUS" }
-          ]
-        },
-        { "math": [ "(u_characters_nearby('radius': 45, 'attitude': 'any')", "==", "0" ] }
-      ]
-    },
-    "effect": [
-      { "run_eocs": "EOC_PARACLESIAN_BROKE_FAE_BAN" },
-      {
-        "u_message": "You awaken with a start as a terrible feeling of crushing loneliness grips you.  You were meant to live in close contat with humans, not wake up to an empty home.",
-        "type": "bad"
-      }
-    ]
-  },
+    "id": "EOC_HOMULLUS_FAE_BAN_DIDNT_SLEEP_NEAR_HUMANS",
+    "eoc_type": "EVENT",
+    "required_event": "character_wakes_up",
+    "condition": {
+      "and": [
+        {
+          "or": [
+            { "and": [ { "u_has_trait": "HOMULLUS_BACKSTAGE" }, { "u_has_trait": "HOMULLUS_REGEN_STAMINA" } ] },
+            { "u_has_trait": "THRESH_HOMULLUS" }
+          ]
+        },
+        { "math": [ "(u_characters_nearby('radius': 45, 'attitude': 'any')", "==", "0" ] }
+      ]
+    },
+    "effect": [
+      { "run_eocs": "EOC_PARACLESIAN_BROKE_FAE_BAN" },
+      {
+        "u_message": "You awaken with a start as a terrible feeling of crushing loneliness grips you.  You were meant to live in close contat with humans, not wake up to an empty home.",
+        "type": "bad"
+      }
+    ]
+  },
   {
-    "type": "effect_on_condition",
-    "id": "EOC_HOMULLUS_FAE_BAN_PICKY_EATER",
-    "eoc_type": "EVENT",
-    "required_event": "gains_mutation",
-    "//": "Automatically gain the Picky Eater trait when gaining the Top of the Food Chain trait",
-    "condition": {
-      "and": [
-        { "compare_string": [ "HOMULLUS_EAT_DEMIHUMANS", { "context_val": "trait" } ] },
-        { "u_has_trait": "HOMULLUS" } }
-      ]
-    },
-    "effect": [ { "u_add_trait": "PICKYEATER" } ]
-  },
+    "type": "effect_on_condition",
+    "id": "EOC_HOMULLUS_FAE_BAN_PICKY_EATER",
+    "eoc_type": "EVENT",
+    "required_event": "gains_mutation",
+    "//": "Automatically gain the Picky Eater and Junkfood Intolerance traits when gaining the Top of the Food Chain trait",
+    "condition": {
+      "and": [ { "compare_string": [ "HOMULLUS_EAT_DEMIHUMANS", { "context_val": "trait" } ] }, { "u_has_trait": "HOMULLUS" } ]
+    },
+    "effect": [ { "u_add_trait": "PICKYEATER" }, { "u_add_trait": "ANTIJUNK" } ]
+  },
   {
     "type": "effect_on_condition",
     "id": "EOC_SALAMANDER_FAE_BAN_GET_WET",

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_fae_bans.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_fae_bans.json
@@ -227,9 +227,23 @@
     "id": "EOC_HOMULLUS_FAE_BAN_PICKY_EATER",
     "eoc_type": "EVENT",
     "required_event": "gains_mutation",
-    "//": "Automatically gain the Picky Eater and Junkfood Intolerance traits when gaining the Top of the Food Chain trait",
+    "//": "Automatically gain the Picky Eater and Junkfood Intolerance traits when gaining the The Top of the Food Chain trait",
     "condition": {
       "and": [ { "compare_string": [ "HOMULLUS_EAT_DEMIHUMANS", { "context_val": "trait" } ] }, { "u_has_trait": "HOMULLUS" } ]
+    },
+    "effect": [ { "u_add_trait": "PICKYEATER" }, { "u_add_trait": "ANTIJUNK" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_HOMULLUS_FAE_BAN_KEEP_FOOD_TRAITS",
+    "//": "This is to prevent the Homullus from purifying those traits away as long as they have The Top of the Food Chain.",
+    "eoc_type": "EVENT",
+    "required_event": "character_wakes_up",
+    "condition": {
+      "and": [
+        { "u_has_trait": "HOMULLUS_EAT_DEMIHUMANS" },
+        { "or": [ { "not": { "u_has_trait": "PICKYEATER" } }, { "not": { "u_has_trait": "ANTIJUNK" } } ] }
+      ]
     },
     "effect": [ { "u_add_trait": "PICKYEATER" }, { "u_add_trait": "ANTIJUNK" } ]
   },

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_fae_bans.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_fae_bans.json
@@ -236,12 +236,12 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_HOMULLUS_FAE_BAN_KEEP_FOOD_TRAITS",
-    "//": "This is to prevent the Homullus from purifying those traits away as long as they have The Top of the Food Chain.",
+    "//": "This is to prevent the Homullus from purifying those traits away as long as they have The Top of the Food Chain, or are post-threshold.",
     "eoc_type": "EVENT",
     "required_event": "character_wakes_up",
     "condition": {
       "and": [
-        { "u_has_trait": "HOMULLUS_EAT_DEMIHUMANS" },
+        { "or": [ { "u_has_trait": "HOMULLUS_EAT_DEMIHUMANS" }, { "u_has_trait": "THRESH_HOMULLUS" } ] },
         { "or": [ { "not": { "u_has_trait": "PICKYEATER" } }, { "not": { "u_has_trait": "ANTIJUNK" } } ] }
       ]
     },

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_fae_bans.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_fae_bans.json
@@ -211,7 +211,7 @@
             { "u_has_trait": "THRESH_HOMULLUS" }
           ]
         },
-        { "math": [ "(u_characters_nearby('radius': 45, 'attitude': 'any')", "==", "0" ] }
+        { "math": [ "u_characters_nearby('radius': 45, 'attitude': 'any')", "==", "0" ] }
       ]
     },
     "effect": [


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Xedra Evolved] Add Homullus must wake up near humans fae ban + eating restrictions"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Homullus is extremely powerful right now--they can use CBMs, they can use mutagens, they get stronger in cities, they have no problem with iron, and right now their only disadvantage is they can't kill ferals or NPCs.  They need more thematic disadvantages, so here's a start.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add a fae ban that Homullus must wake up near humans--if there are no NPCs within 45 squares when they awaken, they break a ban. This triggers either when they are post-threshold or when they have both Backstage and Take the Line.  The logic here is that, like hobs or domovoi or other house spirits, homullus lived unseen among humanity, protecting us against supernatural threats. 

(I plan to add this kind of logic to other fae bans too, so they don't all just come crashing down when you hit the threshold)

Also slightly edit Top of the Food Chain so that you also gain Picky Eater and Junkfood Intolerance when you get it, and those traits are readded if you purify them away as long as you still have Top of the Food Chain (or are post-threshold).  They're added by EoC, so you don't "lose" a good trait to get them. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Negative traits are granted, sleeping alone breaks fae ban.  Sleeping with a human nearby does not. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

All the Paraclesians need more interesting thematic disadvantages, honestly, but there's only so much that's possible.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
