### PR TITLE
Use item::energy to stash sub-kJ power quantities for more precise power usage

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -14081,11 +14081,11 @@ bool item::process_wet( Character *carrier, const tripoint & /*pos*/ )
     return true;
 }
 
-units::energy item::energy_per_second()
+units::energy item::energy_per_second() const
 {
     units::energy energy_to_burn;
     if( type->tool->turns_per_charge > 0 ) {
-        energy_to_burn += units::from_kilojoule( std::max( ammo_required(),
+        energy_to_burn += units::from_kilojoule( std::max<int64_t>( ammo_required(),
                           1 ) ) / type->tool->turns_per_charge;
     } else if( type->tool->power_draw > 0_mW ) {
         energy_to_burn += type->tool->power_draw * 1_seconds;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -10883,6 +10883,7 @@ units::energy item::energy_remaining( const Character *carrier ) const
 
     // Battery(ammo) contained within
     if( is_magazine() ) {
+        ret += energy;
         for( const item *e : contents.all_items_top( pocket_type::MAGAZINE ) ) {
             if( e->typeId() == itype_battery ) {
                 ret += units::from_kilojoule( static_cast<std::int64_t>( e->charges ) );
@@ -11086,8 +11087,22 @@ units::energy item::energy_consume( units::energy qty, const tripoint &pos, Char
     if( is_battery() || fuel_efficiency >= 0 ) {
         int consumed_kj = contents.ammo_consume( units::to_kilojoule( qty ), pos, fuel_efficiency );
         qty -= units::from_kilojoule( static_cast<std::int64_t>( consumed_kj ) );
-        // fix negative quantity
-        if( qty < 0_J ) {
+        // Either we're out of juice or truncating the value above means we didn't drain quite enough.
+        // In the latter case at least this will bump up energy enough to satisfy the remainder,
+        // if not it will drain the item all the way.
+        // TODO: reconsider what happens with fuel burning, right now this stashes
+        // the remainder of energy from burning the fuel in the item in question,
+        // which potentially allows it to burn less fuel next time.
+        // Do we want an implicit 1kJ battery in the generator to smooth things out?
+        if( qty > energy ) {
+            int64_t residual_drain = contents.ammo_consume( 1, pos, fuel_efficiency );
+            energy += units::from_kilojoule( residual_drain );
+        }
+        if( qty > energy ) {
+            qty -= energy;
+            energy = 0_J;
+        } else {
+            energy -= qty;
             qty = 0_J;
         }
     }
@@ -11107,13 +11122,6 @@ units::energy item::energy_consume( units::energy qty, const tripoint &pos, Char
         units::energy bio_used = std::min( carrier->get_power_level(), qty );
         carrier->mod_power_level( -bio_used );
         qty -= bio_used;
-    }
-
-    // If consumption is not integer kJ we need to consume one extra battery charge to "round up".
-    // Should happen only if battery powered and energy per shot is not integer kJ.
-    if( qty > 0_kJ && is_battery() ) {
-        int consumed_kj = contents.ammo_consume( 1, pos );
-        qty -= units::from_kilojoule( static_cast<std::int64_t>( consumed_kj ) );
     }
 
     return wanted_energy - qty;
@@ -14073,6 +14081,18 @@ bool item::process_wet( Character *carrier, const tripoint & /*pos*/ )
     return true;
 }
 
+units::energy item::energy_per_second()
+{
+    units::energy energy_to_burn;
+    if( type->tool->turns_per_charge > 0 ) {
+        energy_to_burn += units::from_kilojoule( std::max( ammo_required(),
+                          1 ) ) / type->tool->turns_per_charge;
+    } else if( type->tool->power_draw > 0_mW ) {
+        energy_to_burn += type->tool->power_draw * 1_seconds;
+    }
+    return energy_to_burn;
+}
+
 bool item::process_tool( Character *carrier, const tripoint &pos )
 {
     // FIXME: remove this once power armors don't need to be TOOL_ARMOR anymore
@@ -14082,7 +14102,7 @@ bool item::process_tool( Character *carrier, const tripoint &pos )
 
     // if insufficient available charges shutdown the tool
     if( ( type->tool->turns_per_charge > 0 || type->tool->power_draw > 0_W ) &&
-        ammo_remaining( carrier, true ) == 0 ) {
+        energy_remaining( carrier ) < energy_per_second() ) {
         if( carrier && has_flag( flag_USE_UPS ) ) {
             carrier->add_msg_if_player( m_info, _( "You need an UPS to run the %s!" ), tname() );
         }
@@ -14097,20 +14117,19 @@ bool item::process_tool( Character *carrier, const tripoint &pos )
         }
     }
 
-    int energy = 0;
-    if( type->tool->turns_per_charge > 0 &&
-        to_turn<int>( calendar::turn ) % type->tool->turns_per_charge == 0 ) {
-        energy = std::max( ammo_required(), 1 );
-    } else if( type->tool->power_draw > 0_W ) {
-        // kJ (battery unit) per second
-        energy = units::to_kilowatt( type->tool->power_draw );
-        // energy_bat remainder results in chance at additional charge/discharge
-        const int kw_in_mw = units::to_milliwatt( 1_kW );
-        energy += x_in_y( units::to_milliwatt( type->tool->power_draw ) % kw_in_mw, kw_in_mw ) ? 1 : 0;
-    }
+    if( energy_remaining( carrier ) > 0_J ) {
+        energy_consume( energy_per_second(), pos, carrier );
+    } else {
+        // Non-electrical charge consumption.
+        int charges_to_use = 0;
+        if( type->tool->turns_per_charge > 0 &&
+            to_turn<int>( calendar::turn ) % type->tool->turns_per_charge == 0 ) {
+            charges_to_use = std::max( ammo_required(), 1 );
+        }
 
-    if( energy > 0 ) {
-        ammo_consume( energy, pos, carrier );
+        if( charges_to_use > 0 ) {
+            ammo_consume( charges_to_use, pos, carrier );
+        }
     }
 
     type->tick( carrier, *this, pos );

--- a/src/item.h
+++ b/src/item.h
@@ -2458,7 +2458,7 @@ class item : public visitable
 
 
     private:
-        units::energy energy_per_second();
+        units::energy energy_per_second() const;
         int ammo_remaining( const std::set<ammotype> &ammo, const Character *carrier = nullptr,
                             bool include_linked = false ) const;
     public:

--- a/src/item.h
+++ b/src/item.h
@@ -2458,6 +2458,7 @@ class item : public visitable
 
 
     private:
+        units::energy energy_per_second();
         int ammo_remaining( const std::set<ammotype> &ammo, const Character *carrier = nullptr,
                             bool include_linked = false ) const;
     public:

--- a/tests/ammo_test.cpp
+++ b/tests/ammo_test.cpp
@@ -237,12 +237,22 @@ TEST_CASE( "battery_energy_test", "[ammo][energy][item]" )
     }
 
     SECTION( "Non-integer drain from battery" ) {
-        // Battery charge is in chunks of kj. Non integer kj drain is rounded up.
-        // 4.5 kJ drain becomes 5 kJ drain
+        // Battery charge is in mJ now, so check for precise numbers.
+        // 4.5 kJ drain is 4.5 kJ drain
         REQUIRE( test_battery.energy_remaining( nullptr ) == 56_kJ );
         units::energy consumed = test_battery.energy_consume( 4500_J, tripoint_zero, nullptr );
-        CHECK( test_battery.energy_remaining( nullptr ) == 51_kJ );
-        CHECK( consumed == 5_kJ );
+        CHECK( test_battery.energy_remaining( nullptr ) == 51.5_kJ );
+        CHECK( consumed == 4500_J );
+    }
+
+    SECTION( "Tiny Non-integer drain from battery" ) {
+        // Make sure lots of tiny discharges sum up as expected.
+        REQUIRE( test_battery.energy_remaining( nullptr ) == 56_kJ );
+        for( int i = 0; i < 133; ++i ) {
+            units::energy consumed = test_battery.energy_consume( 2_J, tripoint_zero, nullptr );
+            CHECK( consumed == 2_J );
+        }
+        CHECK( test_battery.energy_remaining( nullptr ) == 55734_J );
     }
 
     SECTION( "Non-integer over-drain from battery" ) {


### PR DESCRIPTION
#### Summary
Bugfixes "Allow tiny continuous power draw in electronic devices."

#### Purpose of change
TODO find related issues
We've had issues with low-draw devices that are *supposed* to work for a very long time for practically forever. There are workarounds such as tool::turns_per_charge, but that's gnarly and has weird side effects.
The root cause is that the lower bound of charge resolution has been "one battery charge", which we set at 1kJ because there's also a rather large number of charges we need to handle for e.g. electric cars, and the "number of charges" type is an int.

#### Describe the solution
I poked around and we already have a member of the item class that is type units::energy which is backed by a int64_t and has a resolution of one mJ.  Due to an int64_t being staggeringly large, this really can handle whatever we feel like throwing at it, so why isn't the problem fixed?
The problem is legacy code that treats electrical capacity as "charges" and a whole ton of infrastructure, mostly in crafting code, and specifies power drain in "charges of battery", which again are 1kJ each.
After rooting around though, I realized we don't have to overhaul all the crafting code to fix this particular issue, because the "process_tool()" code responsible for e.g. spending power every turn for an active flashlight doesn't interact with any of that code.
So what I've done here is I updated item::process_tool() to call item::energy_consume() and item::energy_consume() to use item::energy to stash residual energy as needed.  So if your flashlight has 10 "charges" of battery and you try to spend 20J, it spends one "charge", but stashes the remaining 980J of energy in item::energy, which can be used next turn instead of burning more charges.

#### Describe alternatives you've considered
There's a huge overhaul I eventually want to happen here where the itype_battery item that represents a distinct amount of charge just goes away and instead a battery item like a light_battery instead just uses it's item::energy member and islot::battery::max_charges member to handle how much charge it can hold.  That requires overhauling a huge amount of crafting code though and I'm not up to that at the moment.

#### Testing
Added tests for an exemplar, specifically having a small LED flashlight run for the intended 10 hours on one set of batteries.
Before this change it would round up from 1.5J per turn to 1kJ per turn, so it would run for one hour instead of about 10.

#### Additional context
See e.g. #75903 for other aspects of the same problem.