### PR TITLE
Bugfix: Reach attack around corners

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -7795,7 +7795,7 @@ bool map::sees( const tripoint &F, const tripoint &T, const int range,
 }
 
 bool map::sees( const tripoint_bub_ms &F, const tripoint_bub_ms &T, const int range,
-                int &bresenham_slope, bool with_fields ) const
+                int &bresenham_slope, bool with_fields, bool allow_cached ) const
 {
     bool ( map:: * f_transparent )( const tripoint & p ) const =
         with_fields ? &map::is_transparent : &map::is_transparent_wo_fields;
@@ -7807,9 +7807,11 @@ bool map::sees( const tripoint_bub_ms &F, const tripoint_bub_ms &T, const int ra
         return false; // Out of range!
     }
     const point key = sees_cache_key( F, T );
-    char cached = skew_cache.get( key, -1 );
-    if( cached >= 0 ) {
-        return cached > 0;
+    if( allow_cached ) {
+        char cached = skew_cache.get( key, -1 );
+        if( cached >= 0 ) {
+            return cached > 0;
+        }
     }
     bool visible = true;
 
@@ -8056,8 +8058,9 @@ std::vector<tripoint_bub_ms> map::find_clear_path( const tripoint_bub_ms &source
     // Not totally sure of the derivation.
     const int max_start_offset = std::abs( ideal_start_offset ) * 2 + 1;
     for( int horizontal_offset = -1; horizontal_offset <= max_start_offset; ++horizontal_offset ) {
-        int candidate_offset = horizontal_offset * start_sign;
-        if( sees( source, destination, rl_dist( source, destination ), candidate_offset ) ) {
+        int candidate_offset = horizontal_offset * ( start_sign == 0 ? 1 : start_sign );
+        if( sees( source, destination, rl_dist( source, destination ),
+                  candidate_offset, /*with_fields=*/true, /*allow_cached=*/false ) ) {
             return line_to( source, destination, candidate_offset, 0 );
         }
     }

--- a/src/map.h
+++ b/src/map.h
@@ -701,7 +701,7 @@ class map
         bool sees( const tripoint &F, const tripoint &T, int range, int &bresenham_slope,
                    bool with_fields = true ) const;
         bool sees( const tripoint_bub_ms &F, const tripoint_bub_ms &T, int range, int &bresenham_slope,
-                   bool with_fields = true ) const;
+                   bool with_fields = true, bool allow_cached = true ) const;
         point sees_cache_key( const tripoint_bub_ms &from, const tripoint_bub_ms &to ) const;
     public:
         /**

--- a/tests/map_path_test.cpp
+++ b/tests/map_path_test.cpp
@@ -1,0 +1,244 @@
+#include "cata_catch.h"
+#include "coordinates.h"
+#include "coords_fwd.h"
+#include "coordinate_constants.h"
+#include "game.h"
+#include "map.h"
+#include "map_helpers.h"
+#include "type_id.h"
+
+static void place_obstacle( map &m, const std::vector<tripoint_bub_ms> &places )
+{
+    const ter_id t_wall_metal( "t_wall_metal" );
+    for( const tripoint_bub_ms &p : places ) {
+        m.ter_set( p, t_wall_metal );
+    }
+    m.set_transparency_cache_dirty( 0 );
+    m.build_map_cache( 0 );
+    for( const tripoint_bub_ms &p : places ) {
+        REQUIRE( !m.is_transparent( p.raw() ) );
+    }
+}
+
+static void expect_path( const std::vector<tripoint_bub_ms> &expected,
+                         const std::vector<tripoint_bub_ms> &actual )
+{
+    THEN( "path avoids obstacle" ) {
+        CHECK( expected == actual );
+    }
+}
+
+static map &setup_map_without_obstacles()
+{
+    const ter_id t_floor( "t_floor" );
+    map &here = get_map();
+    clear_map();
+    const tripoint_bub_ms topleft = tripoint_bub_ms_zero;
+    const tripoint_bub_ms bottomright { 20, 20, 0 };
+    for( const tripoint_bub_ms &p : here.points_in_rectangle( topleft, bottomright ) ) {
+        here.ter_set( p, t_floor );
+    }
+    return here;
+}
+
+TEST_CASE( "find_clear_path_with_adjacent_obstacles", "[map]" )
+{
+    const tripoint_bub_ms p_center{ 10, 10, 0 };
+    // Adjacent mapsquares
+    const tripoint_bub_ms nw = p_center + tripoint_rel_ms_north_west;
+    const tripoint_bub_ms n = p_center + tripoint_rel_ms_north;
+    const tripoint_bub_ms ne = p_center + tripoint_rel_ms_north_east;
+    const tripoint_bub_ms e = p_center + tripoint_rel_ms_east;
+    const tripoint_bub_ms se = p_center + tripoint_rel_ms_south_east;
+    const tripoint_bub_ms s = p_center + tripoint_rel_ms_south;
+    const tripoint_bub_ms sw = p_center + tripoint_rel_ms_south_west;
+    const tripoint_bub_ms w = p_center + tripoint_rel_ms_west;
+    // Mapsquares further out
+    const tripoint_bub_ms n_nw = n + tripoint_rel_ms_north_west;
+    const tripoint_bub_ms n_n = n + tripoint_rel_ms_north;
+    const tripoint_bub_ms n_ne = n + tripoint_rel_ms_north_east;
+    const tripoint_bub_ms e_ne = e + tripoint_rel_ms_north_east;
+    const tripoint_bub_ms e_e = e + tripoint_rel_ms_east;
+    const tripoint_bub_ms e_se = e + tripoint_rel_ms_south_east;
+    const tripoint_bub_ms s_se = s + tripoint_rel_ms_south_east;
+    const tripoint_bub_ms s_s = s + tripoint_rel_ms_south;
+    const tripoint_bub_ms s_sw = s + tripoint_rel_ms_south_west;
+    const tripoint_bub_ms w_sw = w + tripoint_rel_ms_south_west;
+    const tripoint_bub_ms w_w = w + tripoint_rel_ms_west;
+    const tripoint_bub_ms w_nw = w + tripoint_rel_ms_north_west;
+
+    map &here = setup_map_without_obstacles();
+    GIVEN( "Map has adjacent obstacle directly nw, ne, se, sw" ) {
+        place_obstacle( here, { nw, ne, se, sw } );
+        WHEN( "map::find_clear_path to n_nw" ) {
+            expect_path( { n, n_nw }, here.find_clear_path( p_center, n_nw ) );
+        }
+        WHEN( "map::find_clear_path to n_n" ) {
+            expect_path( { n, n_n }, here.find_clear_path( p_center, n_n ) );
+        }
+        WHEN( "map::find_clear_path to n_ne" ) {
+            expect_path( { n, n_ne }, here.find_clear_path( p_center, n_ne ) );
+        }
+        WHEN( "map::find_clear_path to e_ne" ) {
+            expect_path( { e, e_ne }, here.find_clear_path( p_center, e_ne ) );
+        }
+        WHEN( "map::find_clear_path to e_e" ) {
+            expect_path( { e, e_e }, here.find_clear_path( p_center, e_e ) );
+        }
+        WHEN( "map::find_clear_path to e_se" ) {
+            expect_path( { e, e_se }, here.find_clear_path( p_center, e_se ) );
+        }
+        WHEN( "map::find_clear_path to s_se" ) {
+            expect_path( { s, s_se }, here.find_clear_path( p_center, s_se ) );
+        }
+        WHEN( "map::find_clear_path to s_s" ) {
+            expect_path( { s, s_s }, here.find_clear_path( p_center, s_s ) );
+        }
+        WHEN( "map::find_clear_path to s_sw" ) {
+            expect_path( { s, s_sw }, here.find_clear_path( p_center, s_sw ) );
+        }
+        WHEN( "map::find_clear_path to w_sw" ) {
+            expect_path( { w, w_sw }, here.find_clear_path( p_center, w_sw ) );
+        }
+        WHEN( "map::find_clear_path to w_w" ) {
+            expect_path( { w, w_w }, here.find_clear_path( p_center, w_w ) );
+        }
+        WHEN( "map::find_clear_path to w_nw" ) {
+            expect_path( { w, w_nw }, here.find_clear_path( p_center, w_nw ) );
+        }
+    }
+    GIVEN( "Map has adjacent obstacle directly n, e, s, w" ) {
+        place_obstacle( here, { n, e, s, w } );
+        WHEN( "map::find_clear_path to n_nw" ) {
+            expect_path( { nw, n_nw }, here.find_clear_path( p_center, n_nw ) );
+        }
+        WHEN( "map::find_clear_path to n_ne" ) {
+            expect_path( { ne, n_ne }, here.find_clear_path( p_center, n_ne ) );
+        }
+        WHEN( "map::find_clear_path to e_ne" ) {
+            expect_path( { ne, e_ne }, here.find_clear_path( p_center, e_ne ) );
+        }
+        WHEN( "map::find_clear_path to e_se" ) {
+            expect_path( { se, e_se }, here.find_clear_path( p_center, e_se ) );
+        }
+        WHEN( "map::find_clear_path to s_se" ) {
+            expect_path( { se, s_se }, here.find_clear_path( p_center, s_se ) );
+        }
+        WHEN( "map::find_clear_path to s_sw" ) {
+            expect_path( { sw, s_sw }, here.find_clear_path( p_center, s_sw ) );
+        }
+        WHEN( "map::find_clear_path to w_sw" ) {
+            expect_path( { sw, w_sw }, here.find_clear_path( p_center, w_sw ) );
+        }
+        WHEN( "map::find_clear_path to w_nw" ) {
+            expect_path( { nw, w_nw }, here.find_clear_path( p_center, w_nw ) );
+        }
+    }
+    clear_map();
+}
+
+
+TEST_CASE( "find_clear_path_5tiles_with_obstacles", "[map]" )
+{
+    map &here = setup_map_without_obstacles();
+    const tripoint_bub_ms source{ 10, 10, 0 };
+    const tripoint_bub_ms target{ 5, 8, 0 };
+    GIVEN( "Map has obstacle southeast of target" ) {
+        /*
+         * Map layout:   t=target  s=source  o=obstacle
+         * t . . . . . .
+         * . o . . . . .
+         * . . . . . s .
+         */
+        const tripoint_bub_ms obstacle{ 6, 9, 0 };
+        place_obstacle( here, { obstacle } );
+        WHEN( "map::find_clear_path to target" ) {
+            const std::vector<tripoint_bub_ms> path = here.find_clear_path( source, target );
+            THEN( "path avoids obstacle" ) {
+                CHECK( path[0] == tripoint_bub_ms{ 9, 9, 0 } );
+                CHECK( path[1] == tripoint_bub_ms{ 8, 9, 0 } );
+                CHECK( path[2] == tripoint_bub_ms{ 7, 9, 0 } );
+                CHECK( path[3] == tripoint_bub_ms{ 6, 8, 0 } );
+                CHECK( path[4] == tripoint_bub_ms{ 5, 8, 0 } );
+                const bool path_contains_obstacle = std::find( path.begin(), path.end(), obstacle ) != path.end();
+                CHECK_FALSE( path_contains_obstacle );
+            }
+            CHECK( here.sees( source, target, -1 ) );
+            CHECK( here.sees( target, source, -1 ) );
+        }
+    }
+    GIVEN( "Map has obstacle east of target" ) {
+        /*
+         * Map layout:   t=target  s=source  o=obstacle
+         * t o . . . . .
+         * . . . . . . .
+         * . . . . . s .
+         */
+        const tripoint_bub_ms obstacle{ 6, 8, 0 };
+        place_obstacle( here, { obstacle } );
+        WHEN( "map::find_clear_path to target" ) {
+            const std::vector<tripoint_bub_ms> path = here.find_clear_path( source, target );
+            THEN( "path avoids obstacle" ) {
+                CHECK( path[0] == tripoint_bub_ms{ 9, 10, 0 } );
+                CHECK( path[1] == tripoint_bub_ms{ 8, 9, 0 } );
+                CHECK( path[2] == tripoint_bub_ms{ 7, 9, 0 } );
+                CHECK( path[3] == tripoint_bub_ms{ 6, 9, 0 } );
+                CHECK( path[4] == tripoint_bub_ms{ 5, 8, 0 } );
+                const bool path_contains_obstacle = std::find( path.begin(), path.end(), obstacle ) != path.end();
+                CHECK_FALSE( path_contains_obstacle );
+            }
+            CHECK( here.sees( source, target, -1 ) );
+            CHECK( here.sees( target, source, -1 ) );
+        }
+    }
+    GIVEN( "Map has obstacle northwest of source" ) {
+        /*
+         * Map layout:   t=target  s=source  o=obstacle
+         * t . . . . . .
+         * . . . . o . .
+         * . . . . . s .
+         */
+        const tripoint_bub_ms obstacle{ 9, 9, 0 };
+        place_obstacle( here, { obstacle } );
+        WHEN( "map::find_clear_path to target" ) {
+            const std::vector<tripoint_bub_ms> path = here.find_clear_path( source, target );
+            THEN( "path avoids obstacle" ) {
+                CHECK( path[0] == tripoint_bub_ms{ 9, 10, 0 } );
+                CHECK( path[1] == tripoint_bub_ms{ 8, 9, 0 } );
+                CHECK( path[2] == tripoint_bub_ms{ 7, 9, 0 } );
+                CHECK( path[3] == tripoint_bub_ms{ 6, 8, 0 } );
+                CHECK( path[4] == tripoint_bub_ms{ 5, 8, 0 } );
+                const bool path_contains_obstacle = std::find( path.begin(), path.end(), obstacle ) != path.end();
+                CHECK_FALSE( path_contains_obstacle );
+            }
+            CHECK( here.sees( source, target, -1 ) );
+            CHECK( here.sees( target, source, -1 ) );
+        }
+    }
+    GIVEN( "Map has obstacle west of source" ) {
+        /*
+         * Map layout:   t=target  s=source  o=obstacle
+         * t . . . . . .
+         * . . . . . . .
+         * . . . . o s .
+         */
+        const tripoint_bub_ms obstacle{ 9, 10, 0 };
+        place_obstacle( here, { obstacle } );
+        WHEN( "map::find_clear_path to target" ) {
+            const std::vector<tripoint_bub_ms> path = here.find_clear_path( source, target );
+            THEN( "path avoids obstacle" ) {
+                CHECK( path[0] == tripoint_bub_ms{ 9, 9, 0 } );
+                CHECK( path[1] == tripoint_bub_ms{ 8, 9, 0 } );
+                CHECK( path[2] == tripoint_bub_ms{ 7, 9, 0 } );
+                CHECK( path[3] == tripoint_bub_ms{ 6, 8, 0 } );
+                CHECK( path[4] == tripoint_bub_ms{ 5, 8, 0 } );
+                const bool path_contains_obstacle = std::find( path.begin(), path.end(), obstacle ) != path.end();
+                CHECK_FALSE( path_contains_obstacle );
+            }
+            CHECK( here.sees( source, target, -1 ) );
+            CHECK( here.sees( target, source, -1 ) );
+        }
+    }
+    clear_map();
+}
+


### PR DESCRIPTION


<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Reach attack around corners"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fixes an issue where melee reach attacks would hit a wall before, even if there were other possibilities to draw a straight line to the target. Probably for #61471 .

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

The issue before was two issues:
* `map::sees` returned cached values even if `bresenham_slope` was changed
* `map::find_clear_path` did not try different values for `candidate_offset` if `start_sign` was 0

The first issue was that the algorithm being used in `map::find_clear_path` tries to find a value for `bresenham_slope` (also named `candidate_offset`) that creates a clear path to the target. But in `map::sees` we create a cache key for an LRU cache using only the from and to points, and the cache key specifically does not contain `bresenham_slope`. This made it so that repeated calls to `map::sees` using different values for `bresenham_slope` would always just return the cached value from the first evaluation of the method.

The second issue was that in cases where `start_sign` was 0 in `map::find_clear_path`, then the algorithm for finding a good value for `bresenham_slope` always used `candidate_offset=0` since it incorrectly multiplied the `horizontal_offset` with `0`. In effect, it previously iterated several values for `horizontal_offset`, but all of them resulted in `0` being tried for `bresenham_slope`.

This commit instead updates `map::sees` so that calls from `map::find_clear_path` never allow cached results. The cache will still be populated correctly once a path is chosen, but with this commit, it will also allow calls to attempt using different values for `bresenham_slope`.

The effect of this is that melee reach attacks will now correctly find a straight path when being done adjacent to an obstacle. A side-effect is also that ranged attacks that find a straight path from A to B should now also find a straight path from B to A (they did not always do so before).

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Using a spear to do melee reach attacks:
![melee-reach-1](https://github.com/user-attachments/assets/2d8975e3-ee09-4106-bffa-67718e8dd4e3)

![melee-reach-2](https://github.com/user-attachments/assets/311e3d55-590e-448a-81a4-fff3e70d45f4)

![melee-reach-3](https://github.com/user-attachments/assets/cd094ead-68b6-4e39-9ff6-570f38979a1a)

Recreating similar scenario as in #61471 , using a gun to do a ranged attack:
![ranged-2](https://github.com/user-attachments/assets/b78e453b-0b36-4c41-9709-64cd8d1e1c6a)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Related: #11422 , #36363 , #71605 .
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
