### PR TITLE
move NoScrollbar and NoScrollWithMouse flags from cataimgui::window to uilist_impl

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -537,8 +537,7 @@ cataimgui::window::window( int window_flags )
 
     this->window_flags = window_flags | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize |
                          ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoNavFocus |
-                         ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoScrollbar |
-                         ImGuiWindowFlags_NoScrollWithMouse;
+                         ImGuiWindowFlags_NoBringToFrontOnFocus;
 }
 
 cataimgui::window::window( const std::string &id_, int window_flags ) : window( window_flags )

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -36,11 +36,13 @@ class uilist_impl : cataimgui::window
         uilist &parent;
     public:
         explicit uilist_impl( uilist &parent ) : cataimgui::window( "UILIST",
-                    ImGuiWindowFlags_NoTitleBar ), parent( parent ) {
+                    ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse ),
+            parent( parent ) {
         }
 
         uilist_impl( uilist &parent, const std::string &title ) : cataimgui::window( title,
-                    ImGuiWindowFlags_None ), parent( parent ) {
+                    ImGuiWindowFlags_None | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse ),
+            parent( parent ) {
         }
 
         cataimgui::bounds get_bounds() override {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

I noticed scrollbars and mouse scrolling were disabled when I started working on #73456 again. Looking into it it was disabled as part of the uilist migration, but that was erroneously done on the base imgui window and not the specific implementation.

I'm not sure if this broke any already existing imgui windows. The keybindings menu at least uses a table for scrolling, so it was unaffected.

#### Describe the solution

Move the flags from the general window to the specific uilist_impl, so other windows can use mouse scrolling.

#### Describe alternatives you've considered



#### Testing

uilist still scrolls through entries with mouse wheel.

#### Additional context

