### PR TITLE
Fix clang-tidy complaint about double spaces (0.H)

### DIFF
--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -944,7 +944,7 @@ bool main_menu::new_character_tab()
                 }
                 if( !world->world_saves.empty() ) {
                     if( !query_yn(
-                            _( "Many game features will not work correctly with multiple characters in the same world. Create a new character anyway?" ) ) ) {
+                            _( "Many game features will not work correctly with multiple characters in the same world.  Create a new character anyway?" ) ) ) {
                         return false;
                     }
                 }
@@ -989,7 +989,7 @@ bool main_menu::new_character_tab()
         }
         if( !world->world_saves.empty() ) {
             if( !query_yn(
-                    _( "Many game features will not work correctly with multiple characters in the same world. Create a new character anyway?" ) ) ) {
+                    _( "Many game features will not work correctly with multiple characters in the same world.  Create a new character anyway?" ) ) ) {
                 return false;
             }
         }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Accidentally introduced a clang-tidy complaint after merging #75886 (only in the 0.H branch)

#### Describe the solution
Fix the double space complaint.

#### Describe alternatives you've considered

#### Testing

#### Additional context
