### PR TITLE
Change "stock mount" to "stock" for SIG rattler

### DIFF
--- a/data/json/items/gun/300BLK.json
+++ b/data/json/items/gun/300BLK.json
@@ -140,7 +140,7 @@
       [ "rail", 1 ],
       [ "sights", 1 ],
       [ "sling", 1 ],
-      [ "stock mount", 1 ]
+      [ "stock", 1 ]
     ],
     "pocket_data": [
       {


### PR DESCRIPTION
#### Summary
Bugfixes "Change 'stock mount' to 'stock' modslot for SIG rattler"

#### Purpose of change
This gun has built-in folding stock. It has no slot for standard stock. The folding stock works fine even without propper modslot, but you can use replaceable stock kit on the "stock mount". If you do, the folding stock automatically jumps into the newly created "stock" modslot

#### Describe the solution
Oneliner code change

#### Describe alternatives you've considered
Dont remove this weirdness

#### Testing
Tested

#### Additional context