### PR TITLE
casting a spell casts the wrong spell

### DIFF
--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1786,7 +1786,6 @@ static void cast_spell()
     if( sp.id().is_null() ) {
         return;
     }
-    // spell &sp = player_character.magic->get_spell( selected_spell_id );
     player_character.cast_spell( sp, false, std::nullopt );
 }
 

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1781,13 +1781,12 @@ static void cast_spell()
         }
     }
 
-    const int spell_index = player_character.magic->select_spell( player_character );
-    if( spell_index < 0 ) {
+    spell &sp = player_character.magic->select_spell( player_character );
+    // if no spell was selected
+    if( sp.id().is_null() ) {
         return;
     }
-
-    spell &sp = *player_character.magic->get_spells()[spell_index];
-
+    // spell &sp = player_character.magic->get_spell( selected_spell_id );
     player_character.cast_spell( sp, false, std::nullopt );
 }
 

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1,5 +1,4 @@
 #include "magic.h"
-#include "magic.h"
 
 #include <algorithm>
 #include <cmath>
@@ -2239,19 +2238,6 @@ std::vector<spell *> known_magic::get_spells()
     return spells;
 }
 
-int known_magic::get_spell_index( const spell_id& sp )
-{
-    int current_index = -1, result_index = -1;
-    for (auto& spell_pair : spellbook) {
-        current_index++;
-        if (spell_pair.first == sp) {
-            result_index = current_index;
-            break;
-        }
-    }
-    return result_index;
-}
-
 int known_magic::available_mana() const
 {
     return mana;
@@ -2826,7 +2812,7 @@ int known_magic::get_invlet( const spell_id &sp, std::set<int> &used_invlets )
     return 0;
 }
 
-int known_magic::select_spell( Character &guy )
+spell &known_magic::select_spell( Character &guy )
 {
     std::vector<spell *> known_spells_sorted = get_spells();
 
@@ -2919,10 +2905,12 @@ int known_magic::select_spell( Character &guy )
     spell_menu.query( true, 50, true );
 
     casting_ignore = static_cast<spellcasting_callback *>( spell_menu.callback )->casting_ignore;
-
+    if( spell_menu.ret < 0 ) {
+        static spell null_spell_reference(spell_id::NULL_ID());
+        return null_spell_reference;
+    }
     spell* selected_spell = known_spells_sorted[spell_menu.ret];
-    int original_spell_index = get_spell_index(selected_spell->id());
-    return original_spell_index;
+    return *selected_spell;
 }
 
 void known_magic::on_mutation_gain( const trait_id &mid, Character &guy )
@@ -2979,7 +2967,7 @@ static std::string color_number( const float num )
         return colorize( "0", c_white );
     }
 }
-
+ 
 static void draw_spellbook_info( const spell_type &sp )
 {
     const spell fake_spell( sp.id );

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2906,10 +2906,10 @@ spell &known_magic::select_spell( Character &guy )
 
     casting_ignore = static_cast<spellcasting_callback *>( spell_menu.callback )->casting_ignore;
     if( spell_menu.ret < 0 ) {
-        static spell null_spell_reference(spell_id::NULL_ID());
+        static spell null_spell_reference( spell_id::NULL_ID() );
         return null_spell_reference;
     }
-    spell* selected_spell = known_spells_sorted[spell_menu.ret];
+    spell *selected_spell = known_spells_sorted[spell_menu.ret];
     return *selected_spell;
 }
 
@@ -2967,7 +2967,6 @@ static std::string color_number( const float num )
         return colorize( "0", c_white );
     }
 }
- 
 static void draw_spellbook_info( const spell_type &sp )
 {
     const spell fake_spell( sp.id );

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2239,12 +2239,12 @@ std::vector<spell *> known_magic::get_spells()
     return spells;
 }
 
