### PR TITLE
Allow military NVGs to attach to combat exoskeleton helmets

### DIFF
--- a/data/json/items/armor/combat_exoskeleton.json
+++ b/data/json/items/armor/combat_exoskeleton.json
@@ -11,7 +11,7 @@
     "weight": "13000 g",
     "environmental_protection": 20,
     "warmth": 40,
-    "flags": [ "STURDY", "PADDED", "WATERPROOF", "RAINPROOF", "RAD_PROOF", "ELECTRIC_IMMUNE", "SUN_GLASSES", "COMBAT_TOGGLEABLE" ],
+    "flags": [ "STURDY", "PADDED", "WATERPROOF", "RAINPROOF", "RAD_PROOF", "ELECTRIC_IMMUNE", "SUN_GLASSES", "COMBAT_TOGGLEABLE", "MODULE_HOLDER" ],
     "relic_data": { "passive_effects": [ { "id": "combat_exoskeleton_inactive" } ] },
     "pocket_data": [
       {

--- a/data/json/items/armor/combat_exoskeleton.json
+++ b/data/json/items/armor/combat_exoskeleton.json
@@ -11,7 +11,17 @@
     "weight": "13000 g",
     "environmental_protection": 20,
     "warmth": 40,
-    "flags": [ "STURDY", "PADDED", "WATERPROOF", "RAINPROOF", "RAD_PROOF", "ELECTRIC_IMMUNE", "SUN_GLASSES", "COMBAT_TOGGLEABLE", "MODULE_HOLDER" ],
+    "flags": [
+      "STURDY",
+      "PADDED",
+      "WATERPROOF",
+      "RAINPROOF",
+      "RAD_PROOF",
+      "ELECTRIC_IMMUNE",
+      "SUN_GLASSES",
+      "COMBAT_TOGGLEABLE",
+      "MODULE_HOLDER"
+    ],
     "relic_data": { "passive_effects": [ { "id": "combat_exoskeleton_inactive" } ] },
     "pocket_data": [
       {

--- a/data/json/items/armor/combat_exoskeleton_armor.json
+++ b/data/json/items/armor/combat_exoskeleton_armor.json
@@ -54,6 +54,17 @@
         "description": "Pocket for a flashlight attachment.",
         "flag_restriction": [ "HELMET_HEAD_ATTACHMENT" ],
         "transparent": true
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "ablative": true,
+        "volume_encumber_modifier": 0,
+        "max_contains_volume": "2 L",
+        "max_contains_weight": "2 kg",
+        "moves": 250,
+        "description": "Pocket for a front night vision attachment.",
+        "flag_restriction": [ "HELMET_FRONT_ATTACHMENT" ],
+        "inherits_flags": false
       }
     ]
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Allow military night vision goggles to attach to combat exoskeleton head armors"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Implements #75978

Military night vision goggles were recently made to only be usable when attached to military helmets with the proper mounts. Considering exoskeletons were developed by the military and made to be modular, it seems like an oversight that the suits would not be able to utilize this technology to allow soldiers to see in the dark, without relying on CBMs.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Added `MODULE_HOLDER` to the base exoskeleton, copy/pasted the "HELMET_FRONT_ATTACHMENT" pocket from the army helmet to the heavy exoskeleton head armor, which all other exoskeleton helmets `"copy-from"`.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Create a proprietary solution for the exoskeletons, make a rare drop somewhere. Seems like an unnecessary duplication of code though, and would likely necessitate the creation of a unique flag just for that item. Allowing players to use NVGs with exoskeleton armor doesn't seem like something that needs to be earned, since exoskeletons are locked behind one of the toughest bosses in the game already.

Make the survivor custom-create a bracket to allow the helmet to accept NVGs. This doesn't really help explain the issue as to why the military would not make the exoskeletons have NVG functionality in the first place.

Make the NVG effect built-in to the exoskeleton itself, but the other power armors already do that, and I think to better fit the flavor of the combat exoskeleton we should lean on the modular philosophy of the exoskeleton and use pre-existing NVGs.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Copy/pasted the edited json files into a freshly-installed latest experimental. Inserted all three military NVGs into four different exoskeleton helmet armors, NVG effect was applied each time.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

![image](https://github.com/user-attachments/assets/b6e5177b-fdd2-4ac2-9f45-5881666fd11c)

![image](https://github.com/user-attachments/assets/da7da1ca-f69d-4039-b3fe-4b053ea044fc)

I also considered adding flavor text to all the helmets, mentioning the addition of the new pocket. Since it did not mention the pre-existing pocket for a headlamp though, and to keep this PR small, I opted not to.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
