### PR TITLE
Shorten skull-specific harvestgroups with the power of ``extend``

### DIFF
--- a/data/json/harvest.json
+++ b/data/json/harvest.json
@@ -584,28 +584,6 @@
     ]
   },
   {
-    "id": "mammal_fur_canis",
-    "//": "drops regular stomach and canis skull",
-    "type": "harvest",
-    "entries": [
-      { "drop": "skull_canis", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
-      { "drop": "meat", "type": "flesh", "mass_ratio": 0.3 },
-      { "drop": "meat_scrap", "type": "flesh", "mass_ratio": 0.03 },
-      { "drop": "lung", "type": "flesh", "mass_ratio": 0.0035 },
-      { "drop": "animal_blood", "type": "blood", "mass_ratio": 0.1 },
-      { "drop": "liver", "type": "offal", "mass_ratio": 0.01 },
-      { "drop": "brain", "type": "flesh", "mass_ratio": 0.005 },
-      { "drop": "sweetbread", "type": "flesh", "mass_ratio": 0.002 },
-      { "drop": "kidney", "type": "offal", "mass_ratio": 0.002 },
-      { "drop": "stomach", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
-      { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "bone_marrow", "type": "bone", "mass_ratio": 0.005 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
-      { "drop": "raw_fur", "type": "skin", "mass_ratio": 0.02 },
-      { "drop": "fat", "type": "flesh", "mass_ratio": 0.07 }
-    ]
-  },
-  {
     "id": "mutant_mammal_fur",
     "//": "drops regular stomach",
     "type": "harvest",
@@ -2259,576 +2237,203 @@
   {
     "id": "rat_with_skull",
     "type": "harvest",
-    "entries": [
-      { "drop": "skull_rodent", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
-      { "drop": "meat_scrap", "type": "flesh", "mass_ratio": 0.5 },
-      { "drop": "animal_blood", "type": "blood", "mass_ratio": 0.1 }
-    ]
+    "copy-from": "mammal_tiny",
+    "extend": { "entries": [ { "drop": "skull_rodent", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 } ] }
   },
   {
     "id": "dog_small_with_skull",
     "type": "harvest",
-    "entries": [
-      { "drop": "skull_canis_medium", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
-      { "drop": "meat_scrap", "type": "flesh", "mass_ratio": 0.5 },
-      { "drop": "animal_blood", "type": "blood", "mass_ratio": 0.1 }
-    ]
+    "copy-from": "mammal_tiny",
+    "extend": { "entries": [ { "drop": "skull_canis_medium", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 } ] }
   },
   {
     "id": "dog_small_with_skull_mutant",
     "type": "harvest",
-    "entries": [
-      { "drop": "skull_canis_medium", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
-      { "drop": "mutant_meat_scrap", "type": "flesh", "mass_ratio": 0.5 },
-      { "drop": "mutant_blood", "type": "blood", "mass_ratio": 0.1 }
-    ]
+    "copy-from": "mutant_tiny",
+    "extend": { "entries": [ { "drop": "skull_canis_medium", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 } ] }
   },
   {
     "id": "cat_small_with_skull",
     "type": "harvest",
-    "entries": [
-      { "drop": "skull_feline_small", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
-      { "drop": "meat_scrap", "type": "flesh", "mass_ratio": 0.5 },
-      { "drop": "animal_blood", "type": "blood", "mass_ratio": 0.1 }
-    ]
+    "copy-from": "mammal_tiny",
+    "extend": { "entries": [ { "drop": "skull_feline_small", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 } ] }
   },
   {
     "id": "pig_with_skull",
     "type": "harvest",
-    "entries": [
-      { "drop": "skull_pig", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
-      { "drop": "meat", "type": "flesh", "mass_ratio": 0.29 },
-      { "drop": "meat_scrap", "type": "flesh", "mass_ratio": 0.01 },
-      { "drop": "lung", "type": "flesh", "mass_ratio": 0.0035 },
-      { "drop": "liver", "type": "offal", "mass_ratio": 0.01 },
-      { "drop": "animal_blood", "type": "blood", "mass_ratio": 0.1 },
-      { "drop": "brain", "type": "flesh", "mass_ratio": 0.005 },
-      { "drop": "sweetbread", "type": "flesh", "mass_ratio": 0.002 },
-      { "drop": "kidney", "type": "offal", "mass_ratio": 0.002 },
-      { "drop": "stomach_large", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
-      { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "bone_marrow", "type": "bone", "mass_ratio": 0.005 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
-      { "drop": "raw_leather", "type": "skin", "mass_ratio": 0.02 },
-      { "drop": "fat", "type": "flesh", "mass_ratio": 0.04 },
-      { "drop": "porkbelly", "type": "flesh", "mass_ratio": 0.06 }
-    ]
+    "copy-from": "mammal_large_pig",
+    "extend": { "entries": [ { "drop": "skull_pig", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 } ] }
   },
   {
     "id": "boar_with_skull",
     "type": "harvest",
-    "entries": [
-      { "drop": "skull_pig", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
-      { "drop": "meat", "type": "flesh", "mass_ratio": 0.29 },
-      { "drop": "meat_scrap", "type": "flesh", "mass_ratio": 0.01 },
-      { "drop": "lung", "type": "flesh", "mass_ratio": 0.0035 },
-      { "drop": "liver", "type": "offal", "mass_ratio": 0.01 },
-      { "drop": "animal_blood", "type": "blood", "mass_ratio": 0.1 },
-      { "drop": "brain", "type": "flesh", "mass_ratio": 0.005 },
-      { "drop": "sweetbread", "type": "flesh", "mass_ratio": 0.002 },
-      { "drop": "kidney", "type": "offal", "mass_ratio": 0.002 },
-      { "drop": "stomach_large", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
-      { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "bone_marrow", "type": "bone", "mass_ratio": 0.005 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
-      { "drop": "raw_fur", "type": "skin", "mass_ratio": 0.02 },
-      { "drop": "fat", "type": "flesh", "mass_ratio": 0.04 },
-      { "drop": "porkbelly", "type": "flesh", "mass_ratio": 0.06 }
-    ]
+    "copy-from": "mammal_large_boar",
+    "extend": { "entries": [ { "drop": "skull_pig", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 } ] }
   },
   {
     "id": "sheep_with_skull",
     "type": "harvest",
-    "entries": [
-      { "drop": "skull_sheep", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
-      { "drop": "meat", "type": "flesh", "mass_ratio": 0.32 },
-      { "drop": "meat_scrap", "type": "flesh", "mass_ratio": 0.01 },
-      { "drop": "lung", "type": "flesh", "mass_ratio": 0.0035 },
-      { "drop": "liver", "type": "offal", "mass_ratio": 0.01 },
-      { "drop": "animal_blood", "type": "blood", "mass_ratio": 0.1 },
-      { "drop": "brain", "type": "flesh", "mass_ratio": 0.005 },
-      { "drop": "sweetbread", "type": "flesh", "mass_ratio": 0.002 },
-      { "drop": "kidney", "type": "offal", "mass_ratio": 0.002 },
-      { "drop": "stomach_large", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
-      { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "bone_marrow", "type": "bone", "mass_ratio": 0.005 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
-      { "drop": "wool_staple", "type": "skin", "mass_ratio": 0.21 },
-      { "drop": "fat", "type": "flesh", "mass_ratio": 0.07 }
-    ]
+    "copy-from": "mammal_large_wool",
+    "extend": { "entries": [ { "drop": "skull_sheep", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 } ] }
   },
   {
     "id": "goat_with_skull",
     "type": "harvest",
-    "entries": [
-      { "drop": "skull_goat", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
-      { "drop": "meat", "type": "flesh", "mass_ratio": 0.32 },
-      { "drop": "meat_scrap", "type": "flesh", "mass_ratio": 0.01 },
-      { "drop": "lung", "type": "flesh", "mass_ratio": 0.0035 },
-      { "drop": "liver", "type": "offal", "mass_ratio": 0.01 },
-      { "drop": "animal_blood", "type": "blood", "mass_ratio": 0.1 },
-      { "drop": "brain", "type": "flesh", "mass_ratio": 0.005 },
-      { "drop": "sweetbread", "type": "flesh", "mass_ratio": 0.002 },
-      { "drop": "kidney", "type": "offal", "mass_ratio": 0.002 },
-      { "drop": "stomach_large", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
-      { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "bone_marrow", "type": "bone", "mass_ratio": 0.005 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
-      { "drop": "wool_staple", "type": "skin", "mass_ratio": 0.21 },
-      { "drop": "fat", "type": "flesh", "mass_ratio": 0.07 }
-    ]
+    "copy-from": "mammal_large_wool",
+    "extend": { "entries": [ { "drop": "skull_goat", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 } ] }
   },
   {
     "id": "cow_with_skull",
     "type": "harvest",
-    "entries": [
-      { "drop": "skull_bovine", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
-      { "drop": "meat", "type": "flesh", "mass_ratio": 0.32 },
-      { "drop": "meat_scrap", "type": "flesh", "mass_ratio": 0.01 },
-      { "drop": "lung", "type": "flesh", "mass_ratio": 0.0035 },
-      { "drop": "liver", "type": "offal", "mass_ratio": 0.01 },
-      { "drop": "animal_blood", "type": "blood", "mass_ratio": 0.1 },
-      { "drop": "brain", "type": "flesh", "mass_ratio": 0.005 },
-      { "drop": "sweetbread", "type": "flesh", "mass_ratio": 0.002 },
-      { "drop": "kidney", "type": "offal", "mass_ratio": 0.002 },
-      { "drop": "stomach_large", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
-      { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "bone_marrow", "type": "bone", "mass_ratio": 0.005 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
-      { "drop": "raw_leather", "type": "skin", "mass_ratio": 0.02 },
-      { "drop": "fat", "type": "flesh", "mass_ratio": 0.07 }
-    ]
+    "copy-from": "mammal_large_leather",
+    "extend": { "entries": [ { "drop": "skull_bovine", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 } ] }
   },
   {
     "id": "horse_with_skull",
     "type": "harvest",
-    "entries": [
-      { "drop": "skull_equine", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
-      { "drop": "meat", "type": "flesh", "mass_ratio": 0.32 },
-      { "drop": "meat_scrap", "type": "flesh", "mass_ratio": 0.01 },
-      { "drop": "lung", "type": "flesh", "mass_ratio": 0.0035 },
-      { "drop": "liver", "type": "offal", "mass_ratio": 0.01 },
-      { "drop": "animal_blood", "type": "blood", "mass_ratio": 0.1 },
-      { "drop": "brain", "type": "flesh", "mass_ratio": 0.005 },
-      { "drop": "sweetbread", "type": "flesh", "mass_ratio": 0.002 },
-      { "drop": "kidney", "type": "offal", "mass_ratio": 0.002 },
-      { "drop": "stomach_large", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
-      { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "bone_marrow", "type": "bone", "mass_ratio": 0.005 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
-      { "drop": "raw_leather", "type": "skin", "mass_ratio": 0.02 },
-      { "drop": "fat", "type": "flesh", "mass_ratio": 0.07 }
-    ]
+    "copy-from": "mammal_large_leather",
+    "extend": { "entries": [ { "drop": "skull_equine", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 } ] }
   },
   {
     "id": "deer_with_skull",
     "type": "harvest",
-    "entries": [
-      { "drop": "skull_cervine", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
-      { "drop": "meat", "type": "flesh", "mass_ratio": 0.32 },
-      { "drop": "meat_scrap", "type": "flesh", "mass_ratio": 0.01 },
-      { "drop": "lung", "type": "flesh", "mass_ratio": 0.0035 },
-      { "drop": "liver", "type": "offal", "mass_ratio": 0.01 },
-      { "drop": "animal_blood", "type": "blood", "mass_ratio": 0.1 },
-      { "drop": "brain", "type": "flesh", "mass_ratio": 0.005 },
-      { "drop": "sweetbread", "type": "flesh", "mass_ratio": 0.002 },
-      { "drop": "kidney", "type": "offal", "mass_ratio": 0.002 },
-      { "drop": "stomach_large", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
-      { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "bone_marrow", "type": "bone", "mass_ratio": 0.005 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
-      { "drop": "raw_leather", "type": "skin", "mass_ratio": 0.02 },
-      { "drop": "fat", "type": "flesh", "mass_ratio": 0.07 }
-    ]
+    "copy-from": "mammal_large_leather",
+    "extend": { "entries": [ { "drop": "skull_cervine", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 } ] }
   },
   {
     "id": "moose_with_skull",
     "type": "harvest",
-    "entries": [
-      { "drop": "skull_moose", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
-      { "drop": "meat", "type": "flesh", "mass_ratio": 0.32 },
-      { "drop": "meat_scrap", "type": "flesh", "mass_ratio": 0.01 },
-      { "drop": "lung", "type": "flesh", "mass_ratio": 0.0035 },
-      { "drop": "liver", "type": "offal", "mass_ratio": 0.01 },
-      { "drop": "animal_blood", "type": "blood", "mass_ratio": 0.1 },
-      { "drop": "brain", "type": "flesh", "mass_ratio": 0.005 },
-      { "drop": "sweetbread", "type": "flesh", "mass_ratio": 0.002 },
-      { "drop": "kidney", "type": "offal", "mass_ratio": 0.002 },
-      { "drop": "stomach_large", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
-      { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "bone_marrow", "type": "bone", "mass_ratio": 0.005 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
-      { "drop": "raw_fur", "type": "skin", "mass_ratio": 0.02 },
-      { "drop": "fat", "type": "flesh", "mass_ratio": 0.07 }
-    ]
+    "copy-from": "mammal_large_fur",
+    "extend": { "entries": [ { "drop": "skull_moose", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 } ] }
   },
   {
     "id": "tusked_moose_with_skull",
     "type": "harvest",
-    "entries": [
-      { "drop": "skull_moose_tusked", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
-      { "drop": "mutant_meat", "type": "flesh", "mass_ratio": 0.32 },
-      { "drop": "mutant_meat_scrap", "type": "flesh", "mass_ratio": 0.01 },
-      { "drop": "mutant_lung", "type": "offal", "mass_ratio": 0.0035 },
-      { "drop": "mutant_blood", "type": "blood", "mass_ratio": 0.1 },
-      { "drop": "mutant_liver", "type": "offal", "mass_ratio": 0.01 },
-      { "drop": "mutant_brain", "type": "offal", "mass_ratio": 0.005 },
-      { "drop": "mutant_kidney", "type": "offal", "mass_ratio": 0.002 },
-      { "drop": "stomach_large", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
-      { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "mutant_marrow", "type": "bone", "mass_ratio": 0.005 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
-      { "drop": "raw_fur", "type": "skin", "mass_ratio": 0.02 },
-      { "drop": "mutant_fat", "type": "flesh", "mass_ratio": 0.07 }
-    ]
+    "copy-from": "mutant_mammal_large_fur",
+    "extend": { "entries": [ { "drop": "skull_moose_tusked", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 } ] }
   },
   {
     "id": "dog_small_with_skull_leather",
     "type": "harvest",
-    "entries": [
-      { "drop": "skull_canis_medium", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
-      { "drop": "meat", "type": "flesh", "mass_ratio": 0.28 },
-      { "drop": "meat_scrap", "type": "flesh", "mass_ratio": 0.05 },
-      { "drop": "lung", "type": "flesh", "mass_ratio": 0.0035 },
-      { "drop": "animal_blood", "type": "blood", "mass_ratio": 0.1 },
-      { "drop": "liver", "type": "offal", "mass_ratio": 0.01 },
-      { "drop": "brain", "type": "flesh", "mass_ratio": 0.005 },
-      { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
-      { "drop": "raw_leather", "type": "skin", "mass_ratio": 0.02 },
-      { "drop": "fat", "type": "flesh", "mass_ratio": 0.07 }
-    ]
+    "copy-from": "mammal_small_leather",
+    "extend": { "entries": [ { "drop": "skull_canis_medium", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 } ] }
   },
   {
     "id": "dog_small_with_skull_fur",
     "type": "harvest",
-    "entries": [
-      { "drop": "skull_canis_medium", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
-      { "drop": "meat", "type": "flesh", "mass_ratio": 0.28 },
-      { "drop": "meat_scrap", "type": "flesh", "mass_ratio": 0.05 },
-      { "drop": "lung", "type": "flesh", "mass_ratio": 0.0035 },
-      { "drop": "liver", "type": "offal", "mass_ratio": 0.01 },
-      { "drop": "brain", "type": "flesh", "mass_ratio": 0.005 },
-      { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "animal_blood", "type": "blood", "mass_ratio": 0.1 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
-      { "drop": "raw_fur", "type": "skin", "mass_ratio": 0.02 },
-      { "drop": "fat", "type": "flesh", "mass_ratio": 0.07 }
-    ]
+    "copy-from": "mammal_small_fur",
+    "extend": { "entries": [ { "drop": "skull_canis_medium", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 } ] }
   },
   {
     "id": "incubator_mammal_deer",
     "type": "harvest",
-    "message": "<incubator_mammal>",
-    "entries": [
-      { "drop": "skull_cervine", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
-      { "drop": "meat", "type": "flesh", "mass_ratio": 0.05 },
-      { "drop": "mutant_meat", "type": "flesh", "mass_ratio": 0.2 },
-      { "drop": "meat_scrap", "type": "flesh", "mass_ratio": 0.1 },
-      { "drop": "stomach", "scale_num": [ 0, 1 ], "max": 1, "type": "offal" },
-      { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 }
-    ]
+    "copy-from": "incubator_mammal",
+    "extend": { "entries": [ { "drop": "skull_cervine", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 } ] }
   },
   {
     "id": "incubator_mammal_dog",
     "type": "harvest",
-    "message": "<incubator_mammal>",
-    "entries": [
-      { "drop": "skull_canis", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
-      { "drop": "meat", "type": "flesh", "mass_ratio": 0.05 },
-      { "drop": "mutant_meat", "type": "flesh", "mass_ratio": 0.2 },
-      { "drop": "meat_scrap", "type": "flesh", "mass_ratio": 0.1 },
-      { "drop": "stomach", "scale_num": [ 0, 1 ], "max": 1, "type": "offal" },
-      { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 }
-    ]
+    "copy-from": "incubator_mammal",
+    "extend": { "entries": [ { "drop": "skull_canis", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 } ] }
   },
   {
     "id": "dog_with_skull_fur",
     "type": "harvest",
-    "entries": [
-      { "drop": "skull_canis", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
-      { "drop": "meat", "type": "flesh", "mass_ratio": 0.28 },
-      { "drop": "meat_scrap", "type": "flesh", "mass_ratio": 0.05 },
-      { "drop": "lung", "type": "flesh", "mass_ratio": 0.0035 },
-      { "drop": "liver", "type": "offal", "mass_ratio": 0.01 },
-      { "drop": "brain", "type": "flesh", "mass_ratio": 0.005 },
-      { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "animal_blood", "type": "blood", "mass_ratio": 0.1 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
-      { "drop": "raw_fur", "type": "skin", "mass_ratio": 0.02 },
-      { "drop": "fat", "type": "flesh", "mass_ratio": 0.07 }
-    ]
+    "copy-from": "mammal_fur",
+    "extend": { "entries": [ { "drop": "skull_canis", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 } ] }
   },
   {
     "id": "dog_with_skull_fur_mutant",
     "type": "harvest",
-    "entries": [
-      { "drop": "skull_canis", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
-      { "drop": "mutant_meat", "type": "flesh", "mass_ratio": 0.28 },
-      { "drop": "mutant_meat_scrap", "type": "flesh", "mass_ratio": 0.05 },
-      { "drop": "mutant_lung", "type": "flesh", "mass_ratio": 0.0035 },
-      { "drop": "mutant_liver", "type": "offal", "mass_ratio": 0.01 },
-      { "drop": "mutant_brain", "type": "flesh", "mass_ratio": 0.005 },
-      { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "mutant_blood", "type": "blood", "mass_ratio": 0.1 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
-      { "drop": "raw_fur", "type": "skin", "mass_ratio": 0.02 },
-      { "drop": "mutant_fat", "type": "flesh", "mass_ratio": 0.07 }
-    ]
+    "copy-from": "mutant_mammal_fur",
+    "extend": { "entries": [ { "drop": "skull_canis", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 } ] }
   },
   {
     "id": "dog_with_skull_leather",
     "type": "harvest",
-    "entries": [
-      { "drop": "skull_canis", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
-      { "drop": "meat", "type": "flesh", "mass_ratio": 0.28 },
-      { "drop": "meat_scrap", "type": "flesh", "mass_ratio": 0.05 },
-      { "drop": "lung", "type": "flesh", "mass_ratio": 0.0035 },
-      { "drop": "animal_blood", "type": "blood", "mass_ratio": 0.1 },
-      { "drop": "liver", "type": "offal", "mass_ratio": 0.01 },
-      { "drop": "brain", "type": "flesh", "mass_ratio": 0.005 },
-      { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
-      { "drop": "raw_leather", "type": "skin", "mass_ratio": 0.02 },
-      { "drop": "fat", "type": "flesh", "mass_ratio": 0.07 }
-    ]
+    "copy-from": "mammal_leather",
+    "extend": { "entries": [ { "drop": "skull_canis", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 } ] }
   },
   {
     "id": "dog_tiny_with_skull",
     "type": "harvest",
-    "entries": [
-      { "drop": "skull_canis_small", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
-      { "drop": "meat_scrap", "type": "flesh", "mass_ratio": 0.5 },
-      { "drop": "animal_blood", "type": "blood", "mass_ratio": 0.1 }
-    ]
+    "copy-from": "mammal_tiny",
+    "extend": { "entries": [ { "drop": "skull_canis_small", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 } ] }
   },
   {
     "id": "llama_with_skull",
     "type": "harvest",
-    "entries": [
-      { "drop": "skull_llama", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
-      { "drop": "meat", "type": "flesh", "mass_ratio": 0.32 },
-      { "drop": "meat_scrap", "type": "flesh", "mass_ratio": 0.01 },
-      { "drop": "lung", "type": "flesh", "mass_ratio": 0.0035 },
-      { "drop": "liver", "type": "offal", "mass_ratio": 0.01 },
-      { "drop": "animal_blood", "type": "blood", "mass_ratio": 0.1 },
-      { "drop": "brain", "type": "flesh", "mass_ratio": 0.005 },
-      { "drop": "sweetbread", "type": "flesh", "mass_ratio": 0.002 },
-      { "drop": "kidney", "type": "offal", "mass_ratio": 0.002 },
-      { "drop": "stomach_large", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
-      { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "bone_marrow", "type": "bone", "mass_ratio": 0.005 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
-      { "drop": "wool_staple", "type": "skin", "mass_ratio": 0.21 },
-      { "drop": "fat", "type": "flesh", "mass_ratio": 0.07 }
-    ]
+    "copy-from": "mammal_large_wool",
+    "extend": { "entries": [ { "drop": "skull_llama", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 } ] }
   },
   {
     "id": "cat_medium_with_skull",
     "type": "harvest",
-    "entries": [
-      { "drop": "skull_feline_medium", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
-      { "drop": "meat", "type": "flesh", "mass_ratio": 0.28 },
-      { "drop": "meat_scrap", "type": "flesh", "mass_ratio": 0.05 },
-      { "drop": "lung", "type": "flesh", "mass_ratio": 0.0035 },
-      { "drop": "liver", "type": "offal", "mass_ratio": 0.01 },
-      { "drop": "brain", "type": "flesh", "mass_ratio": 0.005 },
-      { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "animal_blood", "type": "blood", "mass_ratio": 0.1 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
-      { "drop": "raw_fur", "type": "skin", "mass_ratio": 0.02 },
-      { "drop": "fat", "type": "flesh", "mass_ratio": 0.07 }
-    ]
+    "copy-from": "mammal_small_fur",
+    "extend": { "entries": [ { "drop": "skull_feline_medium", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 } ] }
   },
   {
     "id": "cougar_with_skull",
     "type": "harvest",
-    "entries": [
-      { "drop": "skull_cougar", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
-      { "drop": "meat", "type": "flesh", "mass_ratio": 0.3 },
-      { "drop": "meat_scrap", "type": "flesh", "mass_ratio": 0.03 },
-      { "drop": "lung", "type": "flesh", "mass_ratio": 0.0035 },
-      { "drop": "animal_blood", "type": "blood", "mass_ratio": 0.1 },
-      { "drop": "liver", "type": "offal", "mass_ratio": 0.01 },
-      { "drop": "brain", "type": "flesh", "mass_ratio": 0.005 },
-      { "drop": "sweetbread", "type": "flesh", "mass_ratio": 0.002 },
-      { "drop": "kidney", "type": "offal", "mass_ratio": 0.002 },
-      { "drop": "stomach", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
-      { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "bone_marrow", "type": "bone", "mass_ratio": 0.005 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
-      { "drop": "raw_fur", "type": "skin", "mass_ratio": 0.02 },
-      { "drop": "fat", "type": "flesh", "mass_ratio": 0.07 }
-    ]
+    "copy-from": "mammal_fur",
+    "extend": { "entries": [ { "drop": "skull_cougar", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 } ] }
   },
   {
     "id": "raccoon_with_skull",
     "type": "harvest",
-    "entries": [
-      { "drop": "skull_raccoon", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
-      { "drop": "meat", "type": "flesh", "mass_ratio": 0.28 },
-      { "drop": "meat_scrap", "type": "flesh", "mass_ratio": 0.05 },
-      { "drop": "lung", "type": "flesh", "mass_ratio": 0.0035 },
-      { "drop": "liver", "type": "offal", "mass_ratio": 0.01 },
-      { "drop": "brain", "type": "flesh", "mass_ratio": 0.005 },
-      { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "animal_blood", "type": "blood", "mass_ratio": 0.1 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
-      { "drop": "raw_fur", "type": "skin", "mass_ratio": 0.02 },
-      { "drop": "fat", "type": "flesh", "mass_ratio": 0.07 }
-    ]
+    "copy-from": "mammal_small_fur",
+    "extend": { "entries": [ { "drop": "skull_raccoon", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 } ] }
   },
   {
     "id": "raccoon_with_skull_mutant",
     "type": "harvest",
-    "entries": [
-      { "drop": "skull_raccoon", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
-      { "drop": "mutant_meat", "type": "flesh", "mass_ratio": 0.28 },
-      { "drop": "mutant_meat_scrap", "type": "flesh", "mass_ratio": 0.05 },
-      { "drop": "mutant_lung", "type": "flesh", "mass_ratio": 0.0035 },
-      { "drop": "mutant_liver", "type": "offal", "mass_ratio": 0.01 },
-      { "drop": "mutant_brain", "type": "flesh", "mass_ratio": 0.005 },
-      { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "mutant_blood", "type": "blood", "mass_ratio": 0.1 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
-      { "drop": "raw_fur", "type": "skin", "mass_ratio": 0.02 },
-      { "drop": "mutant_fat", "type": "flesh", "mass_ratio": 0.07 }
-    ]
+    "copy-from": "mutant_mammal_small_fur",
+    "extend": { "entries": [ { "drop": "skull_raccoon", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 } ] }
   },
   {
     "id": "bear_with_skull",
     "type": "harvest",
-    "entries": [
-      { "drop": "skull_bear", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
-      { "drop": "meat", "type": "flesh", "mass_ratio": 0.32 },
-      { "drop": "meat_scrap", "type": "flesh", "mass_ratio": 0.01 },
-      { "drop": "lung", "type": "flesh", "mass_ratio": 0.0035 },
-      { "drop": "liver", "type": "offal", "mass_ratio": 0.01 },
-      { "drop": "animal_blood", "type": "blood", "mass_ratio": 0.1 },
-      { "drop": "brain", "type": "flesh", "mass_ratio": 0.005 },
-      { "drop": "sweetbread", "type": "flesh", "mass_ratio": 0.002 },
-      { "drop": "kidney", "type": "offal", "mass_ratio": 0.002 },
-      { "drop": "stomach_large", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
-      { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "bone_marrow", "type": "bone", "mass_ratio": 0.005 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
-      { "drop": "raw_fur", "type": "skin", "mass_ratio": 0.02 },
-      { "drop": "fat", "type": "flesh", "mass_ratio": 0.07 }
-    ]
+    "copy-from": "mammal_large_fur",
+    "extend": { "entries": [ { "drop": "skull_bear", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 } ] }
   },
   {
     "id": "opossum_with_skull",
     "type": "harvest",
-    "entries": [
-      { "drop": "skull_opossum", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
-      { "drop": "meat", "type": "flesh", "mass_ratio": 0.28 },
-      { "drop": "meat_scrap", "type": "flesh", "mass_ratio": 0.05 },
-      { "drop": "lung", "type": "flesh", "mass_ratio": 0.0035 },
-      { "drop": "liver", "type": "offal", "mass_ratio": 0.01 },
-      { "drop": "brain", "type": "flesh", "mass_ratio": 0.005 },
-      { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "animal_blood", "type": "blood", "mass_ratio": 0.1 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
-      { "drop": "raw_fur", "type": "skin", "mass_ratio": 0.02 },
-      { "drop": "fat", "type": "flesh", "mass_ratio": 0.07 }
-    ]
+    "copy-from": "mammal_small_fur",
+    "extend": { "entries": [ { "drop": "skull_opossum", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 } ] }
   },
   {
     "id": "skunk_with_skull",
     "type": "harvest",
-    "entries": [
-      { "drop": "skull_skunk", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
-      { "drop": "meat", "type": "flesh", "mass_ratio": 0.28 },
-      { "drop": "meat_scrap", "type": "flesh", "mass_ratio": 0.05 },
-      { "drop": "lung", "type": "flesh", "mass_ratio": 0.0035 },
-      { "drop": "liver", "type": "offal", "mass_ratio": 0.01 },
-      { "drop": "brain", "type": "flesh", "mass_ratio": 0.005 },
-      { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "animal_blood", "type": "blood", "mass_ratio": 0.1 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
-      { "drop": "raw_fur", "type": "skin", "mass_ratio": 0.02 },
-      { "drop": "fat", "type": "flesh", "mass_ratio": 0.07 }
-    ]
+    "copy-from": "mammal_small_fur",
+    "extend": { "entries": [ { "drop": "skull_skunk", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 } ] }
   },
   {
     "id": "beaver_with_skull",
     "type": "harvest",
-    "entries": [
-      { "drop": "skull_beaver", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
-      { "drop": "meat", "type": "flesh", "mass_ratio": 0.28 },
-      { "drop": "meat_scrap", "type": "flesh", "mass_ratio": 0.05 },
-      { "drop": "lung", "type": "flesh", "mass_ratio": 0.0035 },
-      { "drop": "liver", "type": "offal", "mass_ratio": 0.01 },
-      { "drop": "brain", "type": "flesh", "mass_ratio": 0.005 },
-      { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "animal_blood", "type": "blood", "mass_ratio": 0.1 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
-      { "drop": "raw_fur", "type": "skin", "mass_ratio": 0.02 },
-      { "drop": "fat", "type": "flesh", "mass_ratio": 0.07 }
-    ]
+    "copy-from": "mammal_small_fur",
+    "extend": { "entries": [ { "drop": "skull_beaver", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 } ] }
   },
   {
     "id": "dog_triclopean_with_skull",
     "type": "harvest",
-    "entries": [
-      { "drop": "skull_canis_triclopean", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
-      { "drop": "meat", "type": "flesh", "mass_ratio": 0.28 },
-      { "drop": "meat_scrap", "type": "flesh", "mass_ratio": 0.05 },
-      { "drop": "lung", "type": "flesh", "mass_ratio": 0.0035 },
-      { "drop": "liver", "type": "offal", "mass_ratio": 0.01 },
-      { "drop": "brain", "type": "flesh", "mass_ratio": 0.005 },
-      { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "animal_blood", "type": "blood", "mass_ratio": 0.1 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
-      { "drop": "raw_fur", "type": "skin", "mass_ratio": 0.02 },
-      { "drop": "fat", "type": "flesh", "mass_ratio": 0.07 }
-    ]
+    "copy-from": "mammal_small_fur",
+    "extend": { "entries": [ { "drop": "skull_canis_triclopean", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 } ] }
   },
   {
     "id": "spideer_with_skull",
     "type": "harvest",
-    "entries": [
-      { "drop": "skull_cervine_spideer", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
-      { "drop": "mutant_meat", "type": "flesh", "mass_ratio": 0.32 },
-      { "drop": "mutant_meat_scrap", "type": "flesh", "mass_ratio": 0.01 },
-      { "drop": "mutant_lung", "type": "offal", "mass_ratio": 0.0035 },
-      { "drop": "mutant_liver", "type": "offal", "mass_ratio": 0.01 },
-      { "drop": "mutant_blood", "type": "blood", "mass_ratio": 0.1 },
-      { "drop": "mutant_brain", "type": "offal", "mass_ratio": 0.005 },
-      { "drop": "mutant_kidney", "type": "offal", "mass_ratio": 0.002 },
-      { "drop": "stomach_large", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
-      { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "mutant_marrow", "type": "bone", "mass_ratio": 0.005 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
-      { "drop": "raw_leather", "type": "skin", "mass_ratio": 0.02 },
-      { "drop": "mutant_fat", "type": "flesh", "mass_ratio": 0.07 }
-    ]
+    "copy-from": "mutant_mammal_large_leather",
+    "extend": { "entries": [ { "drop": "skull_cervine_spideer", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 } ] }
   },
   {
     "id": "cerbearus_with_skulls",
     "type": "harvest",
-    "entries": [
-      { "drop": "skull_bear", "type": "bone", "scale_num": [ 3, 3 ], "max": 3 },
-      { "drop": "mutant_meat", "type": "flesh", "mass_ratio": 0.32 },
-      { "drop": "mutant_meat_scrap", "type": "flesh", "mass_ratio": 0.01 },
-      { "drop": "mutant_lung", "type": "offal", "mass_ratio": 0.0035 },
-      { "drop": "mutant_blood", "type": "blood", "mass_ratio": 0.1 },
-      { "drop": "mutant_liver", "type": "offal", "mass_ratio": 0.01 },
-      { "drop": "mutant_brain", "type": "offal", "mass_ratio": 0.005 },
-      { "drop": "mutant_kidney", "type": "offal", "mass_ratio": 0.002 },
-      { "drop": "stomach_large", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
-      { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "mutant_marrow", "type": "bone", "mass_ratio": 0.005 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
-      { "drop": "raw_fur", "type": "skin", "mass_ratio": 0.02 },
-      { "drop": "mutant_fat", "type": "flesh", "mass_ratio": 0.07 }
-    ]
+    "copy-from": "mutant_mammal_large_fur",
+    "extend": { "entries": [ { "drop": "skull_bear", "type": "bone", "scale_num": [ 3, 3 ], "max": 3 } ] }
   },
   {
     "id": "rabbit_with_skull",
-    "//": "mammal_small_fur + skull_rabbit",
     "type": "harvest",
     "copy-from": "mammal_small_fur",
     "extend": { "entries": [ { "drop": "skull_rabbit", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 } ] }

--- a/data/json/items/resources/bone.json
+++ b/data/json/items/resources/bone.json
@@ -182,7 +182,7 @@
     "id": "skull_canis_triclopean",
     "name": { "str": "triclopean canine skull" },
     "description": "The skull of a what looks like a dog, although it has an extra eye socket.",
-    "copy-from": "skull_canis_medium"
+    "copy-from": "skull_canis"
   },
   {
     "type": "GENERIC",

--- a/data/json/monsters/mammal.json
+++ b/data/json/monsters/mammal.json
@@ -1425,7 +1425,7 @@
     "dodge": 2,
     "vision_night": 6,
     "stomach_size": 650,
-    "harvest": "mammal_fur_canis",
+    "harvest": "dog_with_skull_fur",
     "reproduction": { "baby_monster": "mon_dog_gpyrenees_pup", "baby_count": 7, "baby_timer": 320 },
     "//2": "1-7 puppies & 300-320 days per-litter for size medium canines"
   },
@@ -2626,7 +2626,7 @@
     "melee_damage": [ { "damage_type": "cut", "amount": 4 } ],
     "dodge": 4,
     "vision_night": 5,
-    "harvest": "mammal_fur_canis",
+    "harvest": "dog_with_skull_fur",
     "dissect": "dissect_lupine_sample_single",
     "weakpoint_sets": [ "wps_animal_quadruped" ],
     "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology", "prof_wp_canine" ],

--- a/data/json/monsters/mutant_mammal.json
+++ b/data/json/monsters/mutant_mammal.json
@@ -145,7 +145,7 @@
       { "id": "scratch_grab_required" }
     ],
     "stomach_size": 500,
-    "harvest": "mutant_mammal_fur",
+    "harvest": "dog_with_skull_fur_mutant",
     "path_settings": { "max_dist": 7 },
     "extend": { "flags": [ "NO_BREED" ] }
   },
@@ -159,7 +159,7 @@
     "melee_dice_sides": 8,
     "melee_damage": [ { "damage_type": "cut", "amount": 4 } ],
     "path_settings": { "max_dist": 7 },
-    "harvest": "mutant_mammal_fur",
+    "harvest": "dog_with_skull_fur_mutant",
     "extend": { "flags": [ "NO_BREED", "BADVENOM" ] }
   },
   {

--- a/data/mods/Xedra_Evolved/harvest.json
+++ b/data/mods/Xedra_Evolved/harvest.json
@@ -30,18 +30,9 @@
   },
   {
     "id": "fae_march_lord",
-    "//": "same as fae_changeling but with a skull.",
     "type": "harvest",
-    "entries": [
-      { "drop": "skull_march_lord", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
-      { "drop": "fae_meat", "type": "flesh", "mass_ratio": 0.3 },
-      { "drop": "fae_meat_scrap", "type": "flesh", "mass_ratio": 0.03 },
-      { "drop": "fae_organs", "type": "flesh", "mass_ratio": 0.1 },
-      { "drop": "fae_blood", "type": "blood", "mass_ratio": 0.1 },
-      { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
-      { "drop": "fat", "type": "flesh", "mass_ratio": 0.04 }
-    ]
+    "copy-from": "fae_changeling",
+    "extend": { "entries": [ { "drop": "skull_march_lord", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 } ] }
   },
   {
     "id": "stoneling",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
My prayers have been answered
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Shortened all skull-specific harvestgroups with ``copy-from`` and ``extend``
- Changed the base item for the triclopean dog skull since I messed that up last time I touched it
- Removed ``mammal_fur_canis``, replaced it with a functionally identical group we already had
- Gave mutant coyotes harvestgroups with skulls
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Making new harvestgroups for mutant beavers. Maybe next time, they still don't spawn currently and I am waiting for #75830 to tackle that
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested specifically for the incubator harvests with snippets - not only does the syntax work by extending, the snippets get carried over properly as well
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
More should be able to be done regarding some harvestgroups that differ only with snippets, but I think that warrants a separate PR as I did not author those harvestgroups and would need to compare them to be sure the snippets is truly the only difference
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
