### PR TITLE
Replace pf_special with a scoped enum (PathfindingFlag) and add more flags

### DIFF
--- a/src/map.h
+++ b/src/map.h
@@ -102,7 +102,7 @@ template<typename T>
 struct weighted_int_list;
 struct field_proc_data;
 
-enum pf_special : int;
+class PathfindingFlags;
 
 using relic_procgen_id = string_id<relic_procgen_data>;
 
@@ -814,17 +814,17 @@ class map
         // Includes climbing, bashing and opening doors.
         int cost_to_pass( const tripoint_bub_ms &cur, const tripoint_bub_ms &p,
                           const pathfinding_settings &settings,
-                          pf_special p_special ) const;
+                          PathfindingFlags p_special ) const;
         // Pathfinding cost helper that computes the cost of moving into |p|
         // from |cur| based on perceived danger.
         // Includes moving through traps.
         int cost_to_avoid( const tripoint_bub_ms &cur, const tripoint_bub_ms &p,
                            const pathfinding_settings &settings,
-                           pf_special p_special ) const;
+                           PathfindingFlags p_special ) const;
         // Sum of cost_to_pass and cost_to_avoid.
         int extra_cost( const tripoint_bub_ms &cur, const tripoint_bub_ms &p,
                         const pathfinding_settings &settings,
-                        pf_special p_special ) const;
+                        PathfindingFlags p_special ) const;
     public:
 
         // Vehicles: Common to 2D and 3D


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

The current flags do not support all functionalities required (e.g. whether a piece of terrain is sheltered or unsheltered), and lack granularity with e.g. GOESUPDOWN requiring extra checks for ramps,  whether it goes up or goes down, and so forth.

Additionally, using a scoped enum is good practice and will hopefully prevent accidental misuse of the enum type.

#### Describe the solution

Part of #75945. The additional flags aren't presently used as they are intended to be part of a new pathfinding implementation.

I've assigned the `RAMP` flag to imply `GOESUP` and not `GOESDOWN`. I'm not sure if this is correct.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

There have been exactly zero functionality changes. The new flags are compatible with the old ones, and have been swapped in where appropriate. If it compiles, it should run.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
