### PR TITLE
main: properly handle SIGINT

### DIFF
--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -103,6 +103,9 @@ namespace turn_handler
 bool cleanup_at_end()
 {
     avatar &u = get_avatar();
+    if( g->uquit == QUIT_EXIT ) {
+        return true;
+    }
     if( g->uquit == QUIT_DIED || g->uquit == QUIT_SUICIDE ) {
         // Put (non-hallucinations) into the overmap so they are not lost.
         for( monster &critter : g->all_monsters() ) {

--- a/src/flexbuffer_json.cpp
+++ b/src/flexbuffer_json.cpp
@@ -7,6 +7,7 @@
 
 #include "cata_unreachable.h"
 #include "filesystem.h"
+#include "game.h"
 #include "json.h"
 
 namespace
@@ -252,6 +253,9 @@ bool JsonValue::read( std::string &s, bool throw_on_error ) const
 void JsonObject::report_unvisited() const
 {
 #ifndef CATA_IN_TOOL
+    if( g && g->uquit == quit_status::QUIT_EXIT ) {
+        return;
+    }
     if( !std::uncaught_exceptions() && report_unvisited_members && !visited_fields_bitset_.all() ) {
         std::vector<size_t> skipped_members;
         skipped_members.reserve( visited_fields_bitset_.size() );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2800,8 +2800,27 @@ bool game::try_get_right_click_action( action_id &act, const tripoint_bub_ms &mo
     return true;
 }
 
+bool game::query_exit_to_OS()
+{
+    const int old_timeout = inp_mngr.get_timeout();
+    inp_mngr.reset_timeout();
+    uquit = QUIT_EXIT_PENDING; // change it before query so input_context doesn't get confused
+    if( query_yn( _( "Really Quit?  All unsaved changes will be lost." ) ) ) {
+        uquit = QUIT_EXIT;
+        throw exit_exception();
+    }
+    uquit = QUIT_NO;
+    inp_mngr.set_timeout( old_timeout );
+    ui_manager::redraw_invalidated();
+    catacurses::doupdate();
+    return false;
+}
+
 bool game::is_game_over()
 {
+    if( uquit == QUIT_EXIT ) {
+        return query_exit_to_OS();
+    }
     if( uquit == QUIT_DIED || uquit == QUIT_WATCH ) {
         Creature *player_killer = u.get_killer();
         if( player_killer && player_killer->as_character() ) {

--- a/src/game.h
+++ b/src/game.h
@@ -57,6 +57,8 @@ enum quit_status {
     QUIT_NOSAVED,   // Quit without saving
     QUIT_DIED,      // Actual death
     QUIT_WATCH,     // Died, and watching aftermath
+    QUIT_EXIT,      // Skip main menu and quit directly to OS
+    QUIT_EXIT_PENDING, // same as above, used temporarily so input_context doesn't get confused
 };
 
 enum safe_mode_type {
@@ -1033,6 +1035,8 @@ class game
         void bury_screen() const;// Bury a dead character (record their last words)
         void death_screen();     // Display our stats, "GAME OVER BOO HOO"
     public:
+        bool query_exit_to_OS();
+        class exit_exception: public std::exception {};
         /**
          * If there is a robot (that can be disabled), query the player
          * and try to disable it.

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -333,6 +333,9 @@ input_context game::get_player_input( std::string &action )
 
         creature_tracker &creatures = get_creature_tracker();
         do {
+            if( g->uquit == QUIT_EXIT ) {
+                break;
+            }
             if( bWeatherEffect && get_option<bool>( "ANIMATION_RAIN" ) ) {
                 /*
                 Location to add rain drop animation bits! Since it refreshes w_terrain it can be added to the animation section easily
@@ -3097,6 +3100,10 @@ bool game::handle_action()
     // If performing an action with right mouse button, co-ordinates
     // of location clicked.
     std::optional<tripoint_bub_ms> mouse_target;
+
+    if( uquit == QUIT_EXIT ) {
+        return false;
+    }
 
     if( uquit == QUIT_WATCH && action == "QUIT" ) {
         uquit = QUIT_DIED;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -44,6 +44,7 @@
 #include "field_type.h"
 #include "filesystem.h"
 #include "flag.h"
+#include "game.h"
 #include "gates.h"
 #include "harvest.h"
 #include "input.h"
@@ -102,6 +103,7 @@
 #include "translations.h"
 #include "trap.h"
 #include "type_id.h"
+#include "ui_manager.h"
 #include "veh_type.h"
 #include "vehicle_group.h"
 #include "vitamin.h"
@@ -122,6 +124,20 @@ DynamicDataLoader &DynamicDataLoader::get_instance()
     static DynamicDataLoader theDynamicDataLoader;
     return theDynamicDataLoader;
 }
+
+namespace
+{
+
+void check_sigint()
+{
+    if( g && g->uquit == quit_status::QUIT_EXIT ) {
+        if( g->query_exit_to_OS() ) {
+            throw game::exit_exception();
+        }
+    }
+}
+
+} // namespace
 
 void DynamicDataLoader::load_object( const JsonObject &jo, const std::string &src,
                                      const cata_path &base_path,
@@ -172,6 +188,7 @@ void DynamicDataLoader::load_deferred( deferred_json &data )
             }
             ++it;
             inp_mngr.pump_events();
+            check_sigint();
         }
         data.erase( data.begin(), it );
         if( data.size() == n ) {
@@ -613,6 +630,7 @@ void DynamicDataLoader::load_all_from_json( const JsonValue &jsin, const std::st
         // find type and dispatch each object until array close
         for( JsonObject jo : ja ) {
             load_object( jo, src, base_path, full_path );
+            check_sigint();
         }
     } else {
         // not an object or an array?
@@ -842,6 +860,7 @@ void DynamicDataLoader::finalize_loaded_data()
     for( const named_entry &e : entries ) {
         loading_ui::show( _( "Finalizing" ), e.first );
         e.second();
+        check_sigint();
     }
 
     if( !get_option<bool>( "SKIP_VERIFICATION" ) ) {
@@ -946,5 +965,6 @@ void DynamicDataLoader::check_consistency()
     for( const named_entry &e : entries ) {
         loading_ui::show( _( "Verifying" ), e.first );
         e.second();
+        check_sigint();
     }
 }

--- a/src/input_context.cpp
+++ b/src/input_context.cpp
@@ -134,6 +134,7 @@ static const std::string ANY_INPUT = "ANY_INPUT";
 static const std::string HELP_KEYBINDINGS = "HELP_KEYBINDINGS";
 static const std::string COORDINATE = "COORDINATE";
 static const std::string TIMEOUT = "TIMEOUT";
+static const std::string QUIT = "QUIT";
 
 const std::string &input_context::input_to_action( const input_event &inp ) const
 {
@@ -445,6 +446,10 @@ const std::string &input_context::handle_input( const int timeout )
             break;
         }
 
+        if( g->uquit == QUIT_EXIT ) {
+            result = &QUIT;
+            break;
+        }
         const std::string &action = input_to_action( next_action );
 
         //Special global key to toggle language to english and back

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -143,42 +143,30 @@ namespace
 // Used only if AttachConsole() works
 FILE *CONOUT;
 #endif
-void exit_handler( int s )
-{
-    const int old_timeout = inp_mngr.get_timeout();
-    inp_mngr.reset_timeout();
-    if( s != 2 || query_yn( _( "Really Quit?  All unsaved changes will be lost." ) ) ) {
-        deinitDebug();
-
-        int exit_status = 0;
-        g.reset();
-
-        catacurses::endwin();
-
-#if defined(__ANDROID__)
-        // Avoid capturing SIGABRT on exit on Android in crash report
-        // Can be removed once the SIGABRT on exit problem is fixed
-        signal( SIGABRT, SIG_DFL );
-#endif
 
 #if !defined(_WIN32)
-        if( s == 2 ) {
-            struct sigaction sigIntHandler;
-            sigIntHandler.sa_handler = SIG_DFL;
-            sigemptyset( &sigIntHandler.sa_mask );
-            sigIntHandler.sa_flags = 0;
-            sigaction( SIGINT, &sigIntHandler, nullptr );
-            kill( getpid(), s );
-        } else
-#endif
-        {
-            imclient.reset();
-            exit( exit_status );
-        }
+extern "C" void sigint_handler( int /* s */ )
+{
+    if( g->uquit != QUIT_EXIT_PENDING ) {
+        g->uquit = QUIT_EXIT;
     }
-    inp_mngr.set_timeout( old_timeout );
-    ui_manager::redraw_invalidated();
-    catacurses::doupdate();
+}
+#endif
+
+void exit_handler( int /* s */ )
+{
+    deinitDebug();
+
+    g.reset();
+
+    catacurses::endwin();
+
+#if defined(__ANDROID__)
+    // Avoid capturing SIGABRT on exit on Android in crash report
+    // Can be removed once the SIGABRT on exit problem is fixed
+    signal( SIGABRT, SIG_DFL );
+#endif
+
 }
 
 struct arg_handler {
@@ -836,7 +824,7 @@ int main( int argc, const char *argv[] )
 
 #if !defined(_WIN32)
     struct sigaction sigIntHandler;
-    sigIntHandler.sa_handler = exit_handler;
+    sigIntHandler.sa_handler = sigint_handler;
     sigemptyset( &sigIntHandler.sa_mask );
     sigIntHandler.sa_flags = 0;
     sigaction( SIGINT, &sigIntHandler, nullptr );
@@ -870,7 +858,11 @@ int main( int argc, const char *argv[] )
 
         shared_ptr_fast<ui_adaptor> ui = g->create_or_get_main_ui_adaptor();
         get_event_bus().send<event_type::game_begin>( getVersionString() );
-        while( !do_turn() ) {}
+        try {
+            while( !do_turn() ) { }
+        } catch( game::exit_exception const &/* ex */ ) {
+            break;
+        }
     }
 
     exit_handler( -999 );

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -706,6 +706,10 @@ bool main_menu::opening_screen()
 #endif
 
     while( !start ) {
+        if( g->uquit == QUIT_EXIT ) {
+            return false;
+        }
+
         ui_manager::redraw();
         std::string action = ctxt.handle_input();
         input_event sInput = ctxt.get_raw_input();
@@ -795,9 +799,12 @@ bool main_menu::opening_screen()
         // also check special keys
         if( action == "QUIT" ) {
 #if !defined(EMSCRIPTEN)
+            g->uquit = QUIT_EXIT_PENDING;
             if( query_yn( _( "Really quit?" ) ) ) {
+                g->uquit = QUIT_EXIT;
                 return false;
             }
+            g->uquit = QUIT_NO;
 #endif
         } else if( action == "LEFT" || action == "PREV_TAB" || action == "RIGHT" || action == "NEXT_TAB" ) {
             sel_line = 0;
@@ -1110,6 +1117,8 @@ bool main_menu::load_game( std::string const &worldname, save_t const &savegame 
 
     try {
         g->setup();
+    } catch( game::exit_exception const &/* ex */ ) {
+        return false;
     } catch( const std::exception &err ) {
         debugmsg( "Error: %s", err.what() );
         return false;

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -3522,8 +3522,9 @@ static void CheckMessages()
         try_sdl_update();
     }
     if( quit ) {
-        catacurses::endwin();
-        exit( 0 );
+        if( g->uquit != quit_status::QUIT_EXIT_PENDING ) {
+            g->uquit = quit_status::QUIT_EXIT;
+        }
     }
 }
 

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -1025,7 +1025,8 @@ void uilist::query( bool loop, int timeout, bool allow_unfiltered_hotkeys )
             if( entries[ selected ].enabled || allow_disabled ) {
                 ret = entries[selected].retval;
             }
-        } else if( allow_cancel && ret_act == "UILIST.QUIT" ) {
+        } else if( ( allow_cancel && ret_act == "UILIST.QUIT" ) ||
+                   ( g->uquit == QUIT_EXIT && ret_act == "QUIT" ) ) {
             ret = UILIST_CANCEL;
         } else if( ret_act == "TIMEOUT" ) {
             ret = UILIST_WAIT_INPUT;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
- We're handling SIGINT (Ctr+C) by killing ourselves
- Killing ourselves doesn't immediately terminate execution
- Sometimes the OS doesn't terminate us in time and execution proceeds as if SIGINT was cancelled and the game tries to refresh display, leading to a segfault since we've already manually destroyed some game objects.
- Additionally, the sig handler does not comply with [MSC54-CPP](https://wiki.sei.cmu.edu/confluence/display/cplusplus/MSC54-CPP.+A+signal+handler+must+be+a+plain+old+function), so we've been relying on UB this entire time

* Fixes: #8417
* Fixes: #77011

* Closes: #76173
* Closes: #77050 
these both do similar things in that they try to move execution to a less crashy path before the OS takes over, but don't address the core issue.

#### Describe the solution
Split SIGINT handling to a separate function
Move all non-`SIG30-C`-compliant code out of the sig handler
Add a new quit reason (`QUIT_EXIT`) and pass it up to the main loop as an exception,  then exit gracefully.

#### Describe alternatives you've considered
Give up on pedantry and just revert #67893 since the old code worked fine and for all edge cases despite being `wrong`.

Instead of passing an exception, I could pepper `QUIT_EXIT` checks all over the place.

#### Testing
Send SIGINT or other signals, or try to close the window while playing the game in various states: opening menu, loading files, finalizing data, verifying data, loading save file, waiting for input, doing an activity, and in various UIs. The game should prompt and quit correctly with no crashes.

#### Additional context
It can take a long time for the prompt to appear during some init stages. More `QUIT_EXIT` checks can be peppered around the code if needed.

UIs that don't use a `QUIT` keybinding won't react to SIGINT.

There might be other edge cases. Doing it correctly without an unified input loop is hard work.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
