### PR TITLE
CI: use ubuntu 24.04 over ubuntu 20.04 in linux tiles builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
             content: application/zip
             sound: 1
           - name: Linux Tiles x64
-            os: ubuntu-20.04
+            os: ubuntu-24.04
             mxe: none
             android: none
             libbacktrace: 1
@@ -98,7 +98,7 @@ jobs:
             ext: tar.gz
             content: application/gzip
           - name: Linux Tiles Sounds x64
-            os: ubuntu-20.04
+            os: ubuntu-24.04
             mxe: none
             android: none
             libbacktrace: 1
@@ -108,7 +108,7 @@ jobs:
             ext: tar.gz
             content: application/gzip
           - name: Linux Curses x64
-            os: ubuntu-20.04
+            os: ubuntu-24.04
             mxe: none
             android: none
             libbacktrace: 1


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Build "Use the newer ubuntu24.04 image in Linux tiles builds"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Please do not merge until people had time to review this.

Fixes #54886
Fixes #73667

This hopefully fixes those arcane and cursed issues. GCC 9 is unsupported anyways.
Special thanks to `#gcc` on libera.chat. Your mystic ways fascinate me.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

CC @akrieger.

So why am I doing this?

1. I can very reliably reproduce the crashing on any of our Linux tiles builds, which are built using a ubuntu 20.04 image.
2. I can not reproduce on my own build on Arch Linux, with gcc 14.2.1+r32+geccf707e5ce-1.
3. I can not reproduce on the build I made the CI in my fork produce using this ubuntu 24.04 image.

I tried compiling gcc9 myself on Arch but after 10h of gcc failing to build because of random reasons, I stopped. I also spent 6h of compiling cdda over and over and over again with different flags because I initially thought that the [Arch Linux flag defaults](https://wiki.archlinux.org/title/Arch_package_guidelines/Security) may interfere with that heap overflow because e.g FORTIFY_SOURCE may prevent them. No change in behavior when I disabled all of them to have a completely plain default build.

The wise folks in `#gcc` eventually pointed me at the fact that I am using completely a different compiler version than you. So I unsuccessfully tried to compile gcc9 and then went to say fuck it, lets just make the CI use a newer version of gcc and that works.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

CI in my fork built it successfully. It runs and does not crash.

The only thing I am worried about is that on Arch, I need `-Wno-error=maybe-uninitialized`. I do not know what part in the chain complained about this specifically and because it compiled just fine on the CI, it might not apply to us at all.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
