### PR TITLE
Add enchantment for range dodges

### DIFF
--- a/doc/MAGIC.md
+++ b/doc/MAGIC.md
@@ -878,6 +878,7 @@ Character status value  | Description
 `POWER_TRICKLE`         | Generates this amount of millijoules each second. Default value is zero, so better to use `add`
 `RANGE`                 | Modifies your characters range with firearms
 `RANGED_DAMAGE`         | Adds damage to ranged attacks.
+`RANGE_DODGE`           | Chance to dodge projectile attack, no matter of it's speed; Consumes dodges similarly to melee dodges, and fails, if character has no dodges left. `add` and `multiply` behave equally. `add: 0.5` would result in 50% chance to avoid projectile
 `READING_EXP`           | Changes the minimum you learn from each reading increment.
 `READING_SPEED_MULTIPLIER`  | Changes how fast you can read books; Lesser value means faster book reading, with cap of 1 second.
 `RECOIL_MODIFIER`       | Affects recoil when shooting a gun.  Positive value increase the dispersion, negative decrease one.

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1203,6 +1203,25 @@ void Creature::messaging_projectile_attack( const Creature *source,
     }
 }
 
+void Creature::print_proj_avoid_msg( Creature *source, viewer &player_view )
+{
+    // "Avoid" rather than "dodge", because it includes removing self from the line of fire
+    //  rather than just Matrix-style bullet dodging
+    if( source != nullptr && player_view.sees( *source ) ) {
+        add_msg_player_or_npc(
+            m_warning,
+            _( "You avoid %s projectile!" ),
+            get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ? _( "<npcname> avoids %s projectile." ) : "",
+            source->disp_name( true ) );
+    } else {
+        add_msg_player_or_npc(
+            m_warning,
+            _( "You avoid an incoming projectile!" ),
+            get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ? _( "<npcname> avoids an incoming projectile." ) :
+            "" );
+    }
+}
+
 /**
  * Attempts to harm a creature with a projectile.
  *
@@ -1243,10 +1262,15 @@ void Creature::deal_projectile_attack( Creature *source, dealt_projectile_attack
         on_try_dodge(); // There's a dodge roll in accuracy_projectile_attack()
     }
 
-    // Supernatural dodges
-    double range_dodge_chance = enchantment_cache->modify_value( enchant_vals::mod::RANGE_DODGE, 1 ) - 1.0f;
-    if ( x_in_y( range_dodge_chance, 1.0f ) ) {
-        on_try_dodge();
+    Character *guy = as_character();
+    if( guy ) {
+        double range_dodge_chance = guy->enchantment_cache->modify_value( enchant_vals::mod::RANGE_DODGE,
+                                    1.0f ) - 1.0f;
+        if( x_in_y( range_dodge_chance, 1.0f ) ) {
+            on_try_dodge();
+            print_proj_avoid_msg( source, player_view );
+            return;
+        }
     }
 
     if( goodhit >= 1.0 && !magic ) {
@@ -1254,21 +1278,7 @@ void Creature::deal_projectile_attack( Creature *source, dealt_projectile_attack
         if( !print_messages ) {
             return;
         }
-        // "Avoid" rather than "dodge", because it includes removing self from the line of fire
-        //  rather than just Matrix-style bullet dodging
-        if( source != nullptr && player_view.sees( *source ) ) {
-            add_msg_player_or_npc(
-                m_warning,
-                _( "You avoid %s projectile!" ),
-                get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ? _( "<npcname> avoids %s projectile." ) : "",
-                source->disp_name( true ) );
-        } else {
-            add_msg_player_or_npc(
-                m_warning,
-                _( "You avoid an incoming projectile!" ),
-                get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ? _( "<npcname> avoids an incoming projectile." ) :
-                "" );
-        }
+        print_proj_avoid_msg( source, player_view );
         return;
     }
 

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1243,6 +1243,12 @@ void Creature::deal_projectile_attack( Creature *source, dealt_projectile_attack
         on_try_dodge(); // There's a dodge roll in accuracy_projectile_attack()
     }
 
+    // Supernatural dodges
+    double range_dodge_chance = enchantment_cache->modify_value( enchant_vals::mod::RANGE_DODGE, 1 ) - 1.0f;
+    if ( x_in_y( range_dodge_chance, 1.0f ) ) {
+        on_try_dodge();
+    }
+
     if( goodhit >= 1.0 && !magic ) {
         attack.missed_by = 1.0; // Arbitrary value
         if( !print_messages ) {

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1203,7 +1203,7 @@ void Creature::messaging_projectile_attack( const Creature *source,
     }
 }
 
-void Creature::print_proj_avoid_msg( Creature *source, viewer &player_view )
+void Creature::print_proj_avoid_msg( Creature *source, viewer &player_view ) const
 {
     // "Avoid" rather than "dodge", because it includes removing self from the line of fire
     //  rather than just Matrix-style bullet dodging

--- a/src/creature.h
+++ b/src/creature.h
@@ -1343,7 +1343,7 @@ class Creature : public viewer
         // do messaging and SCT for projectile hit
         void messaging_projectile_attack( const Creature *source,
                                           const projectile_attack_results &hit_selection, int total_damage ) const;
-        void print_proj_avoid_msg( Creature *source, viewer &player_view );
+        void print_proj_avoid_msg( Creature *source, viewer &player_view ) const;
 };
 std::unique_ptr<talker> get_talker_for( Creature &me );
 std::unique_ptr<talker> get_talker_for( const Creature &me );

--- a/src/creature.h
+++ b/src/creature.h
@@ -1343,6 +1343,7 @@ class Creature : public viewer
         // do messaging and SCT for projectile hit
         void messaging_projectile_attack( const Creature *source,
                                           const projectile_attack_results &hit_selection, int total_damage ) const;
+        void print_proj_avoid_msg( Creature *source, viewer &player_view );
 };
 std::unique_ptr<talker> get_talker_for( Creature &me );
 std::unique_ptr<talker> get_talker_for( const Creature &me );

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -76,6 +76,7 @@ namespace io
             case enchant_vals::mod::REGEN_HP: return "REGEN_HP";
             case enchant_vals::mod::REGEN_HP_AWAKE: return "REGEN_HP_AWAKE";
             case enchant_vals::mod::MUT_INSTABILITY_MOD: return "MUT_INSTABILITY_MOD";
+            case enchant_vals::mod::RANGE_DODGE: return "RANGE_DODGE";
             case enchant_vals::mod::HUNGER: return "HUNGER";
             case enchant_vals::mod::THIRST: return "THIRST";
             case enchant_vals::mod::SLEEPINESS: return "SLEEPINESS";

--- a/src/magic_enchantment.h
+++ b/src/magic_enchantment.h
@@ -49,6 +49,7 @@ enum class mod : int {
     FAT_TO_MAX_HP,
     CARDIO_MULTIPLIER,
     MUT_INSTABILITY_MOD,
+    RANGE_DODGE,
     MAX_HP,        // for all limbs! use with caution
     REGEN_HP,
     REGEN_HP_AWAKE,


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Request from discord
#### Describe the solution
Add an enchantment, that allow to dodge projectile no matter of it's speed
#### Testing
```json
  {
    "type": "mutation",
    "id": "DEBUG_AAAAAA",
    "name": { "str": "Debug AAAAAAAAAAAAAAAAAAA" },
    "points": 99,
    "valid": false,
    "description": "If you need to survive the deadliest bug attacks.",
    "enchantments": [ { "values": [ { "value": "RANGE_DODGE", "add": 0.99 } ] } ],
    "debug": true
  },
  ```
![image](https://github.com/user-attachments/assets/5a85a525-f80d-4fb8-844e-3e0ed9fb28b6)