### PR TITLE
Massively increase overmap UI search range

### DIFF
--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1310,7 +1310,7 @@ static bool search( const ui_adaptor &om_ui, tripoint_abs_omt &curs, const tripo
     std::vector<point_abs_omt> locations;
     std::vector<point_abs_om> overmap_checked;
 
-    const int radius = OMAPX; // arbitrary
+    const int radius = OMAPX * 5; // arbitrary
     for( const tripoint_abs_omt &p : points_in_radius( curs, radius ) ) {
         overmap_with_local_coords om_loc = overmap_buffer.get_existing_om_global( p );
 
@@ -1335,7 +1335,7 @@ static bool search( const ui_adaptor &om_ui, tripoint_abs_omt &curs, const tripo
 
     if( locations.empty() ) {
         sfx::play_variant_sound( "menu_error", "default", 100 );
-        popup( _( "No results found." ) );
+        popup( _( "No results found within %d tiles." ), radius );
         return false;
     }
 


### PR DESCRIPTION
#### Summary
Features "Massively increase overmap UI search range"

#### Purpose of change
* Closes #36789 if merged

Overmap only searches 180 tiles away?! [Our missions search as far away as 2400](https://github.com/CleverRaven/Cataclysm-DDA/pull/73925#pullrequestreview-2065078860)! Surely we can search further than 180?

#### Describe the solution
Make the search radius FIVE TIMES WIDER! (~24.77x more tiles searched)

Adjust the "No results found" message so it tells you how far it searches. If I had known the range was so short before I would have done this waaaaaaaaaaaaay earlier.

#### Describe alternatives you've considered
Adjustable search range? Sounds like effort

#### Testing
Showcasing a successful search from 181 OMTs away, which previously failed. The result is found despite being located on another overmap.

https://github.com/user-attachments/assets/234b4baf-d792-4915-bc69-f9c5380aa7ff


#### Additional context
My only possible concern is performance, but as you can see from the testing it is still instant for my computer.

It looks like the value was previously this low due to performance concerns (see #36816 and linked issues therein), but this is still lightning fast so 🤷.

If performance problems DO appear with this, I'll have to figure something out with ~~adjustable search ranges~~ multiple passes, or perhaps another solution (Kevin did not seem to like adjustable ranges, which is fair... you could easily put in a range that'd freeze any computer). That should still easily be possible.
