### PR TITLE
Extend/delete support for harvest lists

### DIFF
--- a/data/json/harvest.json
+++ b/data/json/harvest.json
@@ -2830,19 +2830,8 @@
     "id": "rabbit_with_skull",
     "//": "mammal_small_fur + skull_rabbit",
     "type": "harvest",
-    "entries": [
-      { "drop": "skull_rabbit", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
-      { "drop": "meat", "type": "flesh", "mass_ratio": 0.28 },
-      { "drop": "meat_scrap", "type": "flesh", "mass_ratio": 0.05 },
-      { "drop": "lung", "type": "flesh", "mass_ratio": 0.0035 },
-      { "drop": "liver", "type": "offal", "mass_ratio": 0.01 },
-      { "drop": "brain", "type": "flesh", "mass_ratio": 0.005 },
-      { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "animal_blood", "type": "blood", "mass_ratio": 0.1 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
-      { "drop": "raw_fur", "type": "skin", "mass_ratio": 0.02 },
-      { "drop": "fat", "type": "flesh", "mass_ratio": 0.07 }
-    ]
+    "copy-from": "mammal_small_fur",
+    "extend": { "entries": [ { "drop": "skull_rabbit", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 } ] }
   },
   {
     "id": "mi-go",

--- a/src/harvest.cpp
+++ b/src/harvest.cpp
@@ -153,6 +153,30 @@ void harvest_entry::deserialize( const JsonObject &jo )
     load( jo );
 }
 
+bool harvest_entry::operator==( const harvest_entry &rhs ) const
+{
+    return drop == rhs.drop;
+}
+
+class harvest_entry_reader : public generic_typed_reader<harvest_entry_reader>
+{
+    public:
+        harvest_entry get_next( const JsonValue &jv ) const {
+            JsonObject jo = jv.get_object();
+            harvest_entry ret;
+            mandatory( jo, false, "drop", ret.drop );
+
+            optional( jo, false, "type", ret.type, harvest_drop_type_id::NULL_ID() );
+            optional( jo, false, "base_num", ret.base_num, { 1.0f, 1.0f } );
+            optional( jo, false, "scale_num", ret.scale_num, { 0.0f, 0.0f } );
+            optional( jo, false, "max", ret.max, 1000 );
+            optional( jo, false, "mass_ratio", ret.mass_ratio, 0.00f );
+            optional( jo, false, "flags", ret.flags );
+            optional( jo, false, "faults", ret.faults );
+            return ret;
+        }
+};
+
 void harvest_list::finalize()
 {
     std::transform( entries_.begin(), entries_.end(), std::inserter( names_, names_.begin() ),
@@ -172,7 +196,7 @@ void harvest_list::finalize_all()
 void harvest_list::load( const JsonObject &obj, const std::string_view )
 {
     mandatory( obj, was_loaded, "id", id );
-    mandatory( obj, was_loaded, "entries", entries_ );
+    mandatory( obj, was_loaded, "entries", entries_, harvest_entry_reader{} );
 
     optional( obj, was_loaded, "butchery_requirements", butchery_requirements_,
               butchery_requirements_default );
@@ -230,22 +254,22 @@ void harvest_list::reset()
     harvest_list_factory.reset();
 }
 
-std::list<harvest_entry>::const_iterator harvest_list::begin() const
+std::vector<harvest_entry>::const_iterator harvest_list::begin() const
 {
     return entries().begin();
 }
 
-std::list<harvest_entry>::const_iterator harvest_list::end() const
+std::vector<harvest_entry>::const_iterator harvest_list::end() const
 {
     return entries().end();
 }
 
-std::list<harvest_entry>::const_reverse_iterator harvest_list::rbegin() const
+std::vector<harvest_entry>::const_reverse_iterator harvest_list::rbegin() const
 {
     return entries().rbegin();
 }
 
-std::list<harvest_entry>::const_reverse_iterator harvest_list::rend() const
+std::vector<harvest_entry>::const_reverse_iterator harvest_list::rend() const
 {
     return entries().rend();
 }

--- a/src/harvest.h
+++ b/src/harvest.h
@@ -90,6 +90,9 @@ struct harvest_entry {
     bool was_loaded = false;
     void load( const JsonObject &jo );
     void deserialize( const JsonObject &jo );
+
+    // only compares mandatory members for reader identity checks
+    bool operator==( const harvest_entry &rhs ) const;
 };
 
 class harvest_list
@@ -106,7 +109,7 @@ class harvest_list
 
         bool is_null() const;
 
-        const std::list<harvest_entry> &entries() const {
+        const std::vector<harvest_entry> &entries() const {
             return entries_;
         }
 
@@ -130,10 +133,10 @@ class harvest_list
 
         std::string describe( int at_skill = -1 ) const;
 
-        std::list<harvest_entry>::const_iterator begin() const;
-        std::list<harvest_entry>::const_iterator end() const;
-        std::list<harvest_entry>::const_reverse_iterator rbegin() const;
-        std::list<harvest_entry>::const_reverse_iterator rend() const;
+        std::vector<harvest_entry>::const_iterator begin() const;
+        std::vector<harvest_entry>::const_iterator end() const;
+        std::vector<harvest_entry>::const_reverse_iterator rbegin() const;
+        std::vector<harvest_entry>::const_reverse_iterator rend() const;
 
         /** Fills out the set of cached names. */
         static void finalize_all();
@@ -149,7 +152,7 @@ class harvest_list
         static const std::vector<harvest_list> &get_all();
 
     private:
-        std::list<harvest_entry> entries_;
+        std::vector<harvest_entry> entries_;
         std::set<std::string> names_;
         translation message_;
         butchery_requirements_id butchery_requirements_;


### PR DESCRIPTION
#### Summary
Infrastructure "Extend/delete support for harvest lists"

#### Purpose of change

Fixes #75958
Fixes #61525

#### Describe the solution

Add and use `harvest_entry_reader`. Readers apparently can't handle std::list containers, so I changed the `harvest_list::entries_` member to std::vector.
Since the equality check for harvest entries only checks the `drop` member, giving that should be enough for `delete`.
Also changed the `rabbit_with_skull` harvest to copy-from mammal_small_fur and extend with the skull to test functionality.

#### Describe alternatives you've considered



#### Testing

Butchered a rabbit to check results.

#### Additional context

Result of full butchery of mon_rabbit
![grafik](https://github.com/user-attachments/assets/48e4fb45-85a9-40eb-80c2-986e2885b3c2)
