### PR TITLE
Improve performance in npc::has_potential_los

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -7776,18 +7776,19 @@ bool map::sees( const tripoint_bub_ms &F, const tripoint_bub_ms &T, const int ra
     return sees( F.raw(), T.raw(), range, dummy, with_fields );
 }
 
-point map::sees_cache_key( const tripoint_bub_ms &from, const tripoint_bub_ms &to ) const
+// TODO: Change this to a hash function on the map implementation. This will also allow us to
+// account for the complete lack of entropy in the top 16 bits.
+int64_t map::sees_cache_key( const tripoint_bub_ms &from, const tripoint_bub_ms &to ) const
 {
-
     // Canonicalize the order of the tripoints so the cache is reflexive.
     const tripoint_bub_ms &min = from < to ? from : to;
     const tripoint_bub_ms &max = !( from < to ) ? from : to;
 
-    // A little gross, just pack the values into a point.
-    return point(
-               min.x() << 16 | min.y() << 8 | ( min.z() + OVERMAP_DEPTH ),
-               max.x() << 16 | max.y() << 8 | ( max.z() + OVERMAP_DEPTH )
-           );
+    // A little gross, just pack the values into an integer.
+    return
+        static_cast<int64_t>( min.x() )  << 50 | static_cast<int64_t>( min.y() ) << 40 |
+        ( static_cast<int64_t>( min.z() ) + OVERMAP_DEPTH ) << 30 | max.x() << 20 | max.y() << 10 |
+        ( max.z() + OVERMAP_DEPTH );
 }
 
 /**
@@ -7811,10 +7812,10 @@ bool map::sees( const tripoint_bub_ms &F, const tripoint_bub_ms &T, const int ra
         bresenham_slope = 0;
         return false; // Out of range!
     }
-    const point key = sees_cache_key( F, T );
+    const int64_t key = sees_cache_key( F, T );
     if( allow_cached ) {
         char cached = skew_cache.get( key, -1 );
-        if( cached >= 0 ) {
+        if( cached != -1 ) {
             return cached > 0;
         }
     }
@@ -11115,9 +11116,9 @@ void map::invalidate_max_populated_zlev( int zlev )
 
 bool map::has_potential_los( const tripoint_bub_ms &from, const tripoint_bub_ms &to ) const
 {
-    const point key = sees_cache_key( from, to );
+    const int64_t key = sees_cache_key( from, to );
     char cached = skew_vision_cache.get( key, -1 );
-    if( cached >= 0 ) {
+    if( cached != -1 ) {
         return cached > 0;
     }
     return true;

--- a/src/map.h
+++ b/src/map.h
@@ -702,7 +702,7 @@ class map
                    bool with_fields = true ) const;
         bool sees( const tripoint_bub_ms &F, const tripoint_bub_ms &T, int range, int &bresenham_slope,
                    bool with_fields = true, bool allow_cached = true ) const;
-        point sees_cache_key( const tripoint_bub_ms &from, const tripoint_bub_ms &to ) const;
+        int64_t sees_cache_key( const tripoint_bub_ms &from, const tripoint_bub_ms &to ) const;
     public:
         /**
         * Returns coverage of target in relation to the observer. Target is loc2, observer is loc1.
@@ -2602,7 +2602,7 @@ class map
         /**
          * Cache of coordinate pairs recently checked for visibility.
          */
-        using lru_cache_t = lru_cache<point, char>;
+        using lru_cache_t = lru_cache<int64_t, char>;
         mutable lru_cache_t skew_vision_cache;
         mutable lru_cache_t skew_vision_wo_fields_cache;
 


### PR DESCRIPTION
#### Summary
Performance "NPCs take less time to check for enemies."

#### Purpose of change

See #75947.

#### Describe the solution

Replace using a `point` as a key to the cache with `int64_t`. Honestly, I am not sure why this works. I thought perhaps that the hash function for points was bad, but running a benchmark on QuickBench ([link](https://quick-bench.com/q/TUHQXo1fUn1iOr5C7daANiDgANg)) returns basically the exact same numbers, for both hits and misses, which is not what I would expect from an ~8x speedup.

Function call numbers also seem low - at 50 NPCs each acting every tick, there should be approximately 9,000,000 calls to `npc::has_potential_los` each in-game hour, but VS only measured ~350000 over several. 

A potential problem is it relies on all dimensions in the given `tripoint_bub_ms` being <1024. I didn't add bounds checking because the previous solution (using a point and two int32s) has the same issue. 

#### Describe alternatives you've considered

- Replacing `std::unordered_map` with an alternative implementation. The benchmarks I looked at - [here](https://martin.ankerl.com/2022/08/27/hashmap-bench-01/#jg__dense_hash_map) and [here](https://www.reedbeta.com/blog/data-oriented-hash-table/#windows) - indicate that the best alternative implementations are 2-3x faster. In this case, I managed to get a decent speedup without but it may still be an option in future.

#### Testing
Before
![image](https://github.com/user-attachments/assets/bfe2e6f1-bdde-4253-955d-880a458068d5)

After
![image](https://github.com/user-attachments/assets/da06b384-868c-4e0c-900a-7e657512c9bb)


#### Additional context

