### PR TITLE
Print church/school bell ringing sound in the message log once again

### DIFF
--- a/src/computer_session.cpp
+++ b/src/computer_session.cpp
@@ -496,7 +496,7 @@ void computer_session::action_toll()
         reset_terminal();
     } else {
         comp.next_attempt = calendar::turn + 1_minutes;
-        sounds::sound( get_player_character().pos(), 120, sounds::sound_t::music,
+        sounds::sound( get_player_character().pos(), 120, sounds::sound_t::alarm,
                        //~ the sound of a church bell ringing
                        _( "Bohm…  Bohm…  Bohm…" ), true, "environment", "church_bells" );
 


### PR DESCRIPTION
#### Summary
Interface "Print church/school bells ringing sound in the message log once again"

#### Purpose of change
#27227 and #32995 restricted some sounds from printing their descriptions in the message log. More precisely, only sounds from electronic speech and alarm categories will print their descriptions if they're originating from player position. Descriptions for all other sounds (if they're originating from player position) won't be printed. Church/school bells ringing is implemented as originating from player position, so it doesn't print its description.

#### Describe the solution
Changed sound type for church/school bells from `music` to `alarm`.

#### Describe alternatives you've considered
Change source of source for bells from player position to somewhere else. Don't know what solution is "proper".

#### Testing
Found church, activated its computer, made the bells ring. Checked that `Bohm…  Bohm…  Bohm…` sound is printed in message log.

#### Additional context
None.
