### PR TITLE
fix the crash by bulding the font atlas

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -280,6 +280,8 @@ void cataimgui::client::load_fonts( const Font_Ptr &cata_font,
         io.Fonts->Fonts[0]->SetFallbackStrSizeCallback( GetFallbackStrWidth );
         io.Fonts->Fonts[0]->SetFallbackCharSizeCallback( GetFallbackCharWidth );
         io.Fonts->Fonts[0]->SetRenderFallbackCharCallback( CanRenderFallbackChar );
+        io.Fonts->Build();
+        ImGui::SetCurrentFont( ImGui::GetDefaultFont() );
         ImGui_ImplSDLRenderer2_SetFallbackGlyphDrawCallback( [&]( const ImFontGlyphToDraw & glyph ) {
             std::string uni_string = std::string( glyph.uni_str );
             point p( int( glyph.pos.x ), int( glyph.pos.y - 3 ) );

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -851,6 +851,8 @@ int main( int argc, const char *argv[] )
 
 #if defined(LOCALIZE)
     if( get_option<std::string>( "USE_LANG" ).empty() && !SystemLocale::Language().has_value() ) {
+        imclient->new_frame(); // we have to prime the pump, because of reasons
+        imclient->end_frame();
         const std::string lang = select_language();
         get_options().get_option( "USE_LANG" ).setValue( lang );
         set_language_from_options();


### PR DESCRIPTION
#### Summary
Bugfixes "fix the crash in select_language by building the font atlas first"

#### Purpose of change

Fixes #75818

#### Describe the solution

The main thing is that we have to actually build the font atlas before the font is usable. This is normally done the first time you call `ImGui::NewFrame()`, but the `uilist` needs to measure some text before it draws anything. Chicken and egg, you see? So main.cpp needs to start and end a frame before it creates this uilist.

In the happy path where the user’s locale is directly usable, we instead start with `main_menu::opening_screen()`, which puts a `ui_adaptor` on the stack and then calls `ui_manager::redraw()`. Thus a new frame has already been started by the time any `uilist` is created.

I also made `cataimgui::client::load_fonts()` build the atlas right away. Technically this is unnecessary, as the atlas would just be built during the first frame, but I want to be able to remove that first useless frame one day, and building the font atlas is the first step. There must be other things initialized during that first frame though, because without it the `select_language` menu appears by is unusably small. Something to look into in the future.

#### Testing

Run the game with no config directory and `LANG=zu_ZA.utf8` in the environment. As there is no South African Zulu translation, the game will ask the user to choose a different language.