### PR TITLE
fix the skill editor to use the text property instead of textformatted

### DIFF
--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -2171,6 +2171,7 @@ static void character_edit_menu()
 {
     std::vector< tripoint > locations;
     uilist charmenu;
+    charmenu.title = _( "Edit which character?" );
     int charnum = 0;
     avatar &player_character = get_avatar();
     charmenu.addentry( charnum++, true, MENU_AUTOASSIGN, "%s", _( "You" ) );

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -392,7 +392,6 @@ void uilist::init()
     extra_space_right = 0.0;
     ret = UILIST_WAIT_INPUT;
     text.clear();          // header text, after (maybe) folding, populates:
-    textformatted.clear(); // folded to textwidth
     title.clear();         // Makes use of the top border, no folding, sets min width if w_width is auto
     ret_evt = input_event(); // last input event
     keymap.clear();        // keymap[input_event] == index, for entries[index]

--- a/src/ui.h
+++ b/src/ui.h
@@ -450,8 +450,6 @@ class uilist // NOLINT(cata-xy)
     public:
         // Iternal states
         // TODO make private
-        std::vector<std::string> textformatted;
-
         catacurses::window window;
 
         int vshift = 0;

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -1118,8 +1118,8 @@ void debug_menu::wishskill( Character *you, bool change_theory )
 {
     const int skoffset = 1;
     uilist skmenu;
-    skmenu.text = change_theory ?
-                  _( "Select a skill to modify its theory level" ) : _( "Select a skill to modify" );
+    skmenu.title = change_theory ?
+                   _( "Select a skill to modify its theory level" ) : _( "Select a skill to modify" );
     skmenu.allow_anykey = true;
     skmenu.additional_actions = {
         { "LEFT", to_translation( "Decrease skill" ) },
@@ -1184,9 +1184,7 @@ void debug_menu::wishskill( Character *you, bool change_theory )
             } else {
                 you->set_skill_level( skill.ident(), skset );
             }
-            skmenu.textformatted[0] = string_format( _( "%s set to %d             " ),
-                                      skill.name(),
-                                      get_level( skill ) );
+            skmenu.text = string_format( _( "%s set to %d" ), skill.name(), get_level( skill ) );
             skmenu.entries[skill_id + skoffset].txt = string_format( _( "@ %d: %s  " ),
                     get_level( skill ),
                     skill.name() );


### PR DESCRIPTION
#### Summary
Bugfixes "fix skill editor to use the text property instead of textformatted"
#### Purpose of change

Fixes #75679

#### Testing
Use the debug menu to edit a skill level, either your own or an npc’s.

