### PR TITLE
Silence clang-tidy warning about useless const

### DIFF
--- a/src/game.h
+++ b/src/game.h
@@ -853,7 +853,7 @@ class game
         // Handle phasing through walls, returns true if it handled the move
         bool phasing_move( const tripoint &dest, bool via_ramp = false );
         // Handle shifting through terrain and walls, with distance defined by enchantment.
-        bool phasing_move_enchant( const tripoint &dest, const int phase_distance = 0 );
+        bool phasing_move_enchant( const tripoint &dest, int phase_distance = 0 );
         bool can_move_furniture( tripoint fdest, const tripoint &dp );
         // Regular movement. Returns false if it failed for any reason
         // TODO: Get rid of untyped overload


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Noticed a clang-tidy warning here https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/10539190251/job/29202849881?pr=75865#step:9:891
i.e. "Error: /home/runner/work/Cataclysm-DDA/Cataclysm-DDA/src/game.h:856:58: error: parameter 'phase_distance' is const-qualified in the function declaration; const-qualification of parameters only has an effect in function definitions [readability-avoid-const-params-in-decls,-warnings-as-errors]"

#### Describe the solution
Remove the const.

#### Testing
Clang tidy job should pass.