### PR TITLE
[EOC] fix somethings and add somethings for #75675 string input

### DIFF
--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -3050,8 +3050,9 @@ Store string from `set_string_var` in the variable object `target_var`
 
 | Property | Optionality | Type | Description |
 | --- | --- | --- | --- |
-| "title" | **mandatory** | string, [variable object](##variable-object) | The title of the input popup window, can be localized (e.g., `"title": { "i18n": true, "str": "Input a value:" }`). |
-| "description" | **mandatory** | string, [variable object](##variable-object) | The description of the input popup window, can be localized. |
+| "title" | optional | string, [variable object](##variable-object) | The title of the input popup window, can be localized (e.g., `"title": { "i18n": true, "str": "Input a value:" }`). |
+| "description" | optional | string, [variable object](##variable-object) | The description of the input popup window, can be localized. |
+| "default_text" | optional | string, [variable object](##variable-object) | The default text in the input popup window, can be localized. |
 | "width" | optional | integer | The character length of the input box. Default is 20. |
 | "identifier" | optional | string | Input boxes with the same identifier share input history. Default is `""`. |
 | "only_digits" | optional | boolean | Whether the input is purely numeric. Default is false. |
@@ -3060,7 +3061,7 @@ Store string from `set_string_var` in the variable object `target_var`
 
 | Avatar | Character | NPC | Monster |  Furniture | Item |
 | ------ | --------- | --------- | ---- | ------- | --- | 
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ |
+| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 ##### Examples
 Replace value of variable `foo` with value `bar`

--- a/lang/string_extractor/parsers/effect.py
+++ b/lang/string_extractor/parsers/effect.py
@@ -87,6 +87,13 @@ def parse_effect(effects, origin, comment=""):
                         comment="String input window's description in {}"
                         .format(comment)
                     )
+                if "default_text" in string_input:
+                    write_translation_or_var(
+                        string_input["default_text"],
+                        origin,
+                        comment="String input window's default_text in {}"
+                        .format(comment)
+                    )
             if ("u_spawn_monster" in eff or "npc_spawn_monster" in eff or
                     "u_spawn_npc" in eff or "npc_spawn_npc" in eff):
                 if "u_spawn_monster" in eff or "npc_spawn_monster" in eff:

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -4830,19 +4830,31 @@ talk_effect_fun_t::func f_set_string_var( const JsonObject &jo, std::string_view
         if( input_params.has_value() ) {
             string_input_popup popup;
             popup
-            .title( input_params.value().title.evaluate( d ) )
-            .description( input_params.value().description.evaluate( d ) )
+            .title( input_params.value().title ? input_params.value().title->evaluate( d ) : "" )
+            .description( input_params.value().description ? input_params.value().description->evaluate(
+                              d ) : "" )
             .width( input_params.value().width )
-            .identifier( input_params.value().identifier );
+            .identifier( input_params.value().identifier ? input_params.value().identifier->evaluate(
+                             d ) : "" );
 
             if( input_params.value().only_digits ) {
-                int num_temp;
+                int num_temp = 0;
+                try {
+                    num_temp = std::stoi( input_params.value().default_text.has_value() ?
+                                          input_params.value().default_text->evaluate(
+                                              d ) : "0" );
+                } catch( const std::out_of_range &e ) {
+                    debugmsg( "The number is too large to fit in an int." );
+                } catch( const std::invalid_argument &e ) {
+                };
                 popup.edit( num_temp );
                 if( !popup.canceled() ) {
                     str = std::to_string( num_temp );
                 }
             } else {
-                std::string str_temp;
+                std::string str_temp = input_params.value().default_text ?
+                                       input_params.value().default_text->evaluate(
+                                           d ) : "";
                 popup.edit( str_temp );
                 if( !popup.canceled() ) {
                     str = str_temp;

--- a/src/string_input_popup.cpp
+++ b/src/string_input_popup.cpp
@@ -680,11 +680,16 @@ string_input_params string_input_params::parse_string_input_params( const JsonOb
         const JsonValue &jv_description = jo.get_member( "description" );
         p.description = get_str_translation_or_var( jv_description, "" );
     }
+    if( jo.has_member( "default_text" ) ) {
+        const JsonValue &jv_default_text = jo.get_member( "default_text" );
+        p.default_text = get_str_translation_or_var( jv_default_text, "" );
+    }
     if( jo.has_int( "width" ) ) {
         p.width = jo.get_int( "width" );
     }
-    if( jo.has_string( "identifier" ) ) {
-        p.identifier = jo.get_string( "identifier" );
+    if( jo.has_member( "identifier" ) ) {
+        const JsonValue &jv_identifier = jo.get_member( "identifier" );
+        p.identifier = get_str_or_var( jv_identifier, "" );
     }
     if( jo.has_bool( "only_digits" ) ) {
         p.only_digits = jo.get_bool( "only_digits" );

--- a/src/string_input_popup.h
+++ b/src/string_input_popup.h
@@ -294,10 +294,11 @@ class string_input_popup // NOLINT(cata-xy)
 };
 
 struct string_input_params {
-    str_translation_or_var title;
-    str_translation_or_var description;
+    std::optional<str_translation_or_var> title;
+    std::optional<str_translation_or_var> description;
+    std::optional<str_translation_or_var> default_text;
     int width = 20;
-    std::string identifier;
+    std::optional<str_or_var> identifier;
     bool only_digits = false;
     static string_input_params parse_string_input_params( const JsonObject &jo );
 };


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "[EOC] fix somethings and add somethings for #75675 string input"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

Here are some follow-up works for my last PR #75675.

#### Describe the solution

1. Add a default_text field that supports default text in the user input window.
2. Make all fields opptional.
3. Allow the `identifier` field to accept `variable object`.
4. Check whether the numercial input exceeds the range of int.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

I test it in my mod.

[BookReader.zip](https://github.com/user-attachments/files/16741145/BookReader.zip)

This is a demo mod to read a book in CDDA.

The book reader interface is like this:

![image](https://github.com/user-attachments/assets/87b650b0-e871-4b8b-bf30-53fe63a362c8)


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
