### PR TITLE
satisfy tests with double spaces

### DIFF
--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -1008,7 +1008,7 @@ bool main_menu::new_character_tab()
                 }
                 if( !world->world_saves.empty() ) {
                     if( !query_yn(
-                            _( "Many game features will not work correctly with multiple characters in the same world. Create a new character anyway?" ) ) ) {
+                            _( "Many game features will not work correctly with multiple characters in the same world.  Create a new character anyway?" ) ) ) {
                         return false;
                     }
                 }
@@ -1053,7 +1053,7 @@ bool main_menu::new_character_tab()
         }
         if( !world->world_saves.empty() ) {
             if( !query_yn(
-                    _( "Many game features will not work correctly with multiple characters in the same world. Create a new character anyway?" ) ) ) {
+                    _( "Many game features will not work correctly with multiple characters in the same world.  Create a new character anyway?" ) ) ) {
                 return false;
             }
         }


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Satisfy clang
#### Describe the solution
add double space where needed
#### Additional context
```
Error: /home/runner/work/Cataclysm-DDA/Cataclysm-DDA/src/main_menu.cpp:1011:119: error: insufficient spaces at this location.  2 required, but only 1 found. [cata-text-style,-warnings-as-errors]
 1011 |                             _( "Many game features will not work correctly with multiple characters in the same world. Create a new character anyway?" ) ) ) {
      |                                                                                                                       ^
      |                                                                                                                        
Error: /home/runner/work/Cataclysm-DDA/Cataclysm-DDA/src/main_menu.cpp:1056:111: error: insufficient spaces at this location.  2 required, but only 1 found. [cata-text-style,-warnings-as-errors]
 1056 |                     _( "Many game features will not work correctly with multiple characters in the same world. Create a new character anyway?" ) ) ) {
      |                                                                                                               ^
      |                                                                                                                

```