### PR TITLE
fix light_cell_rechargeable not fitting in batteries itemgroup

### DIFF
--- a/data/json/itemgroups/electronics.json
+++ b/data/json/itemgroups/electronics.json
@@ -159,7 +159,7 @@
       { "item": "light_battery_cell", "charges": 1000, "prob": 160, "count": [ 0, 8 ] },
       { "item": "light_battery_cell", "charges": 1000, "prob": 16, "count": [ 0, 16 ] },
       { "item": "light_cell_rechargeable", "charges": 1000, "prob": 16, "count": [ 0, 8 ] },
-      { "item": "light_cell_rechargeable", "charges": 1000, "prob": 1, "count": [ 0, 16 ] },
+      { "item": "light_cell_rechargeable", "charges": 1000, "prob": 1, "count": [ 0, 12 ] },
       { "item": "medium_battery_cell", "charges": 1000, "prob": 15, "count": [ 0, 4 ] }
     ]
   }


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Idk why this bug was reported elsewhere, but gonna fix it separately to not scope creep
#### Describe the solution
tweak amount of batteries in itemgroup to not cause error
#### Additional context
`(all_mods)=> (continued from above) ERROR : src/item_group.cpp:147 [void put_into_container(Item_spawn_data::ItemList &, std::size_t, const std::optional<itype_id> &, const std::optional<std::string> &, const bool, time_point, Item_spawn_data::overflow_behaviour, const std::string &)] item light_cell_rechargeable could not be put in container box_paper_small when spawning item group batteries: pocket is holding too much weight.  This can be resolved either by changing the container or contents to ensure that they fit, or by specifying an overflow behaviour via "on_overflow" on the item group.`