### PR TITLE
Add indoor flagpole and use it for Hub01 American flags

### DIFF
--- a/data/json/furniture_and_terrain/furniture-decorative.json
+++ b/data/json/furniture_and_terrain/furniture-decorative.json
@@ -334,5 +334,25 @@
       "sound_vol": 16,
       "items": [ { "item": "glass_shard", "count": [ 25, 50 ] }, { "item": "splinter", "count": [ 5, 15 ] } ]
     }
+  },
+  {
+    "type": "furniture",
+    "id": "f_indoor_flagpole",
+    "name": "indoor flagpole",
+    "description": "A 2.5-meter tall flagpole on a weighted stand.  You could hoist up a flag here.",
+    "symbol": "F",
+    "color": "light_gray",
+    "move_cost_mod": 2,
+    "coverage": 20,
+    "required_str": 1,
+    "flags": [ "TRANSPARENT", "PLACE_ITEM" ],
+    "max_volume": "2 L",
+    "bash": {
+      "str_min": 10,
+      "str_max": 30,
+      "sound": "crunch!",
+      "sound_fail": "whack!",
+      "items": [ { "item": "material_aluminium_ingot", "count": [ 4, 8 ] }, { "item": "scrap", "count": [ 2, 6 ] } ]
+    }
   }
 ]

--- a/data/json/mapgen/robofachq_static.json
+++ b/data/json/mapgen/robofachq_static.json
@@ -380,7 +380,7 @@
         "M": "t_ramp_up_high",
         "m": "t_ramp_up_low"
       },
-      "furniture": { "6": "f_console", ":": "f_server", "f": "f_filing_cabinet" },
+      "furniture": { "6": "f_console", ":": "f_server", "f": "f_filing_cabinet", "A": "f_indoor_flagpole" },
       "item": { "A": { "item": "american_flag" } },
       "items": { "f": { "item": "file_room", "chance": 100, "repeat": [ 10, 30 ] } },
       "monster": { "T": { "monster": "mon_robofac_laserturret_mk1" } },
@@ -459,7 +459,15 @@
         "R": "t_railing",
         "W": "t_water_dispenser"
       },
-      "furniture": { "6": "f_console", ":": "f_server", "K": "f_counter", "H": "f_armchair", "L": "f_locker", "f": "f_filing_cabinet" },
+      "furniture": {
+        "6": "f_console",
+        ":": "f_server",
+        "K": "f_counter",
+        "H": "f_armchair",
+        "L": "f_locker",
+        "f": "f_filing_cabinet",
+        "A": "f_indoor_flagpole"
+      },
       "item": { "A": { "item": "american_flag" } },
       "items": {
         "F": { "item": "fridge", "chance": 80 },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Currently Hub01 has American flags just lying on the floor. That won't do.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add a new flagpole item for indoor flags and insert the flag into it.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Flag + pole spawns as expected
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Unfortunately it doesn't seem like looks_like works with layered furniture sprites so I can't looks_like f_flagpole for interim sprite solution, hopefully some kind soul will sprite these.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
