### PR TITLE
fix GitHub errors; save `overmap_fast_travel` & `overmap_fast_scroll`

### DIFF
--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -382,6 +382,8 @@ void uistatedata::serialize( JsonOut &json ) const
     json.member( "overmap_debug_weather", overmap_debug_weather );
     json.member( "overmap_visible_weather", overmap_visible_weather );
     json.member( "overmap_debug_mongroup", overmap_debug_mongroup );
+    json.member( "overmap_fast_travel", overmap_fast_travel );
+    json.member( "overmap_fast_scroll", overmap_fast_scroll );
     json.member( "distraction_noise", distraction_noise );
     json.member( "distraction_pain", distraction_pain );
     json.member( "distraction_attack", distraction_attack );
@@ -455,6 +457,8 @@ void uistatedata::deserialize( const JsonObject &jo )
     jo.read( "overmap_debug_weather", overmap_debug_weather );
     jo.read( "overmap_visible_weather", overmap_visible_weather );
     jo.read( "overmap_debug_mongroup", overmap_debug_mongroup );
+    jo.read( "overmap_fast_travel", overmap_fast_travel );
+    jo.read( "overmap_fast_scroll", overmap_fast_scroll );
     jo.read( "distraction_noise", distraction_noise );
     jo.read( "distraction_pain", distraction_pain );
     jo.read( "distraction_attack", distraction_attack );

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -1285,8 +1285,9 @@ void talk_function::distribute_food_auto( npc &p )
     zone_manager &mgr = zone_manager::get_manager();
     const tripoint_abs_ms &npc_abs_loc = p.get_location();
     // 3x3 square with NPC in the center, includes NPC's tile and all adjacent ones, for overflow
-    const tripoint top_left = npc_abs_loc.raw() + point{-1, -1}; // Awful hack, zones want the raw value
-    const tripoint bottom_right = npc_abs_loc.raw() + point{1, 1}; // Awful hack, zones want the raw value
+    // TODO: fix point types; Awful hack, zones want the raw value
+    const tripoint top_left = npc_abs_loc.raw() + point_north_west;
+    const tripoint bottom_right = npc_abs_loc.raw() + point_south_east;
     std::string zone_name = "ERROR IF YOU SEE THIS (dummy zone talk_function::distribute_food_auto)";
     const faction_id &fac_id = p.get_fac_id();
     mgr.add( zone_name, zone_type_CAMP_FOOD, fac_id, false, true, top_left, bottom_right );

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -73,7 +73,6 @@
 
 class character_id;
 
-static const activity_id ACT_AUTODRIVE( "ACT_AUTODRIVE" );
 static const activity_id ACT_TRAVELLING( "ACT_TRAVELLING" );
 
 static const mongroup_id GROUP_FOREST( "GROUP_FOREST" );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

`overmap_fast_travel` & `overmap_fast_scroll` should save now. ~(TODO: check)~

Fix some Github Errors:

<details>

<summary>
Images of errors
</summary>

![image](https://github.com/user-attachments/assets/10fdcf61-0146-4199-ab63-c89026b2c5da)

![image](https://github.com/user-attachments/assets/53de3dfc-aefe-474d-a67f-017eaa1ac36e)

![image](https://github.com/user-attachments/assets/5ab0a76c-4280-4927-98e5-3abd19feb259)

</details>

The errors/warnings can be seen here (for example):
 - #76141

#### Describe the solution

Also removed the comment. It didn't seem helpful. Otherwise, the line would have to split for Astyle.

#### Describe alternatives you've considered

#### Testing

1. Compiled locally.
2. ~Let GitHub finish tests.~ GitHub doesn't report the test failures in this PR.
3. Check `overmap_fast_travel` & `overmap_fast_scroll` should save now.
     1. Load a save.
     2. Open `m`ap.
     3. See that fast scroll is off.
     4. Toggle it.
     5. Save game.
     6. Restart CDDA.
     7. Load a save.
     8. Open `m`ap.
     9. See that fast scroll is on (in new version) off (in old version).

#### Additional context