### PR TITLE
Prevent automatic assignment of hotkeys to passive mutations

### DIFF
--- a/src/mutation_ui.cpp
+++ b/src/mutation_ui.cpp
@@ -110,7 +110,7 @@ void avatar::power_mutations()
         // New mutations are initialized with no key at all, so we have to do this here.
         if( mut.second.key == ' ' ) {
             for( const char &letter : mutation_chars ) {
-                if( trait_by_invlet( letter ).is_null() ) {
+                if( trait_by_invlet( letter ).is_null() && mut.first->activated ) {
                     mut.second.key = letter;
                     break;
                 }


### PR DESCRIPTION
#### Summary
Interface "Prevent automatically assigning keys to passive mutations"

#### Purpose of change
Stops passive mutations from being assigned characters. I've already done this with bionics, but I forgot that mutations did this too.

#### Describe the solution
During invlet assignment, check if the mutation is active before assigning an invlet

#### Testing
Created a new character with several passive and active mutations. Only active mutations had hotkeys.

#### Additional context
Mutation hotkeys are assigned every time the mutations menu is opened instead of being persistent for some reason.