### PR TITLE
fix ImTui rendering by defining the IMTUI define

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -962,11 +962,11 @@ SOURCES += $(THIRD_PARTY_SOURCES)
 IMGUI_SOURCES = $(IMGUI_DIR)/imgui.cpp $(IMGUI_DIR)/imgui_demo.cpp $(IMGUI_DIR)/imgui_draw.cpp $(IMGUI_DIR)/imgui_tables.cpp $(IMGUI_DIR)/imgui_widgets.cpp
 
 ifeq ($(SDL), 1)
-	OTHERS += -DIMGUI_DISABLE_OBSOLETE_KEYIO
+	DEFINES += -DIMGUI_DISABLE_OBSOLETE_KEYIO
 	IMGUI_SOURCES += $(IMGUI_DIR)/imgui_impl_sdl2.cpp $(IMGUI_DIR)/imgui_impl_sdlrenderer2.cpp
 else
 	IMGUI_SOURCES += $(IMTUI_DIR)/imtui-impl-ncurses.cpp $(IMTUI_DIR)/imtui-impl-text.cpp
-  OTHERS += -DIMTUI
+	DEFINES += -DIMTUI
 endif
 
 SOURCES += $(IMGUI_SOURCES)


### PR DESCRIPTION
#### Summary
Interface "make ImTui render text as text, so that the players can read our spiffy new menus"

#### Purpose of change

So that the player can tell what the game is asking them, we should render text as text.

#### Describe the solution

We just need to actually add -DIMTUI to the command line. We do that by adding it to the DEFINES variable.

#### Testing

Ran the game. Can read the text in the Load Character menu!

#### Additional context

Fixes #75362
