### PR TITLE
show spell components in new spell ui and fix color tags in it

### DIFF
--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2541,9 +2541,12 @@ void spellcasting_callback::display_spell_info( size_t index )
 
     ImGui::TextColored( c_yellow, "%s", sp.spell_class() == trait_NONE ? _( "Classless" ) :
                         sp.spell_class()->name().c_str() );
-    ImGui::TextWrapped( "%s", sp.description().c_str() );
+    // we remove 6 characteres from the width because there seems to be issues with wrapping in this menu (even with TextWrapped)
+    // TODO(thePotatomancer): investigate and fix the strange wrapping issues in this menu as well as other imgui menus
+    float spell_info_width = ImGui::GetContentRegionAvail().x - ( ImGui::CalcTextSize( " " ).x * 6 );
+    cataimgui::draw_colored_text( sp.description().c_str(), spell_info_width );
     ImGui::NewLine();
-    ImGui::TextWrapped( "%s", remove_color_tags(sp.enumerate_spell_data( pc )).c_str() );
+    cataimgui::draw_colored_text( sp.enumerate_spell_data( pc ).c_str(), spell_info_width );
     ImGui::NewLine();
 
     // Calculates temp_level_adjust from EoC, saves it to the spell for later use, and prepares to display the result
@@ -2598,10 +2601,11 @@ void spellcasting_callback::display_spell_info( size_t index )
                                       sp.energy_cost_string( pc ).c_str(),
                                       sp.energy_string().c_str(), energy_cur.c_str() ) );
     } else {
-        ImGui::TextColored( c_red, "%s", _( "Not Enough Stamina" ) );
+        ImGui::TextColored( c_red, "%s %s", _( "Not Enough" ), sp.energy_string().c_str() );
         ImGui::SameLine( 0, 0 );
-        ImGui::Text( ": %s %s", sp.energy_cost_string( pc ).c_str(),
-                     sp.energy_string().c_str() );
+        cataimgui::draw_colored_text( string_format( ": %s %s",
+                                      sp.energy_cost_string( pc ).c_str(),
+                                      sp.energy_string().c_str() ) );
     }
     const bool c_t_encumb = sp.casting_time_encumbered( pc );
     std::string psi_cast_time = c_t_encumb ? _( "Channeling Time (impeded)" ) : _( "Channeling Time" );
@@ -2737,19 +2741,20 @@ void spellcasting_callback::display_spell_info( size_t index )
     }
 
     // TODO(db48x): rewrite to display via ImGui directly, so that wrapping can be done correctly
+    // TODO(thePotatomancer): once we do rewrite it make sure to pass wrapping info to draw_colored_text or skip it entirely
     float width = ImGui::GetContentRegionAvail().x / ImGui::CalcTextSize( "X" ).x;
     if( sp.has_components() ) {
         if( !sp.components().get_components().empty() ) {
             for( const std::string &line : sp.components().get_folded_components_list(
-                     width - 2, c_light_gray, pc.crafting_inventory( pc.pos(), 0, false ), return_true<item> ) ) {
-                ImGui::TextWrapped("%s", remove_color_tags(line).c_str());
+                     width - 6, c_light_gray, pc.crafting_inventory( pc.pos(), 0, false ), return_true<item> ) ) {
+                cataimgui::draw_colored_text( line );
                 ImGui::NewLine();
             }
         }
         if( !( sp.components().get_tools().empty() && sp.components().get_qualities().empty() ) ) {
             for( const std::string &line : sp.components().get_folded_tools_list(
-                     width - 2, c_light_gray, pc.crafting_inventory( pc.pos(), 0, false ) ) ) {
-                ImGui::TextWrapped("%s", remove_color_tags(line).c_str());
+                     width - 6, c_light_gray, pc.crafting_inventory( pc.pos(), 0, false ) ) ) {
+                cataimgui::draw_colored_text( line );
                 ImGui::NewLine();
             }
         }

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2397,7 +2397,6 @@ static void reflesh_favorite( uilist *menu, std::vector<spell *> known_spells )
 class spellcasting_callback : public uilist_callback
 {
     private:
-        int selected_sp = 0;
         int scroll_pos = 0;
         std::vector<spell *> known_spells;
         void display_spell_info( size_t index );
@@ -2542,9 +2541,9 @@ void spellcasting_callback::display_spell_info( size_t index )
     // we remove 6 characteres from the width because there seems to be issues with wrapping in this menu (even with TextWrapped)
     // TODO(thePotatomancer): investigate and fix the strange wrapping issues in this menu as well as other imgui menus
     float spell_info_width = ImGui::GetContentRegionAvail().x - ( ImGui::CalcTextSize( " " ).x * 6 );
-    cataimgui::draw_colored_text( sp.description().c_str(), spell_info_width );
+    cataimgui::draw_colored_text( sp.description(), spell_info_width );
     ImGui::NewLine();
-    cataimgui::draw_colored_text( sp.enumerate_spell_data( pc ).c_str(), spell_info_width );
+    cataimgui::draw_colored_text( sp.enumerate_spell_data( pc ), spell_info_width );
     ImGui::NewLine();
 
     // Calculates temp_level_adjust from EoC, saves it to the spell for later use, and prepares to display the result

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2399,9 +2399,7 @@ class spellcasting_callback : public uilist_callback
     private:
         int selected_sp = 0;
         int scroll_pos = 0;
-        std::vector<std::string> info_txt;
         std::vector<spell *> known_spells;
-        void spell_info_text( const spell &sp, int width );
         void display_spell_info( size_t index );
     public:
         // invlets reserved for special functions

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2543,7 +2543,7 @@ void spellcasting_callback::display_spell_info( size_t index )
                         sp.spell_class()->name().c_str() );
     ImGui::TextWrapped( "%s", sp.description().c_str() );
     ImGui::NewLine();
