### PR TITLE
Replace u/npc_has_var with compare_string

### DIFF
--- a/data/json/effects_on_condition/computer_eocs.json
+++ b/data/json/effects_on_condition/computer_eocs.json
@@ -50,19 +50,19 @@
     "//": "todo: make it not reveal fungal towers and such? would require edits in reveal_map code, to accept blacklist of locations?",
     "condition": {
       "or": [
-        { "npc_has_var": "map_cache", "value": "has" },
-        { "npc_has_var": "map_cache", "value": "lack" },
-        { "npc_has_var": "map_cache", "value": "read" }
+        { "compare_string": [ "has", { "npc_val": "map_cache" } ] },
+        { "compare_string": [ "lack", { "npc_val": "map_cache" } ] },
+        { "compare_string": [ "read", { "npc_val": "map_cache" } ] }
       ]
     },
     "false_effect": [ { "npc_add_var": "map_cache", "possible_values": [ "has", "lack" ] }, { "run_eocs": "EOC_CHECK_MAP_CACHE" } ],
     "effect": [
       {
-        "if": { "npc_has_var": "map_cache", "value": "read" },
+        "if": { "compare_string": [ "read", { "npc_val": "map_cache" } ] },
         "then": [ { "u_message": "You already noted everything map application on this phone can offer." } ]
       },
       {
-        "if": { "npc_has_var": "map_cache", "value": "has" },
+        "if": { "compare_string": [ "has", { "npc_val": "map_cache" } ] },
         "then": [
           { "location_variable_adjust": { "npc_val": "spawn_location_omt" }, "z_adjust": 0, "z_override": true },
           { "reveal_map": { "npc_val": "spawn_location_omt" }, "radius": { "math": [ "rng(11, 36)" ] } },
@@ -71,7 +71,7 @@
         ]
       },
       {
-        "if": { "npc_has_var": "map_cache", "value": "lack" },
+        "if": { "compare_string": [ "lack", { "npc_val": "map_cache" } ] },
         "then": [ { "u_message": "Whoever used this phone didn't ever open their map application.  Worthless." } ]
       }
     ]

--- a/data/json/effects_on_condition/example_eocs.json
+++ b/data/json/effects_on_condition/example_eocs.json
@@ -76,7 +76,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_item_transporter_test_2",
-    "condition": { "u_has_var": "eoc_sample_item_transporter_set_coordinates", "value": "yes" },
+    "condition": { "compare_string": [ "yes", { "u_val": "eoc_sample_item_transporter_set_coordinates" } ] },
     "effect": [
       {
         "u_run_inv_eocs": "manual_mult",
@@ -128,12 +128,12 @@
     "id": "EOC_if_else_test",
     "effect": [
       {
-        "if": { "u_has_var": "eoc_sample_if_else_test", "value": "yes" },
+        "if": { "compare_string": [ "yes", { "u_val": "eoc_sample_if_else_test" } ] },
         "then": { "u_message": "You have variable." },
         "else": [
           { "u_message": "You don't have variable." },
           {
-            "if": { "not": { "u_has_var": "eoc_sample_if_else_test", "value": "yes" } },
+            "if": { "not": { "compare_string": [ "yes", { "u_val": "eoc_sample_if_else_test" } ] } },
             "then": [ { "u_add_var": "eoc_sample_if_else_test", "value": "yes" }, { "u_message": "Variable added." } ]
           }
         ]

--- a/data/json/effects_on_condition/mapgen_eocs/lab_mapgen_eocs.json
+++ b/data/json/effects_on_condition/mapgen_eocs/lab_mapgen_eocs.json
@@ -46,7 +46,7 @@
       "and": [
         { "u_at_om_location": "lab_security_z-1" },
         { "u_has_item": "id_science_security_yellow" },
-        { "not": { "u_has_var": "check_trap_trigger_valid_security_employee", "value": "yes" } }
+        { "not": { "compare_string": [ "yes", { "u_val": "check_trap_trigger_valid_security_employee" } ] } }
       ]
     },
     "effect": [

--- a/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
@@ -657,7 +657,9 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_PORTAL_YRAX_ATTENTION",
-    "condition": { "and": [ "u_is_outside", { "u_has_var": "u_met_apeirohedra", "value": "yes" }, { "one_in_chance": 400 } ] },
+    "condition": {
+      "and": [ "u_is_outside", { "compare_string": [ "yes", { "u_val": "u_met_apeirohedra" } ] }, { "one_in_chance": 400 } ]
+    },
     "effect": [
       { "u_message": "An alien construct emerges from the storm.", "type": "neutral" },
       { "u_spawn_monster": "mon_yrax_quadraphract", "real_count": 1, "min_radius": 10, "max_radius": 15 }

--- a/data/json/effects_on_condition/npc_eocs/appearance_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/appearance_eocs.json
@@ -232,22 +232,22 @@
     "effect": [
       { "run_eocs": "assign_random_natural_hair_color" },
       {
-        "if": { "u_has_var": "mutation_hair_color_natural_hair_color_black", "value": "yes" },
+        "if": { "compare_string": [ "yes", { "u_val": "mutation_hair_color_natural_hair_color_black" } ] },
         "then": [ { "u_add_trait": { "context_val": "trait_id" }, "variant": "black" } ],
         "else": {
-          "if": { "u_has_var": "mutation_hair_color_natural_hair_color_blond", "value": "yes" },
+          "if": { "compare_string": [ "yes", { "u_val": "mutation_hair_color_natural_hair_color_blond" } ] },
           "then": [ { "u_add_trait": { "context_val": "trait_id" }, "variant": "blond" } ],
           "else": {
-            "if": { "u_has_var": "mutation_hair_color_natural_hair_color_brown", "value": "yes" },
+            "if": { "compare_string": [ "yes", { "u_val": "mutation_hair_color_natural_hair_color_brown" } ] },
             "then": [ { "u_add_trait": { "context_val": "trait_id" }, "variant": "brown" } ],
             "else": {
-              "if": { "u_has_var": "mutation_hair_color_natural_hair_color_gray", "value": "yes" },
+              "if": { "compare_string": [ "yes", { "u_val": "mutation_hair_color_natural_hair_color_gray" } ] },
               "then": [ { "u_add_trait": { "context_val": "trait_id" }, "variant": "gray" } ],
               "else": {
-                "if": { "u_has_var": "mutation_hair_color_natural_hair_color_red", "value": "yes" },
+                "if": { "compare_string": [ "yes", { "u_val": "mutation_hair_color_natural_hair_color_red" } ] },
                 "then": [ { "u_add_trait": { "context_val": "trait_id" }, "variant": "red" } ],
                 "else": {
-                  "if": { "u_has_var": "mutation_hair_color_natural_hair_color_white", "value": "yes" },
+                  "if": { "compare_string": [ "yes", { "u_val": "mutation_hair_color_natural_hair_color_white" } ] },
                   "then": [ { "u_add_trait": { "context_val": "trait_id" }, "variant": "white" } ]
                 }
               }
@@ -393,12 +393,12 @@
     "id": "assign_random_natural_hair_color",
     "condition": {
       "and": [
-        { "not": { "u_has_var": "mutation_hair_color_natural_hair_color_black", "value": "yes" } },
-        { "not": { "u_has_var": "mutation_hair_color_natural_hair_color_blond", "value": "yes" } },
-        { "not": { "u_has_var": "mutation_hair_color_natural_hair_color_brown", "value": "yes" } },
-        { "not": { "u_has_var": "mutation_hair_color_natural_hair_color_gray", "value": "yes" } },
-        { "not": { "u_has_var": "mutation_hair_color_natural_hair_color_red", "value": "yes" } },
-        { "not": { "u_has_var": "mutation_hair_color_natural_hair_color_white", "value": "yes" } }
+        { "not": { "compare_string": [ "yes", { "u_val": "mutation_hair_color_natural_hair_color_black" } ] } },
+        { "not": { "compare_string": [ "yes", { "u_val": "mutation_hair_color_natural_hair_color_blond" } ] } },
+        { "not": { "compare_string": [ "yes", { "u_val": "mutation_hair_color_natural_hair_color_brown" } ] } },
+        { "not": { "compare_string": [ "yes", { "u_val": "mutation_hair_color_natural_hair_color_gray" } ] } },
+        { "not": { "compare_string": [ "yes", { "u_val": "mutation_hair_color_natural_hair_color_red" } ] } },
+        { "not": { "compare_string": [ "yes", { "u_val": "mutation_hair_color_natural_hair_color_white" } ] } }
       ]
     },
     "effect": [
@@ -417,7 +417,7 @@
   {
     "type": "effect_on_condition",
     "id": "natural_hair_color_black",
-    "condition": { "not": { "u_has_var": "mutation_hair_color_picked_hair_color", "value": "yes" } },
+    "condition": { "not": { "compare_string": [ "yes", { "u_val": "mutation_hair_color_picked_hair_color" } ] } },
     "effect": [
       { "u_add_var": "mutation_hair_color_natural_hair_color_black", "value": "yes" },
       { "u_add_var": "mutation_hair_color_picked_hair_color", "value": "yes" }
@@ -426,7 +426,7 @@
   {
     "type": "effect_on_condition",
     "id": "natural_hair_color_blond",
-    "condition": { "not": { "u_has_var": "mutation_hair_color_picked_hair_color", "value": "yes" } },
+    "condition": { "not": { "compare_string": [ "yes", { "u_val": "mutation_hair_color_picked_hair_color" } ] } },
     "effect": [
       { "u_add_var": "mutation_hair_color_natural_hair_color_blond", "value": "yes" },
       { "u_add_var": "mutation_hair_color_picked_hair_color", "value": "yes" }
@@ -435,7 +435,7 @@
   {
     "type": "effect_on_condition",
     "id": "natural_hair_color_brown",
-    "condition": { "not": { "u_has_var": "mutation_hair_color_picked_hair_color", "value": "yes" } },
+    "condition": { "not": { "compare_string": [ "yes", { "u_val": "mutation_hair_color_picked_hair_color" } ] } },
     "effect": [
       { "u_add_var": "mutation_hair_color_natural_hair_color_brown", "value": "yes" },
       { "u_add_var": "mutation_hair_color_picked_hair_color", "value": "yes" }
@@ -444,7 +444,7 @@
   {
     "type": "effect_on_condition",
     "id": "natural_hair_color_gray",
-    "condition": { "not": { "u_has_var": "mutation_hair_color_picked_hair_color", "value": "yes" } },
+    "condition": { "not": { "compare_string": [ "yes", { "u_val": "mutation_hair_color_picked_hair_color" } ] } },
     "effect": [
       { "u_add_var": "mutation_hair_color_natural_hair_color_gray", "value": "yes" },
       { "u_add_var": "mutation_hair_color_picked_hair_color", "value": "yes" }
@@ -453,7 +453,7 @@
   {
     "type": "effect_on_condition",
     "id": "natural_hair_color_white",
-    "condition": { "not": { "u_has_var": "mutation_hair_color_picked_hair_color", "value": "yes" } },
+    "condition": { "not": { "compare_string": [ "yes", { "u_val": "mutation_hair_color_picked_hair_color" } ] } },
     "effect": [
       { "u_add_var": "mutation_hair_color_natural_hair_color_white", "value": "yes" },
       { "u_add_var": "mutation_hair_color_picked_hair_color", "value": "yes" }
@@ -462,7 +462,7 @@
   {
     "type": "effect_on_condition",
     "id": "natural_hair_color_red",
-    "condition": { "not": { "u_has_var": "mutation_hair_color_picked_hair_color", "value": "yes" } },
+    "condition": { "not": { "compare_string": [ "yes", { "u_val": "mutation_hair_color_picked_hair_color" } ] } },
     "effect": [
       { "u_add_var": "mutation_hair_color_natural_hair_color_red", "value": "yes" },
       { "u_add_var": "mutation_hair_color_picked_hair_color", "value": "yes" }

--- a/data/json/effects_on_condition/npc_eocs/godco_npc_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/godco_npc_eocs.json
@@ -37,7 +37,7 @@
         }
       ]
     },
-    "deactivate_condition": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" },
+    "deactivate_condition": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] },
     "effect": [ { "u_add_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } ]
   },
   {
@@ -47,11 +47,11 @@
     "global": true,
     "condition": {
       "and": [
-        { "u_has_var": "general_completed_theresa_going_away", "value": "yes" },
+        { "compare_string": [ "yes", { "u_val": "general_completed_theresa_going_away" } ] },
         { "u_near_om_location": "godco_3", "range": 12 }
       ]
     },
-    "deactivate_condition": { "u_has_var": "general_completed_theresa_gone", "value": "yes" },
+    "deactivate_condition": { "compare_string": [ "yes", { "u_val": "general_completed_theresa_gone" } ] },
     "effect": [
       { "mapgen_update": "theresa_remove", "om_terrain": "godco_3" },
       { "u_lose_var": "general_completed_theresa_going_away" },

--- a/data/json/effects_on_condition/npc_eocs/godco_npc_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/godco_npc_eocs.json
@@ -111,10 +111,10 @@
     "condition": {
       "and": [
         { "math": [ "godco_has_canningpots", "==", "1" ] },
-        { "not": { "npc_has_var": "dialogue_missions_got_mission", "value": "yes" } }
+        { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_missions_got_mission" } ] } }
       ]
     },
-    "deactivate_condition": { "npc_has_var": "dialogue_missions_got_mission", "value": "yes" },
+    "deactivate_condition": { "compare_string": [ "yes", { "npc_val": "dialogue_missions_got_mission" } ] },
     "effect": [
       { "offer_mission": "MISSION_GODCO_FOOD_GUARD_CANNING_STARTUP" },
       { "npc_add_var": "dialogue_missions_got_mission", "value": "yes" }

--- a/data/json/effects_on_condition/npc_eocs/isherwood_barry_rescue_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/isherwood_barry_rescue_eocs.json
@@ -148,7 +148,7 @@
       "and": [
         { "math": [ "isherwood_barry_rescued", "!=", "1" ] },
         { "math": [ "isherwood_family_coming", "!=", "1" ] },
-        { "u_has_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" },
+        { "compare_string": [ "yes", { "u_val": "general_meeting_barry_following" } ] },
         { "u_near_om_location": "horse_farm_isherwood_13", "range": 30 }
       ]
     },
@@ -307,7 +307,7 @@
     "condition": {
       "and": [
         { "u_has_mission": "MISSION_ISHERWOOD_CHRIS_1" },
-        { "not": { "u_has_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" } },
+        { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_barry_following" } ] } },
         {
           "and": [
             { "not": { "u_near_om_location": "barry_mi-go_scout_tower_1", "range": 2 } },
@@ -494,7 +494,7 @@
         { "u_near_om_location": "barry_mi-go_scout_tower_4", "range": 3 }
       ]
     },
-    "deactivate_condition": { "u_has_var": "u_been_to_migos", "value": "yes" },
+    "deactivate_condition": { "compare_string": [ "yes", { "u_val": "u_been_to_migos" } ] },
     "effect": [ { "u_add_var": "u_been_to_migos", "value": "yes" } ]
   }
 ]

--- a/data/json/encounters/randec_independent_travelers.json
+++ b/data/json/encounters/randec_independent_travelers.json
@@ -22,7 +22,7 @@
     "type": "effect_on_condition",
     "id": "EOC_traveler_random_destination_direction",
     "//": "Picks a random direction for the NPC in question to be going in.  Used for dialogue checks.",
-    "condition": { "not": { "u_has_var": "dialogue_travel_direction_picked_direction", "value": "yes" } },
+    "condition": { "not": { "compare_string": [ "yes", { "u_val": "dialogue_travel_direction_picked_direction" } ] } },
     "effect": [
       {
         "weighted_list_eocs": [

--- a/data/json/encounters/randenc_refugee_center.json
+++ b/data/json/encounters/randenc_refugee_center.json
@@ -11,7 +11,7 @@
         { "not": { "u_near_om_location": "evac_center_13", "range": 2 } },
         "is_day",
         { "one_in_chance": 10 },
-        { "u_has_var": "mission_flag_FMShopkeep_Mission1", "value": "yes" },
+        { "compare_string": [ "yes", { "u_val": "mission_flag_FMShopkeep_Mission1" } ] },
         { "math": [ "time_since(u_timer_RC_Shoppers_RandEnc)", ">=", "time('1 d')" ] }
       ]
     },
@@ -58,7 +58,7 @@
         { "not": { "u_near_om_location": "evac_center_13", "range": 2 } },
         "is_day",
         { "one_in_chance": 15 },
-        { "u_has_var": "mission_flag_FMShopkeep_Mission1", "value": "yes" },
+        { "compare_string": [ "yes", { "u_val": "mission_flag_FMShopkeep_Mission1" } ] },
         { "math": [ "time_since(u_timer_JohnBailey_RandEnc)", ">=", "time('3 d')" ] }
       ]
     },

--- a/data/json/items/tool/science.json
+++ b/data/json/items/tool/science.json
@@ -1372,7 +1372,7 @@
         },
         {
           "id": "EOC_MIGO_BIO_TECH_SETUP",
-          "condition": { "not": { "npc_has_var": "mbt_f_function_set", "value": "yes" } },
+          "condition": { "not": { "compare_string": [ "yes", { "npc_val": "mbt_f_function_set" } ] } },
           "effect": [
             { "npc_add_var": "mbt_f_function_set", "value": "yes" },
             { "npc_add_var": "mbt_f_function", "possible_values": [ "morale", "focus", "pain", "sleepiness" ] }
@@ -1380,7 +1380,7 @@
         },
         {
           "id": "EOC_MIGO_BIO_TECH_MORALE",
-          "condition": { "npc_has_var": "mbt_f_function", "value": "morale" },
+          "condition": { "compare_string": [ "morale", { "npc_val": "mbt_f_function" } ] },
           "effect": [
             { "u_message": "You feel amazing!" },
             {
@@ -1394,7 +1394,7 @@
         },
         {
           "id": "EOC_MIGO_BIO_TECH_FOCUS",
-          "condition": { "npc_has_var": "mbt_f_function", "value": "focus" },
+          "condition": { "compare_string": [ "focus", { "npc_val": "mbt_f_function" } ] },
           "effect": [
             { "u_message": "You feel incredibly focused!" },
             { "math": [ "u_val('focus')", "+=", "min( u_val('focus') + 30, 130)" ] }
@@ -1402,12 +1402,12 @@
         },
         {
           "id": "EOC_MIGO_BIO_TECH_PAIN",
-          "condition": { "npc_has_var": "mbt_f_function", "value": "pain" },
+          "condition": { "compare_string": [ "pain", { "npc_val": "mbt_f_function" } ] },
           "effect": [ { "u_message": "You feel your aches and pains fade away!" }, { "math": [ "u_pain()", "-=", "30" ] } ]
         },
         {
           "id": "EOC_MIGO_BIO_TECH_SLEEPINESS",
-          "condition": { "npc_has_var": "mbt_f_function", "value": "sleepiness" },
+          "condition": { "compare_string": [ "sleepiness", { "npc_val": "mbt_f_function" } ] },
           "effect": [ { "u_message": "You instantly feel more awake!" }, { "math": [ "u_val('sleepiness')", "-=", "30" ] } ]
         }
       ]

--- a/data/json/npcs/Backgrounds/OtherSurvivorStories/Brigitte_LaCroix_Background.json
+++ b/data/json/npcs/Backgrounds/OtherSurvivorStories/Brigitte_LaCroix_Background.json
@@ -11,7 +11,7 @@
           "and": [
             { "math": [ "npc_randomize_dialogue_direction", "==", "1" ] },
             { "npc_has_trait": "BOSS_Brigitte_LaCroix_01" },
-            { "not": { "u_has_var": "BOSS_mission_directions", "value": "Brigitte_LaCroix" } }
+            { "not": { "compare_string": [ "Brigitte_LaCroix", { "u_val": "BOSS_mission_directions" } ] } }
           ]
         },
         "effect": { "assign_mission": "directions_Brigitte_LaCroix" },

--- a/data/json/npcs/Backgrounds/OtherSurvivorStories/Lapin_01.json
+++ b/data/json/npcs/Backgrounds/OtherSurvivorStories/Lapin_01.json
@@ -11,7 +11,7 @@
           "and": [
             { "math": [ "npc_randomize_dialogue_direction", "==", "1" ] },
             { "npc_has_trait": "BOSS_Lapin_01" },
-            { "not": { "u_has_var": "BOSS_mission_directions", "value": "lapin" } }
+            { "not": { "compare_string": [ "lapin", { "u_val": "BOSS_mission_directions" } ] } }
           ]
         },
         "effect": { "assign_mission": "directions_lapin" },

--- a/data/json/npcs/Backgrounds/OtherSurvivorStories/NC_Farmer_background.json
+++ b/data/json/npcs/Backgrounds/OtherSurvivorStories/NC_Farmer_background.json
@@ -14,7 +14,7 @@
           "and": [
             { "math": [ "npc_randomize_dialogue_direction", "==", "1" ] },
             { "npc_has_trait": "BOSS_NC_FARMER_01" },
-            { "not": { "u_has_var": "BOSS_mission_directions", "value": "farmer" } }
+            { "not": { "compare_string": [ "farmer", { "u_val": "BOSS_mission_directions" } ] } }
           ]
         },
         "effect": { "assign_mission": "directions_farmer" },

--- a/data/json/npcs/Backgrounds/OtherSurvivorStories/NC_SURVIVOR_CHEF_background.json
+++ b/data/json/npcs/Backgrounds/OtherSurvivorStories/NC_SURVIVOR_CHEF_background.json
@@ -14,7 +14,7 @@
           "and": [
             { "math": [ "npc_randomize_dialogue_direction", "==", "1" ] },
             { "npc_has_trait": "BOSS_NC_SURVIVOR_CHEF_01" },
-            { "not": { "u_has_var": "BOSS_mission_directions", "value": "chef" } }
+            { "not": { "compare_string": [ "chef", { "u_val": "BOSS_mission_directions" } ] } }
           ]
         },
         "effect": { "assign_mission": "directions_chef" },

--- a/data/json/npcs/Backgrounds/hospital_2.json
+++ b/data/json/npcs/Backgrounds/hospital_2.json
@@ -99,8 +99,7 @@
     "id": "BGSS_HOSPITAL_2_STORY4",
     "type": "talk_topic",
     "dynamic_line": {
-      "u_has_var": "mission_BGSS_hospital_2_started_quest",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "mission_BGSS_hospital_2_started_quest" } ],
       "no": {
         "gendered_line": "Well, I still didn't have any food.  Eventually I had to climb down the side of the building… so I did, as quietly as I could.  It was night, and I have pretty good nightvision.  Apparently the zombies don't, because I was able to slip right past them and steal a bicycle that was just laying on the side of the road.  I'd kind of scouted out my route from above… I'm not from a big city, the hospital was the tallest building around.  I avoided the major military blockades, and headed out of town towards a friend's old cabin.  I had to fight off a couple of the <zombies>, but I managed to avoid any big fuss, by some miracle.  I never made it to the cabin, but that's not important now.",
         "relevant_genders": [ "npc" ]
@@ -116,11 +115,11 @@
         "text": "Any chance you could point the way to that cabin for me?",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "mission_BGSS_hospital_2_started_quest", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "u_val": "mission_BGSS_hospital_2_started_quest" } ] } },
             {
               "not": {
                 "and": [
-                  { "u_has_var": "general_BGSS_hospital_2_asked_about_quest", "value": "yes" },
+                  { "compare_string": [ "yes", { "u_val": "general_BGSS_hospital_2_asked_about_quest" } ] },
                   { "math": [ "time_since(u_timer_timers_hospital_2_asked_about_quest)", "<", "time('8 h')" ] }
                 ]
               }

--- a/data/json/npcs/Backgrounds/prepper_1.json
+++ b/data/json/npcs/Backgrounds/prepper_1.json
@@ -12,22 +12,22 @@
       {
         "text": "You said you could tell me more about the shelter if I wanted.  How did these things get built?",
         "topic": "BGSS_PREPPER_1_LMOE2",
-        "condition": { "u_has_var": "mission_BGSS_prepper_1_finished_quest", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "mission_BGSS_prepper_1_finished_quest" } ] }
       },
       {
         "text": "What do you think happened?  You must have some interesting theories on why everything went to shit.",
         "//": "If the player already confronted the Prepper about their shelter and is gated out of that part of the conversation, this allows the player to still have a fun chat about apocalypse theories with them.",
         "topic": "BGSS_PREPPER_1_FOUND_LMOE7",
-        "condition": { "u_has_var": "mission_BGSS_prepper_1_asked_about_shelter", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "mission_BGSS_prepper_1_asked_about_shelter" } ] }
       },
       {
         "text": "Hey, uh…  I noticed you left a computer down in your shelter.  I didn't intend to pry, but you said I could go through everything.  So, I read a little of what you wrote.  You wanna talk about it?",
         "topic": "BGSS_PREPPER_1_FOUND_LMOE6",
         "condition": {
           "and": [
-            { "u_has_var": "mission_BGSS_prepper_1_found_computer", "value": "yes" },
-            { "not": { "u_has_var": "mission_BGSS_prepper_1_asked_about_shelter", "value": "yes" } },
-            { "u_has_var": "mission_BGSS_prepper_1_finished_quest", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "mission_BGSS_prepper_1_found_computer" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "mission_BGSS_prepper_1_asked_about_shelter" } ] } },
+            { "compare_string": [ "yes", { "u_val": "mission_BGSS_prepper_1_finished_quest" } ] }
           ]
         }
       },
@@ -66,8 +66,7 @@
     "id": "BGSS_PREPPER_1_LMOE",
     "type": "talk_topic",
     "dynamic_line": {
-      "u_has_var": "mission_BGSS_prepper_1_started_quest",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "mission_BGSS_prepper_1_started_quest" } ],
       "no": {
         "gendered_line": "I never made it there and can't imagine I ever will.  Every time I've tried I've been headed off by the <zombies>.",
         "relevant_genders": [ "npc" ]
@@ -82,12 +81,12 @@
         "condition": {
           "and": [
             { "not": { "u_has_mission": "directions_prepper_1_SHELTER" } },
-            { "not": { "u_has_var": "mission_BGSS_prepper_1_found_computer", "value": "yes" } },
-            { "not": { "u_has_var": "mission_BGSS_prepper_1_finished_quest", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "u_val": "mission_BGSS_prepper_1_found_computer" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "mission_BGSS_prepper_1_finished_quest" } ] } },
             {
               "not": {
                 "and": [
-                  { "u_has_var": "general_BGSS_prepper_1_asked_about_quest", "value": "yes" },
+                  { "compare_string": [ "yes", { "u_val": "general_BGSS_prepper_1_asked_about_quest" } ] },
                   { "math": [ "time_since(u_timer_timers_prepper_1_asked_about_quest)", "<", "time('8 h')" ] }
                 ]
               }
@@ -120,9 +119,9 @@
         "topic": "BGSS_PREPPER_1_FOUND_LMOE1",
         "condition": {
           "and": [
-            { "u_has_var": "mission_BGSS_prepper_1_found_computer", "value": "yes" },
-            { "not": { "u_has_var": "mission_BGSS_prepper_1_asked_about_shelter", "value": "yes" } },
-            { "not": { "u_has_var": "mission_BGSS_prepper_1_finished_quest", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "mission_BGSS_prepper_1_found_computer" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "mission_BGSS_prepper_1_asked_about_shelter" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "mission_BGSS_prepper_1_finished_quest" } ] } }
           ]
         },
         "effect": { "u_add_var": "mission_BGSS_prepper_1_asked_about_shelter", "value": "yes" }
@@ -148,8 +147,8 @@
         "text": "You wouldn't keep ALL your tricks and secrets from me, though, would you?  After everything we've been through?",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "mission_BGSS_prepper_1_asked_about_secrets", "value": "yes" } },
-            { "not": { "u_has_var": "mission_BGSS_prepper_1_found_computer", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "mission_BGSS_prepper_1_asked_about_secrets" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "mission_BGSS_prepper_1_found_computer" } ] } }
           ]
         },
         "//": "Even though material possessions have been made trivially easy to obtain in the apocalypse, the prepper still values their stash, hence the difficult trial here.",
@@ -578,7 +577,7 @@
       {
         "text": "I met this woman who was… uh… obsessed with bones?  She said that since <the_cataclysm>, the bones of living things 'hum' with some kind of special power and that she wants to collect lots of them to either end the world or save the world.  I'm honestly still not entirely clear how or what's supposed to happen…  How about that idea?  Did THAT ever cross your mind?",
         "//": "This option only shows if you've asked Brigitte LaCroix, the Boneseer, about her theory on the Cataclysm.",
-        "condition": { "u_has_var": "dialogue_song_asked_about_song", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_song_asked_about_song" } ] },
         "topic": "BGSS_PREPPER_1_FOUND_LMOE9_BONE_SEER"
       },
       {

--- a/data/json/npcs/Backgrounds/rural_1.json
+++ b/data/json/npcs/Backgrounds/rural_1.json
@@ -32,8 +32,7 @@
     "id": "BGSS_RURAL_1_STORY3",
     "type": "talk_topic",
     "dynamic_line": {
-      "u_has_var": "mission_BGSS_rural_1_started_quest",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "mission_BGSS_rural_1_started_quest" } ],
       "no": {
         "gendered_line": "That was the first thing to really shake me out of it.  I didn't really have any very close friends, but there were people back in town I cared about a bit.  I had sent some texts, but I hadn't really twigged that they hadn't replied for days.  I got in my truck and tried to get back to town.  Didn't get far before I hit a <zombie> infested pileup blocking the highway, and that's when I started to put it all together.  Never did get to town.  Unfortunately I led the <zombies> back to my farm, and had to bug out of there.  Might go back and clear it out, someday.",
         "relevant_genders": [ "npc" ]
@@ -48,11 +47,11 @@
         "text": "I could help you clear out your farm if you wanted.  You just have to show me the way…",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "mission_BGSS_rural_1_started_quest", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "u_val": "mission_BGSS_rural_1_started_quest" } ] } },
             {
               "not": {
                 "and": [
-                  { "u_has_var": "general_BGSS_rural_1_asked_about_quest", "value": "yes" },
+                  { "compare_string": [ "yes", { "u_val": "general_BGSS_rural_1_asked_about_quest" } ] },
                   { "math": [ "time_since(u_timer_timers_rural_1_asked_about_quest)", "<", "time('8 h')" ] }
                 ]
               }

--- a/data/json/npcs/Kindred/NPC_Brigitte_LaCroix.json
+++ b/data/json/npcs/Kindred/NPC_Brigitte_LaCroix.json
@@ -100,12 +100,10 @@
     "type": "talk_topic",
     "id": "TALK_BONE_SEER",
     "dynamic_line": {
-      "u_has_var": "dialogue_first_meeting_talked_to_seer",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_seer" } ],
       "no": "You there.  Quiet down.  Can you hear it?  The song?",
       "yes": {
-        "u_has_var": "dialogue_song_asked_about_song",
-        "value": "yes",
+        "compare_string": [ "yes", { "u_val": "dialogue_song_asked_about_song" } ],
         "no": { "gendered_line": "You're back.  Have you come to listen to the song?", "relevant_genders": [ "u" ] },
         "yes": {
           "u_has_trait": "seer_mark",
@@ -119,57 +117,59 @@
       {
         "text": "What song?",
         "topic": "TALK_BONE_SEER_SONG",
-        "condition": { "not": { "u_has_var": "dialogue_song_asked_about_song", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "dialogue_song_asked_about_song" } ] } }
       },
       {
         "text": "So about the songs…",
         "topic": "TALK_BONE_SEER_SONG2",
-        "condition": { "u_has_var": "dialogue_song_asked_about_song", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_song_asked_about_song" } ] }
       },
       {
         "text": "Do others follow this belief as well?",
         "topic": "TALK_BONE_SEER_OTHERS",
-        "condition": { "u_has_var": "dialogue_song_asked_about_song", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_song_asked_about_song" } ] }
       },
       {
         "text": "Can you tell me more about yourself?",
         "topic": "TALK_BONE_SEER_ABOUT",
-        "condition": { "u_has_var": "dialogue_song_asked_about_song", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_song_asked_about_song" } ] }
       },
       {
         "text": "You mentioned some cycle before.  What does that mean?",
         "topic": "TALK_BONE_SEER_CYCLE",
-        "condition": { "u_has_var": "dialogue_song_asked_about_song", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_song_asked_about_song" } ] }
       },
       {
         "text": "I've met Cooper.",
         "topic": "TALK_BONE_SEER_METCOOPER",
         "condition": {
           "and": [
-            { "u_has_var": "dialogue_first_meeting_talked_to_cooper", "value": "yes" },
-            { "u_has_var": "dialogue_kindred_cooper_knows_cooper", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_cooper" } ] },
+            { "compare_string": [ "yes", { "u_val": "dialogue_kindred_cooper_knows_cooper" } ] }
           ]
         }
       },
       {
         "text": "Would you like to join me on my travels?",
         "topic": "TALK_SUGGEST_FOLLOW_SEER",
-        "condition": { "and": [ { "not": "npc_following" }, { "u_has_var": "dialogue_song_asked_about_song", "value": "yes" } ] }
+        "condition": {
+          "and": [ { "not": "npc_following" }, { "compare_string": [ "yes", { "u_val": "dialogue_song_asked_about_song" } ] } ]
+        }
       },
       {
         "text": "Is there a way I can help you with your song?",
         "topic": "TALK_MISSION_LIST_SEER",
-        "condition": { "u_has_var": "dialogue_song_asked_about_song", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_song_asked_about_song" } ] }
       },
       {
         "text": "I have to go.",
         "topic": "TALK_DONE",
-        "condition": { "not": { "u_has_var": "dialogue_song_asked_about_song", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "dialogue_song_asked_about_song" } ] } }
       },
       {
         "text": "I have to get going.  Take care, Seer.",
         "topic": "TALK_DONE",
-        "condition": { "u_has_var": "dialogue_song_asked_about_song", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_song_asked_about_song" } ] }
       }
     ]
   },
@@ -222,7 +222,7 @@
       {
         "text": "Wait, Cooper?  Darren Cooper?  I've already met him.",
         "topic": "TALK_BONE_SEER_METCOOPER2",
-        "condition": { "u_has_var": "dialogue_first_meeting_talked_to_cooper", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_cooper" } ] }
       },
       { "text": "What exactly did he do?", "topic": "TALK_BONE_SEER_COOPER2" },
       {
@@ -474,20 +474,20 @@
       {
         "text": "I've confronted him.  He ended up attacking me.",
         "topic": "TALK_BONE_SEER_COOPERFIGHT",
-        "condition": { "u_has_var": "dialogue_cooper_fought_cooper", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_cooper_fought_cooper" } ] }
       },
       {
         "text": "He was reasonable.  We talked, then parted ways peacefully.",
         "topic": "TALK_BONE_SEER_COOPERPEACE",
-        "condition": { "not": { "u_has_var": "dialogue_cooper_fought_cooper", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "dialogue_cooper_fought_cooper" } ] } }
       },
       {
         "text": "I agree with him.  What he does is necessary.",
         "topic": "TALK_BONE_SEER_COOPERAGREE",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "dialogue_cooper_fought_cooper", "value": "yes" } },
-            { "u_has_var": "dialogue_cooper_cooper_friendly", "value": "yes" }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_cooper_fought_cooper" } ] } },
+            { "compare_string": [ "yes", { "u_val": "dialogue_cooper_cooper_friendly" } ] }
           ]
         }
       }
@@ -516,20 +516,20 @@
       {
         "text": "I've confronted him.  He ended up attacking me.",
         "topic": "TALK_BONE_SEER_COOPERFIGHT",
-        "condition": { "u_has_var": "dialogue_cooper_fought_cooper", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_cooper_fought_cooper" } ] }
       },
       {
         "text": "He was reasonable.  We talked, then parted ways peacefully.",
         "topic": "TALK_BONE_SEER_COOPERPEACE",
-        "condition": { "not": { "u_has_var": "dialogue_cooper_fought_cooper", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "dialogue_cooper_fought_cooper" } ] } }
       },
       {
         "text": "I agree with him.  What he does is necessary.",
         "topic": "TALK_BONE_SEER_COOPERAGREE",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "dialogue_cooper_fought_cooper", "value": "yes" } },
-            { "u_has_var": "dialogue_cooper_cooper_friendly", "value": "yes" }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_cooper_fought_cooper" } ] } },
+            { "compare_string": [ "yes", { "u_val": "dialogue_cooper_cooper_friendly" } ] }
           ]
         }
       }

--- a/data/json/npcs/Kindred/NPC_Darren_Cooper.json
+++ b/data/json/npcs/Kindred/NPC_Darren_Cooper.json
@@ -94,8 +94,7 @@
     "type": "talk_topic",
     "id": "TALK_KINDRED_COOPER",
     "dynamic_line": {
-      "u_has_var": "dialogue_first_meeting_talked_to_cooper",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_cooper" } ],
       "no": {
         "u_has_trait": "seer_mark",
         "yes": {
@@ -106,10 +105,13 @@
       },
       "yes": {
         "u_has_trait": "seer_mark",
-        "no": { "u_has_var": "dialogue_cooper_cooper_friendly", "value": "yes", "yes": "Hello again, traveler.", "no": "Yes?" },
+        "no": {
+          "compare_string": [ "yes", { "u_val": "dialogue_cooper_cooper_friendly" } ],
+          "yes": "Hello again, traveler.",
+          "no": "Yes?"
+        },
         "yes": {
-          "u_has_var": "dialogue_cooper_cooper_friendly",
-          "value": "yes",
+          "compare_string": [ "yes", { "u_val": "dialogue_cooper_cooper_friendly" } ],
           "no": "What do you want, Kindred?",
           "yes": "Kindred.  What can I do for you?"
         }
@@ -122,10 +124,10 @@
         "topic": "TALK_KNOWS_COOPER1",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "dialogue_cooper_confronted_cooper", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_cooper_confronted_cooper" } ] } },
             { "u_has_trait": "seer_mark" },
-            { "u_has_var": "dialogue_kindred_cooper_knows_cooper", "value": "yes" },
-            { "not": { "u_has_var": "dialogue_kindred_cooper_knows_cooper_kill", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "dialogue_kindred_cooper_knows_cooper" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_kindred_cooper_knows_cooper_kill" } ] } }
           ]
         }
       },
@@ -134,10 +136,10 @@
         "topic": "TALK_KNOWS_COOPER_CARVE",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "dialogue_cooper_confronted_cooper", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_cooper_confronted_cooper" } ] } },
             { "u_has_trait": "seer_mark" },
-            { "u_has_var": "dialogue_kindred_cooper_knows_cooper", "value": "yes" },
-            { "u_has_var": "dialogue_kindred_cooper_knows_cooper_kill", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "dialogue_kindred_cooper_knows_cooper" } ] },
+            { "compare_string": [ "yes", { "u_val": "dialogue_kindred_cooper_knows_cooper_kill" } ] }
           ]
         }
       },
@@ -146,11 +148,11 @@
         "topic": "TALK_COOPER_AGREE",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "dialogue_cooper_confronted_cooper", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_cooper_confronted_cooper" } ] } },
             { "u_has_trait": "seer_mark" },
-            { "u_has_var": "dialogue_kindred_cooper_knows_cooper", "value": "yes" },
-            { "u_has_var": "dialogue_kindred_cooper_knows_cooper_kill", "value": "yes" },
-            { "u_has_var": "dialogue_kindred_admires_cooper", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "dialogue_kindred_cooper_knows_cooper" } ] },
+            { "compare_string": [ "yes", { "u_val": "dialogue_kindred_cooper_knows_cooper_kill" } ] },
+            { "compare_string": [ "yes", { "u_val": "dialogue_kindred_admires_cooper" } ] }
           ]
         }
       },
@@ -159,9 +161,9 @@
         "topic": "TALK_COOPER_NOTFMLR",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "dialogue_first_meeting_talked_to_cooper", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_cooper" } ] } },
             { "u_has_trait": "seer_mark" },
-            { "not": { "u_has_var": "dialogue_kindred_cooper_knows_cooper", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_kindred_cooper_knows_cooper" } ] } }
           ]
         }
       },
@@ -171,8 +173,8 @@
         "condition": {
           "and": [
             { "not": { "u_has_trait": "seer_mark" } },
-            { "not": { "u_has_var": "dialogue_kindred_cooper_knows_cooper", "value": "yes" } },
-            { "not": { "u_has_var": "dialogue_first_meeting_talked_to_cooper", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_kindred_cooper_knows_cooper" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_cooper" } ] } }
           ]
         }
       },
@@ -182,9 +184,9 @@
         "condition": {
           "and": [
             { "not": { "u_has_trait": "seer_mark" } },
-            { "not": { "u_has_var": "dialogue_first_meeting_talked_to_cooper", "value": "yes" } },
-            { "u_has_var": "dialogue_kindred_cooper_knows_cooper", "value": "yes" },
-            { "u_has_var": "dialogue_kindred_cooper_knows_cooper_kill", "value": "yes" }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_cooper" } ] } },
+            { "compare_string": [ "yes", { "u_val": "dialogue_kindred_cooper_knows_cooper" } ] },
+            { "compare_string": [ "yes", { "u_val": "dialogue_kindred_cooper_knows_cooper_kill" } ] }
           ]
         }
       },
@@ -194,9 +196,9 @@
         "condition": {
           "and": [
             { "not": { "u_has_trait": "seer_mark" } },
-            { "not": { "u_has_var": "dialogue_first_meeting_talked_to_cooper", "value": "yes" } },
-            { "u_has_var": "dialogue_kindred_cooper_knows_cooper", "value": "yes" },
-            { "not": { "u_has_var": "dialogue_kindred_cooper_knows_cooper_kill", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_cooper" } ] } },
+            { "compare_string": [ "yes", { "u_val": "dialogue_kindred_cooper_knows_cooper" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_kindred_cooper_knows_cooper_kill" } ] } }
           ]
         }
       },
@@ -206,9 +208,9 @@
         "condition": {
           "and": [
             { "not": { "u_has_trait": "seer_mark" } },
-            { "not": { "u_has_var": "dialogue_first_meeting_talked_to_cooper", "value": "yes" } },
-            { "u_has_var": "dialogue_kindred_cooper_knows_cooper", "value": "yes" },
-            { "u_has_var": "dialogue_kindred_admires_cooper", "value": "yes" }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_cooper" } ] } },
+            { "compare_string": [ "yes", { "u_val": "dialogue_kindred_cooper_knows_cooper" } ] },
+            { "compare_string": [ "yes", { "u_val": "dialogue_kindred_admires_cooper" } ] }
           ]
         }
       },
@@ -218,10 +220,10 @@
         "condition": {
           "and": [
             { "not": { "u_has_trait": "seer_mark" } },
-            { "u_has_var": "dialogue_first_meeting_talked_to_cooper", "value": "yes" },
-            { "u_has_var": "dialogue_kindred_cooper_knows_cooper", "value": "yes" },
-            { "not": { "u_has_var": "dialogue_first_meeting_cooper_goal_k", "value": "yes" } },
-            { "not": { "u_has_var": "dialogue_kindred_cooper_knows_cooper_kill", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_cooper" } ] },
+            { "compare_string": [ "yes", { "u_val": "dialogue_kindred_cooper_knows_cooper" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_cooper_goal_k" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_kindred_cooper_knows_cooper_kill" } ] } }
           ]
         }
       },
@@ -231,25 +233,25 @@
         "condition": {
           "and": [
             { "not": { "u_has_trait": "seer_mark" } },
-            { "u_has_var": "dialogue_first_meeting_talked_to_cooper", "value": "yes" },
-            { "u_has_var": "dialogue_kindred_cooper_knows_cooper", "value": "yes" },
-            { "not": { "u_has_var": "dialogue_first_meeting_cooper_goal_k", "value": "yes" } },
-            { "u_has_var": "dialogue_kindred_cooper_knows_cooper_kill", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_cooper" } ] },
+            { "compare_string": [ "yes", { "u_val": "dialogue_kindred_cooper_knows_cooper" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_cooper_goal_k" } ] } },
+            { "compare_string": [ "yes", { "u_val": "dialogue_kindred_cooper_knows_cooper_kill" } ] }
           ]
         }
       },
       {
         "text": "Could you tell me about yourself?",
         "topic": "TALK_COOPER_ABOUT",
-        "condition": { "and": [ { "u_has_var": "dialogue_first_meeting_talked_to_cooper", "value": "yes" } ] }
+        "condition": { "and": [ { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_cooper" } ] } ] }
       },
       {
         "text": "I'll be going now.",
         "topic": "TALK_DONE",
         "condition": {
           "and": [
-            { "u_has_var": "dialogue_first_meeting_talked_to_cooper", "value": "yes" },
-            { "not": { "u_has_var": "dialogue_cooper_cooper_friendly", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_cooper" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_cooper_cooper_friendly" } ] } }
           ]
         }
       },
@@ -257,7 +259,10 @@
         "text": "Remind me what happened between you and Brigitte.",
         "topic": "TALK_COOPERS_SIDE",
         "condition": {
-          "and": [ { "u_has_var": "dialogue_first_meeting_talked_to_cooper", "value": "yes" }, { "u_has_trait": "seer_mark" } ]
+          "and": [
+            { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_cooper" } ] },
+            { "u_has_trait": "seer_mark" }
+          ]
         }
       },
       {
@@ -265,8 +270,8 @@
         "topic": "TALK_COOPER_FIGHT",
         "condition": {
           "and": [
-            { "u_has_var": "dialogue_first_meeting_talked_to_cooper", "value": "yes" },
-            { "u_has_var": "dialogue_kindred_cooper_knows_cooper_kill", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_cooper" } ] },
+            { "compare_string": [ "yes", { "u_val": "dialogue_kindred_cooper_knows_cooper_kill" } ] }
           ]
         }
       },
@@ -276,8 +281,8 @@
         "condition": {
           "and": [
             { "not": { "u_has_trait": "seer_mark" } },
-            { "u_has_var": "dialogue_first_meeting_talked_to_cooper", "value": "yes" },
-            { "u_has_var": "dialogue_first_meeting_cooper_goal_k", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_cooper" } ] },
+            { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_cooper_goal_k" } ] }
           ]
         }
       },
@@ -287,23 +292,23 @@
         "condition": {
           "and": [
             { "not": { "u_has_trait": "seer_mark" } },
-            { "u_has_var": "dialogue_first_meeting_talked_to_cooper", "value": "yes" },
-            { "u_has_var": "dialogue_first_meeting_cooper_goal_dk", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_cooper" } ] },
+            { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_cooper_goal_dk" } ] }
           ]
         }
       },
       {
         "text": "The woman you mentioned - Brigitte - why isn't she with you?",
         "topic": "TALK_COOPERS_SIDE",
-        "condition": { "u_has_var": "dialogue_first_meeting_cooper_goal_k", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_cooper_goal_k" } ] }
       },
       {
         "text": "I was just checking in.  Take care.",
         "topic": "TALK_DONE",
         "condition": {
           "and": [
-            { "u_has_var": "dialogue_first_meeting_talked_to_cooper", "value": "yes" },
-            { "u_has_var": "dialogue_cooper_cooper_friendly", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_cooper" } ] },
+            { "compare_string": [ "yes", { "u_val": "dialogue_cooper_cooper_friendly" } ] }
           ]
         }
       }
@@ -353,18 +358,18 @@
       {
         "text": "What do you mean by 'necessary'?",
         "topic": "TALK_COOPER_NECESSARY",
-        "condition": { "not": { "u_has_var": "dialogue_kindred_cooper_knows_cooper_kill", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "dialogue_kindred_cooper_knows_cooper_kill" } ] } }
       },
       {
         "text": "What are you actually trying to accomplish?",
         "topic": "TALK_COOPER_GOAL",
-        "condition": { "not": { "u_has_var": "dialogue_first_meeting_cooper_goal_k", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_cooper_goal_k" } ] } }
       },
       { "text": "Can't have been easy to split off, but I understand why you did it.", "topic": "TALK_COOPER_AGREE" },
       {
         "text": "Necessary?  You kill innocent people!",
         "topic": "TALK_COOPER_NECESSARY",
-        "condition": { "u_has_var": "dialogue_kindred_cooper_knows_cooper_kill", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_kindred_cooper_knows_cooper_kill" } ] }
       }
     ]
   },
@@ -377,7 +382,7 @@
       {
         "text": "Why do you kill people?",
         "topic": "TALK_COOPER_GOAL",
-        "condition": { "not": { "u_has_var": "dialogue_first_meeting_cooper_goal_k", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_cooper_goal_k" } ] } }
       },
       { "text": "Are you going to kill me?", "topic": "TALK_COOPER_KILL_PLAYER" },
       { "text": "You're a monster.", "topic": "TALK_COOPER_MONSTER" },
@@ -389,7 +394,7 @@
       {
         "text": "Do you have any proof that this will work?",
         "topic": "TALK_COOPER_WORK",
-        "condition": { "u_has_var": "dialogue_first_meeting_cooper_goal_k", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_cooper_goal_k" } ] }
       }
     ]
   },
@@ -440,7 +445,7 @@
       {
         "text": "That being said, I need to know why you do it - what purpose it fills.",
         "topic": "TALK_COOPER_GOAL",
-        "condition": { "not": { "u_has_var": "dialogue_first_meeting_cooper_goal_k", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_cooper_goal_k" } ] } }
       }
     ]
   },
@@ -460,15 +465,15 @@
       {
         "text": "What about the woman you mentioned - Brigitte - what happened to her?",
         "topic": "TALK_COOPERS_SIDE",
-        "condition": { "u_has_var": "dialogue_first_meeting_cooper_goal_k", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_cooper_goal_k" } ] }
       },
       {
         "text": "Brigitte was right.  I can't reason with you.  You have to be stopped.",
         "topic": "TALK_COOPER_FIGHT",
         "condition": {
           "and": [
-            { "u_has_var": "dialogue_kindred_cooper_knows_cooper", "value": "yes" },
-            { "u_has_var": "dialogue_cooper_knows_cooper_kill", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "dialogue_kindred_cooper_knows_cooper" } ] },
+            { "compare_string": [ "yes", { "u_val": "dialogue_cooper_knows_cooper_kill" } ] }
           ]
         }
       },
@@ -477,8 +482,8 @@
         "topic": "TALK_COOPER_FIGHT",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "dialogue_kindred_cooper_knows_cooper", "value": "yes" } },
-            { "u_has_var": "dialogue_cooper_knows_cooper_kill", "value": "yes" }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_kindred_cooper_knows_cooper" } ] } },
+            { "compare_string": [ "yes", { "u_val": "dialogue_cooper_knows_cooper_kill" } ] }
           ]
         }
       },
@@ -516,15 +521,15 @@
       {
         "text": "You mentioned a woman, Brigitte.  Why isn't she with you?  What happened?",
         "topic": "TALK_COOPERS_SIDE",
-        "condition": { "not": { "u_has_var": "dialogue_song_asked_about_song", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "dialogue_song_asked_about_song" } ] } }
       },
       {
         "text": "Wait, Brigitte LaCroix?  I've met her.",
         "topic": "TALK_COOPER_KNOWBRIG",
         "condition": {
           "and": [
-            { "u_has_var": "dialogue_song_asked_about_song", "value": "yes" },
-            { "not": { "u_has_var": "dialogue_cooper_cooper_friendly", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "dialogue_song_asked_about_song" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_cooper_cooper_friendly" } ] } }
           ]
         }
       },
@@ -544,8 +549,7 @@
     "type": "talk_topic",
     "id": "TALK_COOPER_ABOUT",
     "dynamic_line": {
-      "u_has_var": "dialogue_cooper_cooper_friendly",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "dialogue_cooper_cooper_friendly" } ],
       "no": "Sorry, but I don't know you that well and I'd rather not go into that.",
       "yes": "I was born here in New England, lived here all my life.  Was an accountant before the Collapse, if you can believe that.  There wasn't really anything special about my life before I learned about the Song, so there isn't much to say."
     },
@@ -553,17 +557,17 @@
       {
         "text": "I understand.",
         "topic": "TALK_KINDRED_COOPER",
-        "condition": { "not": { "u_has_var": "dialogue_cooper_cooper_friendly", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "dialogue_cooper_cooper_friendly" } ] } }
       },
       {
         "text": "Do you have a favorite food?",
         "topic": "TALK_COOPER_FOOD",
-        "condition": { "u_has_var": "dialogue_cooper_cooper_friendly", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_cooper_cooper_friendly" } ] }
       },
       {
         "text": "I see.  Thanks for sharing.",
         "topic": "TALK_KINDRED_COOPER",
-        "condition": { "u_has_var": "dialogue_cooper_cooper_friendly", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_cooper_cooper_friendly" } ] }
       }
     ]
   },

--- a/data/json/npcs/Lighthouse_Family/NPC_lighthouse_girl.json
+++ b/data/json/npcs/Lighthouse_Family/NPC_lighthouse_girl.json
@@ -43,17 +43,20 @@
     "dynamic_line": {
       "u_has_mission": "MISSION_lighthouse_man_3",
       "yes": {
-        "u_has_var": "flag_death_lighthouse_woman_dead",
-        "value": "yes",
+        "compare_string": [ "yes", { "u_val": "flag_death_lighthouse_woman_dead" } ],
         "yes": "Thank you for saving me.  It's a shame my mother didn't make it… you did everything you could, and I don't blame you for it…",
         "no": "Thank you!"
       },
-      "no": { "u_has_var": "flag_death_lighthouse_woman_dead", "value": "yes", "yes": "Poor, poor mama…", "no": "Hello." }
+      "no": {
+        "compare_string": [ "yes", { "u_val": "flag_death_lighthouse_woman_dead" } ],
+        "yes": "Poor, poor mama…",
+        "no": "Hello."
+      }
     },
     "responses": [
       {
         "text": "Hi.",
-        "condition": { "u_has_var": "flag_help_lighthouse_family_safe", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "flag_help_lighthouse_family_safe" } ] },
         "topic": "TALK_lighthouse_girl_1",
         "effect": { "npc_first_topic": "TALK_lighthouse_girl_1" },
         "switch": true
@@ -62,7 +65,7 @@
         "truefalsetext": {
           "true": "I'm sorry…",
           "false": "…",
-          "condition": { "u_has_var": "flag_death_lighthouse_woman_dead", "value": "yes" }
+          "condition": { "compare_string": [ "yes", { "u_val": "flag_death_lighthouse_woman_dead" } ] }
         },
         "topic": "TALK_DONE",
         "switch": true

--- a/data/json/npcs/Lighthouse_Family/NPC_lighthouse_man.json
+++ b/data/json/npcs/Lighthouse_Family/NPC_lighthouse_man.json
@@ -70,7 +70,7 @@
       },
       {
         "text": "Has anyone come recently?",
-        "condition": { "u_has_var": "global_safe_space_lighthouse_fixed", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "global_safe_space_lighthouse_fixed" } ] },
         "trial": { "type": "CONDITION", "condition": { "math": [ "time_since(n_time_survivors_wait)", ">=", "time('14 d')" ] } },
         "success": {
           "topic": "TALK_lighthouse_man_survivors_yes",
@@ -235,8 +235,8 @@
           "and": [
             { "u_has_mission": "MISSION_lighthouse_man_3" },
             { "not": "mission_complete" },
-            { "u_has_var": "flag_safe_lighthouse_woman", "value": "yes" },
-            { "u_has_var": "flag_safe_lighthouse_girl", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "flag_safe_lighthouse_woman" } ] },
+            { "compare_string": [ "yes", { "u_val": "flag_safe_lighthouse_girl" } ] }
           ]
         },
         "effect": [ "mission_success", { "npc_first_topic": "TALK_lighthouse_man_1" } ]
@@ -247,15 +247,15 @@
         "condition": {
           "and": [
             "mission_complete",
-            { "not": { "u_has_var": "flag_safe_lighthouse_woman", "value": "yes" } },
-            { "u_has_var": "flag_death_lighthouse_girl_dead", "value": "yes" }
+            { "not": { "compare_string": [ "yes", { "u_val": "flag_safe_lighthouse_woman" } ] } },
+            { "compare_string": [ "yes", { "u_val": "flag_death_lighthouse_girl_dead" } ] }
           ]
         }
       },
       {
         "text": "I'm sorry, I failed you… I couldn't bring your wife alive…",
         "topic": "TALK_lighthouse_man_fail",
-        "condition": { "and": [ "mission_complete", { "u_has_var": "flag_safe_lighthouse_girl", "value": "yes" } ] }
+        "condition": { "and": [ "mission_complete", { "compare_string": [ "yes", { "u_val": "flag_safe_lighthouse_girl" } ] } ] }
       },
       {
         "text": "I'm sorry, I failed you… I couldn't bring your daughter alive…",
@@ -263,8 +263,8 @@
         "condition": {
           "and": [
             { "not": "mission_complete" },
-            { "u_has_var": "flag_safe_lighthouse_woman", "value": "yes" },
-            { "u_has_var": "flag_death_lighthouse_girl_dead", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "flag_safe_lighthouse_woman" } ] },
+            { "compare_string": [ "yes", { "u_val": "flag_death_lighthouse_girl_dead" } ] }
           ]
         }
       },
@@ -454,7 +454,7 @@
     "name": { "str": "Fixing lighthouse" },
     "description": "Mikhail asked you to find someone, who have enough expertise to fix the mechanism of lighthouse.",
     "goal": "MGOAL_CONDITION",
-    "goal_condition": { "u_has_var": "global_safe_space_lighthouse_fixed", "value": "ready" },
+    "goal_condition": { "compare_string": [ "ready", { "u_val": "global_safe_space_lighthouse_fixed" } ] },
     "difficulty": 0,
     "value": 100000,
     "end": {

--- a/data/json/npcs/Lighthouse_Family/NPC_lighthouse_man.json
+++ b/data/json/npcs/Lighthouse_Family/NPC_lighthouse_man.json
@@ -59,13 +59,13 @@
       {
         "text": "How are you doing?",
         "topic": "TALK_lighthouse_man_hay",
-        "condition": { "npc_has_var": "flag_help_helped_lighthouse_man", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "npc_val": "flag_help_helped_lighthouse_man" } ] }
       },
       { "text": "Do you need any help?", "topic": "TALK_MISSION_LIST" },
       {
         "text": "Care to trade?",
         "topic": "TALK_lighthouse_man_1",
-        "condition": { "npc_has_var": "flag_help_helped_lighthouse_man", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "npc_val": "flag_help_helped_lighthouse_man" } ] },
         "effect": "start_trade"
       },
       {
@@ -141,7 +141,7 @@
         "topic": "TALK_lighthouse_man_cleaned",
         "condition": {
           "and": [
-            { "npc_has_var": "count_cleaning_lighthouse_man", "value": "1" },
+            { "compare_string": [ "1", { "npc_val": "count_cleaning_lighthouse_man" } ] },
             "at_safe_space",
             { "npc_at_om_location": "lighthouse_z1" }
           ]
@@ -153,7 +153,7 @@
         "topic": "TALK_lighthouse_man_cleaned",
         "condition": {
           "and": [
-            { "npc_has_var": "count_cleaning_lighthouse_man", "value": "2" },
+            { "compare_string": [ "2", { "npc_val": "count_cleaning_lighthouse_man" } ] },
             "at_safe_space",
             { "npc_at_om_location": "lighthouse_z2" }
           ]
@@ -165,7 +165,7 @@
         "topic": "TALK_lighthouse_man_cleaned",
         "condition": {
           "and": [
-            { "npc_has_var": "count_cleaning_lighthouse_man", "value": "3" },
+            { "compare_string": [ "3", { "npc_val": "count_cleaning_lighthouse_man" } ] },
             "at_safe_space",
             { "npc_at_om_location": "lighthouse_z3" }
           ]
@@ -177,7 +177,7 @@
         "topic": "TALK_lighthouse_man_cleaned",
         "condition": {
           "and": [
-            { "npc_has_var": "count_cleaning_lighthouse_man", "value": "4" },
+            { "compare_string": [ "4", { "npc_val": "count_cleaning_lighthouse_man" } ] },
             "at_safe_space",
             { "npc_at_om_location": "lighthouse_z4" }
           ]
@@ -188,7 +188,7 @@
         "text": "Yes.  Top floor is clear.",
         "condition": {
           "and": [
-            { "npc_has_var": "count_cleaning_lighthouse_man", "value": "5" },
+            { "compare_string": [ "5", { "npc_val": "count_cleaning_lighthouse_man" } ] },
             "at_safe_space",
             { "npc_at_om_location": "lighthouse_z5" }
           ]
@@ -200,7 +200,7 @@
         "text": "Looks like that's over.",
         "condition": {
           "and": [
-            { "npc_has_var": "count_cleaning_lighthouse_man", "value": "6" },
+            { "compare_string": [ "6", { "npc_val": "count_cleaning_lighthouse_man" } ] },
             "at_safe_space",
             { "npc_at_om_location": "lighthouse_ground" }
           ]
@@ -346,7 +346,7 @@
     "name": { "str": "House cleaning" },
     "description": "Clean lighthouse from <zombies> with Mikhail.",
     "goal": "MGOAL_CONDITION",
-    "goal_condition": { "npc_has_var": "count_cleaning_lighthouse_man", "value": "7" },
+    "goal_condition": { "compare_string": [ "7", { "npc_val": "count_cleaning_lighthouse_man" } ] },
     "difficulty": 0,
     "value": 5000,
     "start": {

--- a/data/json/npcs/Lighthouse_Family/NPC_lighthouse_woman.json
+++ b/data/json/npcs/Lighthouse_Family/NPC_lighthouse_woman.json
@@ -43,17 +43,20 @@
     "dynamic_line": {
       "u_has_mission": "MISSION_lighthouse_man_3",
       "yes": {
-        "u_has_var": "flag_death_lighthouse_girl_dead",
-        "value": "yes",
+        "compare_string": [ "yes", { "u_val": "flag_death_lighthouse_girl_dead" } ],
         "yes": "Thank you for saving me.  It's a shame my Angelina didn't make it… you did everything you could, and I don't blame you for it…",
         "no": "Thank you!"
       },
-      "no": { "u_has_var": "flag_death_lighthouse_girl_dead", "value": "yes", "yes": "Poor, poor Angelina…", "no": "Hello." }
+      "no": {
+        "compare_string": [ "yes", { "u_val": "flag_death_lighthouse_girl_dead" } ],
+        "yes": "Poor, poor Angelina…",
+        "no": "Hello."
+      }
     },
     "responses": [
       {
         "text": "Hi.",
-        "condition": { "u_has_var": "flag_help_lighthouse_family_safe", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "flag_help_lighthouse_family_safe" } ] },
         "topic": "TALK_lighthouse_woman_1",
         "effect": { "npc_first_topic": "TALK_lighthouse_woman_1" },
         "switch": true
@@ -62,7 +65,7 @@
         "truefalsetext": {
           "true": "I'm sorry…",
           "false": "…",
-          "condition": { "u_has_var": "flag_death_lighthouse_girl_dead", "value": "yes" }
+          "condition": { "compare_string": [ "yes", { "u_val": "flag_death_lighthouse_girl_dead" } ] }
         },
         "topic": "TALK_DONE",
         "switch": true

--- a/data/json/npcs/TALK_CITY_COP.json
+++ b/data/json/npcs/TALK_CITY_COP.json
@@ -3,8 +3,7 @@
     "type": "talk_topic",
     "id": "TALK_CITY_COP",
     "dynamic_line": {
-      "u_has_var": "dialogue_survivor_cop_talked_to_survivor_cop",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "dialogue_survivor_cop_talked_to_survivor_cop" } ],
       "no": {
         "gendered_line": "STOP, Put your hands in the air!  Ha, startled you didn't I… there is no law anymore…",
         "relevant_genders": [ "npc" ]

--- a/data/json/npcs/TALK_CYBORG_1.json
+++ b/data/json/npcs/TALK_CYBORG_1.json
@@ -3,8 +3,7 @@
     "id": "TALK_CYBORG_1",
     "type": "talk_topic",
     "dynamic_line": {
-      "npc_has_var": "dialogue_cyborg_cyborg_has_talked",
-      "value": "yes",
+      "compare_string": [ "yes", { "npc_val": "dialogue_cyborg_cyborg_has_talked" } ],
       "no": {
         "gendered_line": "I… I'm free.  *Zzzt* I'm actually free!  *bzzz* Look, you're the first person I've seen in a long time.",
         "relevant_genders": [ "npc" ]
@@ -15,7 +14,7 @@
     "responses": [
       {
         "switch": true,
-        "condition": { "npc_has_var": "dialogue_cyborg_cyborg_has_talked", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "npc_val": "dialogue_cyborg_cyborg_has_talked" } ] },
         "text": "Hey.  Let's chat for a second.",
         "topic": "TALK_STRANGER_NEUTRAL"
       },

--- a/data/json/npcs/TALK_TEST.json
+++ b/data/json/npcs/TALK_TEST.json
@@ -645,7 +645,7 @@
       {
         "text": "This is a npc_has_var, npc_remove_var test response.",
         "topic": "TALK_DONE",
-        "condition": { "npc_has_var": "test_var_test_test", "value": "reeb" },
+        "condition": { "compare_string": [ "reeb", { "npc_val": "test_var_test_test" } ] },
         "effect": { "npc_lose_var": "test_var_test_test" }
       }
     ]

--- a/data/json/npcs/TALK_TEST.json
+++ b/data/json/npcs/TALK_TEST.json
@@ -628,22 +628,22 @@
         "text": "This is a u_add_var test response.",
         "topic": "TALK_DONE",
         "effect": { "u_add_var": "test_var_test_test", "value": "beer" },
-        "condition": { "not": { "u_has_var": "test_var_test_test", "value": "beer" } }
+        "condition": { "not": { "compare_string": [ "beer", { "u_val": "test_var_test_test" } ] } }
       },
       {
         "text": "This is a npc_add_var test response.",
         "topic": "TALK_DONE",
         "effect": { "npc_add_var": "test_var_test_test", "value": "reeb" },
-        "condition": { "not": { "u_has_var": "test_var_test_test", "value": "beer" } }
+        "condition": { "not": { "compare_string": [ "beer", { "u_val": "test_var_test_test" } ] } }
       },
       {
-        "text": "This is a u_has_var, u_remove_var test response.",
+        "text": "This is a compare_string, u_remove_var test response.",
         "topic": "TALK_DONE",
-        "condition": { "u_has_var": "test_var_test_test", "value": "beer" },
+        "condition": { "compare_string": [ "beer", { "u_val": "test_var_test_test" } ] },
         "effect": { "u_lose_var": "test_var_test_test" }
       },
       {
-        "text": "This is a npc_has_var, npc_remove_var test response.",
+        "text": "This is a compare_string, npc_remove_var test response.",
         "topic": "TALK_DONE",
         "condition": { "compare_string": [ "reeb", { "npc_val": "test_var_test_test" } ] },
         "effect": { "npc_lose_var": "test_var_test_test" }

--- a/data/json/npcs/TALK_TRUE_FOODPERSON.json
+++ b/data/json/npcs/TALK_TRUE_FOODPERSON.json
@@ -5,12 +5,10 @@
     "dynamic_line": {
       "u_is_wearing": "foodperson_mask",
       "yes": {
-        "npc_has_var": "dialogue_foodperson_foodperson_has_talked",
-        "value": "yes",
+        "compare_string": [ "yes", { "npc_val": "dialogue_foodperson_foodperson_has_talked" } ],
         "no": "What sorcery is this?",
         "yes": {
-          "npc_has_var": "dialogue_foodperson_foodperson_meeting_solved",
-          "value": "yes",
+          "compare_string": [ "yes", { "npc_val": "dialogue_foodperson_foodperson_meeting_solved" } ],
           "no": { "gendered_line": "So you're back… explain yourself!", "relevant_genders": [ "u" ] },
           "yes": "Greetings friend, it's nice to see you."
         }
@@ -19,12 +17,10 @@
         "u_is_wearing": "foodkid_badge",
         "yes": "Welcome home Foodkid!",
         "no": {
-          "npc_has_var": "dialogue_foodperson_npc_foodperson_impressed",
-          "value": "yes",
+          "compare_string": [ "yes", { "npc_val": "dialogue_foodperson_npc_foodperson_impressed" } ],
           "yes": "Greetings friend, it's nice to see you.",
           "no": {
-            "npc_has_var": "dialogue_foodperson_foodperson_has_talked",
-            "value": "yes",
+            "compare_string": [ "yes", { "npc_val": "dialogue_foodperson_foodperson_has_talked" } ],
             "no": "Greeting citizen, what brings you to the FoodLair?",
             "yes": "Still here?  Take your time, it's rough out there."
           }
@@ -38,7 +34,7 @@
           "or": [
             {
               "and": [
-                { "npc_has_var": "dialogue_foodperson_foodperson_has_talked", "value": "yes" },
+                { "compare_string": [ "yes", { "npc_val": "dialogue_foodperson_foodperson_has_talked" } ] },
                 {
                   "not": { "or": [ { "u_is_wearing": "foodperson_mask" }, { "u_is_wearing": "foodperson_mask_on" } ] }
                 }
@@ -46,7 +42,7 @@
             },
             {
               "and": [
-                { "npc_has_var": "dialogue_foodperson_foodperson_meeting_solved", "value": "yes" },
+                { "compare_string": [ "yes", { "npc_val": "dialogue_foodperson_foodperson_meeting_solved" } ] },
                 {
                   "or": [
                     { "u_has_trait": "PROF_FOODP" },
@@ -63,7 +59,7 @@
       {
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "dialogue_foodperson_foodperson_has_talked", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_foodperson_foodperson_has_talked" } ] } },
             {
               "and": [
                 { "not": { "or": [ { "u_is_wearing": "foodperson_mask" }, { "u_is_wearing": "foodperson_mask_on" } ] } },
@@ -78,7 +74,7 @@
       {
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "dialogue_foodperson_foodperson_meeting_solved", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_foodperson_foodperson_meeting_solved" } ] } },
             { "not": { "u_has_trait": "PROF_FOODP" } },
             { "or": [ { "u_is_wearing": "foodperson_mask" }, { "u_is_wearing": "foodperson_mask_on" } ] }
           ]
@@ -91,7 +87,7 @@
       {
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "dialogue_foodperson_foodperson_meeting_solved", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_foodperson_foodperson_meeting_solved" } ] } },
             { "or": [ { "u_is_wearing": "foodperson_mask" }, { "u_is_wearing": "foodperson_mask_on" } ] },
             { "u_has_trait": "PROF_FOODP" }
           ]
@@ -102,7 +98,7 @@
       {
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "dialogue_foodperson_foodperson_meeting_solved", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_foodperson_foodperson_meeting_solved" } ] } },
             { "or": [ { "u_is_wearing": "foodperson_mask" }, { "u_is_wearing": "foodperson_mask_on" } ] },
             { "u_has_trait": "PROF_FOODP" }
           ]
@@ -113,7 +109,7 @@
       {
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "dialogue_foodperson_foodperson_meeting_solved", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_foodperson_foodperson_meeting_solved" } ] } },
             { "or": [ { "u_is_wearing": "foodperson_mask" }, { "u_is_wearing": "foodperson_mask_on" } ] },
             { "not": { "u_has_trait": "PROF_FOODP" } }
           ]
@@ -181,12 +177,12 @@
         "text": "Are you interested in some trading?",
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "dialogue_foodperson_npc_failed_trade", "value": "yes" } },
-            { "not": { "npc_has_var": "dialogue_foodperson_npc_success_trade", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_foodperson_npc_failed_trade" } ] } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_foodperson_npc_success_trade" } ] } },
             {
               "not": {
                 "and": [
-                  { "npc_has_var": "dialogue_foodperson_npc_foodpersons_sharing", "value": "yes" },
+                  { "compare_string": [ "yes", { "npc_val": "dialogue_foodperson_npc_foodpersons_sharing" } ] },
                   {
                     "or": [
                       { "u_has_trait": "PROF_FOODP" },
@@ -206,14 +202,14 @@
         "text": "Let's trade?",
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "dialogue_foodperson_npc_failed_trade", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_foodperson_npc_failed_trade" } ] } },
             {
               "or": [
-                { "npc_has_var": "dialogue_foodperson_npc_success_trade", "value": "yes" },
-                { "npc_has_var": "dialogue_foodperson_npc_foodperson_impressed", "value": "yes" },
+                { "compare_string": [ "yes", { "npc_val": "dialogue_foodperson_npc_success_trade" } ] },
+                { "compare_string": [ "yes", { "npc_val": "dialogue_foodperson_npc_foodperson_impressed" } ] },
                 {
                   "and": [
-                    { "npc_has_var": "dialogue_foodperson_npc_foodpersons_sharing", "value": "yes" },
+                    { "compare_string": [ "yes", { "npc_val": "dialogue_foodperson_npc_foodpersons_sharing" } ] },
                     {
                       "or": [
                         { "u_has_trait": "PROF_FOODP" },
@@ -233,12 +229,12 @@
         "text": "I'm looking for a place to stay.",
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "dialogue_foodperson_npc_failed_shelter", "value": "yes" } },
-            { "not": { "npc_has_var": "dialogue_foodperson_npc_success_shelter", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_foodperson_npc_failed_shelter" } ] } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_foodperson_npc_success_shelter" } ] } },
             {
               "not": {
                 "and": [
-                  { "npc_has_var": "dialogue_foodperson_npc_foodpersons_sharing", "value": "yes" },
+                  { "compare_string": [ "yes", { "npc_val": "dialogue_foodperson_npc_foodpersons_sharing" } ] },
                   {
                     "or": [
                       { "u_has_trait": "PROF_FOODP" },
@@ -258,12 +254,12 @@
         "text": "I want to get stronger.  Please teach me.",
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "dialogue_foodperson_npc_failed_training", "value": "yes" } },
-            { "not": { "npc_has_var": "dialogue_foodperson_npc_success_training", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_foodperson_npc_failed_training" } ] } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_foodperson_npc_success_training" } ] } },
             {
               "not": {
                 "and": [
-                  { "npc_has_var": "dialogue_foodperson_npc_foodpersons_sharing", "value": "yes" },
+                  { "compare_string": [ "yes", { "npc_val": "dialogue_foodperson_npc_foodpersons_sharing" } ] },
                   {
                     "or": [
                       { "u_has_trait": "PROF_FOODP" },
@@ -283,14 +279,14 @@
         "text": "Please share your knowledge.",
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "dialogue_foodperson_npc_failed_training", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_foodperson_npc_failed_training" } ] } },
             {
               "or": [
-                { "npc_has_var": "dialogue_foodperson_npc_success_training", "value": "yes" },
-                { "npc_has_var": "dialogue_foodperson_npc_foodperson_impressed", "value": "yes" },
+                { "compare_string": [ "yes", { "npc_val": "dialogue_foodperson_npc_success_training" } ] },
+                { "compare_string": [ "yes", { "npc_val": "dialogue_foodperson_npc_foodperson_impressed" } ] },
                 {
                   "and": [
-                    { "npc_has_var": "dialogue_foodperson_npc_foodpersons_sharing", "value": "yes" },
+                    { "compare_string": [ "yes", { "npc_val": "dialogue_foodperson_npc_foodpersons_sharing" } ] },
                     {
                       "or": [
                         { "u_has_trait": "PROF_FOODP" },
@@ -309,13 +305,13 @@
         "text": "I'm building up a team, people with special abilities.",
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "dialogue_foodperson_npc_failed_team", "value": "yes" } },
-            { "not": { "npc_has_var": "dialogue_foodperson_npc_success_team", "value": "yes" } },
-            { "not": { "npc_has_var": "dialogue_foodperson_npc_foodperson_impressed", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_foodperson_npc_failed_team" } ] } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_foodperson_npc_success_team" } ] } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_foodperson_npc_foodperson_impressed" } ] } },
             {
               "not": {
                 "and": [
-                  { "npc_has_var": "dialogue_foodperson_npc_foodpersons_sharing", "value": "yes" },
+                  { "compare_string": [ "yes", { "npc_val": "dialogue_foodperson_npc_foodpersons_sharing" } ] },
                   {
                     "or": [
                       { "u_has_trait": "PROF_FOODP" },
@@ -337,7 +333,10 @@
       {
         "text": "Can you tell me again about this sidekick offer?",
         "condition": {
-          "and": [ { "npc_has_var": "dialogue_foodperson_npc_sidekick_offer", "value": "yes" }, { "not": "has_assigned_mission" } ]
+          "and": [
+            { "compare_string": [ "yes", { "npc_val": "dialogue_foodperson_npc_sidekick_offer" } ] },
+            { "not": "has_assigned_mission" }
+          ]
         },
         "topic": "TALK_FOODPERSON_SIDEKICK"
       },
@@ -345,7 +344,7 @@
         "text": "Alright, I thought about this, what do you say about we team up?",
         "condition": {
           "and": [
-            { "npc_has_var": "dialogue_foodperson_npc_foodpersons_sharing", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "dialogue_foodperson_npc_foodpersons_sharing" } ] },
             {
               "or": [
                 { "u_has_trait": "PROF_FOODP" },

--- a/data/json/npcs/cabin_chemist/chemist_npc.json
+++ b/data/json/npcs/cabin_chemist/chemist_npc.json
@@ -42,8 +42,8 @@
         "topic": "TALK_NPC_CABIN_CHEMIST_STORY",
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "dialogue_story_told_u_backstory", "value": "yes" } },
-            { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" }
+            { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_story_told_u_backstory" } ] } },
+            { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] }
           ]
         }
       },
@@ -52,8 +52,8 @@
         "topic": "TALK_NPC_CABIN_CHEMIST_STORY",
         "condition": {
           "and": [
-            { "npc_has_var": "dialogue_story_told_u_backstory", "value": "yes" },
-            { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" }
+            { "compare_string": [ "yes", { "npc_val": "dialogue_story_told_u_backstory" } ] },
+            { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] }
           ]
         }
       },
@@ -61,32 +61,35 @@
         "text": "I'd like to ask you a few questions.",
         "topic": "TALK_FRIEND_CONVERSATION",
         "condition": {
-          "and": [ { "math": [ "n_npc_trust()", ">=", "2" ] }, { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" } ]
+          "and": [
+            { "math": [ "n_npc_trust()", ">=", "2" ] },
+            { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] }
+          ]
         }
       },
       {
         "text": "What is this place?",
         "topic": "TALK_NPC_CABIN_CHEMIST_HOME",
-        "condition": { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] }
       },
       {
         "text": "Brewed anything new lately?",
         "topic": "TALK_NPC_CABIN_CHEMIST_ASK_INTERVAL",
-        "condition": { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] }
       },
       {
         "text": "Care to trade?",
         "topic": "TALK_NPC_CABIN_CHEMIST_INTRO",
         "effect": "start_trade",
-        "condition": { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] }
       },
       {
         "text": "I'd like to buy in bulk.",
         "topic": "TALK_CABIN_CHEMIST_BULK_SELL",
         "condition": {
           "and": [
-            { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" },
-            { "npc_has_var": "dialogue_trade_mass_chem_tradeable", "value": "yes" }
+            { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] },
+            { "compare_string": [ "yes", { "npc_val": "dialogue_trade_mass_chem_tradeable" } ] }
           ]
         }
       },
@@ -94,7 +97,7 @@
         "text": "Any jobs you need done?",
         "condition": {
           "and": [
-            { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] },
             { "not": "has_assigned_mission" },
             { "not": "has_many_assigned_missions" }
           ]
@@ -107,8 +110,7 @@
     "type": "talk_topic",
     "id": "TALK_NPC_CABIN_CHEMIST",
     "dynamic_line": {
-      "npc_has_var": "dialogue_first_meeting_knows_u",
-      "value": "yes",
+      "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ],
       "yes": "It's nice to see you again <u_name>.  What can I do for you?",
       "no": {
         "gendered_line": "It's nice to see a new face around here.  I'm <npc_name>, it's a pleasure meeting you.",
@@ -119,12 +121,12 @@
     "responses": [
       {
         "text": "Nice to meet you too, I'm <u_name>.",
-        "condition": { "not": { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] } },
         "topic": "TALK_NPC_CABIN_CHEMIST_INTRO"
       },
       {
         "text": "Hands up!  Hand over everything you've got, and nobody gets hurt!",
-        "condition": { "not": { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] } },
         "trial": { "type": "INTIMIDATE", "difficulty": 30 },
         "success": { "topic": "TALK_WEAPON_DROPPED", "effect": "drop_weapon", "opinion": { "trust": -4, "fear": 3 } },
         "failure": { "topic": "TALK_DONE", "effect": "hostile" }
@@ -149,8 +151,7 @@
     "id": "TALK_NPC_CABIN_CHEMIST_STORY",
     "speaker_effect": { "effect": { "npc_add_var": "dialogue_story_told_u_backstory", "value": "yes" } },
     "dynamic_line": {
-      "npc_has_var": "dialogue_story_told_u_backstory",
-      "value": "yes",
+      "compare_string": [ "yes", { "npc_val": "dialogue_story_told_u_backstory" } ],
       "yes": {
         "gendered_line": "Like I said before, I'm a chemist.  I've been living out here for a while, decided to set up shop in this old cabin.  I even found some good equipment out here, and a couple useful things here in the cupboards.  I decided to stay right here.",
         "relevant_genders": [ "npc" ]

--- a/data/json/npcs/campus/great_library_librarian_talk.json
+++ b/data/json/npcs/campus/great_library_librarian_talk.json
@@ -3,8 +3,7 @@
     "id": "TALK_GREAT_LIBRARY_LIBRARIAN",
     "type": "talk_topic",
     "dynamic_line": {
-      "u_has_var": "general_meeting_u_met_Elvira",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Elvira" } ],
       "yes": [
         "*whispering.  \"Welcome back to the Library.\"",
         "*whispering.  \"Hello again.  Can I help you find something?\"",
@@ -16,29 +15,29 @@
       {
         "text": "Hello, who are you?  This is a library, is it?",
         "topic": "TALK_GREAT_LIBRARY_LIBRARIAN_Intro",
-        "condition": { "not": { "u_has_var": "general_meeting_u_met_Elvira", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Elvira" } ] } },
         "effect": { "u_add_var": "general_meeting_u_met_Elvira", "value": "yes" }
       },
       {
         "text": "Oh sorry, I'm not interested right now.",
         "topic": "TALK_DONE",
-        "condition": { "not": { "u_has_var": "general_meeting_u_met_Elvira", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Elvira" } ] } }
       },
       {
         "text": "I wanted to talk.",
         "topic": "TALK_GREAT_LIBRARY_LIBRARIAN_Talk",
-        "condition": { "u_has_var": "general_meeting_u_met_Elvira", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Elvira" } ] }
       },
       {
         "text": "Let me see what you have.",
         "topic": "TALK_GREAT_LIBRARY_LIBRARIAN_DoneTrading",
-        "condition": { "u_has_var": "general_meeting_u_met_Elvira", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Elvira" } ] },
         "effect": "start_trade"
       },
       {
         "text": "Just saying hello.",
         "topic": "TALK_DONE",
-        "condition": { "u_has_var": "general_meeting_u_met_Elvira", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Elvira" } ] }
       }
     ]
   },
@@ -134,12 +133,12 @@
       {
         "text": "Are there any other settlements around?",
         "topic": "TALK_GREAT_LIBRARY_LIBRARIAN_Robofac",
-        "condition": { "not": { "u_has_var": "general_free_merchants_u_hub01_breadcrumb_accepted", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "general_free_merchants_u_hub01_breadcrumb_accepted" } ] } }
       },
       {
         "text": "Are there any other settlements around?",
         "topic": "TALK_GREAT_LIBRARY_LIBRARIAN_OutsideWorld2",
-        "condition": { "u_has_var": "general_free_merchants_u_hub01_breadcrumb_accepted", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "general_free_merchants_u_hub01_breadcrumb_accepted" } ] }
       },
       { "text": "That's fine for now.", "topic": "TALK_GREAT_LIBRARY_LIBRARIAN_Talk" }
     ]

--- a/data/json/npcs/computers/TALK_MSU14.json
+++ b/data/json/npcs/computers/TALK_MSU14.json
@@ -36,7 +36,7 @@
       },
       {
         "text": "Attempt to access System 14.",
-        "condition": { "not": { "u_has_var": "computer_hacking_msu14_hack", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "computer_hacking_msu14_hack" } ] } },
         "trial": { "type": "SKILL_CHECK", "difficulty": 5, "skill_required": "computer" },
         "success": { "topic": "MSU14_UNIT_ACCESS" },
         "failure": { "topic": "MSU14_HACK_FAILURE" }
@@ -65,12 +65,12 @@
       {
         "text": "View and print the Talon Schematics.",
         "topic": "MSU14_DOCS_SUCCESS",
-        "condition": { "not": { "u_has_var": "computer_hacking_msu14_printed_docs", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "computer_hacking_msu14_printed_docs" } ] } }
       },
       {
         "text": "View and print the Talon Schematics.",
         "topic": "MSU14_DOCS_FAILURE",
-        "condition": { "u_has_var": "computer_hacking_msu14_printed_docs", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "computer_hacking_msu14_printed_docs" } ] }
       },
       { "text": "Return.", "topic": "MSU14_MAIN" }
     ]

--- a/data/json/npcs/exodii/common_talk.json
+++ b/data/json/npcs/exodii/common_talk.json
@@ -29,12 +29,12 @@
       {
         "text": "Can you give me directions?",
         "topic": "TALK_Directions_exodii_true",
-        "condition": { "npc_has_var": "exodii_mission_wh_correct", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "npc_val": "exodii_mission_wh_correct" } ] }
       },
       {
         "text": "Can you give me directions?",
         "topic": "TALK_Directions_exodii_false",
-        "condition": { "npc_has_var": "exodii_mission_wh_correct", "value": "alternate" },
+        "condition": { "compare_string": [ "alternate", { "npc_val": "exodii_mission_wh_correct" } ] },
         "effect": [
           { "math": [ "exodii_mission_wh_chance", "-=", "1" ] },
           { "math": [ "exodii_mission_wh_chance", "=", "max( exodii_mission_wh_chance, 1 )" ] }

--- a/data/json/npcs/exodii/exodii_Luliya.json
+++ b/data/json/npcs/exodii/exodii_Luliya.json
@@ -53,27 +53,29 @@
     "type": "talk_topic",
     "id": "TALK_LULIYA",
     "dynamic_line": {
-      "u_has_var": "general_meeting_u_met_luliya",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "general_meeting_u_met_luliya" } ],
       "yes": [ "Inikwani dehina metahi tegwazhi." ],
       "no": "&You see a tall golden figure with female features.  Strapped to the back of the head with copper wire is a glass cylinder containing long frizzy black hair.  The body stands still and emits an unpleasant beeping sound.  On the back there is a large red button with strange markings.  There is a golden harp of some kind in their hand."
     },
     "responses": [
       {
         "text": "[Push the big red button.]",
-        "condition": { "not": { "u_has_var": "general_meeting_u_met_luliya", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_luliya" } ] } },
         "topic": "TALK_LULIYA_BUTTON"
       },
       {
         "text": "[Use Stethoscope] Is this alive?",
         "condition": {
-          "and": [ { "not": { "u_has_var": "general_meeting_u_met_luliya", "value": "yes" } }, { "u_has_item": "stethoscope" } ]
+          "and": [
+            { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_luliya" } ] } },
+            { "u_has_item": "stethoscope" }
+          ]
         },
         "topic": "TALK_LULIYA_PULSE"
       },
       {
         "text": "[Do nothing.]",
-        "condition": { "not": { "u_has_var": "general_meeting_u_met_luliya", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_luliya" } ] } },
         "topic": "TALK_DONE"
       },
       {
@@ -81,8 +83,8 @@
         "topic": "TALK_LULIYA_ENGLISH",
         "condition": {
           "and": [
-            { "u_has_var": "general_meeting_u_met_luliya", "value": "yes" },
-            { "not": { "u_has_var": "general_language_u_not_english_luliya", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_luliya" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "general_language_u_not_english_luliya" } ] } }
           ]
         }
       },
@@ -91,8 +93,8 @@
         "topic": "TALK_LULIYA_NAME",
         "condition": {
           "and": [
-            { "u_has_var": "general_meeting_u_met_luliya", "value": "yes" },
-            { "not": { "u_has_var": "general_name_u_luliya_name", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_luliya" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "general_name_u_luliya_name" } ] } }
           ]
         }
       },
@@ -100,7 +102,7 @@
         "text": "I heard you playing that.  [You point at the golden harp she holds]  La la la.  Do you like music, Luliya?",
         "condition": {
           "and": [
-            { "u_has_var": "general_name_u_luliya_name", "value": "yes" },
+            { "compare_string": [ "yes", { "u_val": "general_name_u_luliya_name" } ] },
             { "math": [ "time_since(u_timer_meeting_luliya_music_timer)", ">=", "time('3 d')" ] }
           ]
         },
@@ -108,7 +110,7 @@
       },
       {
         "text": "I can't understand you.",
-        "condition": { "u_has_var": "general_meeting_u_met_luliya", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_luliya" } ] },
         "topic": "TALK_DONE"
       }
     ]

--- a/data/json/npcs/exodii/exodii_merchant_missions.json
+++ b/data/json/npcs/exodii/exodii_merchant_missions.json
@@ -122,7 +122,7 @@
       { "text": "Why can't one of you do this?", "topic": "TALK_EXODII_MERCHANT_mission_1_explain" },
       {
         "text": "Well, today's your lucky day, my metal friend.  I already know the place quite well.",
-        "condition": { "u_has_var": "dialogue_intercom_u_discovered_robofac_intercom", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_intercom_u_discovered_robofac_intercom" } ] },
         "topic": "TALK_EXODII_MERCHANT_mission_1_met_hub"
       },
       {

--- a/data/json/npcs/exodii/exodii_merchant_talk.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk.json
@@ -32,12 +32,12 @@
       {
         "text": "Can you do something for me?",
         "topic": "TALK_EXODII_MERCHANT_DoSomething",
-        "condition": { "u_has_var": "general_meeting_u_met_Rubik", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Rubik" } ] }
       },
       {
         "text": "I'm here to talk about a job.",
         "topic": "TALK_EXODII_MERCHANT_TalkJob",
-        "condition": { "u_has_var": "general_meeting_u_met_Rubik", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Rubik" } ] }
       },
       { "text": "I don't understand a word you're saying.", "topic": "TALK_EXODII_MERCHANT_Dialect" },
       { "text": "Are you some kind of robot?", "topic": "TALK_EXODII_MERCHANT_Robot" },
@@ -49,25 +49,25 @@
       {
         "text": "What are you doing here?",
         "topic": "TALK_EXODII_MERCHANT_Purpose",
-        "condition": { "u_has_var": "general_meeting_u_met_Rubik", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Rubik" } ] }
       },
       { "text": "What kind of place is this?", "topic": "TALK_EXODII_MERCHANT_Base" },
       {
         "text": "[PER 6] Some of this tech looks… weird.",
         "topic": "TALK_EXODII_MERCHANT_Tech",
-        "condition": { "and": [ { "u_has_var": "general_meeting_u_met_Rubik", "value": "yes" }, { "u_has_perception": 6 } ] }
+        "condition": { "and": [ { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Rubik" } ] }, { "u_has_perception": 6 } ] }
       },
       {
         "text": "What's with those weird metal zombies I've been seeing?  They resemble some of the robots around here.",
-        "condition": { "u_has_var": "dialogue_exodii_seen_zomborg", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_exodii_seen_zomborg" } ] },
         "topic": "TALK_EXODII_MERCHANT_Zomborgs"
       },
       {
         "text": "You wanted to ask me some questions earlier, and I think I was rude about it.  What did you want to ask?",
         "condition": {
           "and": [
-            { "u_has_var": "dialogue_started_rubik_intro", "value": "yes" },
-            { "not": { "u_has_var": "dialogue_midpoint_rubik_intro", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "dialogue_started_rubik_intro" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_midpoint_rubik_intro" } ] } }
           ]
         },
         "topic": "TALK_EXODII_MERCHANT_Talk_Intro1b"
@@ -76,9 +76,9 @@
         "text": "Can we continue our conversation about your arrival in this world?",
         "condition": {
           "and": [
-            { "u_has_var": "dialogue_started_rubik_intro", "value": "yes" },
-            { "u_has_var": "dialogue_midpoint_rubik_intro", "value": "yes" },
-            { "not": { "u_has_var": "dialogue_completed_rubik_intro", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "dialogue_started_rubik_intro" } ] },
+            { "compare_string": [ "yes", { "u_val": "dialogue_midpoint_rubik_intro" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_completed_rubik_intro" } ] } }
           ]
         },
         "topic": "TALK_EXODII_MERCHANT_Talk_Intro2a"
@@ -90,9 +90,7 @@
             { "u_has_faction_trust": 2 },
             { "u_has_mission": "MISSION_ISHERWOOD_CHRIS_1_GET_GEAR" },
             { "math": [ "isherwood_gear_status", "<", "1" ] },
-            {
-              "not": { "npc_has_var": "npc_bought_riot_gear", "type": "dialogue", "context": "exodii", "value": "yes" }
-            }
+            { "not": { "compare_string": [ "yes", { "npc_val": "npc_dialogue_exodii_npc_bought_riot_gear" } ] } }
           ]
         },
         "topic": "TALK_EXODII_MERCHANT_You_Buy_Riot_Gear"
@@ -115,8 +113,7 @@
         "Ah, a returnin', an I'm ken."
       ],
       "no": {
-        "u_has_var": "general_meeting_u_met_Rubik",
-        "value": "yes",
+        "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Rubik" } ],
         "yes": [
           "And a fine return, matey.\"  Rubik puts a hand on the countertop, and gestures you closer with the other.",
           "Fine and you still ain't dead.\"  Their gravelly voice is cheerful.  \"What brings ye roun' Rubik's neckawoods?",
@@ -133,7 +130,7 @@
       },
       {
         "sentinel": "first_meeting_effects",
-        "condition": { "not": { "u_has_var": "general_meeting_u_met_Rubik", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Rubik" } ] } },
         "effect": [ { "math": [ "u_timer_first_meeting_u_met_Rubik", "=", "time('now')" ] } ]
       },
       {
@@ -151,38 +148,38 @@
       {
         "text": "Who are you?  What is this place?",
         "topic": "TALK_EXODII_MERCHANT_New",
-        "condition": { "not": { "u_has_var": "general_meeting_u_met_Rubik", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Rubik" } ] } },
         "effect": { "u_add_var": "general_meeting_u_met_Rubik", "value": "yes" }
       },
       {
         "text": "What've you got for trade?",
         "effect": "start_trade",
         "topic": "TALK_EXODII_MERCHANT_DoneTrade",
-        "condition": { "u_has_var": "general_meeting_u_met_Rubik", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Rubik" } ] }
       },
       {
         "text": "Actually, I wanted to talk.",
         "topic": "TALK_EXODII_MERCHANT_Talk",
-        "condition": { "u_has_var": "general_meeting_u_met_Rubik", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Rubik" } ] }
       },
       {
         "text": "Can you do something for me?",
         "topic": "TALK_EXODII_MERCHANT_DoSomething",
-        "condition": { "u_has_var": "general_meeting_u_met_Rubik", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Rubik" } ] }
       },
       {
         "text": "I'm here to talk about a job.",
         "topic": "TALK_EXODII_MERCHANT_TalkJob",
-        "condition": { "u_has_var": "general_meeting_u_met_Rubik", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Rubik" } ] }
       },
       {
         "text": "Hell no, I'm out of here.",
-        "condition": { "not": { "u_has_var": "general_meeting_u_met_Rubik", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Rubik" } ] } },
         "topic": "TALK_DONE"
       },
       {
         "text": "Just popping in to say hi.  See you later, alligator.",
-        "condition": { "u_has_var": "general_meeting_u_met_Rubik", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Rubik" } ] },
         "topic": "TALK_DONE"
       },
       {
@@ -190,7 +187,7 @@
         "condition": {
           "and": [
             { "math": [ "time_since(u_timer_exodii_cybor_rescue_operating)", "<", "time('1 d')" ] },
-            { "u_has_var": "dialogue_exodii_cybor_rescue_ongoing", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "dialogue_exodii_cybor_rescue_ongoing" } ] }
           ]
         },
         "topic": "TALK_EXODII_MERCHANT_Experiment_Cyborg_Rescue_Ongoing"
@@ -200,7 +197,7 @@
         "condition": {
           "and": [
             { "math": [ "time_since(u_timer_exodii_cybor_rescue_operating)", ">", "time('1 d')" ] },
-            { "u_has_var": "dialogue_exodii_cybor_rescue_ongoing", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "dialogue_exodii_cybor_rescue_ongoing" } ] }
           ]
         },
         "topic": "TALK_EXODII_MERCHANT_Experiment_Cyborg_Rescue_Complete"
@@ -209,8 +206,8 @@
         "text": "Fast, can you help this lad?",
         "condition": {
           "and": [
-            { "u_has_var": "general_meeting_u_met_Rubik", "value": "yes" },
-            { "not": { "u_has_var": "dialogue_exodii_cybor_rescue_ongoing", "value": "yes" } },
+            { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Rubik" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_exodii_cybor_rescue_ongoing" } ] } },
             {
               "or": [
                 { "u_has_items": { "item": "bot_broken_cyborg", "count": 1 } },
@@ -342,8 +339,7 @@
     "id": "TALK_EXODII_MERCHANT_Talk",
     "type": "talk_topic",
     "dynamic_line": {
-      "u_has_var": "dialogue_started_rubik_intro",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "dialogue_started_rubik_intro" } ],
       "yes": {
         "//~": "You can surely try.  I'm not the greatest speaker, and I won't just chat forever for free, you know.",
         "str": "Sure as you c'n try.  Us're not the greatest yarker, nor do it all for gratis, kennit."
@@ -372,7 +368,10 @@
       {
         "text": "I think I'm ready to try becoming a cyborg now.",
         "condition": {
-          "and": [ { "u_has_var": "mission_completed_anusfetick", "value": "yes" }, { "not": { "u_has_trait": "CBM_Interface" } } ]
+          "and": [
+            { "compare_string": [ "yes", { "u_val": "mission_completed_anusfetick" } ] },
+            { "not": { "u_has_trait": "CBM_Interface" } }
+          ]
         },
         "topic": "TALK_EXODII_MERCHANT_ExodizeMe2"
       },
@@ -381,16 +380,21 @@
         "topic": "TALK_EXODII_MERCHANT_Exodize",
         "condition": {
           "and": [
-            { "u_has_var": "knowledge_exodization_u_knows_exodiilore", "value": "yes" },
+            { "compare_string": [ "yes", { "u_val": "knowledge_exodization_u_knows_exodiilore" } ] },
             {
-              "not": { "or": [ { "u_has_mission": "RUBIK_ANUS_FETICK" }, { "u_has_var": "mission_completed_anusfetick", "value": "yes" } ] }
+              "not": {
+                "or": [
+                  { "u_has_mission": "RUBIK_ANUS_FETICK" },
+                  { "compare_string": [ "yes", { "u_val": "mission_completed_anusfetick" } ] }
+                ]
+              }
             }
           ]
         }
       },
       {
         "text": "Would you be willing to sell some of your robots?",
-        "condition": { "u_has_var": "dialogue_exodii_rubik_offered_robosell", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_exodii_rubik_offered_robosell" } ] },
         "topic": "TALK_EXODII_MERCHANT_Robot_Buy"
       },
       {
@@ -424,13 +428,13 @@
       },
       {
         "text": "I paid a visit to the bunker.",
-        "condition": { "and": [ { "u_has_var": "mission_completed_u_scouted_bunker", "value": "yes" } ] },
+        "condition": { "and": [ { "compare_string": [ "yes", { "u_val": "mission_completed_u_scouted_bunker" } ] } ] },
         "effect": [ { "u_lose_var": "mission_completed_u_scouted_bunker" }, { "math": [ "exodii_knows_hub01", "=", "1" ] } ],
         "topic": "TALK_EXODII_MERCHANT_mission_1_complete"
       },
       {
         "text": "I found the warehouse.",
-        "condition": { "and": [ { "u_has_var": "mission_completed_u_found_warehouse", "value": "yes" } ] },
+        "condition": { "and": [ { "compare_string": [ "yes", { "u_val": "mission_completed_u_found_warehouse" } ] } ] },
         "effect": [ { "u_lose_var": "mission_completed_u_found_warehouse" }, { "math": [ "warehouse_was_found", "=", "1" ] } ],
         "topic": "TALK_EXODII_MERCHANT_mission_2_complete"
       },
@@ -454,7 +458,9 @@
     "responses": [
       {
         "text": "Of course, it is time for us to talk.",
-        "condition": { "u_has_var": "dialogue_exodii_cybor_rescue_ongoing_current_type", "value": "yank_out_all_bionics_from_prototype" },
+        "condition": {
+          "compare_string": [ "yank_out_all_bionics_from_prototype", { "u_val": "dialogue_exodii_cybor_rescue_ongoing_current_type" } ]
+        },
         "effect": [
           { "u_add_var": "dialogue_exodii_cybor_rescue_ongoing", "value": "no" },
           { "u_add_var": "dialogue_exodii_cybor_rescue_ongoing_current_type", "value": "none" },
@@ -472,7 +478,9 @@
       },
       {
         "text": "Of course, it is time for us to talk.",
-        "condition": { "u_has_var": "dialogue_exodii_cybor_rescue_ongoing_current_type", "value": "repair_and_rescue_prototype" },
+        "condition": {
+          "compare_string": [ "repair_and_rescue_prototype", { "u_val": "dialogue_exodii_cybor_rescue_ongoing_current_type" } ]
+        },
         "effect": [
           { "u_add_var": "dialogue_exodii_cybor_rescue_ongoing", "value": "no" },
           { "u_add_var": "dialogue_exodii_cybor_rescue_ongoing_current_type", "value": "none" },
@@ -489,7 +497,9 @@
       },
       {
         "text": "Of course, it is time for us to talk.",
-        "condition": { "u_has_var": "dialogue_exodii_cybor_rescue_ongoing_current_type", "value": "reverse_cybernization_prototype" },
+        "condition": {
+          "compare_string": [ "reverse_cybernization_prototype", { "u_val": "dialogue_exodii_cybor_rescue_ongoing_current_type" } ]
+        },
         "effect": [
           { "u_add_var": "dialogue_exodii_cybor_rescue_ongoing", "value": "no" },
           { "u_add_var": "dialogue_exodii_cybor_rescue_ongoing_current_type", "value": "none" },
@@ -506,7 +516,9 @@
       },
       {
         "text": "Let's see what I get.",
-        "condition": { "u_has_var": "dialogue_exodii_cybor_rescue_ongoing_current_type", "value": "pull_out_from_rotten_cyborg" },
+        "condition": {
+          "compare_string": [ "pull_out_from_rotten_cyborg", { "u_val": "dialogue_exodii_cybor_rescue_ongoing_current_type" } ]
+        },
         "effect": [
           { "u_add_var": "dialogue_exodii_cybor_rescue_ongoing", "value": "no" },
           { "u_add_var": "dialogue_exodii_cybor_rescue_ongoing_current_type", "value": "none" },
@@ -517,7 +529,7 @@
       },
       {
         "text": "It is time to put this body to rest.",
-        "condition": { "u_has_var": "dialogue_exodii_cybor_rescue_ongoing_current_type", "value": "dress_up_rotten_cyborg" },
+        "condition": { "compare_string": [ "dress_up_rotten_cyborg", { "u_val": "dialogue_exodii_cybor_rescue_ongoing_current_type" } ] },
         "effect": [
           { "u_add_var": "dialogue_exodii_cybor_rescue_ongoing", "value": "no" },
           { "u_add_var": "dialogue_exodii_cybor_rescue_ongoing_current_type", "value": "none" },
@@ -746,7 +758,7 @@
     "responses": [
       {
         "text": "I don't know what fusillies and mobbings are.",
-        "condition": { "not": { "u_has_var": "dictionary_known_fussily", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "dictionary_known_fussily" } ] } },
         "topic": "TALK_EXODII_MERCHANT_Talk_Intro5"
       },
       {
@@ -825,7 +837,7 @@
     "responses": [
       {
         "text": "You said this was an especially good jump?",
-        "condition": { "not": { "u_has_var": "dialogue_completed_rubik_intro", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "dialogue_completed_rubik_intro" } ] } },
         "topic": "TALK_EXODII_MERCHANT_Talk_Intro3"
       },
       { "text": "Can we talk about something else?", "topic": "TALK_EXODII_MERCHANT_Talk" },
@@ -896,7 +908,7 @@
           "not": {
             "or": [
               { "u_has_mission": "RUBIK_ANUS_FETICK" },
-              { "u_has_var": "mission_completed_anusfetick", "value": "yes" },
+              { "compare_string": [ "yes", { "u_val": "mission_completed_anusfetick" } ] },
               { "u_has_trait": "CBM_Interface" }
             ]
           }
@@ -930,7 +942,7 @@
               "not": {
                 "or": [
                   { "u_has_mission": "RUBIK_ANUS_FETICK" },
-                  { "u_has_var": "mission_completed_anusfetick", "value": "yes" },
+                  { "compare_string": [ "yes", { "u_val": "mission_completed_anusfetick" } ] },
                   { "u_has_trait": "CBM_Interface" }
                 ]
               }
@@ -1109,7 +1121,7 @@
         "condition": {
           "and": [
             { "not": { "u_has_mission": "EXODII_MISSION_CONTACT_HUB" } },
-            { "not": { "u_has_var": "mission_completed_u_scouted_bunker", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "u_val": "mission_completed_u_scouted_bunker" } ] } },
             { "math": [ "exodii_knows_hub01", "!=", "1" ] }
           ]
         },
@@ -1120,7 +1132,7 @@
         "condition": {
           "and": [
             { "not": { "u_has_mission": "EXODII_MISSION_WAREHOUSE" } },
-            { "not": { "u_has_var": "mission_completed_u_found_warehouse", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "u_val": "mission_completed_u_found_warehouse" } ] } },
             { "math": [ "warehouse_was_found", "!=", "1" ] },
             { "math": [ "exodii_knows_hub01", "==", "1" ] }
           ]
@@ -1169,7 +1181,7 @@
     },
     "responses": [
       {
-        "condition": { "u_has_var": "knowledge_exodii_transdimensional_u_knows_exodiilore", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "knowledge_exodii_transdimensional_u_knows_exodiilore" } ] },
         "text": "Wait, am I following this right?  You're from a place where this happened before, and you escaped to our world?",
         "topic": "TALK_EXODII_MERCHANT_Exodus3"
       },
@@ -1491,7 +1503,7 @@
           "not": {
             "or": [
               { "u_has_mission": "RUBIK_ANUS_FETICK" },
-              { "u_has_var": "mission_completed_anusfetick", "value": "yes" },
+              { "compare_string": [ "yes", { "u_val": "mission_completed_anusfetick" } ] },
               { "u_has_trait": "CBM_Interface" }
             ]
           }
@@ -1500,7 +1512,7 @@
       {
         "text": "Wait.  I thought you were still flesh and bone, under that metal.",
         "topic": "TALK_EXODII_MERCHANT_Survival2",
-        "condition": { "u_has_var": "knowledge_rubik_is_cyborg_u_knows_exodiilore", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "knowledge_rubik_is_cyborg_u_knows_exodiilore" } ] }
       },
       { "text": "What was it you were saying before?", "topic": "TALK_NONE" },
       { "text": "Well, I'd better be going.  Bye.", "topic": "TALK_DONE" }

--- a/data/json/npcs/exodii/exodii_merchant_talk_exodization.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk_exodization.json
@@ -79,7 +79,7 @@
         "text": "If I just keep on killing zombies, you'll help turn me into a cyborg?  Why are we still yarkin', then?  Sign me the heck up.",
         "condition": {
           "or": [
-            { "not": { "u_has_var": "decisions_blobpsychosis_u_declined_exodization", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "u_val": "decisions_blobpsychosis_u_declined_exodization" } ] } },
             { "math": [ "time_since(u_timer_blobpsychosis_u_declined_exodization)", ">=", "time('2 d')" ] }
           ]
         },
@@ -90,7 +90,7 @@
         "text": "If I just keep on killing zombies, you'll help turn me into a cyborg?  Why are we still yarkin', then?  Sign me the heck up.",
         "condition": {
           "and": [
-            { "u_has_var": "decisions_blobpsychosis_u_declined_exodization", "value": "yes" },
+            { "compare_string": [ "yes", { "u_val": "decisions_blobpsychosis_u_declined_exodization" } ] },
             { "math": [ "time_since(u_timer_blobpsychosis_u_declined_exodization)", "<", "time('2 d')" ] }
           ]
         },
@@ -120,7 +120,7 @@
         "text": "Fine, whatever.  It doesn't matter, if you're gonna turn me into a horrifying fusion of machine and human, sign me the heck up.",
         "condition": {
           "or": [
-            { "not": { "u_has_var": "decisions_blobpsychosis_u_declined_exodization", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "u_val": "decisions_blobpsychosis_u_declined_exodization" } ] } },
             { "math": [ "time_since(u_timer_blobpsychosis_u_declined_exodization)", ">=", "time('2 d')" ] }
           ]
         },
@@ -131,7 +131,7 @@
         "text": "Fine, whatever.  It doesn't matter, if you're gonna turn me into a horrifying fusion of machine and human, sign me the heck up.",
         "condition": {
           "and": [
-            { "u_has_var": "decisions_blobpsychosis_u_declined_exodization", "value": "yes" },
+            { "compare_string": [ "yes", { "u_val": "decisions_blobpsychosis_u_declined_exodization" } ] },
             { "math": [ "time_since(u_timer_blobpsychosis_u_declined_exodization)", "<", "time('2 d')" ] }
           ]
         },
@@ -157,7 +157,12 @@
       {
         "text": "One thousand units of, uh, anesthetic, coming up.  Can we talk about something else?",
         "condition": {
-          "not": { "or": [ { "u_has_mission": "RUBIK_ANUS_FETICK" }, { "u_has_var": "mission_completed_anusfetick", "value": "yes" } ] }
+          "not": {
+            "or": [
+              { "u_has_mission": "RUBIK_ANUS_FETICK" },
+              { "compare_string": [ "yes", { "u_val": "mission_completed_anusfetick" } ] }
+            ]
+          }
         },
         "effect": { "assign_mission": "RUBIK_ANUS_FETICK" },
         "topic": "TALK_EXODII_MERCHANT_Talk"
@@ -165,14 +170,24 @@
       {
         "text": "One thousand units of, uh, anesthetic, coming up.  I'd better start looking.",
         "condition": {
-          "not": { "or": [ { "u_has_mission": "RUBIK_ANUS_FETICK" }, { "u_has_var": "mission_completed_anusfetick", "value": "yes" } ] }
+          "not": {
+            "or": [
+              { "u_has_mission": "RUBIK_ANUS_FETICK" },
+              { "compare_string": [ "yes", { "u_val": "mission_completed_anusfetick" } ] }
+            ]
+          }
         },
         "effect": { "assign_mission": "RUBIK_ANUS_FETICK" },
         "topic": "TALK_DONE"
       },
       {
         "text": "Something's weird, I shouldn't have ever reached this dialogue option.  I'd better go file a bug report.",
-        "condition": { "or": [ { "u_has_mission": "RUBIK_ANUS_FETICK" }, { "u_has_var": "mission_completed_anusfetick", "value": "yes" } ] },
+        "condition": {
+          "or": [
+            { "u_has_mission": "RUBIK_ANUS_FETICK" },
+            { "compare_string": [ "yes", { "u_val": "mission_completed_anusfetick" } ] }
+          ]
+        },
         "topic": "TALK_DONE"
       }
     ]
@@ -207,7 +222,7 @@
     },
     "speaker_effect": [
       {
-        "condition": { "not": { "u_has_var": "decisions_blobpsychosis_u_declined_exodization", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "decisions_blobpsychosis_u_declined_exodization" } ] } },
         "//": "Rubik considers it a good sign that you might be a bit unsure about diving into exodization.",
         "effect": [
           { "u_add_faction_trust": 2 },

--- a/data/json/npcs/godco/classes.json
+++ b/data/json/npcs/godco/classes.json
@@ -580,7 +580,7 @@
       { "item": "icon", "price": 100 },
       {
         "group": "NC_EVAC_SHOPKEEP_misc",
-        "condition": { "not": { "npc_has_var": "general_meeting_u_paidoff", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_paidoff" } ] } },
         "markup": 3
       }
     ],

--- a/data/json/npcs/godco/godco_missions.json
+++ b/data/json/npcs/godco/godco_missions.json
@@ -1341,7 +1341,7 @@
     "description": "Go to the location Helena told you about and see who's there.",
     "goal": "MGOAL_CONDITION",
     "difficulty": 1,
-    "goal_condition": { "u_has_var": "general_meeting_u_met_Gavin", "value": "yes" },
+    "goal_condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Gavin" } ] },
     "value": 0,
     "start": "reveal_refugee_center",
     "end": {

--- a/data/json/npcs/godco/members/NPC_Arturo_Maldonado.json
+++ b/data/json/npcs/godco/members/NPC_Arturo_Maldonado.json
@@ -46,8 +46,7 @@
             "npc_has_effect": "Arturo_visions_timer",
             "yes": "Hi, <name_g>.  Could I pat you on the shoulder?  I wanna be sure you're here.",
             "no": {
-              "npc_has_var": "general_meeting_u_met_godco_arturo",
-              "value": "yes",
+              "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_arturo" } ],
               "yes": "Hi, <name_g>.  What's up?",
               "no": "Hi, <name_g>.  Could I pat you on the shoulder?  I wanna be sure you're here."
             }
@@ -67,7 +66,7 @@
         "effect": { "npc_add_var": "general_meeting_u_met_godco_arturo", "value": "yes" },
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "general_meeting_u_met_godco_arturo", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_arturo" } ] } },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
         },
@@ -83,7 +82,7 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
-            { "npc_has_var": "general_meeting_u_met_godco_arturo", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_arturo" } ] },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
         },
@@ -94,7 +93,7 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_anger()", ">=", "5" ] },
-            { "npc_has_var": "general_meeting_u_met_godco_arturo", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_arturo" } ] },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
         },
@@ -105,7 +104,7 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_anger()", ">=", "5" ] },
-            { "npc_has_var": "general_meeting_u_met_godco_arturo", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_arturo" } ] },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
         },
@@ -116,7 +115,7 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
-            { "npc_has_var": "general_meeting_u_met_godco_arturo", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_arturo" } ] },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
         },

--- a/data/json/npcs/godco/members/NPC_Arturo_Maldonado.json
+++ b/data/json/npcs/godco/members/NPC_Arturo_Maldonado.json
@@ -33,8 +33,7 @@
     "type": "talk_topic",
     "id": "TALK_GODCO_Arturo_1",
     "dynamic_line": {
-      "u_has_var": "dialogue_godco_godco_notalk_to_u",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ],
       "yes": "I must be seeing things again!  Stay away from me!",
       "no": {
         "math": [ "n_npc_anger()", ">=", "5" ],
@@ -67,14 +66,14 @@
         "condition": {
           "and": [
             { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_arturo" } ] } },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_GODCO_Arturo_Firstmeet"
       },
       {
         "text": "Are you alright?",
-        "condition": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] },
         "topic": "TALK_GODCO_Arturo_U_Mutant"
       },
       {
@@ -83,7 +82,7 @@
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
             { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_arturo" } ] },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_GODCO_Arturo_2"
@@ -94,7 +93,7 @@
           "and": [
             { "math": [ "n_npc_anger()", ">=", "5" ] },
             { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_arturo" } ] },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_GODCO_Arturo_Angry"
@@ -105,7 +104,7 @@
           "and": [
             { "math": [ "n_npc_anger()", ">=", "5" ] },
             { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_arturo" } ] },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_DONE"
@@ -116,7 +115,7 @@
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
             { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_arturo" } ] },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_DONE"

--- a/data/json/npcs/godco/members/NPC_Aunt_Theresa.json
+++ b/data/json/npcs/godco/members/NPC_Aunt_Theresa.json
@@ -43,8 +43,7 @@
           "math": [ "n_npc_value()", ">=", "3" ],
           "yes": "&Theresa looks up from her knitting, with a sparkle in her eyes.  \"Come on in, <granny_name_g>.  I'm glad to see you again, have a seat.\"",
           "no": {
-            "npc_has_var": "general_meeting_u_met_godco_theresa",
-            "value": "yes",
+            "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_theresa" } ],
             "yes": "Praise the Lord.  It's good to see you're still around, <granny_name_g>.",
             "no": "Welcome, <granny_name_g>.  I don't think I recognize you, I'm Theresa."
           }
@@ -57,7 +56,7 @@
         "effect": { "npc_add_var": "general_meeting_u_met_godco_theresa", "value": "yes" },
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "general_meeting_u_met_godco_theresa", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_theresa" } ] } },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
         },
@@ -68,7 +67,7 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
-            { "npc_has_var": "general_meeting_u_met_godco_theresa", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_theresa" } ] },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
         },
@@ -79,7 +78,7 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_anger()", ">=", "5" ] },
-            { "npc_has_var": "general_meeting_u_met_godco_theresa", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_theresa" } ] },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
         },
@@ -127,7 +126,7 @@
         "text": "I'm here about the scarf.",
         "condition": {
           "and": [
-            { "npc_has_var": "general_trade_u_want_scarf", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_trade_u_want_scarf" } ] },
             { "math": [ "time_since(n_timer_trade_knitting)", ">=", "time('1 d')" ] }
           ]
         },
@@ -138,7 +137,7 @@
         "text": "I'm here about the blanket.",
         "condition": {
           "and": [
-            { "npc_has_var": "general_trade_u_want_blanket", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_trade_u_want_blanket" } ] },
             { "math": [ "time_since(n_timer_trade_knitting)", ">=", "time('2 d')" ] }
           ]
         },
@@ -149,7 +148,7 @@
         "text": "I'm here about the quilt.",
         "condition": {
           "and": [
-            { "npc_has_var": "general_trade_u_want_quilt", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_trade_u_want_quilt" } ] },
             { "math": [ "time_since(n_timer_trade_knitting)", ">=", "time('7 d')" ] }
           ]
         },

--- a/data/json/npcs/godco/members/NPC_Aunt_Theresa.json
+++ b/data/json/npcs/godco/members/NPC_Aunt_Theresa.json
@@ -33,8 +33,7 @@
     "type": "talk_topic",
     "id": "TALK_GODCO_Theresa_1",
     "dynamic_line": {
-      "u_has_var": "dialogue_godco_godco_notalk_to_u",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ],
       "yes": "I have no interest in dealing with you, unnatural abomination.  Keep away from me.",
       "no": {
         "math": [ "n_npc_anger()", ">=", "5" ],
@@ -57,7 +56,7 @@
         "condition": {
           "and": [
             { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_theresa" } ] } },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_GODCO_Theresa_Firstmeet"
@@ -68,7 +67,7 @@
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
             { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_theresa" } ] },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_GODCO_Theresa_2"
@@ -79,7 +78,7 @@
           "and": [
             { "math": [ "n_npc_anger()", ">=", "5" ] },
             { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_theresa" } ] },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_GODCO_Theresa_Anger"
@@ -89,20 +88,23 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_DONE"
       },
       {
         "text": "What's the insults for?",
-        "condition": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] },
         "topic": "TALK_GODCO_Theresa_You_Mutant"
       },
       {
         "text": "Fuck you then, I'm leaving.",
         "condition": {
-          "and": [ { "math": [ "n_npc_anger()", ">=", "5" ] }, { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } ]
+          "and": [
+            { "math": [ "n_npc_anger()", ">=", "5" ] },
+            { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] }
+          ]
         },
         "topic": "TALK_DONE"
       }

--- a/data/json/npcs/godco/members/NPC_Chloe_Taylor_King.json
+++ b/data/json/npcs/godco/members/NPC_Chloe_Taylor_King.json
@@ -9,8 +9,7 @@
         "math": [ "n_npc_value()", ">=", "3" ],
         "yes": [ "Aw hey, it's you again, <u_name>.  How have you been?", "Aw hey, it's you again, <name_g>.  How have you been?" ],
         "no": {
-          "npc_has_var": "general_meeting_u_met_chloe",
-          "value": "yes",
+          "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_chloe" } ],
           "yes": [ "Hey <u_name>, what's up?", "Hey <name_g>, what's up?" ],
           "no": "Oh… hi.  I don't know you.  My name's Chloe."
         }
@@ -20,7 +19,7 @@
       {
         "text": "Nice to meet you, Chloe.  What's up?",
         "topic": "TALK_GODCO_chloe_2",
-        "condition": { "not": { "npc_has_var": "general_meeting_u_met_chloe", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_chloe" } ] } },
         "effect": { "npc_add_var": "general_meeting_u_met_chloe", "value": "yes" }
       },
       {
@@ -29,7 +28,7 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
-            { "not": { "npc_has_var": "general_meeting_u_met_chloe", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_chloe" } ] } }
           ]
         },
         "effect": { "npc_add_var": "general_meeting_u_met_chloe", "value": "yes" }
@@ -38,13 +37,19 @@
         "text": "Do you wanna shoot the breeze?",
         "topic": "TALK_GODCO_chloe_idle_chat",
         "condition": {
-          "and": [ { "math": [ "n_npc_anger()", "<", "5" ] }, { "npc_has_var": "general_meeting_u_met_chloe", "value": "yes" } ]
+          "and": [
+            { "math": [ "n_npc_anger()", "<", "5" ] },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_chloe" } ] }
+          ]
         }
       },
       {
         "text": "Do you need any help?",
         "condition": {
-          "and": [ { "math": [ "n_npc_anger()", "<", "5" ] }, { "npc_has_var": "general_meeting_u_met_chloe", "value": "yes" } ]
+          "and": [
+            { "math": [ "n_npc_anger()", "<", "5" ] },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_chloe" } ] }
+          ]
         },
         "topic": "TALK_GODCO_chloe_help"
       },
@@ -52,13 +57,19 @@
         "text": "Do you wanna shoot the breeze?",
         "topic": "TALK_GODCO_chloe_angry",
         "condition": {
-          "and": [ { "math": [ "n_npc_anger()", ">=", "5" ] }, { "npc_has_var": "general_meeting_u_met_chloe", "value": "yes" } ]
+          "and": [
+            { "math": [ "n_npc_anger()", ">=", "5" ] },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_chloe" } ] }
+          ]
         }
       },
       {
         "text": "Do you need any help?",
         "condition": {
-          "and": [ { "math": [ "n_npc_anger()", ">=", "5" ] }, { "npc_has_var": "general_meeting_u_met_chloe", "value": "yes" } ]
+          "and": [
+            { "math": [ "n_npc_anger()", ">=", "5" ] },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_chloe" } ] }
+          ]
         },
         "topic": "TALK_GODCO_chloe_angry"
       },
@@ -66,14 +77,20 @@
         "text": "Just saying hello.  Keep safe.",
         "topic": "TALK_DONE",
         "condition": {
-          "and": [ { "math": [ "n_npc_anger()", "<", "5" ] }, { "npc_has_var": "general_meeting_u_met_chloe", "value": "yes" } ]
+          "and": [
+            { "math": [ "n_npc_anger()", "<", "5" ] },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_chloe" } ] }
+          ]
         }
       },
       {
         "text": "Okay <name_b>, I'll leave.",
         "topic": "TALK_DONE",
         "condition": {
-          "and": [ { "math": [ "n_npc_anger()", ">=", "5" ] }, { "npc_has_var": "general_meeting_u_met_chloe", "value": "yes" } ]
+          "and": [
+            { "math": [ "n_npc_anger()", ">=", "5" ] },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_chloe" } ] }
+          ]
         }
       }
     ]
@@ -88,8 +105,8 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_value()", ">=", "3" ] },
-            { "npc_has_var": "told_backstory_second_attempt", "value": "yes" },
-            { "not": { "npc_has_var": "general_meeting_told_backstory", "value": "yes" } }
+            { "compare_string": [ "yes", { "npc_val": "told_backstory_second_attempt" } ] },
+            { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_told_backstory" } ] } }
           ]
         },
         "trial": { "type": "PERSUADE", "difficulty": 30 },
@@ -101,7 +118,7 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_value()", ">=", "3" ] },
-            { "not": { "npc_has_var": "general_meeting_told_about_sonia", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_told_about_sonia" } ] } }
           ]
         },
         "topic": "TALK_GODCO_chloe_sonia"
@@ -109,7 +126,10 @@
       {
         "text": "How'd you and Sonia come to meet again?",
         "condition": {
-          "and": [ { "math": [ "n_npc_value()", ">=", "3" ] }, { "npc_has_var": "general_meeting_told_about_sonia", "value": "yes" } ]
+          "and": [
+            { "math": [ "n_npc_value()", ">=", "3" ] },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_told_about_sonia" } ] }
+          ]
         },
         "topic": "TALK_GODCO_chloe_sonia"
       },

--- a/data/json/npcs/godco/members/NPC_Corrie_Kaja_Dosia.json
+++ b/data/json/npcs/godco/members/NPC_Corrie_Kaja_Dosia.json
@@ -21,15 +21,15 @@
       {
         "text": "Want to come with me?",
         "topic": "TALK_GODCO_Corrie_Recruit",
-        "condition": { "npc_has_var": "mission_completed_godco_corrie_machine", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "npc_val": "mission_completed_godco_corrie_machine" } ] }
       },
       {
         "text": "What needs to be done?",
         "topic": "TALK_GODCO_Corrie_Mission",
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "mission_completed_godco_corrie_machine", "value": "in-progress" } },
-            { "not": { "npc_has_var": "mission_completed_godco_corrie_machine", "value": "yes" } }
+            { "not": { "compare_string": [ "in-progress", { "npc_val": "mission_completed_godco_corrie_machine" } ] } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "mission_completed_godco_corrie_machine" } ] } }
           ]
         }
       }
@@ -49,7 +49,7 @@
         "effect": { "npc_add_var": "general_meeting_u_met_godco_corrie", "value": "yes" },
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "general_meeting_u_met_godco_corrie", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_corrie" } ] } },
             { "not": { "u_has_var": "general_meeting_godco_joinee", "value": "yes" } },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
@@ -61,7 +61,7 @@
         "effect": { "npc_add_var": "general_meeting_u_met_godco_corrie", "value": "yes" },
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "general_meeting_u_met_godco_corrie", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_corrie" } ] } },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } },
             { "u_has_var": "general_meeting_godco_joinee", "value": "yes" }
           ]
@@ -73,7 +73,7 @@
         "effect": { "npc_add_var": "general_meeting_u_met_godco_corrie", "value": "yes" },
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "general_meeting_u_met_godco_corrie", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_corrie" } ] } },
             { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" }
           ]
         },
@@ -82,20 +82,26 @@
       {
         "text": "Hey Corrie, you free?",
         "condition": {
-          "and": [ { "math": [ "n_npc_anger()", "<", "5" ] }, { "npc_has_var": "general_meeting_u_met_godco_corrie", "value": "yes" } ]
+          "and": [
+            { "math": [ "n_npc_anger()", "<", "5" ] },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_corrie" } ] }
+          ]
         },
         "topic": "TALK_GODCO_Corrie_2"
       },
       {
         "text": "Hey Corrie, you free?",
         "condition": {
-          "and": [ { "math": [ "n_npc_anger()", ">=", "5" ] }, { "npc_has_var": "general_meeting_u_met_godco_corrie", "value": "yes" } ]
+          "and": [
+            { "math": [ "n_npc_anger()", ">=", "5" ] },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_corrie" } ] }
+          ]
         },
         "topic": "TALK_GODCO_Corrie_Angry"
       },
       {
         "text": "Hey Corrie.  I gotta go.",
-        "condition": { "npc_has_var": "general_meeting_u_met_godco_corrie", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_corrie" } ] },
         "topic": "TALK_DONE"
       }
     ]

--- a/data/json/npcs/godco/members/NPC_Corrie_Kaja_Dosia.json
+++ b/data/json/npcs/godco/members/NPC_Corrie_Kaja_Dosia.json
@@ -50,8 +50,8 @@
         "condition": {
           "and": [
             { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_corrie" } ] } },
-            { "not": { "u_has_var": "general_meeting_godco_joinee", "value": "yes" } },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_godco_joinee" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_GODCO_Corrie_FirstmeetA"
@@ -62,8 +62,8 @@
         "condition": {
           "and": [
             { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_corrie" } ] } },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } },
-            { "u_has_var": "general_meeting_godco_joinee", "value": "yes" }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } },
+            { "compare_string": [ "yes", { "u_val": "general_meeting_godco_joinee" } ] }
           ]
         },
         "topic": "TALK_GODCO_Corrie_FirstmeetB"
@@ -74,7 +74,7 @@
         "condition": {
           "and": [
             { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_corrie" } ] } },
-            { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] }
           ]
         },
         "topic": "TALK_GODCO_Corrie_FirstmeetC"
@@ -164,8 +164,8 @@
         "topic": "TALK_GODCO_Corrie_Result_rewardIcon",
         "condition": {
           "and": [
-            { "u_has_var": "mission_reward_godco_machine_reward", "value": "icon" },
-            { "u_has_var": "mission_reward_unclaimed_machine_reward", "value": "yes" }
+            { "compare_string": [ "icon", { "u_val": "mission_reward_godco_machine_reward" } ] },
+            { "compare_string": [ "yes", { "u_val": "mission_reward_unclaimed_machine_reward" } ] }
           ]
         }
       },
@@ -174,8 +174,8 @@
         "topic": "TALK_GODCO_Corrie_Result_rewardRation",
         "condition": {
           "and": [
-            { "u_has_var": "mission_reward_godco_machine_reward", "value": "ration" },
-            { "u_has_var": "mission_reward_unclaimed_machine_reward", "value": "yes" }
+            { "compare_string": [ "ration", { "u_val": "mission_reward_godco_machine_reward" } ] },
+            { "compare_string": [ "yes", { "u_val": "mission_reward_unclaimed_machine_reward" } ] }
           ]
         }
       },

--- a/data/json/npcs/godco/members/NPC_Darryl_Johnstone.json
+++ b/data/json/npcs/godco/members/NPC_Darryl_Johnstone.json
@@ -36,8 +36,7 @@
     "type": "talk_topic",
     "id": "TALK_GODCO_Darryl_1",
     "dynamic_line": {
-      "u_has_var": "dialogue_godco_godco_notalk_to_u",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ],
       "yes": { "gendered_line": "What the <swear> are you, sinner?  Get away from me.", "relevant_genders": [ "u" ] },
       "no": {
         "math": [ "n_npc_anger()", ">=", "5" ],
@@ -73,7 +72,7 @@
         "condition": {
           "and": [
             { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_darryl" } ] } },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_GODCO_Darryl_Farm"
@@ -84,7 +83,7 @@
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
             { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_darryl" } ] },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_GODCO_Darryl_2"
@@ -95,7 +94,7 @@
           "and": [
             { "math": [ "n_npc_anger()", ">=", "5" ] },
             { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_darryl" } ] },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_GODCO_Darryl_Angry"
@@ -106,7 +105,7 @@
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
             { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_darryl" } ] },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_GODCO_Darryl_Trade"
@@ -117,7 +116,7 @@
           "and": [
             { "math": [ "n_npc_anger()", ">=", "5" ] },
             { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_darryl" } ] },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_GODCO_Darryl_Angry"
@@ -138,20 +137,23 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_DONE"
       },
       {
         "text": "What's the poor attitude about?",
-        "condition": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] },
         "topic": "TALK_GODCO_Darryl_You_Mutant"
       },
       {
         "text": "Fuck you <name_b>, I'm outta here.",
         "condition": {
-          "or": [ { "math": [ "n_npc_anger()", ">=", "5" ] }, { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } ]
+          "or": [
+            { "math": [ "n_npc_anger()", ">=", "5" ] },
+            { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] }
+          ]
         },
         "topic": "TALK_DONE"
       }
@@ -167,7 +169,7 @@
         "text": "How are the chickens?",
         "condition": {
           "and": [
-            { "u_has_var": "general_trade_darryl_built_coop", "value": "yes" },
+            { "compare_string": [ "yes", { "u_val": "general_trade_darryl_built_coop" } ] },
             { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_darryl" } ] }
           ]
         },

--- a/data/json/npcs/godco/members/NPC_Darryl_Johnstone.json
+++ b/data/json/npcs/godco/members/NPC_Darryl_Johnstone.json
@@ -19,7 +19,7 @@
     "responses": [
       {
         "text": "About that well…",
-        "condition": { "npc_has_var": "mission_completed_godco_darryl_mission1", "value": "in-progress" },
+        "condition": { "compare_string": [ "in-progress", { "npc_val": "mission_completed_godco_darryl_mission1" } ] },
         "topic": "TALK_MISSION_LIST"
       },
       {
@@ -43,8 +43,7 @@
         "math": [ "n_npc_anger()", ">=", "5" ],
         "yes": "Shove off, we've got no good words for each other.",
         "no": {
-          "npc_has_var": "general_meeting_u_met_godco_darryl",
-          "value": "yes",
+          "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_darryl" } ],
           "yes": [
             "Praise the Lord.",
             "Welcome back.",
@@ -63,7 +62,7 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
-            { "npc_has_var": "mission_completed_godco_darryl_mission1", "value": "in-progress" }
+            { "compare_string": [ "in-progress", { "npc_val": "mission_completed_godco_darryl_mission1" } ] }
           ]
         },
         "topic": "TALK_MISSION_LIST"
@@ -73,7 +72,7 @@
         "effect": { "npc_add_var": "general_meeting_u_met_godco_darryl", "value": "yes" },
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "general_meeting_u_met_godco_darryl", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_darryl" } ] } },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
         },
@@ -84,7 +83,7 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
-            { "npc_has_var": "general_meeting_u_met_godco_darryl", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_darryl" } ] },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
         },
@@ -95,7 +94,7 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_anger()", ">=", "5" ] },
-            { "npc_has_var": "general_meeting_u_met_godco_darryl", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_darryl" } ] },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
         },
@@ -106,7 +105,7 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
-            { "npc_has_var": "general_meeting_u_met_godco_darryl", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_darryl" } ] },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
         },
@@ -117,7 +116,7 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_anger()", ">=", "5" ] },
-            { "npc_has_var": "general_meeting_u_met_godco_darryl", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_darryl" } ] },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
         },
@@ -129,7 +128,7 @@
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
             { "math": [ "darryl_building_coop", "==", "2" ] },
-            { "npc_has_var": "general_meeting_u_met_godco_darryl", "value": "yes" }
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_darryl" } ] }
           ]
         },
         "topic": "TALK_GODCO_Darryl_Trade_Eggs"
@@ -169,7 +168,7 @@
         "condition": {
           "and": [
             { "u_has_var": "general_trade_darryl_built_coop", "value": "yes" },
-            { "npc_has_var": "general_meeting_u_met_godco_darryl", "value": "yes" }
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_darryl" } ] }
           ]
         },
         "topic": "TALK_GODCO_Darryl_Trade_Eggs"

--- a/data/json/npcs/godco/members/NPC_Father_Greenwood.json
+++ b/data/json/npcs/godco/members/NPC_Father_Greenwood.json
@@ -32,8 +32,7 @@
       "math": [ "n_npc_anger()", ">=", "8" ],
       "yes": "What brings you back here?  Come to exploit me again?",
       "no": {
-        "u_has_var": "dialogue_godco_godco_notalk_to_u",
-        "value": "yes",
+        "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ],
         "yes": "The Lord be with you…  You don't seem all too well, I pray for you.",
         "no": {
           "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_greenwood" } ],
@@ -57,7 +56,7 @@
         "condition": {
           "and": [
             { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_greenwood" } ] } },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_GODCO_Greenwood_Firstmeet"
@@ -65,7 +64,10 @@
       {
         "text": "Good to see you again, Reverend.  I wanted to talk.",
         "condition": {
-          "and": [ { "math": [ "n_npc_anger()", "<", "8" ] }, { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } ]
+          "and": [
+            { "math": [ "n_npc_anger()", "<", "8" ] },
+            { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] }
+          ]
         },
         "topic": "TALK_GODCO_Greenwood_2"
       },
@@ -75,7 +77,7 @@
           "and": [
             { "math": [ "n_npc_anger()", "<", "8" ] },
             { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_greenwood" } ] },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_MISSION_LIST"
@@ -88,7 +90,7 @@
           "and": [
             { "math": [ "n_npc_anger()", "<", "8" ] },
             { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_greenwood" } ] },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         }
       },
@@ -98,7 +100,7 @@
         "condition": {
           "and": [
             { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_greenwood" } ] } },
-            { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] }
           ]
         },
         "topic": "TALK_GODCO_Greenwood_You_Mutant"

--- a/data/json/npcs/godco/members/NPC_Father_Greenwood.json
+++ b/data/json/npcs/godco/members/NPC_Father_Greenwood.json
@@ -36,8 +36,7 @@
         "value": "yes",
         "yes": "The Lord be with you…  You don't seem all too well, I pray for you.",
         "no": {
-          "npc_has_var": "general_meeting_u_met_godco_greenwood",
-          "value": "yes",
+          "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_greenwood" } ],
           "yes": {
             "u_male": true,
             "yes": [ "The Lord be with you, brother.", "Good to see you're still around, <u_name>." ],
@@ -57,7 +56,7 @@
         "effect": { "npc_add_var": "general_meeting_u_met_godco_greenwood", "value": "yes" },
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "general_meeting_u_met_godco_greenwood", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_greenwood" } ] } },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
         },
@@ -75,7 +74,7 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_anger()", "<", "8" ] },
-            { "npc_has_var": "general_meeting_u_met_godco_greenwood", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_greenwood" } ] },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
         },
@@ -88,7 +87,7 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_anger()", "<", "8" ] },
-            { "npc_has_var": "general_meeting_u_met_godco_greenwood", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_greenwood" } ] },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
         }
@@ -98,7 +97,7 @@
         "effect": { "npc_add_var": "general_meeting_u_met_godco_greenwood", "value": "yes" },
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "general_meeting_u_met_godco_greenwood", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_greenwood" } ] } },
             { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" }
           ]
         },

--- a/data/json/npcs/godco/members/NPC_Felicity_Powell.json
+++ b/data/json/npcs/godco/members/NPC_Felicity_Powell.json
@@ -31,7 +31,7 @@
         "condition": {
           "and": [
             { "math": [ "time_since(n_timer_trade_writing_manuscript)", ">=", "time('30 d')" ] },
-            { "not": { "npc_has_var": "general_trade_gave_u_manuscript", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "general_trade_gave_u_manuscript" } ] } }
           ]
         },
         "topic": "TALK_GODCO_Felicity_Manuscript"
@@ -46,8 +46,7 @@
       "math": [ "n_npc_anger()", ">=", "5" ],
       "yes": "Please, go away.  I don't want to talk to you right now.",
       "no": {
-        "npc_has_var": "general_meeting_u_met_godco_felicity",
-        "value": "yes",
+        "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_felicity" } ],
         "yes": [ "Oh, hi.", "Hey, good to see you're still around.", "Hey <u_name>, nice to see you." ],
         "no": "Oh, hi there.  My name's Felicity, nice to see a new face."
       }
@@ -58,7 +57,7 @@
         "effect": { "npc_add_var": "general_meeting_u_met_godco_felicity", "value": "yes" },
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "general_meeting_u_met_godco_felicity", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_felicity" } ] } },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
         },
@@ -69,7 +68,7 @@
         "effect": { "npc_add_var": "general_meeting_u_met_godco_felicity", "value": "yes" },
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "general_meeting_u_met_godco_felicity", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_felicity" } ] } },
             { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" }
           ]
         },
@@ -78,7 +77,10 @@
       {
         "text": "Hi Felicity.  Got a minute?",
         "condition": {
-          "and": [ { "math": [ "n_npc_anger()", "<", "5" ] }, { "npc_has_var": "general_meeting_u_met_godco_felicity", "value": "yes" } ]
+          "and": [
+            { "math": [ "n_npc_anger()", "<", "5" ] },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_felicity" } ] }
+          ]
         },
         "topic": "TALK_GODCO_Felicity_2"
       },
@@ -87,7 +89,7 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_anger()", ">=", "5" ] },
-            { "npc_has_var": "general_meeting_u_met_godco_felicity", "value": "yes" }
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_felicity" } ] }
           ]
         },
         "topic": "TALK_GODCO_Felicity_2"

--- a/data/json/npcs/godco/members/NPC_Felicity_Powell.json
+++ b/data/json/npcs/godco/members/NPC_Felicity_Powell.json
@@ -58,7 +58,7 @@
         "condition": {
           "and": [
             { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_felicity" } ] } },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_GODCO_Felicity_Firstmeet"
@@ -69,7 +69,7 @@
         "condition": {
           "and": [
             { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_felicity" } ] } },
-            { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] }
           ]
         },
         "topic": "TALK_GODCO_Felicity_Firstmeet2"

--- a/data/json/npcs/godco/members/NPC_Gemma_Johnstone.json
+++ b/data/json/npcs/godco/members/NPC_Gemma_Johnstone.json
@@ -31,7 +31,7 @@
           "and": [
             { "math": [ "n_npc_value()", ">=", "3" ] },
             { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_gemma" } ] },
-            { "not": { "u_has_var": "general_meeting_godco_joinee", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_godco_joinee" } ] } }
           ]
         }
       }
@@ -41,8 +41,7 @@
     "type": "talk_topic",
     "id": "TALK_GODCO_Gemma_1",
     "dynamic_line": {
-      "u_has_var": "dialogue_godco_godco_notalk_to_u",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ],
       "yes": {
         "gendered_line": "The Lord isn't with you, and that's obvious.  Get out of my sight, sinner.",
         "relevant_genders": [ "u" ]
@@ -64,8 +63,8 @@
         "condition": {
           "and": [
             { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_gemma" } ] } },
-            { "not": { "u_has_var": "general_meeting_godco_joinee", "value": "yes" } },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_godco_joinee" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "effect": { "npc_add_var": "general_meeting_u_met_godco_gemma", "value": "yes" }
@@ -75,8 +74,8 @@
         "topic": "TALK_GODCO_Gemma_Join",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "general_meeting_godco_joinee", "value": "yes" } },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_godco_joinee" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "effect": { "npc_add_var": "general_meeting_u_met_godco_gemma", "value": "yes" }
@@ -87,8 +86,8 @@
         "condition": {
           "and": [
             { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_gemma" } ] } },
-            { "u_has_var": "general_meeting_godco_joinee", "value": "yes" },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "general_meeting_godco_joinee" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "effect": { "npc_add_var": "general_meeting_u_met_godco_gemma", "value": "yes" }
@@ -108,7 +107,7 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_DONE"
@@ -126,12 +125,12 @@
       {
         "text": "What's the harsh reception about?",
         "topic": "TALK_GODCO_Gemma_You_Mutant",
-        "condition": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] }
       },
       {
         "text": "Fine then, screw you.",
         "topic": "TALK_DONE",
-        "condition": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] }
       }
     ]
   },

--- a/data/json/npcs/godco/members/NPC_Gemma_Johnstone.json
+++ b/data/json/npcs/godco/members/NPC_Gemma_Johnstone.json
@@ -21,7 +21,7 @@
       { "text": "What does a dorm leader do exactly?", "topic": "TALK_GODCO_Gemma_Leader" },
       {
         "text": "Can I help you with anything?",
-        "condition": { "npc_has_var": "general_meeting_u_met_godco_gemma", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_gemma" } ] },
         "topic": "TALK_GODCO_Gemma_Help"
       },
       {
@@ -30,7 +30,7 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_value()", ">=", "3" ] },
-            { "npc_has_var": "general_meeting_u_met_godco_gemma", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_gemma" } ] },
             { "not": { "u_has_var": "general_meeting_godco_joinee", "value": "yes" } }
           ]
         }
@@ -51,8 +51,7 @@
         "math": [ "n_npc_anger()", ">=", "5" ],
         "yes": "I'm rather busy at the moment, I don't have the time to talk right now.",
         "no": {
-          "npc_has_var": "general_meeting_u_met_godco_gemma",
-          "value": "yes",
+          "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_gemma" } ],
           "yes": [ "Praise the Lord.", "Good to see you're still around, <granny_name_g>.", "Hey <u_name>.  How can I help you?" ],
           "no": "Great to see a new face.  I'm Gemma.  Will you be staying here with us?"
         }
@@ -64,7 +63,7 @@
         "topic": "TALK_GODCO_Gemma_Leave",
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "general_meeting_u_met_godco_gemma", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_gemma" } ] } },
             { "not": { "u_has_var": "general_meeting_godco_joinee", "value": "yes" } },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
@@ -87,7 +86,7 @@
         "topic": "TALK_GODCO_Gemma_Firstmeet",
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "general_meeting_u_met_godco_gemma", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_gemma" } ] } },
             { "u_has_var": "general_meeting_godco_joinee", "value": "yes" },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
@@ -98,7 +97,10 @@
         "text": "Hi, Gemma.  How're you doing?",
         "topic": "TALK_GODCO_Gemma_Mood",
         "condition": {
-          "and": [ { "math": [ "n_npc_anger()", "<", "5" ] }, { "npc_has_var": "general_meeting_u_met_godco_gemma", "value": "yes" } ]
+          "and": [
+            { "math": [ "n_npc_anger()", "<", "5" ] },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_gemma" } ] }
+          ]
         }
       },
       {
@@ -115,7 +117,10 @@
         "text": "Are you sure?  I've got all the time in the world.",
         "topic": "TALK_GODCO_Gemma_Angry",
         "condition": {
-          "and": [ { "math": [ "n_npc_anger()", ">=", "5" ] }, { "npc_has_var": "general_meeting_u_met_godco_gemma", "value": "yes" } ]
+          "and": [
+            { "math": [ "n_npc_anger()", ">=", "5" ] },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_gemma" } ] }
+          ]
         }
       },
       {
@@ -197,8 +202,7 @@
     "type": "talk_topic",
     "id": "TALK_GODCO_Gemma_Mood",
     "dynamic_line": {
-      "npc_has_var": "mission_meeting_gemma_got_supplements",
-      "value": "yes",
+      "compare_string": [ "yes", { "npc_val": "mission_meeting_gemma_got_supplements" } ],
       "yes": "I'm feeling great!  Even if the world's over, I always have myself and God above.",
       "no": "I'm feeling alright, just working away."
     },
@@ -206,12 +210,12 @@
       {
         "text": "I'm happy to hear that, Gemma.  I'd best be going.",
         "topic": "TALK_DONE",
-        "condition": { "npc_has_var": "mission_meeting_gemma_got_supplements", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "npc_val": "mission_meeting_gemma_got_supplements" } ] }
       },
       {
         "text": "I'll see you around.",
         "topic": "TALK_DONE",
-        "condition": { "not": { "npc_has_var": "mission_meeting_gemma_got_supplements", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "npc_val": "mission_meeting_gemma_got_supplements" } ] } }
       }
     ]
   },

--- a/data/json/npcs/godco/members/NPC_Helena_Misinter.json
+++ b/data/json/npcs/godco/members/NPC_Helena_Misinter.json
@@ -18,7 +18,7 @@
       { "text": "Could you tell me about the community?", "topic": "TALK_GODCO_Helena_Community" },
       {
         "text": "Can I help you with anything?",
-        "condition": { "npc_has_var": "general_meeting_u_met_godco_helena", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_helena" } ] },
         "topic": "TALK_MISSION_LIST"
       },
       {
@@ -27,7 +27,7 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_value()", ">=", "3" ] },
-            { "npc_has_var": "general_meeting_u_met_godco_helena", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_helena" } ] },
             { "not": { "u_has_var": "general_meeting_godco_joinee", "value": "yes" } }
           ]
         }
@@ -45,8 +45,7 @@
         "math": [ "n_npc_anger()", ">=", "5" ],
         "yes": "What brings you here <name_b>?  You know we don't want anything to do with you.",
         "no": {
-          "npc_has_var": "general_meeting_u_met_godco_helena",
-          "value": "yes",
+          "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_helena" } ],
           "yes": [ "Praise the Lord.", "Blessings to you.", "Bless you, <u_name>." ],
           "no": "Stranger, what brings you to our holy home?"
         }
@@ -58,7 +57,7 @@
         "effect": { "npc_add_var": "general_meeting_u_met_godco_helena", "value": "yes" },
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "general_meeting_u_met_godco_helena", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_helena" } ] } },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
         },
@@ -69,7 +68,7 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
-            { "npc_has_var": "general_meeting_u_met_godco_helena", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_helena" } ] },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
         },

--- a/data/json/npcs/godco/members/NPC_Helena_Misinter.json
+++ b/data/json/npcs/godco/members/NPC_Helena_Misinter.json
@@ -28,7 +28,7 @@
           "and": [
             { "math": [ "n_npc_value()", ">=", "3" ] },
             { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_helena" } ] },
-            { "not": { "u_has_var": "general_meeting_godco_joinee", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_godco_joinee" } ] } }
           ]
         }
       }
@@ -38,8 +38,7 @@
     "type": "talk_topic",
     "id": "TALK_GODCO_Helena_1",
     "dynamic_line": {
-      "u_has_var": "dialogue_godco_godco_notalk_to_u",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ],
       "yes": { "gendered_line": "Get away from here, sinner, we don't want your kind here.", "relevant_genders": [ "u" ] },
       "no": {
         "math": [ "n_npc_anger()", ">=", "5" ],
@@ -58,7 +57,7 @@
         "condition": {
           "and": [
             { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_helena" } ] } },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_GODCO_Helena_Firstmeet"
@@ -69,7 +68,7 @@
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
             { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_helena" } ] },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_GODCO_Helena_2"
@@ -78,7 +77,7 @@
         "text": "Why might that be?",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } },
             { "math": [ "n_npc_anger()", ">=", "5" ] }
           ]
         },
@@ -88,7 +87,7 @@
         "text": "I can't talk right now.",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } },
             { "math": [ "n_npc_anger()", "<", "5" ] }
           ]
         },
@@ -97,7 +96,10 @@
       {
         "text": "Fine then.",
         "condition": {
-          "or": [ { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" }, { "math": [ "n_npc_anger()", ">=", "5" ] } ]
+          "or": [
+            { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] },
+            { "math": [ "n_npc_anger()", ">=", "5" ] }
+          ]
         },
         "topic": "TALK_DONE"
       }
@@ -112,7 +114,7 @@
       {
         "text": "I'm not doing much wandering, I'm staying here.",
         "topic": "TALK_GODCO_Gemma_Firstmeet",
-        "condition": { "u_has_var": "general_meeting_godco_joinee", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_godco_joinee" } ] }
       },
       { "text": "I'm just passing through.  I'll see you around.", "topic": "TALK_DONE" }
     ]
@@ -143,16 +145,16 @@
       { "text": "About that job…", "topic": "TALK_MISSION_INQUIRE", "condition": "has_assigned_mission" },
       {
         "text": "Corrie and I have finished that solar cart.",
-        "condition": { "u_has_var": "mission_completed_godco_corrie_machine", "value": "in-progress" },
+        "condition": { "compare_string": [ "in-progress", { "u_val": "mission_completed_godco_corrie_machine" } ] },
         "topic": "TALK_GODCO_Helena_Negotiate"
       },
       {
         "text": "Olwen's finished the radio transmitter she was working on.",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "general_meeting_u_met_Gavin", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Gavin" } ] } },
             { "not": { "u_has_mission": "MISSION_GODCO_HELENA_VISIT_MERCHANTS" } },
-            { "u_has_var": "general_mission_godco_has_radio", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "general_mission_godco_has_radio" } ] }
           ]
         },
         "topic": "TALK_GODCO_Helena_Contact_FreeMerch"
@@ -226,12 +228,12 @@
     "responses": [
       {
         "text": "I'll have some icons.",
-        "condition": { "u_has_var": "mission_completed_godco_corrie_machine", "value": "in-progress" },
+        "condition": { "compare_string": [ "in-progress", { "u_val": "mission_completed_godco_corrie_machine" } ] },
         "topic": "TALK_GODCO_Helena_machineIcon"
       },
       {
         "text": "I want Corrie to have some extra rations.",
-        "condition": { "u_has_var": "mission_completed_godco_corrie_machine", "value": "in-progress" },
+        "condition": { "compare_string": [ "in-progress", { "u_val": "mission_completed_godco_corrie_machine" } ] },
         "topic": "TALK_GODCO_Helena_machineFood"
       },
       { "text": "Let's negotiate some other time.", "topic": "TALK_DONE" }
@@ -279,8 +281,8 @@
         "text": "I presume you want me to pay a visit?",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "general_meeting_u_met_Gavin", "value": "yes" } },
-            { "not": { "u_has_var": "found_refugee_center", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Gavin" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "found_refugee_center" } ] } }
           ]
         },
         "topic": "TALK_GODCO_Helena_Accept_Contact_FreeMerch"
@@ -289,8 +291,8 @@
         "text": "Oh, I've met them before!",
         "condition": {
           "or": [
-            { "u_has_var": "general_meeting_u_met_Gavin", "value": "yes" },
-            { "u_has_var": "found_refugee_center", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Gavin" } ] },
+            { "compare_string": [ "yes", { "u_val": "found_refugee_center" } ] }
           ]
         },
         "topic": "TALK_GODCO_Helena_Accept_Contact_FreeMerch"

--- a/data/json/npcs/godco/members/NPC_Jane_Schulz.json
+++ b/data/json/npcs/godco/members/NPC_Jane_Schulz.json
@@ -61,8 +61,7 @@
       "math": [ "n_npc_anger()", ">=", "5" ],
       "yes": "&Jane glaces at you, scowls, and ignores your presence.",
       "no": {
-        "npc_has_var": "general_meeting_u_met_godco_jane",
-        "value": "yes",
+        "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_jane" } ],
         "yes": [ "How can I help you?", "<u_name>, what can I do for you?" ],
         "no": "Oh, I don't think we've met before.  My name's Jane, I'm the local doctor."
       }
@@ -71,20 +70,26 @@
       {
         "text": "Nice to meet you too, Jane.",
         "effect": { "npc_add_var": "general_meeting_u_met_godco_jane", "value": "yes" },
-        "condition": { "not": { "npc_has_var": "general_meeting_u_met_godco_jane", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_jane" } ] } },
         "topic": "TALK_GODCO_Jane_Firstmeet"
       },
       {
         "text": "Hi, Jane.  Got a minute?",
         "condition": {
-          "and": [ { "math": [ "n_npc_anger()", "<", "5" ] }, { "npc_has_var": "general_meeting_u_met_godco_jane", "value": "yes" } ]
+          "and": [
+            { "math": [ "n_npc_anger()", "<", "5" ] },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_jane" } ] }
+          ]
         },
         "topic": "TALK_GODCO_Jane_2"
       },
       {
         "text": "Hi, Jane.  Got a minute?",
         "condition": {
-          "and": [ { "math": [ "n_npc_anger()", ">=", "5" ] }, { "npc_has_var": "general_meeting_u_met_godco_jane", "value": "yes" } ]
+          "and": [
+            { "math": [ "n_npc_anger()", ">=", "5" ] },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_jane" } ] }
+          ]
         },
         "topic": "TALK_GODCO_Jane_Angry"
       },
@@ -192,20 +197,19 @@
     "type": "talk_topic",
     "id": "TALK_GODCO_Jane_Follow",
     "dynamic_line": {
-      "npc_has_var": "mission_meeting_jane_willing_to_follow",
-      "value": "yes",
+      "compare_string": [ "yes", { "npc_val": "mission_meeting_jane_willing_to_follow" } ],
       "yes": "I'm up for it, Arturo's got enough medicine for two-and-half months.  It's thankless work around here, so let's blow this joint.",
       "no": "I'd like to leave, but I've got to take care of Arturo.  He's always low or nearly out of antipsychotics, so I do what I can."
     },
     "responses": [
       {
         "text": "Alright.  Wanna chat?",
-        "condition": { "not": { "npc_has_var": "mission_meeting_jane_willing_to_follow", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "npc_val": "mission_meeting_jane_willing_to_follow" } ] } },
         "topic": "TALK_GODCO_Jane_2"
       },
       {
         "text": "Let's go.",
-        "condition": { "npc_has_var": "mission_meeting_jane_willing_to_follow", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "npc_val": "mission_meeting_jane_willing_to_follow" } ] },
         "effect": "follow",
         "topic": "TALK_DONE"
       }

--- a/data/json/npcs/godco/members/NPC_Jeremiah_Weaver.json
+++ b/data/json/npcs/godco/members/NPC_Jeremiah_Weaver.json
@@ -150,8 +150,7 @@
     "type": "talk_topic",
     "id": "TALK_GODCO_Jeremiah_Plans",
     "dynamic_line": {
-      "npc_has_var": "general_mission_jeremiah_apprentice",
-      "value": "yes",
+      "compare_string": [ "yes", { "npc_val": "general_mission_jeremiah_apprentice" } ],
       "yes": "I don't know, exactly.  I think I'll stay here and do what I can for the community.",
       "no": "I'd like to study herbology with Kostas, it seems like a useful skill these days.  I do feel bad for Jane though, she's a skilled doctor and nobody here cares, they all just think any illness can be prayed away."
     },
@@ -162,7 +161,7 @@
           "and": [
             { "not": { "u_has_var": "general_mission_convince_kostas", "value": "yes" } },
             { "not": { "u_has_var": "general_mission_kostas_teach_jeremiah", "value": "yes" } },
-            { "not": { "npc_has_var": "general_mission_jeremiah_apprentice", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "general_mission_jeremiah_apprentice" } ] } }
           ]
         },
         "topic": "TALK_GODCO_Jeremiah_Apprenticeship"

--- a/data/json/npcs/godco/members/NPC_Jeremiah_Weaver.json
+++ b/data/json/npcs/godco/members/NPC_Jeremiah_Weaver.json
@@ -35,8 +35,7 @@
       "math": [ "n_npc_anger()", ">=", "5" ],
       "yes": "What are you doing around here <name_b>?  Get lost.",
       "no": {
-        "u_has_var": "general_meeting_u_met_godco_jeremiah",
-        "value": "yes",
+        "compare_string": [ "yes", { "u_val": "general_meeting_u_met_godco_jeremiah" } ],
         "yes": [ "Hey, look who's back.", "Hey again.", "Hey again <u_name>.", "Oh, hey, it's you again." ],
         "no": "Oh, uh… you look new.  Didn't think we'd see new people here.  Hey."
       }
@@ -47,7 +46,7 @@
         "effect": { "u_add_var": "general_meeting_u_met_godco_jeremiah", "value": "yes" },
         "condition": {
           "and": [
-            { "not": { "u_has_var": "general_meeting_u_met_godco_jeremiah", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_godco_jeremiah" } ] } },
             { "not": { "u_has_effect": "godco_joinee" } }
           ]
         },
@@ -58,7 +57,7 @@
         "effect": { "u_add_var": "general_meeting_u_met_godco_jeremiah", "value": "yes" },
         "condition": {
           "and": [
-            { "not": { "u_has_var": "general_meeting_u_met_godco_jeremiah", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_godco_jeremiah" } ] } },
             { "u_has_effect": "godco_joinee" }
           ]
         },
@@ -68,14 +67,20 @@
         "text": "Hey, Jerry.  What's up?",
         "topic": "TALK_GODCO_Jeremiah_2",
         "condition": {
-          "and": [ { "math": [ "n_npc_anger()", "<", "5" ] }, { "u_has_var": "general_meeting_u_met_godco_jeremiah", "value": "yes" } ]
+          "and": [
+            { "math": [ "n_npc_anger()", "<", "5" ] },
+            { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_godco_jeremiah" } ] }
+          ]
         }
       },
       {
         "text": "What's with the attitude?",
         "topic": "TALK_GODCO_Jeremiah_Angry",
         "condition": {
-          "and": [ { "math": [ "n_npc_anger()", ">=", "5" ] }, { "u_has_var": "general_meeting_u_met_godco_jeremiah", "value": "yes" } ]
+          "and": [
+            { "math": [ "n_npc_anger()", ">=", "5" ] },
+            { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_godco_jeremiah" } ] }
+          ]
         }
       },
       {
@@ -102,7 +107,7 @@
       { "text": "I noticed you're holding a D&D handbook.  Do you play much?", "topic": "TALK_GODCO_Jeremiah_Dnd" },
       {
         "text": "I've convinced Kostas to take you on.",
-        "condition": { "u_has_var": "general_mission_kostas_teach_jeremiah", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "general_mission_kostas_teach_jeremiah" } ] },
         "topic": "TALK_GODCO_Jeremiah_Kostas_Convinced"
       },
       { "text": "I'd better get going.", "topic": "TALK_DONE" }
@@ -159,8 +164,8 @@
         "text": "When do you plan on starting that apprenticeship?",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "general_mission_convince_kostas", "value": "yes" } },
-            { "not": { "u_has_var": "general_mission_kostas_teach_jeremiah", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "u_val": "general_mission_convince_kostas" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "general_mission_kostas_teach_jeremiah" } ] } },
             { "not": { "compare_string": [ "yes", { "npc_val": "general_mission_jeremiah_apprentice" } ] } }
           ]
         },

--- a/data/json/npcs/godco/members/NPC_Julian_Ray.json
+++ b/data/json/npcs/godco/members/NPC_Julian_Ray.json
@@ -28,8 +28,8 @@
           "and": [
             { "math": [ "n_npc_value()", ">=", "3" ] },
             { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_julian" } ] },
-            { "not": { "u_has_var": "general_meeting_godco_joinee", "value": "yes" } },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_godco_joinee" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         }
       },
@@ -39,8 +39,8 @@
         "condition": {
           "and": [
             { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_julian" } ] },
-            { "not": { "u_has_var": "general_meeting_godco_joinee", "value": "yes" } },
-            { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" }
+            { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_godco_joinee" } ] } },
+            { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] }
           ]
         }
       }
@@ -50,8 +50,7 @@
     "type": "talk_topic",
     "id": "TALK_GODCO_Julian_1",
     "dynamic_line": {
-      "u_has_var": "dialogue_godco_godco_notalk_to_u",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ],
       "yes": "Hey…  I'm Julian, the guy in charge of this room.  Are you… planning on sticking around or somethin'?",
       "no": {
         "math": [ "n_npc_anger()", ">=", "5" ],
@@ -70,8 +69,8 @@
         "condition": {
           "and": [
             { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_julian" } ] } },
-            { "not": { "u_has_var": "general_meeting_godco_joinee", "value": "yes" } },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_godco_joinee" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "effect": { "npc_add_var": "general_meeting_u_met_godco_julian", "value": "yes" }
@@ -82,8 +81,8 @@
         "condition": {
           "and": [
             { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_julian" } ] } },
-            { "not": { "u_has_var": "general_meeting_godco_joinee", "value": "yes" } },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_godco_joinee" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "effect": { "npc_add_var": "general_meeting_u_met_godco_julian", "value": "yes" }
@@ -94,8 +93,8 @@
         "condition": {
           "and": [
             { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_julian" } ] } },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } },
-            { "u_has_var": "general_meeting_godco_joinee", "value": "yes" }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } },
+            { "compare_string": [ "yes", { "u_val": "general_meeting_godco_joinee" } ] }
           ]
         },
         "effect": { "npc_add_var": "general_meeting_u_met_godco_julian", "value": "yes" }
@@ -106,8 +105,8 @@
         "condition": {
           "and": [
             { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_julian" } ] } },
-            { "not": { "u_has_var": "general_meeting_godco_joinee", "value": "yes" } },
-            { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" }
+            { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_godco_joinee" } ] } },
+            { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] }
           ]
         },
         "effect": { "npc_add_var": "general_meeting_u_met_godco_julian", "value": "yes" }
@@ -139,8 +138,7 @@
     "type": "talk_topic",
     "id": "TALK_GODCO_Julian_2",
     "dynamic_line": {
-      "u_has_var": "general_meeting_godco_joinee",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "general_meeting_godco_joinee" } ],
       "yes": [ "If you have complaints, please don't tell anyone.", "You're still staying here, joinee?", "Need anything, joinee?" ],
       "no": [ "Need anything?", "Go on…" ]
     },

--- a/data/json/npcs/godco/members/NPC_Julian_Ray.json
+++ b/data/json/npcs/godco/members/NPC_Julian_Ray.json
@@ -27,7 +27,7 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_value()", ">=", "3" ] },
-            { "npc_has_var": "general_meeting_u_met_godco_julian", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_julian" } ] },
             { "not": { "u_has_var": "general_meeting_godco_joinee", "value": "yes" } },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
@@ -38,7 +38,7 @@
         "topic": "TALK_GODCO_Julian_Mutant_Join",
         "condition": {
           "and": [
-            { "npc_has_var": "general_meeting_u_met_godco_julian", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_julian" } ] },
             { "not": { "u_has_var": "general_meeting_godco_joinee", "value": "yes" } },
             { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" }
           ]
@@ -57,8 +57,7 @@
         "math": [ "n_npc_anger()", ">=", "5" ],
         "yes": "Why are you still around, don't you have someone else to bother?",
         "no": {
-          "npc_has_var": "general_meeting_u_met_godco_julian",
-          "value": "yes",
+          "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_julian" } ],
           "yes": [ "Praise the Lord.", "Hey, <name_g>.", "Good to see you again <u_name>." ],
           "no": "Hey, a new face.  I'm Julian, the guy in charge of this room.  You're planning on sticking around or somethin'?"
         }
@@ -70,7 +69,7 @@
         "topic": "TALK_GODCO_Julian_Leave",
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "general_meeting_u_met_godco_julian", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_julian" } ] } },
             { "not": { "u_has_var": "general_meeting_godco_joinee", "value": "yes" } },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
@@ -82,7 +81,7 @@
         "topic": "TALK_GODCO_Julian_Join",
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "general_meeting_u_met_godco_julian", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_julian" } ] } },
             { "not": { "u_has_var": "general_meeting_godco_joinee", "value": "yes" } },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
@@ -94,7 +93,7 @@
         "topic": "TALK_GODCO_Julian_2",
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "general_meeting_u_met_godco_julian", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_julian" } ] } },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } },
             { "u_has_var": "general_meeting_godco_joinee", "value": "yes" }
           ]
@@ -106,7 +105,7 @@
         "topic": "TALK_GODCO_Julian_Mutant_Join",
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "general_meeting_u_met_godco_julian", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_julian" } ] } },
             { "not": { "u_has_var": "general_meeting_godco_joinee", "value": "yes" } },
             { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" }
           ]
@@ -117,14 +116,20 @@
         "text": "Hey, good to see you again.",
         "topic": "TALK_GODCO_Julian_2",
         "condition": {
-          "and": [ { "math": [ "n_npc_anger()", "<", "5" ] }, { "npc_has_var": "general_meeting_u_met_godco_julian", "value": "yes" } ]
+          "and": [
+            { "math": [ "n_npc_anger()", "<", "5" ] },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_julian" } ] }
+          ]
         }
       },
       {
         "text": "Nope, just me and you pal.  What's the attitude about?",
         "topic": "TALK_GODCO_Julian_Angry",
         "condition": {
-          "and": [ { "math": [ "n_npc_anger()", ">=", "5" ] }, { "npc_has_var": "general_meeting_u_met_godco_julian", "value": "yes" } ]
+          "and": [
+            { "math": [ "n_npc_anger()", ">=", "5" ] },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_julian" } ] }
+          ]
         }
       },
       { "text": "Hello, Julian.  I can't stay to talk.", "topic": "TALK_DONE" }
@@ -182,7 +187,7 @@
     "responses": [
       {
         "text": "How did you make it out?",
-        "condition": { "not": { "npc_has_var": "general_meeting_told_backstory", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_told_backstory" } ] } },
         "trial": { "type": "PERSUADE", "difficulty": 30 },
         "failure": { "topic": "TALK_GODCO_Julian_NoChat" },
         "success": { "topic": "TALK_GODCO_Julian_Riots" }

--- a/data/json/npcs/godco/members/NPC_Katherine_Weaver.json
+++ b/data/json/npcs/godco/members/NPC_Katherine_Weaver.json
@@ -90,8 +90,7 @@
     "type": "talk_topic",
     "id": "TALK_GODCO_Katherine_1",
     "dynamic_line": {
-      "u_has_var": "dialogue_godco_godco_notalk_to_u",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ],
       "yes": { "gendered_line": "Oh well, yet another sinner.  Don't talk to me.", "relevant_genders": [ "u" ] },
       "no": {
         "math": [ "n_npc_anger()", ">=", "5" ],
@@ -111,7 +110,7 @@
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
             { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_katherine" } ] },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         }
       },
@@ -121,7 +120,7 @@
         "condition": {
           "and": [
             { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_katherine" } ] } },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_GODCO_Katherine_Firstmeet"
@@ -131,7 +130,7 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_anger()", ">=", "5" ] },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_GODCO_Katherine_Angry"
@@ -141,7 +140,7 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_DONE"
@@ -151,7 +150,7 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_anger()", ">=", "5" ] },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_DONE"
@@ -159,7 +158,10 @@
       {
         "text": "Alright, fuck you then.",
         "condition": {
-          "or": [ { "math": [ "n_npc_anger()", ">=", "5" ] }, { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } ]
+          "or": [
+            { "math": [ "n_npc_anger()", ">=", "5" ] },
+            { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] }
+          ]
         },
         "topic": "TALK_DONE"
       }
@@ -228,8 +230,7 @@
     "type": "talk_topic",
     "id": "TALK_GODCO_Katherine_Corrie",
     "dynamic_line": {
-      "u_has_var": "mission_completed_godco_corrie_machine",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "mission_completed_godco_corrie_machine" } ],
       "yes": "She knows this and that about electronics.  The generator we have here was made by her.  Nice to have one here, even though there's not much use for it yet.",
       "no": "I hear she knows this and that about electronics.    She keeps herself occupied by doing menial tasks around the camp, looking for payment."
     }
@@ -258,8 +259,7 @@
     "type": "talk_topic",
     "id": "TALK_GODCO_Katherine_Zachary",
     "dynamic_line": {
-      "u_has_var": "mission_completed_godco_corrie_machine",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "mission_completed_godco_corrie_machine" } ],
       "yes": "He can keep his distance with his smug nothingness.  At least he's a bit more useful than some of the others.  He helped Corrie make that generator.",
       "no": "I'm not planning to communicate with him, that's for certain.  He can keep his distance with his smug nothingness.  At least he knows how to cut lumber."
     }

--- a/data/json/npcs/godco/members/NPC_Katherine_Weaver.json
+++ b/data/json/npcs/godco/members/NPC_Katherine_Weaver.json
@@ -97,8 +97,7 @@
         "math": [ "n_npc_anger()", ">=", "5" ],
         "yes": "Please go away, I'm not in the mood to talk right now.",
         "no": {
-          "npc_has_var": "general_meeting_u_met_godco_katherine",
-          "value": "yes",
+          "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_katherine" } ],
           "yes": [ "Praise the Lord.", "<u_name>, bless you." ],
           "no": { "gendered_line": "Oh well, yet another survivor.  Welcome to our group, I'm Katherine.", "relevant_genders": [ "u" ] }
         }
@@ -111,7 +110,7 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
-            { "npc_has_var": "general_meeting_u_met_godco_katherine", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_katherine" } ] },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
         }
@@ -121,7 +120,7 @@
         "effect": { "npc_add_var": "general_meeting_u_met_godco_katherine", "value": "yes" },
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "general_meeting_u_met_godco_katherine", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_katherine" } ] } },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
         },

--- a/data/json/npcs/godco/members/NPC_Kostas_Walsman.json
+++ b/data/json/npcs/godco/members/NPC_Kostas_Walsman.json
@@ -22,7 +22,7 @@
         "topic": "TALK_GODCO_Kostas_Tea_2",
         "condition": {
           "and": [
-            { "npc_has_var": "knowledge_completed_godco_kostas_tea", "value": "in-progress" },
+            { "compare_string": [ "in-progress", { "npc_val": "knowledge_completed_godco_kostas_tea" } ] },
             { "u_has_items": { "item": "pine_bough", "count": 12 } }
           ]
         },
@@ -54,8 +54,7 @@
         "math": [ "n_npc_anger()", ">=", "5" ],
         "yes": "&Kostas looks up at you and scorns.  \"I'm rather busy right now with an important project, go away please.\"",
         "no": {
-          "npc_has_var": "general_meeting_u_met_godco_kostas",
-          "value": "yes",
+          "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_kostas" } ],
           "yes": [ "Praise the Lord.", "<u_name>, how can I help you?" ],
           "no": {
             "gendered_line": "You must be new here, nice to meet you.  They call me Kostas, I'm the local herbalist.",
@@ -70,7 +69,7 @@
         "effect": { "npc_add_var": "general_meeting_u_met_godco_kostas", "value": "yes" },
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "general_meeting_u_met_godco_kostas", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_kostas" } ] } },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
         },
@@ -81,7 +80,7 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
-            { "npc_has_var": "general_meeting_u_met_godco_kostas", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_kostas" } ] },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
         },
@@ -92,7 +91,7 @@
         "condition": {
           "and": [
             { "not": { "npc_has_effect": "failed_persuade" } },
-            { "npc_has_var": "general_meeting_u_met_godco_kostas", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_kostas" } ] },
             { "u_has_var": "general_mission_convince_kostas", "value": "yes" }
           ]
         },
@@ -104,7 +103,7 @@
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } },
-            { "npc_has_var": "general_meeting_u_met_godco_kostas", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_kostas" } ] },
             { "npc_has_effect": "godco_kostas_trade" }
           ]
         },
@@ -116,7 +115,7 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_anger()", ">=", "5" ] },
-            { "npc_has_var": "general_meeting_u_met_godco_kostas", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_kostas" } ] },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
         },
@@ -128,7 +127,7 @@
           "and": [
             { "math": [ "n_npc_anger()", ">=", "5" ] },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } },
-            { "npc_has_var": "general_meeting_u_met_godco_kostas", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_kostas" } ] },
             { "npc_has_effect": "godco_kostas_trade" }
           ]
         },
@@ -216,8 +215,7 @@
     "type": "talk_topic",
     "id": "TALK_GODCO_Kostas_Herbalism",
     "dynamic_line": {
-      "npc_has_var": "knowledge_completed_godco_kostas_tea",
-      "value": "yes",
+      "compare_string": [ "yes", { "npc_val": "knowledge_completed_godco_kostas_tea" } ],
       "yes": [
         "Nature can provide.  You can live off the land if you learn how.",
         "Foraging is about recognizing the abundance that is around us all the time, not seeking out rare species.",
@@ -231,7 +229,7 @@
       {
         "text": "Can I try your pine needle tea?",
         "topic": "TALK_GODCO_Kostas_Tea",
-        "condition": { "not": { "npc_has_var": "knowledge_completed_godco_kostas_tea", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "npc_val": "knowledge_completed_godco_kostas_tea" } ] } },
         "effect": { "npc_add_var": "knowledge_completed_godco_kostas_tea", "value": "in-progress" }
       },
       { "text": "What were you saying before?", "topic": "TALK_NONE" },

--- a/data/json/npcs/godco/members/NPC_Kostas_Walsman.json
+++ b/data/json/npcs/godco/members/NPC_Kostas_Walsman.json
@@ -47,8 +47,7 @@
     "type": "talk_topic",
     "id": "TALK_GODCO_Kostas_1",
     "dynamic_line": {
-      "u_has_var": "dialogue_godco_godco_notalk_to_u",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ],
       "yes": "A sin against God, did you know that's what you are?  Get away from me.",
       "no": {
         "math": [ "n_npc_anger()", ">=", "5" ],
@@ -70,7 +69,7 @@
         "condition": {
           "and": [
             { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_kostas" } ] } },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_GODCO_Kostas_2"
@@ -81,7 +80,7 @@
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
             { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_kostas" } ] },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_GODCO_Kostas_2"
@@ -92,7 +91,7 @@
           "and": [
             { "not": { "npc_has_effect": "failed_persuade" } },
             { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_kostas" } ] },
-            { "u_has_var": "general_mission_convince_kostas", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "general_mission_convince_kostas" } ] }
           ]
         },
         "topic": "TALK_GODCO_Kostas_Jeremiah"
@@ -102,7 +101,7 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } },
             { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_kostas" } ] },
             { "npc_has_effect": "godco_kostas_trade" }
           ]
@@ -116,7 +115,7 @@
           "and": [
             { "math": [ "n_npc_anger()", ">=", "5" ] },
             { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_kostas" } ] },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_GODCO_Kostas_Angry"
@@ -126,7 +125,7 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_anger()", ">=", "5" ] },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } },
             { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_kostas" } ] },
             { "npc_has_effect": "godco_kostas_trade" }
           ]
@@ -143,20 +142,23 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_DONE"
       },
       {
         "text": "What the hell are you talking about?",
-        "condition": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] },
         "topic": "TALK_GODCO_Kostas_You_Mutant"
       },
       {
         "text": "Alright then.",
         "condition": {
-          "or": [ { "math": [ "n_npc_anger()", ">=", "5" ] }, { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } ]
+          "or": [
+            { "math": [ "n_npc_anger()", ">=", "5" ] },
+            { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] }
+          ]
         },
         "topic": "TALK_DONE"
       }

--- a/data/json/npcs/godco/members/NPC_Maria_Serrano.json
+++ b/data/json/npcs/godco/members/NPC_Maria_Serrano.json
@@ -28,8 +28,7 @@
     "type": "talk_topic",
     "id": "TALK_GODCO_Maria",
     "dynamic_line": {
-      "u_has_var": "dialogue_godco_godco_notalk_to_u",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ],
       "yes": "Ahh!  What the <swear> are you?  Get the <swear> away from me!",
       "no": {
         "math": [ "n_npc_anger()", ">=", "5" ],
@@ -48,7 +47,7 @@
         "condition": {
           "and": [
             { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_maria" } ] } },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_GODCO_Maria_Feeling"
@@ -59,7 +58,7 @@
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
             { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_maria" } ] },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_GODCO_Maria_2"
@@ -70,7 +69,7 @@
           "and": [
             { "math": [ "n_npc_anger()", ">=", "5" ] },
             { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_maria" } ] },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_GODCO_Maria_Angry"
@@ -80,7 +79,7 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_DONE"
@@ -88,7 +87,10 @@
       {
         "text": "Alright, alright, chill the <swear> out, I'm leaving!",
         "condition": {
-          "or": [ { "math": [ "n_npc_anger()", ">=", "5" ] }, { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } ]
+          "or": [
+            { "math": [ "n_npc_anger()", ">=", "5" ] },
+            { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] }
+          ]
         },
         "topic": "TALK_DONE"
       }

--- a/data/json/npcs/godco/members/NPC_Maria_Serrano.json
+++ b/data/json/npcs/godco/members/NPC_Maria_Serrano.json
@@ -35,8 +35,7 @@
         "math": [ "n_npc_anger()", ">=", "5" ],
         "yes": "Buzz off <name_b>, I'm not interested in  <swear> chatting with you.",
         "no": {
-          "npc_has_var": "general_meeting_u_met_godco_maria",
-          "value": "yes",
+          "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_maria" } ],
           "yes": [ "Hey <name_g>!  Nice to see you again!", "Hey <u_name>!  Nice to see you again!" ],
           "no": "I don't think I've met you before, have I?  I'm Maria Serrano, it's nice to see an new face."
         }
@@ -48,7 +47,7 @@
         "effect": { "npc_add_var": "general_meeting_u_met_godco_maria", "value": "yes" },
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "general_meeting_u_met_godco_maria", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_maria" } ] } },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
         },
@@ -59,7 +58,7 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
-            { "npc_has_var": "general_meeting_u_met_godco_maria", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_maria" } ] },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
         },
@@ -70,7 +69,7 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_anger()", ">=", "5" ] },
-            { "npc_has_var": "general_meeting_u_met_godco_maria", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_maria" } ] },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
         },
@@ -103,12 +102,12 @@
       { "text": "Is there anything I can do for you?", "topic": "TALK_MISSION_LIST" },
       {
         "text": "Could you sew something for me?",
-        "condition": { "npc_has_var": "general_trade_can_sew_for_u", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "npc_val": "general_trade_can_sew_for_u" } ] },
         "topic": "TALK_GODCO_Maria_Tailor_Something"
       },
       {
         "text": "How's my order going?",
-        "condition": { "npc_has_var": "general_trade_can_sew_for_u", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "npc_val": "general_trade_can_sew_for_u" } ] },
         "topic": "TALK_GODCO_Maria_Retrieve_Order"
       },
       { "text": "I'd better get going.", "topic": "TALK_DONE" }
@@ -266,7 +265,7 @@
         "text": "I ordered a t-shirt.",
         "condition": {
           "and": [
-            { "npc_has_var": "general_trade_u_want_tshirt", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_trade_u_want_tshirt" } ] },
             { "math": [ "time_since(n_timer_trade_knitting)", ">=", "time('2 d')" ] }
           ]
         },
@@ -281,7 +280,7 @@
         "text": "I ordered a pair of pants.",
         "condition": {
           "and": [
-            { "npc_has_var": "general_trade_u_want_pants", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_trade_u_want_pants" } ] },
             { "math": [ "time_since(n_timer_trade_knitting)", ">=", "time('2 d')" ] }
           ]
         },
@@ -296,7 +295,7 @@
         "text": "I ordered a jacket.",
         "condition": {
           "and": [
-            { "npc_has_var": "general_trade_u_want_jacket", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_trade_u_want_jacket" } ] },
             { "math": [ "time_since(n_timer_trade_knitting)", ">=", "time('2 d')" ] }
           ]
         },
@@ -311,7 +310,7 @@
         "text": "I ordered a dress.",
         "condition": {
           "and": [
-            { "npc_has_var": "general_trade_u_want_dress", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_trade_u_want_dress" } ] },
             { "math": [ "time_since(n_timer_trade_knitting)", ">=", "time('2 d')" ] }
           ]
         },
@@ -326,7 +325,7 @@
         "text": "I ordered a duster.",
         "condition": {
           "and": [
-            { "npc_has_var": "general_trade_u_want_duster", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_trade_u_want_duster" } ] },
             { "math": [ "time_since(n_timer_trade_knitting)", ">=", "time('4 d')" ] }
           ]
         },
@@ -341,7 +340,7 @@
         "text": "I ordered a trench coat.",
         "condition": {
           "and": [
-            { "npc_has_var": "general_trade_u_want_trenchcoat", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_trade_u_want_trenchcoat" } ] },
             { "math": [ "time_since(n_timer_trade_knitting)", ">=", "time('4 d')" ] }
           ]
         },
@@ -356,7 +355,7 @@
         "text": "I ordered a backpack.",
         "condition": {
           "and": [
-            { "npc_has_var": "general_trade_u_want_backpack", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_trade_u_want_backpack" } ] },
             { "math": [ "time_since(n_timer_trade_knitting)", ">=", "time('4 d')" ] }
           ]
         },
@@ -371,7 +370,7 @@
         "text": "I ordered a gambeson.",
         "condition": {
           "and": [
-            { "npc_has_var": "general_trade_u_want_gambeson", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_trade_u_want_gambeson" } ] },
             { "math": [ "time_since(n_timer_trade_knitting)", ">=", "time('4 d')" ] }
           ]
         },

--- a/data/json/npcs/godco/members/NPC_Olwen_Powell.json
+++ b/data/json/npcs/godco/members/NPC_Olwen_Powell.json
@@ -24,8 +24,7 @@
       "math": [ "n_npc_anger()", ">=", "5" ],
       "yes": "What in the world are you still doing around here, come back to screw me over?",
       "no": {
-        "npc_has_var": "general_meeting_u_met_godco_olwen",
-        "value": "yes",
+        "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_olwen" } ],
         "yes": [ "Hey, <name_g>.", "Good to see you again.", "What can I do for you?", "You don't look too shabby, <u_name>." ],
         "no": "I definitely haven't met you yet.  Nice to meet you, I'm Olwen."
       }
@@ -34,14 +33,17 @@
       {
         "text": "I'm just a traveler.",
         "effect": { "npc_add_var": "general_meeting_u_met_godco_olwen", "value": "yes" },
-        "condition": { "not": { "npc_has_var": "general_meeting_u_met_godco_olwen", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_olwen" } ] } },
         "topic": "TALK_GODCO_Olwen_Firstmeet"
       },
       {
         "text": "Hi, Olwen.  What's up?",
         "topic": "TALK_GODCO_Olwen_2",
         "condition": {
-          "and": [ { "math": [ "n_npc_anger()", "<", "5" ] }, { "npc_has_var": "general_meeting_u_met_godco_olwen", "value": "yes" } ]
+          "and": [
+            { "math": [ "n_npc_anger()", "<", "5" ] },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_olwen" } ] }
+          ]
         }
       },
       {
@@ -53,7 +55,10 @@
         "text": "What's with the attitude?",
         "topic": "TALK_GODCO_Olwen_Angry",
         "condition": {
-          "and": [ { "math": [ "n_npc_anger()", ">=", "5" ] }, { "npc_has_var": "general_meeting_u_met_godco_olwen", "value": "yes" } ]
+          "and": [
+            { "math": [ "n_npc_anger()", ">=", "5" ] },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_olwen" } ] }
+          ]
         }
       },
       {
@@ -136,7 +141,7 @@
     "responses": [
       {
         "text": "Can you teach me anything?",
-        "condition": { "npc_has_var": "general_training_olwen_can_teach", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "npc_val": "general_training_olwen_can_teach" } ] },
         "topic": "TALK_TRAIN"
       },
       { "text": "Is there anything I can help you with?", "topic": "TALK_MISSION_LIST" },

--- a/data/json/npcs/godco/members/NPC_Olwen_Powell.json
+++ b/data/json/npcs/godco/members/NPC_Olwen_Powell.json
@@ -77,8 +77,8 @@
         "text": "I'm just a curious traveler.",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "general_meeting_godco_joinee", "value": "yes" } },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_godco_joinee" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_GODCO_Olwen_Traveler"
@@ -87,8 +87,8 @@
         "text": "I'm seeking asylum here.",
         "condition": {
           "and": [
-            { "u_has_var": "general_meeting_godco_joinee", "value": "yes" },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "general_meeting_godco_joinee" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_GODCO_Olwen_Joinee"
@@ -97,8 +97,8 @@
         "text": "I'm just a curious traveler.",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "general_meeting_godco_joinee", "value": "yes" } },
-            { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" }
+            { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_godco_joinee" } ] } },
+            { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] }
           ]
         },
         "topic": "TALK_GODCO_Olwen_Mutant_Traveler"

--- a/data/json/npcs/godco/members/NPC_Russell_Connelly.json
+++ b/data/json/npcs/godco/members/NPC_Russell_Connelly.json
@@ -43,8 +43,7 @@
     "type": "talk_topic",
     "id": "TALK_GODCO_Russell_1",
     "dynamic_line": {
-      "u_has_var": "dialogue_godco_godco_notalk_to_u",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ],
       "yes": "Get away from me, demon.  I shoot crazy sinners like you on a regular basis, and my rifle's right here.",
       "no": {
         "math": [ "n_npc_anger()", ">=", "5" ],
@@ -63,7 +62,7 @@
         "condition": {
           "and": [
             { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_russell" } ] } },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_GODCO_Russell_Firstmeet"
@@ -74,7 +73,7 @@
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
             { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_russell" } ] },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_GODCO_Russell_2"
@@ -84,7 +83,7 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_DONE"
@@ -92,7 +91,10 @@
       {
         "text": "Chill out man, I'll leave you alone.",
         "condition": {
-          "or": [ { "math": [ "n_npc_anger()", ">=", "5" ] }, { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } ]
+          "or": [
+            { "math": [ "n_npc_anger()", ">=", "5" ] },
+            { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] }
+          ]
         },
         "topic": "TALK_DONE"
       }
@@ -105,12 +107,12 @@
     "responses": [
       {
         "text": "I'm just a curious traveler.  What's up with you?",
-        "condition": { "not": { "u_has_var": "general_meeting_godco_joinee", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_godco_joinee" } ] } },
         "topic": "TALK_GODCO_Russell_Story"
       },
       {
         "text": "I'm seeking asylum here.  What's up with you?",
-        "condition": { "u_has_var": "general_meeting_godco_joinee", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_godco_joinee" } ] },
         "topic": "TALK_GODCO_Russell_Story"
       },
       { "text": "Actually I'm just heading out.", "topic": "TALK_GODCO_Russell_StoryB" }
@@ -205,7 +207,7 @@
       {
         "text": "I hate to break it to you, but I came here because I don't want to see the world.",
         "topic": "TALK_GODCO_Russell_Joinee",
-        "condition": { "u_has_var": "general_meeting_godco_joinee", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_godco_joinee" } ] }
       },
       { "text": "What were you saying before?", "topic": "TALK_NONE" },
       { "text": "I'm humbled by your words.  Well, bye.", "topic": "TALK_DONE" }

--- a/data/json/npcs/godco/members/NPC_Russell_Connelly.json
+++ b/data/json/npcs/godco/members/NPC_Russell_Connelly.json
@@ -50,8 +50,7 @@
         "math": [ "n_npc_anger()", ">=", "5" ],
         "yes": "Get away from me <name_b>.  I'm not interested in whatever <swear> thing you have to say right now.",
         "no": {
-          "npc_has_var": "general_meeting_u_met_godco_russell",
-          "value": "yes",
+          "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_russell" } ],
           "yes": [ "Praise the Lord, <name_g>.", "Praise the Lord, <u_name>.", "Greetings, <name_g><punc>  You okay?" ],
           "no": "Huh, so it was you over there.  It's always great to see a new face.  Name's Russell, Russell Connelly."
         }
@@ -63,7 +62,7 @@
         "effect": { "npc_add_var": "general_meeting_u_met_godco_russell", "value": "yes" },
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "general_meeting_u_met_godco_russell", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_russell" } ] } },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
         },
@@ -74,7 +73,7 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
-            { "npc_has_var": "general_meeting_u_met_godco_russell", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_russell" } ] },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
         },

--- a/data/json/npcs/godco/members/NPC_Sonia_Greene.json
+++ b/data/json/npcs/godco/members/NPC_Sonia_Greene.json
@@ -25,7 +25,10 @@
       {
         "text": "Now that your guitar is fixed, could you play something for me?",
         "condition": {
-          "and": [ { "npc_has_var": "mission_completed_sonia_guitar_fixed", "value": "yes" }, { "npc_has_item": "acoustic_guitar" } ]
+          "and": [
+            { "compare_string": [ "yes", { "npc_val": "mission_completed_sonia_guitar_fixed" } ] },
+            { "npc_has_item": "acoustic_guitar" }
+          ]
         },
         "topic": "TALK_GODCO_Sonia_Play_For_U"
       },
@@ -39,8 +42,7 @@
       "math": [ "n_npc_anger()", ">=", "5" ],
       "yes": "&Sonia glances at you harshly, then turns away.  \"Come back later, I'm busy right now.\"",
       "no": {
-        "npc_has_var": "general_meeting_u_met_godco_sonia",
-        "value": "yes",
+        "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_sonia" } ],
         "yes": [
           { "gendered_line": "Well now, good to see you again, friend.", "relevant_genders": [ "u" ] },
           "Nice of you to come around <u_name>."
@@ -52,20 +54,26 @@
       {
         "text": "Sonia?  Nice to meet you, I'm <u_name>.  How are things here?",
         "effect": { "npc_add_var": "general_meeting_u_met_godco_sonia", "value": "yes" },
-        "condition": { "not": { "npc_has_var": "general_meeting_u_met_godco_sonia", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_sonia" } ] } },
         "topic": "TALK_GODCO_Sonia_Feeling"
       },
       {
         "text": "Hey Sonia.  What's up?",
         "condition": {
-          "and": [ { "math": [ "n_npc_anger()", "<", "5" ] }, { "npc_has_var": "general_meeting_u_met_godco_sonia", "value": "yes" } ]
+          "and": [
+            { "math": [ "n_npc_anger()", "<", "5" ] },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_sonia" } ] }
+          ]
         },
         "topic": "TALK_GODCO_Sonia_Tunes"
       },
       {
         "text": "Hey Sonia.  What's up?",
         "condition": {
-          "and": [ { "math": [ "n_npc_anger()", ">=", "5" ] }, { "npc_has_var": "general_meeting_u_met_godco_sonia", "value": "yes" } ]
+          "and": [
+            { "math": [ "n_npc_anger()", ">=", "5" ] },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_sonia" } ] }
+          ]
         },
         "topic": "TALK_GODCO_Sonia_Angry"
       },
@@ -86,8 +94,7 @@
     "id": "TALK_GODCO_Sonia_Tunes",
     "dynamic_line": [
       {
-        "npc_has_var": "mission_completed_sonia_guitar_fixed",
-        "value": "yes",
+        "compare_string": [ "yes", { "npc_val": "mission_completed_sonia_guitar_fixed" } ],
         "yes": "Just playing some good ol' tunes.  There's so much negativity around here, someone's gotta cheer people up, ya know?",
         "no": "Nothin' much, just sitting around and biding my time, getting any work I can.  I might play something to cheer everyone up, if my guitar wasn't busted."
       }

--- a/data/json/npcs/godco/members/NPC_Tom_Powell.json
+++ b/data/json/npcs/godco/members/NPC_Tom_Powell.json
@@ -56,8 +56,7 @@
     "type": "talk_topic",
     "id": "TALK_GODCO_Tom_1",
     "dynamic_line": {
-      "u_has_var": "dialogue_godco_godco_notalk_to_u",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ],
       "yes": "What the <swear> are you?  Get the <swear> away from me!",
       "no": {
         "math": [ "n_npc_anger()", ">=", "5" ],
@@ -78,7 +77,7 @@
         "condition": {
           "and": [
             { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_tom" } ] } },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "effect": { "npc_add_var": "general_meeting_u_met_godco_tom", "value": "yes" },
@@ -90,7 +89,7 @@
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
             { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_tom" } ] },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_GODCO_Tom_2"
@@ -101,7 +100,7 @@
           "and": [
             { "math": [ "n_npc_anger()", ">=", "5" ] },
             { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_tom" } ] },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_GODCO_Tom_Angry"
@@ -111,7 +110,7 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_DONE"
@@ -121,14 +120,14 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_anger()", ">=", "5" ] },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_DONE"
       },
       {
         "text": "Alright, alright, chill the <swear> out, I'm leaving!",
-        "condition": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] },
         "topic": "TALK_DONE"
       }
     ]
@@ -140,12 +139,12 @@
     "responses": [
       {
         "text": "I'm just a curious traveler.  What about you, how are you doing?",
-        "condition": { "not": { "u_has_var": "general_meeting_godco_joinee", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_godco_joinee" } ] } },
         "topic": "TALK_GODCO_Tom_Firstmeet2"
       },
       {
         "text": "I'm seeking asylum here.  What about you, how are you doing?",
-        "condition": { "u_has_var": "general_meeting_godco_joinee", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_godco_joinee" } ] },
         "topic": "TALK_GODCO_Tom_Firstmeet2"
       },
       { "text": "Actually I'm just heading out.", "topic": "TALK_DONE" }

--- a/data/json/npcs/godco/members/NPC_Tom_Powell.json
+++ b/data/json/npcs/godco/members/NPC_Tom_Powell.json
@@ -63,8 +63,7 @@
         "math": [ "n_npc_anger()", ">=", "5" ],
         "yes": "It's you again <u_name>, you have some nerve coming around after what you've done.",
         "no": {
-          "npc_has_var": "general_meeting_u_met_godco_tom",
-          "value": "yes",
+          "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_tom" } ],
           "yes": "Hey, it's you again <u_name>!  Any news from the outside world?",
           "no": {
             "gendered_line": "Ah, another survivor!  I hope you come in peace.  I'm Tom, nice to meet you.",
@@ -78,7 +77,7 @@
         "text": "Nice to meet you, Tom.",
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "general_meeting_u_met_godco_tom", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_tom" } ] } },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
         },
@@ -90,7 +89,7 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
-            { "npc_has_var": "general_meeting_u_met_godco_tom", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_tom" } ] },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
         },
@@ -101,7 +100,7 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_anger()", ">=", "5" ] },
-            { "npc_has_var": "general_meeting_u_met_godco_tom", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_tom" } ] },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
         },

--- a/data/json/npcs/godco/members/NPC_Zachary_Montes.json
+++ b/data/json/npcs/godco/members/NPC_Zachary_Montes.json
@@ -38,13 +38,16 @@
       {
         "text": "Don't worry, I'm not going to hurt you.",
         "effect": { "npc_add_var": "general_meeting_u_met_godco_zachary", "value": "yes" },
-        "condition": { "not": { "npc_has_var": "general_meeting_u_met_godco_zachary", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_zachary" } ] } },
         "topic": "TALK_GODCO_Zachary_Intro"
       },
       {
         "text": "Hey, good to see you're still around.",
         "condition": {
-          "and": [ { "math": [ "n_npc_anger()", "<", "5" ] }, { "npc_has_var": "general_meeting_u_met_godco_zachary", "value": "yes" } ]
+          "and": [
+            { "math": [ "n_npc_anger()", "<", "5" ] },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_zachary" } ] }
+          ]
         },
         "topic": "TALK_GODCO_Zachary_Intro_2"
       },

--- a/data/json/npcs/godco/members/NPC_Zachary_Montes.json
+++ b/data/json/npcs/godco/members/NPC_Zachary_Montes.json
@@ -67,8 +67,7 @@
       "u_has_mission": "MISSION_GODCO_ZACHARY_KILL_NIGHTMARE",
       "yes": "I ain't leaving, <name_g>.  Not until you or someone else has checked out that nightmare for me.",
       "no": {
-        "u_has_var": "mission_meeting_zachary_willing_to_follow",
-        "value": "yes",
+        "compare_string": [ "yes", { "u_val": "mission_meeting_zachary_willing_to_follow" } ],
         "yes": "Thanks, <name_g>.  I sure owe you one.",
         "no": "I ain't leaving, <name_g>.  Not until that eldritch screeching nightmare is dead 'n buried."
       }
@@ -79,7 +78,7 @@
         "condition": {
           "and": [
             { "not": { "u_has_mission": "MISSION_GODCO_ZACHARY_KILL_NIGHTMARE" } },
-            { "not": { "u_has_var": "mission_meeting_zachary_willing_to_follow", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "mission_meeting_zachary_willing_to_follow" } ] } }
           ]
         },
         "topic": "TALK_GODCO_Zachary_Nightmare"
@@ -168,8 +167,7 @@
     "type": "talk_topic",
     "id": "TALK_GODCO_Zachary_Follow",
     "dynamic_line": {
-      "u_has_var": "mission_meeting_zachary_willing_to_follow",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "mission_meeting_zachary_willing_to_follow" } ],
       "yes": {
         "gendered_line": "After what you did for me, I'll follow you to the ends of the Earth!  No one around here's stood up for me like that, I owe ya one.",
         "relevant_genders": [ "u" ]
@@ -179,12 +177,12 @@
     "responses": [
       {
         "text": "That's understandable.",
-        "condition": { "not": { "u_has_var": "mission_meeting_zachary_willing_to_follow", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "mission_meeting_zachary_willing_to_follow" } ] } },
         "topic": "TALK_GODCO_Zachary_Intro_2"
       },
       {
         "text": "Let's hit the road.",
-        "condition": { "u_has_var": "mission_meeting_zachary_willing_to_follow", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "mission_meeting_zachary_willing_to_follow" } ] },
         "effect": "follow",
         "topic": "TALK_DONE"
       }

--- a/data/json/npcs/godco/members/cook.json
+++ b/data/json/npcs/godco/members/cook.json
@@ -7,8 +7,7 @@
     "id": "TALK_GODCO_chef",
     "type": "talk_topic",
     "dynamic_line": {
-      "u_has_var": "dialogue_godco_godco_notalk_to_u",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ],
       "yes": "Could you be on your way, please?  We don't take kindly to sinners like you.",
       "no": {
         "math": [ "n_npc_anger()", ">=", "5" ],
@@ -30,7 +29,7 @@
         "condition": {
           "and": [
             { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_chef" } ] } },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "effect": { "npc_add_var": "general_meeting_u_met_godco_chef", "value": "yes" }
@@ -41,7 +40,7 @@
         "condition": {
           "and": [
             { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_chef" } ] } },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "effect": { "npc_add_var": "general_meeting_u_met_godco_chef", "value": "yes" }
@@ -53,7 +52,7 @@
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
             { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_chef" } ] },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         }
       },
@@ -64,8 +63,8 @@
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
             { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_chef" } ] },
-            { "not": { "u_has_var": "general_meeting_godco_joinee", "value": "yes" } },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_godco_joinee" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         }
       },
@@ -76,7 +75,7 @@
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
             { "not": { "npc_has_effect": "u_got_meal" } },
-            { "u_has_var": "general_meeting_godco_joinee", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "general_meeting_godco_joinee" } ] }
           ]
         }
       },
@@ -98,7 +97,7 @@
       {
         "text": "Okay, man.  I'll be on my way.",
         "topic": "TALK_DONE",
-        "condition": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] }
       }
     ]
   },
@@ -121,14 +120,20 @@
       {
         "text": "Could you tell me about Katherine?",
         "condition": {
-          "and": [ { "math": [ "n_npc_value()", ">=", "3" ] }, { "u_has_var": "dialogue_godco_u_know_about_family", "value": "yes" } ]
+          "and": [
+            { "math": [ "n_npc_value()", ">=", "3" ] },
+            { "compare_string": [ "yes", { "u_val": "dialogue_godco_u_know_about_family" } ] }
+          ]
         },
         "topic": "TALK_GODCO_chef_katherine"
       },
       {
         "text": "Could you tell me about Jeremiah?",
         "condition": {
-          "and": [ { "math": [ "n_npc_value()", ">=", "3" ] }, { "u_has_var": "dialogue_godco_u_know_about_family", "value": "yes" } ]
+          "and": [
+            { "math": [ "n_npc_value()", ">=", "3" ] },
+            { "compare_string": [ "yes", { "u_val": "dialogue_godco_u_know_about_family" } ] }
+          ]
         },
         "topic": "TALK_GODCO_chef_jeremiah"
       },

--- a/data/json/npcs/godco/members/cook.json
+++ b/data/json/npcs/godco/members/cook.json
@@ -14,8 +14,7 @@
         "math": [ "n_npc_anger()", ">=", "5" ],
         "yes": "Could you be on your way, please?  I'm rather busy.",
         "no": {
-          "npc_has_var": "general_meeting_u_met_godco_chef",
-          "value": "yes",
+          "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_chef" } ],
           "yes": [ "Welcome back.", "Hello again.  What do you need?", "*waves you over.  \"Hey <u_name>.  How's it going for you?\"" ],
           "no": {
             "gendered_line": "Hello stranger, I don't think we've met before.  Its nice to meet you, name's Simon.",
@@ -30,7 +29,7 @@
         "topic": "TALK_GODCO_chef_intro",
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "general_meeting_u_met_godco_chef", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_chef" } ] } },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
         },
@@ -41,7 +40,7 @@
         "topic": "TALK_DONE",
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "general_meeting_u_met_godco_chef", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_chef" } ] } },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
         },
@@ -53,7 +52,7 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
-            { "npc_has_var": "general_meeting_u_met_godco_chef", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_chef" } ] },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
         }
@@ -64,7 +63,7 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
-            { "npc_has_var": "general_meeting_u_met_godco_chef", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_chef" } ] },
             { "not": { "u_has_var": "general_meeting_godco_joinee", "value": "yes" } },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
@@ -84,14 +83,17 @@
       {
         "text": "Can I do anything for you?",
         "condition": {
-          "and": [ { "math": [ "n_npc_anger()", "<", "5" ] }, { "npc_has_var": "general_meeting_u_met_godco_chef", "value": "yes" } ]
+          "and": [
+            { "math": [ "n_npc_anger()", "<", "5" ] },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_chef" } ] }
+          ]
         },
         "topic": "TALK_MISSION_LIST"
       },
       {
         "text": "Just saying hello.  Keep safe.",
         "topic": "TALK_DONE",
-        "condition": { "npc_has_var": "general_meeting_u_met_godco_chef", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_godco_chef" } ] }
       },
       {
         "text": "Okay, man.  I'll be on my way.",

--- a/data/json/npcs/godco/members/foodguard.json
+++ b/data/json/npcs/godco/members/foodguard.json
@@ -3,8 +3,7 @@
     "type": "talk_topic",
     "id": "TALK_GODCO_guard_food",
     "dynamic_line": {
-      "u_has_var": "dialogue_godco_godco_notalk_to_u",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ],
       "yes": "You better step away from me real quick, sinner.  I don't want your kind here.",
       "no": {
         "math": [ "n_npc_anger()", ">=", "5" ],
@@ -24,7 +23,7 @@
         "condition": {
           "and": [
             { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_food_guard" } ] } },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_GODCO_guard_food_who"
@@ -35,7 +34,7 @@
         "condition": {
           "and": [
             { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_food_guard" } ] } },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_DONE"
@@ -46,7 +45,7 @@
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
             { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_food_guard" } ] },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_GODCO_guard_food_who"
@@ -57,7 +56,7 @@
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
             { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_food_guard" } ] },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_GODCO_guard_food_idlechat"
@@ -68,7 +67,7 @@
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
             { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_food_guard" } ] },
-            { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] } }
           ]
         },
         "topic": "TALK_DONE"
@@ -76,7 +75,10 @@
       {
         "text": "Alright then, fuck you <name_b>.",
         "condition": {
-          "or": [ { "math": [ "n_npc_anger()", ">=", "5" ] }, { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } ]
+          "or": [
+            { "math": [ "n_npc_anger()", ">=", "5" ] },
+            { "compare_string": [ "yes", { "u_val": "dialogue_godco_godco_notalk_to_u" } ] }
+          ]
         },
         "topic": "TALK_DONE"
       }

--- a/data/json/npcs/godco/members/foodguard.json
+++ b/data/json/npcs/godco/members/foodguard.json
@@ -10,8 +10,7 @@
         "math": [ "n_npc_anger()", ">=", "5" ],
         "yes": "What brings you around here <name_b>?  I don't want to see your face for a while.",
         "no": {
-          "npc_has_var": "general_meeting_u_met_food_guard",
-          "value": "yes",
+          "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_food_guard" } ],
           "yes": [ "Hey there.", "You're back.", "So…?" ],
           "no": "Hello.  What brings you around here?"
         }
@@ -24,7 +23,7 @@
         "effect": { "npc_add_var": "general_meeting_u_met_food_guard", "value": "yes" },
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "general_meeting_u_met_food_guard", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_food_guard" } ] } },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
         },
@@ -35,7 +34,7 @@
         "effect": { "npc_add_var": "general_meeting_u_met_food_guard", "value": "yes" },
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "general_meeting_u_met_food_guard", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_food_guard" } ] } },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
         },
@@ -46,7 +45,7 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
-            { "npc_has_var": "general_meeting_u_met_food_guard", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_food_guard" } ] },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
         },
@@ -57,7 +56,7 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
-            { "npc_has_var": "general_meeting_u_met_food_guard", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_food_guard" } ] },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
         },
@@ -68,7 +67,7 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_anger()", "<", "5" ] },
-            { "npc_has_var": "general_meeting_u_met_food_guard", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_food_guard" } ] },
             { "not": { "u_has_var": "dialogue_godco_godco_notalk_to_u", "value": "yes" } }
           ]
         },

--- a/data/json/npcs/godco/shared_effects.json
+++ b/data/json/npcs/godco/shared_effects.json
@@ -39,7 +39,7 @@
       {
         "text": "This is a fake response to prevent errors.  Please dont give the player the variable below.",
         "topic": "TALK_DONE",
-        "condition": { "u_has_var": "this_is_fake_shared_godco_value_display", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "this_is_fake_shared_godco_value_display" } ] }
       }
     ]
   }

--- a/data/json/npcs/godco/visitors/TALK_CARAVAN_GUARD_PREDATORY.json
+++ b/data/json/npcs/godco/visitors/TALK_CARAVAN_GUARD_PREDATORY.json
@@ -10,14 +10,14 @@
         "condition": {
           "and": [
             { "u_has_mission": "MISSION_INVESTIGATE_TRADER" },
-            { "not": { "npc_has_var": "general_trade_u_talked_about_records", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "general_trade_u_talked_about_records" } ] } }
           ]
         },
         "topic": "TALK_CARAVAN_GUARD_PREDATORY_PICKUP"
       },
       {
         "text": "I'm back for the records, and I have the money.",
-        "condition": { "npc_has_var": "general_trade_u_owe_20", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "npc_val": "general_trade_u_owe_20" } ] },
         "effect": {
           "u_buy_item": "godcotrader_accounting_records_dirty",
           "cost": 2000,
@@ -28,7 +28,7 @@
       },
       {
         "text": "I'm back for the records, and I have the money.",
-        "condition": { "npc_has_var": "general_trade_u_owe_50", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "npc_val": "general_trade_u_owe_50" } ] },
         "effect": {
           "u_buy_item": "godcotrader_accounting_records_dirty",
           "cost": 5000,
@@ -39,7 +39,7 @@
       },
       {
         "text": "I'm back for the records, and I have the money.",
-        "condition": { "npc_has_var": "general_trade_u_owe_150", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "npc_val": "general_trade_u_owe_150" } ] },
         "effect": {
           "u_buy_item": "godcotrader_accounting_records_dirty",
           "cost": 15000,

--- a/data/json/npcs/holdouts/Mr_Lapin.json
+++ b/data/json/npcs/holdouts/Mr_Lapin.json
@@ -241,7 +241,7 @@
     "start": {
       "assign_mission_target": { "om_terrain": "farm_isherwood_2", "om_special": "Isherwood Farm Mutable", "reveal_radius": 3, "search_range": 360 }
     },
-    "goal_condition": { "u_has_var": "u_met_an_isherwood", "value": "yes" },
+    "goal_condition": { "compare_string": [ "yes", { "u_val": "u_met_an_isherwood" } ] },
     "value": 5000,
     "origins": [ "ORIGIN_SECONDARY" ],
     "dialogue": {

--- a/data/json/npcs/holdouts/NC_GLOOSCAP.json
+++ b/data/json/npcs/holdouts/NC_GLOOSCAP.json
@@ -14,8 +14,7 @@
     "type": "talk_topic",
     "id": "TALK_GLOOSCAP",
     "dynamic_line": {
-      "u_has_var": "general_meeting_u_met_glooscap",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "general_meeting_u_met_glooscap" } ],
       "yes": [
         "Good to see you again, how can I help you?",
         {
@@ -37,29 +36,32 @@
     "responses": [
       {
         "text": "Glooscap?  That's a funny name.  Is it foreign?",
-        "condition": { "not": { "u_has_var": "general_meeting_u_met_glooscap", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_glooscap" } ] } },
         "topic": "TALK_GLOOSCAP_WHERE"
       },
       {
         "text": "[INT 11]  Like the Wabanaki myth?",
         "topic": "TALK_GLOOSCAP_MYTH",
         "condition": {
-          "and": [ { "u_has_intelligence": 11 }, { "not": { "u_has_var": "general_meeting_u_accused_malsumis", "value": "yes" } } ]
+          "and": [
+            { "u_has_intelligence": 11 },
+            { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_u_accused_malsumis" } ] } }
+          ]
         }
       },
       {
         "text": "So.  You're dressed like a hunter.  Are you a hunter?",
         "condition": {
           "and": [
-            { "u_has_var": "general_meeting_u_met_glooscap", "value": "yes" },
-            { "not": { "u_has_var": "general_meeting_u_befriended_glooscap", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_glooscap" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_u_befriended_glooscap" } ] } }
           ]
         },
         "topic": "TALK_GLOOSCAP_HUNTER"
       },
       {
         "text": "Have you had any luck out there?",
-        "condition": { "u_has_var": "general_meeting_u_befriended_glooscap", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_befriended_glooscap" } ] },
         "effect": "start_trade",
         "topic": "TALK_GLOOSCAP"
       },

--- a/data/json/npcs/holdouts/Rural-Cowboy_Friendly.json
+++ b/data/json/npcs/holdouts/Rural-Cowboy_Friendly.json
@@ -14,8 +14,7 @@
     "type": "talk_topic",
     "id": "TALK_COWBOYFR_MAIN",
     "dynamic_line": {
-      "u_has_var": "dialogue_first_meeting_talked_to_cowboyfr",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_cowboyfr" } ],
       "yes": "Hello again.",
       "no": "Ayuh, I was thinkin' it's just another monstah skulkin' about.  Who are you?"
     },
@@ -24,27 +23,27 @@
       {
         "text": "Just a survivor, looking around.  What are you doing here?",
         "topic": "TALK_COWBOYFR_INTRODUCTION",
-        "condition": { "not": { "u_has_var": "dialogue_first_meeting_talked_to_cowboyfr", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_cowboyfr" } ] } }
       },
       {
         "text": "What did you before all this?",
         "topic": "TALK_COWBOYFR_BACKGROUND",
-        "condition": { "u_has_var": "dialogue_first_meeting_talked_to_cowboyfr", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_cowboyfr" } ] }
       },
       {
         "text": "Is there something I can do for you?",
         "topic": "TALK_COWBOYFR_HELP",
-        "condition": { "u_has_var": "dialogue_first_meeting_talked_to_cowboyfr", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_cowboyfr" } ] }
       },
       {
         "text": "How about we travel together?",
         "topic": "TALK_COWBOYFR_FOLLOW",
-        "condition": { "u_has_var": "dialogue_first_meeting_talked_to_cowboyfr", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_cowboyfr" } ] }
       },
       {
         "text": "What's with the accent?",
         "topic": "TALK_COWBOYFR_ACCENT",
-        "condition": { "u_has_var": "dialogue_first_meeting_talked_to_cowboyfr", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_cowboyfr" } ] }
       }
     ]
   },

--- a/data/json/npcs/holdouts/Rural-Cowboy_Nihilist.json
+++ b/data/json/npcs/holdouts/Rural-Cowboy_Nihilist.json
@@ -13,25 +13,29 @@
   {
     "type": "talk_topic",
     "id": "TALK_COWBOYN_MAIN",
-    "dynamic_line": { "u_has_var": "dialogue_first_meeting_talked_to_cowboyn", "value": "yes", "yes": "Yeah?", "no": "Oh.  Hey there." },
+    "dynamic_line": {
+      "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_cowboyn" } ],
+      "yes": "Yeah?",
+      "no": "Oh.  Hey there."
+    },
     "speaker_effect": { "effect": { "u_add_var": "dialogue_first_meeting_talked_to_cowboyn", "value": "yes" } },
     "responses": [
       {
         "text": "Thought I heard someone.  What are you doing here?",
         "topic": "TALK_COWBOYN_INTRODUCTION1",
-        "condition": { "not": { "u_has_var": "dialogue_first_meeting_talked_to_cowboyn", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_cowboyn" } ] } }
       },
       {
         "text": "How did you get here?",
         "topic": "TALK_COWBOYN_BACKGROUND",
         "condition": {
           "and": [
-            { "u_has_var": "dialogue_first_meeting_talked_to_cowboyn", "value": "yes" },
+            { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_cowboyn" } ] },
             {
               "not": {
                 "or": [
-                  { "u_has_var": "dialogue_cowboyn_cowboynmota", "value": "yes" },
-                  { "u_has_var": "dialogue_cowboyn_cowboynmots", "value": "yes" }
+                  { "compare_string": [ "yes", { "u_val": "dialogue_cowboyn_cowboynmota" } ] },
+                  { "compare_string": [ "yes", { "u_val": "dialogue_cowboyn_cowboynmots" } ] }
                 ]
               }
             }
@@ -43,15 +47,15 @@
         "topic": "TALK_COWBOYN_FOLLOW",
         "condition": {
           "or": [
-            { "u_has_var": "dialogue_cowboyn_cowboynmota", "value": "yes" },
-            { "u_has_var": "dialogue_cowboyn_cowboynmots", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "dialogue_cowboyn_cowboynmota" } ] },
+            { "compare_string": [ "yes", { "u_val": "dialogue_cowboyn_cowboynmots" } ] }
           ]
         }
       },
       {
         "text": "See you around.",
         "topic": "TALK_DONE",
-        "condition": { "u_has_var": "dialogue_first_meeting_talked_to_cowboyn", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_cowboyn" } ] }
       }
     ]
   },
@@ -59,8 +63,7 @@
     "type": "talk_topic",
     "id": "TALK_COWBOYN_BACKGROUND",
     "dynamic_line": {
-      "u_has_var": "dialogue_cowboyn_cowboynmota",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "dialogue_cowboyn_cowboynmota" } ],
       "no": {
         "gendered_line": "Lived in a nearby town.  Normal life.  9 to 5 job.  When it all happened, we ran away to find some safety.  But there's no safety anymore, is there?",
         "relevant_genders": [ "npc" ]
@@ -73,8 +76,8 @@
         "topic": "TALK_COWBOYN_PARTNER",
         "condition": {
           "or": [
-            { "not": { "u_has_var": "dialogue_first_meeting_cowboynmota", "value": "yes" } },
-            { "not": { "u_has_var": "dialogue_first_meeting_cowboynmots", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_cowboynmota" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_cowboynmots" } ] } }
           ]
         }
       },
@@ -83,8 +86,8 @@
         "topic": "TALK_COWBOYN_MAIN",
         "condition": {
           "or": [
-            { "u_has_var": "dialogue_first_meeting_cowboynmota", "value": "yes" },
-            { "u_has_var": "dialogue_first_meeting_cowboynmots", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_cowboynmota" } ] },
+            { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_cowboynmots" } ] }
           ]
         }
       }
@@ -159,8 +162,7 @@
     "type": "talk_topic",
     "id": "TALK_COWBOYN_FOLLOW",
     "dynamic_line": {
-      "u_has_var": "dialogue_cowboyn_cowboynmots",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "dialogue_cowboyn_cowboynmots" } ],
       "yes": "I dunno.  Maybe.  Might give me something to do while I think about all this.",
       "no": { "gendered_line": "I told you to just leave me alone.", "relevant_genders": [ "npc" ] }
     },
@@ -168,18 +170,18 @@
       {
         "text": "It will.  Let's get going.",
         "topic": "TALK_DONE",
-        "condition": { "u_has_var": "dialogue_cowboyn_cowboynmots", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_cowboyn_cowboynmots" } ] },
         "effect": "follow"
       },
       {
         "text": "On a second thought, wait here a while.",
         "topic": "TALK_DONE",
-        "condition": { "u_has_var": "dialogue_cowboyn_cowboynmots", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_cowboyn_cowboynmots" } ] }
       },
       {
         "text": "Alright.  Goodbye.",
         "topic": "TALK_DONE",
-        "condition": { "not": { "u_has_var": "dialogue_cowboyn_cowboynmots", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "dialogue_cowboyn_cowboynmots" } ] } }
       }
     ]
   }

--- a/data/json/npcs/holdouts/Rural-Cowboy_Trader.json
+++ b/data/json/npcs/holdouts/Rural-Cowboy_Trader.json
@@ -15,8 +15,7 @@
     "type": "talk_topic",
     "id": "TALK_COWBOYT_MAIN",
     "dynamic_line": {
-      "u_has_var": "dialogue_first_meeting_talked_to_cowboyt",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_cowboyt" } ],
       "yes": "Hey there.",
       "no": "Hey!  Who goes there?"
     },
@@ -25,37 +24,37 @@
       {
         "text": "Just another survivor.  What are you doing here?",
         "topic": "TALK_COWBOYT_INTRODUCTION",
-        "condition": { "not": { "u_has_var": "dialogue_first_meeting_talked_to_cowboyt", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_cowboyt" } ] } }
       },
       {
         "text": "I'm you, from the future.  I've come to warn you.",
         "topic": "TALK_COWBOYT_JOKE",
-        "condition": { "not": { "u_has_var": "dialogue_first_meeting_talked_to_cowboyt", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_cowboyt" } ] } }
       },
       {
         "text": "I am a ghost.  I died here 37 years ago, yet I cannot depart this mortal realm.",
         "topic": "TALK_COWBOYT_JOKE",
-        "condition": { "not": { "u_has_var": "dialogue_first_meeting_talked_to_cowboyt", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_cowboyt" } ] } }
       },
       {
         "text": "What did you before all this?",
         "topic": "TALK_COWBOYT_BACKGROUND",
-        "condition": { "u_has_var": "dialogue_first_meeting_talked_to_cowboyt", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_cowboyt" } ] }
       },
       {
         "text": "Is there something I can help you with?",
         "topic": "TALK_MISSION_LIST",
-        "condition": { "u_has_var": "dialogue_first_meeting_talked_to_cowboyt", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_cowboyt" } ] }
       },
       {
         "text": "How about we travel together?",
         "topic": "TALK_COWBOYT_FOLLOW",
-        "condition": { "u_has_var": "dialogue_first_meeting_talked_to_cowboyt", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_cowboyt" } ] }
       },
       {
         "text": "See you around.",
         "topic": "TALK_DONE",
-        "condition": { "u_has_var": "dialogue_first_meeting_talked_to_cowboyt", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_cowboyt" } ] }
       }
     ]
   },

--- a/data/json/npcs/isherwood_farm/Isherwood_Rescue_NPC_Duplicates.json
+++ b/data/json/npcs/isherwood_farm/Isherwood_Rescue_NPC_Duplicates.json
@@ -5,10 +5,7 @@
     "dynamic_line": {
       "follower_present": "NC_ISHERWOOD_BARRY",
       "no": {
-        "u_has_var": "barry_following",
-        "type": "general",
-        "context": "meeting",
-        "value": "yes",
+        "compare_string": [ "yes", { "u_val": "general_meeting_barry_following" } ],
         "no": [
           "What's up?  Change of plans?",
           "Everything OK?",
@@ -33,7 +30,7 @@
         "condition": {
           "and": [
             { "math": [ "isherwood_family_coming", "==", "1" ] },
-            { "u_has_var": "barry_following", "type": "general", "context": "meeting", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "general_meeting_barry_following" } ] }
           ]
         },
         "effect": [

--- a/data/json/npcs/isherwood_farm/NPC_Barry_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Barry_Isherwood.json
@@ -259,7 +259,7 @@
         "topic": "TALK_ISHERWOOD_BARRY_Skywalker",
         "condition": {
           "and": [
-            { "u_has_var": "too_short_to_be_a_stormtrooper", "value": "unclear" },
+            { "compare_string": [ "unclear", { "u_val": "too_short_to_be_a_stormtrooper" } ] },
             {
               "and": [
                 { "not": { "npc_near_om_location": "barry_mi-go_scout_tower_1", "range": 3 } },
@@ -310,7 +310,7 @@
         "topic": "TALK_ISHERWOOD_BARRY_TOWER_farm",
         "condition": {
           "and": [
-            { "u_has_var": "u_dont_know_about_farm", "type": "general", "context": "knowledge", "value": "yes" },
+            { "compare_string": [ "yes", { "u_val": "general_knowledge_u_dont_know_about_farm" } ] },
             { "not": { "u_has_mission": "MISSION_ISHERWOOD_BARRY_RETURN_TO_FARM" } },
             {
               "and": [
@@ -328,7 +328,7 @@
         "topic": "TALK_ISHERWOOD_BARRY_TOWER_farm_directions",
         "condition": {
           "and": [
-            { "u_has_var": "u_thinking_about_farm", "type": "general", "context": "knowledge", "value": "yes" },
+            { "compare_string": [ "yes", { "u_val": "general_knowledge_u_thinking_about_farm" } ] },
             { "not": { "u_has_mission": "MISSION_ISHERWOOD_BARRY_RETURN_TO_FARM" } },
             {
               "and": [
@@ -407,8 +407,7 @@
               "concatenate": [
                 "*lights up as you approach, but also looks wary.  \"",
                 {
-                  "u_has_var": "too_short_to_be_a_stormtrooper",
-                  "value": "unclear",
+                  "compare_string": [ "unclear", { "u_val": "too_short_to_be_a_stormtrooper" } ],
                   "yes": "Hey, Jedi.\"",
                   "no": "Hey, <name_g>.\""
                 },

--- a/data/json/npcs/isherwood_farm/NPC_Carlos_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Carlos_Isherwood.json
@@ -65,7 +65,12 @@
         "text": "Hi, Jack and Claire suggested I come talk to you about a job.",
         "topic": "TALK_CARLOS_FORGE",
         "effect": [ { "u_add_var": "u_met_Carlos_Isherwood", "value": "yes" } ],
-        "condition": { "and": [ { "not": { "u_is_wearing": "badge_marshal" } }, { "u_has_var": "u_learned_about_jesse", "value": "yes" } ] }
+        "condition": {
+          "and": [
+            { "not": { "u_is_wearing": "badge_marshal" } },
+            { "compare_string": [ "yes", { "u_val": "u_learned_about_jesse" } ] }
+          ]
+        }
       },
       {
         "text": "Can I do anything for you?",
@@ -126,7 +131,10 @@
         "text": "Look, I took it off to show I'm not here as a marshal.  I'm just here as a traveler, someone who can maybe help you out.  I know you've got problems bigger than you can handle right now.",
         "topic": "TALK_ISHERWOOD_CARLOS_MarshalSaveBarry",
         "condition": {
-          "and": [ { "u_has_var": "u_learned_barry_missing", "value": "yes" }, { "not": { "u_is_wearing": "badge_marshal" } } ]
+          "and": [
+            { "compare_string": [ "yes", { "u_val": "u_learned_barry_missing" } ] },
+            { "not": { "u_is_wearing": "badge_marshal" } }
+          ]
         }
       },
       { "text": "…(Leave)", "topic": "TALK_DONE" }
@@ -167,7 +175,10 @@
         "text": "Fine.  Thanks.  Tell me more about what happened to Barry.",
         "topic": "TALK_CARLOS_BARRY",
         "condition": {
-          "and": [ { "not": { "u_is_wearing": "badge_marshal" } }, { "u_has_var": "u_learned_barry_missing", "value": "yes" } ]
+          "and": [
+            { "not": { "u_is_wearing": "badge_marshal" } },
+            { "compare_string": [ "yes", { "u_val": "u_learned_barry_missing" } ] }
+          ]
         }
       },
       { "text": "Let's talk about something else.", "topic": "TALK_ISHERWOOD_CARLOS_TOPICS" },
@@ -184,7 +195,10 @@
         "text": "I heard about Barry, can you tell me what captured him?",
         "topic": "TALK_CARLOS_BARRY",
         "condition": {
-          "and": [ { "not": { "u_is_wearing": "badge_marshal" } }, { "u_has_var": "u_learned_barry_missing", "value": "yes" } ]
+          "and": [
+            { "not": { "u_is_wearing": "badge_marshal" } },
+            { "compare_string": [ "yes", { "u_val": "u_learned_barry_missing" } ] }
+          ]
         }
       },
       { "text": "Let's talk about something else.", "topic": "TALK_ISHERWOOD_CARLOS_TOPICS" },
@@ -274,7 +288,10 @@
         "text": "I heard about Barry, can you tell me what captured him?",
         "topic": "TALK_CARLOS_BARRY",
         "condition": {
-          "and": [ { "u_has_var": "u_learned_barry_missing", "value": "yes" }, { "not": { "u_is_wearing": "badge_marshal" } } ]
+          "and": [
+            { "compare_string": [ "yes", { "u_val": "u_learned_barry_missing" } ] },
+            { "not": { "u_is_wearing": "badge_marshal" } }
+          ]
         }
       },
       {
@@ -295,12 +312,12 @@
       {
         "text": "Where can I find Chris?",
         "topic": "TALK_CARLOS_CHRIS1",
-        "condition": { "not": { "u_has_var": "u_found_chris_for_carlos", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "u_found_chris_for_carlos" } ] } }
       },
       {
         "text": "Where can I find Chris?",
         "topic": "TALK_CARLOS_CHRIS2",
-        "condition": { "u_has_var": "u_found_chris_for_carlos", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "u_found_chris_for_carlos" } ] }
       },
       { "text": "Can I do anything for you?", "topic": "TALK_MISSION_LIST" },
       { "text": "I'd better get going.", "topic": "TALK_DONE" }

--- a/data/json/npcs/isherwood_farm/NPC_Carlos_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Carlos_Isherwood.json
@@ -280,7 +280,7 @@
       {
         "text": "Is your forge operational?",
         "topic": "TALK_CARLOS_FORGE1",
-        "condition": { "not": { "npc_has_var": "carlos_has_anvil", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "npc_val": "carlos_has_anvil" } ] } }
       },
       {
         "text": "Is your forge operational?",

--- a/data/json/npcs/isherwood_farm/NPC_Chris_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Chris_Isherwood.json
@@ -66,7 +66,10 @@
         "text": "I was talking to Luke earlier, said you had some interesting ideas about the world ending.  Is it tied to Barry's abduction?",
         "topic": "TALK_CHRIS_THEORIES",
         "condition": {
-          "and": [ { "not": { "u_is_wearing": "badge_marshal" } }, { "u_has_var": "u_heard_about_chris_ideas", "value": "yes" } ]
+          "and": [
+            { "not": { "u_is_wearing": "badge_marshal" } },
+            { "compare_string": [ "yes", { "u_val": "u_heard_about_chris_ideas" } ] }
+          ]
         }
       },
       {
@@ -191,8 +194,7 @@
           "u_is_wearing": "badge_marshal",
           "yes": "I see that badge.  You need to leave our land, my relatives have no fondness for Marshals.\"",
           "no": {
-            "u_has_var": "isherwood_chris_marshal_badge",
-            "value": "seen",
+            "compare_string": [ "seen", { "u_val": "isherwood_chris_marshal_badge" } ],
             "yes": {
               "gendered_line": "I see you took the badge off.  Fine, then, but you'd better not let anyone here know you've got ties to the Marshals.\"",
               "relevant_genders": [ "u" ]
@@ -222,7 +224,9 @@
       {
         "text": "I was talking to Luke earlier, said you had some interesting ideas about the world ending.",
         "topic": "TALK_CHRIS_THEORIES",
-        "condition": { "and": [ { "not": { "u_is_wearing": "badge_marshal" } }, { "u_has_var": "u_heard_about_chris", "value": "yes" } ] }
+        "condition": {
+          "and": [ { "not": { "u_is_wearing": "badge_marshal" } }, { "compare_string": [ "yes", { "u_val": "u_heard_about_chris" } ] } ]
+        }
       },
       { "text": "Let's talk about something else.", "topic": "TALK_ISHERWOOD_CHRIS_TOPICS" },
       { "text": "I'd better get going.", "topic": "TALK_DONE" }
@@ -380,7 +384,7 @@
     "responses": [
       {
         "text": "What about Lisa?  She seems like she could handle herself.",
-        "condition": { "u_has_var": "u_met_lisa_isherwood", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "u_met_lisa_isherwood" } ] },
         "topic": "TALK_ISHERWOOD_CHRIS_RESCUE_BARRY_TAKE_LISA2"
       },
       {
@@ -491,8 +495,8 @@
         "text": "We're going to need some way to breach the tower itself, possibly some form of explosives.  Do you know anyone who could help us with that?",
         "condition": {
           "and": [
-            { "u_has_var": "u_been_to_migos", "value": "yes" },
-            { "not": { "u_has_var": "chris_planned_for_bomb", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "u_been_to_migos" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "chris_planned_for_bomb" } ] } }
           ]
         },
         "topic": "TALK_ISHERWOOD_CHRIS_RESCUE_BARRY_PLAN_Bomb"
@@ -547,8 +551,8 @@
         "text": "We're going to need some way to breach the tower itself, possibly some form of explosives.  Do you know anyone who could help us with that?",
         "condition": {
           "and": [
-            { "u_has_var": "u_been_to_migos", "value": "yes" },
-            { "not": { "u_has_var": "chris_planned_for_bomb", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "u_been_to_migos" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "chris_planned_for_bomb" } ] } }
           ]
         },
         "topic": "TALK_ISHERWOOD_CHRIS_RESCUE_BARRY_PLAN_Bomb"

--- a/data/json/npcs/isherwood_farm/NPC_Claire_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Claire_Isherwood.json
@@ -140,7 +140,9 @@
         "text": "Hi, Jack suggested I stop by and say hello.",
         "topic": "TALK_ISHERWOOD_CLAIRE_TALK3",
         "effect": [ { "u_add_var": "u_met_Claire_Isherwood", "value": "yes" } ],
-        "condition": { "and": [ { "not": { "u_is_wearing": "badge_marshal" } }, { "u_has_var": "u_met_Jack_Isherwood", "value": "yes" } ] }
+        "condition": {
+          "and": [ { "not": { "u_is_wearing": "badge_marshal" } }, { "compare_string": [ "yes", { "u_val": "u_met_Jack_Isherwood" } ] } ]
+        }
       },
       {
         "text": "Can I do anything for you?",

--- a/data/json/npcs/isherwood_farm/NPC_Eddie_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Eddie_Isherwood.json
@@ -132,7 +132,7 @@
         "topic": "TALK_ISHERWOOD_EDDIE_Marshal",
         "condition": {
           "and": [
-            { "u_has_var": "isherwood_luke_marshal_questions", "value": "known" },
+            { "compare_string": [ "known", { "u_val": "isherwood_luke_marshal_questions" } ] },
             { "not": { "u_is_wearing": "badge_marshal" } }
           ]
         }
@@ -245,7 +245,10 @@
         "text": "I heard about Barry, such a tragedy.  Can you tell me more about what happened?",
         "topic": "TALK_ISHERWOOD_EDDIE2",
         "condition": {
-          "and": [ { "not": { "u_is_wearing": "badge_marshal" } }, { "u_has_var": "u_learned_barry_missing", "value": "yes" } ]
+          "and": [
+            { "not": { "u_is_wearing": "badge_marshal" } },
+            { "compare_string": [ "yes", { "u_val": "u_learned_barry_missing" } ] }
+          ]
         }
       },
       { "text": "Let's talk about something else.", "topic": "TALK_ISHERWOOD_EDDIE_TOPICS" },

--- a/data/json/npcs/isherwood_farm/NPC_Jack_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Jack_Isherwood.json
@@ -171,7 +171,10 @@
         "text": "I'm here to deliver some resources.",
         "topic": "TALK_ISHERWOOD_JACK_RESOURCES",
         "condition": {
-          "and": [ { "not": { "u_is_wearing": "badge_marshal" } }, { "u_has_var": "u_scavenge_for_Jack_Isherwood", "value": "yes" } ]
+          "and": [
+            { "not": { "u_is_wearing": "badge_marshal" } },
+            { "compare_string": [ "yes", { "u_val": "u_scavenge_for_Jack_Isherwood" } ] }
+          ]
         }
       },
       {
@@ -182,7 +185,9 @@
       {
         "text": "Hey, good to see you again.",
         "topic": "TALK_ISHERWOOD_JACK_TOPICS",
-        "condition": { "and": [ { "not": { "u_is_wearing": "badge_marshal" } }, { "u_has_var": "u_met_Jack_Isherwood", "value": "yes" } ] }
+        "condition": {
+          "and": [ { "not": { "u_is_wearing": "badge_marshal" } }, { "compare_string": [ "yes", { "u_val": "u_met_Jack_Isherwood" } ] } ]
+        }
       },
       {
         "text": "Can I do anything for you?",
@@ -296,7 +301,10 @@
         "text": "I'm here to deliver some resources.",
         "topic": "TALK_ISHERWOOD_JACK_RESOURCES",
         "condition": {
-          "and": [ { "not": { "u_is_wearing": "badge_marshal" } }, { "u_has_var": "u_scavenge_for_Jack_Isherwood", "value": "yes" } ]
+          "and": [
+            { "not": { "u_is_wearing": "badge_marshal" } },
+            { "compare_string": [ "yes", { "u_val": "u_scavenge_for_Jack_Isherwood" } ] }
+          ]
         }
       },
       { "text": "A farm must be a pretty safe place these days.", "topic": "TALK_JACK_FARM" },

--- a/data/json/npcs/isherwood_farm/NPC_Jesse_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Jesse_Isherwood.json
@@ -81,7 +81,9 @@
       {
         "text": "Hi, Jack and Claire suggested I come down here and meet you.",
         "topic": "TALK_MET_JACK_CLAIRE",
-        "condition": { "and": [ { "not": { "u_is_wearing": "badge_marshal" } }, { "u_has_var": "u_met_Jack_Isherwood", "value": "yes" } ] }
+        "condition": {
+          "and": [ { "not": { "u_is_wearing": "badge_marshal" } }, { "compare_string": [ "yes", { "u_val": "u_met_Jack_Isherwood" } ] } ]
+        }
       },
       {
         "text": "Can I do anything for you?",

--- a/data/json/npcs/isherwood_farm/NPC_Lisa_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Lisa_Isherwood.json
@@ -72,13 +72,20 @@
         "text": "Hi, I'm looking for Jesse.",
         "topic": "TALK_LISA_JESSE",
         "effect": [ { "u_add_var": "u_met_Lisa_Isherwood", "value": "yes" } ],
-        "condition": { "and": [ { "not": { "u_is_wearing": "badge_marshal" } }, { "u_has_var": "u_learned_about_jesse", "value": "yes" } ] }
+        "condition": {
+          "and": [
+            { "not": { "u_is_wearing": "badge_marshal" } },
+            { "compare_string": [ "yes", { "u_val": "u_learned_about_jesse" } ] }
+          ]
+        }
       },
       {
         "text": "Hi, I'm looking for Chris.",
         "topic": "TALK_LISA_CHRIS",
         "effect": [ { "u_add_var": "u_met_Lisa_Isherwood", "value": "yes" } ],
-        "condition": { "and": [ { "not": { "u_is_wearing": "badge_marshal" } }, { "u_has_var": "u_heard_about_chris", "value": "yes" } ] }
+        "condition": {
+          "and": [ { "not": { "u_is_wearing": "badge_marshal" } }, { "compare_string": [ "yes", { "u_val": "u_heard_about_chris" } ] } ]
+        }
       },
       {
         "text": "I talked to Chris about rescuing Barry.  He thinks you might be able to help.",

--- a/data/json/npcs/isherwood_farm/NPC_Luke_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Luke_Isherwood.json
@@ -61,8 +61,7 @@
           "u_is_wearing": "badge_marshal",
           "yes": ", then scowls as he spots the Old Guard Marshal badge gleaming on your chest.  \"I see that badge.  You should leave before my father spots it.\"",
           "no": {
-            "u_has_var": "isherwood_luke_marshal_badge",
-            "value": "seen",
+            "compare_string": [ "seen", { "u_val": "isherwood_luke_marshal_badge" } ],
             "yes": ", and nods once when he sees you've taken off your marshal badge.  \"Tread carefully around here, we don't have a lot of respect for your type of lawman.\"",
             "no": {
               "u_male": true,
@@ -85,26 +84,29 @@
         "text": "What's wrong with me being a marshal?",
         "topic": "TALK_ISHERWOOD_LUKE_Marshal",
         "condition": {
-          "and": [ { "u_has_var": "isherwood_luke_marshal_badge", "value": "seen" }, { "not": { "u_is_wearing": "badge_marshal" } } ]
+          "and": [
+            { "compare_string": [ "seen", { "u_val": "isherwood_luke_marshal_badge" } ] },
+            { "not": { "u_is_wearing": "badge_marshal" } }
+          ]
         }
       },
       {
         "text": "Your dad said you were out here fixing up this place.",
         "topic": "TALK_ISHERWOOD_LUKE_TALK1",
         "effect": [ { "u_add_var": "u_met_Luke_Isherwood", "value": "yes" }, { "u_add_var": "u_met_an_isherwood", "value": "yes" } ],
-        "condition": { "u_has_var": "u_met_Eddie_Isherwood", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "u_met_Eddie_Isherwood" } ] }
       },
       {
         "text": "How are those books doing for you?",
         "topic": "TALK_ISHERWOOD_LUKE_BOOKS1",
-        "condition": { "not": { "u_has_var": "u_saved_barry_isherwood", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "u_saved_barry_isherwood" } ] } }
       },
       {
         "text": "Chris and I have a little project for you that we've cooked up, if you're interested.",
         "condition": {
           "and": [
             { "u_has_mission": "MISSION_ISHERWOOD_CHRIS_1" },
-            { "u_has_var": "chris_planned_for_bomb", "value": "yes" },
+            { "compare_string": [ "yes", { "u_val": "chris_planned_for_bomb" } ] },
             {
               "and": [
                 { "not": { "u_has_mission": "MISSION_LUKE_RETRIEVE_TRUCK" } },
@@ -214,7 +216,7 @@
       {
         "text": "Because of Barry?",
         "topic": "TALK_ISHERWOOD_LUKE_BOOKS_BARRY",
-        "condition": { "u_has_var": "u_learned_barry_missing", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "u_learned_barry_missing" } ] }
       },
       { "text": "Let's talk about something else.", "topic": "TALK_ISHERWOOD_LUKE_TOPICS" },
       { "text": "I'd better get going.", "topic": "TALK_DONE" }
@@ -254,8 +256,7 @@
       "concatenate": [
         "*gestures around at the worn down shed surrounding you.  \"I've been cleaning up this old building to make it into a workshop.  I want to put up a pottery kiln and forge.  My dad doesn't want me leaving the farm to find some things",
         {
-          "u_has_var": "u_saved_barry_isherwood",
-          "value": "yes",
+          "compare_string": [ "yes", { "u_val": "u_saved_barry_isherwood" } ],
           "yes": ", says it is too dangerous.  After what happened with Barry, well, I tend to agree with him.\"  He smiles thinly.  \"Don't want you to have to run out saving another one of us, right?\"",
           "no": ", says it's too dangerous.  I used to think he was being a pain in the butt, but lately…\" he stops abruptly, and says nothing more."
         }
@@ -309,12 +310,12 @@
       {
         "text": "I already know Barry got captured.  I just wanted to know a bit more about it.  Maybe I can help.",
         "topic": "TALK_LUKE_BARRY2",
-        "condition": { "u_has_var": "u_learned_barry_missing", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "u_learned_barry_missing" } ] }
       },
       {
         "text": "I might be able to help, though.",
         "topic": "TALK_LUKE_BARRYhelp",
-        "condition": { "not": { "u_has_var": "u_learned_barry_missing", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "u_learned_barry_missing" } ] } }
       },
       { "text": "Let's talk about something else.", "topic": "TALK_ISHERWOOD_LUKE_TOPICS" },
       { "text": "I'd better get going.", "topic": "TALK_DONE" }
@@ -377,8 +378,8 @@
         "topic": "TALK_LUKE_EDDIE_NoBarry",
         "condition": {
           "and": [
-            { "u_has_var": "u_met_Eddie_Isherwood", "value": "yes" },
-            { "not": { "u_has_var": "u_saved_barry_isherwood", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "u_met_Eddie_Isherwood" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "u_saved_barry_isherwood" } ] } }
           ]
         }
       },
@@ -386,7 +387,10 @@
         "text": "Tell me about your dad.",
         "topic": "TALK_LUKE_EDDIE_YesBarry",
         "condition": {
-          "and": [ { "u_has_var": "u_met_Eddie_Isherwood", "value": "yes" }, { "u_has_var": "u_saved_barry_isherwood", "value": "yes" } ]
+          "and": [
+            { "compare_string": [ "yes", { "u_val": "u_met_Eddie_Isherwood" } ] },
+            { "compare_string": [ "yes", { "u_val": "u_saved_barry_isherwood" } ] }
+          ]
         }
       },
       { "text": "I'd better get going.", "topic": "TALK_DONE" }

--- a/data/json/npcs/island_prison/prisoners.json
+++ b/data/json/npcs/island_prison/prisoners.json
@@ -130,8 +130,7 @@
     "id": "TALK_PRISONER_GREET",
     "type": "talk_topic",
     "dynamic_line": {
-      "u_has_var": "dialogue_first_meeting_first_meeting",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_first_meeting" } ],
       "no": {
         "gendered_line": "Hey, who the fuck are you?  I haven't seen you 'round.  Ah, fuck it, it doesn't matter.\nHere's the rules.  The first and most important one: ALWAYS CLOSE THE FUCKING ENTRY DOOR BEHIND YOUR ASS!  If you're okay with that, the following rules are: don't fuck with us, don't steal from us, don't start a fight without a reason with someone from us.  Got it, punk?  Now get lost.",
         "relevant_genders": [ "u" ]
@@ -143,15 +142,15 @@
       {
         "text": "Yeah, I got it.  See ya.",
         "topic": "TALK_DONE",
-        "condition": { "not": { "u_has_var": "dialogue_first_meeting_first_meeting", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_first_meeting" } ] } }
       },
       {
         "text": "I just wanted to ask if you have a job for me.",
         "topic": "TALK_PRISONER_ANNOYED",
         "condition": {
           "and": [
-            { "u_has_var": "dialogue_first_meeting_first_meeting", "value": "yes" },
-            { "not": { "u_has_var": "dialogue_annoyed_greeter_talked_to_greeter", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_first_meeting" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_annoyed_greeter_talked_to_greeter" } ] } }
           ]
         }
       },
@@ -160,9 +159,9 @@
         "topic": "TALK_PRISONER_ANGRY",
         "condition": {
           "and": [
-            { "u_has_var": "dialogue_first_meeting_first_meeting", "value": "yes" },
-            { "u_has_var": "dialogue_annoyed_greeter_talked_to_greeter", "value": "yes" },
-            { "not": { "u_has_var": "dialogue_angry_greeter_talked_to_greeter", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_first_meeting" } ] },
+            { "compare_string": [ "yes", { "u_val": "dialogue_annoyed_greeter_talked_to_greeter" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_angry_greeter_talked_to_greeter" } ] } }
           ]
         }
       },
@@ -171,8 +170,8 @@
         "topic": "TALK_PRISONER_READY_TO_MUG",
         "condition": {
           "and": [
-            { "u_has_var": "dialogue_first_meeting_first_meeting", "value": "yes" },
-            { "u_has_var": "dialogue_angry_greeter_talked_to_greeter", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_first_meeting" } ] },
+            { "compare_string": [ "yes", { "u_val": "dialogue_angry_greeter_talked_to_greeter" } ] }
           ]
         }
       },
@@ -183,8 +182,7 @@
     "id": "TALK_PRISONER_ANNOYED",
     "type": "talk_topic",
     "dynamic_line": {
-      "u_has_var": "dialogue_annoyed_greeter_talked_to_greeter",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "dialogue_annoyed_greeter_talked_to_greeter" } ],
       "no": "Do I have a <swear> exclamation sign over my <swear> head, like I'm a <swear> quest-giver from some <swear> video game?",
       "yes": "<get_lost>"
     },
@@ -193,7 +191,7 @@
       {
         "text": "No, of course not!  Sorry, I'm leaving.",
         "topic": "TALK_DONE",
-        "condition": { "not": { "u_has_var": "dialogue_annoyed_greeter_talked_to_greeter", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "dialogue_annoyed_greeter_talked_to_greeter" } ] } }
       },
       { "text": "Hey, <fuck_you>!", "topic": "TALK_DONE", "effect": "hostile" }
     ]
@@ -202,8 +200,7 @@
     "id": "TALK_PRISONER_ANGRY",
     "type": "talk_topic",
     "dynamic_line": {
-      "u_has_var": "dialogue_annoyed_greeter_talked_to_greeter",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "dialogue_annoyed_greeter_talked_to_greeter" } ],
       "no": "<get_lost>",
       "yes": {
         "gendered_line": "Are you deaf or stupid?  I said I don't give a fuck for you and your <swear> problems.  Bother me one more time, and you'll regret that.  <get_lost>",
@@ -215,7 +212,7 @@
       {
         "text": "Ok, sorry, I promise I won't bother you anymore.",
         "topic": "TALK_DONE",
-        "condition": { "not": { "u_has_var": "dialogue_angry_greeter_talked_to_greeter", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "dialogue_angry_greeter_talked_to_greeter" } ] } }
       },
       { "text": "Hey, <fuck_you>!", "topic": "TALK_DONE", "effect": "hostile" }
     ]
@@ -246,26 +243,21 @@
     "id": "TALK_PRISONER_LEADER_GREET",
     "type": "talk_topic",
     "dynamic_line": {
-      "u_has_var": "mission_military_id_prisoner_leader_mission",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "mission_military_id_prisoner_leader_mission" } ],
       "yes": "I have nothing more to say to you.  <get_lost>",
       "no": {
-        "u_has_var": "mission_accepted_prisoner_leader_mission",
-        "value": "yes",
+        "compare_string": [ "yes", { "u_val": "mission_accepted_prisoner_leader_mission" } ],
         "yes": "So, what are you waiting for?",
         "no": {
-          "u_has_var": "mission_completed_prisoner_leader_mission",
-          "value": "yes",
+          "compare_string": [ "yes", { "u_val": "mission_completed_prisoner_leader_mission" } ],
           "yes": {
             "gendered_line": "I don't know if you know, but there are sewers underneath the prison.  I was planning an escape long before <the_cataclysm>, and while I was working on cleaning the sewers, I noticed a damaged wall section.  There was a flow of fresh air coming out of it, so I think it's leading to the surface.  It could be your way to freedom.  Feel free to use it.",
             "relevant_genders": [ "npc" ]
           },
           "no": {
-            "u_has_var": "dialogue_first_meeting_talked_to_leader",
-            "value": "yes",
+            "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_leader" } ],
             "yes": {
-              "u_has_var": "dialogue_cannibal_talked_to_leader",
-              "value": "yes",
+              "compare_string": [ "yes", { "u_val": "dialogue_cannibal_talked_to_leader" } ],
               "no": "It's you again.",
               "yes": "You are what you eat, as they say."
             },
@@ -281,8 +273,8 @@
         "topic": "TALK_PRISONER_LEADER_INQUIRY",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "dialogue_first_meeting_talked_to_leader", "value": "yes" } },
-            { "not": { "u_has_var": "mission_completed_prisoner_leader_mission", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_leader" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "mission_completed_prisoner_leader_mission" } ] } }
           ]
         }
       },
@@ -291,8 +283,8 @@
         "topic": "TALK_PRISONER_LEADER_FROWN",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "dialogue_first_meeting_talked_to_leader", "value": "yes" } },
-            { "not": { "u_has_var": "mission_completed_prisoner_leader_mission", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_leader" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "mission_completed_prisoner_leader_mission" } ] } }
           ]
         }
       },
@@ -302,9 +294,9 @@
         "condition": {
           "and": [
             { "u_has_trait": "CANNIBAL" },
-            { "not": { "u_has_var": "dialogue_first_meeting_talked_to_leader", "value": "yes" } },
-            { "not": { "u_has_var": "dialogue_cannibal_talked_to_leader", "value": "yes" } },
-            { "not": { "u_has_var": "mission_completed_prisoner_leader_mission", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_leader" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_cannibal_talked_to_leader" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "mission_completed_prisoner_leader_mission" } ] } }
           ]
         }
       },
@@ -313,25 +305,25 @@
         "topic": "TALK_PRISONER_LEADER_GIVES_WORK",
         "condition": {
           "and": [
-            { "u_has_var": "dialogue_first_meeting_talked_to_leader", "value": "yes" },
-            { "not": { "u_has_var": "mission_accepted_prisoner_leader_mission", "value": "yes" } },
-            { "not": { "u_has_var": "mission_completed_prisoner_leader_mission", "value": "yes" } },
-            { "not": { "u_has_var": "mission_military_id_prisoner_leader_mission", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_leader" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "mission_accepted_prisoner_leader_mission" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "mission_completed_prisoner_leader_mission" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "mission_military_id_prisoner_leader_mission" } ] } }
           ]
         }
       },
       {
         "text": "I'm on my way.",
         "topic": "TALK_DONE",
-        "condition": { "u_has_var": "mission_accepted_prisoner_leader_mission", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "mission_accepted_prisoner_leader_mission" } ] }
       },
       {
         "text": "I don't know if I'll take your advice, but thanks nevertheless.",
         "topic": "TALK_DONE",
         "condition": {
           "and": [
-            { "u_has_var": "mission_completed_prisoner_leader_mission", "value": "yes" },
-            { "not": { "u_has_var": "mission_military_id_prisoner_leader_mission", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "mission_completed_prisoner_leader_mission" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "mission_military_id_prisoner_leader_mission" } ] } }
           ]
         }
       },
@@ -340,8 +332,8 @@
         "topic": "TALK_PRISONER_LEADER_DEMANDED_SUBSTANTIAL_REWARD",
         "condition": {
           "and": [
-            { "u_has_var": "mission_completed_prisoner_leader_mission", "value": "yes" },
-            { "not": { "u_has_var": "mission_military_id_prisoner_leader_mission", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "mission_completed_prisoner_leader_mission" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "mission_military_id_prisoner_leader_mission" } ] } }
           ]
         }
       },
@@ -350,17 +342,17 @@
         "topic": "TALK_DONE",
         "condition": {
           "and": [
-            { "u_has_var": "dialogue_first_meeting_talked_to_leader", "value": "yes" },
-            { "not": { "u_has_var": "mission_accepted_prisoner_leader_mission", "value": "yes" } },
-            { "not": { "u_has_var": "mission_completed_prisoner_leader_mission", "value": "yes" } },
-            { "not": { "u_has_var": "mission_military_id_prisoner_leader_mission", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_leader" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "mission_accepted_prisoner_leader_mission" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "mission_completed_prisoner_leader_mission" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "mission_military_id_prisoner_leader_mission" } ] } }
           ]
         }
       },
       {
         "text": "Okay.",
         "topic": "TALK_DONE",
-        "condition": { "u_has_var": "mission_military_id_prisoner_leader_mission", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "mission_military_id_prisoner_leader_mission" } ] }
       }
     ]
   },
@@ -425,8 +417,7 @@
     "id": "TALK_PRISONER_LEADER_GIVES_WORK",
     "type": "talk_topic",
     "dynamic_line": {
-      "u_has_var": "mission_accepted_prisoner_leader_mission",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "mission_accepted_prisoner_leader_mission" } ],
       "no": "I need you to retrieve some stuff from a locked safe.  Interested?",
       "yes": "So, what are you waiting for?"
     },
@@ -437,7 +428,7 @@
         "condition": {
           "and": [
             { "u_has_item": "id_military" },
-            { "not": { "u_has_var": "mission_accepted_prisoner_leader_mission", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "mission_accepted_prisoner_leader_mission" } ] } }
           ]
         }
       },
@@ -446,8 +437,8 @@
         "topic": "TALK_PRISONER_LEADER_ASKED_ABOUT_SAFE_CONTENTS",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "mission_military_id_prisoner_leader_mission", "value": "yes" } },
-            { "not": { "u_has_var": "mission_accepted_prisoner_leader_mission", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "mission_military_id_prisoner_leader_mission" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "mission_accepted_prisoner_leader_mission" } ] } }
           ]
         }
       },
@@ -456,8 +447,8 @@
         "topic": "TALK_PRISONER_LEADER_ASKED_ABOUT_WHAT_FOR_DO_YOU_NEED_IT",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "mission_military_id_prisoner_leader_mission", "value": "yes" } },
-            { "not": { "u_has_var": "mission_accepted_prisoner_leader_mission", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "mission_military_id_prisoner_leader_mission" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "mission_accepted_prisoner_leader_mission" } ] } }
           ]
         }
       },
@@ -466,23 +457,23 @@
         "topic": "TALK_MISSION_OFFER",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "mission_military_id_prisoner_leader_mission", "value": "yes" } },
-            { "not": { "u_has_var": "mission_accepted_prisoner_leader_mission", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "mission_military_id_prisoner_leader_mission" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "mission_accepted_prisoner_leader_mission" } ] } }
           ]
         }
       },
       {
         "text": "I have a bad feeling about this.  Sorry, I'll pass.",
         "topic": "TALK_DONE",
-        "condition": { "not": { "u_has_var": "mission_accepted_prisoner_leader_mission", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "mission_accepted_prisoner_leader_mission" } ] } }
       },
       {
         "text": "I'm on my way.",
         "topic": "TALK_DONE",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "mission_military_id_prisoner_leader_mission", "value": "yes" } },
-            { "u_has_var": "mission_accepted_prisoner_leader_mission", "value": "yes" }
+            { "not": { "compare_string": [ "yes", { "u_val": "mission_military_id_prisoner_leader_mission" } ] } },
+            { "compare_string": [ "yes", { "u_val": "mission_accepted_prisoner_leader_mission" } ] }
           ]
         }
       }

--- a/data/json/npcs/isolated_road/isolated_road_cody_dialogue.json
+++ b/data/json/npcs/isolated_road/isolated_road_cody_dialogue.json
@@ -22,15 +22,15 @@
       { "text": "What's with all the weapons and armor?", "topic": "TALK_BLACKSMITH_SHOP_ABOUT" },
       {
         "text": "What is this place?",
-        "condition": { "not": { "u_has_var": "dialogue_artisans_blacksmith_mentioned_jay", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_mentioned_jay" } ] } },
         "topic": "TALK_BLACKSMITH_LOCATION_ABOUT"
       },
       {
         "text": "Are you and Jay close?",
         "condition": {
           "and": [
-            { "u_has_var": "dialogue_artisans_blacksmith_mentioned_jay", "value": "yes" },
-            { "not": { "u_has_var": "dialogue_artisans_blacksmith_accepted_quest", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_mentioned_jay" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_accepted_quest" } ] } }
           ]
         },
         "topic": "TALK_BLACKSMITH_JAY"
@@ -39,8 +39,8 @@
         "text": "[Motion to the sketches.] What is it that you are working on?",
         "condition": {
           "and": [
-            { "u_has_var": "dialogue_artisans_seen_blacksmith_sketches", "value": "yes" },
-            { "not": { "u_has_var": "dialogue_artisans_artisans_made_up", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "dialogue_artisans_seen_blacksmith_sketches" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_artisans_artisans_made_up" } ] } }
           ]
         },
         "topic": "TALK_BLACKSMITH_PROTOTYPE_NOT_FEELING_IT"
@@ -49,15 +49,15 @@
         "text": "[Motion to the sketches.] You seem more excited about this stuff recently.",
         "condition": {
           "and": [
-            { "u_has_var": "dialogue_artisans_seen_blacksmith_sketches", "value": "yes" },
-            { "u_has_var": "dialogue_artisans_artisans_made_up", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "dialogue_artisans_seen_blacksmith_sketches" } ] },
+            { "compare_string": [ "yes", { "u_val": "dialogue_artisans_artisans_made_up" } ] }
           ]
         },
         "topic": "TALK_BLACKSMITH_PROTOTYPE_FEELING_IT"
       },
       {
         "text": "I'd like to know more about some of your 'special' projects.",
-        "condition": { "and": [ { "u_has_var": "dialogue_artisans_blacksmith_can_prototype", "value": "yes" } ] },
+        "condition": { "and": [ { "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_can_prototype" } ] } ] },
         "topic": "TALK_BLACKSMITH_PROTOTYPE"
       },
       {
@@ -65,7 +65,7 @@
         "condition": {
           "and": [
             { "u_has_items": { "item": "bp_nomad_jumpsuit", "count": 1 } },
-            { "not": { "u_has_var": "dialogue_artisans_blacksmith_crafting_EXODII", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_crafting_EXODII" } ] } }
           ]
         },
         "topic": "TALK_BLACKSMITH_PROTOTYPE_EXODII"
@@ -75,7 +75,7 @@
         "condition": {
           "and": [
             { "u_has_items": { "item": "FMCNote", "count": 100 } },
-            { "u_has_var": "dialogue_artisans_blacksmith_can_buy_coop", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_can_buy_coop" } ] }
           ]
         },
         "effect": [
@@ -92,14 +92,14 @@
       },
       {
         "text": "Why do you hate merch?",
-        "condition": { "u_has_var": "dialogue_artisans_blacksmith_hates_currency", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_hates_currency" } ] },
         "topic": "TALK_BLACKSMITH_MONEY_RAMBLE"
       },
       {
         "text": "Any jobs you need done?",
         "condition": {
           "and": [
-            { "u_has_var": "dialogue_artisans_artisans_made_up", "value": "yes" },
+            { "compare_string": [ "yes", { "u_val": "dialogue_artisans_artisans_made_up" } ] },
             { "and": [ { "not": "has_assigned_mission" }, { "not": "has_many_assigned_missions" } ] }
           ]
         },
@@ -109,9 +109,9 @@
         "text": "Could you make me a suit of armor?",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "dialogue_artisans_gunsmith_mentioned_quest", "value": "yes" } },
-            { "not": { "u_has_var": "dialogue_artisans_blacksmith_crafting", "value": "yes" } },
-            { "u_has_var": "dialogue_artisans_blacksmith_heard_the_deal", "value": "yes" }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_artisans_gunsmith_mentioned_quest" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_crafting" } ] } },
+            { "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_heard_the_deal" } ] }
           ]
         },
         "topic": "TALK_BLACKSMITH_NOT_INTERESTED_FABRICATE"
@@ -120,11 +120,10 @@
         "text": "Could you make me a suit of armor?",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "dialogue_artisans_blacksmith_crafting", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_crafting" } ] } },
             {
               "//": "this variable means that you have completed quest 1 for Cody and shown Jay",
-              "u_has_var": "dialogue_artisans_gunsmith_mentioned_quest",
-              "value": "yes"
+              "compare_string": [ "yes", { "u_val": "dialogue_artisans_gunsmith_mentioned_quest" } ]
             }
           ]
         },
@@ -136,8 +135,8 @@
           "and": [
             { "math": [ "time_since(u_timer_artisans_u_waiting_on_armor)", "<", "time('21 d')" ] },
             { "math": [ "u_number_artisans_blacksmith_wait", "==", "3" ] },
-            { "u_has_var": "dialogue_artisans_blacksmith_crafting", "value": "yes" },
-            { "u_has_var": "dialogue_artisans_u_current_project", "value": "armor" }
+            { "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_crafting" } ] },
+            { "compare_string": [ "armor", { "u_val": "dialogue_artisans_u_current_project" } ] }
           ]
         },
         "topic": "TALK_BLACKSMITH_ARMOR_NOT_READY"
@@ -148,8 +147,8 @@
           "and": [
             { "math": [ "time_since(u_timer_artisans_u_waiting_on_armor)", ">=", "time('21 d')" ] },
             { "math": [ "u_number_artisans_blacksmith_wait", "==", "3" ] },
-            { "u_has_var": "dialogue_artisans_blacksmith_crafting", "value": "yes" },
-            { "u_has_var": "dialogue_artisans_u_current_project", "value": "armor" }
+            { "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_crafting" } ] },
+            { "compare_string": [ "armor", { "u_val": "dialogue_artisans_u_current_project" } ] }
           ]
         },
         "topic": "TALK_BLACKSMITH_ARMOR_READY"
@@ -160,8 +159,8 @@
           "and": [
             { "math": [ "time_since(u_timer_artisans_u_waiting_on_armor)", "<", "time('28 d')" ] },
             { "math": [ "u_number_artisans_blacksmith_wait", "==", "4" ] },
-            { "u_has_var": "dialogue_artisans_blacksmith_crafting", "value": "yes" },
-            { "u_has_var": "dialogue_artisans_u_current_project", "value": "armor" }
+            { "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_crafting" } ] },
+            { "compare_string": [ "armor", { "u_val": "dialogue_artisans_u_current_project" } ] }
           ]
         },
         "topic": "TALK_BLACKSMITH_ARMOR_NOT_READY"
@@ -172,8 +171,8 @@
           "and": [
             { "math": [ "time_since(u_timer_artisans_u_waiting_on_armor)", ">=", "time('28 d')" ] },
             { "math": [ "u_number_artisans_blacksmith_wait", "==", "4" ] },
-            { "u_has_var": "dialogue_artisans_blacksmith_crafting", "value": "yes" },
-            { "u_has_var": "dialogue_artisans_u_current_project", "value": "armor" }
+            { "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_crafting" } ] },
+            { "compare_string": [ "armor", { "u_val": "dialogue_artisans_u_current_project" } ] }
           ]
         },
         "topic": "TALK_BLACKSMITH_ARMOR_READY"
@@ -184,8 +183,8 @@
           "and": [
             { "math": [ "time_since(u_timer_artisans_u_waiting_on_armor)", "<", "time('35 d')" ] },
             { "math": [ "u_number_artisans_blacksmith_wait", "==", "5" ] },
-            { "u_has_var": "dialogue_artisans_blacksmith_crafting", "value": "yes" },
-            { "u_has_var": "dialogue_artisans_u_current_project", "value": "armor" }
+            { "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_crafting" } ] },
+            { "compare_string": [ "armor", { "u_val": "dialogue_artisans_u_current_project" } ] }
           ]
         },
         "topic": "TALK_BLACKSMITH_ARMOR_NOT_READY"
@@ -196,8 +195,8 @@
           "and": [
             { "math": [ "time_since(u_timer_artisans_u_waiting_on_armor)", ">=", "time('35 d')" ] },
             { "math": [ "u_number_artisans_blacksmith_wait", "==", "5" ] },
-            { "u_has_var": "dialogue_artisans_blacksmith_crafting", "value": "yes" },
-            { "u_has_var": "dialogue_artisans_u_current_project", "value": "armor" }
+            { "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_crafting" } ] },
+            { "compare_string": [ "armor", { "u_val": "dialogue_artisans_u_current_project" } ] }
           ]
         },
         "topic": "TALK_BLACKSMITH_ARMOR_READY"
@@ -206,15 +205,15 @@
         "text": "You mentioned you'd need some special materials to make that nomad armor?",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "dialogue_artisans_blacksmith_has_exodii_items", "value": "yes" } },
-            { "u_has_var": "dialogue_artisans_blacksmith_crafting_EXODII", "value": "yes" }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_has_exodii_items" } ] } },
+            { "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_crafting_EXODII" } ] }
           ]
         },
         "topic": "TALK_BLACKSMITH_PROTOTYPE_EXODII_ITEMS"
       },
       {
         "text": "Let's trade.",
-        "condition": { "u_has_var": "dialogue_artisans_blacksmith_heard_the_deal", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_heard_the_deal" } ] },
         "topic": "TALK_BLACKSMITH_SERVICES",
         "effect": "start_trade"
       },

--- a/data/json/npcs/isolated_road/isolated_road_cody_fabricate.json
+++ b/data/json/npcs/isolated_road/isolated_road_cody_fabricate.json
@@ -49,8 +49,7 @@
     "//": "this is all the dialogue related to working on armor with Cody",
     "type": "talk_topic",
     "dynamic_line": {
-      "u_has_var": "dialogue_artisans_blacksmith_crafting_EXODII",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_crafting_EXODII" } ],
       "yes": "Alright, <u_val:number_artisans_blacksmith_thickness>mm, so the next question is time.  Currently, it's the classic problem: if you want quality, you gotta wait.  Two processes I could offer that you would be hard-pressed to find anywhere else are either really great high carbon steel, or I can go through the lengthy process of tempering.  High carbon will take three weeks to process and do the work, and tempering will take me four.  For five I could, I think, create a suit of that nomad armor.  It would incorporate climate control, help you support more weight, and it'll have a jumpsuit built in, but you won't be able to wear normal clothes with it.",
       "no": "Alright, <u_val:number_artisans_blacksmith_thickness>mm, so the next question is time.  Currently, it's the classic problem: if you want quality, you gotta wait.  Two processes I could offer that you would be hard-pressed to find anywhere else are either really great high carbon steel, or I can go through the lengthy process of tempering.  High carbon will take three weeks to process and do the work, and tempering will take me four."
     },
@@ -68,7 +67,7 @@
       },
       {
         "text": "[5 weeks, CBM-integrated protection] I'd like nomad armor.",
-        "condition": { "u_has_var": "dialogue_artisans_blacksmith_has_exodii_items", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_has_exodii_items" } ] },
         "effect": [ { "math": [ "u_number_artisans_blacksmith_wait", "=", "5" ] } ],
         "topic": "TALK_BLACKSMITH_FABRICATE_MEASUREMENTS"
       }
@@ -104,7 +103,7 @@
         "condition": {
           "and": [
             { "u_has_items": { "item": "FMCNote", "count": 350 } },
-            { "u_has_var": "number_artisans_blacksmith_thickness", "value": "1.2" }
+            { "compare_string": [ "1.2", { "u_val": "number_artisans_blacksmith_thickness" } ] }
           ]
         },
         "effect": [ { "u_sell_item": "FMCNote", "count": 350, "true_eocs": "EOC_blacksmith_crafting_armor" } ],
@@ -115,7 +114,7 @@
         "condition": {
           "and": [
             { "u_has_items": { "item": "FMCNote", "count": 400 } },
-            { "u_has_var": "number_artisans_blacksmith_thickness", "value": "2" }
+            { "compare_string": [ "2", { "u_val": "number_artisans_blacksmith_thickness" } ] }
           ]
         },
         "effect": [ { "u_sell_item": "FMCNote", "count": 400, "true_eocs": "EOC_blacksmith_crafting_armor" } ],
@@ -126,7 +125,7 @@
         "condition": {
           "and": [
             { "u_has_items": { "item": "FMCNote", "count": 500 } },
-            { "u_has_var": "number_artisans_blacksmith_thickness", "value": "4" }
+            { "compare_string": [ "4", { "u_val": "number_artisans_blacksmith_thickness" } ] }
           ]
         },
         "effect": [ { "u_sell_item": "FMCNote", "count": 500, "true_eocs": "EOC_blacksmith_crafting_armor" } ],
@@ -137,7 +136,7 @@
         "condition": {
           "and": [
             { "u_has_items": { "item": "FMCNote", "count": 600 } },
-            { "u_has_var": "number_artisans_blacksmith_thickness", "value": "6" }
+            { "compare_string": [ "6", { "u_val": "number_artisans_blacksmith_thickness" } ] }
           ]
         },
         "effect": [ { "u_sell_item": "FMCNote", "count": 600, "true_eocs": "EOC_blacksmith_crafting_armor" } ],
@@ -155,8 +154,8 @@
         "text": "Thanks.",
         "condition": {
           "and": [
-            { "u_has_var": "number_artisans_blacksmith_wait", "value": "3" },
-            { "u_has_var": "number_artisans_blacksmith_thickness", "value": "1.2" }
+            { "compare_string": [ "3", { "u_val": "number_artisans_blacksmith_wait" } ] },
+            { "compare_string": [ "1.2", { "u_val": "number_artisans_blacksmith_thickness" } ] }
           ]
         },
         "effect": [
@@ -170,8 +169,8 @@
         "text": "Thanks.",
         "condition": {
           "and": [
-            { "u_has_var": "number_artisans_blacksmith_wait", "value": "4" },
-            { "u_has_var": "number_artisans_blacksmith_thickness", "value": "1.2" }
+            { "compare_string": [ "4", { "u_val": "number_artisans_blacksmith_wait" } ] },
+            { "compare_string": [ "1.2", { "u_val": "number_artisans_blacksmith_thickness" } ] }
           ]
         },
         "effect": [
@@ -185,8 +184,8 @@
         "text": "Thanks.",
         "condition": {
           "and": [
-            { "u_has_var": "number_artisans_blacksmith_wait", "value": "5" },
-            { "u_has_var": "number_artisans_blacksmith_thickness", "value": "1.2" }
+            { "compare_string": [ "5", { "u_val": "number_artisans_blacksmith_wait" } ] },
+            { "compare_string": [ "1.2", { "u_val": "number_artisans_blacksmith_thickness" } ] }
           ]
         },
         "effect": [
@@ -201,8 +200,8 @@
         "text": "Thanks.",
         "condition": {
           "and": [
-            { "u_has_var": "number_artisans_blacksmith_wait", "value": "3" },
-            { "u_has_var": "number_artisans_blacksmith_thickness", "value": "2" }
+            { "compare_string": [ "3", { "u_val": "number_artisans_blacksmith_wait" } ] },
+            { "compare_string": [ "2", { "u_val": "number_artisans_blacksmith_thickness" } ] }
           ]
         },
         "effect": [
@@ -216,8 +215,8 @@
         "text": "Thanks.",
         "condition": {
           "and": [
-            { "u_has_var": "number_artisans_blacksmith_wait", "value": "4" },
-            { "u_has_var": "number_artisans_blacksmith_thickness", "value": "2" }
+            { "compare_string": [ "4", { "u_val": "number_artisans_blacksmith_wait" } ] },
+            { "compare_string": [ "2", { "u_val": "number_artisans_blacksmith_thickness" } ] }
           ]
         },
         "effect": [
@@ -231,8 +230,8 @@
         "text": "Thanks.",
         "condition": {
           "and": [
-            { "u_has_var": "number_artisans_blacksmith_wait", "value": "5" },
-            { "u_has_var": "number_artisans_blacksmith_thickness", "value": "2" }
+            { "compare_string": [ "5", { "u_val": "number_artisans_blacksmith_wait" } ] },
+            { "compare_string": [ "2", { "u_val": "number_artisans_blacksmith_thickness" } ] }
           ]
         },
         "effect": [
@@ -247,8 +246,8 @@
         "text": "Thanks.",
         "condition": {
           "and": [
-            { "u_has_var": "number_artisans_blacksmith_wait", "value": "3" },
-            { "u_has_var": "number_artisans_blacksmith_thickness", "value": "4" }
+            { "compare_string": [ "3", { "u_val": "number_artisans_blacksmith_wait" } ] },
+            { "compare_string": [ "4", { "u_val": "number_artisans_blacksmith_thickness" } ] }
           ]
         },
         "effect": [
@@ -262,8 +261,8 @@
         "text": "Thanks.",
         "condition": {
           "and": [
-            { "u_has_var": "number_artisans_blacksmith_wait", "value": "4" },
-            { "u_has_var": "number_artisans_blacksmith_thickness", "value": "4" }
+            { "compare_string": [ "4", { "u_val": "number_artisans_blacksmith_wait" } ] },
+            { "compare_string": [ "4", { "u_val": "number_artisans_blacksmith_thickness" } ] }
           ]
         },
         "effect": [
@@ -277,8 +276,8 @@
         "text": "Thanks.",
         "condition": {
           "and": [
-            { "u_has_var": "number_artisans_blacksmith_wait", "value": "5" },
-            { "u_has_var": "number_artisans_blacksmith_thickness", "value": "4" }
+            { "compare_string": [ "5", { "u_val": "number_artisans_blacksmith_wait" } ] },
+            { "compare_string": [ "4", { "u_val": "number_artisans_blacksmith_thickness" } ] }
           ]
         },
         "effect": [
@@ -293,8 +292,8 @@
         "text": "Thanks.",
         "condition": {
           "and": [
-            { "u_has_var": "number_artisans_blacksmith_wait", "value": "3" },
-            { "u_has_var": "number_artisans_blacksmith_thickness", "value": "6" }
+            { "compare_string": [ "3", { "u_val": "number_artisans_blacksmith_wait" } ] },
+            { "compare_string": [ "6", { "u_val": "number_artisans_blacksmith_thickness" } ] }
           ]
         },
         "effect": [
@@ -308,8 +307,8 @@
         "text": "Thanks.",
         "condition": {
           "and": [
-            { "u_has_var": "number_artisans_blacksmith_wait", "value": "4" },
-            { "u_has_var": "number_artisans_blacksmith_thickness", "value": "6" }
+            { "compare_string": [ "4", { "u_val": "number_artisans_blacksmith_wait" } ] },
+            { "compare_string": [ "6", { "u_val": "number_artisans_blacksmith_thickness" } ] }
           ]
         },
         "effect": [
@@ -323,8 +322,8 @@
         "text": "Thanks.",
         "condition": {
           "and": [
-            { "u_has_var": "number_artisans_blacksmith_wait", "value": "5" },
-            { "u_has_var": "number_artisans_blacksmith_thickness", "value": "6" }
+            { "compare_string": [ "5", { "u_val": "number_artisans_blacksmith_wait" } ] },
+            { "compare_string": [ "6", { "u_val": "number_artisans_blacksmith_thickness" } ] }
           ]
         },
         "effect": [

--- a/data/json/npcs/isolated_road/isolated_road_cody_prototype.json
+++ b/data/json/npcs/isolated_road/isolated_road_cody_prototype.json
@@ -8,12 +8,12 @@
     "responses": [
       {
         "text": "Are you and Jay close?",
-        "condition": { "not": { "u_has_var": "dialogue_artisans_blacksmith_accepted_quest", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_accepted_quest" } ] } },
         "topic": "TALK_BLACKSMITH_JAY"
       },
       {
         "text": "I'm sure we'll fix things soon!",
-        "condition": { "u_has_var": "dialogue_artisans_blacksmith_accepted_quest", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_accepted_quest" } ] },
         "topic": "TALK_BLACKSMITH_SERVICES"
       },
       { "text": "Alright.", "topic": "TALK_BLACKSMITH_SERVICES" }
@@ -52,12 +52,12 @@
     "responses": [
       {
         "text": "Can you work on one of these projects for me?",
-        "condition": { "u_has_var": "dialogue_artisans_blacksmith_crafting", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_crafting" } ] },
         "topic": "TALK_BLACKSMITH_BUSY"
       },
       {
         "text": "[Motion to the picture of some kind of rifle.] What's the 'OBREZ'?",
-        "condition": { "not": { "u_has_var": "dialogue_artisans_blacksmith_crafting", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_crafting" } ] } },
         "topic": "TALK_BLACKSMITH_OBREZ"
       },
       {
@@ -65,7 +65,7 @@
         "condition": {
           "and": [
             { "math": [ "time_since(u_timer_artisans_u_waiting_on_prototype)", "<", "time('7 d')" ] },
-            { "u_has_var": "dialogue_artisans_u_current_project", "value": "obrez" }
+            { "compare_string": [ "obrez", { "u_val": "dialogue_artisans_u_current_project" } ] }
           ]
         },
         "topic": "TALK_BLACKSMITH_PROTOTYPE_ONGOING"
@@ -75,14 +75,14 @@
         "condition": {
           "and": [
             { "math": [ "time_since(u_timer_artisans_u_waiting_on_prototype)", ">", "time('7 d')" ] },
-            { "u_has_var": "dialogue_artisans_u_current_project", "value": "obrez" }
+            { "compare_string": [ "obrez", { "u_val": "dialogue_artisans_u_current_project" } ] }
           ]
         },
         "topic": "TALK_BLACKSMITH_OBREZ_COMPLETE"
       },
       {
         "text": "[Motion to the picture of a switchblade.] What's the 'PRESSIN'?",
-        "condition": { "not": { "u_has_var": "dialogue_artisans_blacksmith_crafting", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_crafting" } ] } },
         "topic": "TALK_BLACKSMITH_PRESSIN"
       },
       {
@@ -90,7 +90,7 @@
         "condition": {
           "and": [
             { "math": [ "time_since(u_timer_artisans_u_waiting_on_prototype)", "<", "time('7 d')" ] },
-            { "u_has_var": "dialogue_artisans_u_current_project", "value": "pressin" }
+            { "compare_string": [ "pressin", { "u_val": "dialogue_artisans_u_current_project" } ] }
           ]
         },
         "topic": "TALK_BLACKSMITH_PROTOTYPE_ONGOING"
@@ -100,14 +100,14 @@
         "condition": {
           "and": [
             { "math": [ "time_since(u_timer_artisans_u_waiting_on_prototype)", ">", "time('7 d')" ] },
-            { "u_has_var": "dialogue_artisans_u_current_project", "value": "pressin" }
+            { "compare_string": [ "pressin", { "u_val": "dialogue_artisans_u_current_project" } ] }
           ]
         },
         "topic": "TALK_BLACKSMITH_PRESSIN_COMPLETE"
       },
       {
         "text": "[Motion to the picture of a mace styled with fire on the head.] What's the 'LOUVERTURE'?",
-        "condition": { "not": { "u_has_var": "dialogue_artisans_blacksmith_crafting", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_crafting" } ] } },
         "topic": "TALK_BLACKSMITH_LOUVERTURE"
       },
       {
@@ -115,7 +115,7 @@
         "condition": {
           "and": [
             { "math": [ "time_since(u_timer_artisans_u_waiting_on_prototype)", "<", "time('14 d')" ] },
-            { "u_has_var": "dialogue_artisans_u_current_project", "value": "LOUVERTURE" }
+            { "compare_string": [ "LOUVERTURE", { "u_val": "dialogue_artisans_u_current_project" } ] }
           ]
         },
         "topic": "TALK_BLACKSMITH_PROTOTYPE_ONGOING"
@@ -125,14 +125,14 @@
         "condition": {
           "and": [
             { "math": [ "time_since(u_timer_artisans_u_waiting_on_prototype)", ">", "time('14 d')" ] },
-            { "u_has_var": "dialogue_artisans_u_current_project", "value": "LOUVERTURE" }
+            { "compare_string": [ "LOUVERTURE", { "u_val": "dialogue_artisans_u_current_project" } ] }
           ]
         },
         "topic": "TALK_BLACKSMITH_LOUVERTURE_COMPLETE"
       },
       {
         "text": "[Motion to the picture of a sledge hammer with a piston jutting from one face of the head.] What's the 'DISORDER'?",
-        "condition": { "not": { "u_has_var": "dialogue_artisans_blacksmith_crafting", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "dialogue_artisans_blacksmith_crafting" } ] } },
         "topic": "TALK_BLACKSMITH_DISORDER"
       },
       {
@@ -140,7 +140,7 @@
         "condition": {
           "and": [
             { "math": [ "time_since(u_timer_artisans_u_waiting_on_prototype)", "<", "time('14 d')" ] },
-            { "u_has_var": "dialogue_artisans_u_current_project", "value": "DISORDER" }
+            { "compare_string": [ "DISORDER", { "u_val": "dialogue_artisans_u_current_project" } ] }
           ]
         },
         "topic": "TALK_BLACKSMITH_PROTOTYPE_ONGOING"
@@ -150,7 +150,7 @@
         "condition": {
           "and": [
             { "math": [ "time_since(u_timer_artisans_u_waiting_on_prototype)", ">", "time('14 d')" ] },
-            { "u_has_var": "dialogue_artisans_u_current_project", "value": "DISORDER" }
+            { "compare_string": [ "DISORDER", { "u_val": "dialogue_artisans_u_current_project" } ] }
           ]
         },
         "topic": "TALK_BLACKSMITH_DISORDER_COMPLETE"

--- a/data/json/npcs/isolated_road/isolated_road_jay_dialogue.json
+++ b/data/json/npcs/isolated_road/isolated_road_jay_dialogue.json
@@ -14,7 +14,7 @@
       { "text": "What's your deal?", "topic": "TALK_GUNSMITH_ABOUT" },
       {
         "text": "Munitions?",
-        "condition": { "not": { "u_has_var": "dialogue_artisans_gunsmith_knows_about_conversion", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "dialogue_artisans_gunsmith_knows_about_conversion" } ] } },
         "topic": "TALK_GUNSMITH_SHOP_ABOUT"
       },
       {
@@ -22,7 +22,7 @@
         "condition": {
           "and": [
             { "u_has_items": { "item": "broken_kord", "count": 1 } },
-            { "not": { "u_has_var": "dialogue_artisans_gunsmith_mentioned_quest", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_artisans_gunsmith_mentioned_quest" } ] } }
           ]
         },
         "topic": "TALK_GUNSMITH_KORD"
@@ -31,8 +31,8 @@
         "text": "I'm interested in helping with that thing for Cody.",
         "condition": {
           "and": [
-            { "u_has_var": "dialogue_artisans_gunsmith_mentioned_quest", "value": "yes" },
-            { "not": { "u_has_var": "dialogue_artisans_gunsmith_accepted_quest", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "dialogue_artisans_gunsmith_mentioned_quest" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_artisans_gunsmith_accepted_quest" } ] } }
           ]
         },
         "effect": [
@@ -47,7 +47,7 @@
           "and": [
             { "math": [ "time_since(u_timer_artisans_u_waiting_on_rounds)", "<", "time('1 d')" ] },
             { "math": [ "u_number_artisans_gunsmith_ammo_amount", "==", "200" ] },
-            { "u_has_var": "dialogue_artisans_gunsmith_has_rounds_ordered", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "dialogue_artisans_gunsmith_has_rounds_ordered" } ] }
           ]
         },
         "topic": "TALK_GUNSMITH_BULLET_PICKUP_NOT_YET"
@@ -58,7 +58,7 @@
           "and": [
             { "math": [ "time_since(u_timer_artisans_u_waiting_on_rounds)", "<", "time('5 d')" ] },
             { "math": [ "u_number_artisans_gunsmith_ammo_amount", "==", "800" ] },
-            { "u_has_var": "dialogue_artisans_gunsmith_has_rounds_ordered", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "dialogue_artisans_gunsmith_has_rounds_ordered" } ] }
           ]
         },
         "topic": "TALK_GUNSMITH_BULLET_PICKUP_NOT_YET"
@@ -69,7 +69,7 @@
           "and": [
             { "math": [ "time_since(u_timer_artisans_u_waiting_on_rounds)", ">=", "time('1 d')" ] },
             { "math": [ "u_number_artisans_gunsmith_ammo_amount", "==", "200" ] },
-            { "u_has_var": "dialogue_artisans_gunsmith_has_rounds_ordered", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "dialogue_artisans_gunsmith_has_rounds_ordered" } ] }
           ]
         },
         "topic": "TALK_GUNSMITH_BULLET_PICKUP"
@@ -80,7 +80,7 @@
           "and": [
             { "math": [ "time_since(u_timer_artisans_u_waiting_on_rounds)", ">=", "time('5 d')" ] },
             { "math": [ "u_number_artisans_gunsmith_ammo_amount", "==", "800" ] },
-            { "u_has_var": "dialogue_artisans_gunsmith_has_rounds_ordered", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "dialogue_artisans_gunsmith_has_rounds_ordered" } ] }
           ]
         },
         "topic": "TALK_GUNSMITH_BULLET_PICKUP"
@@ -89,8 +89,8 @@
         "text": "I'd like to exchange some rounds.",
         "condition": {
           "and": [
-            { "u_has_var": "dialogue_artisans_gunsmith_knows_about_conversion", "value": "yes" },
-            { "not": { "u_has_var": "dialogue_artisans_gunsmith_has_rounds_ordered", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "dialogue_artisans_gunsmith_knows_about_conversion" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_artisans_gunsmith_has_rounds_ordered" } ] } }
           ]
         },
         "topic": "TALK_BULLET_EXCHANGE"
@@ -99,8 +99,8 @@
         "text": "Are you and Cody close?",
         "condition": {
           "and": [
-            { "u_has_var": "dialogue_artisans_gunsmith_mentioned_cody", "value": "yes" },
-            { "not": { "u_has_var": "dialogue_artisans_gunsmith_accepted_quest", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "dialogue_artisans_gunsmith_mentioned_cody" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_artisans_gunsmith_accepted_quest" } ] } }
           ]
         },
         "topic": "TALK_GUNSMITH_CODY"
@@ -115,7 +115,7 @@
         "text": "Any jobs you need done?",
         "condition": {
           "and": [
-            { "u_has_var": "dialogue_artisans_artisans_made_up", "value": "yes" },
+            { "compare_string": [ "yes", { "u_val": "dialogue_artisans_artisans_made_up" } ] },
             { "and": [ { "not": "has_assigned_mission" }, { "not": "has_many_assigned_missions" } ] }
           ]
         },

--- a/data/json/npcs/lumbermill_employees/TALK_lumbermill_logger.json
+++ b/data/json/npcs/lumbermill_employees/TALK_lumbermill_logger.json
@@ -3,8 +3,7 @@
     "type": "talk_topic",
     "id": "TALK_NPC_LUMBERMILL_LOGGER",
     "dynamic_line": {
-      "npc_has_var": "dialogue_first_meeting_talked_to_logger",
-      "value": "yes",
+      "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_talked_to_logger" } ],
       "yes": "Hello there.  Nice to see you, <name_g>.",
       "no": "A stranger out here?  Who are you?"
     },
@@ -13,19 +12,19 @@
       {
         "text": "Nice to meet you.",
         "topic": "TALK_NPC_LUMBERMILL_LOGGER_INTRO",
-        "condition": { "not": { "npc_has_var": "dialogue_first_meeting_talked_to_logger", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_talked_to_logger" } ] } }
       },
       {
         "text": "Hands up, <name_b>!",
         "trial": { "type": "INTIMIDATE", "difficulty": 30 },
         "success": { "topic": "TALK_WEAPON_DROPPED", "effect": "drop_weapon", "opinion": { "trust": -4, "fear": 3 } },
         "failure": { "topic": "TALK_DONE", "effect": "hostile" },
-        "condition": { "not": { "npc_has_var": "dialogue_first_meeting_talked_to_logger", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_talked_to_logger" } ] } }
       },
       {
         "text": "Pleasure to see you again.",
         "topic": "TALK_NPC_LUMBERMILL_LOGGER_INTRO",
-        "condition": { "npc_has_var": "dialogue_first_meeting_talked_to_logger", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_talked_to_logger" } ] }
       },
       { "text": "See ya.", "topic": "TALK_DONE" }
     ]
@@ -42,7 +41,7 @@
         "condition": {
           "and": [
             { "math": [ "n_npc_trust()", ">=", "2" ] },
-            { "npc_has_var": "dialogue_first_meeting_talked_to_logger", "value": "yes" }
+            { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_talked_to_logger" } ] }
           ]
         }
       },
@@ -52,7 +51,7 @@
         "condition": {
           "and": [
             { "u_has_mission": "EXODII_MISSION_WAREHOUSE" },
-            { "not": { "npc_has_var": "asked_about_exodii_warehouse_mission", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "asked_about_exodii_warehouse_mission" } ] } }
           ]
         },
         "effect": { "run_eocs": [ "EOC_exodii_mission_wh_directions_chance" ] }
@@ -73,8 +72,7 @@
       "concatenate": [
         "&You describe the warehouse to the best of your ability.  The logger considers for a moment",
         {
-          "npc_has_var": "exodii_mission_wh_correct",
-          "value": "no",
+          "compare_string": [ "no", { "npc_val": "exodii_mission_wh_correct" } ],
           "yes": {
             "gendered_line": ", then frowns.  \"I think I'd remember something like that, no.  Sorry.\"",
             "relevant_genders": [ "npc" ]
@@ -92,7 +90,7 @@
         "//": "The other responses are stored in common_talk.json in the exodii folder, to avoid repetition.",
         "text": "Oh well.  Thanks anyway.  I'll go ask around.",
         "topic": "TALK_DONE",
-        "condition": { "npc_has_var": "exodii_mission_wh_correct", "value": "no" },
+        "condition": { "compare_string": [ "no", { "npc_val": "exodii_mission_wh_correct" } ] },
         "effect": [
           { "math": [ "exodii_mission_wh_chance", "-=", "1" ] },
           { "math": [ "exodii_mission_wh_chance", "=", "max( exodii_mission_wh_chance, 1 )" ] }

--- a/data/json/npcs/lumbermill_employees/TALK_lumbermill_merchant.json
+++ b/data/json/npcs/lumbermill_employees/TALK_lumbermill_merchant.json
@@ -3,8 +3,7 @@
     "type": "talk_topic",
     "id": "TALK_NPC_LUMBERMILL_MERCHANT",
     "dynamic_line": {
-      "npc_has_var": "dialogue_first_meeting_talked_to_merchant",
-      "value": "yes",
+      "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_talked_to_merchant" } ],
       "yes": "Hello there.  Nice to see you again.",
       "no": "A new face at the mill?  Who might you be?"
     },
@@ -13,19 +12,19 @@
       {
         "text": "Nice to meet you.",
         "topic": "TALK_NPC_LUMBERMILL_MERCHANT_INTRO",
-        "condition": { "not": { "npc_has_var": "dialogue_first_meeting_talked_to_merchant", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_talked_to_merchant" } ] } }
       },
       {
         "text": "Hands up!",
         "trial": { "type": "INTIMIDATE", "difficulty": 30 },
         "success": { "topic": "TALK_WEAPON_DROPPED", "effect": "drop_weapon", "opinion": { "trust": -4, "fear": 3 } },
         "failure": { "topic": "TALK_DONE", "effect": "hostile" },
-        "condition": { "not": { "npc_has_var": "dialogue_first_meeting_talked_to_merchant", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_talked_to_merchant" } ] } }
       },
       {
         "text": "Pleasure to see you again.",
         "topic": "TALK_NPC_LUMBERMILL_MERCHANT_INTRO",
-        "condition": { "npc_has_var": "dialogue_first_meeting_talked_to_merchant", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_talked_to_merchant" } ] }
       },
       { "text": "See ya.", "topic": "TALK_DONE" }
     ]
@@ -39,7 +38,7 @@
       {
         "text": "I'd like to ask you a few questions.",
         "topic": "TALK_FRIEND_CONVERSATION",
-        "condition": { "npc_has_var": "dialogue_first_meeting_talked_to_merchant", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_talked_to_merchant" } ] }
       },
       { "text": "Can I purchase some of your wares?", "topic": "TALK_LUMBERMILL_FABRICATE" },
       {

--- a/data/json/npcs/militia/GM_Militia_Guard.json
+++ b/data/json/npcs/militia/GM_Militia_Guard.json
@@ -33,10 +33,7 @@
     "type": "talk_topic",
     "id": "TALK_MILITIA_Guard1",
     "dynamic_line": {
-      "u_has_var": "talked_to_LODGEMAIN",
-      "type": "dialogue",
-      "context": "first_meeting",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_LODGEMAIN" } ],
       "yes": "Hello again.",
       "no": "I'm busy on watch duty.  Talk to the Boss upstairs."
     },

--- a/data/json/npcs/militia/GM_Militia_Merchant.json
+++ b/data/json/npcs/militia/GM_Militia_Merchant.json
@@ -137,10 +137,7 @@
     "type": "talk_topic",
     "id": "TALK_MILITIA_MAIN",
     "dynamic_line": {
-      "u_has_var": "talked_to_MILITIAMAIN",
-      "type": "dialogue",
-      "context": "first_meeting",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_MILITIAMAIN" } ],
       "yes": "Hello again.",
       "no": "Welcome to our camp.  Behave yourself while you are here.  What can I do for you?"
     },
@@ -149,23 +146,23 @@
       {
         "text": "What do you do here?",
         "topic": "TALK_MILITIA_INTRODUCTION",
-        "condition": { "not": { "u_has_var": "talked_to_MILITIAEMAIN", "type": "dialogue", "context": "first_meeting", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_MILITIAMAIN" } ] } }
       },
       {
         "text": "What's the story behind this place?",
         "topic": "TALK_MILITIA_BACKGROUND",
-        "condition": { "u_has_var": "talked_to_MILITIAMAIN", "type": "dialogue", "context": "first_meeting", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_MILITIAMAIN" } ] }
       },
       {
         "text": "Is there something I can do for you?",
         "topic": "TALK_MILITIA_HELP",
-        "condition": { "u_has_var": "talked_to_MILITIAMAIN", "type": "dialogue", "context": "first_meeting", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_MILITIAMAIN" } ] }
       },
       { "text": "Do you have anything to trade?", "topic": "TALK_MILITIA_TRADE" },
       {
         "text": "Time for me to leave",
         "topic": "TALK_MILITIA_BYE",
-        "condition": { "u_has_var": "talked_to_MILITIAMAIN", "type": "dialogue", "context": "first_meeting", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_MILITIAMAIN" } ] }
       }
     ]
   },

--- a/data/json/npcs/mine/spiral_madman.json
+++ b/data/json/npcs/mine/spiral_madman.json
@@ -69,17 +69,17 @@
       {
         "text": "Hello there!",
         "topic": "TALK_SPIRAL_MADMAN_GENERIC",
-        "condition": { "not": { "u_has_var": "dialogue_first_meeting_first_meeting", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_first_meeting" } ] } }
       },
       {
         "text": "I'm outta here.  Bye.",
         "topic": "TALK_DONE",
-        "condition": { "not": { "u_has_var": "dialogue_first_meeting_first_meeting", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_first_meeting" } ] } }
       },
       {
         "text": "Poor fellow - looks like you're out of your mind.  Can't help you, sorry.  I'm outta here.  Bye.",
         "topic": "TALK_DONE",
-        "condition": { "u_has_var": "dialogue_first_meeting_first_meeting", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_first_meeting" } ] }
       }
     ]
   },

--- a/data/json/npcs/missiondef.json
+++ b/data/json/npcs/missiondef.json
@@ -970,7 +970,7 @@
     "global": true,
     "condition": { "math": [ "time_since(u_timer_time_of_last_succession)", ">", "time('90 d')" ] },
     "effect": [ { "remove_active_mission": "MISSION_CAMP_LEADERSHIP_CHANGE" }, { "u_lose_var": "time_of_last_succession" } ],
-    "deactivate_condition": { "not": { "u_has_var": "time_of_last_succession", "value": "yes" } }
+    "deactivate_condition": { "not": { "compare_string": [ "yes", { "u_val": "time_of_last_succession" } ] } }
   },
   {
     "type": "effect_on_condition",

--- a/data/json/npcs/other/NPC_pizzaiolo.json
+++ b/data/json/npcs/other/NPC_pizzaiolo.json
@@ -27,7 +27,7 @@
       {
         "text": "If you still want to travel with me, let's go.",
         "topic": "TALK_DONE",
-        "condition": { "npc_has_var": "dialogue_pizzaiolo_u_helped_pizzaiolo", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "npc_val": "dialogue_pizzaiolo_u_helped_pizzaiolo" } ] },
         "effect": [ "follow", { "npc_lose_var": "dialogue_pizzaiolo_u_helped_pizzaiolo" } ]
       },
       { "text": "Goodbye.", "topic": "TALK_DONE" }

--- a/data/json/npcs/other/TALK_ANIMAL_SHELTER_SURVIVOR.json
+++ b/data/json/npcs/other/TALK_ANIMAL_SHELTER_SURVIVOR.json
@@ -7,8 +7,7 @@
     "type": "talk_topic",
     "id": "TALK_NPC_ANIMAL_SHELTER_SURVIVOR",
     "dynamic_line": {
-      "npc_has_var": "dialogue_first_meeting_knows_u",
-      "value": "yes",
+      "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ],
       "yes": "<greet>",
       "no": "Finally, someone who isn't part of those <zombies>."
     },
@@ -19,17 +18,17 @@
         "trial": { "type": "INTIMIDATE", "difficulty": 30 },
         "success": { "topic": "TALK_WEAPON_DROPPED", "effect": "drop_weapon", "opinion": { "trust": -4, "fear": 3 } },
         "failure": { "topic": "TALK_DONE", "effect": "hostile" },
-        "condition": { "not": { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] } }
       },
       {
         "text": "Hey, nice to meet you.",
         "topic": "TALK_NPC_ANIMAL_SHELTER_SURVIVOR_INTRO",
-        "condition": { "not": { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] } }
       },
       {
         "text": "<greet>",
         "topic": "TALK_NPC_ANIMAL_SHELTER_SURVIVOR_INTRO",
-        "condition": { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] }
       },
       { "text": "Bye.", "topic": "TALK_DONE" }
     ]
@@ -44,7 +43,10 @@
         "text": "I'd like to ask you a few questions.",
         "topic": "TALK_FRIEND_CONVERSATION",
         "condition": {
-          "and": [ { "math": [ "n_npc_trust()", ">=", "2" ] }, { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" } ]
+          "and": [
+            { "math": [ "n_npc_trust()", ">=", "2" ] },
+            { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] }
+          ]
         }
       },
       {

--- a/data/json/npcs/other/TALK_GUN_STORE_SURVIVOR.json
+++ b/data/json/npcs/other/TALK_GUN_STORE_SURVIVOR.json
@@ -3,8 +3,7 @@
     "type": "talk_topic",
     "id": "TALK_NPC_GUN_STORE_SURVIVOR",
     "dynamic_line": {
-      "npc_has_var": "dialogue_first_meeting_knows_u",
-      "value": "yes",
+      "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ],
       "yes": "<greet>",
       "no": { "gendered_line": "Hey stranger.  How's life treatin' ya these days?", "relevant_genders": [ "u" ] }
     },
@@ -15,17 +14,17 @@
         "trial": { "type": "INTIMIDATE", "difficulty": 30 },
         "success": { "topic": "TALK_WEAPON_DROPPED", "effect": "drop_weapon", "opinion": { "trust": -4, "fear": 3 } },
         "failure": { "topic": "TALK_DONE", "effect": "hostile" },
-        "condition": { "not": { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] } }
       },
       {
         "text": "Hey, nice to meet you.",
         "topic": "TALK_NPC_GUN_STORE_SURVIVOR_INTRO",
-        "condition": { "not": { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] } }
       },
       {
         "text": "<greet>",
         "topic": "TALK_NPC_GUN_STORE_SURVIVOR_INTRO",
-        "condition": { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] }
       },
       { "text": "Bye.", "topic": "TALK_DONE" }
     ]
@@ -40,7 +39,10 @@
         "text": "I'd like to ask you a few questions.",
         "topic": "TALK_FRIEND_CONVERSATION",
         "condition": {
-          "and": [ { "math": [ "n_npc_trust()", ">=", "2" ] }, { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" } ]
+          "and": [
+            { "math": [ "n_npc_trust()", ">=", "2" ] },
+            { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] }
+          ]
         }
       },
       {
@@ -79,7 +81,10 @@
         "text": "I'd like to ask you a few questions.",
         "topic": "TALK_FRIEND_CONVERSATION",
         "condition": {
-          "and": [ { "math": [ "n_npc_trust()", ">=", "2" ] }, { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" } ]
+          "and": [
+            { "math": [ "n_npc_trust()", ">=", "2" ] },
+            { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] }
+          ]
         }
       },
       {
@@ -112,7 +117,10 @@
         "text": "I'd like to ask you a few questions.",
         "topic": "TALK_FRIEND_CONVERSATION",
         "condition": {
-          "and": [ { "math": [ "n_npc_trust()", ">=", "2" ] }, { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" } ]
+          "and": [
+            { "math": [ "n_npc_trust()", ">=", "2" ] },
+            { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] }
+          ]
         }
       },
       {

--- a/data/json/npcs/other/TALK_NPC_APARTMENT_SURVIVOR.json
+++ b/data/json/npcs/other/TALK_NPC_APARTMENT_SURVIVOR.json
@@ -3,8 +3,7 @@
     "type": "talk_topic",
     "id": "TALK_NPC_APARTMENT_SURVIVOR",
     "dynamic_line": {
-      "npc_has_var": "dialogue_first_meeting_knows_u",
-      "value": "yes",
+      "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ],
       "yes": "<greet>",
       "no": "Freeze you <swear> <zombies>!"
     },
@@ -13,19 +12,19 @@
       {
         "text": "&Hold up your hands.  \"Don't worry, I'm not going to hurt you\"",
         "topic": "TALK_NPC_APARTMENT_SURVIVOR_CALM",
-        "condition": { "not": { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] } }
       },
       {
         "text": "Hand over your stuff!  Don't make any sudden moves, or you die!",
         "trial": { "type": "INTIMIDATE", "difficulty": 30 },
         "success": { "topic": "TALK_WEAPON_DROPPED", "effect": "drop_weapon", "opinion": { "trust": -4, "fear": 3 } },
         "failure": { "topic": "TALK_DONE", "effect": "hostile" },
-        "condition": { "not": { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] } }
       },
       {
         "text": "<greet>",
         "topic": "TALK_NPC_APARTMENT_SURVIVOR_INTRO",
-        "condition": { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] }
       },
       { "text": "Bye.", "topic": "TALK_DONE" }
     ]
@@ -52,7 +51,10 @@
         "text": "I'd like to ask you a few questions.",
         "topic": "TALK_FRIEND_CONVERSATION",
         "condition": {
-          "and": [ { "math": [ "n_npc_trust()", ">=", "2" ] }, { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" } ]
+          "and": [
+            { "math": [ "n_npc_trust()", ">=", "2" ] },
+            { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] }
+          ]
         }
       },
       { "text": "Care to trade?", "topic": "TALK_NPC_APARTMENT_SURVIVOR_INTRO", "effect": "start_trade" },

--- a/data/json/npcs/other/TALK_NPC_CAMPER.json
+++ b/data/json/npcs/other/TALK_NPC_CAMPER.json
@@ -3,8 +3,7 @@
     "type": "talk_topic",
     "id": "TALK_NPC_CAMPER_SURVIVOR",
     "dynamic_line": {
-      "npc_has_var": "dialogue_first_meeting_knows_u",
-      "value": "yes",
+      "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ],
       "yes": "<greet>.",
       "no": { "gendered_line": "Hey, stranger.  Glad to see a new face around here.", "relevant_genders": [ "npc", "u" ] }
     },
@@ -16,7 +15,7 @@
         "trial": { "type": "INTIMIDATE", "difficulty": 30 },
         "success": { "topic": "TALK_WEAPON_DROPPED", "effect": "drop_weapon", "opinion": { "trust": -4, "fear": 3 } },
         "failure": { "topic": "TALK_DONE", "effect": "hostile" },
-        "condition": { "not": { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] } }
       },
       { "text": "Bye.", "topic": "TALK_DONE" }
     ]
@@ -31,7 +30,10 @@
         "text": "I'd like to ask you a few questions.",
         "topic": "TALK_FRIEND_CONVERSATION",
         "condition": {
-          "and": [ { "math": [ "n_npc_trust()", ">=", "2" ] }, { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" } ]
+          "and": [
+            { "math": [ "n_npc_trust()", ">=", "2" ] },
+            { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] }
+          ]
         }
       },
       { "text": "Care to trade?", "topic": "TALK_NPC_CAMPER_SURVIVOR_INTRO", "effect": "start_trade" },

--- a/data/json/npcs/other/TALK_NPC_MOONSHINER.json
+++ b/data/json/npcs/other/TALK_NPC_MOONSHINER.json
@@ -3,8 +3,7 @@
     "type": "talk_topic",
     "id": "TALK_NPC_MOONSHINER",
     "dynamic_line": {
-      "npc_has_var": "dialogue_first_meeting_knows_u",
-      "value": "yes",
+      "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ],
       "yes": "Hey <name_g>.",
       "no": { "gendered_line": "Haven't seen someone new in a while.  What brings you around here?", "relevant_genders": [ "npc" ] }
     },
@@ -13,19 +12,19 @@
       {
         "text": "Just wandering, <name_g>.",
         "topic": "TALK_NPC_MOONSHINER_INTRO",
-        "condition": { "not": { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] } }
       },
       {
         "text": "I'll make this real simple for you.  Hand over your stuff, and no one gets hurt, capiche?",
         "trial": { "type": "INTIMIDATE", "difficulty": 30 },
         "success": { "topic": "TALK_WEAPON_DROPPED", "effect": "drop_weapon", "opinion": { "trust": -4, "fear": 3 } },
         "failure": { "topic": "TALK_DONE", "effect": "hostile" },
-        "condition": { "not": { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] } }
       },
       {
         "text": "<greet>",
         "topic": "TALK_NPC_MOONSHINER_INTRO",
-        "condition": { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] }
       },
       { "text": "Bye.", "topic": "TALK_DONE" }
     ]
@@ -40,7 +39,10 @@
         "text": "I'd like to ask you a few questions.",
         "topic": "TALK_FRIEND_CONVERSATION",
         "condition": {
-          "and": [ { "math": [ "n_npc_trust()", ">=", "2" ] }, { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" } ]
+          "and": [
+            { "math": [ "n_npc_trust()", ">=", "2" ] },
+            { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] }
+          ]
         }
       },
       { "text": "Can I purchase any of your liquor?", "topic": "TALK_NPC_MOONSHINER_INTRO", "effect": "start_trade" },

--- a/data/json/npcs/other/TALK_NPC_PREPPER_SURVIVOR.json
+++ b/data/json/npcs/other/TALK_NPC_PREPPER_SURVIVOR.json
@@ -3,8 +3,7 @@
     "type": "talk_topic",
     "id": "TALK_NPC_PREPPER_SURVIVOR",
     "dynamic_line": {
-      "npc_has_var": "dialogue_first_meeting_knows_u",
-      "value": "yes",
+      "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ],
       "yes": "<greet>",
       "no": "Freeze you <swear> <zombies>!"
     },
@@ -13,19 +12,19 @@
       {
         "text": "&Hold up your hands.  \"Don't worry, I'm not going to hurt you\"",
         "topic": "TALK_NPC_PREPPER_SURVIVOR_CALM",
-        "condition": { "not": { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] } }
       },
       {
         "text": "Hand over your stuff!  Don't make any sudden moves, or you die!",
         "trial": { "type": "INTIMIDATE", "difficulty": 30 },
         "success": { "topic": "TALK_WEAPON_DROPPED", "effect": "drop_weapon", "opinion": { "trust": -4, "fear": 3 } },
         "failure": { "topic": "TALK_DONE", "effect": "hostile" },
-        "condition": { "not": { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] } }
       },
       {
         "text": "<greet>",
         "topic": "TALK_NPC_PREPPER_SURVIVOR_INTRO",
-        "condition": { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] }
       },
       { "text": "Bye.", "topic": "TALK_DONE" }
     ]
@@ -52,7 +51,10 @@
         "text": "I'd like to ask you a few questions.",
         "topic": "TALK_FRIEND_CONVERSATION",
         "condition": {
-          "and": [ { "math": [ "n_npc_trust()", ">=", "2" ] }, { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" } ]
+          "and": [
+            { "math": [ "n_npc_trust()", ">=", "2" ] },
+            { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] }
+          ]
         }
       },
       {

--- a/data/json/npcs/other/TALK_shelter_survivors.json
+++ b/data/json/npcs/other/TALK_shelter_survivors.json
@@ -2,18 +2,22 @@
   {
     "type": "talk_topic",
     "id": "TALK_NPC_EVAC_SURVIVOR",
-    "dynamic_line": { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes", "yes": "<greet>.", "no": "Don't come any closer!" },
+    "dynamic_line": {
+      "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ],
+      "yes": "<greet>.",
+      "no": "Don't come any closer!"
+    },
     "speaker_effect": { "effect": { "npc_add_var": "dialogue_first_meeting_knows_u", "value": "yes" } },
     "responses": [
       {
         "text": "What's wrong?",
         "topic": "TALK_NPC_EVAC_SURVIVOR_CALM",
-        "condition": { "not": { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] } }
       },
       {
         "text": "<greet>.",
         "topic": "TALK_NPC_EVAC_SURVIVOR_INTRO",
-        "condition": { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] }
       },
       { "text": "Bye.", "topic": "TALK_DONE" }
     ]
@@ -40,7 +44,10 @@
         "text": "I'd like to ask you a few questions.",
         "topic": "TALK_FRIEND_CONVERSATION",
         "condition": {
-          "and": [ { "math": [ "n_npc_trust()", ">=", "2" ] }, { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" } ]
+          "and": [
+            { "math": [ "n_npc_trust()", ">=", "2" ] },
+            { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] }
+          ]
         }
       },
       { "text": "Care to trade?", "topic": "TALK_NPC_EVAC_SURVIVOR_INTRO", "effect": "start_trade" },

--- a/data/json/npcs/other/homeless/TALK_homeless_survivor.json
+++ b/data/json/npcs/other/homeless/TALK_homeless_survivor.json
@@ -13,12 +13,12 @@
       {
         "text": "Nice to meet you.",
         "topic": "TALK_NPC_HOMELESS_SURVIVOR_INTRO",
-        "condition": { "not": { "npc_has_var": "dialogue_first_meeting_talked_to_homeless", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_talked_to_homeless" } ] } }
       },
       {
         "text": "Pleasure to see you again.",
         "topic": "TALK_NPC_HOMELESS_SURVIVOR_INTRO",
-        "condition": { "npc_has_var": "dialogue_first_meeting_talked_to_homeless", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_talked_to_homeless" } ] }
       },
       { "text": "See ya.", "topic": "TALK_DONE" }
     ]
@@ -32,7 +32,7 @@
       {
         "text": "I'd like to ask you a few questions.",
         "topic": "TALK_FRIEND_CONVERSATION",
-        "condition": { "npc_has_var": "dialogue_first_meeting_talked_to_homeless", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_talked_to_homeless" } ] }
       },
       { "text": "Care to trade?", "topic": "TALK_NPC_HOMELESS_SURVIVOR_INTRO", "effect": "start_trade" },
       {

--- a/data/json/npcs/other/homeless/TALK_homeless_survivor.json
+++ b/data/json/npcs/other/homeless/TALK_homeless_survivor.json
@@ -3,8 +3,7 @@
     "type": "talk_topic",
     "id": "TALK_NPC_HOMELESS_SURVIVOR",
     "dynamic_line": {
-      "u_has_var": "dialogue_first_meeting_talked_to_homeless",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_homeless" } ],
       "yes": "Hello there.  Nice to see you again.",
       "no": "Who are you?"
     },

--- a/data/json/npcs/other/homeless/group_camp/TALK_homeless_broker.json
+++ b/data/json/npcs/other/homeless/group_camp/TALK_homeless_broker.json
@@ -3,8 +3,7 @@
     "type": "talk_topic",
     "id": "TALK_NPC_HOMELESS_BROKER",
     "dynamic_line": {
-      "npc_has_var": "dialogue_first_meeting_talked_to_homeless",
-      "value": "yes",
+      "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_talked_to_homeless" } ],
       "yes": "Hello there.  Nice to see you again.",
       "no": "Who are you?  Would you like to trade?"
     },
@@ -13,19 +12,19 @@
       {
         "text": "Nice to meet you.",
         "topic": "TALK_NPC_HOMELESS_BROKER_INTRO",
-        "condition": { "not": { "npc_has_var": "dialogue_first_meeting_talked_to_homeless", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_talked_to_homeless" } ] } }
       },
       {
         "text": "Hands up!",
         "trial": { "type": "INTIMIDATE", "difficulty": 30 },
         "success": { "topic": "TALK_WEAPON_DROPPED", "effect": "drop_weapon", "opinion": { "trust": 4, "fear": -3 } },
         "failure": { "topic": "TALK_DONE", "effect": "hostile" },
-        "condition": { "not": { "npc_has_var": "dialogue_first_meeting_talked_to_homeless", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_talked_to_homeless" } ] } }
       },
       {
         "text": "Pleasure to see you again.",
         "topic": "TALK_NPC_HOMELESS_BROKER_INTRO",
-        "condition": { "npc_has_var": "dialogue_first_meeting_talked_to_homeless", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_talked_to_homeless" } ] }
       },
       { "text": "See ya.", "topic": "TALK_DONE" }
     ]
@@ -39,17 +38,17 @@
       {
         "text": "I'd like to ask you a few questions.",
         "topic": "TALK_FRIEND_CONVERSATION",
-        "condition": { "npc_has_var": "dialogue_first_meeting_talked_to_homeless", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_talked_to_homeless" } ] }
       },
       {
         "text": "Where might your friends be?",
         "topic": "TALK_NPC_HOMELESS_BROKER_FRIENDS",
-        "condition": { "npc_has_var": "dialogue_first_meeting_told_about_buddies", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_told_about_buddies" } ] }
       },
       {
         "text": "Can I stay here?",
         "topic": "TALK_NPC_HOMELESS_BROKER_STAY",
-        "condition": { "npc_has_var": "dialogue_first_meeting_told_about_buddies", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_told_about_buddies" } ] }
       },
       {
         "text": "Can I purchase some of your wares?",
@@ -59,7 +58,7 @@
       {
         "text": "How's that smoker coming along?",
         "topic": "TALK_NPC_HOMELESS_BROKER_SMOKERACK",
-        "condition": { "npc_has_var": "dialogue_trade_smoked_meat_tradeable", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "npc_val": "dialogue_trade_smoked_meat_tradeable" } ] }
       },
       {
         "text": "Any jobs you need done?",

--- a/data/json/npcs/other/homeless/group_camp/TALK_homeless_group_survivors.json
+++ b/data/json/npcs/other/homeless/group_camp/TALK_homeless_group_survivors.json
@@ -3,8 +3,7 @@
     "type": "talk_topic",
     "id": "TALK_NPC_HOMELESS_GROUP_SURVIVOR",
     "dynamic_line": {
-      "npc_has_var": "dialogue_first_meeting_talked_to_homeless",
-      "value": "yes",
+      "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_talked_to_homeless" } ],
       "yes": "Hello there.  Nice to see you again.",
       "no": "Who are you, and what are you doing here?"
     },
@@ -13,19 +12,19 @@
       {
         "text": "Nice to meet you.  I mean no harm.",
         "topic": "TALK_NPC_HOMELESS_GROUP_SURVIVOR_INTRO",
-        "condition": { "not": { "npc_has_var": "dialogue_first_meeting_talked_to_homeless", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_talked_to_homeless" } ] } }
       },
       {
         "text": "Hand over your stuff!  Don't make any sudden moves, or you die!",
         "trial": { "type": "INTIMIDATE", "difficulty": 30 },
         "success": { "topic": "TALK_WEAPON_DROPPED", "effect": "drop_weapon", "opinion": { "trust": 4, "fear": -3 } },
         "failure": { "topic": "TALK_DONE", "effect": "hostile" },
-        "condition": { "not": { "npc_has_var": "dialogue_first_meeting_talked_to_homeless", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_talked_to_homeless" } ] } }
       },
       {
         "text": "Pleasure to see you again.",
         "topic": "TALK_NPC_HOMELESS_GROUP_SURVIVOR_INTRO",
-        "condition": { "npc_has_var": "dialogue_first_meeting_talked_to_homeless", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_talked_to_homeless" } ] }
       },
       { "text": "See ya.", "topic": "TALK_DONE" }
     ]
@@ -39,22 +38,22 @@
       {
         "text": "I'd like to ask you a few questions.",
         "topic": "TALK_FRIEND_CONVERSATION",
-        "condition": { "npc_has_var": "dialogue_first_meeting_talked_to_homeless", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_talked_to_homeless" } ] }
       },
       {
         "text": "Where might your friends be?",
         "topic": "TALK_NPC_HOMELESS_GROUP_SURVIVOR_FRIENDS",
-        "condition": { "npc_has_var": "dialogue_first_meeting_told_about_buddies", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_told_about_buddies" } ] }
       },
       {
         "text": "Can I stay here?",
         "topic": "TALK_NPC_HOMELESS_BROKER_STAY",
-        "condition": { "npc_has_var": "dialogue_first_meeting_told_about_buddies", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_told_about_buddies" } ] }
       },
       {
         "text": "What's with that guy in the tent?",
         "topic": "TALK_NPC_HOMELESS_GROUP_SURVIVOR_BROKER",
-        "condition": { "npc_has_var": "dialogue_first_meeting_told_about_buddies", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_told_about_buddies" } ] }
       },
       { "text": "Want to trade?", "topic": "TALK_NPC_HOMELESS_GROUP_SURVIVOR_NOTRADE" },
       {

--- a/data/json/npcs/other/meteorologist.json
+++ b/data/json/npcs/other/meteorologist.json
@@ -55,12 +55,10 @@
     "type": "talk_topic",
     "id": [ "TALK_meteorologist_1" ],
     "dynamic_line": {
-      "npc_has_var": "flag_mission_u_helped_meteorologist",
-      "value": "yes",
+      "compare_string": [ "yes", { "npc_val": "flag_mission_u_helped_meteorologist" } ],
       "yes": "Run, I need to run, where to run…",
       "no": {
-        "npc_has_var": "general_meeting_u_met_meteorologist",
-        "value": "yes",
+        "compare_string": [ "yes", { "npc_val": "general_meeting_u_met_meteorologist" } ],
         "yes": {
           "gendered_line": "Air temperature, precipitation, but what about… oh, I'm sorry, I didn't notice you.  Hello.",
           "relevant_genders": [ "npc" ]
@@ -81,7 +79,7 @@
       {
         "text": "Maybe I can help you with your problem?",
         "topic": "TALK_meteorologist_safety",
-        "condition": { "npc_has_var": "flag_mission_u_helped_meteorologist", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "npc_val": "flag_mission_u_helped_meteorologist" } ] },
         "switch": true
       },
       {

--- a/data/json/npcs/random_encounters/camper_van_traveler.json
+++ b/data/json/npcs/random_encounters/camper_van_traveler.json
@@ -40,13 +40,16 @@
       {
         "text": "Do you have anything that you'd like to sell?",
         "topic": "TALK_NPC_CAMPER_VAN_TRAVELER_TRADE",
-        "condition": { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] }
       },
       {
         "text": "I'd like to ask you a few questions.",
         "topic": "TALK_FRIEND_CONVERSATION",
         "condition": {
-          "and": [ { "math": [ "n_npc_trust()", ">=", "2" ] }, { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" } ]
+          "and": [
+            { "math": [ "n_npc_trust()", ">=", "2" ] },
+            { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] }
+          ]
         }
       },
       {
@@ -54,9 +57,9 @@
         "topic": "TALK_NPC_CAMPER_VAN_TRAVELER_EXODII_MISSION_WAREHOUSE",
         "condition": {
           "and": [
-            { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] },
             { "u_has_mission": "EXODII_MISSION_WAREHOUSE" },
-            { "not": { "npc_has_var": "asked_about_exodii_warehouse_mission", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "asked_about_exodii_warehouse_mission" } ] } }
           ]
         },
         "effect": { "run_eocs": [ "EOC_exodii_mission_wh_directions_chance" ] }
@@ -64,25 +67,25 @@
       {
         "text": "Where did you say you were going again?",
         "topic": "TALK_NPC_CAMPER_VAN_TRAVELER_DESTINATION",
-        "condition": { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] }
       },
       {
         "text": "What did you do before <the_cataclysm>?",
         "topic": "TALK_NPC_CAMPER_VAN_TRAVELER_BACKSTORY",
-        "condition": { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] }
       },
       {
         "text": "I'd like to ask you a few questions.",
         "topic": "TALK_FRIEND_CONVERSATION",
-        "condition": { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] }
       },
       {
         "text": "Have you found anything out of the ordinary out in the wastes?",
         "topic": "TALK_NPC_CAMPER_VAN_TRAVELER_INTERESTING_THINGS",
         "condition": {
           "and": [
-            { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" },
-            { "not": { "npc_has_var": "dialogue_camper_van_traveler_gave_directions", "value": "yes" } }
+            { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] },
+            { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_camper_van_traveler_gave_directions" } ] } }
           ]
         },
         "effect": [
@@ -96,8 +99,8 @@
         "topic": "TALK_NPC_CAMPER_VAN_TRAVELER_INTERESTING_THINGS",
         "condition": {
           "and": [
-            { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" },
-            { "npc_has_var": "dialogue_camper_van_traveler_gave_directions", "value": "yes" }
+            { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] },
+            { "compare_string": [ "yes", { "npc_val": "dialogue_camper_van_traveler_gave_directions" } ] }
           ]
         },
         "switch": true,
@@ -109,8 +112,7 @@
     "type": "talk_topic",
     "id": "TALK_NPC_CAMPER_VAN_TRAVELER",
     "dynamic_line": {
-      "npc_has_var": "dialogue_first_meeting_knows_u",
-      "value": "yes",
+      "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ],
       "yes": "<greet>",
       "no": {
         "gendered_line": "I didn't think anyone was around here.  Pleased to meet you, I'm <npc_name>.",
@@ -129,12 +131,12 @@
         "trial": { "type": "INTIMIDATE", "difficulty": 30 },
         "success": { "topic": "TALK_WEAPON_DROPPED", "effect": "drop_weapon", "opinion": { "trust": -4, "fear": 3 } },
         "failure": { "topic": "TALK_DONE", "effect": "hostile" },
-        "condition": { "not": { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] } }
       },
       {
         "text": "Good to meet you too.  What are you doing out here?",
         "topic": "TALK_NPC_CAMPER_VAN_TRAVELER_DESTINATION",
-        "condition": { "not": { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] } }
       },
       { "text": "<end_talking>", "topic": "TALK_DONE" }
     ]
@@ -146,8 +148,7 @@
       "concatenate": [
         "&You describe the warehouse to the best of your ability.  <npc_name> considers for a moment",
         {
-          "npc_has_var": "exodii_mission_wh_correct",
-          "value": "no",
+          "compare_string": [ "no", { "npc_val": "exodii_mission_wh_correct" } ],
           "yes": {
             "gendered_line": ", then frowns.  \"I don't believe I've heard about anything like that, no.  Sorry.\"",
             "relevant_genders": [ "npc" ]
@@ -162,7 +163,7 @@
         "//": "The other responses are stored in common_talk.json in the exodii folder, to avoid repetition.",
         "text": "Oh well.  Thanks anyway.  I'll go ask around.",
         "topic": "TALK_DONE",
-        "condition": { "npc_has_var": "exodii_mission_wh_correct", "value": "no" },
+        "condition": { "compare_string": [ "no", { "npc_val": "exodii_mission_wh_correct" } ] },
         "effect": [
           { "math": [ "exodii_mission_wh_chance", "-=", "1" ] },
           { "math": [ "exodii_mission_wh_chance", "=", "max( exodii_mission_wh_chance, 1 )" ] }
@@ -174,26 +175,22 @@
     "type": "talk_topic",
     "id": "TALK_NPC_CAMPER_VAN_TRAVELER_DESTINATION",
     "dynamic_line": {
-      "npc_has_var": "dialogue_travel_direction_travel_direction",
-      "value": "north",
+      "compare_string": [ "north", { "npc_val": "dialogue_travel_direction_travel_direction" } ],
       "yes": {
         "gendered_line": "I'm going north, up towards the border and the big wide wilderness.  I heard that there's some sort of safe spot up there, where people didn't go crazy and try to kill each other.  I don't know whether or not that's true, but at the very least, the colder climate might help keep the <zombies> down.",
         "relevant_genders": [ "npc" ]
       },
       "no": {
-        "npc_has_var": "dialogue_travel_direction_travel_direction",
-        "value": "south",
+        "compare_string": [ "south", { "npc_val": "dialogue_travel_direction_travel_direction" } ],
         "yes": "I'm going south.  Hopefully somebody down there fared better than the people I knew up here.  Besides, I won't have to worry about freezing my <swear> butt off when winter comes.",
         "no": {
-          "npc_has_var": "dialogue_travel_direction_travel_direction",
-          "value": "east",
+          "compare_string": [ "east", { "npc_val": "dialogue_travel_direction_travel_direction" } ],
           "yes": {
             "gendered_line": "I'm going east, towards the coastline.  I heard some rumors that Rhode Island was still holding itself together, so I'm going to go and check that out.  Heck, I might just go out to sea myself, live on an old oil rig or something like that.",
             "relevant_genders": [ "npc" ]
           },
           "no": {
-            "npc_has_var": "dialogue_travel_direction_travel_direction",
-            "value": "west",
+            "compare_string": [ "west", { "npc_val": "dialogue_travel_direction_travel_direction" } ],
             "yes": "I'm going west, see how things are out there in tumbleweed territory.  You see, the Midwest didn't have a whole lot of people in it compared the the East Coast, so there logically shouldn't be as many <zombies> as there are here.  I just hope that everything hasn't <swear> collapsed, that someone's still holding on.",
             "no": "ERROR: DIRECTION PARAMETERS EITHER NOT PICKED OR OUT OF BOUNDS"
           }
@@ -258,7 +255,7 @@
         "condition": {
           "and": [
             { "math": [ "npc_randomize_dialogue_direction", "==", "1" ] },
-            { "not": { "npc_has_var": "camper_van_traveler_mission_directions", "value": "isherwood" } }
+            { "not": { "compare_string": [ "isherwood", { "npc_val": "camper_van_traveler_mission_directions" } ] } }
           ]
         },
         "effect": [
@@ -273,7 +270,9 @@
         "condition": {
           "and": [
             { "math": [ "npc_randomize_dialogue_direction", "==", "2" ] },
-            { "not": { "npc_has_var": "camper_van_traveler_mission_directions", "value": "chem_chabin" } }
+            {
+              "not": { "compare_string": [ "chem_chabin", { "npc_val": "camper_van_traveler_mission_directions" } ] }
+            }
           ]
         },
         "effect": [
@@ -288,7 +287,7 @@
         "condition": {
           "and": [
             { "math": [ "npc_randomize_dialogue_direction", "==", "3" ] },
-            { "not": { "npc_has_var": "camper_van_traveler_mission_directions", "value": "cowboy" } }
+            { "not": { "compare_string": [ "cowboy", { "npc_val": "camper_van_traveler_mission_directions" } ] } }
           ]
         },
         "effect": [

--- a/data/json/npcs/random_encounters/free_merchant_caravans.json
+++ b/data/json/npcs/random_encounters/free_merchant_caravans.json
@@ -130,7 +130,7 @@
         "condition": {
           "and": [
             { "not": { "u_has_mission": "MISSION_REACH_REFUGEE_CENTER" } },
-            { "not": { "u_has_var": "found_refugee_center", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "found_refugee_center" } ] } }
           ]
         }
       },
@@ -156,7 +156,7 @@
         "condition": {
           "and": [
             { "not": { "u_has_mission": "MISSION_REACH_REFUGEE_CENTER" } },
-            { "not": { "u_has_var": "found_refugee_center", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "found_refugee_center" } ] } }
           ]
         }
       },
@@ -224,7 +224,7 @@
         "condition": {
           "and": [
             { "not": { "u_has_mission": "MISSION_REACH_REFUGEE_CENTER" } },
-            { "not": { "u_has_var": "found_refugee_center", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "found_refugee_center" } ] } }
           ]
         }
       },
@@ -243,7 +243,7 @@
         "condition": {
           "and": [
             { "not": { "u_has_mission": "MISSION_REACH_REFUGEE_CENTER" } },
-            { "not": { "u_has_var": "found_refugee_center", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "found_refugee_center" } ] } }
           ]
         }
       },
@@ -261,7 +261,7 @@
         "condition": {
           "and": [
             { "not": { "u_has_mission": "MISSION_REACH_REFUGEE_CENTER" } },
-            { "not": { "u_has_var": "found_refugee_center", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "found_refugee_center" } ] } }
           ]
         }
       },

--- a/data/json/npcs/random_encounters/john_bailey.json
+++ b/data/json/npcs/random_encounters/john_bailey.json
@@ -172,7 +172,7 @@
         "condition": {
           "and": [
             { "u_has_mission": "EXODII_MISSION_WAREHOUSE" },
-            { "not": { "npc_has_var": "asked_about_exodii_warehouse_mission", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "asked_about_exodii_warehouse_mission" } ] } }
           ]
         },
         "effect": { "run_eocs": [ "EOC_exodii_mission_wh_directions_chance" ] }
@@ -228,8 +228,7 @@
       "concatenate": [
         "&You describe the warehouse to the best of your ability.  John listens intently",
         {
-          "npc_has_var": "exodii_mission_wh_correct",
-          "value": "no",
+          "compare_string": [ "no", { "npc_val": "exodii_mission_wh_correct" } ],
           "yes": ", then shakes his head.  \"I don't believe I've heard about anything like that, no.  Sorry.\"",
           "no": ", looking thoughtful.  \"I can't guarantee it, but I'm pretty sure I've seen something like that.  It was far away, and the weather was bad.  Could've been a church or something, but it didn't look right for that.\""
         }
@@ -241,7 +240,7 @@
         "//": "The other responses are stored in common_talk.json in the exodii folder, to avoid repetition.",
         "text": "Oh well, thanks John.  I'll go ask around.",
         "topic": "TALK_DONE",
-        "condition": { "npc_has_var": "exodii_mission_wh_correct", "value": "no" },
+        "condition": { "compare_string": [ "no", { "npc_val": "exodii_mission_wh_correct" } ] },
         "effect": [
           { "math": [ "exodii_mission_wh_chance", "-=", "1" ] },
           { "math": [ "exodii_mission_wh_chance", "=", "max( exodii_mission_wh_chance, 1 )" ] }

--- a/data/json/npcs/random_encounters/john_bailey.json
+++ b/data/json/npcs/random_encounters/john_bailey.json
@@ -140,8 +140,7 @@
     "type": "talk_topic",
     "id": "TALK_RC_John_Bailey_1",
     "dynamic_line": {
-      "u_has_var": "u_met_John_Bailey",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "u_met_John_Bailey" } ],
       "yes": "*looks up at you, taking a moment to place your face, then grins broadly.  He looks about the same as when you last saw him, perhaps a little more fit.  \"So, you're still playing on the 'living' team, huh?  Glad to see you're still kicking around.  Always good to run into a familiar face nowadays.\"",
       "no": "*glances your way, then makes eye contact as you move closer to speak.  He is a strong-looking man in his mid forties, his hair greying and his face flecked with stubble and travel dust.  The clothes he's wearing are clearly scavenged, though they fit well, and he has the build of someone who until recently had the luxury of carrying a few extra pounds.  \"Hi there.\"  He presents his hand to shake.  \"You don't look like you belong here.  Name's Bailey, John Bailey.\""
     },
@@ -186,8 +185,7 @@
     "dynamic_line": {
       "concatenate": [
         {
-          "u_has_var": "RC_John_Bailey_2_John_Bailey_Convo",
-          "value": "seen",
+          "compare_string": [ "seen", { "u_val": "RC_John_Bailey_2_John_Bailey_Convo" } ],
           "yes": "Like I said,\" John shrugs.  \"I'm just checking ",
           "no": "Same as you, I imagine,\" John shrugs.  \"Checking "
         },
@@ -203,7 +201,7 @@
       {
         "text": "Got time to teach me anything?",
         "topic": "TALK_RC_John_Bailey_Teach",
-        "condition": { "u_has_var": "John_Bailey_teach", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "John_Bailey_teach" } ] }
       },
       { "text": "Sounds about the same as me, yep.  I'd better get back to it.", "topic": "TALK_DONE" }
     ]

--- a/data/json/npcs/random_encounters/refugee_caravans.json
+++ b/data/json/npcs/random_encounters/refugee_caravans.json
@@ -134,7 +134,7 @@
         "condition": {
           "and": [
             { "not": { "u_has_mission": "MISSION_REACH_REFUGEE_CENTER" } },
-            { "not": { "u_has_var": "found_refugee_center", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "found_refugee_center" } ] } }
           ]
         }
       },
@@ -153,7 +153,7 @@
         "condition": {
           "and": [
             { "not": { "u_has_mission": "MISSION_REACH_REFUGEE_CENTER" } },
-            { "not": { "u_has_var": "found_refugee_center", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "found_refugee_center" } ] } }
           ]
         }
       },
@@ -243,7 +243,7 @@
         "condition": {
           "and": [
             { "not": { "u_has_mission": "MISSION_REACH_REFUGEE_CENTER" } },
-            { "not": { "u_has_var": "found_refugee_center", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "found_refugee_center" } ] } }
           ]
         }
       },
@@ -267,7 +267,7 @@
         "condition": {
           "and": [
             { "not": { "u_has_mission": "MISSION_REACH_REFUGEE_CENTER" } },
-            { "not": { "u_has_var": "found_refugee_center", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "found_refugee_center" } ] } }
           ]
         }
       },
@@ -292,7 +292,7 @@
         "condition": {
           "and": [
             { "not": { "u_has_mission": "MISSION_REACH_REFUGEE_CENTER" } },
-            { "not": { "u_has_var": "found_refugee_center", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "found_refugee_center" } ] } }
           ]
         }
       },

--- a/data/json/npcs/random_encounters/refugee_caravans.json
+++ b/data/json/npcs/random_encounters/refugee_caravans.json
@@ -54,7 +54,7 @@
         "condition": {
           "and": [
             { "u_has_mission": "EXODII_MISSION_WAREHOUSE" },
-            { "not": { "npc_has_var": "asked_about_exodii_warehouse_mission", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "asked_about_exodii_warehouse_mission" } ] } }
           ]
         },
         "effect": { "run_eocs": [ "EOC_exodii_mission_wh_directions_chance" ] }
@@ -96,8 +96,7 @@
       "concatenate": [
         "&You describe the warehouse to the best of your ability.  The refugee nods along",
         {
-          "npc_has_var": "exodii_mission_wh_correct",
-          "value": "no",
+          "compare_string": [ "no", { "npc_val": "exodii_mission_wh_correct" } ],
           "yes": ", then frowns.  \"Nope, not ringing any bells, sorry.\"",
           "no": {
             "gendered_line": ", looking thoughtful.  \"Maybe, yeah.  I saw a weird building sort of like that a while back, but we were on the move and couldn't stop to check it out.\"",
@@ -112,7 +111,7 @@
         "//": "The other responses are stored in common_talk.json in the exodii folder, to avoid repetition.",
         "text": "Oh well.  Thanks anyway.  I'll go ask around.",
         "topic": "TALK_DONE",
-        "condition": { "npc_has_var": "exodii_mission_wh_correct", "value": "no" },
+        "condition": { "compare_string": [ "no", { "npc_val": "exodii_mission_wh_correct" } ] },
         "effect": [
           { "math": [ "exodii_mission_wh_chance", "-=", "1" ] },
           { "math": [ "exodii_mission_wh_chance", "=", "max( exodii_mission_wh_chance, 1 )" ] }

--- a/data/json/npcs/refugee_center/beggars/BEGGAR_1_Reena_Sandhu.json
+++ b/data/json/npcs/refugee_center/beggars/BEGGAR_1_Reena_Sandhu.json
@@ -68,8 +68,7 @@
     "type": "talk_topic",
     "id": "TALK_REFUGEE_BEGGAR_1",
     "dynamic_line": {
-      "u_has_var": "general_recruit_reena_recruited",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "general_recruit_reena_recruited" } ],
       "yes": {
         "npc_has_effect": "beggar_has_eaten",
         "yes": "So, any luck with convincing the others to come on your crazy adventure yet?",
@@ -90,7 +89,7 @@
     },
     "responses": [
       {
-        "condition": { "u_has_var": "general_recruit_beggars_recruited", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "general_recruit_beggars_recruited" } ] },
         "text": "I've talked to the others, and they're all willing to come.  So, you joining us?",
         "topic": "TALK_REFUGEE_BEGGAR_1_RECRUITED"
       },
@@ -180,7 +179,7 @@
         "topic": "TALK_REFUGEE_BEGGAR_1_JOIN"
       },
       {
-        "condition": { "and": [ "u_has_camp", { "not": { "u_has_var": "general_recruit_reena_recruited", "value": "yes" } } ] },
+        "condition": { "and": [ "u_has_camp", { "not": { "compare_string": [ "yes", { "u_val": "general_recruit_reena_recruited" } ] } } ] },
         "text": "I have a camp of my own, away from here.  You could come there.  There aren't many people left, we could use anyone regardless of skills.",
         "topic": "TALK_REFUGEE_BEGGAR_1_RECRUIT1"
       },
@@ -210,7 +209,7 @@
         "topic": "TALK_REFUGEE_BEGGAR_1_JOIN"
       },
       {
-        "condition": { "and": [ "u_has_camp", { "not": { "u_has_var": "general_recruit_reena_recruited", "value": "yes" } } ] },
+        "condition": { "and": [ "u_has_camp", { "not": { "compare_string": [ "yes", { "u_val": "general_recruit_reena_recruited" } ] } } ] },
         "text": "I have a camp of my own, away from here.  Maybe you can't scavenge, but we can use any warm bodies that can lift a tool.  You'd be safer and better fed there.",
         "topic": "TALK_REFUGEE_BEGGAR_1_RECRUIT1"
       },
@@ -240,7 +239,7 @@
         "topic": "TALK_REFUGEE_BEGGAR_1_JOIN"
       },
       {
-        "condition": { "and": [ "u_has_camp", { "not": { "u_has_var": "general_recruit_reena_recruited", "value": "yes" } } ] },
+        "condition": { "and": [ "u_has_camp", { "not": { "compare_string": [ "yes", { "u_val": "general_recruit_reena_recruited" } ] } } ] },
         "text": "I have a camp of my own, away from here.  Maybe they can't use your skills here, but I could.",
         "topic": "TALK_REFUGEE_BEGGAR_1_RECRUIT1"
       },

--- a/data/json/npcs/refugee_center/beggars/BEGGAR_2_Dino_Dave.json
+++ b/data/json/npcs/refugee_center/beggars/BEGGAR_2_Dino_Dave.json
@@ -69,7 +69,10 @@
       { "condition": "has_assigned_mission", "text": "About that shopping list of yours…", "topic": "TALK_MISSION_INQUIRE" },
       {
         "condition": {
-          "and": [ { "npc_has_var": "mission_dinodave_cardboard_donor", "value": "yes" }, { "not": "has_no_available_mission" } ]
+          "and": [
+            { "compare_string": [ "yes", { "npc_val": "mission_dinodave_cardboard_donor" } ] },
+            { "not": "has_no_available_mission" }
+          ]
         },
         "text": "Is there anything else I can do for you?",
         "topic": "TALK_MISSION_OFFER"

--- a/data/json/npcs/refugee_center/beggars/BEGGAR_2_Dino_Dave.json
+++ b/data/json/npcs/refugee_center/beggars/BEGGAR_2_Dino_Dave.json
@@ -87,7 +87,10 @@
       },
       {
         "condition": {
-          "and": [ { "u_has_mission": "MISSION_BEGGAR_2_PERMISSION" }, { "u_has_var": "mission_Dave_Permission", "value": "yes" } ]
+          "and": [
+            { "u_has_mission": "MISSION_BEGGAR_2_PERMISSION" },
+            { "compare_string": [ "yes", { "u_val": "mission_Dave_Permission" } ] }
+          ]
         },
         "text": "We've done it, Dave!  Smokes says you can build yourself a house up on the roof if you want.  You've got to keep it nice and clean, and help out the people down here by looking out for zombies, but you can still use the washrooms and things downstairs when you need to.  What do you say?",
         "topic": "TALK_REFUGEE_BEGGAR_2_PERMISSION"
@@ -213,8 +216,7 @@
       "concatenate": [
         "Well… I had it all pretty together,\u0020",
         {
-          "u_has_var": "general_recruit_beggars_recruited",
-          "value": "yes",
+          "compare_string": [ "yes", { "u_val": "general_recruit_beggars_recruited" } ],
           "yes": "but the others have left, and\u0020",
           "no": "and I feel bad with all the help you've given me already, but\u0020"
         },
@@ -223,7 +225,7 @@
     },
     "responses": [
       {
-        "condition": { "not": { "u_has_var": "general_recruit_beggars_recruited", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "general_recruit_beggars_recruited" } ] } },
         "text": "Why don't you leave this place?  Come with me, I could use some help out there.",
         "topic": "TALK_REFUGEE_BEGGAR_2_JOIN"
       },
@@ -384,7 +386,7 @@
     "difficulty": 1,
     "value": 0,
     "goal": "MGOAL_CONDITION",
-    "goal_condition": { "u_has_var": "mission_Dave_Permission", "value": "yes" },
+    "goal_condition": { "compare_string": [ "yes", { "u_val": "mission_Dave_Permission" } ] },
     "count": 5,
     "origins": [ "ORIGIN_SECONDARY" ],
     "dialogue": {

--- a/data/json/npcs/refugee_center/beggars/BEGGAR_3_Luo_Meizhen.json
+++ b/data/json/npcs/refugee_center/beggars/BEGGAR_3_Luo_Meizhen.json
@@ -94,8 +94,7 @@
       "npc_has_effect": "insulted_luo",
       "yes": { "gendered_line": "Fuck off, dickwaddle.", "relevant_genders": [ "u" ] },
       "no": {
-        "u_has_var": "general_recruit_luo_recruited",
-        "value": "yes",
+        "compare_string": [ "yes", { "u_val": "general_recruit_luo_recruited" } ],
         "yes": "Yo.  Anyone else keen on moving from this bus stop to your tent city?",
         "no": {
           "compare_string": [ "yes", { "npc_val": "general_conversation_dont_insult_luo" } ],
@@ -121,7 +120,7 @@
     },
     "responses": [
       {
-        "condition": { "u_has_var": "general_recruit_beggars_recruited", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "general_recruit_beggars_recruited" } ] },
         "text": "I've talked to the others, and they're all willing to come.  So, you joining us?",
         "topic": "TALK_REFUGEE_BEGGAR_3_RECRUITED2"
       },
@@ -242,14 +241,14 @@
     "responses": [
       { "text": "You think you were treated like that because of your race?", "topic": "TALK_REFUGEE_BEGGAR_3_RACISM" },
       {
-        "condition": { "u_has_var": "general_conversation_told_about_FM_evacuation", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "general_conversation_told_about_FM_evacuation" } ] },
         "text": "Does that mean you were part of that back room evacuation I heard about?",
         "topic": "TALK_REFUGEE_BEGGAR_3_EVACUATION"
       },
       { "text": "Why stay out here then?", "topic": "TALK_REFUGEE_BEGGAR_3_WHYSTAY" },
       { "text": "What did you do before <the_cataclysm>?", "topic": "TALK_REFUGEE_BEGGAR_3_EXPERTISE" },
       {
-        "condition": { "and": [ "u_has_camp", { "not": { "u_has_var": "general_recruit_luo_recruited", "value": "yes" } } ] },
+        "condition": { "and": [ "u_has_camp", { "not": { "compare_string": [ "yes", { "u_val": "general_recruit_luo_recruited" } ] } } ] },
         "text": "I have a camp of my own, away from here.  No paperwork required.  Want to come?",
         "topic": "TALK_REFUGEE_BEGGAR_3_RECRUIT1"
       },
@@ -292,7 +291,7 @@
     "dynamic_line": "Sure.  My grandparents were from China.  That means I'm obviously personally responsible for all this.  Do you think there's some other reason they let hundreds of other educated people in and I'm sitting out here?",
     "responses": [
       {
-        "condition": { "not": { "u_has_var": "general_recruit_luo_recruited", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "general_recruit_luo_recruited" } ] } },
         "text": "I don't care if you're Chinese.  You can travel with me if you want.",
         "topic": "TALK_REFUGEE_BEGGAR_3_JOIN"
       },
@@ -300,7 +299,7 @@
         "condition": {
           "and": [
             { "u_has_perception": 9 },
-            { "not": { "u_has_var": "general_recruit_luo_recruited", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "u_val": "general_recruit_luo_recruited" } ] } },
             { "not": { "compare_string": [ "yes", { "npc_val": "general_conversation_dont_insult_luo" } ] } }
           ]
         },
@@ -318,7 +317,7 @@
       { "text": "Why stay out here then?", "topic": "TALK_REFUGEE_BEGGAR_3_WHYSTAY" },
       { "text": "What did you do before <the_cataclysm>?", "topic": "TALK_REFUGEE_BEGGAR_3_EXPERTISE" },
       {
-        "condition": { "and": [ "u_has_camp", { "not": { "u_has_var": "general_recruit_luo_recruited", "value": "yes" } } ] },
+        "condition": { "and": [ "u_has_camp", { "not": { "compare_string": [ "yes", { "u_val": "general_recruit_luo_recruited" } ] } } ] },
         "text": "It'd be temporary.  I have a base set up.  There are only a few of us survivors left, we need to work together",
         "topic": "TALK_REFUGEE_BEGGAR_3_RECRUIT1"
       },
@@ -334,15 +333,15 @@
       { "text": "You sound more optimistic than usual.", "topic": "TALK_REFUGEE_BEGGAR_3_WHYSTAY2" },
       { "text": "What did you do before <the_cataclysm>?", "topic": "TALK_REFUGEE_BEGGAR_3_EXPERTISE" },
       {
-        "condition": { "and": [ "u_has_camp", { "not": { "u_has_var": "general_recruit_luo_recruited", "value": "yes" } } ] },
+        "condition": { "and": [ "u_has_camp", { "not": { "compare_string": [ "yes", { "u_val": "general_recruit_luo_recruited" } ] } } ] },
         "text": "It'd be temporary.  I have a base set up.  There are only a few of us survivors left, we need to work together",
         "topic": "TALK_REFUGEE_BEGGAR_3_RECRUIT1"
       },
       {
         "condition": {
           "and": [
-            { "u_has_var": "general_conversation_luo_doctorate", "value": "yes" },
-            { "not": { "u_has_var": "general_recruit_luo_recruited", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "general_conversation_luo_doctorate" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "general_recruit_luo_recruited" } ] } }
           ]
         },
         "text": "So, about that doctorate of yours…",
@@ -359,7 +358,7 @@
     "responses": [
       { "text": "What did you do before <the_cataclysm>?", "topic": "TALK_REFUGEE_BEGGAR_3_EXPERTISE" },
       {
-        "condition": { "and": [ "u_has_camp", { "not": { "u_has_var": "general_recruit_luo_recruited", "value": "yes" } } ] },
+        "condition": { "and": [ "u_has_camp", { "not": { "compare_string": [ "yes", { "u_val": "general_recruit_luo_recruited" } ] } } ] },
         "text": "It'd be temporary.  I have a base set up.  There are only a few of us survivors left, we need to work together",
         "topic": "TALK_REFUGEE_BEGGAR_3_RECRUIT1"
       },
@@ -426,8 +425,8 @@
       {
         "condition": {
           "and": [
-            { "u_has_var": "general_conversation_luo_doctorate", "value": "yes" },
-            { "not": { "u_has_var": "general_recruit_luo_recruited", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "general_conversation_luo_doctorate" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "general_recruit_luo_recruited" } ] } }
           ]
         },
         "text": "So, about that doctorate of yours…",
@@ -446,8 +445,8 @@
       {
         "condition": {
           "and": [
-            { "u_has_var": "general_conversation_luo_doctorate", "value": "yes" },
-            { "not": { "u_has_var": "general_recruit_luo_recruited", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "general_conversation_luo_doctorate" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "general_recruit_luo_recruited" } ] } }
           ]
         },
         "text": "So, about that doctorate of yours…",
@@ -467,8 +466,8 @@
       {
         "condition": {
           "and": [
-            { "u_has_var": "general_conversation_luo_doctorate", "value": "yes" },
-            { "not": { "u_has_var": "general_recruit_luo_recruited", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "general_conversation_luo_doctorate" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "general_recruit_luo_recruited" } ] } }
           ]
         },
         "text": "So, about that doctorate of yours…",
@@ -488,8 +487,8 @@
         "condition": {
           "and": [
             { "or": [ { "u_has_perception": 9 }, { "u_has_intelligence": 9 } ] },
-            { "not": { "u_has_var": "general_conversation_luo_doctorate", "value": "yes" } },
-            { "not": { "u_has_var": "general_recruit_luo_recruited", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "general_conversation_luo_doctorate" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "general_recruit_luo_recruited" } ] } }
           ]
         },
         "text": "What had you working at the university bookstore in the first place?  Are you an academic yourself?",
@@ -499,8 +498,8 @@
       {
         "condition": {
           "and": [
-            { "u_has_var": "general_conversation_luo_doctorate", "value": "yes" },
-            { "not": { "u_has_var": "general_recruit_luo_recruited", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "general_conversation_luo_doctorate" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "general_recruit_luo_recruited" } ] } }
           ]
         },
         "text": "What's this I hear about you having a doctorate?",

--- a/data/json/npcs/refugee_center/beggars/BEGGAR_3_Luo_Meizhen.json
+++ b/data/json/npcs/refugee_center/beggars/BEGGAR_3_Luo_Meizhen.json
@@ -98,11 +98,9 @@
         "value": "yes",
         "yes": "Yo.  Anyone else keen on moving from this bus stop to your tent city?",
         "no": {
-          "npc_has_var": "general_conversation_dont_insult_luo",
-          "value": "yes",
+          "compare_string": [ "yes", { "npc_val": "general_conversation_dont_insult_luo" } ],
           "yes": {
-            "npc_has_var": "general_conversation_apology_luo",
-            "value": "yes",
+            "compare_string": [ "yes", { "npc_val": "general_conversation_apology_luo" } ],
             "yes": {
               "npc_has_effect": "beggar_has_eaten",
               "yes": "Hey there.  Good to see you again.",
@@ -145,8 +143,8 @@
       {
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "general_conversation_apology_luo", "value": "yes" } },
-            { "npc_has_var": "general_conversation_dont_insult_luo", "value": "yes" },
+            { "not": { "compare_string": [ "yes", { "npc_val": "general_conversation_apology_luo" } ] } },
+            { "compare_string": [ "yes", { "npc_val": "general_conversation_dont_insult_luo" } ] },
             { "not": { "npc_has_effect": "insulted_luo" } }
           ]
         },
@@ -158,7 +156,7 @@
         "condition": {
           "and": [
             { "u_has_item": "veggy_tainted" },
-            { "npc_has_var": "general_recruit_luo_attempt_recruit", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_recruit_luo_attempt_recruit" } ] },
             { "not": { "npc_has_effect": "insulted_luo" } }
           ]
         },
@@ -169,7 +167,7 @@
         "condition": {
           "and": [
             { "u_has_item": "veggy_tainted" },
-            { "not": { "npc_has_var": "general_recruit_luo_attempt_recruit", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "general_recruit_luo_attempt_recruit" } ] } },
             { "not": { "npc_has_effect": "insulted_luo" } }
           ]
         },
@@ -258,8 +256,8 @@
       {
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "general_conversation_apology_luo", "value": "yes" } },
-            { "npc_has_var": "general_conversation_dont_insult_luo", "value": "yes" },
+            { "not": { "compare_string": [ "yes", { "npc_val": "general_conversation_apology_luo" } ] } },
+            { "compare_string": [ "yes", { "npc_val": "general_conversation_dont_insult_luo" } ] },
             { "not": { "npc_has_effect": "insulted_luo" } }
           ]
         },
@@ -271,7 +269,7 @@
         "condition": {
           "and": [
             { "u_has_item": "veggy_tainted" },
-            { "npc_has_var": "general_recruit_luo_attempt_recruit", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "general_recruit_luo_attempt_recruit" } ] },
             { "not": { "npc_has_effect": "insulted_luo" } }
           ]
         },
@@ -303,7 +301,7 @@
           "and": [
             { "u_has_perception": 9 },
             { "not": { "u_has_var": "general_recruit_luo_recruited", "value": "yes" } },
-            { "not": { "npc_has_var": "general_conversation_dont_insult_luo", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "general_conversation_dont_insult_luo" } ] } }
           ]
         },
         "text": "I mean, racism could definitely be a part of it… but you are visibly in poor shape.  They need strong survivor material.",
@@ -416,12 +414,12 @@
     "speaker_effect": [ { "effect": { "npc_add_var": "general_recruit_luo_attempt_recruit", "value": "yes" } } ],
     "responses": [
       {
-        "condition": { "npc_has_var": "general_recruit_luo_owed", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "npc_val": "general_recruit_luo_owed" } ] },
         "text": "Oh, come on.  I'm not a random stranger anymore, I brought you that crazy mushroom didn't I?",
         "topic": "TALK_REFUGEE_BEGGAR_3_RECRUITED1"
       },
       {
-        "condition": { "not": { "npc_has_var": "general_recruit_luo_owed", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "npc_val": "general_recruit_luo_owed" } ] } },
         "text": "What better choice do you have?  It's not like it would be just you and me, the others out here can come too.",
         "topic": "TALK_REFUGEE_BEGGAR_3_RECRUIT2"
       },
@@ -562,8 +560,7 @@
     "type": "talk_topic",
     "id": "TALK_REFUGEE_BEGGAR_3_MYCUS3",
     "dynamic_line": {
-      "npc_has_var": "general_recruit_luo_attempt_recruit",
-      "value": "yes",
+      "compare_string": [ "yes", { "npc_val": "general_recruit_luo_attempt_recruit" } ],
       "yes": "If you get me a sample, I'll join your crazy camp expedition.  Hell, if you bring me a sample maybe I'll help you set up a lab to study this stuff.  Almost anything could work, but if this stuff is as dangerous as you make it sound, maybe make sure it's not a sporulating body.",
       "no": "I dunno, scientific interest?  If you don't bring me anything, no worries.  I'm positively swimming in entertainment here, as you can see."
     },
@@ -571,7 +568,10 @@
     "responses": [
       {
         "condition": {
-          "and": [ { "u_has_item": "veggy_tainted" }, { "npc_has_var": "general_recruit_luo_attempt_recruit", "value": "yes" } ]
+          "and": [
+            { "u_has_item": "veggy_tainted" },
+            { "compare_string": [ "yes", { "npc_val": "general_recruit_luo_attempt_recruit" } ] }
+          ]
         },
         "text": "It just so happens I have a chunk of fungal matter on me right now.",
         "topic": "TALK_REFUGEE_BEGGAR_3_MYCUS4_RECRUIT"
@@ -580,7 +580,7 @@
         "condition": {
           "and": [
             { "u_has_item": "veggy_tainted" },
-            { "not": { "npc_has_var": "general_recruit_luo_attempt_recruit", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "general_recruit_luo_attempt_recruit" } ] } }
           ]
         },
         "text": "It just so happens I have a chunk of fungal matter on me right now.",

--- a/data/json/npcs/refugee_center/beggars/BEGGAR_4_Brandon_Garder.json
+++ b/data/json/npcs/refugee_center/beggars/BEGGAR_4_Brandon_Garder.json
@@ -100,7 +100,7 @@
     },
     "responses": [
       {
-        "condition": { "u_has_var": "general_recruit_beggars_recruited", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "general_recruit_beggars_recruited" } ] },
         "text": "I've talked to the others, and they're all willing to come.  So, you joining us?",
         "topic": "TALK_REFUGEE_BEGGAR_4_RECRUITED"
       },
@@ -281,7 +281,7 @@
     "dynamic_line": "That's awful nice of you.  Tell you what: if you can help Dave get himself sorted out, so I don't feel like I've gotta stay here keeping an eye on the poor fella, then I'll come along.",
     "responses": [
       {
-        "condition": { "u_has_var": "general_recruit_dave_happy", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "general_recruit_dave_happy" } ] },
         "text": "I think I've sorted Dave out pretty well, don't you?  Would you consider coming with me now?",
         "topic": "TALK_REFUGEE_BEGGAR_4_RECRUIT2"
       },

--- a/data/json/npcs/refugee_center/beggars/BEGGAR_5_Yusuke_Taylor.json
+++ b/data/json/npcs/refugee_center/beggars/BEGGAR_5_Yusuke_Taylor.json
@@ -188,9 +188,9 @@
       {
         "condition": {
           "and": [
-            { "u_has_var": "general_recruit_reena_recruited", "value": "yes" },
-            { "u_has_var": "general_recruit_luo_recruited", "value": "yes" },
-            { "u_has_var": "general_recruit_brendan_recruited", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "general_recruit_reena_recruited" } ] },
+            { "compare_string": [ "yes", { "u_val": "general_recruit_luo_recruited" } ] },
+            { "compare_string": [ "yes", { "u_val": "general_recruit_brendan_recruited" } ] }
           ]
         },
         "text": "I've spoken to all your friends, and except for Dave, they're good to go.  Dave wants to stay here.  How about you?",

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Aleesha_Seward.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Aleesha_Seward.json
@@ -70,7 +70,7 @@
         "condition": {
           "and": [
             { "u_has_mission": "MISSION_REFUGEE_Boris_CLEANUP" },
-            { "not": { "npc_has_var": "mission_Boris_mission_1_cleanup_asked", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "mission_Boris_mission_1_cleanup_asked" } ] } }
           ]
         },
         "trial": { "type": "PERSUADE", "difficulty": 25 },

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Alonso_Lautrec.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Alonso_Lautrec.json
@@ -106,12 +106,12 @@
       {
         "text": "Why aren't you wearing any pants?",
         "topic": "TALK_REFUGEE_Alonso_Pants1",
-        "condition": { "not": { "u_has_var": "mission_flag_Alonso_pants", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "mission_flag_Alonso_pants" } ] } }
       },
       {
         "text": "About those special pants a sexy clown hid in a shop for mysterious reasons…",
         "topic": "TALK_MISSION_INQUIRE",
-        "condition": { "u_has_var": "mission_flag_Alonso_pants", "value": "in_progress" }
+        "condition": { "compare_string": [ "in_progress", { "u_val": "mission_flag_Alonso_pants" } ] }
       },
       { "text": "What's your story?", "topic": "TALK_REFUGEE_Alonso_Background" },
       { "text": "How are things here?", "topic": "TALK_REFUGEE_Alonso_Situation" },

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Alonso_Lautrec.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Alonso_Lautrec.json
@@ -86,7 +86,7 @@
         "condition": {
           "and": [
             { "u_has_mission": "MISSION_REFUGEE_Boris_CLEANUP" },
-            { "not": { "npc_has_var": "mission_Boris_mission_1_cleanup_asked", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "mission_Boris_mission_1_cleanup_asked" } ] } }
           ]
         },
         "topic": "TALK_REFUGEE_Alonso_Refuse_Boris_Mission_1"
@@ -98,8 +98,8 @@
         "condition": {
           "and": [
             { "u_has_perception": 10 },
-            { "not": { "npc_has_var": "general_none_Alonso_accent", "value": "asked" } },
-            { "not": { "npc_has_var": "general_none_Alonso_accent", "value": "accepted" } }
+            { "not": { "compare_string": [ "asked", { "npc_val": "general_none_Alonso_accent" } ] } },
+            { "not": { "compare_string": [ "accepted", { "npc_val": "general_none_Alonso_accent" } ] } }
           ]
         }
       },
@@ -209,8 +209,7 @@
     "type": "talk_topic",
     "id": "TALK_REFUGEE_Alonso_2",
     "dynamic_line": {
-      "npc_has_var": "general_none_Alonso_accent",
-      "value": "asked",
+      "compare_string": [ "asked", { "npc_val": "general_none_Alonso_accent" } ],
       "no": "Now that you are here, everything.  Is there anything Alonso can… *do for you*?",
       "yes": "Well, it's a lot better now that you're here.  Nice to see a familiar face."
     },
@@ -223,8 +222,7 @@
     "type": "talk_topic",
     "id": "TALK_REFUGEE_Alonso_Forward",
     "dynamic_line": {
-      "npc_has_var": "general_none_Alonso_accent",
-      "value": "asked",
+      "compare_string": [ "asked", { "npc_val": "general_none_Alonso_accent" } ],
       "no": "Alonso cannot help himself, in the face of someone so fine as you.",
       "yes": "You know me, I gotta be me, right?"
     },
@@ -274,8 +272,7 @@
     "type": "talk_topic",
     "id": "TALK_REFUGEE_Alonso_CalledOut3",
     "dynamic_line": {
-      "npc_has_var": "general_none_Alonso_accent",
-      "value": "asked",
+      "compare_string": [ "asked", { "npc_val": "general_none_Alonso_accent" } ],
       "yes": "Fine.  As a favor to you, I'll be a guy from Brooklyn.",
       "no": "Alonso thanks you for your kindness, and will remain his glorious self."
     },
@@ -285,8 +282,7 @@
     "type": "talk_topic",
     "id": "TALK_REFUGEE_Alonso_Background",
     "dynamic_line": {
-      "npc_has_var": "general_none_Alonso_accent",
-      "value": "asked",
+      "compare_string": [ "asked", { "npc_val": "general_none_Alonso_accent" } ],
       "no": "Alonso has many a tale to tell, all slow and drawn-out like, a sensual seduction of the -- how you say?  Ears.  There are dark days ahead, but perhaps together we can bring a little light?  Or at least a little heat.  This is a science joke I make for you.  Friction, it is the joke.",
       "yes": "I'm tryin' ta forget, y'know?  Don't like thinkin' about the past.  Better to plan for the future, even if the future looks grim."
     },
@@ -299,8 +295,7 @@
     "type": "talk_topic",
     "id": "TALK_REFUGEE_Alonso_Pants1",
     "dynamic_line": {
-      "npc_has_var": "general_none_Alonso_accent",
-      "value": "asked",
+      "compare_string": [ "asked", { "npc_val": "general_none_Alonso_accent" } ],
       "no": "Why were you looking though?  I kid, I know she is hard to miss!  In English, the special package she is a woman no?  No.  I see.  And so do you it seems.  Yes.  There was such a clown, a clown of enormous physical beauty.  The pale, perfect skin, the ruby red lips, amazing hair, and what a sense of humor.  I laugh still, though I have lost everything.  My pants, my money, my many illegal imported triple magnum condoms I stole from a priest.  All lost to that one beautiful night.  The candles, the balloons, the singing.  It was the most romantic children's birthday party you could hope to imagine.  I would do it all again, and there was so much we did.  It was the end of that party, but the beginning of something beautiful, for several hours in that open minivan we found.  But you do not want to hear of such pleasures, I do not want to get you excited, for what can I do when I look so foolish, and lack the protection needed for more serious excitement.  Though and you must understand, Alonso's tongue is good for more than just the telling of long and saucy stories yes?",
       "yes": "Yeah, I fucked up and got drunk at a kiddy party I crashed, broke into a van with the party clown I was seein' (hey don't judge me, it took me a long time to make that happen, clowns are very givin' lovers) and I lost my pants, includin' all my money and all my triple magnum condoms I stole off a dead priest at a bar.  I'd be mad, but at least I'm safe, I made it here.  But I got no game here y'know?  I look like the clown when I should be knee deep in hotness here.  Look around, it's straight hotties!"
     },
@@ -314,8 +309,7 @@
     "type": "talk_topic",
     "id": "TALK_REFUGEE_Alonso_Situation",
     "dynamic_line": {
-      "npc_has_var": "general_none_Alonso_accent",
-      "value": "asked",
+      "compare_string": [ "asked", { "npc_val": "general_none_Alonso_accent" } ],
       "no": "Here in the center, Alonso is a bit lonely.  We get a few brave, strong travelers like yourself, though, and seeing them brightens Alonso's day.  Normally I am more popular, but something seems to be troubling the spirits of these people during these terrible times.",
       "yes": "Could be better.  I don't really got any friends here in the center, but seeing travelers like you always brightens my day."
     },
@@ -364,8 +358,7 @@
     "dynamic_line": {
       "concatenate": [
         {
-          "npc_has_var": "general_none_Alonso_accent",
-          "value": "asked",
+          "compare_string": [ "asked", { "npc_val": "general_none_Alonso_accent" } ],
           "no": "My jewel of the New England, I give to you my biggest prize.",
           "yes": { "gendered_line": "Yo, you're crazy hot!  I'm not stupid!", "relevant_genders": [ "u" ] }
         },
@@ -391,8 +384,7 @@
     "dynamic_line": {
       "concatenate": [
         {
-          "npc_has_var": "general_none_Alonso_accent",
-          "value": "asked",
+          "compare_string": [ "asked", { "npc_val": "general_none_Alonso_accent" } ],
           "no": "I give to you what of I got.  And this is Alonso so I mean it's a lot.",
           "yes": "Yeeeeah it's on!"
         },
@@ -418,8 +410,7 @@
     "dynamic_line": {
       "concatenate": [
         {
-          "npc_has_var": "general_none_Alonso_accent",
-          "value": "asked",
+          "compare_string": [ "asked", { "npc_val": "general_none_Alonso_accent" } ],
           "no": "My jewel of the New England, I give to you my biggest prize.",
           "yes": { "gendered_line": "Yo, you're crazy hot!  I'm not stupid!", "relevant_genders": [ "u" ] }
         },
@@ -443,8 +434,7 @@
     "type": "talk_topic",
     "id": "TALK_REFUGEE_Alonso_Too_Young",
     "dynamic_line": {
-      "npc_has_var": "general_none_Alonso_accent",
-      "value": "asked",
+      "compare_string": [ "asked", { "npc_val": "general_none_Alonso_accent" } ],
       "no": "Alonso thinks maybe we should wait a few years?",
       "yes": "Sorry kid, you're younger than my little sister was.  Seems wrong."
     },
@@ -454,8 +444,7 @@
     "type": "talk_topic",
     "id": "TALK_REFUGEE_Alonso_Refuse_Boris_Mission_1",
     "dynamic_line": {
-      "npc_has_var": "general_none_Alonso_accent",
-      "value": "asked",
+      "compare_string": [ "asked", { "npc_val": "general_none_Alonso_accent" } ],
       "no": "Alonso, alas, is sorry, but he cannot sully his hands with blood.  It is not that he does not wish to prove his strength, but he… he is not strong enough.",
       "yes": "I'm sorry.  I… saw things back there, when it all went sideways.  I can't go back, not for anything."
     },

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Boris_Borichenko.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Boris_Borichenko.json
@@ -86,7 +86,7 @@
         "condition": {
           "and": [
             { "u_has_mission": "MISSION_REFUGEE_Boris_CLEANUP" },
-            { "not": { "npc_has_var": "mission_Boris_mission_1_cleanup_asked", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "mission_Boris_mission_1_cleanup_asked" } ] } }
           ]
         },
         "topic": "TALK_REFUGEE_Boris_Refuse_Boris_Mission_1"
@@ -96,7 +96,7 @@
         "condition": {
           "and": [
             { "u_has_mission": "MISSION_REFUGEE_Boris_CLEANUP" },
-            { "not": { "npc_has_var": "mission_Boris_mission_1_cleanup_asked", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "mission_Boris_mission_1_cleanup_asked" } ] } },
             { "math": [ "u_mission_cleanup_promises_Boris_mission_1", "==", "2" ] }
           ]
         },
@@ -107,7 +107,7 @@
         "condition": {
           "and": [
             { "u_has_mission": "MISSION_REFUGEE_Boris_CLEANUP" },
-            { "not": { "npc_has_var": "mission_Boris_mission_1_cleanup_asked", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "mission_Boris_mission_1_cleanup_asked" } ] } },
             { "math": [ "u_mission_cleanup_promises_Boris_mission_1", "==", "3" ] }
           ]
         },
@@ -118,7 +118,7 @@
         "condition": {
           "and": [
             { "u_has_mission": "MISSION_REFUGEE_Boris_CLEANUP" },
-            { "not": { "npc_has_var": "mission_Boris_mission_1_cleanup_asked", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "mission_Boris_mission_1_cleanup_asked" } ] } },
             { "math": [ "u_mission_cleanup_promises_Boris_mission_1", "==", "4" ] }
           ]
         },

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Boris_Borichenko.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Boris_Borichenko.json
@@ -127,29 +127,29 @@
       {
         "text": "Is there anything I can help you out with?",
         "topic": "TALK_REFUGEE_Boris_Work1",
-        "condition": { "not": { "u_has_var": "mission_completed_Boris_mission_1", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "mission_completed_Boris_mission_1" } ] } }
       },
       {
         "text": "Got anything else I can help out with?",
         "topic": "TALK_MISSION_LIST",
         "condition": {
           "and": [
-            { "u_has_var": "mission_completed_Boris_mission_1", "value": "yes" },
-            { "not": { "u_has_var": "mission_completed_Boris_mission_3", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "mission_completed_Boris_mission_1" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "mission_completed_Boris_mission_3" } ] } }
           ]
         }
       },
       {
         "text": "So, have you had a chance to get that laptop working and look at it yet?",
         "topic": "TALK_REFUGEE_Boris_ReadLaptop1",
-        "condition": { "u_has_var": "mission_completed_Boris_mission_3", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "mission_completed_Boris_mission_3" } ] }
       },
       {
         "text": "Now that you've got your tools and shop set up, do you think you could teach me a thing or two about construction?",
         "topic": "TALK_REFUGEE_Boris_Teach",
         "condition": {
           "and": [
-            { "u_has_var": "mission_completed_Boris_mission_2", "value": "yes" },
+            { "compare_string": [ "yes", { "u_val": "mission_completed_Boris_mission_2" } ] },
             { "math": [ "time_since(n_timer_flag_Boris_teach)", ">", "time('1 d')" ] }
           ]
         }
@@ -250,22 +250,22 @@
       {
         "text": "It seems like carpentry work would be something the Free Merchants need.  Why are you so bored?",
         "topic": "TALK_REFUGEE_Boris_Work1",
-        "condition": { "not": { "u_has_var": "mission_completed_Boris_mission_1", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "mission_completed_Boris_mission_1" } ] } }
       },
       {
         "text": "Could you teach me something about carpentry?",
         "topic": "TALK_REFUGEE_Boris_NoTeach",
-        "condition": { "not": { "u_has_var": "mission_completed_Boris_mission_2", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "mission_completed_Boris_mission_2" } ] } }
       },
       {
         "text": "Could you teach me something about carpentry?",
         "topic": "TALK_REFUGEE_Boris_Teach",
-        "condition": { "u_has_var": "mission_completed_Boris_mission_2", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "mission_completed_Boris_mission_2" } ] }
       },
       {
         "text": "Now that things are cleaned up in the back, is there anything holding you back from working?",
         "topic": "TALK_MISSION_LIST",
-        "condition": { "u_has_var": "mission_completed_Boris_mission_1", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "mission_completed_Boris_mission_1" } ] }
       },
       { "text": "What were you saying before?", "topic": "TALK_NONE" },
       { "text": "I'd better get going.", "topic": "TALK_DONE" }
@@ -338,15 +338,14 @@
     "type": "talk_topic",
     "id": "TALK_REFUGEE_Boris_Work1",
     "dynamic_line": {
-      "u_has_var": "mission_flag_FMShopkeep_Mission1",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "mission_flag_FMShopkeep_Mission1" } ],
       "yes": "Well, now that you mention it, with the back bay cleared I could probably set up back there and start work.  I don't know if I can handle it.  The last time I was back there was the last time I saw… if… if someone were to clean up back there, wipe away some memories, then I could start renovating it into a better living space.",
       "no": "There isn't much to do with a hammer and a saw here indoors, and working outside is too dangerous.  If we had enough space for me to do some shuffling around, I could build some privacy walls in here.  I tried to set up a bit of a shop in the garage space, but I had to keep taking everything down for caravan loading and unloading and couldn't get anything done.  The caravans bring food, so they get priority, I can't argue with that."
     },
     "responses": [
       {
         "text": "What do you need to get things cleaned up?  Can I help?",
-        "condition": { "u_has_var": "mission_flag_FMShopkeep_Mission1", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "mission_flag_FMShopkeep_Mission1" } ] },
         "topic": "TALK_REFUGEE_Boris_Work2"
       },
       { "text": "I'm sorry.  What were you saying before?", "topic": "TALK_NONE" },
@@ -369,12 +368,12 @@
     "responses": [
       {
         "text": "Is there anything I can do to help?",
-        "condition": { "not": { "u_has_var": "mission_completed_Boris_mission_1", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "mission_completed_Boris_mission_1" } ] } },
         "topic": "TALK_REFUGEE_Boris_Work1"
       },
       {
         "text": "Is there anything more I can do to help?",
-        "condition": { "u_has_var": "mission_completed_Boris_mission_1", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "mission_completed_Boris_mission_1" } ] },
         "topic": "TALK_MISSION_LIST"
       },
       { "text": "What were you saying before?", "topic": "TALK_NONE" },
@@ -402,15 +401,13 @@
       "concatenate": [
         "Everyone agrees this is bad.  Sleeping on a cot on the floor, crowded in with strangers",
         {
-          "u_has_var": "mission_completed_Boris_mission_1",
-          "value": "yes",
+          "compare_string": [ "yes", { "u_val": "mission_completed_Boris_mission_1" } ],
           "yes": ", but it is a bit better since we cleaned up our dead",
           "no": ", woken by zombies in the night"
         },
         ".  To me, though, that is all just a drop in the bucket",
         {
-          "u_has_var": "mission_completed_Boris_mission_3",
-          "value": "yes",
+          "compare_string": [ "yes", { "u_val": "mission_completed_Boris_mission_3" } ],
           "yes": ".  What is killing me is being forced to sit with nothing but my thoughts of what I've lost.",
           "no": ".  I have spent so much time, just regretting what I have lost.  Thank you for bringing back what little you could."
         }

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Dana_Nunez.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Dana_Nunez.json
@@ -117,7 +117,10 @@
         "text": "I spoke to the foreman over at Tacoma Ranch.  If you're willing to put in the work, they'll find some work for you over there.",
         "topic": "TALK_REFUGEE_Dana_Tacoma2",
         "condition": {
-          "and": [ { "u_has_mission": "MISSION_TACOMA_Nunez" }, { "u_has_var": "recruit_general_Nunez_Tacoma", "value": "phase_2" } ]
+          "and": [
+            { "u_has_mission": "MISSION_TACOMA_Nunez" },
+            { "compare_string": [ "phase_2", { "u_val": "recruit_general_Nunez_Tacoma" } ] }
+          ]
         },
         "effect": { "u_add_var": "recruit_general_Nunez_Tacoma", "value": "phase_3" }
       },
@@ -131,15 +134,15 @@
       {
         "text": "Your husband said to ask you what you'd think about getting out of this place and coming to work for me at my own camp.",
         "topic": "TALK_REFUGEE_Dana_Recruit",
-        "condition": { "u_has_var": "recruit_general_Pablo_ask_recruit", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "recruit_general_Pablo_ask_recruit" } ] }
       },
       {
         "text": "You seem pretty unhappy about the quality of your bread.  Is there something I can do to help?",
         "topic": "TALK_DANA_Sourdough",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "mission_flag_Dana_Sourdough", "value": "yes" } },
-            { "u_has_var": "knowledge_Dana_Sourdough", "value": "yes" }
+            { "not": { "compare_string": [ "yes", { "u_val": "mission_flag_Dana_Sourdough" } ] } },
+            { "compare_string": [ "yes", { "u_val": "knowledge_Dana_Sourdough" } ] }
           ]
         }
       },
@@ -153,7 +156,7 @@
         "topic": "TALK_REFUGEE_Dana_Background_baking",
         "condition": {
           "and": [
-            { "u_has_var": "knowledge_trade_Dana_Bread_Sales", "value": "yes" },
+            { "compare_string": [ "yes", { "u_val": "knowledge_trade_Dana_Bread_Sales" } ] },
             { "not": { "npc_has_effect": "dana_sourdough_revival" } }
           ]
         }
@@ -221,7 +224,7 @@
             { "not": { "npc_has_effect": "dana_baking_sold" } },
             { "not": { "npc_has_effect": "dana_barter_success" } },
             { "u_has_items": { "item": "flour", "count": 8 } },
-            { "not": { "u_has_var": "mission_flag_Dana_Sourdough", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "mission_flag_Dana_Sourdough" } ] } }
           ]
         },
         "effect": [ { "u_sell_item": "flour", "count": 8 }, { "u_spawn_item": "sourdough_bread" } ]
@@ -235,7 +238,7 @@
             { "not": { "npc_has_effect": "dana_baking_sold" } },
             { "not": { "npc_has_effect": "dana_barter_success" } },
             { "u_has_items": { "item": "FMCNote", "count": 2 } },
-            { "not": { "u_has_var": "mission_flag_Dana_Sourdough", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "mission_flag_Dana_Sourdough" } ] } }
           ]
         },
         "effect": [ { "u_sell_item": "FMCNote", "count": 2 }, { "u_spawn_item": "sourdough_bread" } ]
@@ -249,7 +252,7 @@
             { "not": { "npc_has_effect": "dana_baking_sold" } },
             { "npc_has_effect": "dana_barter_success" },
             { "u_has_items": { "item": "flour", "count": 6 } },
-            { "not": { "u_has_var": "mission_flag_Dana_Sourdough", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "mission_flag_Dana_Sourdough" } ] } }
           ]
         },
         "effect": [ { "u_sell_item": "flour", "count": 6 }, { "u_spawn_item": "sourdough_bread" } ]
@@ -263,7 +266,7 @@
             { "not": { "npc_has_effect": "dana_baking_sold" } },
             { "npc_has_effect": "dana_barter_success" },
             { "u_has_items": { "item": "FMCNote", "count": 1 } },
-            { "not": { "u_has_var": "mission_flag_Dana_Sourdough", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "mission_flag_Dana_Sourdough" } ] } }
           ]
         },
         "effect": [ { "u_sell_item": "FMCNote", "count": 1 }, { "u_spawn_item": "sourdough_bread" } ]
@@ -277,7 +280,7 @@
             { "not": { "npc_has_effect": "dana_baking_sold" } },
             { "not": { "npc_has_effect": "dana_barter_success" } },
             { "u_has_items": { "item": "flour", "count": 8 } },
-            { "u_has_var": "mission_flag_Dana_Sourdough", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "mission_flag_Dana_Sourdough" } ] }
           ]
         },
         "effect": [ { "u_sell_item": "flour", "count": 8 }, { "u_spawn_item": "Dana_sourdough_bread" } ]
@@ -291,7 +294,7 @@
             { "not": { "npc_has_effect": "dana_baking_sold" } },
             { "not": { "npc_has_effect": "dana_barter_success" } },
             { "u_has_items": { "item": "FMCNote", "count": 2 } },
-            { "u_has_var": "mission_flag_Dana_Sourdough", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "mission_flag_Dana_Sourdough" } ] }
           ]
         },
         "effect": [ { "u_sell_item": "FMCNote", "count": 2 }, { "u_spawn_item": "Dana_sourdough_bread" } ]
@@ -305,7 +308,7 @@
             { "not": { "npc_has_effect": "dana_baking_sold" } },
             { "npc_has_effect": "dana_barter_success" },
             { "u_has_items": { "item": "flour", "count": 6 } },
-            { "u_has_var": "mission_flag_Dana_Sourdough", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "mission_flag_Dana_Sourdough" } ] }
           ]
         },
         "effect": [ { "u_sell_item": "flour", "count": 6 }, { "u_spawn_item": "Dana_sourdough_bread" } ]
@@ -319,7 +322,7 @@
             { "not": { "npc_has_effect": "dana_baking_sold" } },
             { "npc_has_effect": "dana_barter_success" },
             { "u_has_items": { "item": "FMCNote", "count": 1 } },
-            { "u_has_var": "mission_flag_Dana_Sourdough", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "mission_flag_Dana_Sourdough" } ] }
           ]
         },
         "effect": [ { "u_sell_item": "FMCNote", "count": 1 }, { "u_spawn_item": "Dana_sourdough_bread" } ]
@@ -332,8 +335,7 @@
     "dynamic_line": {
       "npc_has_effect": "dana_baking_sold",
       "no": {
-        "u_has_var": "knowledge_trade_Dana_Bread_Sales",
-        "value": "yes",
+        "compare_string": [ "yes", { "u_val": "knowledge_trade_Dana_Bread_Sales" } ],
         "yes": "I sure do, if you've got the flour or the merch for me, I'd be happy to trade you another loaf.",
         "no": "I do a bit.  I got a sourdough starter going almost as soon as I arrived, and it's making passable bread already.  I cooked some up yesterday actually, I could probably trade a loaf of fresh bread for, say, about eight cups of flour, or two merch."
       },
@@ -348,7 +350,7 @@
             { "not": { "npc_has_effect": "dana_baking_sold" } },
             { "not": { "npc_has_effect": "dana_barter_fail" } },
             { "not": { "npc_has_effect": "dana_barter_success" } },
-            { "not": { "u_has_var": "mission_flag_Dana_Sourdough", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "mission_flag_Dana_Sourdough" } ] } }
           ]
         },
         "trial": { "type": "PERSUADE", "difficulty": 20 },
@@ -368,7 +370,7 @@
             { "not": { "npc_has_effect": "dana_baking_sold" } },
             { "not": { "npc_has_effect": "dana_barter_fail" } },
             { "not": { "npc_has_effect": "dana_barter_success" } },
-            { "u_has_var": "mission_flag_Dana_Sourdough", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "mission_flag_Dana_Sourdough" } ] }
           ]
         },
         "trial": { "type": "PERSUADE", "difficulty": 5 },
@@ -420,8 +422,7 @@
     "type": "talk_topic",
     "id": "TALK_REFUGEE_Dana_Background_baking2",
     "dynamic_line": {
-      "u_has_var": "mission_flag_Dana_Sourdough",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "mission_flag_Dana_Sourdough" } ],
       "yes": [
         "Great, here's a loaf of the best damn sourdough bread in the world.  I used to make that claim as a joke, but I feel like now there's a fighting chance nobody else can beat me.",
         "Nice.  Enjoy the mighty bounty of Landough Calrisean.",
@@ -440,7 +441,7 @@
       {
         "text": "You seem pretty unhappy about the quality of your bread.  Is there something I can do to help?",
         "topic": "TALK_DANA_Sourdough",
-        "condition": { "not": { "u_has_var": "mission_flag_Dana_Sourdough", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "mission_flag_Dana_Sourdough" } ] } }
       },
       { "text": "It smells awesome.  I'm going to head out now, thanks!", "topic": "TALK_DONE" }
     ]
@@ -507,8 +508,7 @@
     "type": "talk_topic",
     "id": "TALK_REFUGEE_Dana_Tacoma",
     "dynamic_line": {
-      "u_has_var": "recruit_general_Nunez_Tacoma",
-      "value": "phase_1",
+      "compare_string": [ "phase_1", { "u_val": "recruit_general_Nunez_Tacoma" } ],
       "no": "Huh.  I've made a few friends here, but not so much as I'd stick around here with no future prospects, hoping someone downstairs dies to make room for me.  It does sound nice, if they're looking for more workers.",
       "yes": { "gendered_line": "Have you heard anything back from the ranch about jobs yet?", "relevant_genders": [ "u" ] }
     },

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Dana_Nunez.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Dana_Nunez.json
@@ -108,7 +108,7 @@
         "condition": {
           "and": [
             { "u_has_mission": "MISSION_REFUGEE_Boris_CLEANUP" },
-            { "not": { "npc_has_var": "mission_Boris_mission_1_cleanup_asked", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "mission_Boris_mission_1_cleanup_asked" } ] } }
           ]
         },
         "topic": "TALK_REFUGEE_Refuse_Boris_Mission_1"

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Dino_Dave.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Dino_Dave.json
@@ -6,8 +6,7 @@
       "concatenate": [
         "*sits in a surprisingly well-built room made of lovingly assembled cardboard boxes.  The area is quite clean and cozy.  The whole building is built on top of cargo pallets, insulated with scraps, and waterproofed with plastic.  It shows an unexpected amount of design prowess.  \"Hello, my noble knight errant,\" Dave intones, his voice solemn.",
         {
-          "u_has_var": "dialogue_dave_u_cardboard_gift",
-          "value": "finished",
+          "compare_string": [ "finished", { "u_val": "dialogue_dave_u_cardboard_gift" } ],
           "yes": "  \"We hope our gift to you will help repay our great debt.\"",
           "no": "  \"We owe you a great debt for your actions of the past.  Some day, we shall repay it.  Until then, you are welcome here, now and always.\""
         }
@@ -23,7 +22,7 @@
         "effect": [ { "u_add_var": "dialogue_dave_u_cardboard_gift", "value": "finished" } ],
         "condition": {
           "and": [
-            { "u_has_var": "dialogue_dave_u_cardboard_gift", "value": "in_progress" },
+            { "compare_string": [ "in_progress", { "u_val": "dialogue_dave_u_cardboard_gift" } ] },
             { "math": [ "time_since(u_timer_dave_creating_gift)", ">", "time('1 d')" ] }
           ]
         }
@@ -80,8 +79,8 @@
         ],
         "condition": {
           "and": [
-            { "not": { "u_has_var": "dialogue_dave_u_cardboard_gift", "value": "finished" } },
-            { "not": { "u_has_var": "dialogue_dave_u_cardboard_gift", "value": "in_progress" } }
+            { "not": { "compare_string": [ "finished", { "u_val": "dialogue_dave_u_cardboard_gift" } ] } },
+            { "not": { "compare_string": [ "in_progress", { "u_val": "dialogue_dave_u_cardboard_gift" } ] } }
           ]
         }
       },

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Draco_Dune.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Draco_Dune.json
@@ -76,8 +76,7 @@
     "type": "talk_topic",
     "id": "TALK_REFUGEE_Draco_1",
     "dynamic_line": {
-      "u_has_var": "general_meeting_u_met_Draco_Dune",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Draco_Dune" } ],
       "yes": { "gendered_line": "Always good to see you, friend.", "relevant_genders": [ "u" ] },
       "no": "Well now, good to see another new face!  Welcome to the center, friend, I'm Draco."
     },
@@ -98,8 +97,8 @@
         "text": "Hi, Draco, how are you doing?",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "general_meeting_Draco_Dune_convo_depth", "value": "3" } },
-            { "not": { "u_has_var": "general_meeting_Draco_Dune_convo_depth", "value": "7" } }
+            { "not": { "compare_string": [ "3", { "u_val": "general_meeting_Draco_Dune_convo_depth" } ] } },
+            { "not": { "compare_string": [ "7", { "u_val": "general_meeting_Draco_Dune_convo_depth" } ] } }
           ]
         },
         "topic": "TALK_REFUGEE_Draco_2"
@@ -108,15 +107,15 @@
         "text": "Hi again, Draco, nice to see you too.",
         "condition": {
           "and": [
-            { "u_has_var": "general_meeting_Draco_Dune_convo_depth", "value": "3" },
-            { "not": { "u_has_var": "general_meeting_Draco_Dune_convo_depth", "value": "7" } }
+            { "compare_string": [ "3", { "u_val": "general_meeting_Draco_Dune_convo_depth" } ] },
+            { "not": { "compare_string": [ "7", { "u_val": "general_meeting_Draco_Dune_convo_depth" } ] } }
           ]
         },
         "topic": "TALK_REFUGEE_Draco_5a"
       },
       {
         "text": "Hi again, Draco, nice to see you too.",
-        "condition": { "u_has_var": "general_meeting_Draco_Dune_convo_depth", "value": "7" },
+        "condition": { "compare_string": [ "7", { "u_val": "general_meeting_Draco_Dune_convo_depth" } ] },
         "topic": "TALK_REFUGEE_Draco_7"
       },
       { "text": "Hi Draco, nice to see you too.  I gotta go though.", "topic": "TALK_DONE" }
@@ -249,8 +248,7 @@
     "type": "talk_topic",
     "id": "TALK_REFUGEE_Draco_7",
     "dynamic_line": {
-      "u_has_var": "general_mission_NC_REFUGEE_Draco_has_guitar",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "general_mission_NC_REFUGEE_Draco_has_guitar" } ],
       "yes": {
         "gendered_line": "My savior!  My patron of the arts!  You're always welcome here, friend.",
         "relevant_genders": [ "u" ]
@@ -262,22 +260,22 @@
       {
         "text": "Let's talk about getting you that guitar.",
         "topic": "TALK_MISSION_LIST",
-        "condition": { "not": { "u_has_var": "general_mission_NC_REFUGEE_Draco_has_guitar", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "general_mission_NC_REFUGEE_Draco_has_guitar" } ] } }
       },
       {
         "text": "I've been thinking about that deal you mentioned.",
-        "condition": { "u_has_var": "general_barter_NC_REFUGEE_Draco_offered_weed_deal", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "general_barter_NC_REFUGEE_Draco_offered_weed_deal" } ] },
         "topic": "TALK_REFUGEE_Draco_10_approve"
       },
       {
         "text": "Anything you buying or selling, by chance?",
-        "condition": { "not": { "u_has_var": "general_barter_NC_REFUGEE_Draco_offered_weed_deal", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "general_barter_NC_REFUGEE_Draco_offered_weed_deal" } ] } },
         "effect": { "u_add_var": "general_barter_NC_REFUGEE_Draco_offered_weed_deal", "value": "yes" },
         "topic": "TALK_REFUGEE_Draco_8"
       },
       {
         "text": "Do you know any tunes good to dance to?",
-        "condition": { "u_has_var": "general_mission_NC_REFUGEE_Draco_has_guitar", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "general_mission_NC_REFUGEE_Draco_has_guitar" } ] },
         "topic": "TALK_REFUGEE_Draco_Dance"
       },
       { "text": "See you around, Draco.", "topic": "TALK_DONE" }
@@ -349,7 +347,7 @@
         "condition": {
           "and": [
             { "u_has_items": { "item": "weed", "count": 5 } },
-            { "not": { "u_has_var": "general_mission_NC_REFUGEE_Draco_has_guitar", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "u_val": "general_mission_NC_REFUGEE_Draco_has_guitar" } ] } },
             { "not": { "npc_has_effect": "u_sold_to_Draco" } }
           ]
         },
@@ -365,7 +363,7 @@
         "condition": {
           "and": [
             { "u_has_items": { "item": "weed", "count": 5 } },
-            { "u_has_var": "general_mission_NC_REFUGEE_Draco_has_guitar", "value": "yes" },
+            { "compare_string": [ "yes", { "u_val": "general_mission_NC_REFUGEE_Draco_has_guitar" } ] },
             { "not": { "npc_has_effect": "u_sold_to_Draco" } }
           ]
         },
@@ -381,7 +379,7 @@
         "condition": {
           "and": [
             { "u_has_items": { "item": "joint", "count": 5 } },
-            { "not": { "u_has_var": "general_mission_NC_REFUGEE_Draco_has_guitar", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "u_val": "general_mission_NC_REFUGEE_Draco_has_guitar" } ] } },
             { "not": { "npc_has_effect": "u_sold_to_Draco" } }
           ]
         },
@@ -397,7 +395,7 @@
         "condition": {
           "and": [
             { "u_has_items": { "item": "joint", "count": 5 } },
-            { "u_has_var": "general_mission_NC_REFUGEE_Draco_has_guitar", "value": "yes" },
+            { "compare_string": [ "yes", { "u_val": "general_mission_NC_REFUGEE_Draco_has_guitar" } ] },
             { "not": { "npc_has_effect": "u_sold_to_Draco" } }
           ]
         },

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Fatima_Al_Jadir.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Fatima_Al_Jadir.json
@@ -95,7 +95,7 @@
       {
         "text": "Hey, you free for a bit of teaching?",
         "topic": "TALK_REFUGEE_Fatima_Teach",
-        "condition": { "u_has_var": "knowledge_trade_Fatima_Teacher", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "knowledge_trade_Fatima_Teacher" } ] }
       },
       { "text": "Is there anything I can do to help you out?", "topic": "TALK_MISSION_LIST" },
       { "text": "What were you saying before?", "topic": "TALK_NONE" },
@@ -165,12 +165,10 @@
     "type": "talk_topic",
     "id": "TALK_REFUGEE_Fatima_Teach",
     "dynamic_line": {
-      "u_has_var": "barter_flag_Fatima_barter_success",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "barter_flag_Fatima_barter_success" } ],
       "yes": "Sure.  As agreed, 3 merch.",
       "no": {
-        "u_has_var": "mission_flag_Fatima_Mission1",
-        "value": "yes",
+        "compare_string": [ "yes", { "u_val": "mission_flag_Fatima_Mission1" } ],
         "no": "Sure, I could teach you the basics, I'll have to charge you though.  Let's say, 5 merch for a teaching session, plus a bit in trade depending on how in-depth you're looking for?",
         "yes": {
           "gendered_line": "Sure, I could teach you the basics, it'll cost you merch though.  Since you helped me out, I can shave a bit off the price, let's say 4 merch, plus a bit in trade depending on how in-depth you're looking for?",
@@ -186,8 +184,8 @@
         "topic": "TALK_TRAIN",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "barter_flag_Fatima_barter_success", "value": "yes" } },
-            { "not": { "u_has_var": "mission_flag_Fatima_Mission1", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "u_val": "barter_flag_Fatima_barter_success" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "mission_flag_Fatima_Mission1" } ] } },
             { "u_has_items": { "item": "FMCNote", "count": 5 } }
           ]
         },
@@ -199,8 +197,8 @@
         "topic": "TALK_TRAIN",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "barter_flag_Fatima_barter_success", "value": "yes" } },
-            { "u_has_var": "mission_flag_Fatima_Mission1", "value": "yes" },
+            { "not": { "compare_string": [ "yes", { "u_val": "barter_flag_Fatima_barter_success" } ] } },
+            { "compare_string": [ "yes", { "u_val": "mission_flag_Fatima_Mission1" } ] },
             { "u_has_items": { "item": "FMCNote", "count": 4 } }
           ]
         },
@@ -212,7 +210,7 @@
         "topic": "TALK_TRAIN",
         "condition": {
           "and": [
-            { "u_has_var": "barter_flag_Fatima_barter_success", "value": "yes" },
+            { "compare_string": [ "yes", { "u_val": "barter_flag_Fatima_barter_success" } ] },
             { "u_has_items": { "item": "FMCNote", "count": 3 } }
           ]
         },
@@ -223,8 +221,8 @@
         "condition": {
           "and": [
             { "math": [ "time_since(n_timer_flag_Fatima_barter_fail)", ">", "time('1 d')" ] },
-            { "not": { "u_has_var": "barter_flag_Fatima_barter_success", "value": "yes" } },
-            { "not": { "u_has_var": "mission_flag_Fatima_Mission1", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "barter_flag_Fatima_barter_success" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "mission_flag_Fatima_Mission1" } ] } }
           ]
         },
         "trial": { "type": "PERSUADE", "difficulty": 35 },
@@ -236,8 +234,8 @@
         "condition": {
           "and": [
             { "math": [ "time_since(n_timer_flag_Fatima_barter_fail)", ">", "time('1 d')" ] },
-            { "not": { "u_has_var": "barter_flag_Fatima_barter_success", "value": "yes" } },
-            { "u_has_var": "mission_flag_Fatima_Mission1", "value": "yes" }
+            { "not": { "compare_string": [ "yes", { "u_val": "barter_flag_Fatima_barter_success" } ] } },
+            { "compare_string": [ "yes", { "u_val": "mission_flag_Fatima_Mission1" } ] }
           ]
         },
         "trial": { "type": "PERSUADE", "difficulty": 15 },
@@ -277,8 +275,7 @@
     "type": "talk_topic",
     "id": "TALK_REFUGEE_Fatima_Situation",
     "dynamic_line": {
-      "u_has_var": "mission_completed_Jenny_mission_2",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "mission_completed_Jenny_mission_2" } ],
       "no": "It's tense here.  I know I'd feel a lot better if I had something to do with my skills, or even if I just had a quiet place to pray sometimes.  I feel a bit self-conscious praying in the common areas.  Jenny was talking about some project ideas she had that could get me doing my job again, but I admit I'm pretty nervous about going outside.",
       "yes": "Things are still tense, but I've been busy lately.  Jenny's had her project going and got me started helping her out with it, and for some reason that seems to have been the tipping point: I'm getting chances to do a lot more welding work now.  It's helping.  I feel a bit self-conscious praying in the common areas, and of course, we don't go outside if we can help it."
     }

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Fatima_Al_Jadir.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Fatima_Al_Jadir.json
@@ -84,7 +84,7 @@
         "condition": {
           "and": [
             { "u_has_mission": "MISSION_REFUGEE_Boris_CLEANUP" },
-            { "not": { "npc_has_var": "mission_Boris_mission_1_cleanup_asked", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "mission_Boris_mission_1_cleanup_asked" } ] } }
           ]
         },
         "topic": "TALK_REFUGEE_Refuse_Boris_Mission_1"

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Garry_Villeneuve.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Garry_Villeneuve.json
@@ -80,7 +80,7 @@
         "condition": {
           "and": [
             { "u_has_mission": "MISSION_REFUGEE_Boris_CLEANUP" },
-            { "not": { "npc_has_var": "mission_Boris_mission_1_cleanup_asked", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "mission_Boris_mission_1_cleanup_asked" } ] } }
           ]
         },
         "trial": { "type": "PERSUADE", "difficulty": 25 },

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Guneet_Singh.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Guneet_Singh.json
@@ -78,7 +78,7 @@
         "condition": {
           "and": [
             { "u_has_mission": "MISSION_REFUGEE_Boris_CLEANUP" },
-            { "not": { "npc_has_var": "mission_Boris_mission_1_cleanup_asked", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "mission_Boris_mission_1_cleanup_asked" } ] } }
           ]
         },
         "trial": { "type": "PERSUADE", "difficulty": 15 },

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Jenny_Forcette.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Jenny_Forcette.json
@@ -103,12 +103,12 @@
       },
       {
         "text": "What are you working on?",
-        "condition": { "not": { "u_has_var": "mission_completed_Jenny_mission_3", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "mission_completed_Jenny_mission_3" } ] } },
         "topic": "TALK_REFUGEE_JENNY_Project1"
       },
       {
         "text": "How's everything going with that defense system?",
-        "condition": { "u_has_var": "mission_completed_Jenny_mission_3", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "mission_completed_Jenny_mission_3" } ] },
         "topic": "TALK_REFUGEE_JENNY_Project3"
       },
       { "text": "Tell me a bit about your background.", "topic": "TALK_REFUGEE_JENNY_Background1" },
@@ -119,7 +119,7 @@
         "condition": {
           "and": [
             { "math": [ "time_since(n_timer_flag_Jenny_teach)", ">", "time('1 d')" ] },
-            { "u_has_var": "knowledge_flag_Jenny_teach", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "knowledge_flag_Jenny_teach" } ] }
           ]
         }
       },
@@ -179,13 +179,13 @@
         "condition": {
           "and": [
             { "math": [ "time_since(n_timer_flag_Jenny_teach)", ">", "time('1 d')" ] },
-            { "not": { "u_has_var": "knowledge_flag_Jenny_teach", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "knowledge_flag_Jenny_teach" } ] } }
           ]
         }
       },
       {
         "text": "So, did anyone tell you there are actual no-kidding talking cyborg-robot people out there now?",
-        "condition": { "u_has_var": "general_meeting_u_met_Rubik", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Rubik" } ] },
         "topic": "TALK_REFUGEE_JENNY_Exodii"
       },
       { "text": "Sorry about your luck.  What were you saying before?", "topic": "TALK_NONE" },
@@ -227,7 +227,7 @@
     "responses": [
       {
         "text": "Well, I know they're cyborgs, from some other dimension.  I think they're humans underneath the machines though.  Some of them kinda speak English.",
-        "condition": { "u_has_var": "knowledge_exodization_u_knows_exodiilore", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "knowledge_exodization_u_knows_exodiilore" } ] },
         "topic": "TALK_REFUGEE_JENNY_Exodii2"
       },
       { "text": "What were you saying before?", "topic": "TALK_NONE" },
@@ -363,8 +363,7 @@
     "type": "talk_topic",
     "id": "TALK_REFUGEE_JENNY_Project1",
     "dynamic_line": {
-      "u_has_var": "Jenny_pneumatics",
-      "value": "mission_complete",
+      "compare_string": [ "mission_complete", { "u_val": "Jenny_pneumatics" } ],
       "no": {
         "math": [ "time_since('cataclysm', 'unit':'days') >= 60" ],
         "no": "I recently came into possession of this mold for making high-caliber air rifle bullets.  I'm kinda working on a design that would use them to protect the base.  Got a long way to go, though.  If you happen to see anything in your travels about high-powered air rifles, it would help a lot.",
@@ -380,7 +379,7 @@
         "condition": {
           "and": [
             { "not": { "u_has_mission": "MISSION_REFUGEE_Jenny_GET_PNEUMATICS" } },
-            { "not": { "u_has_var": "Jenny_pneumatics", "value": "mission_complete" } },
+            { "not": { "compare_string": [ "mission_complete", { "u_val": "Jenny_pneumatics" } ] } },
             { "math": [ "time_since('cataclysm', 'unit':'days') < 60" ] }
           ]
         }

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Jenny_Forcette.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Jenny_Forcette.json
@@ -96,7 +96,7 @@
         "condition": {
           "and": [
             { "u_has_mission": "MISSION_REFUGEE_Boris_CLEANUP" },
-            { "not": { "npc_has_var": "mission_Boris_mission_1_cleanup_asked", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "mission_Boris_mission_1_cleanup_asked" } ] } }
           ]
         },
         "topic": "TALK_REFUGEE_Refuse_Boris_Mission_1"

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_John_Clemens.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_John_Clemens.json
@@ -83,7 +83,7 @@
         "condition": {
           "and": [
             { "u_has_mission": "MISSION_REFUGEE_Boris_CLEANUP" },
-            { "not": { "npc_has_var": "mission_Boris_mission_1_cleanup_asked", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "mission_Boris_mission_1_cleanup_asked" } ] } }
           ]
         },
         "topic": "TALK_REFUGEE_Refuse_Boris_Mission_1"

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Mandeep_Singh.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Mandeep_Singh.json
@@ -85,7 +85,7 @@
         "condition": {
           "and": [
             { "u_has_mission": "MISSION_REFUGEE_Boris_CLEANUP" },
-            { "not": { "npc_has_var": "mission_Boris_mission_1_cleanup_asked", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "mission_Boris_mission_1_cleanup_asked" } ] } }
           ]
         },
         "topic": "TALK_REFUGEE_Refuse_Boris_Mission_1"

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Mangalpreet_Singh.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Mangalpreet_Singh.json
@@ -79,7 +79,7 @@
         "condition": {
           "and": [
             { "u_has_mission": "MISSION_REFUGEE_Boris_CLEANUP" },
-            { "not": { "npc_has_var": "mission_Boris_mission_1_cleanup_asked", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "mission_Boris_mission_1_cleanup_asked" } ] } }
           ]
         },
         "topic": "TALK_REFUGEE_Refuse_Boris_Mission_1"

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Mangalpreet_Singh.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Mangalpreet_Singh.json
@@ -153,8 +153,7 @@
           "no": ".  I have these things, but I do not have peace.  No one here does"
         },
         {
-          "u_has_var": "mission_completed_Boris_mission_1",
-          "value": "yes",
+          "compare_string": [ "yes", { "u_val": "mission_completed_Boris_mission_1" } ],
           "yes": ".  Still, we have so much work to do to make a home here.",
           "no": ".  We are crowded, we are plagued by the sounds and the memories of the dead.  The situation is grim."
         }

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Pablo_Nunez.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Pablo_Nunez.json
@@ -109,7 +109,10 @@
         "text": "Dana wanted me to be the one to let you know: they've got work for you over at the ranch.  You could get out of here if you want.",
         "topic": "TALK_REFUGEE_Pablo_Tacoma2",
         "condition": {
-          "and": [ { "u_has_mission": "MISSION_TACOMA_Nunez" }, { "u_has_var": "recruit_general_Nunez_Tacoma", "value": "phase_3" } ]
+          "and": [
+            { "u_has_mission": "MISSION_TACOMA_Nunez" },
+            { "compare_string": [ "phase_3", { "u_val": "recruit_general_Nunez_Tacoma" } ] }
+          ]
         }
       },
       { "text": "What were you saying before?", "topic": "TALK_NONE" },
@@ -189,7 +192,7 @@
       {
         "text": "I've been back to the quarantined area, cleared it out.  It was ugly back there.",
         "topic": "TALK_REFUGEE_Pablo_Background2_cleared",
-        "condition": { "u_has_var": "mission_flag_FMShopkeep_Mission1", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "mission_flag_FMShopkeep_Mission1" } ] }
       }
     ]
   },
@@ -213,7 +216,7 @@
         "effect": { "assign_mission": "MISSION_TACOMA_Nunez" },
         "condition": {
           "and": [
-            { "u_has_var": "knowledge_flag_tacoma_started", "value": "yes" },
+            { "compare_string": [ "yes", { "u_val": "knowledge_flag_tacoma_started" } ] },
             { "not": { "u_has_mission": "MISSION_TACOMA_Nunez" } }
           ]
         }

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Pablo_Nunez.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Pablo_Nunez.json
@@ -98,7 +98,7 @@
         "condition": {
           "and": [
             { "u_has_mission": "MISSION_REFUGEE_Boris_CLEANUP" },
-            { "not": { "npc_has_var": "mission_Boris_mission_1_cleanup_asked", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "mission_Boris_mission_1_cleanup_asked" } ] } }
           ]
         },
         "topic": "TALK_REFUGEE_Refuse_Boris_Mission_1"

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Rhyzaea_Johnny.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Rhyzaea_Johnny.json
@@ -73,7 +73,7 @@
         "condition": {
           "and": [
             { "u_has_mission": "MISSION_REFUGEE_Boris_CLEANUP" },
-            { "not": { "npc_has_var": "mission_Boris_mission_1_cleanup_asked", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "mission_Boris_mission_1_cleanup_asked" } ] } }
           ]
         },
         "trial": { "type": "PERSUADE", "difficulty": 15 },

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Stan_Borichenko.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Stan_Borichenko.json
@@ -80,7 +80,7 @@
         "condition": {
           "and": [
             { "u_has_mission": "MISSION_REFUGEE_Boris_CLEANUP" },
-            { "not": { "npc_has_var": "mission_Boris_mission_1_cleanup_asked", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "mission_Boris_mission_1_cleanup_asked" } ] } }
           ]
         },
         "topic": "TALK_REFUGEE_Refuse_Boris_Mission_1"

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Stan_Borichenko.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Stan_Borichenko.json
@@ -152,8 +152,7 @@
       "concatenate": [
         "Mostly my family and I have just been mourning.  This isn't the best place to do it.  ",
         {
-          "u_has_var": "mission_completed_Boris_mission_1",
-          "value": "yes",
+          "compare_string": [ "yes", { "u_val": "mission_completed_Boris_mission_1" } ],
           "yes": "Still, now that we've found ways to make this community a bit of our own, I feel like maybe there's a chance things will get better.  Sometimes, when he's working, Boris seems like himself again and I have some hope.",
           "no": "I hope we'll have something productive to do soon; Boris, in particular, has skills to contribute that might help him feel alive again."
         }
@@ -172,14 +171,12 @@
       "concatenate": [
         "He's a strong man.  The things we've been through… that he's been through, before any of this.  If anyone can survive the loss we've seen, it's him.  But he pushes it all down, ",
         {
-          "u_has_var": "mission_completed_Boris_mission_1",
-          "value": "yes",
+          "compare_string": [ "yes", { "u_val": "mission_completed_Boris_mission_1" } ],
           "yes": "if he's left with it too long.  Having work has been helping him.  Cleaning up that back room might seem small, but it was a big deal for him.",
           "no": "and if he keeps it up, I don't know how much of him will be left.  He needs something to *do*.  We can't just sit here, trapped like rats in a cage forever."
         },
         {
-          "u_has_var": "mission_completed_Boris_mission_3",
-          "value": "yes",
+          "compare_string": [ "yes", { "u_val": "mission_completed_Boris_mission_3" } ],
           "yes": "  Even more, though, having a little memory of Ash has been more than we could ever have asked.  I thought it might hurt him, dwelling on those memories, but instead it's given both of us some strength back.",
           "no": ""
         }

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Uyen_Tran.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Uyen_Tran.json
@@ -94,7 +94,7 @@
       { "text": "How are things here?", "topic": "TALK_REFUGEE_Uyen_Situation" },
       {
         "text": "Could you teach me a bit about first aid?",
-        "condition": { "u_has_var": "knowledge_flag_Uyen_teach", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "knowledge_flag_Uyen_teach" } ] },
         "topic": "TALK_REFUGEE_Uyen_Teach"
       },
       { "text": "What do you think happened to the world?", "topic": "TALK_REFUGEE_Uyen_World" },
@@ -258,8 +258,7 @@
           "no": ", as long as this doesn't last too long."
         },
         {
-          "u_has_var": "mission_completed_Boris_mission_1",
-          "value": "yes",
+          "compare_string": [ "yes", { "u_val": "mission_completed_Boris_mission_1" } ],
           "yes": ".  With the back room cleared, we've had some chances to come and go, and spread out a bit.  It's made a huge difference to morale.\"  She looks around at the other refugees.  \"We'll have to see what the future holds.",
           "no": ".  The situation is pretty tight, though.\"  She glances around at the huddled crowds of people in the room.  \"If we're stuck here for too long people are going to start getting a bit stir crazy."
         }

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Uyen_Tran.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Uyen_Tran.json
@@ -83,7 +83,7 @@
         "condition": {
           "and": [
             { "u_has_mission": "MISSION_REFUGEE_Boris_CLEANUP" },
-            { "not": { "npc_has_var": "mission_Boris_mission_1_cleanup_asked", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "mission_Boris_mission_1_cleanup_asked" } ] } }
           ]
         },
         "trial": { "type": "PERSUADE", "difficulty": 10 },

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Vanessa_Toby.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Vanessa_Toby.json
@@ -89,7 +89,7 @@
         "condition": {
           "and": [
             { "u_has_mission": "MISSION_REFUGEE_Boris_CLEANUP" },
-            { "not": { "npc_has_var": "mission_Boris_mission_1_cleanup_asked", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "mission_Boris_mission_1_cleanup_asked" } ] } }
           ]
         },
         "topic": "TALK_REFUGEE_Vanessa_Refuse_Boris_Mission_1"
@@ -231,7 +231,7 @@
       {
         "text": "Actually, you owe me a free haircut, remember?",
         "topic": "TALK_CUT_YOUR_HAIR",
-        "condition": { "npc_has_var": "mission_services_owed_haircut_1", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "npc_val": "mission_services_owed_haircut_1" } ] },
         "effect": [
           { "npc_add_var": "mission_services_owed_haircut_1", "value": "no" },
           { "npc_add_effect": "vanessa_haircut_in_progress", "duration": 100 }

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Vanessa_Toby.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Vanessa_Toby.json
@@ -104,7 +104,7 @@
           "and": [
             { "not": { "npc_has_effect": "vanessa_haircut_in_progress" } },
             { "not": { "npc_has_effect": "vanessa_shave_in_progress" } },
-            { "u_has_var": "mission_flag_Vanessa_Mission1", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "mission_flag_Vanessa_Mission1" } ] }
           ]
         }
       },
@@ -164,7 +164,7 @@
       {
         "text": "Could you give me a haircut?",
         "topic": "TALK_REFUGEE_Vanessa_Haircut_no",
-        "condition": { "not": { "u_has_var": "mission_flag_Vanessa_Mission1", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "mission_flag_Vanessa_Mission1" } ] } }
       }
     ]
   },
@@ -179,14 +179,12 @@
           "no": "You want the sarcastic version, or the really sarcastic version?  I'm stuck in a dank shitty brick building with two dozen strangers, the world's dead"
         },
         {
-          "u_has_var": "knowledge_flag_tacoma_started",
-          "value": "yes",
+          "compare_string": [ "yes", { "u_val": "knowledge_flag_tacoma_started" } ],
           "yes": ", and all anyone will talk about is this new ranch they're building, as though it'll solve all our food problems",
           "no": ", and there's not enough food to go around"
         },
         {
-          "u_has_var": "mission_flag_Vanessa_Mission1",
-          "value": "yes",
+          "compare_string": [ "yes", { "u_val": "mission_flag_Vanessa_Mission1" } ],
           "no": ".  Why don't you fuckin' figure it out?",
           "yes": ".  At least I can do some work to keep me busy though, and the extra merch does go a long way to keeping my belly full.  People like getting a good haircut."
         }

--- a/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_broker.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_broker.json
@@ -34,7 +34,7 @@
         "condition": {
           "and": [
             { "u_has_mission": "MISSION_REFUGEE_Boris_CLEANUP" },
-            { "not": { "npc_has_var": "mission_Boris_mission_1_cleanup_asked", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "mission_Boris_mission_1_cleanup_asked" } ] } }
           ]
         },
         "topic": "TALK_FREE_MERCHANT_STOCKS_Boris_Mission_1"

--- a/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_broker.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_broker.json
@@ -42,12 +42,12 @@
       {
         "text": "Are you able to buy some canning supplies?",
         "topic": "TALK_FREE_MERCHANT_STOCKS_JARS",
-        "condition": { "u_has_var": "mission_flag_FMBroker_Mission1", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "mission_flag_FMBroker_Mission1" } ] }
       },
       {
         "text": "I was told you had work for me?",
         "topic": "TALK_MISSION_LIST",
-        "condition": { "u_has_var": "mission_flag_FMShopkeep_Mission5", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "mission_flag_FMShopkeep_Mission5" } ] }
       },
       { "text": "Who are you?", "topic": "TALK_FREE_MERCHANT_STOCKS_NEW" },
       {
@@ -59,16 +59,16 @@
       {
         "text": "What's the deal with the closed-off areas of the building?",
         "topic": "TALK_FREE_MERCHANT_STOCKS_SEALED1",
-        "condition": { "not": { "u_has_var": "mission_flag_FMShopkeep_Mission1", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "mission_flag_FMShopkeep_Mission1" } ] } }
       },
       {
         "text": "What are you going to do with that back bay area now that I've cleaned it out for you?",
         "topic": "TALK_FREE_MERCHANT_STOCKS_SEALED2",
-        "condition": { "u_has_var": "mission_flag_FMShopkeep_Mission1", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "mission_flag_FMShopkeep_Mission1" } ] }
       },
       {
         "text": "Tell me more about that ranch of yours.",
-        "condition": { "u_has_var": "knowledge_flag_tacoma_started", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "knowledge_flag_tacoma_started" } ] },
         "topic": "TALK_FREE_MERCHANT_STOCKS_RANCH"
       },
       { "text": "What were you saying before that?", "topic": "TALK_NONE" },
@@ -170,8 +170,7 @@
     "type": "talk_topic",
     "id": "TALK_FREE_MERCHANT_STOCKS_BEGGARS",
     "dynamic_line": {
-      "u_has_var": "general_recruit_beggars_recruited",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "general_recruit_beggars_recruited" } ],
       "yes": "I do.  I don't know what you did to convince them to move out, but our supply chain and I both thank you.  I hope it wasn't too unseemly.",
       "no": "Even once we got things sorted out, there weren't enough beds for everyone, and definitely not enough supplies.  These are harsh times.  We're doing what we can for those folks… at least they've got shelter."
     }

--- a/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_guard_generic.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_guard_generic.json
@@ -30,7 +30,7 @@
         "condition": {
           "and": [
             { "u_has_mission": "MISSION_REFUGEE_Boris_CLEANUP" },
-            { "not": { "npc_has_var": "mission_Boris_mission_1_cleanup_asked", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "mission_Boris_mission_1_cleanup_asked" } ] } }
           ]
         },
         "topic": "TALK_GUARD_Boris_Mission_1"

--- a/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_teamster.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_teamster.json
@@ -43,7 +43,7 @@
         "condition": {
           "and": [
             { "u_has_mission": "MISSION_REFUGEE_Boris_CLEANUP" },
-            { "not": { "npc_has_var": "mission_Boris_mission_1_cleanup_asked", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "mission_Boris_mission_1_cleanup_asked" } ] } }
           ]
         },
         "topic": "TALK_FREE_MERCHANT_TEAMSTER_Boris_Mission_1"
@@ -75,7 +75,7 @@
         "condition": {
           "and": [
             { "u_has_mission": "EXODII_MISSION_WAREHOUSE" },
-            { "not": { "npc_has_var": "asked_about_exodii_warehouse_mission", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "asked_about_exodii_warehouse_mission" } ] } }
           ]
         },
         "effect": { "run_eocs": [ "EOC_exodii_mission_wh_directions_chance" ] }
@@ -248,8 +248,7 @@
       "concatenate": [
         "&You describe the warehouse to the best of your ability.  The teamster considers for a moment",
         {
-          "npc_has_var": "exodii_mission_wh_correct",
-          "value": "no",
+          "compare_string": [ "no", { "npc_val": "exodii_mission_wh_correct" } ],
           "yes": {
             "gendered_line": ", then frowns.  \"I don't believe I've heard about anything like that, no.  Sorry.\"",
             "relevant_genders": [ "npc" ]
@@ -267,7 +266,7 @@
         "//": "The other responses are stored in common_talk.json in the exodii folder, to avoid repetition.",
         "text": "Oh well.  Thanks anyway.  I'll go ask around.",
         "topic": "TALK_DONE",
-        "condition": { "npc_has_var": "exodii_mission_wh_correct", "value": "no" },
+        "condition": { "compare_string": [ "no", { "npc_val": "exodii_mission_wh_correct" } ] },
         "effect": [
           { "math": [ "exodii_mission_wh_chance", "-=", "1" ] },
           { "math": [ "exodii_mission_wh_chance", "=", "max( exodii_mission_wh_chance, 1 )" ] }

--- a/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_teamster.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_teamster.json
@@ -85,7 +85,7 @@
         "condition": {
           "and": [
             { "math": [ "godco_freemerch_representative_dead", "!=", "0" ] },
-            { "u_has_var": "general_trade_u_think_suspicious_price", "value": "yes" },
+            { "compare_string": [ "yes", { "u_val": "general_trade_u_think_suspicious_price" } ] },
             { "not": { "u_has_mission": "MISSION_INVESTIGATE_TRADER" } }
           ]
         },
@@ -116,7 +116,7 @@
       {
         "text": "I wanted to tell you about a potential new trading partner I met recently.",
         "topic": "TALK_FREE_MERCHANT_TEAMSTER_FACTION_INTRO",
-        "condition": { "u_has_var": "general_meeting_u_met_Rubik", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Rubik" } ] }
       }
     ]
   },
@@ -125,8 +125,7 @@
     "id": "TALK_FREE_MERCHANT_TEAMSTER",
     "type": "talk_topic",
     "dynamic_line": {
-      "u_has_var": "general_meeting_u_met_teamster",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "general_meeting_u_met_teamster" } ],
       "yes": "What can I help you with?",
       "no": "Well now, a new face.  Nice ta meet ya.  I'm the one sendin' out these here caravans far and wide.  What can I do ya for?"
     },
@@ -183,7 +182,7 @@
         "condition": {
           "and": [
             { "math": [ "npc_randomize_dialogue_direction", "==", "1" ] },
-            { "not": { "u_has_var": "teamster_mission_directions", "value": "isherwood" } }
+            { "not": { "compare_string": [ "isherwood", { "u_val": "teamster_mission_directions" } ] } }
           ]
         },
         "effect": { "assign_mission": "directions_isherwood" },
@@ -195,7 +194,7 @@
         "condition": {
           "and": [
             { "math": [ "npc_randomize_dialogue_direction", "==", "2" ] },
-            { "not": { "u_has_var": "teamster_mission_directions", "value": "hub01" } }
+            { "not": { "compare_string": [ "hub01", { "u_val": "teamster_mission_directions" } ] } }
           ]
         },
         "effect": { "assign_mission": "directions_hub01" },
@@ -207,7 +206,7 @@
         "condition": {
           "and": [
             { "math": [ "npc_randomize_dialogue_direction", "==", "3" ] },
-            { "not": { "u_has_var": "teamster_mission_directions", "value": "exodii" } }
+            { "not": { "compare_string": [ "exodii", { "u_val": "teamster_mission_directions" } ] } }
           ]
         },
         "effect": { "assign_mission": "directions_exodii" },
@@ -219,7 +218,7 @@
         "condition": {
           "and": [
             { "math": [ "npc_randomize_dialogue_direction", "==", "4" ] },
-            { "not": { "u_has_var": "teamster_mission_directions", "value": "artisans" } }
+            { "not": { "compare_string": [ "artisans", { "u_val": "teamster_mission_directions" } ] } }
           ]
         },
         "effect": { "assign_mission": "directions_artisans" },
@@ -282,7 +281,7 @@
       {
         "text": "[Tell them about Rubik and the Exodii.]",
         "topic": "TALK_FREE_MERCHANT_TEAMSTER_EXODII_1",
-        "condition": { "u_has_var": "general_meeting_u_met_Rubik", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Rubik" } ] }
       },
       { "text": "Hold on, what were you saying before?", "topic": "TALK_NONE" },
       { "text": "Actually, I have to go.  Maybe later.", "topic": "TALK_DONE" }

--- a/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_missions.json
+++ b/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_missions.json
@@ -18,7 +18,7 @@
       }
     },
     "end": { "effect": { "math": [ "free_merchants_hub_trade_route", "=", "1" ] } },
-    "goal_condition": { "u_has_var": "dialogue_intercom_completed_free_merchants_hub_delivery_1", "value": "yes" },
+    "goal_condition": { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_free_merchants_hub_delivery_1" } ] },
     "value": 5000,
     "origins": [ "ORIGIN_SECONDARY" ],
     "dialogue": {

--- a/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_talk.json
+++ b/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_talk.json
@@ -3,8 +3,7 @@
     "id": "TALK_FREE_MERCHANTS_MERCHANT",
     "type": "talk_topic",
     "dynamic_line": {
-      "u_has_var": "general_meeting_u_met_Gavin",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Gavin" } ],
       "yes": [ "Welcome back.", "Hello again.  What do you need?", "*looks up.  \"Hey.\"" ],
       "no": "*waves you over.  \"I haven't seen you before.  Welcome to our little homely house.\""
     },
@@ -12,7 +11,7 @@
       {
         "text": "Who are you?  This is a refugee center, right?",
         "topic": "TALK_FREE_MERCHANTS_MERCHANT_Intro",
-        "condition": { "not": { "u_has_var": "general_meeting_u_met_Gavin", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Gavin" } ] } },
         "effect": { "u_add_var": "general_meeting_u_met_Gavin", "value": "yes" }
       },
       {
@@ -29,23 +28,23 @@
       {
         "text": "Just passing through, don't mind me.",
         "topic": "TALK_DONE",
-        "condition": { "not": { "u_has_var": "general_meeting_u_met_Gavin", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Gavin" } ] } }
       },
       {
         "text": "I wanted to talk.",
         "topic": "TALK_FREE_MERCHANTS_MERCHANT_Talk",
-        "condition": { "u_has_var": "general_meeting_u_met_Gavin", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Gavin" } ] }
       },
       {
         "text": "Let's trade.",
         "topic": "TALK_FREE_MERCHANTS_MERCHANT_DoneTrading",
-        "condition": { "u_has_var": "general_meeting_u_met_Gavin", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Gavin" } ] },
         "effect": "start_trade"
       },
       {
         "text": "Just saying hello.  Keep safe.",
         "topic": "TALK_DONE",
-        "condition": { "u_has_var": "general_meeting_u_met_Gavin", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Gavin" } ] }
       }
     ]
   },
@@ -134,14 +133,14 @@
       { "text": "You mentioned you were selling hardware?", "topic": "TALK_FREE_MERCHANTS_MERCHANT_SellingHardware" },
       {
         "text": "What's with these people in the lobby?  Are they with you?",
-        "condition": { "not": { "u_has_var": "general_recruit_beggars_recruited", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "general_recruit_beggars_recruited" } ] } },
         "topic": "TALK_FREE_MERCHANTS_MERCHANT_Beggars"
       },
       {
         "text": "I took care of your beggar problem.",
         "condition": {
           "and": [
-            { "u_has_var": "general_recruit_beggars_recruited", "value": "yes" },
+            { "compare_string": [ "yes", { "u_val": "general_recruit_beggars_recruited" } ] },
             { "compare_string": [ "yes", { "npc_val": "general_recruit_beggars_reward_agreed" } ] }
           ]
         },
@@ -231,7 +230,7 @@
       {
         "text": "I'll see what I can do.  What's merch?",
         "topic": "TALK_FREE_MERCHANTS_MERCHANT_AboutMerch",
-        "condition": { "not": { "u_has_var": "general_free_merchants_u_knows_about_merch", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "general_free_merchants_u_knows_about_merch" } ] } }
       },
       { "text": "No guarantees, but I'll see what I can do.", "topic": "TALK_FREE_MERCHANTS_MERCHANT_Talk" }
     ]
@@ -274,12 +273,12 @@
       {
         "text": "Are there any other settlements around?",
         "topic": "TALK_FREE_MERCHANTS_MERCHANT_Robofac",
-        "condition": { "not": { "u_has_var": "general_free_merchants_u_hub01_breadcrumb_accepted", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "general_free_merchants_u_hub01_breadcrumb_accepted" } ] } }
       },
       {
         "text": "Are there any other settlements around?",
         "topic": "TALK_FREE_MERCHANTS_MERCHANT_OutsideWorld2",
-        "condition": { "u_has_var": "general_free_merchants_u_hub01_breadcrumb_accepted", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "general_free_merchants_u_hub01_breadcrumb_accepted" } ] }
       },
       { "text": "That's fine for now.", "topic": "TALK_FREE_MERCHANTS_MERCHANT_Talk" }
     ]
@@ -292,7 +291,7 @@
       {
         "text": "Wait, basement?  I didn't know this place had a basement.",
         "topic": "TALK_FREE_MERCHANTS_MERCHANT_Basement",
-        "condition": { "not": { "u_has_var": "general_free_merchants_u_knows_about_basement", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "general_free_merchants_u_knows_about_basement" } ] } },
         "effect": { "u_add_var": "general_free_merchants_u_knows_about_basement", "value": "yes" }
       },
       {
@@ -317,7 +316,7 @@
       {
         "text": "I don't see that many of you around.",
         "topic": "TALK_FREE_MERCHANTS_MERCHANT_Basement",
-        "condition": { "not": { "u_has_var": "general_free_merchants_u_knows_about_basement", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "general_free_merchants_u_knows_about_basement" } ] } },
         "effect": { "u_add_var": "general_free_merchants_u_knows_about_basement", "value": "yes" }
       },
       { "text": "I'll keep that in mind.", "topic": "TALK_FREE_MERCHANTS_MERCHANT_Talk" }

--- a/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_talk.json
+++ b/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_talk.json
@@ -21,7 +21,7 @@
         "condition": {
           "and": [
             { "u_has_mission": "EXODII_MISSION_WAREHOUSE" },
-            { "not": { "npc_has_var": "asked_about_exodii_warehouse_mission", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "asked_about_exodii_warehouse_mission" } ] } }
           ]
         },
         "effect": { "run_eocs": [ "EOC_exodii_mission_wh_directions_chance" ] }
@@ -113,7 +113,7 @@
         "condition": {
           "and": [
             { "u_has_mission": "MISSION_REFUGEE_Boris_CLEANUP" },
-            { "not": { "npc_has_var": "mission_Boris_mission_1_cleanup_asked", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "mission_Boris_mission_1_cleanup_asked" } ] } }
           ]
         },
         "topic": "TALK_FREE_MERCHANTS_MERCHANT_BorisCleanup"
@@ -142,7 +142,7 @@
         "condition": {
           "and": [
             { "u_has_var": "general_recruit_beggars_recruited", "value": "yes" },
-            { "npc_has_var": "general_recruit_beggars_reward_agreed", "value": "yes" }
+            { "compare_string": [ "yes", { "npc_val": "general_recruit_beggars_reward_agreed" } ] }
           ]
         },
         "effect": { "npc_lose_var": "general_recruit_beggars_reward_agreed" },
@@ -354,8 +354,7 @@
       "concatenate": [
         "&You describe the warehouse to the best of your ability.  Smokes listens",
         {
-          "npc_has_var": "exodii_mission_wh_correct",
-          "value": "no",
+          "compare_string": [ "no", { "npc_val": "exodii_mission_wh_correct" } ],
           "yes": ", then shakes his head.  \"Not ringing a bell, I think I'd remember if I'd heard about something like that.\"",
           "no": ", then nods slowly.  \"This sounds a bit familiar, I remember a scavenger coming through a while ago with a weird story about a place like that.  Might be nothing though.\""
         }
@@ -367,7 +366,7 @@
         "//": "The other responses are stored in common_talk.json in the exodii folder, to avoid repetition.",
         "text": "Oh well.  Thanks anyway.  I'll go ask around.",
         "topic": "TALK_DONE",
-        "condition": { "npc_has_var": "exodii_mission_wh_correct", "value": "no" },
+        "condition": { "compare_string": [ "no", { "npc_val": "exodii_mission_wh_correct" } ] },
         "effect": [
           { "math": [ "exodii_mission_wh_chance", "-=", "1" ] },
           { "math": [ "exodii_mission_wh_chance", "=", "max( exodii_mission_wh_chance, 1 )" ] }

--- a/data/json/npcs/refugee_center/surface_visitors/NPC_arsonist.json
+++ b/data/json/npcs/refugee_center/surface_visitors/NPC_arsonist.json
@@ -132,7 +132,7 @@
       },
       {
         "text": "How are you doing these days?",
-        "condition": { "u_has_var": "talk_flag_TALK_ARSONIST_SUPPLIED", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "talk_flag_TALK_ARSONIST_SUPPLIED" } ] },
         "topic": "TALK_ARSONIST_TRADING"
       },
       { "text": "Well, bye.", "topic": "TALK_DONE" }

--- a/data/json/npcs/refugee_center/surface_visitors/NPC_old_guard_representative.json
+++ b/data/json/npcs/refugee_center/surface_visitors/NPC_old_guard_representative.json
@@ -20,7 +20,7 @@
         "condition": {
           "and": [
             { "u_has_mission": "MISSION_REFUGEE_Boris_CLEANUP" },
-            { "not": { "npc_has_var": "mission_Boris_mission_1_cleanup_asked", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "mission_Boris_mission_1_cleanup_asked" } ] } }
           ]
         },
         "trial": { "type": "PERSUADE", "difficulty": 15 },

--- a/data/json/npcs/refugee_center/surface_visitors/NPC_old_guard_representative.json
+++ b/data/json/npcs/refugee_center/surface_visitors/NPC_old_guard_representative.json
@@ -36,7 +36,7 @@
         "condition": {
           "or": [
             { "u_has_mission": "MISSION_OLD_GUARD_REP_3" },
-            { "u_has_var": "factional_questline_mission_oldguard-exodii", "value": "encountered_base" }
+            { "compare_string": [ "encountered_base", { "u_val": "factional_questline_mission_oldguard-exodii" } ] }
           ]
         }
       },
@@ -44,7 +44,10 @@
         "text": "I think I can already tell you what you want to know about those 'robots'.",
         "topic": "TALK_OLD_GUARD_REP_MISSION_3_Predone",
         "condition": {
-          "and": [ { "u_has_mission": "MISSION_OLD_GUARD_REP_3" }, { "u_has_var": "general_meeting_u_met_Rubik", "value": "yes" } ]
+          "and": [
+            { "u_has_mission": "MISSION_OLD_GUARD_REP_3" },
+            { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Rubik" } ] }
+          ]
         }
       },
       { "text": "Does the Old Guard need anything?", "topic": "TALK_MISSION_LIST" },
@@ -119,7 +122,7 @@
       {
         "text": "Actually, I've met them.  They seem open to trade and things.  Thought you might want to know.",
         "topic": "TALK_OLD_GUARD_REP_EXODII_2",
-        "condition": { "u_has_var": "general_meeting_u_met_Rubik", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Rubik" } ] }
       },
       { "text": "Can we talk about something else?", "topic": "TALK_OLD_GUARD_REP" }
     ]
@@ -240,7 +243,7 @@
     "name": { "str": "Find Source of Robots" },
     "description": "Go to the supposed source of the weird robots marked on your map and report back to the Old Guard representative what you've seen.",
     "goal": "MGOAL_CONDITION",
-    "goal_condition": { "u_has_var": "missions_old_guard_u_scouted_exodii", "value": "yes" },
+    "goal_condition": { "compare_string": [ "yes", { "u_val": "missions_old_guard_u_scouted_exodii" } ] },
     "difficulty": 2,
     "value": 10000,
     "start": {

--- a/data/json/npcs/refugee_center/surface_visitors/NPC_visiting_scavenger.json
+++ b/data/json/npcs/refugee_center/surface_visitors/NPC_visiting_scavenger.json
@@ -81,7 +81,7 @@
         "condition": {
           "and": [
             { "math": [ "npc_randomize_dialogue_direction", "==", "1" ] },
-            { "not": { "u_has_var": "teamster_mission_directions", "value": "lapin" } }
+            { "not": { "compare_string": [ "lapin", { "u_val": "teamster_mission_directions" } ] } }
           ]
         },
         "effect": { "assign_mission": "directions_lapin" },
@@ -93,7 +93,7 @@
         "condition": {
           "and": [
             { "math": [ "npc_randomize_dialogue_direction", "==", "2" ] },
-            { "not": { "u_has_var": "teamster_mission_directions", "value": "isherwood" } }
+            { "not": { "compare_string": [ "isherwood", { "u_val": "teamster_mission_directions" } ] } }
           ]
         },
         "effect": { "assign_mission": "directions_isherwood" },
@@ -105,7 +105,7 @@
         "condition": {
           "and": [
             { "math": [ "npc_randomize_dialogue_direction", "==", "3" ] },
-            { "not": { "u_has_var": "teamster_mission_directions", "value": "exodii" } }
+            { "not": { "compare_string": [ "exodii", { "u_val": "teamster_mission_directions" } ] } }
           ]
         },
         "effect": { "assign_mission": "directions_exodii" },

--- a/data/json/npcs/robofac/NPC_Cranberry_Foster.json
+++ b/data/json/npcs/robofac/NPC_Cranberry_Foster.json
@@ -105,12 +105,10 @@
     "id": "TALK_ROBOFAC_MERC_1",
     "type": "talk_topic",
     "dynamic_line": {
-      "u_has_var": "general_meeting_u_met_Cranberry",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Cranberry" } ],
       "no": "&There's a person reclined on the sofa here.  They're very tall, with their legs reaching to the other armrest, and they're wearing a set of Hub 01's modular armor.  An environmental suit in blue-and-brown is crumpled in a misshapen heap on the floor near the table, and leaning against the far armrest is a rifle looking like nothing you've seen before.\n\nThey look up towards you as you come through the door and wave a hand.  \"Placeholder text.\"",
       "yes": {
-        "u_has_var": "dialogue_robofac_merc_1_robofac_merc_1_stay",
-        "value": "yes",
+        "compare_string": [ "yes", { "u_val": "dialogue_robofac_merc_1_robofac_merc_1_stay" } ],
         "no": [ "Did I scare you off the first time?", "Hi again, other person.", "*waves." ],
         "yes": {
           "compare_string": [ "yes", { "npc_val": "general_robofac_merc_1_temporal_follower" } ],
@@ -143,8 +141,8 @@
         "topic": "TALK_ROBOFAC_MERC_1_PLACEHOLDER_TEXT",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "general_meeting_u_met_Cranberry", "value": "yes" } },
-            { "not": { "u_has_var": "dialogue_robofac_merc_1_robofac_merc_1_stay", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Cranberry" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_robofac_merc_1_robofac_merc_1_stay" } ] } }
           ]
         }
       },
@@ -153,8 +151,8 @@
         "topic": "TALK_ROBOFAC_MERC_1_WHO",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "general_meeting_u_met_Cranberry", "value": "yes" } },
-            { "not": { "u_has_var": "dialogue_robofac_merc_1_robofac_merc_1_stay", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Cranberry" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_robofac_merc_1_robofac_merc_1_stay" } ] } }
           ]
         }
       },
@@ -163,8 +161,8 @@
         "topic": "TALK_ROBOFAC_MERC_1_WHO",
         "condition": {
           "and": [
-            { "u_has_var": "general_meeting_u_met_Cranberry", "value": "yes" },
-            { "not": { "u_has_var": "dialogue_robofac_merc_1_robofac_merc_1_stay", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Cranberry" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_robofac_merc_1_robofac_merc_1_stay" } ] } }
           ]
         }
       },
@@ -178,7 +176,7 @@
         "text": "I wanted to talk.",
         "condition": {
           "and": [
-            { "u_has_var": "dialogue_robofac_merc_1_robofac_merc_1_stay", "value": "yes" },
+            { "compare_string": [ "yes", { "u_val": "dialogue_robofac_merc_1_robofac_merc_1_stay" } ] },
             { "not": { "compare_string": [ "yes", { "npc_val": "general_robofac_merc_1_temporal_follower" } ] } }
           ]
         },
@@ -188,7 +186,7 @@
         "text": "Want help with something else?",
         "condition": {
           "and": [
-            { "u_has_var": "general_robofac_merc_1_helped_with_missions", "value": "yes" },
+            { "compare_string": [ "yes", { "u_val": "general_robofac_merc_1_helped_with_missions" } ] },
             { "not": { "compare_string": [ "yes", { "npc_val": "general_robofac_merc_1_temporal_follower" } ] } },
             { "not": "has_many_assigned_mission" },
             { "not": "has_assigned_mission" }
@@ -221,7 +219,7 @@
         "text": "Anything on your mind?",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "general_robofac_merc_1_has_gold_deal", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "u_val": "general_robofac_merc_1_has_gold_deal" } ] } },
             { "not": "has_many_assigned_mission" },
             { "not": "has_assigned_mission" }
           ]
@@ -230,27 +228,27 @@
       },
       {
         "text": "Anything on your mind?",
-        "condition": { "u_has_var": "general_robofac_merc_1_has_gold_deal", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "general_robofac_merc_1_has_gold_deal" } ] },
         "topic": "TALK_ROBOFAC_MERC_1_RANDOM_THOUGHTS"
       },
       {
         "text": "What was <the_cataclysm> like for you?",
-        "condition": { "not": { "u_has_var": "general_robofac_merc_1_helped_with_missions", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "general_robofac_merc_1_helped_with_missions" } ] } },
         "topic": "TALK_ROBOFAC_MERC_1_BACKGROUND_NO"
       },
       {
         "text": "What was <the_cataclysm> like for you?",
         "condition": {
           "and": [
-            { "u_has_var": "general_robofac_merc_1_helped_with_missions", "value": "yes" },
-            { "not": { "u_has_var": "general_robofac_merc_1_heard_backstory", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "general_robofac_merc_1_helped_with_missions" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "general_robofac_merc_1_heard_backstory" } ] } }
           ]
         },
         "topic": "TALK_ROBOFAC_MERC_1_BACKGROUND"
       },
       {
         "text": "Want help with something?",
-        "condition": { "not": { "u_has_var": "general_robofac_merc_1_helped_with_missions", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "general_robofac_merc_1_helped_with_missions" } ] } },
         "topic": "TALK_MISSION_LIST"
       },
       { "text": "What do you know about our employers?", "topic": "TALK_ROBOFAC_MERC_1_ASK_HUB" },
@@ -265,7 +263,7 @@
                 { "math": [ "u_skill('gun')", ">=", "2" ] }
               ]
             },
-            { "not": { "u_has_var": "dialogue_robofac_merc_1_robofac_merc_1_HWP", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_robofac_merc_1_robofac_merc_1_HWP" } ] } }
           ]
         },
         "topic": "TALK_ROBOFAC_MERC_1_HWP"
@@ -274,8 +272,8 @@
         "text": "What's the deal with your gun again?",
         "condition": {
           "and": [
-            { "u_has_var": "dialogue_robofac_merc_1_robofac_merc_1_HWP", "value": "yes" },
-            { "not": { "u_has_var": "dialogue_hub_rnd_u_can_research_rifle", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "dialogue_robofac_merc_1_robofac_merc_1_HWP" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_can_research_rifle" } ] } }
           ]
         },
         "topic": "TALK_ROBOFAC_MERC_1_HWP_EXPLANATION"
@@ -284,9 +282,9 @@
         "text": "I've helped you out now.  Do you think you could vouch for me with our employers?",
         "condition": {
           "and": [
-            { "u_has_var": "dialogue_robofac_merc_1_robofac_merc_1_HWP", "value": "yes" },
-            { "u_has_var": "favor_owed_to_u_robofac_merc_1_favor", "value": "1" },
-            { "not": { "u_has_var": "dialogue_hub_rnd_u_can_research_rifle", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "dialogue_robofac_merc_1_robofac_merc_1_HWP" } ] },
+            { "compare_string": [ "1", { "u_val": "favor_owed_to_u_robofac_merc_1_favor" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_can_research_rifle" } ] } }
           ]
         },
         "topic": "TALK_ROBOFAC_MERC_1_HWP_YES"
@@ -295,9 +293,9 @@
         "text": "How can I get a gun like that?",
         "condition": {
           "and": [
-            { "u_has_var": "dialogue_robofac_merc_1_robofac_merc_1_HWP", "value": "yes" },
-            { "not": { "u_has_var": "favor_owed_to_u_robofac_merc_1_favor", "value": "1" } },
-            { "not": { "u_has_var": "dialogue_hub_rnd_u_can_research_rifle", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "dialogue_robofac_merc_1_robofac_merc_1_HWP" } ] },
+            { "not": { "compare_string": [ "1", { "u_val": "favor_owed_to_u_robofac_merc_1_favor" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_can_research_rifle" } ] } }
           ]
         },
         "topic": "TALK_ROBOFAC_MERC_1_HWP_NO"
@@ -306,7 +304,7 @@
         "text": "I just realized, we've been in touch for a while now and I don't actually know; are you a man or a woman?",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "dialogue_robofac_merc_1_asked_gender", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_robofac_merc_1_asked_gender" } ] } },
             { "math": [ "n_npc_trust()", ">=", "3" ] }
           ]
         },
@@ -314,7 +312,7 @@
       },
       {
         "text": "About the gold you wanted…",
-        "condition": { "u_has_var": "general_robofac_merc_1_has_gold_deal", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "general_robofac_merc_1_has_gold_deal" } ] },
         "topic": "TALK_ROBOFAC_MERC_1_GOLD_MISSION_QUERY"
       },
       { "text": "Well, I should get going.", "topic": "TALK_DONE" }

--- a/data/json/npcs/robofac/NPC_Cranberry_Foster.json
+++ b/data/json/npcs/robofac/NPC_Cranberry_Foster.json
@@ -113,8 +113,7 @@
         "value": "yes",
         "no": [ "Did I scare you off the first time?", "Hi again, other person.", "*waves." ],
         "yes": {
-          "npc_has_var": "general_robofac_merc_1_temporal_follower",
-          "value": "yes",
+          "compare_string": [ "yes", { "npc_val": "general_robofac_merc_1_temporal_follower" } ],
           "yes": [
             "Better keep our eyes on the road.",
             "*looks at you expectantly.",
@@ -180,7 +179,7 @@
         "condition": {
           "and": [
             { "u_has_var": "dialogue_robofac_merc_1_robofac_merc_1_stay", "value": "yes" },
-            { "not": { "npc_has_var": "general_robofac_merc_1_temporal_follower", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "general_robofac_merc_1_temporal_follower" } ] } }
           ]
         },
         "topic": "TALK_ROBOFAC_MERC_1_MAIN"
@@ -190,7 +189,7 @@
         "condition": {
           "and": [
             { "u_has_var": "general_robofac_merc_1_helped_with_missions", "value": "yes" },
-            { "not": { "npc_has_var": "general_robofac_merc_1_temporal_follower", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "general_robofac_merc_1_temporal_follower" } ] } },
             { "not": "has_many_assigned_mission" },
             { "not": "has_assigned_mission" }
           ]
@@ -199,7 +198,7 @@
       },
       {
         "text": "Let's set up a combat strategy.",
-        "condition": { "npc_has_var": "general_robofac_merc_1_temporal_follower", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "npc_val": "general_robofac_merc_1_temporal_follower" } ] },
         "topic": "TALK_DONE",
         "effect": "npc_rules_menu"
       },

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/BAR_ENCOUNTER_MERCENARIES/BEM_anchor_seller.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/BAR_ENCOUNTER_MERCENARIES/BEM_anchor_seller.json
@@ -3,8 +3,7 @@
     "id": [ "BEM_ANCHOR_SELLER_1", "BEM_ANCHOR_SELLER_ASK" ],
     "type": "talk_topic",
     "dynamic_line": {
-      "u_has_var": "dialogue_BEM_ANCHOR_SELLER_ANCHOR_SELLER_paranormal",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "dialogue_BEM_ANCHOR_SELLER_ANCHOR_SELLER_paranormal" } ],
       "yes": { "gendered_line": "Sorry I'd rather be left alone right now.", "relevant_genders": [ "npc" ] },
       "no": {
         "gendered_line": "&A grim expression and deep sunken eyes imply some malady that can't be simply drowned with alcohol alone.  They interrupt you just as you were about to introduce yourself.  \"This anchor I'm wearing, I don't think I'll be needing it any more.  I-I'm just looking for someone to rid me of it",
@@ -14,22 +13,22 @@
     "responses": [
       {
         "text": "Offer to buy the anchor for 1 HGC.",
-        "condition": { "not": { "u_has_var": "dialogue_BEM_ANCHOR_SELLER_ANCHOR_SELLER_paranormal", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "dialogue_BEM_ANCHOR_SELLER_ANCHOR_SELLER_paranormal" } ] } },
         "topic": "BEM_ANCHOR_SELLER_2"
       },
       {
         "text": "Well, what's that thing for anyways?",
-        "condition": { "not": { "u_has_var": "dialogue_BEM_ANCHOR_SELLER_ANCHOR_SELLER_paranormal", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "dialogue_BEM_ANCHOR_SELLER_ANCHOR_SELLER_paranormal" } ] } },
         "topic": "BEM_ANCHOR_SELLER_ASK"
       },
       {
         "text": "Sorry, I don't think I can help you.",
-        "condition": { "not": { "u_has_var": "dialogue_BEM_ANCHOR_SELLER_ANCHOR_SELLER_paranormal", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "dialogue_BEM_ANCHOR_SELLER_ANCHOR_SELLER_paranormal" } ] } },
         "topic": "TALK_DONE"
       },
       {
         "text": "Alright, see you around then.",
-        "condition": { "u_has_var": "dialogue_BEM_ANCHOR_SELLER_ANCHOR_SELLER_paranormal", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_BEM_ANCHOR_SELLER_ANCHOR_SELLER_paranormal" } ] },
         "topic": "TALK_DONE"
       }
     ]

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/BAR_ENCOUNTER_MERCENARIES/BEM_chatting_veterans.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/BAR_ENCOUNTER_MERCENARIES/BEM_chatting_veterans.json
@@ -48,12 +48,12 @@
     "responses": [
       {
         "text": "Recall that time when you rescued a farmer's son from a citadel full of alien horrors.",
-        "condition": { "u_has_var": "u_saved_barry_isherwood", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "u_saved_barry_isherwood" } ] },
         "topic": "BEM_CHATTING_VETERANS_TELL_STORY_IMPRESSIVE"
       },
       {
         "text": "Tell them about your hunting of a pyramidal robot using a prototype energy rifle.",
-        "condition": { "u_has_var": "dialogue_intercom_completed_robofac_intercom_robot_sm_1", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_robot_sm_1" } ] },
         "topic": "BEM_CHATTING_VETERANS_TELL_STORY_OK"
       },
       {
@@ -63,7 +63,7 @@
       },
       {
         "text": "Tell about your slaying of an insectile horror after getting trapped within its lair.",
-        "condition": { "u_has_var": "general_talk_killed_a_void_spider", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "general_talk_killed_a_void_spider" } ] },
         "topic": "BEM_CHATTING_VETERANS_TELL_STORY_IMPRESSIVE"
       },
       {
@@ -73,12 +73,12 @@
       },
       {
         "text": "Tell them about the horrors uncovered by the mining expeditions of New England.",
-        "condition": { "u_has_var": "general_talk_clearead_amigara_mine", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "general_talk_clearead_amigara_mine" } ] },
         "topic": "BEM_CHATTING_VETERANS_TELL_STORY_IMPRESSIVE"
       },
       {
         "text": "Tell them about the horrors wandering in these very same subway tunnels.",
-        "condition": { "u_has_var": "general_talk_clearead_amigara_mine", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "general_talk_clearead_amigara_mine" } ] },
         "topic": "BEM_CHATTING_VETERANS_TELL_STORY_OK"
       },
       {
@@ -93,17 +93,17 @@
       },
       {
         "text": "Speak about the alien construct you found while lost in an endless sea of black glass.",
-        "condition": { "u_has_var": "general_yrax_u_met_apeirohedra", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "general_yrax_u_met_apeirohedra" } ] },
         "topic": "BEM_CHATTING_VETERANS_TELL_STORY_IMPRESSIVE"
       },
       {
         "text": "Tell them the story of how you were trapped in an infinitely looping corridor, fighting the warped remnants of the researchers there and somehow the damned corridor itself.  And at the end of the day, you're not even sure the headache was worth it.",
-        "condition": { "u_has_var": "dialogue_intercom_completed_robofac_lixa_sm_1", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_lixa_sm_1" } ] },
         "topic": "BEM_CHATTING_VETERANS_TELL_STORY_LIXA"
       },
       {
         "text": "Tell them the story of how you dived into and were forced to fight for your life within a disgusting, toxic hellscape made from the un-living innards of some crushed zombie monstrosity.  All so the intercom could have some damned HDD back.",
-        "condition": { "u_has_var": "dialogue_intercom_completed_robofac_intercom_3", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_3" } ] },
         "topic": "BEM_CHATTING_VETERANS_TELL_STORY_TOWER"
       },
       {

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/BAR_ENCOUNTER_MERCENARIES/BEM_jabberwock.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/BAR_ENCOUNTER_MERCENARIES/BEM_jabberwock.json
@@ -42,8 +42,7 @@
       "u_has_mission": "BEM_jabberwock_mission",
       "yes": "&You see one more traumatized face, all too many and too frequent for any help to be worthwhile.",
       "no": {
-        "u_has_var": "dialogue_bem_completed_bem_jabberwock",
-        "value": "yes",
+        "compare_string": [ "yes", { "u_val": "dialogue_bem_completed_bem_jabberwock" } ],
         "yes": "&You see one more traumatized face, all too many and too frequent for any help to be worthwhile.",
         "no": {
           "gendered_line": "&The mercenary stares intently at a stain in the ceiling, firmly clutching a now cold cup of soup.  No one else seems to be very concerned about this.",
@@ -59,7 +58,7 @@
           "not": {
             "or": [
               { "u_has_mission": "BEM_jabberwock_mission" },
-              { "u_has_var": "dialogue_bem_completed_bem_jabberwock", "value": "yes" }
+              { "compare_string": [ "yes", { "u_val": "dialogue_bem_completed_bem_jabberwock" } ] }
             ]
           }
         }

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/NPC_ANCILLA_BARKEEP.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/NPC_ANCILLA_BARKEEP.json
@@ -97,8 +97,7 @@
         "Oh, what can I do for you today?"
       ],
       "no": {
-        "u_has_var": "dialogue_ancilla_barkeep_first_meet",
-        "value": "yes",
+        "compare_string": [ "yes", { "u_val": "dialogue_ancilla_barkeep_first_meet" } ],
         "yes": "Feel free to lounge around, and ask if there's anything you need.",
         "no": "Welcome to the Terminal, scavenger, longest standing underground bar in the state.  Feel free to ask if you need something."
       }

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/NPC_ANCILLA_DOCTOR.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/NPC_ANCILLA_DOCTOR.json
@@ -80,8 +80,7 @@
       "u_has_faction_trust": 10,
       "yes": "Oh, what can I do for you today?",
       "no": {
-        "u_has_var": "dialogue_ancilla_doctor_first_meet",
-        "value": "yes",
+        "compare_string": [ "yes", { "u_val": "dialogue_ancilla_doctor_first_meet" } ],
         "yes": [
           "Try not to touch anything.  Keeping this place clean is a full time job.",
           { "gendered_line": "I'm free at the moment if you need something.", "relevant_genders": [ "npc" ] },

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/NPC_ANCILLA_HQ_GUARD.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/NPC_ANCILLA_HQ_GUARD.json
@@ -42,8 +42,7 @@
             "Well I can't complain much, money and free food for standing around with a gun?\n\nSure looks like a steal nowadays."
           ],
           "no": {
-            "u_has_var": "dialogue_ancilla_hq_guard_first_meet",
-            "value": "yes",
+            "compare_string": [ "yes", { "u_val": "dialogue_ancilla_hq_guard_first_meet" } ],
             "yes": [
               "If you don't have any business here, you better get going.",
               "Terminal is down there, please move along.",

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
@@ -88,7 +88,7 @@
         "rigid": true,
         "condition": {
           "or": [
-            { "npc_has_var": "dialogue_intercom_npc_bought_protective_gear", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_npc_bought_protective_gear" } ] },
             { "u_has_var": "dialogue_intercom_completed_robofac_intercom_3", "value": "yes" }
           ]
         },
@@ -151,8 +151,7 @@
     "id": "TALK_ROBOFAC_INTERCOM",
     "type": "talk_topic",
     "dynamic_line": {
-      "npc_has_var": "dialogue_intercom_npc_intercom_trade",
-      "value": "yes",
+      "compare_string": [ "yes", { "npc_val": "dialogue_intercom_npc_intercom_trade" } ],
       "yes": [
         "&The intercom is silent.",
         "&The intercom crackles on.",
@@ -173,7 +172,7 @@
     "responses": [
       {
         "text": "[Identify yourself before the intercom.]",
-        "condition": { "npc_has_var": "dialogue_intercom_npc_intercom_trade", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_npc_intercom_trade" } ] },
         "topic": "TALK_ROBOFAC_INTERCOM_SERVICES",
         "effect": {
           "run_eocs": [
@@ -195,7 +194,7 @@
         "topic": "TALK_ROBOFAC_INTERCOM_INTRO",
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "dialogue_intercom_npc_intercom_trade", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_npc_intercom_trade" } ] } },
             { "not": { "u_has_mission": "MISSION_ROBOFAC_INTERCOM_1" } }
           ]
         }
@@ -205,7 +204,7 @@
         "topic": "MISSION_ROBOFAC_INTERCOM_1_INQUIRE",
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "dialogue_intercom_npc_intercom_trade", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_npc_intercom_trade" } ] } },
             { "u_has_mission": "MISSION_ROBOFAC_INTERCOM_1" }
           ]
         }
@@ -294,7 +293,7 @@
           "and": [
             { "u_has_var": "global_portal_storms_u_heard_of_portal_storms", "value": "yes" },
             { "not": { "u_has_var": "global_portal_storms_u_witnessed_portal_storm", "value": "yes" } },
-            { "not": { "npc_has_var": "dialogue_intercom_told_about_portal_storms", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_told_about_portal_storms" } ] } }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_PORTAL_STORMS"
@@ -304,7 +303,7 @@
         "condition": {
           "and": [
             { "u_has_var": "global_portal_storms_u_witnessed_portal_storm", "value": "yes" },
-            { "not": { "npc_has_var": "dialogue_intercom_told_about_portal_storms", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_told_about_portal_storms" } ] } }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_PORTAL_STORMS"
@@ -326,7 +325,7 @@
         "condition": {
           "and": [
             { "u_has_var": "dialogue_intercom_completed_robofac_intercom_1", "value": "yes" },
-            { "not": { "npc_has_var": "dialogue_intercom_told_about_prototype", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_told_about_prototype" } ] } }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_ASK"
@@ -336,7 +335,7 @@
         "condition": {
           "and": [
             { "u_has_var": "dialogue_intercom_completed_robofac_intercom_1", "value": "yes" },
-            { "not": { "npc_has_var": "dialogue_intercom_told_about_armor", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_told_about_armor" } ] } }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_ARMOR_ASK"
@@ -378,7 +377,7 @@
         "condition": {
           "and": [
             { "u_has_mission": "MISSION_ROBOFAC_INTERCOM_3" },
-            { "not": { "npc_has_var": "dialogue_intercom_npc_bought_protective_gear", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_npc_bought_protective_gear" } ] } }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_BUY_PROTECTIVE_GEAR"
@@ -388,7 +387,7 @@
         "condition": {
           "and": [
             { "u_has_var": "dialogue_intercom_completed_robofac_intercom_2", "value": "yes" },
-            { "not": { "npc_has_var": "dialogue_intercom_sold_local_map", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_sold_local_map" } ] } }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_BUY_LOCAL_MAP"

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
@@ -44,7 +44,7 @@
         "condition": {
           "and": [
             { "math": [ "hub01_uhmwpe_researched", "==", "1" ] },
-            { "not": { "u_has_var": "dialogue_hub_rnd_u_can_buy_armor", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_can_buy_armor" } ] } }
           ]
         }
       },
@@ -52,19 +52,19 @@
         "group": "robofac_robots",
         "rigid": true,
         "strict": true,
-        "condition": { "u_has_var": "dialogue_intercom_completed_robofac_intercom_portal_sm_1", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_portal_sm_1" } ] }
       },
       {
         "group": "robofac_gun_mags",
         "rigid": true,
-        "condition": { "u_has_var": "dialogue_hub_rnd_u_has_researched_gun", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_has_researched_gun" } ] },
         "refusal": "You need to earn an HWP first"
       },
       {
         "group": "robofac_gun_kit",
         "rigid": true,
         "strict": true,
-        "condition": { "u_has_var": "dialogue_hub_rnd_u_has_researched_gun", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_has_researched_gun" } ] }
       },
       {
         "group": "robofac_gun_exodii",
@@ -72,7 +72,7 @@
         "strict": true,
         "condition": {
           "and": [
-            { "u_has_var": "dialogue_hub_rnd_u_has_researched_gun", "value": "yes" },
+            { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_has_researched_gun" } ] },
             { "math": [ "hub01_hwp_exotic_researched", "==", "1" ] }
           ]
         }
@@ -81,7 +81,7 @@
         "group": "NC_ROBOFAC_INTERCOM_trade_hm12",
         "rigid": true,
         "strict": true,
-        "condition": { "u_has_var": "dialogue_intercom_completed_robofac_intercom_robot_sm_1", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_robot_sm_1" } ] }
       },
       {
         "group": "NC_ROBOFAC_INTERCOM_trade_envirosuit",
@@ -89,7 +89,7 @@
         "condition": {
           "or": [
             { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_npc_bought_protective_gear" } ] },
-            { "u_has_var": "dialogue_intercom_completed_robofac_intercom_3", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_3" } ] }
           ]
         },
         "refusal": "You're not yet qualified to buy this"
@@ -159,8 +159,7 @@
         "&The intercom says something unintelligible."
       ],
       "no": {
-        "u_has_var": "dialogue_intercom_u_discovered_robofac_intercom",
-        "value": "yes",
+        "compare_string": [ "yes", { "u_val": "dialogue_intercom_u_discovered_robofac_intercom" } ],
         "yes": "&The intercom is silent.",
         "no": "&An intercom is embedded into the wall here, just next to the card reader.  It's a metal box about as big as a dinner plate, with a speaker shaped like a downwards curve and a large camera prominently featured in the center.  You see a single metal button with a dark LED next to it.  The intercom is silent."
       }
@@ -212,7 +211,7 @@
       {
         "text": "[Bang on the metal door.]",
         "topic": "TALK_ROBOFAC_INTERCOM",
-        "condition": { "not": { "u_has_var": "dialogue_intercom_u_met_robofac_intercom", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "dialogue_intercom_u_met_robofac_intercom" } ] } }
       },
       { "text": "[Leave.]", "topic": "TALK_DONE" }
     ],
@@ -274,14 +273,14 @@
       { "text": "Is there anything fancier you can sell?", "topic": "TALK_ROBOFAC_INTERCOM_ASK_INTERVAL" },
       {
         "text": "Let's discuss prototypes.",
-        "condition": { "u_has_var": "dialogue_intercom_u_hub_prototypes", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_intercom_u_hub_prototypes" } ] },
         "topic": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_MENU"
       },
       {
         "text": "The traders at the refugee center asked me to deliver this drive of FEMA data…",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "dialogue_intercom_completed_free_merchants_hub_delivery_1", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_free_merchants_hub_delivery_1" } ] } },
             { "u_has_mission": "MISSION_FREE_MERCHANTS_HUB_DELIVERY_1" }
           ]
         },
@@ -291,8 +290,8 @@
         "text": "You mentioned portal storms.  What are those?",
         "condition": {
           "and": [
-            { "u_has_var": "global_portal_storms_u_heard_of_portal_storms", "value": "yes" },
-            { "not": { "u_has_var": "global_portal_storms_u_witnessed_portal_storm", "value": "yes" } },
+            { "compare_string": [ "yes", { "u_val": "global_portal_storms_u_heard_of_portal_storms" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "global_portal_storms_u_witnessed_portal_storm" } ] } },
             { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_told_about_portal_storms" } ] } }
           ]
         },
@@ -302,7 +301,7 @@
         "text": "Listen, something happened earlier.  The world got… bad.  Things felt very wrong.  Do you know anything about what that was?",
         "condition": {
           "and": [
-            { "u_has_var": "global_portal_storms_u_witnessed_portal_storm", "value": "yes" },
+            { "compare_string": [ "yes", { "u_val": "global_portal_storms_u_witnessed_portal_storm" } ] },
             { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_told_about_portal_storms" } ] } }
           ]
         },
@@ -324,7 +323,7 @@
         "text": "What the hell were you testing out there?",
         "condition": {
           "and": [
-            { "u_has_var": "dialogue_intercom_completed_robofac_intercom_1", "value": "yes" },
+            { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_1" } ] },
             { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_told_about_prototype" } ] } }
           ]
         },
@@ -334,7 +333,7 @@
         "text": "Your scientist was wearing some kind of armor.  What is it?",
         "condition": {
           "and": [
-            { "u_has_var": "dialogue_intercom_completed_robofac_intercom_1", "value": "yes" },
+            { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_1" } ] },
             { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_told_about_armor" } ] } }
           ]
         },
@@ -344,7 +343,7 @@
         "text": "I found this in the collapsed tower with the other data.  Is it useful to your people?  [Hand over the UHMWPE nanofabricator template.]",
         "condition": {
           "and": [
-            { "u_has_var": "dialogue_intercom_completed_robofac_intercom_1", "value": "yes" },
+            { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_1" } ] },
             { "u_has_items": { "item": "template_armor", "count": 1 } }
           ]
         },
@@ -354,9 +353,9 @@
         "text": "I saw that your mercs have specialty rifles.  Would I be able to get one of those?",
         "condition": {
           "and": [
-            { "u_has_var": "dialogue_robofac_merc_1_robofac_merc_1_HWP", "value": "yes" },
-            { "not": { "u_has_var": "dialogue_hub_rnd_u_can_research_rifle", "value": "yes" } },
-            { "not": { "u_has_var": "dialogue_intercom_u_hub_prototypes", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "dialogue_robofac_merc_1_robofac_merc_1_HWP" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_can_research_rifle" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_intercom_u_hub_prototypes" } ] } }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_NO"
@@ -365,9 +364,9 @@
         "text": "I think one of your operatives has vouched for my competency.  I'd like one of those rifles.",
         "condition": {
           "and": [
-            { "u_has_var": "dialogue_robofac_merc_1_robofac_merc_1_HWP", "value": "yes" },
-            { "u_has_var": "dialogue_hub_rnd_u_can_research_rifle", "value": "yes" },
-            { "not": { "u_has_var": "dialogue_intercom_u_hub_prototypes", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "dialogue_robofac_merc_1_robofac_merc_1_HWP" } ] },
+            { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_can_research_rifle" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_intercom_u_hub_prototypes" } ] } }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_GUN_YES"
@@ -386,7 +385,7 @@
         "text": "You mentioned you had a map of the area?",
         "condition": {
           "and": [
-            { "u_has_var": "dialogue_intercom_completed_robofac_intercom_2", "value": "yes" },
+            { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_2" } ] },
             { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_sold_local_map" } ] } }
           ]
         },
@@ -399,9 +398,7 @@
             { "u_has_faction_trust": 5 },
             { "u_has_mission": "MISSION_ISHERWOOD_CHRIS_1_GET_GEAR" },
             { "math": [ "isherwood_gear_status", "<", "1" ] },
-            {
-              "not": { "npc_has_var": "npc_bought_riot_gear", "type": "dialogue", "context": "intercom", "value": "yes" }
-            }
+            { "not": { "compare_string": [ "yes", { "npc_val": "npc_dialogue_exodii_npc_bought_riot_gear" } ] } }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_BUY_RIOT_GEAR"
@@ -410,7 +407,7 @@
         "text": "I'm here and I've got the goods.",
         "condition": {
           "and": [
-            { "npc_has_var": "u_pay_back_on_cash", "type": "dialogue", "context": "intercom", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "npc_dialogue_intercom_u_pay_back_on_cash" } ] },
             { "u_has_items": { "item": "RobofacCoin", "count": 8 } },
             { "u_has_mission": "MISSION_HUB01_PAY_BACK_RIOT_GEAR" }
           ]
@@ -421,7 +418,7 @@
         "text": "Cost of the armor plus everything left in the tower.",
         "condition": {
           "and": [
-            { "npc_has_var": "u_pay_back_on_specimens", "type": "dialogue", "context": "intercom", "value": "yes" },
+            { "compare_string": [ "yes", { "npc_val": "npc_dialogue_intercom_u_pay_back_on_specimens" } ] },
             { "math": [ "isherwood_barry_rescued", "==", "1" ] },
             { "u_has_mission": "MISSION_HUB01_PAY_BACK_RIOT_GEAR" }
           ]
@@ -435,8 +432,7 @@
     "id": "TALK_ROBOFAC_INTERCOM_INTRO",
     "type": "talk_topic",
     "dynamic_line": {
-      "u_has_var": "dialogue_intercom_u_met_robofac_intercom",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "dialogue_intercom_u_met_robofac_intercom" } ],
       "yes": "&The intercom is silent.",
       "no": "&The intercom crackles with static as it turns on.  The LED next to the button lights up a bright red, and the camera lens whirrs as it focuses on you.  There is no immediate response."
     },
@@ -452,9 +448,11 @@
         "text": "The merchant at the refugee center sent me.  You were looking for a hard drive from them?",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "dialogue_intercom_completed_robofac_intercom_1", "value": "yes" } },
-            { "not": { "u_has_var": "dialogue_intercom_completed_free_merchants_hub_delivery_1", "value": "yes" } },
-            { "not": { "u_has_var": "dialogue_intercom_u_started_robofac_hdd_trade", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_1" } ] } },
+            {
+              "not": { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_free_merchants_hub_delivery_1" } ] }
+            },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_intercom_u_started_robofac_hdd_trade" } ] } },
             { "u_has_mission": "MISSION_FREE_MERCHANTS_HUB_DELIVERY_1" }
           ]
         },
@@ -464,9 +462,11 @@
         "text": "About that hard drive…",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "dialogue_intercom_completed_robofac_intercom_1", "value": "yes" } },
-            { "not": { "u_has_var": "dialogue_intercom_completed_free_merchants_hub_delivery_1", "value": "yes" } },
-            { "u_has_var": "dialogue_intercom_u_started_robofac_hdd_trade", "value": "yes" },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_1" } ] } },
+            {
+              "not": { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_free_merchants_hub_delivery_1" } ] }
+            },
+            { "compare_string": [ "yes", { "u_val": "dialogue_intercom_u_started_robofac_hdd_trade" } ] },
             { "u_has_mission": "MISSION_FREE_MERCHANTS_HUB_DELIVERY_1" }
           ]
         },
@@ -476,8 +476,8 @@
         "text": "The traders mentioned you were looking for help.",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "dialogue_intercom_completed_robofac_intercom_1", "value": "yes" } },
-            { "u_has_var": "dialogue_intercom_completed_free_merchants_hub_delivery_1", "value": "yes" }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_1" } ] } },
+            { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_free_merchants_hub_delivery_1" } ] }
           ]
         },
         "trial": { "type": "LIE", "difficulty": 1 },
@@ -496,9 +496,11 @@
         "text": "I have a delivery from the Free Merchants.  You requested a hard drive from them.",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "dialogue_intercom_completed_robofac_intercom_1", "value": "yes" } },
-            { "not": { "u_has_var": "dialogue_intercom_completed_free_merchants_hub_delivery_1", "value": "yes" } },
-            { "not": { "u_has_var": "dialogue_intercom_u_started_robofac_hdd_trade", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_1" } ] } },
+            {
+              "not": { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_free_merchants_hub_delivery_1" } ] }
+            },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_intercom_u_started_robofac_hdd_trade" } ] } },
             { "u_has_mission": "MISSION_FREE_MERCHANTS_HUB_DELIVERY_1" }
           ]
         },
@@ -604,8 +606,7 @@
     ],
     "type": "talk_topic",
     "dynamic_line": {
-      "u_has_var": "dialogue_intercom_u_started_robofac_hdd_trade",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "dialogue_intercom_u_started_robofac_hdd_trade" } ],
       "yes": "&The intercom's tray wordlessly slides open.",
       "no": "&The intercom erupts into static.  Then, it resolves into a voice.  It clears its throat, then speaks slowly and carefully.  \"Understood.  There is a tray embedded beneath the intercom.  Please place the drive into it.\"  On cue, a small portion of the wall beneath the intercom slides out along rails, revealing a large tray several inches deep.  \"You are welcome to leave afterwards.\""
     },

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
@@ -66,7 +66,7 @@
         "condition": {
           "and": [
             { "not": { "u_has_mission": "MISSION_ROBOFAC_INTERCOM_2" } },
-            { "not": { "u_has_var": "dialogue_intercom_completed_robofac_intercom_2", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_2" } ] } }
           ]
         },
         "effect": [ { "u_add_var": "global_portal_storms_u_heard_of_portal_storms", "value": "yes" } ],
@@ -77,8 +77,8 @@
         "condition": {
           "and": [
             { "not": { "u_has_mission": "MISSION_ROBOFAC_INTERCOM_3" } },
-            { "not": { "u_has_var": "dialogue_intercom_completed_robofac_intercom_3", "value": "yes" } },
-            { "u_has_var": "dialogue_intercom_completed_robofac_intercom_2", "value": "yes" }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_3" } ] } },
+            { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_2" } ] }
           ]
         },
         "topic": "MISSION_ROBOFAC_INTERCOM_3_OFFER"
@@ -88,8 +88,12 @@
         "condition": {
           "and": [
             { "not": { "u_has_mission": "MISSION_ROBOFAC_INTERCOM_ROBOT_SM_1" } },
-            { "not": { "u_has_var": "dialogue_intercom_completed_robofac_intercom_robot_sm_1", "value": "yes" } },
-            { "not": { "u_has_var": "dialogue_intercom_completed_robofac_intercom_robot_sm_1", "value": "no" } }
+            {
+              "not": { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_robot_sm_1" } ] }
+            },
+            {
+              "not": { "compare_string": [ "no", { "u_val": "dialogue_intercom_completed_robofac_intercom_robot_sm_1" } ] }
+            }
           ]
         },
         "topic": "MISSION_ROBOFAC_INTERCOM_ROBOT_SM_1_OFFER"
@@ -99,7 +103,9 @@
         "condition": {
           "and": [
             { "not": { "u_has_mission": "MISSION_ROBOFAC_INTERCOM_PORTAL_SM_1" } },
-            { "not": { "u_has_var": "dialogue_intercom_completed_robofac_intercom_portal_sm_1", "value": "yes" } },
+            {
+              "not": { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_portal_sm_1" } ] }
+            },
             { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_told_about_portal_storms" } ] }
           ]
         },
@@ -110,8 +116,12 @@
         "condition": {
           "and": [
             { "not": { "u_has_mission": "MISSION_ROBOFAC_INTERCOM_LIXA_SM_1" } },
-            { "not": { "u_has_var": "dialogue_intercom_completed_robofac_intercom_lixa_sm_1", "value": "yes" } },
-            { "not": { "u_has_var": "dialogue_intercom_completed_robofac_intercom_lixa_sm_1", "value": "no" } },
+            {
+              "not": { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_lixa_sm_1" } ] }
+            },
+            {
+              "not": { "compare_string": [ "no", { "u_val": "dialogue_intercom_completed_robofac_intercom_lixa_sm_1" } ] }
+            },
             { "math": [ "u_portal_storm_recordings_sold", ">", "2" ] }
           ]
         },
@@ -125,7 +135,9 @@
             {
               "or": [
                 { "u_has_mission": "MISSION_ROBOFAC_INTERCOM_PORTAL_SM_1" },
-                { "u_has_var": "dialogue_intercom_completed_robofac_intercom_portal_sm_1", "value": "yes" }
+                {
+                  "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_portal_sm_1" } ]
+                }
               ]
             }
           ]
@@ -136,15 +148,15 @@
         "text": "Do you have any more work for me right now?",
         "condition": {
           "and": [
-            { "u_has_var": "dialogue_intercom_completed_robofac_intercom_2", "value": "yes" },
-            { "u_has_var": "dialogue_intercom_completed_robofac_intercom_2", "value": "yes" },
-            { "u_has_var": "dialogue_intercom_completed_robofac_intercom_3", "value": "yes" },
-            { "u_has_var": "dialogue_intercom_completed_robofac_intercom_portal_sm_1", "value": "yes" },
-            { "u_has_var": "dialogue_intercom_completed_robofac_intercom_lixa_sm_1", "value": "yes" },
+            { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_2" } ] },
+            { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_2" } ] },
+            { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_3" } ] },
+            { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_portal_sm_1" } ] },
+            { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_lixa_sm_1" } ] },
             {
               "or": [
-                { "u_has_var": "dialogue_intercom_completed_robofac_intercom_robot_sm_1", "value": "yes" },
-                { "u_has_var": "dialogue_intercom_completed_robofac_intercom_robot_sm_1", "value": "no" }
+                { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_robot_sm_1" } ] },
+                { "compare_string": [ "no", { "u_val": "dialogue_intercom_completed_robofac_intercom_robot_sm_1" } ] }
               ]
             }
           ]

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
@@ -100,7 +100,7 @@
           "and": [
             { "not": { "u_has_mission": "MISSION_ROBOFAC_INTERCOM_PORTAL_SM_1" } },
             { "not": { "u_has_var": "dialogue_intercom_completed_robofac_intercom_portal_sm_1", "value": "yes" } },
-            { "npc_has_var": "dialogue_intercom_told_about_portal_storms", "value": "yes" }
+            { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_told_about_portal_storms" } ] }
           ]
         },
         "topic": "MISSION_ROBOFAC_INTERCOM_PORTAL_SM_1_OFFER"

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_prototypes.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_prototypes.json
@@ -11,7 +11,7 @@
           "and": [
             { "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_armor)", "<", "time('1 d')" ] },
             { "math": [ "hub01_uhmwpe_researched", "!=", "1" ] },
-            { "u_has_var": "dialogue_hub_rnd_u_gave_armor_disk", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_gave_armor_disk" } ] }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_ARMOR_ONGOING"
@@ -22,7 +22,7 @@
           "and": [
             { "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_armor)", ">", "time('1 d')" ] },
             { "math": [ "hub01_uhmwpe_researched", "!=", "1" ] },
-            { "u_has_var": "dialogue_hub_rnd_u_gave_armor_disk", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_gave_armor_disk" } ] }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_ARMOR_BREAKTHROUGH"
@@ -32,7 +32,7 @@
         "condition": {
           "and": [
             { "u_has_items": { "item": "RobofacCoin", "count": 6 } },
-            { "u_has_var": "dialogue_hub_rnd_u_can_buy_armor", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_can_buy_armor" } ] }
           ]
         },
         "effect": [
@@ -50,8 +50,8 @@
         "text": "I'd like to request a Hybrid Weapons Platform.",
         "condition": {
           "and": [
-            { "u_has_var": "dialogue_robofac_merc_1_robofac_merc_1_HWP", "value": "yes" },
-            { "not": { "u_has_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "dialogue_robofac_merc_1_robofac_merc_1_HWP" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_project_ongoing" } ] } }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_RIFLE_REQUEST"
@@ -62,7 +62,7 @@
           "and": [
             { "math": [ "has_var(u_timer_hub_rnd_u_waiting_on_gun)" ] },
             { "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_gun)", "<", "time('7 d')" ] },
-            { "u_has_var": "dialogue_robofac_merc_1_robofac_merc_1_HWP", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "dialogue_robofac_merc_1_robofac_merc_1_HWP" } ] }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_ONGOING"
@@ -72,8 +72,8 @@
         "effect": { "u_add_var": "dialogue_hub_rnd_u_armor_type", "value": "robofac_armor_pieces_rig" },
         "condition": {
           "and": [
-            { "u_has_var": "dialogue_robofac_merc_1_robofac_merc_1_HWP", "value": "yes" },
-            { "not": { "u_has_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "dialogue_robofac_merc_1_robofac_merc_1_HWP" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_project_ongoing" } ] } }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_ARMOR_REQUEST"
@@ -83,8 +83,8 @@
         "effect": { "u_add_var": "dialogue_hub_rnd_u_armor_type", "value": "robofac_armor_pieces_basic" },
         "condition": {
           "and": [
-            { "u_has_var": "dialogue_robofac_merc_1_robofac_merc_1_HWP", "value": "yes" },
-            { "not": { "u_has_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "dialogue_robofac_merc_1_robofac_merc_1_HWP" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_project_ongoing" } ] } }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_ARMOR_REQUEST"
@@ -94,8 +94,8 @@
         "effect": { "u_add_var": "dialogue_hub_rnd_u_armor_type", "value": "robofac_armor_pieces_nomex" },
         "condition": {
           "and": [
-            { "u_has_var": "dialogue_robofac_merc_1_robofac_merc_1_HWP", "value": "yes" },
-            { "not": { "u_has_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "dialogue_robofac_merc_1_robofac_merc_1_HWP" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_project_ongoing" } ] } }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_ARMOR_REQUEST"
@@ -105,8 +105,8 @@
         "effect": { "u_add_var": "dialogue_hub_rnd_u_armor_type", "value": "robofac_armor_pieces_kevlar" },
         "condition": {
           "and": [
-            { "u_has_var": "dialogue_robofac_merc_1_robofac_merc_1_HWP", "value": "yes" },
-            { "not": { "u_has_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "dialogue_robofac_merc_1_robofac_merc_1_HWP" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_project_ongoing" } ] } }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_ARMOR_REQUEST"
@@ -116,8 +116,8 @@
         "effect": { "u_add_var": "dialogue_hub_rnd_u_armor_type", "value": "robofac_armor_pieces_rubber" },
         "condition": {
           "and": [
-            { "u_has_var": "dialogue_robofac_merc_1_robofac_merc_1_HWP", "value": "yes" },
-            { "not": { "u_has_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "dialogue_robofac_merc_1_robofac_merc_1_HWP" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_project_ongoing" } ] } }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_ARMOR_REQUEST"
@@ -127,10 +127,10 @@
         "effect": { "u_add_var": "dialogue_hub_rnd_u_armor_type", "value": "robofac_armor_pieces_military" },
         "condition": {
           "and": [
-            { "u_has_var": "dialogue_robofac_merc_1_robofac_merc_1_HWP", "value": "yes" },
-            { "not": { "u_has_var": "dialogue_hub_rnd_u_can_buy_armor", "value": "yes" } },
+            { "compare_string": [ "yes", { "u_val": "dialogue_robofac_merc_1_robofac_merc_1_HWP" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_can_buy_armor" } ] } },
             { "math": [ "hub01_uhmwpe_researched", "==", "1" ] },
-            { "not": { "u_has_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_project_ongoing" } ] } }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_ARMOR_REQUEST"
@@ -142,12 +142,14 @@
             { "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_hub)", "<", "time('1 d')" ] },
             {
               "or": [
-                { "u_has_var": "dialogue_hub_rnd_u_armor_type", "value": "robofac_armor_pieces_rig" },
-                { "u_has_var": "dialogue_hub_rnd_u_armor_type", "value": "robofac_armor_pieces_basic" },
-                { "u_has_var": "dialogue_hub_rnd_u_armor_type", "value": "robofac_armor_pieces_rubber" },
-                { "u_has_var": "dialogue_hub_rnd_u_armor_type", "value": "robofac_armor_pieces_nomex" },
-                { "u_has_var": "dialogue_hub_rnd_u_armor_type", "value": "robofac_armor_pieces_kevlar" },
-                { "u_has_var": "dialogue_hub_rnd_u_armor_type", "value": "robofac_armor_pieces_military" }
+                { "compare_string": [ "robofac_armor_pieces_rig", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] },
+                { "compare_string": [ "robofac_armor_pieces_basic", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] },
+                { "compare_string": [ "robofac_armor_pieces_rubber", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] },
+                { "compare_string": [ "robofac_armor_pieces_nomex", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] },
+                { "compare_string": [ "robofac_armor_pieces_kevlar", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] },
+                {
+                  "compare_string": [ "robofac_armor_pieces_military", { "u_val": "dialogue_hub_rnd_u_armor_type" } ]
+                }
               ]
             }
           ]
@@ -161,12 +163,14 @@
             { "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_hub)", ">", "time('1 d')" ] },
             {
               "or": [
-                { "u_has_var": "dialogue_hub_rnd_u_armor_type", "value": "robofac_armor_pieces_rig" },
-                { "u_has_var": "dialogue_hub_rnd_u_armor_type", "value": "robofac_armor_pieces_basic" },
-                { "u_has_var": "dialogue_hub_rnd_u_armor_type", "value": "robofac_armor_pieces_rubber" },
-                { "u_has_var": "dialogue_hub_rnd_u_armor_type", "value": "robofac_armor_pieces_nomex" },
-                { "u_has_var": "dialogue_hub_rnd_u_armor_type", "value": "robofac_armor_pieces_kevlar" },
-                { "u_has_var": "dialogue_hub_rnd_u_armor_type", "value": "robofac_armor_pieces_military" }
+                { "compare_string": [ "robofac_armor_pieces_rig", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] },
+                { "compare_string": [ "robofac_armor_pieces_basic", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] },
+                { "compare_string": [ "robofac_armor_pieces_rubber", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] },
+                { "compare_string": [ "robofac_armor_pieces_nomex", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] },
+                { "compare_string": [ "robofac_armor_pieces_kevlar", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] },
+                {
+                  "compare_string": [ "robofac_armor_pieces_military", { "u_val": "dialogue_hub_rnd_u_armor_type" } ]
+                }
               ]
             }
           ]
@@ -179,7 +183,7 @@
           "and": [
             { "math": [ "has_var(u_timer_hub_rnd_u_waiting_on_gun)" ] },
             { "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_gun)", ">", "time('7 d')" ] },
-            { "u_has_var": "dialogue_robofac_merc_1_robofac_merc_1_HWP", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "dialogue_robofac_merc_1_robofac_merc_1_HWP" } ] }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_RIFLE_BREAKTHROUGH"
@@ -189,7 +193,7 @@
         "condition": {
           "and": [
             { "u_has_items": { "item": "phase_immersion_suit", "count": 1 } },
-            { "not": { "u_has_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_project_ongoing" } ] } }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_PHASE_REPAIR"
@@ -199,7 +203,7 @@
         "condition": {
           "and": [
             { "u_has_items": { "item": "rm13_armor", "count": 1 } },
-            { "not": { "u_has_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_project_ongoing" } ] } }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_RM13_REPAIR"
@@ -209,7 +213,7 @@
         "condition": {
           "and": [
             { "u_has_items": { "item": "combat_exoskeleton_light_salvaged", "count": 1 } },
-            { "not": { "u_has_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_project_ongoing" } ] } }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_EXOSKELETON_REPAIR"
@@ -221,9 +225,9 @@
             { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", ">", "time('now')" ] },
             {
               "or": [
-                { "u_has_var": "dialogue_hub_rnd_u_current_project", "value": "combat_exoskeleton_light_salvaged" },
-                { "u_has_var": "dialogue_hub_rnd_u_current_project", "value": "phase_immersion_suit" },
-                { "u_has_var": "dialogue_hub_rnd_u_current_project", "value": "rm13_armor" }
+                { "compare_string": [ "combat_exoskeleton_light_salvaged", { "u_val": "dialogue_hub_rnd_u_current_project" } ] },
+                { "compare_string": [ "phase_immersion_suit", { "u_val": "dialogue_hub_rnd_u_current_project" } ] },
+                { "compare_string": [ "rm13_armor", { "u_val": "dialogue_hub_rnd_u_current_project" } ] }
               ]
             }
           ]
@@ -235,7 +239,7 @@
         "condition": {
           "and": [
             { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "<", "time('now')" ] },
-            { "u_has_var": "dialogue_hub_rnd_u_current_project", "value": "phase_immersion_suit" }
+            { "compare_string": [ "phase_immersion_suit", { "u_val": "dialogue_hub_rnd_u_current_project" } ] }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_PHASE_REPAIR_COMPLETE"
@@ -245,7 +249,7 @@
         "condition": {
           "and": [
             { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "<", "time('now')" ] },
-            { "u_has_var": "dialogue_hub_rnd_u_current_project", "value": "rm13_armor" }
+            { "compare_string": [ "rm13_armor", { "u_val": "dialogue_hub_rnd_u_current_project" } ] }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_RM13_REPAIR_COMPLETE"
@@ -255,7 +259,9 @@
         "condition": {
           "and": [
             { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "<", "time('now')" ] },
-            { "u_has_var": "dialogue_hub_rnd_u_current_project", "value": "combat_exoskeleton_light_salvaged" }
+            {
+              "compare_string": [ "combat_exoskeleton_light_salvaged", { "u_val": "dialogue_hub_rnd_u_current_project" } ]
+            }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_EXOSKELETON_REPAIR_COMPLETE"
@@ -265,8 +271,8 @@
         "condition": {
           "and": [
             { "u_has_items": { "item": "dimensional_anchor", "count": 1 } },
-            { "not": { "u_has_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" } },
-            { "not": { "u_has_var": "dialogue_hub_rnd_u_completed_anchor_pt_1", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_project_ongoing" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_completed_anchor_pt_1" } ] } }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_ANCHOR_PT_1"
@@ -276,7 +282,7 @@
         "condition": {
           "and": [
             { "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_hub)", "<", "time('5 d')" ] },
-            { "u_has_var": "dialogue_hub_rnd_u_current_project", "value": "anchor_pt_1" }
+            { "compare_string": [ "anchor_pt_1", { "u_val": "dialogue_hub_rnd_u_current_project" } ] }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_ONGOING"
@@ -286,7 +292,7 @@
         "condition": {
           "and": [
             { "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_hub)", ">", "time('5 d')" ] },
-            { "u_has_var": "dialogue_hub_rnd_u_current_project", "value": "anchor_pt_1" }
+            { "compare_string": [ "anchor_pt_1", { "u_val": "dialogue_hub_rnd_u_current_project" } ] }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_ANCHOR_PT_1_COMPLETE"
@@ -295,8 +301,8 @@
         "text": "I would like you to upgrade my modular defense system.",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" } },
-            { "u_has_var": "dialogue_hub_rnd_u_completed_anchor_pt_1", "value": "yes" }
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_project_ongoing" } ] } },
+            { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_completed_anchor_pt_1" } ] }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_ANCHOR_PT_2"
@@ -306,7 +312,7 @@
         "condition": {
           "and": [
             { "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_hub)", "<", "time('2 d')" ] },
-            { "u_has_var": "dialogue_hub_rnd_u_current_project", "value": "anchor_pt_2" }
+            { "compare_string": [ "anchor_pt_2", { "u_val": "dialogue_hub_rnd_u_current_project" } ] }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_ONGOING"
@@ -316,7 +322,7 @@
         "condition": {
           "and": [
             { "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_hub)", ">", "time('2 d')" ] },
-            { "u_has_var": "dialogue_hub_rnd_u_current_project", "value": "anchor_pt_2" }
+            { "compare_string": [ "anchor_pt_2", { "u_val": "dialogue_hub_rnd_u_current_project" } ] }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_ANCHOR_PT_2_COMPLETE"
@@ -326,8 +332,8 @@
         "condition": {
           "and": [
             { "math": [ "hub01_hwp_exotic_researched", "!=", "1" ] },
-            { "not": { "u_has_var": "dialogue_hub_rnd_u_project_ongoing", "value": "yes" } },
-            { "u_has_var": "dialogue_hub_rnd_u_has_researched_gun", "value": "yes" },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_project_ongoing" } ] } },
+            { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_has_researched_gun" } ] },
             {
               "or": [ { "u_has_items": { "item": "pamd68", "count": 1 } }, { "u_has_items": { "item": "pamd71z", "count": 1 } } ]
             }
@@ -340,7 +346,7 @@
         "condition": {
           "and": [
             { "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_hub)", "<", "time('3 d')" ] },
-            { "u_has_var": "dialogue_hub_rnd_u_current_project", "value": "hwp_exodii" }
+            { "compare_string": [ "hwp_exodii", { "u_val": "dialogue_hub_rnd_u_current_project" } ] }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_ONGOING"
@@ -350,7 +356,7 @@
         "condition": {
           "and": [
             { "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_hub)", ">", "time('3 d')" ] },
-            { "u_has_var": "dialogue_hub_rnd_u_current_project", "value": "hwp_exodii" }
+            { "compare_string": [ "hwp_exodii", { "u_val": "dialogue_hub_rnd_u_current_project" } ] }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_HWP_EXODII_COMPLETE"
@@ -491,7 +497,7 @@
         "condition": {
           "and": [
             { "u_has_items": { "item": "RobofacCoin", "count": 3 } },
-            { "u_has_var": "dialogue_hub_rnd_u_armor_type", "value": "robofac_armor_pieces_rig" }
+            { "compare_string": [ "robofac_armor_pieces_rig", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] }
           ]
         },
         "effect": [
@@ -508,7 +514,7 @@
         "condition": {
           "and": [
             { "u_has_items": { "item": "RobofacCoin", "count": 2 } },
-            { "u_has_var": "dialogue_hub_rnd_u_armor_type", "value": "robofac_armor_pieces_basic" }
+            { "compare_string": [ "robofac_armor_pieces_basic", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] }
           ]
         },
         "effect": [
@@ -525,7 +531,7 @@
         "condition": {
           "and": [
             { "u_has_items": { "item": "RobofacCoin", "count": 4 } },
-            { "u_has_var": "dialogue_hub_rnd_u_armor_type", "value": "robofac_armor_pieces_nomex" }
+            { "compare_string": [ "robofac_armor_pieces_nomex", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] }
           ]
         },
         "effect": [
@@ -542,7 +548,7 @@
         "condition": {
           "and": [
             { "u_has_items": { "item": "RobofacCoin", "count": 4 } },
-            { "u_has_var": "dialogue_hub_rnd_u_armor_type", "value": "robofac_armor_pieces_kevlar" }
+            { "compare_string": [ "robofac_armor_pieces_kevlar", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] }
           ]
         },
         "effect": [
@@ -559,7 +565,7 @@
         "condition": {
           "and": [
             { "u_has_items": { "item": "RobofacCoin", "count": 4 } },
-            { "u_has_var": "dialogue_hub_rnd_u_armor_type", "value": "robofac_armor_pieces_rubber" }
+            { "compare_string": [ "robofac_armor_pieces_rubber", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] }
           ]
         },
         "effect": [
@@ -576,7 +582,7 @@
         "condition": {
           "and": [
             { "u_has_items": { "item": "RobofacCoin", "count": 12 } },
-            { "u_has_var": "dialogue_hub_rnd_u_armor_type", "value": "robofac_armor_pieces_military" }
+            { "compare_string": [ "robofac_armor_pieces_military", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] }
           ]
         },
         "effect": [
@@ -605,7 +611,7 @@
       {
         "//": "Armor Rig response.",
         "text": "Sweet, thanks.",
-        "condition": { "u_has_var": "dialogue_hub_rnd_u_armor_type", "value": "robofac_armor_pieces_rig" },
+        "condition": { "compare_string": [ "robofac_armor_pieces_rig", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] },
         "effect": [
           { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "no" },
           { "u_add_var": "dialogue_hub_rnd_u_armor_type", "value": "none" },
@@ -617,7 +623,7 @@
       {
         "//": "Prototype Armor response.",
         "text": "Sweet, thanks.",
-        "condition": { "u_has_var": "dialogue_hub_rnd_u_armor_type", "value": "robofac_armor_pieces_basic" },
+        "condition": { "compare_string": [ "robofac_armor_pieces_basic", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] },
         "effect": [
           { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "no" },
           { "u_add_var": "dialogue_hub_rnd_u_armor_type", "value": "none" },
@@ -632,7 +638,7 @@
       {
         "//": "Turnout Armor response.",
         "text": "Sweet, thanks.",
-        "condition": { "u_has_var": "dialogue_hub_rnd_u_armor_type", "value": "robofac_armor_pieces_nomex" },
+        "condition": { "compare_string": [ "robofac_armor_pieces_nomex", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] },
         "effect": [
           { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "no" },
           { "u_add_var": "dialogue_hub_rnd_u_armor_type", "value": "none" },
@@ -647,7 +653,7 @@
       {
         "//": "Ballistic Armor response.",
         "text": "Sweet, thanks.",
-        "condition": { "u_has_var": "dialogue_hub_rnd_u_armor_type", "value": "robofac_armor_pieces_kevlar" },
+        "condition": { "compare_string": [ "robofac_armor_pieces_kevlar", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] },
         "effect": [
           { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "no" },
           { "u_add_var": "dialogue_hub_rnd_u_armor_type", "value": "none" },
@@ -662,7 +668,7 @@
       {
         "//": "Kinetic Armor response.",
         "text": "Sweet, thanks.",
-        "condition": { "u_has_var": "dialogue_hub_rnd_u_armor_type", "value": "robofac_armor_pieces_rubber" },
+        "condition": { "compare_string": [ "robofac_armor_pieces_rubber", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] },
         "effect": [
           { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "no" },
           { "u_add_var": "dialogue_hub_rnd_u_armor_type", "value": "none" },
@@ -677,7 +683,7 @@
       {
         "//": "Military Armor response.",
         "text": "Sweet, thanks.",
-        "condition": { "u_has_var": "dialogue_hub_rnd_u_armor_type", "value": "robofac_armor_pieces_military" },
+        "condition": { "compare_string": [ "robofac_armor_pieces_military", { "u_val": "dialogue_hub_rnd_u_armor_type" } ] },
         "effect": [
           { "u_add_var": "dialogue_hub_rnd_u_project_ongoing", "value": "no" },
           { "u_add_var": "dialogue_hub_rnd_u_armor_type", "value": "none" },
@@ -1095,12 +1101,12 @@
       },
       {
         "text": "Why not contact them directly?",
-        "condition": { "not": { "u_has_var": "general_meeting_u_met_Rubik", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Rubik" } ] } },
         "topic": "TALK_ROBOFAC_INTERCOM_HWP_EXODII_1"
       },
       {
         "text": "I've met them already.  They seem friendly; if you'd like to reach out to them yourself, I'm sure that they could help.",
-        "condition": { "u_has_var": "general_meeting_u_met_Rubik", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Rubik" } ] },
         "topic": "TALK_ROBOFAC_INTERCOM_HWP_EXODII_2"
       },
       { "text": "What about another project?", "topic": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_MENU" },

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_prototypes.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_prototypes.json
@@ -758,8 +758,7 @@
     "type": "talk_topic",
     "dynamic_line": [
       {
-        "npc_has_var": "phase_suit_reverse_engineered",
-        "value": "yes",
+        "compare_string": [ "yes", { "npc_val": "phase_suit_reverse_engineered" } ],
         "yes": "Certainly; for a fee of ten coins, repairs and adjustments could be completed in two weeks.  We'll also pull suit metrics and haptic data to better understand the situation on the ground.  I'd ask you to make sure everything has been removed from the suit before giving it to us.",
         "no": "The camera starts scanning the armor, after a moment the intercom cracks back to life, 'this technology is currently not within our database, we can probably repair it but we'll need to reverse-engineer it first.  We estimate the repairs to take around a month and a half, and they'll have an increased fee of 12 coins.  Please make sure everything has been removed from the suit before giving it to us.'"
       }
@@ -770,7 +769,7 @@
         "condition": {
           "and": [
             { "u_has_items": { "item": "RobofacCoin", "count": 10 } },
-            { "npc_has_var": "phase_suit_reverse_engineered", "value": "yes" }
+            { "compare_string": [ "yes", { "npc_val": "phase_suit_reverse_engineered" } ] }
           ]
         },
         "effect": [
@@ -788,7 +787,7 @@
         "condition": {
           "and": [
             { "u_has_items": { "item": "RobofacCoin", "count": 12 } },
-            { "not": { "npc_has_var": "phase_suit_reverse_engineered", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "phase_suit_reverse_engineered" } ] } }
           ]
         },
         "effect": [
@@ -829,8 +828,7 @@
     "type": "talk_topic",
     "dynamic_line": [
       {
-        "npc_has_var": "rm13_reverse_engineered",
-        "value": "yes",
+        "compare_string": [ "yes", { "npc_val": "rm13_reverse_engineered" } ],
         "yes": "Yes, that is within our capabilities.  For ten coins, repairs and adjustments can be completed by tomorrow; we will recharge the internal battery as well.  Please note that if you have made any modifications to the armor, it will be reverted to factory standard as part of the repairs.",
         "no": "The camera starts scanning the armor, after a moment the intercom cracks back to life, 'this technology is currently not within our database, we can probably repair it but we'll need to reverse-engineer it first.  We estimate the repairs to take around a month and a half, and they'll have an increased fee of 12 coins.  Please make sure everything has been removed from the suit before giving it to us.'"
       }
@@ -841,7 +839,7 @@
         "condition": {
           "and": [
             { "u_has_items": { "item": "RobofacCoin", "count": 10 } },
-            { "npc_has_var": "rm13_reverse_engineered", "value": "yes" }
+            { "compare_string": [ "yes", { "npc_val": "rm13_reverse_engineered" } ] }
           ]
         },
         "effect": [
@@ -859,7 +857,7 @@
         "condition": {
           "and": [
             { "u_has_items": { "item": "RobofacCoin", "count": 12 } },
-            { "not": { "npc_has_var": "rm13_reverse_engineered", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "rm13_reverse_engineered" } ] } }
           ]
         },
         "effect": [
@@ -900,8 +898,7 @@
     "type": "talk_topic",
     "dynamic_line": [
       {
-        "npc_has_var": "combat_exoskeleton_reverse_engineered",
-        "value": "yes",
+        "compare_string": [ "yes", { "npc_val": "combat_exoskeleton_reverse_engineered" } ],
         "yes": "Certainly, it'll cost you 10 coins and should be ready in two weeks.  Remember to take off any attachments and batteries before turning it in.",
         "no": "'One moment,' the respondent audibly leaves for a moment and after a short period the intercom cracks with life.  'We have never attempted repairs on a military exoskeleton, we will have to reverse-engineer it first, expect this to take around a month and a half, it will also cost you 12 coins.  Please make sure to take off any attachments and batteries before turning it in.'"
       }
@@ -912,7 +909,7 @@
         "condition": {
           "and": [
             { "u_has_items": { "item": "RobofacCoin", "count": 10 } },
-            { "npc_has_var": "combat_exoskeleton_reverse_engineered", "value": "yes" }
+            { "compare_string": [ "yes", { "npc_val": "combat_exoskeleton_reverse_engineered" } ] }
           ]
         },
         "effect": [
@@ -929,7 +926,7 @@
         "condition": {
           "and": [
             { "u_has_items": { "item": "RobofacCoin", "count": 12 } },
-            { "not": { "npc_has_var": "combat_exoskeleton_reverse_engineered", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "combat_exoskeleton_reverse_engineered" } ] } }
           ]
         },
         "effect": [

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_trades.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_trades.json
@@ -213,10 +213,7 @@
     "id": "TALK_ROBOFAC_INTERCOM_BUY_RIOT_GEAR_ON_CREDIT_ACCEPT",
     "type": "talk_topic",
     "dynamic_line": {
-      "npc_has_var": "u_pay_back_on_specimens",
-      "type": "dialogue",
-      "context": "intercom",
-      "value": "yes",
+      "compare_string": [ "yes", { "npc_val": "npc_dialogue_intercom_u_pay_back_on_specimens" } ],
       "yes": "Well it might be more interesting than straight gear.  Tell us when it's available for inspection.  We expect you back in 20 days or less.",
       "no": "20 days then for payment."
     },

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_trades.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_trades.json
@@ -116,8 +116,7 @@
       "math": [ "portal_storm_small_data_sold", ">=", "3" ],
       "yes": "Extrapolating trends from these recordings has become difficult.  Research has requested we only accept higher quality data from now on.",
       "no": {
-        "npc_has_var": "dialogue_intercom_accepted_nre_recording",
-        "value": "yes",
+        "compare_string": [ "yes", { "npc_val": "dialogue_intercom_accepted_nre_recording" } ],
         "no": "Excellent; this should be enough to work with.  Here's your agreed-upon reward.\"  The tray slides shut, and quickly reopens with your payment.  \"Given your performance and our constant need for new data, you are free to keep the recorder for further use.  We are willing to pay for any future data that you're able to record.",
         "yes": "&\"Thank you.\"  The recording changes hands."
       }
@@ -137,8 +136,7 @@
       "math": [ "portal_storm_medium_data_sold", ">=", "15" ],
       "yes": "Extrapolating trends from these recordings has become difficult.  Research has requested we only accept higher quality data from now on.",
       "no": {
-        "npc_has_var": "dialogue_intercom_accepted_nre_recording",
-        "value": "yes",
+        "compare_string": [ "yes", { "npc_val": "dialogue_intercom_accepted_nre_recording" } ],
         "no": "Great!  This looks like a very high-quality recording.  Because this data is much better, we are willing to pay five times what we paid for the base data collected.\"  The tray slides shut, and quickly reopens with your payment.  \"Given your performance and our constant need for new data, you are free to keep the recorder for further use.  We are willing to pay for any future data that you're able to record.",
         "yes": "&\"Excellent.\"  The recording changes hands."
       }
@@ -155,8 +153,7 @@
     "id": "TALK_ROBOFAC_INTERCOM_SELL_PORTAL_STORM_DATA_Large",
     "type": "talk_topic",
     "dynamic_line": {
-      "npc_has_var": "dialogue_intercom_accepted_nre_recording",
-      "value": "yes",
+      "compare_string": [ "yes", { "npc_val": "dialogue_intercom_accepted_nre_recording" } ],
       "no": "Uh… please allow me a second to check this in.\"  The tray slides shut, and the intercom turns off.  Roughly a minute later, it turns back on.  \"Well, it looks like this is a real treasure trove of information.  In fact, you've made quite an impression on R&D, and probably just saved us a few weeks of research at the least.  They demanded you be given a pretty significant accomplishment bonus, so… well, there you go.\"  The tray slides open, revealing an impressive pile of coins.\n\n\"Given your performance and our constant need for new data, you are free to keep the recorder for further use.  We are willing to pay for any future data that you're able to record.",
       "yes": "Fantastic.\"  The recording changes hands.  \"At this rate, we'll have some real results soon."
     },

--- a/data/json/npcs/scrap_trader/scrap_trader.json
+++ b/data/json/npcs/scrap_trader/scrap_trader.json
@@ -60,7 +60,7 @@
       {
         "group": "SCRAPPER_Shop_Specialty_Metals",
         "rigid": true,
-        "condition": { "npc_has_var": "dialogue_trade_specific_metal_tradeable", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "npc_val": "dialogue_trade_specific_metal_tradeable" } ] }
       },
       {
         "group": "no_sell",
@@ -198,7 +198,10 @@
         "text": "I'd like to ask you a few questions.",
         "topic": "TALK_FRIEND_CONVERSATION",
         "condition": {
-          "and": [ { "math": [ "n_npc_trust()", ">=", "2" ] }, { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" } ]
+          "and": [
+            { "math": [ "n_npc_trust()", ">=", "2" ] },
+            { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] }
+          ]
         }
       },
       { "text": "Can I buy anything?", "topic": "TALK_SCRAP_TRADER_BULK_SELL" },
@@ -213,8 +216,7 @@
     "type": "talk_topic",
     "id": "TALK_NPC_SCRAP_TRADER",
     "dynamic_line": {
-      "npc_has_var": "dialogue_first_meeting_knows_u",
-      "value": "yes",
+      "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ],
       "yes": "Hello there.  Nice to see you, <name_g>.",
       "no": "Haven't seen another face in quite a while.  Not a living one, at least.  State your business.  Maybe you got some use for some of this scrap metal?"
     },
@@ -223,19 +225,19 @@
       {
         "text": "Nice to meet you.",
         "topic": "TALK_NPC_SCRAP_TRADER_INTRO",
-        "condition": { "not": { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] } }
       },
       {
         "text": "Hands up, <name_b>!",
         "trial": { "type": "INTIMIDATE", "difficulty": 30 },
         "success": { "topic": "TALK_WEAPON_DROPPED", "effect": "drop_weapon", "opinion": { "trust": -4, "fear": 3 } },
         "failure": { "topic": "TALK_DONE", "effect": "hostile" },
-        "condition": { "not": { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] } }
       },
       {
         "text": "Pleasure to see you again, <name_g>.",
         "topic": "TALK_NPC_SCRAP_TRADER_INTRO",
-        "condition": { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] }
       },
       { "text": "See ya.", "topic": "TALK_DONE" }
     ]
@@ -253,7 +255,7 @@
         "condition": {
           "and": [
             { "u_has_mission": "EXODII_MISSION_WAREHOUSE" },
-            { "not": { "npc_has_var": "asked_about_exodii_warehouse_mission", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "asked_about_exodii_warehouse_mission" } ] } }
           ]
         },
         "effect": { "run_eocs": [ "EOC_exodii_mission_wh_directions_chance" ] }
@@ -308,8 +310,7 @@
       "concatenate": [
         "&You describe the warehouse to the best of your ability.  The scrap trader nods along, listening",
         {
-          "npc_has_var": "exodii_mission_wh_correct",
-          "value": "no",
+          "compare_string": [ "no", { "npc_val": "exodii_mission_wh_correct" } ],
           "yes": ", then shrugs.  \"No, sorry, not ringing any bells.\"",
           "no": ", then raises one eyebrow.  \"Not making any promises, but I did catch just a glimpse of a weird building one time that might be what you're looking for.\""
         }
@@ -321,7 +322,7 @@
         "//": "The other responses are stored in common_talk.json in the exodii folder, to avoid repetition.",
         "text": "Oh well.  Thanks anyway.  I'll go ask around.",
         "topic": "TALK_DONE",
-        "condition": { "npc_has_var": "exodii_mission_wh_correct", "value": "no" },
+        "condition": { "compare_string": [ "no", { "npc_val": "exodii_mission_wh_correct" } ] },
         "effect": [
           { "math": [ "exodii_mission_wh_chance", "-=", "1" ] },
           { "math": [ "exodii_mission_wh_chance", "=", "max( exodii_mission_wh_chance, 1 )" ] }

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_barber.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_barber.json
@@ -21,7 +21,7 @@
         "condition": {
           "and": [
             { "u_has_mission": "MISSION_RANCH_DOCTOR_MEDICAL_ANESTHETIC" },
-            { "not": { "npc_has_var": "mission_tacoma_ranch_doctor_anesthetic_asked", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "mission_tacoma_ranch_doctor_anesthetic_asked" } ] } }
           ]
         },
         "effect": [ { "npc_add_var": "mission_tacoma_ranch_doctor_anesthetic_asked", "value": "yes" } ]

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_bartender.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_bartender.json
@@ -22,7 +22,7 @@
         "condition": {
           "and": [
             { "u_has_mission": "MISSION_RANCH_DOCTOR_MEDICAL_ANESTHETIC" },
-            { "not": { "npc_has_var": "mission_tacoma_ranch_doctor_anesthetic_asked", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "mission_tacoma_ranch_doctor_anesthetic_asked" } ] } }
           ]
         },
         "effect": [ { "npc_add_var": "mission_tacoma_ranch_doctor_anesthetic_asked", "value": "yes" } ]

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_carpenter1.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_carpenter1.json
@@ -21,7 +21,7 @@
         "condition": {
           "and": [
             { "u_has_mission": "MISSION_RANCH_DOCTOR_MEDICAL_ANESTHETIC" },
-            { "not": { "npc_has_var": "mission_tacoma_ranch_doctor_anesthetic_asked", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "mission_tacoma_ranch_doctor_anesthetic_asked" } ] } }
           ]
         },
         "effect": [ { "npc_add_var": "mission_tacoma_ranch_doctor_anesthetic_asked", "value": "yes" } ]

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_carpenter2.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_carpenter2.json
@@ -21,7 +21,7 @@
         "condition": {
           "and": [
             { "u_has_mission": "MISSION_RANCH_DOCTOR_MEDICAL_ANESTHETIC" },
-            { "not": { "npc_has_var": "mission_tacoma_ranch_doctor_anesthetic_asked", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "mission_tacoma_ranch_doctor_anesthetic_asked" } ] } }
           ]
         },
         "effect": [ { "npc_add_var": "mission_tacoma_ranch_doctor_anesthetic_asked", "value": "yes" } ]

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_crop_overseer.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_crop_overseer.json
@@ -21,7 +21,7 @@
         "condition": {
           "and": [
             { "u_has_mission": "MISSION_RANCH_DOCTOR_MEDICAL_ANESTHETIC" },
-            { "not": { "npc_has_var": "mission_tacoma_ranch_doctor_anesthetic_asked", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "mission_tacoma_ranch_doctor_anesthetic_asked" } ] } }
           ]
         },
         "effect": [ { "npc_add_var": "mission_tacoma_ranch_doctor_anesthetic_asked", "value": "yes" } ]
@@ -38,7 +38,7 @@
         "condition": {
           "and": [
             { "not": { "npc_has_trait": "NPC_CONSTRUCTION_LEV_1" } },
-            { "not": { "npc_has_var": "dialogue_tacoma_ranch_purchased_field_1", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_tacoma_ranch_purchased_field_1" } ] } }
           ]
         }
       },
@@ -48,7 +48,7 @@
         "condition": {
           "or": [
             { "npc_has_trait": "NPC_CONSTRUCTION_LEV_1" },
-            { "npc_has_var": "dialogue_tacoma_ranch_purchased_field_1", "value": "yes" }
+            { "compare_string": [ "yes", { "npc_val": "dialogue_tacoma_ranch_purchased_field_1" } ] }
           ]
         }
       },
@@ -66,8 +66,7 @@
     "type": "talk_topic",
     "id": "TALK_RANCH_CROP_OVERSEER_FIELD",
     "dynamic_line": {
-      "npc_has_var": "dialogue_tacoma_ranch_purchased_field_1",
-      "value": "yes",
+      "compare_string": [ "yes", { "npc_val": "dialogue_tacoma_ranch_purchased_field_1" } ],
       "yes": "Back to check on your field?  What can I help you with?",
       "no": {
         "npc_has_trait": "NPC_CONSTRUCTION_LEV_1",
@@ -82,7 +81,7 @@
         "condition": {
           "and": [
             { "not": { "npc_has_trait": "NPC_CONSTRUCTION_LEV_1" } },
-            { "not": { "npc_has_var": "dialogue_tacoma_ranch_purchased_field_1", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_tacoma_ranch_purchased_field_1" } ] } }
           ]
         }
       },
@@ -94,8 +93,10 @@
             { "and": [ { "npc_has_trait": "NPC_CONSTRUCTION_LEV_1" }, { "not": { "npc_has_trait": "NPC_CONSTRUCTION_LEV_2" } } ] },
             {
               "and": [
-                { "npc_has_var": "dialogue_tacoma_ranch_purchased_field_1", "value": "yes" },
-                { "not": { "npc_has_var": "dialogue_tacoma_ranch_purchased_field_1_fence", "value": "yes" } }
+                { "compare_string": [ "yes", { "npc_val": "dialogue_tacoma_ranch_purchased_field_1" } ] },
+                {
+                  "not": { "compare_string": [ "yes", { "npc_val": "dialogue_tacoma_ranch_purchased_field_1_fence" } ] }
+                }
               ]
             }
           ]
@@ -112,7 +113,7 @@
         "condition": {
           "or": [
             { "npc_has_trait": "NPC_CONSTRUCTION_LEV_1" },
-            { "npc_has_var": "dialogue_tacoma_ranch_purchased_field_1", "value": "yes" }
+            { "compare_string": [ "yes", { "npc_val": "dialogue_tacoma_ranch_purchased_field_1" } ] }
           ]
         }
       },
@@ -122,7 +123,7 @@
         "condition": {
           "or": [
             { "npc_has_trait": "NPC_CONSTRUCTION_LEV_1" },
-            { "npc_has_var": "dialogue_tacoma_ranch_purchased_field_1", "value": "yes" }
+            { "compare_string": [ "yes", { "npc_val": "dialogue_tacoma_ranch_purchased_field_1" } ] }
           ]
         }
       },
@@ -189,8 +190,8 @@
         "topic": "TALK_RANCH_CROP_OVERSEER_UPGRADE_FENCE",
         "condition": {
           "and": [
-            { "npc_has_var": "dialogue_tacoma_ranch_purchased_field_1", "value": "yes" },
-            { "not": { "npc_has_var": "dialogue_tacoma_ranch_purchased_field_1_fence", "value": "yes" } }
+            { "compare_string": [ "yes", { "npc_val": "dialogue_tacoma_ranch_purchased_field_1" } ] },
+            { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_tacoma_ranch_purchased_field_1_fence" } ] } }
           ]
         }
       },

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_doctor.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_doctor.json
@@ -57,7 +57,7 @@
       {
         "text": "Could you help me with some bionics?",
         "topic": "TALK_RANCH_DOCTOR_BIONICS",
-        "condition": { "u_has_var": "knowledge_exodization_u_knows_exodiilore", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "knowledge_exodization_u_knows_exodiilore" } ] }
       },
       { "text": "I could use your medical assistance.", "topic": "TALK_RANCH_DOCTOR_AID" },
       { "text": "…", "topic": "TALK_DONE" }
@@ -279,8 +279,8 @@
     "goal_condition": {
       "and": [
         { "u_has_items": { "item": "anesthetic", "count": 3000 } },
-        { "u_has_var": "mission_tacoma_ranch_doctor_anesthetic_scavengers_helped", "value": "yes" },
-        { "u_has_var": "mission_tacoma_ranch_doctor_anesthetic_scrappers_helped", "value": "yes" }
+        { "compare_string": [ "yes", { "u_val": "mission_tacoma_ranch_doctor_anesthetic_scavengers_helped" } ] },
+        { "compare_string": [ "yes", { "u_val": "mission_tacoma_ranch_doctor_anesthetic_scrappers_helped" } ] }
       ]
     },
     "difficulty": 5,

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_doctor.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_doctor.json
@@ -14,8 +14,7 @@
     "type": "talk_topic",
     "id": "TALK_RANCH_DOCTOR",
     "dynamic_line": {
-      "npc_has_var": "dialogue_tacoma_ranch_provides_aid",
-      "value": "yes",
+      "compare_string": [ "yes", { "npc_val": "dialogue_tacoma_ranch_provides_aid" } ],
       "yes": "How can I help you today?",
       "no": "I'm sorry, I don't have time to help you at the moment."
     },
@@ -23,14 +22,14 @@
       {
         "text": "Is there anything else I can help with?",
         "topic": "TALK_MISSION_LIST",
-        "condition": { "and": [ { "npc_has_var": "mission_tacoma_ranch_doctor_completed_supplies", "value": "yes" } ] }
+        "condition": { "and": [ { "compare_string": [ "yes", { "npc_val": "mission_tacoma_ranch_doctor_completed_supplies" } ] } ] }
       },
       {
         "text": "Maybe I could help you with something?",
         "topic": "TALK_RANCH_DOCTOR_SUPPLIES",
         "condition": {
           "and": [
-            { "not": { "npc_has_var": "mission_tacoma_ranch_doctor_completed_supplies", "value": "yes" } },
+            { "not": { "compare_string": [ "yes", { "npc_val": "mission_tacoma_ranch_doctor_completed_supplies" } ] } },
             { "not": { "u_has_mission": "MISSION_RANCH_DOCTOR_SUPPLIES" } }
           ]
         },
@@ -68,8 +67,7 @@
     "id": "TALK_RANCH_DOCTOR_AID",
     "type": "talk_topic",
     "dynamic_line": {
-      "npc_has_var": "dialogue_tacoma_ranch_provides_aid",
-      "value": "yes",
+      "compare_string": [ "yes", { "npc_val": "dialogue_tacoma_ranch_provides_aid" } ],
       "yes": {
         "npc_has_effect": "currently_busy",
         "yes": "I have other patients to attend to.  Come back later.",
@@ -85,7 +83,7 @@
         "condition": {
           "and": [
             { "u_has_items": { "item": "FMCNote", "count": 80 } },
-            { "npc_has_var": "dialogue_tacoma_ranch_provides_aid", "value": "yes" }
+            { "compare_string": [ "yes", { "npc_val": "dialogue_tacoma_ranch_provides_aid" } ] }
           ]
         }
       },
@@ -96,7 +94,7 @@
         "condition": {
           "and": [
             { "u_has_items": { "item": "FMCNote", "count": 200 } },
-            { "npc_has_var": "dialogue_tacoma_ranch_provides_aid", "value": "yes" }
+            { "compare_string": [ "yes", { "npc_val": "dialogue_tacoma_ranch_provides_aid" } ] }
           ]
         }
       },
@@ -114,8 +112,7 @@
     "id": "TALK_RANCH_DOCTOR_BIONICS",
     "type": "talk_topic",
     "dynamic_line": {
-      "npc_has_var": "dialogue_tacoma_ranch_provides_surgery",
-      "value": "yes",
+      "compare_string": [ "yes", { "npc_val": "dialogue_tacoma_ranch_provides_surgery" } ],
       "yes": "If you mean something like pacemaker, then maybe.  What's the trouble?",
       "no": "If you mean something like pacemaker, we can't really do much without anesthesia."
     },

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_farmer1.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_farmer1.json
@@ -21,7 +21,7 @@
         "condition": {
           "and": [
             { "u_has_mission": "MISSION_RANCH_DOCTOR_MEDICAL_ANESTHETIC" },
-            { "not": { "npc_has_var": "mission_tacoma_ranch_doctor_anesthetic_asked", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "mission_tacoma_ranch_doctor_anesthetic_asked" } ] } }
           ]
         },
         "effect": [ { "npc_add_var": "mission_tacoma_ranch_doctor_anesthetic_asked", "value": "yes" } ]

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_farmer2.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_farmer2.json
@@ -21,7 +21,7 @@
         "condition": {
           "and": [
             { "u_has_mission": "MISSION_RANCH_DOCTOR_MEDICAL_ANESTHETIC" },
-            { "not": { "npc_has_var": "mission_tacoma_ranch_doctor_anesthetic_asked", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "mission_tacoma_ranch_doctor_anesthetic_asked" } ] } }
           ]
         },
         "effect": [ { "npc_add_var": "mission_tacoma_ranch_doctor_anesthetic_asked", "value": "yes" } ]

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_foreman.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_foreman.json
@@ -42,13 +42,16 @@
         "text": "Hey, are you looking for workers here?  I know a couple people back at the refugee center that might be willing to come.",
         "topic": "TALK_RANCH_FOREMAN_Nunez",
         "condition": {
-          "and": [ { "u_has_mission": "MISSION_TACOMA_Nunez" }, { "u_has_var": "recruit_general_Nunez_Tacoma", "value": "phase_1" } ]
+          "and": [
+            { "u_has_mission": "MISSION_TACOMA_Nunez" },
+            { "compare_string": [ "phase_1", { "u_val": "recruit_general_Nunez_Tacoma" } ] }
+          ]
         }
       },
       {
         "text": "Hey, are you looking for workers here?",
         "topic": "TALK_RANCH_FOREMAN_Nunez_Clue",
-        "condition": { "not": { "u_has_var": "recruit_general_Nunez_Tacoma", "value": "phase_1" } }
+        "condition": { "not": { "compare_string": [ "phase_1", { "u_val": "recruit_general_Nunez_Tacoma" } ] } }
       },
       { "text": "I've got to go…", "topic": "TALK_DONE" }
     ]
@@ -72,17 +75,14 @@
     "id": "TALK_RANCH_FOREMAN_ANESTHETIC_FOR_DOCTOR",
     "type": "talk_topic",
     "dynamic_line": {
-      "u_has_var": "mission_tacoma_ranch_doctor_anesthetic_scavengers_helped",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "mission_tacoma_ranch_doctor_anesthetic_scavengers_helped" } ],
       "no": {
-        "u_has_var": "mission_tacoma_ranch_doctor_anesthetic_scrappers_helped",
-        "value": "yes",
+        "compare_string": [ "yes", { "u_val": "mission_tacoma_ranch_doctor_anesthetic_scrappers_helped" } ],
         "no": "I don't have anything to offer, but you could talk to the scavenger boss and the scrappers; They might be able to help.",
         "yes": "I don't have anything to offer, but maybe the scavenger boss could help find some materials."
       },
       "yes": {
-        "u_has_var": "mission_tacoma_ranch_doctor_anesthetic_scrappers_helped",
-        "value": "yes",
+        "compare_string": [ "yes", { "u_val": "mission_tacoma_ranch_doctor_anesthetic_scrappers_helped" } ],
         "no": "I don't have anything to offer, but maybe the scrappers could help find some materials.",
         "yes": "I'm afraid I don't have anything to offer."
       }
@@ -93,8 +93,10 @@
         "topic": "TALK_RANCH_FOREMAN",
         "condition": {
           "or": [
-            { "not": { "u_has_var": "mission_tacoma_ranch_doctor_anesthetic_scavengers_helped", "value": "yes" } },
-            { "not": { "u_has_var": "mission_tacoma_ranch_doctor_anesthetic_scrappers_helped", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "mission_tacoma_ranch_doctor_anesthetic_scavengers_helped" } ] } },
+            {
+              "not": { "compare_string": [ "yes", { "u_val": "mission_tacoma_ranch_doctor_anesthetic_scrappers_helped" } ] }
+            }
           ]
         }
       },
@@ -103,8 +105,8 @@
         "topic": "TALK_RANCH_FOREMAN",
         "condition": {
           "and": [
-            { "u_has_var": "mission_tacoma_ranch_doctor_anesthetic_scavengers_helped", "value": "yes" },
-            { "u_has_var": "mission_tacoma_ranch_doctor_anesthetic_scrappers_helped", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "mission_tacoma_ranch_doctor_anesthetic_scavengers_helped" } ] },
+            { "compare_string": [ "yes", { "u_val": "mission_tacoma_ranch_doctor_anesthetic_scrappers_helped" } ] }
           ]
         }
       },

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_nurse.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_nurse.json
@@ -23,7 +23,7 @@
         "condition": {
           "and": [
             { "u_has_mission": "MISSION_RANCH_DOCTOR_MEDICAL_ANESTHETIC" },
-            { "not": { "npc_has_var": "mission_tacoma_ranch_doctor_anesthetic_asked", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "mission_tacoma_ranch_doctor_anesthetic_asked" } ] } }
           ]
         },
         "effect": [ { "npc_add_var": "mission_tacoma_ranch_doctor_anesthetic_asked", "value": "yes" } ]

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_scavenger.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_scavenger.json
@@ -22,8 +22,12 @@
         "condition": {
           "and": [
             { "u_has_mission": "MISSION_RANCH_DOCTOR_MEDICAL_ANESTHETIC" },
-            { "not": { "u_has_var": "mission_tacoma_ranch_doctor_anesthetic_scavengers_helped", "value": "yes" } },
-            { "not": { "u_has_var": "mission_tacoma_ranch_scavenger_hospital_raid_started", "value": "yes" } }
+            {
+              "not": { "compare_string": [ "yes", { "u_val": "mission_tacoma_ranch_doctor_anesthetic_scavengers_helped" } ] }
+            },
+            {
+              "not": { "compare_string": [ "yes", { "u_val": "mission_tacoma_ranch_scavenger_hospital_raid_started" } ] }
+            }
           ]
         },
         "effect": [ { "u_add_var": "mission_tacoma_ranch_scavenger_hospital_raid", "value": "yes" } ]

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_scrapper.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_scrapper.json
@@ -22,7 +22,9 @@
           "and": [
             { "u_has_mission": "MISSION_RANCH_DOCTOR_MEDICAL_ANESTHETIC" },
             { "not": { "u_has_mission": "MISSION_RANCH_SCRAPPER_TOOLS_FOR_SCRAP" } },
-            { "not": { "u_has_var": "mission_tacoma_ranch_doctor_anesthetic_scrappers_helped", "value": "yes" } }
+            {
+              "not": { "compare_string": [ "yes", { "u_val": "mission_tacoma_ranch_doctor_anesthetic_scrappers_helped" } ] }
+            }
           ]
         }
       },

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_sickly_laborer.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_sickly_laborer.json
@@ -21,7 +21,7 @@
         "condition": {
           "and": [
             { "u_has_mission": "MISSION_RANCH_DOCTOR_MEDICAL_ANESTHETIC" },
-            { "not": { "npc_has_var": "mission_tacoma_ranch_doctor_anesthetic_asked", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "mission_tacoma_ranch_doctor_anesthetic_asked" } ] } }
           ]
         },
         "effect": [ { "npc_add_var": "mission_tacoma_ranch_doctor_anesthetic_asked", "value": "yes" } ]

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_woodcutter1.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_woodcutter1.json
@@ -21,7 +21,7 @@
         "condition": {
           "and": [
             { "u_has_mission": "MISSION_RANCH_DOCTOR_MEDICAL_ANESTHETIC" },
-            { "not": { "npc_has_var": "mission_tacoma_ranch_doctor_anesthetic_asked", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "mission_tacoma_ranch_doctor_anesthetic_asked" } ] } }
           ]
         },
         "effect": [ { "npc_add_var": "mission_tacoma_ranch_doctor_anesthetic_asked", "value": "yes" } ]

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_woodcutter2.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_woodcutter2.json
@@ -21,7 +21,7 @@
         "condition": {
           "and": [
             { "u_has_mission": "MISSION_RANCH_DOCTOR_MEDICAL_ANESTHETIC" },
-            { "not": { "npc_has_var": "mission_tacoma_ranch_doctor_anesthetic_asked", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "mission_tacoma_ranch_doctor_anesthetic_asked" } ] } }
           ]
         },
         "effect": [ { "npc_add_var": "mission_tacoma_ranch_doctor_anesthetic_asked", "value": "yes" } ]

--- a/data/json/npcs/tacoma_ranch/Nunez/NPC_Dana_Tacoma.json
+++ b/data/json/npcs/tacoma_ranch/Nunez/NPC_Dana_Tacoma.json
@@ -87,7 +87,7 @@
       {
         "text": "Hey, Pablo!  Dana said you had some plans to build a bakery?",
         "topic": "TALK_TACOMA_Dana_Bakery1",
-        "condition": { "u_has_var": "knowledge_tacoma_bakery", "value": "knows" }
+        "condition": { "compare_string": [ "knows", { "u_val": "knowledge_tacoma_bakery" } ] }
       },
       { "text": "Nice to see you Dana, I'm just checking in.", "topic": "TALK_DONE" }
     ]
@@ -101,7 +101,7 @@
       {
         "text": "Any luck with the pregnancy?",
         "topic": "TALK_TACOMA_Dana_Pregnancy",
-        "condition": { "u_has_var": "knowledge_dana_pregnancy", "value": "knows" }
+        "condition": { "compare_string": [ "knows", { "u_val": "knowledge_dana_pregnancy" } ] }
       },
       { "text": "I'd better go.  See you later.", "topic": "TALK_DONE" }
     ]
@@ -125,7 +125,7 @@
       {
         "text": "Any luck with the pregnancy?",
         "topic": "TALK_TACOMA_Dana_Pregnancy",
-        "condition": { "u_has_var": "knowledge_dana_pregnancy", "value": "knows" }
+        "condition": { "compare_string": [ "knows", { "u_val": "knowledge_dana_pregnancy" } ] }
       },
       { "text": "I'd better go.  See you later.", "topic": "TALK_DONE" }
     ]
@@ -148,7 +148,7 @@
       {
         "text": "Won't you run out of propane?",
         "topic": "TALK_TACOMA_Dana_TrailerPropane",
-        "condition": { "not": { "u_has_var": "knowledge_propane_scavenging", "value": "knows" } }
+        "condition": { "not": { "compare_string": [ "knows", { "u_val": "knowledge_propane_scavenging" } ] } }
       },
       { "text": "I'd better go.  See you later.", "topic": "TALK_DONE" }
     ]
@@ -163,7 +163,7 @@
       {
         "text": "Any luck with the pregnancy?",
         "topic": "TALK_TACOMA_Dana_Pregnancy",
-        "condition": { "u_has_var": "knowledge_dana_pregnancy", "value": "knows" }
+        "condition": { "compare_string": [ "knows", { "u_val": "knowledge_dana_pregnancy" } ] }
       },
       { "text": "I'd better go.  See you later.", "topic": "TALK_DONE" }
     ]

--- a/data/json/npcs/tacoma_ranch/Nunez/NPC_Pablo_Tacoma.json
+++ b/data/json/npcs/tacoma_ranch/Nunez/NPC_Pablo_Tacoma.json
@@ -86,12 +86,12 @@
       {
         "text": "Hey, Pablo!  I heard you might be willing to trade for propane?",
         "topic": "TALK_TACOMA_Pablo_Propane1",
-        "condition": { "u_has_var": "knowledge_propane_scavenging", "value": "knows" }
+        "condition": { "compare_string": [ "knows", { "u_val": "knowledge_propane_scavenging" } ] }
       },
       {
         "text": "Hey, Pablo!  Dana said you had some plans to build a bakery?",
         "topic": "TALK_TACOMA_Pablo_Bakery1",
-        "condition": { "u_has_var": "knowledge_tacoma_bakery", "value": "knows" }
+        "condition": { "compare_string": [ "knows", { "u_val": "knowledge_tacoma_bakery" } ] }
       },
       { "text": "Just popping in to say hi.  Talk to you later!", "topic": "TALK_DONE" }
     ]
@@ -227,12 +227,12 @@
       {
         "text": "I heard you might be willing to trade for propane?",
         "topic": "TALK_TACOMA_Pablo_Propane1",
-        "condition": { "u_has_var": "knowledge_propane_scavenging", "value": "knows" }
+        "condition": { "compare_string": [ "knows", { "u_val": "knowledge_propane_scavenging" } ] }
       },
       {
         "text": "Dana said you had some plans to build a bakery?",
         "topic": "TALK_TACOMA_Pablo_Bakery1",
-        "condition": { "u_has_var": "knowledge_tacoma_bakery", "value": "knows" }
+        "condition": { "compare_string": [ "knows", { "u_val": "knowledge_tacoma_bakery" } ] }
       },
       {
         "text": "I don't mind keeping my eye out for some firebricks for you.",
@@ -240,8 +240,8 @@
         "//": "temporarily disabled by making the condition impossible to achieve.",
         "condition": {
           "and": [
-            { "u_has_var": "firebricks_tacoma_bakery", "value": "known_deleted" },
-            { "not": { "u_has_var": "firebricks_tacoma_bakery", "value": "helped" } }
+            { "compare_string": [ "known_deleted", { "u_val": "firebricks_tacoma_bakery" } ] },
+            { "not": { "compare_string": [ "helped", { "u_val": "firebricks_tacoma_bakery" } ] } }
           ]
         }
       },
@@ -251,8 +251,8 @@
         "//": "temporarily disabled by making the condition impossible to achieve.",
         "condition": {
           "and": [
-            { "u_has_var": "message_jenny_tacoma_mill", "value": "known_deleted" },
-            { "not": { "u_has_var": "message_jenny_tacoma_mill", "value": "helped" } }
+            { "compare_string": [ "known_deleted", { "u_val": "message_jenny_tacoma_mill" } ] },
+            { "not": { "compare_string": [ "helped", { "u_val": "message_jenny_tacoma_mill" } ] } }
           ]
         }
       },
@@ -263,7 +263,7 @@
           "and": [
             { "math": [ "u_skill('survival')", ">=", "4" ] },
             { "math": [ "u_skill('fabrication')", ">=", "4" ] },
-            { "u_has_var": "rootcellar_tacoma_bakery", "value": "known" },
+            { "compare_string": [ "known", { "u_val": "rootcellar_tacoma_bakery" } ] },
             { "not": { "compare_string": [ "helped", { "npc_val": "rootcellar_tacoma_bakery" } ] } }
           ]
         }

--- a/data/json/npcs/tacoma_ranch/Nunez/NPC_Pablo_Tacoma.json
+++ b/data/json/npcs/tacoma_ranch/Nunez/NPC_Pablo_Tacoma.json
@@ -264,7 +264,7 @@
             { "math": [ "u_skill('survival')", ">=", "4" ] },
             { "math": [ "u_skill('fabrication')", ">=", "4" ] },
             { "u_has_var": "rootcellar_tacoma_bakery", "value": "known" },
-            { "not": { "npc_has_var": "rootcellar_tacoma_bakery", "value": "helped" } }
+            { "not": { "compare_string": [ "helped", { "npc_val": "rootcellar_tacoma_bakery" } ] } }
           ]
         }
       }

--- a/data/json/npcs/your_followers/liam_chat.json
+++ b/data/json/npcs/your_followers/liam_chat.json
@@ -18,8 +18,8 @@
         "topic": "TALK_Liam_Jenny_CrushAccuse",
         "condition": {
           "and": [
-            { "u_has_var": "u_liam_jenny_feelings", "value": "crush_suspected" },
-            { "not": { "u_has_var": "u_liam_jenny_feelings", "value": "crushing_hard" } }
+            { "compare_string": [ "crush_suspected", { "u_val": "u_liam_jenny_feelings" } ] },
+            { "not": { "compare_string": [ "crushing_hard", { "u_val": "u_liam_jenny_feelings" } ] } }
           ]
         }
       },
@@ -86,9 +86,7 @@
     "type": "talk_topic",
     "id": "TALK_FRIEND_Liam_CHAT_Friends4ever",
     "dynamic_line": {
-      "u_has_var": "modded",
-      "type": "flag",
-      "value": "ddotd",
+      "compare_string": [ "ddotd", { "u_val": "flag_modded" } ],
       "no": "Aww, of course.  No matter what happens, you're always you and I'm always me, right?  We've been through worse than this.\"  He pauses, his brow furrowed.  \"Well, okay, maybe we haven't.  But we've stuck through it all for so many years, what's a little apocalypse gonna change?  Or a little mutation, or grievous bodily harm, or zombies, or interdimensional monster attacks and serious life-altering PTSD, or whatever.  Who cares.  You're my family, more than my birth family ever was.",
       "yes": "<talk_snippet_modded_liam_Friends4ever>"
     },
@@ -417,7 +415,7 @@
         "topic": "TALK_Liam_Opinions_MISSION_REFUGEE_Jenny_GET_TEXT",
         "condition": {
           "and": [
-            { "not": { "u_has_var": "u_liam_jenny_feelings", "value": "crushing_hard" } },
+            { "not": { "compare_string": [ "crushing_hard", { "u_val": "u_liam_jenny_feelings" } ] } },
             { "u_has_mission": "MISSION_REFUGEE_Jenny_GET_TEXT" }
           ]
         }
@@ -427,7 +425,7 @@
         "topic": "TALK_Liam_Opinions_MISSION_REFUGEE_Jenny_GET_TEXTcrushmode",
         "condition": {
           "and": [
-            { "u_has_var": "u_liam_jenny_feelings", "value": "crushing_hard" },
+            { "compare_string": [ "crushing_hard", { "u_val": "u_liam_jenny_feelings" } ] },
             { "u_has_mission": "MISSION_REFUGEE_Jenny_GET_TEXT" }
           ]
         }
@@ -473,7 +471,7 @@
         "condition": {
           "and": [
             { "u_has_mission": "MISSION_OLD_GUARD_REP_3" },
-            { "not": { "u_has_var": "general_meeting_u_met_Rubik", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Rubik" } ] } }
           ]
         }
       },
@@ -481,7 +479,10 @@
         "text": "What do you think about these robots?  Crazy stuff, hey?",
         "topic": "TALK_Liam_Opinions_MISSION_OLD_GUARD_REP_3-HasMet",
         "condition": {
-          "and": [ { "u_has_mission": "MISSION_OLD_GUARD_REP_3" }, { "u_has_var": "general_meeting_u_met_Rubik", "value": "yes" } ]
+          "and": [
+            { "u_has_mission": "MISSION_OLD_GUARD_REP_3" },
+            { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Rubik" } ] }
+          ]
         }
       },
       {
@@ -794,8 +795,7 @@
     "type": "talk_topic",
     "id": "TALK_Liam_Opinions_MISSION_BROKER_1",
     "dynamic_line": {
-      "u_has_var": "u_liam_opinion_liam_MISSION_FREE_MERCHANTS_EVAC_5",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "u_liam_opinion_liam_MISSION_FREE_MERCHANTS_EVAC_5" } ],
       "yes": "*shakes his head at you.  \"Look, you asked last time, and I told you you didn't have to keep taking jobs like this.  Now you're asking again?  *I dunno, stop offering to bring a billion jars to people if you don't know where to find them.*\"  He laughs.  \"I'm just messing with you.\"  His eyes narrow.  \"Or am I?\"",
       "no": "Look, you're the one that agreed to this.  I don't know why you keep agreeing to this stuff.  Maybe we can check hardware stores?  Or just eat a lot of jarred food, and keep the empties?  A hundred jars.  That's a lot, my friend.\"  He shakes his head.  \"You don't have to agree to do *everything* people ask you to do, you know?"
     },
@@ -813,8 +813,7 @@
     "type": "talk_topic",
     "id": "TALK_Liam_Opinions_directions_isherwood",
     "dynamic_line": {
-      "u_has_var": "u_met_an_isherwood",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "u_met_an_isherwood" } ],
       "yes": "Isn't he just directing us out to that Isherwood farm?",
       "no": "Sounds good.  I'm a bit nervous about what we might find, though.  Who knows what the apocalypse would do to a bunch of gun-toting back country folks?  On the other hand, maybe they're sweet, salt-of-the-earth types.  Only one way to find out!"
     },
@@ -824,8 +823,7 @@
     "type": "talk_topic",
     "id": "TALK_Liam_Opinions_directions_hub01",
     "dynamic_line": {
-      "u_has_var": "dialogue_intercom_u_discovered_robofac_intercom",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "dialogue_intercom_u_discovered_robofac_intercom" } ],
       "yes": {
         "math": [ "u_hub01_completed_missions", ">=", "1" ],
         "yes": "Is that just that Hub place, with the intercom?  Not that it's not cool, but it's nothing new to us.  Woah… we've really seen some shit, haven't we.",
@@ -839,8 +837,7 @@
     "type": "talk_topic",
     "id": "TALK_Liam_Opinions_directions_exodii",
     "dynamic_line": {
-      "u_has_var": "general_meeting_u_met_Rubik",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Rubik" } ],
       "yes": "We've been there, remember?  It's got those cyborg guys, the cockney ones.",
       "no": "Far-fetched and awesome!  Let's go see.  Maybe it's an abandoned theme park or something."
     },
@@ -850,20 +847,17 @@
     "type": "talk_topic",
     "id": "TALK_Liam_Opinions_directions_artisans",
     "dynamic_line": {
-      "u_has_var": "u_met_isolated_road_artisans",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "u_met_isolated_road_artisans" } ],
       "yes": {
         "concatenate": [
           "We've been there, remember",
           {
-            "u_has_var": "u_met_isolated_road_cody",
-            "value": "yes",
+            "compare_string": [ "yes", { "u_val": "u_met_isolated_road_cody" } ],
             "yes": "?  Cody, the blacksmith, she's the food lady",
             "no": "?  I'm guessing the blacksmith we didn't talk to is the one who would have fed us"
           },
           {
-            "u_has_var": "u_met_isolated_road_jay",
-            "value": "yes",
+            "compare_string": [ "yes", { "u_val": "u_met_isolated_road_jay" } ],
             "yes": ", and Jay is the one with the weird bullet bank.",
             "no": ", and the other guy there must be the one with the bullet bank."
           }
@@ -1084,7 +1078,7 @@
       {
         "text": "Dude.  You have a crush on Jenny.",
         "topic": "TALK_Liam_Jenny_CrushAccuse",
-        "condition": { "not": { "u_has_var": "u_liam_jenny_feelings", "value": "crushing_hard" } }
+        "condition": { "not": { "compare_string": [ "crushing_hard", { "u_val": "u_liam_jenny_feelings" } ] } }
       },
       { "text": "Thanks, man.  I'd like your opinion on a different thing though.", "topic": "TALK_Liam_Opinions" }
     ]
@@ -1098,7 +1092,7 @@
       {
         "text": "Dude.  You have a crush on Jenny.",
         "topic": "TALK_Liam_Jenny_CrushAccuse",
-        "condition": { "not": { "u_has_var": "u_liam_jenny_feelings", "value": "crushing_hard" } }
+        "condition": { "not": { "compare_string": [ "crushing_hard", { "u_val": "u_liam_jenny_feelings" } ] } }
       },
       { "text": "Thanks, man.  I'd like your opinion on a different thing though.", "topic": "TALK_Liam_Opinions" }
     ]
@@ -1515,8 +1509,7 @@
     "type": "talk_topic",
     "id": "TALK_Liam_Opinions_MISSION_ISHERWOOD_CLAIRE_1",
     "dynamic_line": {
-      "u_has_var": "u_saved_barry_isherwood",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "u_saved_barry_isherwood" } ],
       "no": "Picking flowers in a field seems okay to me.  I don't mind helping Claire out, she's a nice enough person.  Gotta say though, I get a bit of a weird vibe off these guys.  They're so… I don't know.  It's like we walked into a Norman Rockwell painting in the middle of the end of the world.",
       "yes": "After the shit these poor bastards have gone through, picking some dandelions for them seems kind of anticlimactic.  Still, I am a big fan of dandelion wine."
     },
@@ -1545,8 +1538,7 @@
     "type": "talk_topic",
     "id": "TALK_Liam_Opinions_MISSION_ISHERWOOD_EDDIE_1",
     "dynamic_line": {
-      "u_has_var": "u_saved_barry_isherwood",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "u_saved_barry_isherwood" } ],
       "no": "Even if we work together it's gonna take a while to just find enough good rocks lying around.  We'll probably want to get a shovel and dig around a bit maybe?  Or break up bigger ones with a sledge.  Something about this stuff feels weird to me though.  Too pastoral for the apocalypse.",
       "yes": "Even if we work together it's gonna take a while to just find enough good rocks lying around.  We'll probably want to get a shovel and dig around a bit maybe?  Or break up bigger ones with a sledge.  I'm impressed at these guys, keeping going after everything that's happened."
     },

--- a/data/json/npcs/your_followers/liam_starting_follower.json
+++ b/data/json/npcs/your_followers/liam_starting_follower.json
@@ -112,8 +112,7 @@
     "type": "talk_topic",
     "id": "TALK_Liam_Meeting1",
     "dynamic_line": {
-      "u_has_var": "flag_modded",
-      "value": "ddotd",
+      "compare_string": [ "ddotd", { "u_val": "flag_modded" } ],
       "no": "*, your old friend, stares at you with blank, confused eyes.  He is standing over a freshly mangled corpse, a smoking shotgun at his feet.  \"Holy shit dude.\"  He blinks.  \"Is this about Chris?  If you're here to kill me, just get it over with man.  I don't know what the fuck is happening but I can't take you out too.\"",
       "yes": "<talk_snippet_modded_liam_meeting1>"
     },
@@ -122,7 +121,7 @@
       {
         "text": "Get ahold of yourself, man.  What's happening?  Chris?",
         "topic": "TALK_Liam_Meeting2",
-        "condition": { "not": { "u_has_var": "flag_modded", "value": "ddotd" } }
+        "condition": { "not": { "compare_string": [ "ddotd", { "u_val": "flag_modded" } ] } }
       }
     ]
   },
@@ -169,7 +168,7 @@
     "type": "mission_definition",
     "name": { "str": "Check to see if Liam is OK" },
     "goal": "MGOAL_CONDITION",
-    "goal_condition": { "u_has_var": "talked_liam", "value": "yes" },
+    "goal_condition": { "compare_string": [ "yes", { "u_val": "talked_liam" } ] },
     "start": {
       "assign_mission_target": { "om_terrain": "cabin_liam", "om_special": "cabin_liam", "reveal_radius": 1, "random": false, "search_range": 10 }
     },

--- a/data/json/obsoletion_and_migration_0.I/prosthetics.json
+++ b/data/json/obsoletion_and_migration_0.I/prosthetics.json
@@ -1044,7 +1044,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_AMPUTEE_RESET",
-    "condition": { "not": { "u_has_var": "traits_limbs_amputee_reset", "value": "yes" } },
+    "condition": { "not": { "compare_string": [ "yes", { "u_val": "traits_limbs_amputee_reset" } ] } },
     "effect": [
       {
         "u_message": "Resetting character to non-amputated state.  To continue this game unaltered with the WIP limb system exit the game without saving and add WIP Limb Stuff to this world before reloading.",

--- a/data/mods/Aftershock/npcs/Augustmoon_Salvors/augustmoon_doctor.json
+++ b/data/mods/Aftershock/npcs/Augustmoon_Salvors/augustmoon_doctor.json
@@ -54,8 +54,7 @@
     "type": "talk_topic",
     "id": "TALK_MERCURIAL_DOCTOR",
     "dynamic_line": {
-      "u_has_var": "dialogue_augustmoon_doctor_first_meet",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "dialogue_augustmoon_doctor_first_meet" } ],
       "yes": [
         "Try not to touch anything.  Keeping this place clean is a full time job.",
         { "gendered_line": "I'm free at the moment if you need something.", "relevant_genders": [ "npc" ] }

--- a/data/mods/Aftershock/npcs/Backgrounds/talk_cyborg_abomination.json
+++ b/data/mods/Aftershock/npcs/Backgrounds/talk_cyborg_abomination.json
@@ -3,8 +3,7 @@
     "id": "TALK_CYBORG_Abomination_1",
     "type": "talk_topic",
     "dynamic_line": {
-      "npc_has_var": "dialogue_cyborg_abomination_cyborg_abomination_has_talked",
-      "value": "yes",
+      "compare_string": [ "yes", { "npc_val": "dialogue_cyborg_abomination_cyborg_abomination_has_talked" } ],
       "no": "I… can move again.  I have a real body!  Is this a body?",
       "yes": "Hey again.  *kzzz*"
     },
@@ -12,7 +11,7 @@
     "responses": [
       {
         "switch": true,
-        "condition": { "npc_has_var": "dialogue_cyborg_abomination_cyborg_abomination_has_talked", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "npc_val": "dialogue_cyborg_abomination_cyborg_abomination_has_talked" } ] },
         "text": "So you must have seen some weird stuff?",
         "topic": "TALK_STRANGER_NEUTRAL"
       },

--- a/data/mods/Aftershock/npcs/UICA/augustmoon_longshoreman.json
+++ b/data/mods/Aftershock/npcs/UICA/augustmoon_longshoreman.json
@@ -12,8 +12,7 @@
     "type": "talk_topic",
     "id": "TALK_AUGUSTMOON_LONGSHOREMAN",
     "dynamic_line": {
-      "u_has_var": "dialogue_augustmoon_longshoreman_first_meet",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "dialogue_augustmoon_longshoreman_first_meet" } ],
       "yes": [ "Please retrieve your belongings and move along.  We have a schedule to keep" ],
       "no": "Yes yes, welcome to Port Augustmoon.  Please collect your belongings and head down the docking arm.  Port authority won't be liable for any missing items."
     },

--- a/data/mods/Aftershock/npcs/cyropod_classes.json
+++ b/data/mods/Aftershock/npcs/cyropod_classes.json
@@ -65,8 +65,7 @@
     "id": "TALK_THAWED_1",
     "type": "talk_topic",
     "dynamic_line": {
-      "npc_has_var": "dialogue_thawed_thawed_has_talked",
-      "value": "yes",
+      "compare_string": [ "yes", { "npc_val": "dialogue_thawed_thawed_has_talked" } ],
       "no": "What year is it?  How long have I been asleep?",
       "yes": "Anymore bad news?"
     },
@@ -74,7 +73,7 @@
     "responses": [
       {
         "switch": true,
-        "condition": { "npc_has_var": "dialogue_thawed_thawed_has_talked", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "npc_val": "dialogue_thawed_thawed_has_talked" } ] },
         "text": "Hey.  Let's chat for a second.",
         "topic": "TALK_STRANGER_NEUTRAL"
       },

--- a/data/mods/Aftershock/npcs/cyrus_whately.json
+++ b/data/mods/Aftershock/npcs/cyrus_whately.json
@@ -7,8 +7,7 @@
     "type": "talk_topic",
     "id": "TALK_CYRUS_1",
     "dynamic_line": {
-      "u_has_var": "general_meeting_u_met_cyrus",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "general_meeting_u_met_cyrus" } ],
       "yes": [ "What brings you here today?", "Hello.", "How are you?", "Welcome!", "Are you ready to leave this marble?" ],
       "no": "You look like one of my niece's lab assistants."
     },
@@ -16,27 +15,27 @@
       {
         "text": "Who are you?",
         "effect": { "u_add_var": "general_meeting_u_met_cyrus", "value": "yes" },
-        "condition": { "not": { "u_has_var": "general_meeting_u_met_cyrus", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_cyrus" } ] } },
         "topic": "TALK_CYRUS_firstmeet"
       },
       {
         "text": "What is this place?",
-        "condition": { "u_has_var": "general_meeting_u_met_cyrus", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_cyrus" } ] },
         "topic": "TALK_CYRUS_place"
       },
       {
         "text": "How did you get here?",
-        "condition": { "u_has_var": "general_meeting_u_met_cyrus", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_cyrus" } ] },
         "topic": "TALK_CYRUS_ask_past"
       },
       {
         "text": "How are things here?",
-        "condition": { "u_has_var": "general_meeting_u_met_cyrus", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_cyrus" } ] },
         "topic": "TALK_CYRUS_ask_mood"
       },
       {
         "text": "Can I do anything for you?  Are you as crazy as your niece?",
-        "condition": { "u_has_var": "general_meeting_u_met_cyrus", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_cyrus" } ] },
         "topic": "TALK_MISSION_LIST"
       },
       { "text": "I'm going on my way now.", "topic": "TALK_DONE" }

--- a/data/mods/Aftershock/npcs/milly_whately_dialogue.json
+++ b/data/mods/Aftershock/npcs/milly_whately_dialogue.json
@@ -7,8 +7,7 @@
     "type": "talk_topic",
     "id": "TALK_Millyficent_1",
     "dynamic_line": {
-      "u_has_var": "general_meeting_u_met_millyficent",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "general_meeting_u_met_millyficent" } ],
       "yes": [ "What did you bring me?", "Hello.", "How are you?", "Welcome!", "Do you smell something?" ],
       "no": "New test subjects!  I'm so glad you showed up!"
     },
@@ -16,27 +15,27 @@
       {
         "text": "Who are you?",
         "effect": { "u_add_var": "general_meeting_u_met_millyficent", "value": "yes" },
-        "condition": { "not": { "u_has_var": "general_meeting_u_met_millyficent", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_millyficent" } ] } },
         "topic": "TALK_millyficent_firstmeet"
       },
       {
         "text": "What is this place?",
-        "condition": { "u_has_var": "general_meeting_u_met_millyficent", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_millyficent" } ] },
         "topic": "TALK_millyficent_place"
       },
       {
         "text": "How did you get here?",
-        "condition": { "u_has_var": "general_meeting_u_met_millyficent", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_millyficent" } ] },
         "topic": "TALK_millyficent_ask_past"
       },
       {
         "text": "How are things here?",
-        "condition": { "u_has_var": "general_meeting_u_met_millyficent", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_millyficent" } ] },
         "topic": "TALK_millyficent_ask_mood"
       },
       {
         "text": "Can I do anything for you?  Do I want to?",
-        "condition": { "u_has_var": "general_meeting_u_met_millyficent", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_millyficent" } ] },
         "topic": "TALK_MISSION_LIST"
       },
       { "text": "I'm going on my way now.", "topic": "TALK_DONE" }

--- a/data/mods/Aftershock/npcs/prepnet_dialogue.json
+++ b/data/mods/Aftershock/npcs/prepnet_dialogue.json
@@ -7,8 +7,7 @@
     "type": "talk_topic",
     "id": "TALK_PrepNet_gardener_1",
     "dynamic_line": {
-      "u_has_var": "general_meeting_u_met_prepnet_gardener",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "general_meeting_u_met_prepnet_gardener" } ],
       "yes": [ "Hey there.", "Hello.", "How are you?", "Welcome!", "How's the weather?" ],
       "no": "Howdy!  You seem new, what brings you here?"
     },
@@ -16,27 +15,27 @@
       {
         "text": "Who are you?",
         "effect": { "u_add_var": "general_meeting_u_met_prepnet_gardener", "value": "yes" },
-        "condition": { "not": { "u_has_var": "general_meeting_u_met_prepnet_gardener", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_prepnet_gardener" } ] } },
         "topic": "TALK_PrepNet_gardener_firstmeet"
       },
       {
         "text": "What is this place?",
-        "condition": { "u_has_var": "general_meeting_u_met_prepnet_gardener", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_prepnet_gardener" } ] },
         "topic": "TALK_PrepNet_gardener_place"
       },
       {
         "text": "What's your story?",
-        "condition": { "u_has_var": "general_meeting_u_met_prepnet_gardener", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_prepnet_gardener" } ] },
         "topic": "TALK_PrepNet_gardener_ask_past"
       },
       {
         "text": "How are things here?",
-        "condition": { "u_has_var": "general_meeting_u_met_prepnet_gardener", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_prepnet_gardener" } ] },
         "topic": "TALK_PrepNet_gardener_ask_mood"
       },
       {
         "text": "Can I do anything for you?",
-        "condition": { "u_has_var": "general_meeting_u_met_prepnet_gardener", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_prepnet_gardener" } ] },
         "topic": "TALK_MISSION_LIST"
       },
       { "text": "How do I join the phyle?", "topic": "TALK_PrepNet_gardener_ask_membership" },

--- a/data/mods/Aftershock/npcs/sadie.json
+++ b/data/mods/Aftershock/npcs/sadie.json
@@ -20,8 +20,7 @@
     "type": "talk_topic",
     "id": "TALK_Sadie_1",
     "dynamic_line": {
-      "u_has_var": "general_meeting_u_met_sadie",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "general_meeting_u_met_sadie" } ],
       "yes": [
         "Are we meeting again or did we already do that part?",
         "You remind me of my friend Billy.",
@@ -35,36 +34,36 @@
       {
         "text": "What, who is Billy?",
         "effect": { "u_add_var": "general_meeting_u_met_sadie", "value": "yes" },
-        "condition": { "not": { "u_has_var": "general_meeting_u_met_sadie", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_sadie" } ] } },
         "topic": "TALK_sadie_firstmeet"
       },
       {
         "text": "Die foul creature!",
         "effect": [ { "u_add_var": "general_meeting_u_met_sadie", "value": "yes" }, "insult_combat" ],
-        "condition": { "not": { "u_has_var": "general_meeting_u_met_sadie", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_sadie" } ] } },
         "topic": "TALK_DONE"
       },
       {
         "text": "What did you just inject me with?",
-        "condition": { "u_has_var": "general_injection_sadie_injection", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "general_injection_sadie_injection" } ] },
         "topic": "TALK_sadie_injection"
       },
       {
         "text": "Would you like to come with me Sadie?",
         "topic": "TALK_sadie_follow",
-        "condition": { "and": [ { "not": "npc_following" }, { "u_has_var": "general_heart_sadie_heart", "value": "yes" } ] }
+        "condition": { "and": [ { "not": "npc_following" }, { "compare_string": [ "yes", { "u_val": "general_heart_sadie_heart" } ] } ] }
       },
       {
         "text": "Can you inject me with whatever that was again?",
-        "condition": { "u_has_var": "general_heart_sadie_heart", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "general_heart_sadie_heart" } ] },
         "topic": "TALK_sadie_injection2"
       },
       {
         "text": "How did you get here?",
         "condition": {
           "and": [
-            { "u_has_var": "general_meeting_u_met_sadie", "value": "yes" },
-            { "not": { "u_has_var": "general_heart_sadie_heart", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_sadie" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "general_heart_sadie_heart" } ] } }
           ]
         },
         "topic": "TALK_sadie_ask_past"
@@ -73,15 +72,15 @@
         "text": "How are things here?",
         "condition": {
           "and": [
-            { "u_has_var": "general_meeting_u_met_sadie", "value": "yes" },
-            { "not": { "u_has_var": "general_heart_sadie_heart", "value": "yes" } }
+            { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_sadie" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "general_heart_sadie_heart" } ] } }
           ]
         },
         "topic": "TALK_sadie_ask_mood"
       },
       {
         "text": "Can I do anything for you?",
-        "condition": { "u_has_var": "general_meeting_u_met_sadie", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_sadie" } ] },
         "topic": "TALK_MISSION_LIST"
       },
       { "text": "Goodbye.", "topic": "TALK_DONE" }
@@ -149,8 +148,7 @@
     "id": "TALK_sadie_follow",
     "type": "talk_topic",
     "dynamic_line": {
-      "u_has_var": "general_free_u_freed_sadie",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "general_free_u_freed_sadie" } ],
       "no": [
         "I can't wait to see how wonderful the world must be.  I've heard the shrieking and moaning and cries for help and I just know it's going to be perfect if everyone out there is as sweet and loving as you and Billy."
       ],
@@ -161,13 +159,13 @@
     "responses": [
       {
         "text": "Yes, everyone left is exactly like Billy and me, or worse.",
-        "condition": { "not": { "u_has_var": "general_free_u_freed_sadie", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "general_free_u_freed_sadie" } ] } },
         "effect": [ "follow", { "u_add_var": "general_free_u_freed_sadie", "value": "yes" } ],
         "topic": "TALK_DONE"
       },
       {
         "text": "They're even better.  Let's go.",
-        "condition": { "and": [ { "u_has_var": "general_free_u_freed_sadie", "value": "yes" } ] },
+        "condition": { "and": [ { "compare_string": [ "yes", { "u_val": "general_free_u_freed_sadie" } ] } ] },
         "effect": [ "follow" ],
         "topic": "TALK_DONE"
       }

--- a/data/mods/Aftershock/npcs/whately_generic_dialogue.json
+++ b/data/mods/Aftershock/npcs/whately_generic_dialogue.json
@@ -7,8 +7,7 @@
     "type": "talk_topic",
     "id": "TALK_WHATELY_1",
     "dynamic_line": {
-      "u_has_var": "general_meeting_u_met_whately",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "general_meeting_u_met_whately" } ],
       "yes": [ "Outsider.", "Hello.", "Hospitality rites are civilization.", "Guest.", "How's the madness outside?" ],
       "no": "We don't get outsiders around here all that much."
     },
@@ -16,27 +15,27 @@
       {
         "text": "Who are you?",
         "effect": { "u_add_var": "general_meeting_u_met_whately", "value": "yes" },
-        "condition": { "not": { "u_has_var": "general_meeting_u_met_whately", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_whately" } ] } },
         "topic": "TALK_WHATELY_firstmeet"
       },
       {
         "text": "What is this place?",
-        "condition": { "u_has_var": "general_meeting_u_met_whately", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_whately" } ] },
         "topic": "TALK_WHATELY_place"
       },
       {
         "text": "What's your story?",
-        "condition": { "u_has_var": "general_meeting_u_met_whately", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_whately" } ] },
         "topic": "TALK_WHATELY_ask_past"
       },
       {
         "text": "How are things here?",
-        "condition": { "u_has_var": "general_meeting_u_met_whately", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_whately" } ] },
         "topic": "TALK_WHATELY_ask_mood"
       },
       {
         "text": "Can I do anything for you?",
-        "condition": { "u_has_var": "general_meeting_u_met_whately", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_whately" } ] },
         "topic": "TALK_MISSION_LIST"
       },
       { "text": "How do I join the family?", "topic": "TALK_WHATELY_ask_membership" },

--- a/data/mods/Aftershock/player/bionics.json
+++ b/data/mods/Aftershock/player/bionics.json
@@ -366,7 +366,10 @@
         "name": { "str": "Super Heated Bionic Weapon" },
         "description": "The superheated bionic weapon cuts and burns with ease.",
         "condition": {
-          "and": [ { "u_has_var": "bio_superheater_on", "value": "yes" }, { "u_has_wielded_with_flag": "BIONIC_WEAPON_MELEE" } ]
+          "and": [
+            { "compare_string": [ "yes", { "u_val": "bio_superheater_on" } ] },
+            { "u_has_wielded_with_flag": "BIONIC_WEAPON_MELEE" }
+          ]
         },
         "values": [ { "value": "ITEM_DAMAGE_HEAT", "add": 35 } ]
       }
@@ -389,7 +392,10 @@
         "name": { "str": "Charged Bionic Weapon" },
         "description": "Your bionic weapon sparks under constant electrical charge.",
         "condition": {
-          "and": [ { "u_has_var": "bio_blade_electric_on", "value": "yes" }, { "u_has_wielded_with_flag": "BIONIC_WEAPON_MELEE" } ]
+          "and": [
+            { "compare_string": [ "yes", { "u_val": "bio_blade_electric_on" } ] },
+            { "u_has_wielded_with_flag": "BIONIC_WEAPON_MELEE" }
+          ]
         },
         "hit_you_effect": [ { "id": "bio_blade_electric_arc" } ],
         "values": [ { "value": "ITEM_DAMAGE_ELEC", "add": 10 } ]

--- a/data/mods/BombasticPerks/perkdata/metamagic/careful.json
+++ b/data/mods/BombasticPerks/perkdata/metamagic/careful.json
@@ -2,7 +2,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_metamagic_toggle_careful",
-    "condition": { "u_has_var": "perk_metamagic_careful_deactivated", "value": "yes" },
+    "condition": { "compare_string": [ "yes", { "u_val": "perk_metamagic_careful_deactivated" } ] },
     "effect": [
       { "u_message": "You activate your careful metamagic" },
       { "u_add_var": "perk_metamagic_careful_deactivated", "value": "no" }
@@ -20,7 +20,7 @@
     "condition": {
       "and": [
         { "u_has_trait": "perk_metamagic_careful" },
-        { "not": { "u_has_var": "perk_metamagic_careful_deactivated", "value": "yes" } }
+        { "not": { "compare_string": [ "yes", { "u_val": "perk_metamagic_careful_deactivated" } ] } }
       ]
     },
     "effect": [

--- a/data/mods/BombasticPerks/perkdata/metamagic/intuitive.json
+++ b/data/mods/BombasticPerks/perkdata/metamagic/intuitive.json
@@ -2,7 +2,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_metamagic_toggle_intuitive",
-    "condition": { "u_has_var": "perk_metamagic_intuitive_deactivated", "value": "yes" },
+    "condition": { "compare_string": [ "yes", { "u_val": "perk_metamagic_intuitive_deactivated" } ] },
     "effect": [
       { "u_message": "You activate your intuitive metamagic" },
       { "u_add_var": "perk_metamagic_intuitive_deactivated", "value": "no" }
@@ -20,7 +20,7 @@
     "condition": {
       "and": [
         { "u_has_trait": "perk_metamagic_intuitive" },
-        { "not": { "u_has_var": "perk_metamagic_intuitive_deactivated", "value": "yes" } }
+        { "not": { "compare_string": [ "yes", { "u_val": "perk_metamagic_intuitive_deactivated" } ] } }
       ]
     },
     "effect": [

--- a/data/mods/BombasticPerks/perkdata/metamagic/quicken.json
+++ b/data/mods/BombasticPerks/perkdata/metamagic/quicken.json
@@ -2,7 +2,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_metamagic_toggle_quicken",
-    "condition": { "u_has_var": "perk_metamagic_quicken_deactivated", "value": "yes" },
+    "condition": { "compare_string": [ "yes", { "u_val": "perk_metamagic_quicken_deactivated" } ] },
     "effect": [
       { "u_message": "You activate your quicken metamagic" },
       { "u_add_var": "perk_metamagic_quicken_deactivated", "value": "no" }
@@ -20,7 +20,7 @@
     "condition": {
       "and": [
         { "u_has_trait": "perk_metamagic_quicken" },
-        { "not": { "u_has_var": "perk_metamagic_quicken_deactivated", "value": "yes" } }
+        { "not": { "compare_string": [ "yes", { "u_val": "perk_metamagic_quicken_deactivated" } ] } }
       ]
     },
     "effect": [

--- a/data/mods/BombasticPerks/perkdata/metamagic/reach.json
+++ b/data/mods/BombasticPerks/perkdata/metamagic/reach.json
@@ -2,7 +2,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_metamagic_toggle_reach",
-    "condition": { "u_has_var": "perk_metamagic_reach_deactivated", "value": "yes" },
+    "condition": { "compare_string": [ "yes", { "u_val": "perk_metamagic_reach_deactivated" } ] },
     "effect": [
       { "u_message": "You activate your reach metamagic" },
       { "u_add_var": "perk_metamagic_reach_deactivated", "value": "no" }
@@ -20,7 +20,7 @@
     "condition": {
       "and": [
         { "u_has_trait": "perk_metamagic_reach" },
-        { "not": { "u_has_var": "perk_metamagic_reach_deactivated", "value": "yes" } }
+        { "not": { "compare_string": [ "yes", { "u_val": "perk_metamagic_reach_deactivated" } ] } }
       ]
     },
     "effect": [

--- a/data/mods/BombasticPerks/perkdata/metamagic/silent.json
+++ b/data/mods/BombasticPerks/perkdata/metamagic/silent.json
@@ -2,7 +2,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_metamagic_toggle_silent",
-    "condition": { "u_has_var": "perk_metamagic_silent_deactivated", "value": "yes" },
+    "condition": { "compare_string": [ "yes", { "u_val": "perk_metamagic_silent_deactivated" } ] },
     "effect": [
       { "u_message": "You activate your silent metamagic" },
       { "u_add_var": "perk_metamagic_silent_deactivated", "value": "no" }
@@ -20,7 +20,7 @@
     "condition": {
       "and": [
         { "u_has_trait": "perk_metamagic_silent" },
-        { "not": { "u_has_var": "perk_metamagic_silent_deactivated", "value": "yes" } }
+        { "not": { "compare_string": [ "yes", { "u_val": "perk_metamagic_silent_deactivated" } ] } }
       ]
     },
     "effect": [

--- a/data/mods/BombasticPerks/perkdata/metamagic/still.json
+++ b/data/mods/BombasticPerks/perkdata/metamagic/still.json
@@ -2,7 +2,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_metamagic_toggle_still",
-    "condition": { "u_has_var": "perk_metamagic_still_deactivated", "value": "yes" },
+    "condition": { "compare_string": [ "yes", { "u_val": "perk_metamagic_still_deactivated" } ] },
     "effect": [
       { "u_message": "You activate your still metamagic" },
       { "u_add_var": "perk_metamagic_still_deactivated", "value": "no" }
@@ -20,7 +20,7 @@
     "condition": {
       "and": [
         { "u_has_trait": "perk_metamagic_still" },
-        { "not": { "u_has_var": "perk_metamagic_still_deactivated", "value": "yes" } }
+        { "not": { "compare_string": [ "yes", { "u_val": "perk_metamagic_still_deactivated" } ] } }
       ]
     },
     "effect": [

--- a/data/mods/BombasticPerks/perkdata/metamagic/widen.json
+++ b/data/mods/BombasticPerks/perkdata/metamagic/widen.json
@@ -2,7 +2,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_metamagic_toggle_widen",
-    "condition": { "u_has_var": "perk_metamagic_widen_deactivated", "value": "yes" },
+    "condition": { "compare_string": [ "yes", { "u_val": "perk_metamagic_widen_deactivated" } ] },
     "effect": [
       { "u_message": "You activate your widen metamagic" },
       { "u_add_var": "perk_metamagic_widen_deactivated", "value": "no" }
@@ -20,7 +20,7 @@
     "condition": {
       "and": [
         { "u_has_trait": "perk_metamagic_widen" },
-        { "not": { "u_has_var": "perk_metamagic_widen_deactivated", "value": "yes" } }
+        { "not": { "compare_string": [ "yes", { "u_val": "perk_metamagic_widen_deactivated" } ] } }
       ]
     },
     "effect": [

--- a/data/mods/Defense_Mode/dialogue/TALK_WANDERING_SURVIVOR.json
+++ b/data/mods/Defense_Mode/dialogue/TALK_WANDERING_SURVIVOR.json
@@ -3,8 +3,7 @@
     "type": "talk_topic",
     "id": "TALK_NPC_DEFENSE_WANDERER",
     "dynamic_line": {
-      "npc_has_var": "dialogue_first_meeting_knows_u",
-      "value": "yes",
+      "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ],
       "yes": "<greet>",
       "no": "Freeze you <swear> <zombies>!"
     },
@@ -13,19 +12,19 @@
       {
         "text": "&Hold up your hands.  \"Don't worry, I'm not going to hurt you\"",
         "topic": "TALK_NPC_DEFENSE_WANDERER_CALM",
-        "condition": { "not": { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] } }
       },
       {
         "text": "Hand over your stuff!  Don't make any sudden moves, or you die!",
         "trial": { "type": "INTIMIDATE", "difficulty": 30 },
         "success": { "topic": "TALK_WEAPON_DROPPED", "effect": "drop_weapon", "opinion": { "trust": -4, "fear": 3 } },
         "failure": { "topic": "TALK_DONE", "effect": "hostile" },
-        "condition": { "not": { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] } }
       },
       {
         "text": "Nice to see you.",
         "topic": "TALK_NPC_DEFENSE_WANDERER_INTRO",
-        "condition": { "npc_has_var": "dialogue_first_meeting_knows_u", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "npc_val": "dialogue_first_meeting_knows_u" } ] }
       },
       { "text": "Bye.", "topic": "TALK_DONE" }
     ]

--- a/data/mods/Defense_Mode/effects_on_condition/backend_eocs.json
+++ b/data/mods/Defense_Mode/effects_on_condition/backend_eocs.json
@@ -46,7 +46,7 @@
     "type": "effect_on_condition",
     "id": "defense_mode_money_add_npc",
     "global": false,
-    "condition": { "not": { "npc_has_var": "general_trade_u_got_money", "value": "yes" } },
+    "condition": { "not": { "compare_string": [ "yes", { "npc_val": "general_trade_u_got_money" } ] } },
     "effect": [
       { "u_spend_cash": { "math": [ "wave_number * wave_money_modifier" ] } },
       { "npc_add_var": "general_trade_u_got_money", "value": "yes" }

--- a/data/mods/DinoMod/NPC/BEGGAR_2_Dino_Dave.json
+++ b/data/mods/DinoMod/NPC/BEGGAR_2_Dino_Dave.json
@@ -21,7 +21,7 @@
         "condition": {
           "and": [
             { "not": { "u_has_mission": "MISSION_REACH_FAKE_DAVE" } },
-            { "not": { "u_has_var": "found_fake_dave", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "found_fake_dave" } ] } }
           ]
         }
       },

--- a/data/mods/DinoMod/NPC/NC_BO_BARONYX.json
+++ b/data/mods/DinoMod/NPC/NC_BO_BARONYX.json
@@ -37,12 +37,10 @@
     "type": "talk_topic",
     "id": "TALK_SWAMPER",
     "dynamic_line": {
-      "u_has_var": "dialogue_first_meeting_talked_to_swamper",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_swamper" } ],
       "no": "You look hungry friend.  So much hunger in this world.  This is the time of the eaters.",
       "yes": {
-        "u_has_var": "dialogue_eating_asked_about_eating",
-        "value": "yes",
+        "compare_string": [ "yes", { "u_val": "dialogue_eating_asked_about_eating" } ],
         "no": "Welcome.  Are you hungry friend?",
         "yes": "The eaters will be fed."
       }
@@ -52,18 +50,18 @@
       {
         "text": "Hello.  Who are the eaters?",
         "topic": "TALK_SWAMPER_EATING",
-        "condition": { "not": { "u_has_var": "dialogue_eating_asked_about_eating", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "dialogue_eating_asked_about_eating" } ] } },
         "effect": { "u_add_var": "dialogue_eating_asked_about_eating", "value": "yes" }
       },
       {
         "text": "So about the eaters…",
         "topic": "TALK_SWAMPER_EATING",
-        "condition": { "u_has_var": "dialogue_eating_asked_about_eating", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_eating_asked_about_eating" } ] }
       },
       {
         "text": "You mentioned some pretenders before.  What does that mean?",
         "topic": "TALK_SWAMPER_PRETENDER",
-        "condition": { "u_has_var": "general_mission_NC_SWAMPER_MISSION_1", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "general_mission_NC_SWAMPER_MISSION_1" } ] }
       },
       {
         "text": "Would you like to join me on my travels?",
@@ -74,7 +72,7 @@
       {
         "text": "Is there a way I can help feed the eaters?",
         "topic": "TALK_MISSION_LIST_SWAMPER",
-        "condition": { "u_has_var": "dialogue_eating_asked_about_eating", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_eating_asked_about_eating" } ] }
       },
       { "text": "I have to get going.  Take care, CEO Baronyx.", "topic": "TALK_DONE" }
     ]

--- a/data/mods/DinoMod/NPC/NC_Red.json
+++ b/data/mods/DinoMod/NPC/NC_Red.json
@@ -14,12 +14,10 @@
     "type": "talk_topic",
     "id": "TALK_OLD_GUARD_RED",
     "dynamic_line": {
-      "u_has_var": "dialogue_first_meeting_talked_to_red",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "dialogue_first_meeting_talked_to_red" } ],
       "no": "You there, wanderer.  You have the look of someone who hates dinosaurs.  Are you ready to take this country back?",
       "yes": {
-        "u_has_var": "dialogue_dino_asked_about_kill_dinos",
-        "value": "yes",
+        "compare_string": [ "yes", { "u_val": "dialogue_dino_asked_about_kill_dinos" } ],
         "no": "You're back.  I knew you were a killer.  Are you ready to take this country back?",
         "yes": "It's a good day to shoot some dinos."
       }
@@ -29,14 +27,14 @@
       {
         "text": "Dinosaurs?  What are you talking about?",
         "topic": "TALK_RED_DINOSAURS",
-        "condition": { "not": { "u_has_var": "dialogue_dino_asked_about_kill_dinos", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "dialogue_dino_asked_about_kill_dinos" } ] } },
         "effect": { "u_add_var": "dialogue_dino_asked_about_kill_dinos", "value": "yes" }
       },
       { "text": "Let's trade items.", "topic": "TALK_OLD_GUARD_RED", "effect": "start_trade" },
       {
         "text": "How can I help?",
         "topic": "TALK_MISSION_LIST",
-        "condition": { "u_has_var": "dialogue_dino_asked_about_kill_dinos", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_dino_asked_about_kill_dinos" } ] }
       },
       {
         "text": "Mission update for you, Red.",

--- a/data/mods/DinoMod/NPC/NC_Yoshimi.json
+++ b/data/mods/DinoMod/NPC/NC_Yoshimi.json
@@ -44,8 +44,7 @@
     "type": "talk_topic",
     "id": "TALK_Yoshimi_1",
     "dynamic_line": {
-      "u_has_var": "general_meeting_u_met_yoshimi",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "general_meeting_u_met_yoshimi" } ],
       "yes": [
         "How can I help you, survivor?",
         "Seen any interesting specimens?  I mean dinosaurs.",
@@ -58,28 +57,28 @@
       {
         "text": "You are dressed like a scientist.  Are you a scientist?  You look like a dinosaur.  Are you a dinosaur?  Are you a scientist dinosaur?",
         "effect": { "u_add_var": "general_meeting_u_met_yoshimi", "value": "yes" },
-        "condition": { "not": { "u_has_var": "general_meeting_u_met_yoshimi", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_yoshimi" } ] } },
         "topic": "TALK_yoshimi_firstmeet"
       },
       {
         "text": "Die demon mutant!",
         "effect": [ { "u_add_var": "general_meeting_u_met_yoshimi", "value": "yes" }, "insult_combat" ],
-        "condition": { "not": { "u_has_var": "general_meeting_u_met_yoshimi", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_yoshimi" } ] } },
         "topic": "TALK_DONE"
       },
       {
         "text": "How did you get here?",
-        "condition": { "and": [ { "u_has_var": "mission_flag_Yos_chemistry", "value": "yes" } ] },
+        "condition": { "and": [ { "compare_string": [ "yes", { "u_val": "mission_flag_Yos_chemistry" } ] } ] },
         "topic": "TALK_yoshimi_ask_past"
       },
       {
         "text": "How are things here?",
-        "condition": { "and": [ { "u_has_var": "general_meeting_u_met_yoshimi", "value": "yes" } ] },
+        "condition": { "and": [ { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_yoshimi" } ] } ] },
         "topic": "TALK_yoshimi_ask_mood"
       },
       {
         "text": "You look like you need help.  Can I do something for you?",
-        "condition": { "and": [ { "u_has_var": "general_meeting_u_met_yoshimi", "value": "yes" } ] },
+        "condition": { "and": [ { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_yoshimi" } ] } ] },
         "topic": "TALK_MISSION_LIST"
       },
       { "text": "Goodbye.", "topic": "TALK_DONE" }

--- a/data/mods/Limb_WIP/mutation_eocs/prosthetics_eocs.json
+++ b/data/mods/Limb_WIP/mutation_eocs/prosthetics_eocs.json
@@ -18,7 +18,7 @@
       "and": [
         { "not": { "u_has_trait": "RIGHT_PROSTHETIC_LEG" } },
         { "not": { "u_has_trait": "RIGHT_PEG_LEG" } },
-        { "u_has_var": "traits_limbs_missing_right_leg", "value": "yes" }
+        { "compare_string": [ "yes", { "u_val": "traits_limbs_missing_right_leg" } ] }
       ]
     },
     "effect": [ { "u_add_trait": "NO_RIGHT_LEG" } ]
@@ -42,7 +42,7 @@
       "and": [
         { "not": { "u_has_trait": "LEFT_PROSTHETIC_LEG" } },
         { "not": { "u_has_trait": "LEFT_PEG_LEG" } },
-        { "u_has_var": "traits_limbs_missing_left_leg", "value": "yes" }
+        { "compare_string": [ "yes", { "u_val": "traits_limbs_missing_left_leg" } ] }
       ]
     },
     "effect": [ { "u_add_trait": "NO_LEFT_LEG" } ]
@@ -73,7 +73,7 @@
         { "not": { "u_has_trait": "RIGHT_PROSTHETIC_ARM" } },
         { "not": { "u_has_trait": "RIGHT_NEUROPROSTHETIC_ARM" } },
         { "not": { "u_has_trait": "RIGHT_COSMETIC_PROSTHETIC_ARM" } },
-        { "u_has_var": "traits_limbs_missing_right_arm", "value": "yes" }
+        { "compare_string": [ "yes", { "u_val": "traits_limbs_missing_right_arm" } ] }
       ]
     },
     "effect": [ { "u_add_trait": "NO_RIGHT_ARM" } ]
@@ -104,7 +104,7 @@
         { "not": { "u_has_trait": "LEFT_PROSTHETIC_ARM" } },
         { "not": { "u_has_trait": "LEFT_NEUROPROSTHETIC_ARM" } },
         { "not": { "u_has_trait": "LEFT_COSMETIC_PROSTHETIC_ARM" } },
-        { "u_has_var": "traits_limbs_missing_left_arm", "value": "yes" }
+        { "compare_string": [ "yes", { "u_val": "traits_limbs_missing_left_arm" } ] }
       ]
     },
     "effect": [ { "u_add_trait": "NO_LEFT_ARM" } ]

--- a/data/mods/Magiclysm/enchantments/Boreal_Mage.json
+++ b/data/mods/Magiclysm/enchantments/Boreal_Mage.json
@@ -39,7 +39,7 @@
     "condition": {
       "and": [
         { "u_has_trait": "BOREAL_MAGE" },
-        { "not": { "u_has_var": "attunement_attunement_u_got_boreal_mage_attunement", "value": "yes" } }
+        { "not": { "compare_string": [ "yes", { "u_val": "attunement_attunement_u_got_boreal_mage_attunement" } ] } }
       ]
     },
     "deactivate_condition": { "not": { "u_has_trait": "BOREAL_MAGE" } },

--- a/data/mods/Magiclysm/enchantments/Glacier_Mage.json
+++ b/data/mods/Magiclysm/enchantments/Glacier_Mage.json
@@ -55,7 +55,7 @@
     "condition": {
       "and": [
         { "u_has_trait": "GLACIER_MAGE" },
-        { "not": { "u_has_var": "attunement_attunement_u_got_glacier_mage_attunement", "value": "yes" } }
+        { "not": { "compare_string": [ "yes", { "u_val": "attunement_attunement_u_got_glacier_mage_attunement" } ] } }
       ]
     },
     "deactivate_condition": { "not": { "u_has_trait": "GLACIER_MAGE" } },

--- a/data/mods/Magiclysm/enchantments/Radiaton_Mage.json
+++ b/data/mods/Magiclysm/enchantments/Radiaton_Mage.json
@@ -26,7 +26,9 @@
     "condition": {
       "and": [
         { "u_has_trait": "RADIATION_MAGE" },
-        { "not": { "u_has_var": "attunement_attunement_u_got_radiation_mage_attunement", "value": "yes" } }
+        {
+          "not": { "compare_string": [ "yes", { "u_val": "attunement_attunement_u_got_radiation_mage_attunement" } ] }
+        }
       ]
     },
     "deactivate_condition": { "not": { "u_has_trait": "RADIATION_MAGE" } },

--- a/data/mods/Magiclysm/enchantments/Shaman.json
+++ b/data/mods/Magiclysm/enchantments/Shaman.json
@@ -48,7 +48,7 @@
     "condition": {
       "and": [
         { "u_has_trait": "SHAMAN" },
-        { "not": { "u_has_var": "attunement_attunement_u_got_shaman_attunement", "value": "yes" } }
+        { "not": { "compare_string": [ "yes", { "u_val": "attunement_attunement_u_got_shaman_attunement" } ] } }
       ]
     },
     "deactivate_condition": { "not": { "u_has_trait": "SHAMAN" } },

--- a/data/mods/Magiclysm/enchantments/Soulfire.json
+++ b/data/mods/Magiclysm/enchantments/Soulfire.json
@@ -6,7 +6,7 @@
     "condition": {
       "and": [
         { "u_has_trait": "SOULFIRE" },
-        { "not": { "u_has_var": "attunement_attunement_u_got_soulfire_attunement", "value": "yes" } }
+        { "not": { "compare_string": [ "yes", { "u_val": "attunement_attunement_u_got_soulfire_attunement" } ] } }
       ]
     },
     "deactivate_condition": { "not": { "u_has_trait": "SOULFIRE" } },

--- a/data/mods/Magiclysm/enchantments/Tundra_Mage.json
+++ b/data/mods/Magiclysm/enchantments/Tundra_Mage.json
@@ -48,7 +48,7 @@
     "condition": {
       "and": [
         { "u_has_trait": "TUNDRA_MAGE" },
-        { "not": { "u_has_var": "attunement_attunement_u_got_tundra_mage_attunement", "value": "yes" } }
+        { "not": { "compare_string": [ "yes", { "u_val": "attunement_attunement_u_got_tundra_mage_attunement" } ] } }
       ]
     },
     "deactivate_condition": { "not": { "u_has_trait": "TUNDRA_MAGE" } },

--- a/data/mods/Magiclysm/enchantments/Wither_Mage.json
+++ b/data/mods/Magiclysm/enchantments/Wither_Mage.json
@@ -61,7 +61,7 @@
     "condition": {
       "and": [
         { "u_has_trait": "WITHER_MAGE" },
-        { "not": { "u_has_var": "attunement_attunement_u_got_wither_mage_attunement", "value": "yes" } }
+        { "not": { "compare_string": [ "yes", { "u_val": "attunement_attunement_u_got_wither_mage_attunement" } ] } }
       ]
     },
     "deactivate_condition": { "not": { "u_has_trait": "WITHER_MAGE" } },

--- a/data/mods/Magiclysm/npc/TALK_FORGE_MERCHANT.json
+++ b/data/mods/Magiclysm/npc/TALK_FORGE_MERCHANT.json
@@ -134,8 +134,7 @@
     "id": "TALK_FORGE_LORD_DOING",
     "type": "talk_topic",
     "dynamic_line": {
-      "u_has_var": "general_meeting_u_met_FORGE_LORD",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "general_meeting_u_met_FORGE_LORD" } ],
       "no": "Well here and now I am the law, and the law here is that people purchase my goods, they take them out into the world and they die; or they return to buy more of my goods.  Either way, I write poetry about them.",
       "yes": "Once I was lost in the throes of love, now I've built an empire of material goods.  I've found these two things are equally as powerful, and dangerous."
     },
@@ -143,7 +142,7 @@
       {
         "text": "Good day, sir.",
         "effect": { "u_add_var": "general_meeting_u_met_FORGE_LORD", "value": "yes" },
-        "condition": { "not": { "u_has_var": "general_meeting_u_met_FORGE_LORD", "value": "yes" } },
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_FORGE_LORD" } ] } },
         "topic": "TALK_FORGE_LORD"
       }
     ]

--- a/data/mods/Magiclysm/npc/TALK_HEALER_GREY.json
+++ b/data/mods/Magiclysm/npc/TALK_HEALER_GREY.json
@@ -3,8 +3,7 @@
     "type": "talk_topic",
     "id": "TALK_HEALER_GREY",
     "dynamic_line": {
-      "u_has_var": "dialogue_healer_grey_talked_to_healer_grey",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "dialogue_healer_grey_talked_to_healer_grey" } ],
       "no": "I must purge this land of its curse.  Will you help or hinder our mission?",
       "yes": "Blessed be."
     },

--- a/data/mods/Magiclysm/npc/TALK_OLD_MAGUS.json
+++ b/data/mods/Magiclysm/npc/TALK_OLD_MAGUS.json
@@ -3,8 +3,7 @@
     "type": "talk_topic",
     "id": "TALK_OLD_MAGUS",
     "dynamic_line": {
-      "u_has_var": "dialogue_old_magus_talked_to_old_magus",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "dialogue_old_magus_talked_to_old_magus" } ],
       "no": "Huh?  *mumble mumble* …Who are you?",
       "yes": "Oh, you again."
     },

--- a/data/mods/Magiclysm/npc/TALK_OLD_MAGUS.json
+++ b/data/mods/Magiclysm/npc/TALK_OLD_MAGUS.json
@@ -22,7 +22,7 @@
         "condition": {
           "and": [
             { "not": "has_assigned_mission" },
-            { "not": { "npc_has_var": "dialogue_old_magus_npc_magus_book_done", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_old_magus_npc_magus_book_done" } ] } }
           ]
         }
       },

--- a/data/mods/Magiclysm/npc/TALK_TECHNO_KID.json
+++ b/data/mods/Magiclysm/npc/TALK_TECHNO_KID.json
@@ -3,8 +3,7 @@
     "type": "talk_topic",
     "id": "TALK_TECHNO_KID",
     "dynamic_line": {
-      "u_has_var": "dialogue_techno_kid_talked_to_techno_kid",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "dialogue_techno_kid_talked_to_techno_kid" } ],
       "no": "Do you seek power as well?",
       "yes": "Ah, hello again."
     },

--- a/data/mods/MindOverMatter/npcs/dialogue/Rubik.json
+++ b/data/mods/MindOverMatter/npcs/dialogue/Rubik.json
@@ -26,7 +26,7 @@
       {
         "text": "From the portals…like you, right?  You've seen this before?",
         "topic": "TALK_EXODII_MERCHANT_alien_flora_source",
-        "condition": { "u_has_var": "knowledge_exodii_transdimensional_u_knows_exodiilore", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "knowledge_exodii_transdimensional_u_knows_exodiilore" } ] }
       },
       { "text": "Can we talk about something else?", "topic": "TALK_EXODII_MERCHANT_Talk" },
       { "text": "I've gotta go.  See you later, Rubik.", "topic": "TALK_DONE" }

--- a/data/mods/MindOverMatter/npcs/dialogue/refugee_guards_traitor.json
+++ b/data/mods/MindOverMatter/npcs/dialogue/refugee_guards_traitor.json
@@ -16,7 +16,7 @@
       {
         "text": "It's you.",
         "topic": "TALK_EVAC_GUARD3_direct_accusation",
-        "condition": { "u_has_var": "dialogue_refugee_center_traitor_deep_scanned_evac_guard_3", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_refugee_center_traitor_deep_scanned_evac_guard_3" } ] }
       }
     ]
   },
@@ -64,7 +64,7 @@
       {
         "text": "It's you.",
         "topic": "TALK_EVAC_GUARD3_direct_accusation",
-        "condition": { "u_has_var": "dialogue_refugee_center_traitor_deep_scanned_evac_guard_3", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_refugee_center_traitor_deep_scanned_evac_guard_3" } ] }
       }
     ]
   },

--- a/data/mods/TEST_DATA/factions.json
+++ b/data/mods/TEST_DATA/factions.json
@@ -17,7 +17,7 @@
         "item": "test_nuclear_carafe",
         "markup": 2.0,
         "fixed_adj": 0.1,
-        "condition": { "npc_has_var": "bool_allnighter_thirsty", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "npc_val": "bool_allnighter_thirsty" } ] }
       },
       { "item": "test_multitool", "premium": 25, "markup": 1.1 },
       { "item": "log", "price": 10000000 },

--- a/data/mods/TEST_DATA/npc_shop_cons_rates.json
+++ b/data/mods/TEST_DATA/npc_shop_cons_rates.json
@@ -6,7 +6,11 @@
     "junk_threshold": "10 cent",
     "rates": [
       { "item": "bow_saw", "rate": 2 },
-      { "item": "bow_saw", "rate": 99, "condition": { "npc_has_var": "bool_dinner_bow_saw_eater", "value": "yes" } },
+      {
+        "item": "bow_saw",
+        "rate": 99,
+        "condition": { "compare_string": [ "yes", { "npc_val": "bool_dinner_bow_saw_eater" } ] }
+      },
       { "category": "currency", "rate": 10 },
       { "group": "test_event_item_spawn", "rate": 100 },
       { "group": "test_event_item_spawn", "category": "tools", "rate": 50 }
@@ -21,7 +25,7 @@
   {
     "id": "test_blacklist",
     "type": "shopkeeper_blacklist",
-    "entries": [ { "item": "bow_saw", "condition": { "npc_has_var": "bool_bigotry_hates_bow_saws", "value": "yes" } } ]
+    "entries": [ { "item": "bow_saw", "condition": { "compare_string": [ "yes", { "npc_val": "bool_bigotry_hates_bow_saws" } ] } } ]
   },
   {
     "type": "npc_class",
@@ -41,7 +45,11 @@
     ],
     "shopkeeper_blacklist": "test_blacklist",
     "shopkeeper_price_rules": [
-      { "item": "test_pants_fur", "markup": -100, "condition": { "npc_has_var": "bool_preference_vegan", "value": "yes" } },
+      {
+        "item": "test_pants_fur",
+        "markup": -100,
+        "condition": { "compare_string": [ "yes", { "npc_val": "bool_preference_vegan" } ] }
+      },
       { "item": "battery", "price": 100 }
     ],
     "restock_interval": "99 days"

--- a/data/mods/TEST_DATA/npc_shop_cons_rates.json
+++ b/data/mods/TEST_DATA/npc_shop_cons_rates.json
@@ -36,11 +36,14 @@
     "shopkeeper_consumption_rates": "test_shop_rates",
     "shopkeeper_item_group": [
       { "group": "test_event_item_spawn" },
-      { "group": "test_tools_group", "condition": { "u_has_var": "bool_test_tools_access", "value": "yes" } },
+      {
+        "group": "test_tools_group",
+        "condition": { "compare_string": [ "yes", { "u_val": "bool_test_tools_access" } ] }
+      },
       {
         "group": "test_multitool_group",
         "strict": true,
-        "condition": { "u_has_var": "bool_test_multitool_access", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "u_val": "bool_test_multitool_access" } ] }
       }
     ],
     "shopkeeper_blacklist": "test_blacklist",

--- a/data/mods/Xedra_Evolved/items/book_lore.json
+++ b/data/mods/Xedra_Evolved/items/book_lore.json
@@ -152,7 +152,7 @@
     "type": "effect_on_condition",
     "id": "EOC_LEARN_FROM_VAMPIRE_MENTOR_BOOK",
     "//": "Using roll-remainder allows to grant recipes that do not create items.  Switch them if a better way is found.",
-    "condition": { "not": { "u_has_var": "you_know_vampire_mentor_recipes", "value": "yes" } },
+    "condition": { "not": { "compare_string": [ "yes", { "u_val": "you_know_vampire_mentor_recipes" } ] } },
     "effect": [
       { "u_roll_remainder": [ "stormwrought_blood" ], "type": "recipe" },
       { "u_learn_recipe": "concentrated_underhill_essence" },

--- a/data/mods/Xedra_Evolved/npc/boann.json
+++ b/data/mods/Xedra_Evolved/npc/boann.json
@@ -117,7 +117,7 @@
       },
       {
         "text": "I'm back and I killed the March Lords.",
-        "condition": { "u_has_var": "killed_lords_for_boann", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "killed_lords_for_boann" } ] },
         "effect": [
           { "u_add_trait": "CALL_DAFFODIL" },
           { "math": [ "Boann_Quests_Completed", "++" ] },
@@ -128,7 +128,7 @@
       },
       {
         "text": "I'm back and I killed that dog-like thing.",
-        "condition": { "u_has_var": "killed_dogthing_for_boann", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "killed_dogthing_for_boann" } ] },
         "effect": [
           { "u_spawn_item": "spellbook_hedge_clairvoyance_cone", "count": 1 },
           { "math": [ "Boann_Quests_Completed", "++" ] },
@@ -139,7 +139,7 @@
       },
       {
         "text": "I'm back and I killed the Mi-Go guards.",
-        "condition": { "u_has_var": "killed_five_mi_go_guards_for_boann", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "killed_five_mi_go_guards_for_boann" } ] },
         "effect": [
           { "u_spawn_item": "mana_recharge_sphere", "count": 1 },
           { "math": [ "Boann_Quests_Completed", "++" ] },
@@ -150,7 +150,7 @@
       },
       {
         "text": "I'm back and I killed the armored centipede",
-        "condition": { "u_has_var": "killed_armored_centipede_for_boann", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "killed_armored_centipede_for_boann" } ] },
         "effect": [
           { "u_spawn_item": "boann_insignia", "count": 1 },
           { "math": [ "Boann_Quests_Completed", "++" ] },
@@ -161,7 +161,7 @@
       },
       {
         "text": "I'm back and I killed the automaton.",
-        "condition": { "u_has_var": "killed_automaton_for_boann", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "killed_automaton_for_boann" } ] },
         "effect": [
           { "u_spawn_item": "winter_lord_estoc", "count": 1 },
           { "math": [ "Boann_Quests_Completed", "++" ] },
@@ -188,7 +188,7 @@
       },
       {
         "text": "I'm back and I killed the titan stag beetle",
-        "condition": { "u_has_var": "killed_titan_beetle_for_boann", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "killed_titan_beetle_for_boann" } ] },
         "effect": [
           { "u_spawn_item": "väinämöinens_kantele", "count": 1 },
           { "math": [ "Boann_Quests_Completed", "++" ] },
@@ -213,7 +213,7 @@
       },
       {
         "text": "I'm back and I killed the the star-crowned hound",
-        "condition": { "u_has_var": "killed_star_crown_hound_for_boann", "value": "yes" },
+        "condition": { "compare_string": [ "yes", { "u_val": "killed_star_crown_hound_for_boann" } ] },
         "effect": [
           { "u_spawn_item": "dream_attuning_necklace", "count": 1 },
           { "math": [ "Boann_Quests_Completed", "++" ] },
@@ -299,14 +299,14 @@
       {
         "text": "And when I'll be a knight you'll bring me out of here?",
         "topic": "TALK_QUEST_KNIGHT_OUTWORLD",
-        "condition": { "not": { "u_has_var": "told_about_knight_not_coming", "value": "yes" } }
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "told_about_knight_not_coming" } ] } }
       },
       {
         "text": "[Bring me the heart of a Jabberwock]",
         "condition": {
           "and": [
             { "not": { "u_has_mission": "MISSION_BRING_BOANN_JABBERWOCK_HEART" } },
-            { "not": { "u_has_var": "completed_boann_bring_jabberwock_heart", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "completed_boann_bring_jabberwock_heart" } ] } }
           ]
         },
         "topic": "TALK_BRING_BOANN_JABBERWOCK_HEART_OFFER"
@@ -316,7 +316,7 @@
         "condition": {
           "and": [
             { "not": { "u_has_mission": "MISSION_KILL_TWO_MARCH_LORDS_FOR_BOANN" } },
-            { "not": { "u_has_var": "completed_boann_kill_two_lords", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "completed_boann_kill_two_lords" } ] } }
           ]
         },
         "topic": "TALK_KILL_TWO_MARCH_LORDS_OFFER"
@@ -326,7 +326,7 @@
         "condition": {
           "and": [
             { "not": { "u_has_mission": "MISSION_KILL_DOGTHING_FOR_BOANN" } },
-            { "not": { "u_has_var": "completed_boann_kill_dogthing", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "completed_boann_kill_dogthing" } ] } }
           ]
         },
         "topic": "TALK_KILL_DOGTHING_OFFER"
@@ -336,7 +336,7 @@
         "condition": {
           "and": [
             { "not": { "u_has_mission": "MISSION_KILL_FIVE_MI_GO_GUARDS_FOR_BOANN" } },
-            { "not": { "u_has_var": "completed_boann_kill_five_mi_go_guards", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "completed_boann_kill_five_mi_go_guards" } ] } }
           ]
         },
         "topic": "TALK_KILL_FIVE_MI_GO_GUARDS_OFFER"
@@ -346,7 +346,7 @@
         "condition": {
           "and": [
             { "not": { "u_has_mission": "MISSION_KILL_ARMORED_CENTIPEDE_FOR_BOANN" } },
-            { "not": { "u_has_var": "completed_boann_kill_armored_centipede", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "completed_boann_kill_armored_centipede" } ] } }
           ]
         },
         "topic": "TALK_KILL_ARMORED_CENTIPEDE_OFFER"
@@ -356,7 +356,7 @@
         "condition": {
           "and": [
             { "not": { "u_has_mission": "MISSION_KILL_DREAMFORGED_AUTOMATON_FOR_BOANN" } },
-            { "not": { "u_has_var": "completed_boann_kill_dreamforged_automaton", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "completed_boann_kill_dreamforged_automaton" } ] } }
           ]
         },
         "topic": "TALK_KILL_DREAMFORGED_AUTOMATON_OFFER"
@@ -367,7 +367,7 @@
           "and": [
             { "not": { "u_has_mission": "MISSION_GET_TRIFFID_HEART_FOR_BOANN" } },
             { "math": [ "Boann_Quests_Completed", ">=", "6" ] },
-            { "not": { "u_has_var": "completed_boann_bring_triffid_heart", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "completed_boann_bring_triffid_heart" } ] } }
           ]
         },
         "topic": "TALK_GET_TRIFFID_HEART_OFFER"
@@ -378,7 +378,7 @@
           "and": [
             { "not": { "u_has_mission": "MISSION_KILL_TITAN_BEETLE_FOR_BOANN" } },
             { "math": [ "Boann_Quests_Completed", ">=", "6" ] },
-            { "not": { "u_has_var": "completed_boann_kill_titan_beetle", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "completed_boann_kill_titan_beetle" } ] } }
           ]
         },
         "topic": "TALK_KILL_TITAN_BEETLE_OFFER"
@@ -389,7 +389,7 @@
           "and": [
             { "not": { "u_has_mission": "MISSION_GET_SHADOW_SINGULARITY_PIECE_FOR_BOANN" } },
             { "math": [ "Boann_Quests_Completed", ">=", "6" ] },
-            { "not": { "u_has_var": "completed_boann_bring_shadow_piece", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "completed_boann_bring_shadow_piece" } ] } }
           ]
         },
         "topic": "TALK_GET_SHADOW_SINGULARITY_PIECE_OFFER"
@@ -400,7 +400,7 @@
           "and": [
             { "not": { "u_has_mission": "MISSION_KILL_STAR_CROWN_HOUND_FOR_BOANN" } },
             { "math": [ "Boann_Quests_Completed", ">=", "6" ] },
-            { "not": { "u_has_var": "completed_boann_kill_star_crown_hound", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "completed_boann_kill_star_crown_hound" } ] } }
           ]
         },
         "topic": "TALK_KILL_STAR_CROWN_HOUND_OFFER"
@@ -941,8 +941,7 @@
     "type": "talk_topic",
     "id": "TALK_LEAVE_THIS_WORLD",
     "dynamic_line": {
-      "u_has_var": "u_has_followers",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "u_has_followers" } ],
       "yes": "(Boann lead you and your followers to a hidden ritual circle) This is the exit point.  After the ritual, you will all go through the decontamination process before you are allowed to claim your own barony, as fit for a member of my court.  Your followers will then claim a small part of it for their homes.",
       "no": "(Boann lead you to a hidden ritual circle) This is the exit point.  After the ritual, you'll go through the decontamination process before being allowed to claim your own barony, as fit for a member of my court."
     },

--- a/data/mods/Xedra_Evolved/npc/draco_dune.json
+++ b/data/mods/Xedra_Evolved/npc/draco_dune.json
@@ -36,7 +36,7 @@
     "start": {
       "assign_mission_target": { "om_terrain": "boann_sidhe_island", "om_special": "Boann's Island", "reveal_radius": 6, "search_range": 360 }
     },
-    "goal_condition": { "u_has_var": "general_meeting_u_met_boann_sidhe", "value": "yes" },
+    "goal_condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_boann_sidhe" } ] },
     "value": 5000,
     "origins": [ "ORIGIN_SECONDARY" ],
     "dialogue": {

--- a/data/mods/Xedra_Evolved/npc/npc_vampiresacrifice_chat.json
+++ b/data/mods/Xedra_Evolved/npc/npc_vampiresacrifice_chat.json
@@ -18,7 +18,7 @@
             { "not": { "u_has_mission": "mission_best_friend_gamehunt1" } },
             { "not": { "u_has_mission": "mission_best_friend_gamehunt2" } },
             { "not": { "u_has_mission": "mission_best_friend_gamehunt3" } },
-            { "not": { "u_has_var": "best_friend", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "best_friend" } ] } }
           ]
         },
         "effect": [ { "math": [ "npc_randomize_book_find_mission", "=", "rand(3)" ] } ]
@@ -46,7 +46,7 @@
             { "math": [ "n_npc_trust()", ">=", "10" ] },
             { "math": [ "n_npc_value()", ">=", "10" ] },
             { "u_has_mission": "KILL_YOUR_BEST_FRIEND" },
-            { "not": { "u_has_var": "best_friend", "value": "yes" } }
+            { "not": { "compare_string": [ "yes", { "u_val": "best_friend" } ] } }
           ]
         }
       }
@@ -65,7 +65,7 @@
             { "math": [ "n_npc_trust()", ">=", "10" ] },
             { "math": [ "n_npc_value()", ">=", "10" ] },
             { "u_has_mission": "KILL_YOUR_BEST_FRIEND" },
-            { "u_has_var": "best_friend", "value": "yes" },
+            { "compare_string": [ "yes", { "u_val": "best_friend" } ] },
             { "not": { "npc_has_trait": "VAMPIRE_SACRIFICE" } }
           ]
         }
@@ -170,8 +170,7 @@
     "type": "talk_topic",
     "id": "TALK_FRIEND_FOLLOWER_SACRIFICE",
     "dynamic_line": {
-      "u_has_var": "best_friend",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "best_friend" } ],
       "yes": "You're the best person in the world for me.  I wouldn't ever hesitate to trust you with my life.  I feel that no matter what happens, it'll be fine as you'll be there.",
       "no": "I mean you're ok, I guess."
     },

--- a/data/mods/Xedra_Evolved/npc/talk_rescue.json
+++ b/data/mods/Xedra_Evolved/npc/talk_rescue.json
@@ -40,7 +40,7 @@
           "not": {
             "or": [
               { "u_has_mission": "BRING_INFESTED_ANTIPARASITICS" },
-              { "u_has_var": "mission_completed_antiparasitic", "value": "yes" }
+              { "compare_string": [ "yes", { "u_val": "mission_completed_antiparasitic" } ] }
             ]
           }
         },

--- a/data/mods/Xedra_Evolved/npc/vampire_mentor.json
+++ b/data/mods/Xedra_Evolved/npc/vampire_mentor.json
@@ -46,8 +46,7 @@
     "id": "TALK_VAMPIRE_MENTOR",
     "type": "talk_topic",
     "dynamic_line": {
-      "u_has_var": "general_meeting_u_met_mentor",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "general_meeting_u_met_mentor" } ],
       "yes": [ "Welcome back.", "Hello again." ],
       "no": "Welcome.  What do you seek here?  Fortune?  Safety?  A friend?  A mentor?  What brought you here?"
     },
@@ -70,7 +69,9 @@
       {
         "text": "I've done it.  I am now a true vampire.",
         "topic": "TALK_VAMPIRE_MENTOR_TRUEVAMP",
-        "condition": { "and": [ { "u_has_trait": "VAMPIRE4" }, { "not": { "u_has_var": "told_about_trueness", "value": "yes" } } ] },
+        "condition": {
+          "and": [ { "u_has_trait": "VAMPIRE4" }, { "not": { "compare_string": [ "yes", { "u_val": "told_about_trueness" } ] } } ]
+        },
         "effect": { "u_add_var": "told_about_trueness", "value": "yes" }
       },
       {
@@ -79,7 +80,7 @@
         "condition": {
           "and": [
             { "not": { "u_know_recipe": "xe_vampire_blood_gift_research" } },
-            { "u_has_var": "told_about_trueness", "value": "yes" }
+            { "compare_string": [ "yes", { "u_val": "told_about_trueness" } ] }
           ]
         }
       },
@@ -87,7 +88,10 @@
         "text": "I've lost the book you gave me.  Do you have another?",
         "topic": "TALK_VAMPIRE_MENTOR_BOOK_NEED_NEW",
         "condition": {
-          "and": [ { "u_has_var": "received_mentor_book", "value": "yes" }, { "not": { "u_has_item": "vampire_mentor_book" } } ]
+          "and": [
+            { "compare_string": [ "yes", { "u_val": "received_mentor_book" } ] },
+            { "not": { "u_has_item": "vampire_mentor_book" } }
+          ]
         }
       },
       {
@@ -519,7 +523,7 @@
     "type": "mission_definition",
     "name": { "str": "Kill your best friend" },
     "goal": "MGOAL_CONDITION",
-    "goal_condition": { "npc_has_var": "-", "type": "-", "context": "-", "value": "-" },
+    "goal_condition": { "math": [ "0 == 1" ] },
     "difficulty": 2,
     "value": 240,
     "origins": [ "ORIGIN_SECONDARY" ],
@@ -541,7 +545,7 @@
     "type": "mission_definition",
     "name": { "str": "Find the components for the vampiric ritual" },
     "goal": "MGOAL_CONDITION",
-    "goal_condition": { "npc_has_var": "-", "type": "-", "context": "-", "value": "-" },
+    "goal_condition": { "math": [ "0 == 1" ] },
     "difficulty": 2,
     "value": 240,
     "origins": [ "ORIGIN_SECONDARY" ],

--- a/data/mods/classic_zombies/modinfo.json
+++ b/data/mods/classic_zombies/modinfo.json
@@ -32,7 +32,7 @@
     "eoc_type": "EVENT",
     "required_event": "game_begin",
     "//": "Adding a variable flag to the player allows certain dialogue to be changed that otherwise is hard to change in a mod.",
-    "condition": { "not": { "u_has_var": "flag_modded", "value": "ddotd" } },
+    "condition": { "not": { "compare_string": [ "ddotd", { "u_val": "flag_modded" } ] } },
     "effect": [ { "u_add_var": "flag_modded", "value": "ddotd" } ]
   },
   {

--- a/data/mods/innawood/npcs/Backgrounds/hospital_2.json
+++ b/data/mods/innawood/npcs/Backgrounds/hospital_2.json
@@ -75,8 +75,7 @@
     "id": "BGSS_HOSPITAL_2_STORY4",
     "type": "talk_topic",
     "dynamic_line": {
-      "u_has_var": "mission_BGSS_hospital_2_started_quest",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "mission_BGSS_hospital_2_started_quest" } ],
       "no": "Well, I still didn't have any food.  Eventually I had to climb down… so I did, as quietly as I could.  It was night, and I have pretty good nightvision.  Apparently the giant bugs don't, because I was able to slip right past them and get away.  I'd kind of scouted out my route from above…  I avoided the major spiked blockades, and headed out towards a friend's place.  I had to fight off a couple of the <zombies>, but I managed to avoid any big fuss, by some miracle.  I never made it to the where I was going, but that's not important now.",
       "yes": "Well, I still didn't have any food.  Eventually I had to climb down… so I did, as quietly as I could.  It was night, and I have pretty good nightvision.  Apparently the giant bugs don't, because I was able to slip right past them and get away.  I'd kind of scouted out my route from above…  I avoided the major spiked blockades, and headed out towards a friend's place.  I had to fight off a couple of the <zombies>, but I managed to avoid any big fuss, by some miracle."
     },

--- a/data/mods/innawood/npcs/Backgrounds/prepper_1.json
+++ b/data/mods/innawood/npcs/Backgrounds/prepper_1.json
@@ -35,8 +35,7 @@
     "id": "BGSS_PREPPER_1_LMOE",
     "type": "talk_topic",
     "dynamic_line": {
-      "u_has_var": "mission_BGSS_prepper_1_started_quest",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "mission_BGSS_prepper_1_started_quest" } ],
       "no": "I still haven't made it there.  Every time I've tried I've been headed off by the <zombies>.  Who knows, maybe someday.",
       "yes": "The shelter's in your hands, at this point."
     },

--- a/data/mods/innawood/npcs/Backgrounds/rural_1.json
+++ b/data/mods/innawood/npcs/Backgrounds/rural_1.json
@@ -29,8 +29,7 @@
     "id": "BGSS_RURAL_1_STORY3",
     "type": "talk_topic",
     "dynamic_line": {
-      "u_has_var": "mission_BGSS_rural_1_started_quest",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "mission_BGSS_rural_1_started_quest" } ],
       "no": "That was the first thing to really shake me out of it.  I didn't really have any very close friends, but there were people I cared about a bit.  I started to worry about them.  I headed out, but everything seemed different to me.  Didn't get far before I bumped into a giant fly buzzing, and that's when I started to put it all together.  Never did see my friends again.  My place was trashed anyway, so I've just been wandering since.",
       "yes": "That was the first thing to really shake me out of it.  I didn't really have any very close friends, but there were people I cared about a bit.  I started to worry about them.  I headed out, but everything seemed different to me.  Didn't get far before I bumped into a giant fly buzzing, and that's when I started to put it all together.  Never did see my friends again.  My place was trashed anyway, so I wandered on.  And now I'm here with you."
     },

--- a/data/mods/translate-dialogue/rubik.json
+++ b/data/mods/translate-dialogue/rubik.json
@@ -37,8 +37,7 @@
     "id": "TALK_EXODII_MERCHANT_Talk",
     "type": "talk_topic",
     "dynamic_line": {
-      "u_has_var": "dialogue_started_rubik_intro",
-      "value": "yes",
+      "compare_string": [ "yes", { "u_val": "dialogue_started_rubik_intro" } ],
       "yes": "Sure as you c'n try.  Us're not the greatest yarker, nor do it all for gratis, kennit.\"\n\n[TRANSLATE:] \"You can surely try.  I'm not the greatest speaker, and I won't just chat forever for free, you know.",
       "no": "Oy, c'n I bark you summat first?\"\n\n[TRANSLATE:] \"Hey, can I ask you something first?"
     }

--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -517,6 +517,9 @@ alpha talker has bodytype `migo` , and beta has bodytype `human`
 ```
 
 ### `u_has_var`, `npc_has_var`
+
+**DEPRECATED**, use `compare_string` in format `{ "compare_string": [ "yes", { "npc_val": "name_of_the_variable" } ] }`
+
 - type: string
 - checks do alpha or beta talker has specific variables, that was added `u_add_var` or `npc_add_var`
 - `type`, `context` and `value` of the variable is also required
@@ -532,7 +535,7 @@ Note: Not to be confused with the global `has_var` **(no prefix)**, used as [dia
 #### Examples
 Checks do alpha talker has `u_met_sadie` variable
 ```json
-{ "u_has_var": "general_meeting_u_met_sadie", "value": "yes" }
+{ "compare_string": [ "yes", { "u_val": "general_meeting_u_met_sadie" } ] }
 ```
 
 ### `expects_vars`
@@ -1963,12 +1966,12 @@ Set effects to be executed when conditions are met and when conditions are not m
 Displays a different message the first time it is run and the second time onwards
 ```json
 {
-  "if": { "u_has_var": "eoc_sample_if_else_test", "value": "yes" },
+  "if": { "compare_string": [ "yes", { "u_val": "eoc_sample_if_else_test" } ] },
   "then": { "u_message": "You have variable." },
   "else": [
     { "u_message": "You don't have variable." },
     {
-      "if": { "not": { "u_has_var": "eoc_sample_if_else_test", "value": "yes" } },
+      "if": { "not": { "compare_string": [ "yes", { "u_val": "eoc_sample_if_else_test" } ] } },
       "then": [
         { "u_add_var": "eoc_sample_if_else_test", "value": "yes" },
         { "u_message": "Vriable added." }
@@ -2926,7 +2929,7 @@ Character forget martial art, stored in `ma_id` context value
 
 
 #### `u_add_var`, `npc_add_var`
-Save a personal variable, that you can check later using `u_has_var`, `npc_has_var` or `math` (see [Player or NPC conditions]( #Player_or_NPC_conditions) )
+Save a string as personal variable, that you can check later using `compare_string` (see [Player or NPC conditions](#Player_or_NPC_conditions) )
 
 | Syntax | Optionality | Value  | Info |
 | --- | --- | --- | --- | 

--- a/doc/FACTIONS.md
+++ b/doc/FACTIONS.md
@@ -25,7 +25,7 @@ An NPC faction looks like this:
         "group": "test_item_group",
         "markup": 2.0,
         "fixed_adj": 0.1,
-        "condition": { "npc_has_var": "bool_allnighter_thirsty", "value": "yes" }
+        "condition": { "compare_string": [ "yes", { "npc_val": "bool_allnighter_thirsty" } ] }
       }
     ],
     "relations": {

--- a/doc/NPCs.md
+++ b/doc/NPCs.md
@@ -108,7 +108,7 @@ Controls consumption of shopkeeper's stock of items (simulates purchase by other
     {
       "item": "hammer",
       "rate": 10,
-      "condition": { "npc_has_var": "bool_dinner_hammer_eater", "value": "yes" }
+      "condition": { "compare_string": [ "yes", { "npc_val": "bool_dinner_hammer_eater" } ] }
     },
     { "category": "ammo", "rate": 10 },
     { "group": "EXODII_basic_trade", "rate": 100 }
@@ -126,7 +126,7 @@ Specifies blacklist of items that shopkeeper will not accept for trade.  Format 
   "entries": [
     {
       "item": "hammer",
-      "condition": { "npc_has_var": "bool_test_hammer_hater", "value": "yes" },
+      "condition": { "compare_string": [ "yes", { "npc_val": "bool_test_hammer_hater" } ] },
       "message": "<npcname> hates this item"
     },
     { "category": "ammo" },
@@ -1041,7 +1041,7 @@ Condition | Type | Description
   "topic": "TALK_NONE",
   "condition": {
     "not": {
-      "npc_has_var": "general_examples_has_met_PC", "value": "yes"
+      "compare_string": [ "yes", { "npc_val": "general_examples_has_met_PC" } ]
     }
   },
   "effect": {

--- a/doc/NPCs.md
+++ b/doc/NPCs.md
@@ -64,7 +64,7 @@ Format:
     { "group": "example_shopkeeper_itemgroup3", "trust": 40, "strict": true },
     {
       "group": "example_shopkeeper_itemgroup4",
-      "condition": { "u_has_var": "general_examples_VIP", "value": "yes" }
+      "condition": { "compare_string": [ "yes", { "u_val": "general_examples_VIP" } ] }
     }
   ],
   "shopkeeper_consumption_rates": "basic_shop_rates",
@@ -1134,7 +1134,7 @@ Condition | Type | Description
 {
   "text": "Didn't you say you knew where the Vault was?",
   "topic": "TALK_VAULT_INFO",
-  "condition": { "not": { "u_has_var": "sentinel_old_guard_rep_asked_about_vault", "value": "yes" } },
+  "condition": { "not": { "compare_string": [ "yes", { "u_val": "sentinel_old_guard_rep_asked_about_vault" } ] } },
   "effect": [
     { "u_add_var": "sentinel_old_guard_asked_about_vault", "value": "yes" },
     { "mapgen_update": "hulk_hairstyling", "om_terrain": "necropolis_a_13", "om_special": "Necropolis", "om_terrain_replace": "field", "z": 0 }
@@ -1143,7 +1143,7 @@ Condition | Type | Description
 {
   "text": "Why do zombies keep attacking every time I talk to you?",
   "topic": "TALK_RUN_AWAY_MORE_ZOMBIES",
-  "condition": { "u_has_var": "trigger_learning_experience_even_more_zombies", "value": "yes" },
+  "condition": { "compare_string": [ "yes", { "u_val": "trigger_learning_experience_even_more_zombies" } ] },
   "effect": [
     { "mapgen_update": [ "even_more_zombies", "more zombies" ], "origin_npc": true },
     { "mapgen_update": "more zombies", "origin_npc": true, "offset_x": 1 },

--- a/tests/npc_talk_test.cpp
+++ b/tests/npc_talk_test.cpp
@@ -818,8 +818,8 @@ TEST_CASE( "npc_talk_vars", "[npc_talk]" )
     effects.apply( d );
     gen_response_lines( d, 3 );
     CHECK( d.responses[0].text == "This is a basic test response." );
-    CHECK( d.responses[1].text == "This is a u_has_var, u_remove_var test response." );
-    CHECK( d.responses[2].text == "This is a npc_has_var, npc_remove_var test response." );
+    CHECK( d.responses[1].text == "This is a compare_string, u_remove_var test response." );
+    CHECK( d.responses[2].text == "This is a compare_string, npc_remove_var test response." );
     effects = d.responses[1].success;
     effects.apply( d );
     effects = d.responses[2].success;


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Got told that u/npc_has_var is on a chopping block, because it does the same thing as compare_string, but limited to only two scopes out of four
Well if it's on a chopping block, let's chop it
#### Describe the solution
Use regex to replace all uses of u/npc_has_var with compare_string
Fix manually the rest that was not hit with regex
#### Testing
TBD
#### Additional context
Regex used:
```
"npc_has_var": "([A-Za-z0-9_-]*)",[\n 	]* "value": "([A-Za-z0-9_-]*)"

"compare_string": [ "$2", { "npc_val": "$1" } ]
```

```
"u_has_var": "([A-Za-z0-9_-]*)",[\n 	]* "value": "([A-Za-z0-9_-]*)"

"compare_string": [ "$2", { "u_val": "$1" } ]
```

copy of #76006 without conflicts with #75392