### PR TITLE
Fix haircutting

### DIFF
--- a/data/json/effects_on_condition/item_eocs.json
+++ b/data/json/effects_on_condition/item_eocs.json
@@ -166,7 +166,10 @@
       { "u_lose_trait": "hair_braid" },
       { "u_lose_trait": "hair_detective" },
       { "u_lose_trait": "hair_super_princess" },
-      { "u_lose_trait": "hair_twintails" }
+      { "u_lose_trait": "hair_twintails" },
+      { "u_lose_trait": "hair_bald" },
+      { "u_lose_trait": "hair_fro" },
+      { "u_lose_trait": "hair_ponytail" }
     ]
   },
   {

--- a/data/json/effects_on_condition/npc_eocs/appearance_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/appearance_eocs.json
@@ -232,22 +232,22 @@
     "effect": [
       { "run_eocs": "assign_random_natural_hair_color" },
       {
-        "if": { "compare_string": [ "yes", { "u_val": "mutation_hair_color_natural_hair_color_black" } ] },
+        "if": { "u_has_trait": "natural_hair_color_black" },
         "then": [ { "u_add_trait": { "context_val": "trait_id" }, "variant": "black" } ],
         "else": {
-          "if": { "compare_string": [ "yes", { "u_val": "mutation_hair_color_natural_hair_color_blond" } ] },
+          "if": { "u_has_trait": "natural_hair_color_blond" },
           "then": [ { "u_add_trait": { "context_val": "trait_id" }, "variant": "blond" } ],
           "else": {
-            "if": { "compare_string": [ "yes", { "u_val": "mutation_hair_color_natural_hair_color_brown" } ] },
+            "if": { "u_has_trait": "natural_hair_color_brown" },
             "then": [ { "u_add_trait": { "context_val": "trait_id" }, "variant": "brown" } ],
             "else": {
-              "if": { "compare_string": [ "yes", { "u_val": "mutation_hair_color_natural_hair_color_gray" } ] },
+              "if": { "u_has_trait": "natural_hair_color_gray" },
               "then": [ { "u_add_trait": { "context_val": "trait_id" }, "variant": "gray" } ],
               "else": {
-                "if": { "compare_string": [ "yes", { "u_val": "mutation_hair_color_natural_hair_color_red" } ] },
+                "if": { "u_has_trait": "natural_hair_color_red" },
                 "then": [ { "u_add_trait": { "context_val": "trait_id" }, "variant": "red" } ],
                 "else": {
-                  "if": { "compare_string": [ "yes", { "u_val": "mutation_hair_color_natural_hair_color_white" } ] },
+                  "if": { "u_has_trait": "natural_hair_color_white" },
                   "then": [ { "u_add_trait": { "context_val": "trait_id" }, "variant": "white" } ]
                 }
               }
@@ -392,14 +392,16 @@
     "type": "effect_on_condition",
     "id": "assign_random_natural_hair_color",
     "condition": {
-      "and": [
-        { "not": { "compare_string": [ "yes", { "u_val": "mutation_hair_color_natural_hair_color_black" } ] } },
-        { "not": { "compare_string": [ "yes", { "u_val": "mutation_hair_color_natural_hair_color_blond" } ] } },
-        { "not": { "compare_string": [ "yes", { "u_val": "mutation_hair_color_natural_hair_color_brown" } ] } },
-        { "not": { "compare_string": [ "yes", { "u_val": "mutation_hair_color_natural_hair_color_gray" } ] } },
-        { "not": { "compare_string": [ "yes", { "u_val": "mutation_hair_color_natural_hair_color_red" } ] } },
-        { "not": { "compare_string": [ "yes", { "u_val": "mutation_hair_color_natural_hair_color_white" } ] } }
-      ]
+      "not": {
+        "u_has_any_trait": [
+          "natural_hair_color_black",
+          "natural_hair_color_blond",
+          "natural_hair_color_brown",
+          "natural_hair_color_gray",
+          "natural_hair_color_red",
+          "natural_hair_color_white"
+        ]
+      }
     },
     "effect": [
       {

--- a/data/json/effects_on_condition/npc_eocs/appearance_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/appearance_eocs.json
@@ -418,60 +418,6 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "natural_hair_color_black",
-    "condition": { "not": { "compare_string": [ "yes", { "u_val": "mutation_hair_color_picked_hair_color" } ] } },
-    "effect": [
-      { "u_add_var": "mutation_hair_color_natural_hair_color_black", "value": "yes" },
-      { "u_add_var": "mutation_hair_color_picked_hair_color", "value": "yes" }
-    ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "natural_hair_color_blond",
-    "condition": { "not": { "compare_string": [ "yes", { "u_val": "mutation_hair_color_picked_hair_color" } ] } },
-    "effect": [
-      { "u_add_var": "mutation_hair_color_natural_hair_color_blond", "value": "yes" },
-      { "u_add_var": "mutation_hair_color_picked_hair_color", "value": "yes" }
-    ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "natural_hair_color_brown",
-    "condition": { "not": { "compare_string": [ "yes", { "u_val": "mutation_hair_color_picked_hair_color" } ] } },
-    "effect": [
-      { "u_add_var": "mutation_hair_color_natural_hair_color_brown", "value": "yes" },
-      { "u_add_var": "mutation_hair_color_picked_hair_color", "value": "yes" }
-    ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "natural_hair_color_gray",
-    "condition": { "not": { "compare_string": [ "yes", { "u_val": "mutation_hair_color_picked_hair_color" } ] } },
-    "effect": [
-      { "u_add_var": "mutation_hair_color_natural_hair_color_gray", "value": "yes" },
-      { "u_add_var": "mutation_hair_color_picked_hair_color", "value": "yes" }
-    ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "natural_hair_color_white",
-    "condition": { "not": { "compare_string": [ "yes", { "u_val": "mutation_hair_color_picked_hair_color" } ] } },
-    "effect": [
-      { "u_add_var": "mutation_hair_color_natural_hair_color_white", "value": "yes" },
-      { "u_add_var": "mutation_hair_color_picked_hair_color", "value": "yes" }
-    ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "natural_hair_color_red",
-    "condition": { "not": { "compare_string": [ "yes", { "u_val": "mutation_hair_color_picked_hair_color" } ] } },
-    "effect": [
-      { "u_add_var": "mutation_hair_color_natural_hair_color_red", "value": "yes" },
-      { "u_add_var": "mutation_hair_color_picked_hair_color", "value": "yes" }
-    ]
-  },
-  {
-    "type": "effect_on_condition",
     "id": "black_hair_dye",
     "condition": { "u_has_item": "hair_dye_black" },
     "effect": [

--- a/data/json/mutations/appearance_hair_styles.json
+++ b/data/json/mutations/appearance_hair_styles.json
@@ -1877,7 +1877,6 @@
     "purifiable": false,
     "player_display": false,
     "vanity": true,
-    "processed_eocs": [ "natural_hair_color_black" ],
     "types": [ "hair_color" ]
   },
   {
@@ -1891,7 +1890,6 @@
     "purifiable": false,
     "player_display": false,
     "vanity": true,
-    "processed_eocs": [ "natural_hair_color_blond" ],
     "types": [ "hair_color" ]
   },
   {
@@ -1905,7 +1903,6 @@
     "purifiable": false,
     "player_display": false,
     "vanity": true,
-    "processed_eocs": [ "natural_hair_color_brown" ],
     "types": [ "hair_color" ]
   },
   {
@@ -1919,7 +1916,6 @@
     "purifiable": false,
     "player_display": false,
     "vanity": true,
-    "processed_eocs": [ "natural_hair_color_gray" ],
     "types": [ "hair_color" ]
   },
   {
@@ -1933,7 +1929,6 @@
     "purifiable": false,
     "player_display": false,
     "vanity": true,
-    "processed_eocs": [ "natural_hair_color_red" ],
     "types": [ "hair_color" ]
   },
   {
@@ -1947,7 +1942,6 @@
     "purifiable": false,
     "player_display": false,
     "vanity": true,
-    "processed_eocs": [ "natural_hair_color_white" ],
     "types": [ "hair_color" ]
   },
   {

--- a/data/json/npcs/EOC_talkers/haircutting.json
+++ b/data/json/npcs/EOC_talkers/haircutting.json
@@ -1145,22 +1145,6 @@
         "topic": "TALK_DONE"
       },
       {
-        "text": "Get a mullet.",
-        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
-        "effect": [
-          { "run_eocs": "reset_all_hair_types" },
-          {
-            "u_add_morale": "morale_haircut",
-            "bonus": 3,
-            "max_bonus": 5,
-            "duration": "30 minutes",
-            "decay_start": "30 minutes"
-          },
-          { "run_eoc_with": "reset_natural_hair_color", "variables": { "trait_id": "hair_mullet" } }
-        ],
-        "topic": "TALK_DONE"
-      },
-      {
         "text": "Get a bun cut.",
         "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
         "effect": [


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix haircutting"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
EOC barber_hair, that used by makeshift haircut kit and barber NPCs, has several problems.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
1. If the character's natural hair color is not set when haircutting, random natural hair color trait is assigned. But the hair color is controlled by the variables which are set by processed_eocs of the trait and they become valid after the next turn. So haircutting fails at the first time.
2. Once the natural hair color is set, it cannot be changed anymore even if the character gain another hair color trait. This can currently occur only by debug, but the new hair color changing feature, such as graying of hair as age, is possible. 
3. Some hair styles are not reset, so the character gains 2 hait styles at the same time.
4. Responses of mullet are duplicated.

#### Describe the solution
1&2. Make the natural hair color not to depend on the variables.
3&4. Simply fix.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Create character without any natural hair color trait and use a makeshift haircut kit. The hair style can be changed properly.
When create character with a trait, the hair style is changed properly and random assignment of hair color does not occur.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