-    ImGui::TextWrapped( "%s", sp.enumerate_spell_data( pc ).c_str() );
+    ImGui::TextWrapped( "%s", remove_color_tags(sp.enumerate_spell_data( pc )).c_str() );
     ImGui::NewLine();
 
     // Calculates temp_level_adjust from EoC, saves it to the spell for later use, and prepares to display the result
@@ -2742,13 +2742,15 @@ void spellcasting_callback::display_spell_info( size_t index )
         if( !sp.components().get_components().empty() ) {
             for( const std::string &line : sp.components().get_folded_components_list(
                      width - 2, c_light_gray, pc.crafting_inventory( pc.pos(), 0, false ), return_true<item> ) ) {
-                info_txt.emplace_back( line );
+                ImGui::TextWrapped("%s", remove_color_tags(line).c_str());
+                ImGui::NewLine();
             }
         }
         if( !( sp.components().get_tools().empty() && sp.components().get_qualities().empty() ) ) {
             for( const std::string &line : sp.components().get_folded_tools_list(
                      width - 2, c_light_gray, pc.crafting_inventory( pc.pos(), 0, false ) ) ) {
-                info_txt.emplace_back( line );
+                ImGui::TextWrapped("%s", remove_color_tags(line).c_str());
+                ImGui::NewLine();
             }
         }
     }


### PR DESCRIPTION
fixes color tags in spell info!
Currently the new ui does not display spell
components, and there are colors tags in spell data that are ignored
also changed the message when lacking energy to cast a resource to use the resource name instead of always using stamina :P
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "add spell components back to casting menu and fix color tags in it"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
resolves #75669 and fixes #76138
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
use `(cataimgui::draw_colored_text)` in places where we have color tags
change the display of spell components to also use imgui thus show them in spell info again.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I considered replacing 'get_folded_components_list' with an approach more oriented for imgui but decided the PR started to creep and it's better to achieve in another PR. 
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
1. create a world with magicalysm and Mind Over Matter
2. in debug menu add the player a concentration spell and a component spell (I recommend decaying club and spark sight)
3. in game open spell menu and look at the spell info of the previously added spells
4. ensure the materials and spell info appears without color tags

probably worth checking a spell with tool requirements, I'm not knowledgeable enough on what spells have those requirements since they seem quite rare.
cast until out of mana and check the "not enough" message that it refers to mana instead of stamina where appropriate 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
this is the new fixed state: 
![image](https://github.com/user-attachments/assets/31667369-0b39-4041-8575-f989399ae110)
examples of the broken state are aplenty in the issues referenced
I plan to tackle the popup size issues along with the wrapping issues in uilist in another PR 

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