-int known_magic::get_spell_index( const spell_id& sp )
+int known_magic::get_spell_index( const spell_id &sp )
 {
     int current_index = -1, result_index = -1;
-    for (auto& spell_pair : spellbook) {
+    for( auto &spell_pair : spellbook ) {
         current_index++;
-        if (spell_pair.first == sp) {
+        if( spell_pair.first == sp ) {
             result_index = current_index;
             break;
         }
@@ -2920,8 +2920,8 @@ int known_magic::select_spell( Character &guy )
 
     casting_ignore = static_cast<spellcasting_callback *>( spell_menu.callback )->casting_ignore;
 
-    spell* selected_spell = known_spells_sorted[spell_menu.ret];
-    int original_spell_index = get_spell_index(selected_spell->id());
+    spell *selected_spell = known_spells_sorted[spell_menu.ret];
+    int original_spell_index = get_spell_index( selected_spell->id() );
     return original_spell_index;
 }
 

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1,4 +1,5 @@
 #include "magic.h"
+#include "magic.h"
 
 #include <algorithm>
 #include <cmath>
@@ -2238,6 +2239,19 @@ std::vector<spell *> known_magic::get_spells()
     return spells;
 }
 
+int known_magic::get_spell_index( const spell_id& sp )
+{
+    int current_index = -1, result_index = -1;
+    for (auto& spell_pair : spellbook) {
+        current_index++;
+        if (spell_pair.first == sp) {
+            result_index = current_index;
+            break;
+        }
+    }
+    return result_index;
+}
+
 int known_magic::available_mana() const
 {
     return mana;
@@ -2906,7 +2920,9 @@ int known_magic::select_spell( Character &guy )
 
     casting_ignore = static_cast<spellcasting_callback *>( spell_menu.callback )->casting_ignore;
 
-    return spell_menu.ret;
+    spell* selected_spell = known_spells_sorted[spell_menu.ret];
+    int original_spell_index = get_spell_index(selected_spell->id());
+    return original_spell_index;
 }
 
 void known_magic::on_mutation_gain( const trait_id &mid, Character &guy )

--- a/src/magic.h
+++ b/src/magic.h
@@ -688,6 +688,8 @@ class known_magic
         std::vector<spell_id> spells() const;
         // gets the spell associated with the spell_id to be edited
         spell &get_spell( const spell_id &sp );
+        // gets the index of a spell in the get_spells vector
+        int get_spell_index(const spell_id& sp);
         // opens up a ui that the Character can choose a spell from
         // returns the index of the spell in the vector of spells
         int select_spell( Character &guy );

--- a/src/magic.h
+++ b/src/magic.h
@@ -689,7 +689,7 @@ class known_magic
         // gets the spell associated with the spell_id to be edited
         spell &get_spell( const spell_id &sp );
         // gets the index of a spell in the get_spells vector
-        int get_spell_index(const spell_id& sp);
+        int get_spell_index( const spell_id &sp );
         // opens up a ui that the Character can choose a spell from
         // returns the index of the spell in the vector of spells
         int select_spell( Character &guy );

--- a/src/magic.h
+++ b/src/magic.h
@@ -688,11 +688,9 @@ class known_magic
         std::vector<spell_id> spells() const;
         // gets the spell associated with the spell_id to be edited
         spell &get_spell( const spell_id &sp );
-        // gets the index of a spell in the get_spells vector
-        int get_spell_index(const spell_id& sp);
         // opens up a ui that the Character can choose a spell from
-        // returns the index of the spell in the vector of spells
-        int select_spell( Character &guy );
+        // returns the selected spell
+        spell &select_spell( Character &guy );
         // get all known spells
         std::vector<spell *> get_spells();
         // directly get the character known spells


### PR DESCRIPTION
currently selecting a spell in a long sorted spell list will cast the wrong spell due to select spell returning a sorted spell index while handle_action.cpp looks only at the unsorted spells

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix issues with the spell menu where choosing a spell to cast chooses the wrong one"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
fixes #76042 (and duplicate #76192)
makes is so the spell a player selected is cast.
reproduction:
1. make a world with magicalysm or mind over matter installed
2. make a character with some stating spells (I used dimensional mage with ascended teleporter proficiency)
3. open a spell list, and try to select a spell to cast (any method)
4. look at log and confirm what spell was actually cast
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
`select_spell` will now returns the selected spell instead of an index, making the internal sorting of the function irrelevant for `handle_action.cpp`
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
returning `spell_id` directly from the `uilist` instead of returning an index and converting to a spell. but I am not sure if `spell_id` is always int based, and there is no easy way I saw to convert an int to a `string_id` even if there is an easy way to convert it back to int from one, and returning a spell is more convenient. 
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
The steps detailed in purpose of change, casting multiple spells, using hotkeys and mouse clicks. Also checking that casting spells works as expected when changing spell hotkeys.
enter spell menu and exit it without casting a spell (by pressing esc for example).
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
