### PR TITLE
Lobster in ocean monster group

### DIFF
--- a/data/json/monstergroups/wilderness.json
+++ b/data/json/monstergroups/wilderness.json
@@ -407,6 +407,7 @@
       { "monster": "mon_fish_porgy", "weight": 6, "cost_multiplier": 8, "pack_size": [ 1, 3 ] },
       { "monster": "mon_fish_flounder", "weight": 6, "cost_multiplier": 8, "pack_size": [ 1, 3 ] },
       { "monster": "mon_fish_mackerel", "weight": 6, "cost_multiplier": 8, "pack_size": [ 1, 3 ] },
+      { "monster": "mon_fish_lobster", "weight": 6, "cost_multiplier": 8, "pack_size": [ 1, 1 ] },
       { "monster": "mon_fish_salmon", "weight": 6, "cost_multiplier": 8, "pack_size": [ 4, 6 ] }
     ]
   },
@@ -428,6 +429,7 @@
       { "monster": "mon_fish_pbass", "weight": 5, "cost_multiplier": 3, "pack_size": [ 1, 3 ] },
       { "monster": "mon_fish_bluefish", "weight": 3, "cost_multiplier": 8, "pack_size": [ 1, 3 ] },
       { "monster": "mon_fish_blackfish", "weight": 3, "cost_multiplier": 8, "pack_size": [ 1, 3 ] },
+      { "monster": "mon_fish_lobster", "weight": 6, "cost_multiplier": 8, "pack_size": [ 1, 1 ] },
       { "monster": "mon_fish_porgy", "weight": 3, "cost_multiplier": 8, "pack_size": [ 1, 3 ] }
     ]
   },


### PR DESCRIPTION
#### Summary
Features "Lobster in ocean monster group"

#### Purpose of change
As my [issues#75761](https://github.com/CleverRaven/Cataclysm-DDA/issues/75761) said, let there be lobster in vanilla ocean.

#### Describe the solution
Put `mon_fish_lobster` into `GROUP_OCEAN_SHORE` and `GROUP_OCEAN_DEEP`

#### Describe alternatives you've considered
Delete everything related to living lobster and fresh lobster meat.

#### Testing

#### Additional context
Based on [NOAA](https://www.fisheries.noaa.gov/species/american-lobster/overview) the lobster population around Gulf of Maine/Georges Bank is fine. And the vanilla game is happened around Massachusetts so I make them as often spawn as flounder. But they live alone and are very territorial so if they spawn they will only spawn single.
