### PR TITLE
Allow vitamin-providing drugs to be deposited into faction camp larder

### DIFF
--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -1773,7 +1773,10 @@
       "type": "consume_drug",
       "activation_message": "You take the %s.",
       "vitamins": [ [ "calcium", 24, 48 ], [ "iron", 24, 48 ], [ "vitC", 24, 48 ] ]
-    }
+    },
+    "//": "Yes, the vitamins are intentionally duplicated here. The consume/use/iteminfo UI needs them in use_action, but to actually pass on the vitamins they need to be in the comestible data, as below.",
+    "//2": "TODO: Fix this...",
+    "vitamins": [ [ "calcium", 24, 48 ], [ "iron", 24, 48 ], [ "vitC", 24, 48 ] ]
   },
   {
     "id": "calcium_tablet",

--- a/data/json/materials.json
+++ b/data/json/materials.json
@@ -784,7 +784,8 @@
     "type": "material",
     "id": "drug_filler",
     "name": "Drug filler",
-    "copy-from": "flesh",
+    "copy-from": "powder",
+    "vitamins": [  ],
     "//": "Assumed a gelatine capsule that contain the drug, but can be any another drug filler like glucose, lactose, sucrose and the like.  Created so we don't need to specify three billion chemicals used in pills.",
     "dmg_adj": [ "lightly damaged", "damaged", "very damaged", "thoroughly damaged" ]
   },


### PR DESCRIPTION
#### Summary
Features "Add drugs and mutagens to your faction camp stores."

#### Purpose of change
* Close #75877

#### Describe the solution
Loosen the check to not exclude 0-kcal items that do have vitamins, if player says yes on a query. (Or they can just mash enter a second time and ignore it, which distributes exactly the same as before)

Add some handling to the messages so it lets you know what's going on

#### Describe alternatives you've considered
Some sort of check against the comestible's type

NPCs should maybe get upset/suspicious if you're mixing mutagens into the food supply? But some of them might *want* to mutate, or want for example human purifier(technically a mutagen!) available to them. So that's a whole other issue

#### Testing
Added some food, got the expected kcal+vitamins value

Tried to add some meds with no vitamins or calories, got rejected

Tried to add some multivitamins(meds), multivitamins were added to the larder and consumed from the local map.

Note that despite the "duplicated" vitamins in the multivitamins item, both 'E'ating and 'a'ctivating the item gives only the use_action's amount, not double. So the actual vitamin value of them did not change.


#### Additional context
I added a note because this requires the vitamins on the multivitamins item to be duplicated. use_action and the comestible data are already duplicating this. A problem for another day.

~~I specifically gave drug_filler material an empty vitamin array so it didn't copy-from flesh's default vitamins. Otherwise drugs made of it would always have vitamins and be consumed~~ Vitamins extend by default! So instead it now copies from powder, as many of the drug items were originally using. Powder does not have any default vitamins and will avoid this case.
@GuardianDll I went over #70176 to make sure I got your intention right, I'd appreciate if you just gave this a quick look.


