### PR TITLE
Update notice about camp zones changing... five years ago

### DIFF
--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -5357,8 +5357,7 @@ bool basecamp::validate_sort_points()
 
 bool basecamp::set_sort_points()
 {
-    popup( _( "Sorting zones have changed.  Please create some sorting zones.  "
-              "You must create a camp food zone, and a camp storage zone." ) );
+    popup( _( "Please create some sorting zones.  You must create a camp food zone, and a camp storage zone." ) );
     g->zones_manager();
     return validate_sort_points();
 }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
When first setting up your camp it'll tell you "Camp zones have changed, please make some zones blah blah blah"

It's told me this for basically the entire time I've been playing CDDA. Blame shows they changed *five years ago*. I think people have gotten the message.

I've seen this confuse people, too, so I'm not just doing this to make more work for the translators.

#### Describe the solution
Just remove the reference to them changing.

#### Describe alternatives you've considered


#### Testing
![image](https://github.com/user-attachments/assets/c76dfb85-a5b4-42e1-9d78-d4440ed7d8f4)


#### Additional context
