### PR TITLE
Some professions & hobbies know Gross Anatomy(+more know new butchering profs)

### DIFF
--- a/data/json/hobbies.json
+++ b/data/json/hobbies.json
@@ -210,7 +210,16 @@
     "description": "You take camping to a whole new level.  You have spent nights and weekends surviving in the wild with just a knife to aid you.  Maybe this skill for self-sufficiency can keep you safe.",
     "points": 4,
     "skills": [ { "level": 3, "name": "survival" }, { "level": 1, "name": "fabrication" }, { "level": 1, "name": "cooking" } ],
-    "proficiencies": [ "prof_fibers", "prof_leatherworking_basic", "prof_fibers_rope", "prof_traps", "prof_knapping", "prof_carving" ],
+    "proficiencies": [
+      "prof_fibers",
+      "prof_leatherworking_basic",
+      "prof_fibers_rope",
+      "prof_traps",
+      "prof_knapping",
+      "prof_carving",
+      "prof_butchering_basic",
+      "prof_skinning_basic"
+    ],
     "traits": [ "OUTDOORSMAN" ]
   },
   {
@@ -362,7 +371,7 @@
     "description": "While not the type of wrestler to use folding chairs as weapons, you have experience wrasslin' and tusslin' with others out on the mat.  There's no referees around to see, but hopefully your skills will help you avoid getting pinned by the undead.",
     "points": 5,
     "skills": [ { "level": 3, "name": "melee" }, { "level": 4, "name": "unarmed" }, { "level": 4, "name": "dodge" } ],
-    "proficiencies": [ "prof_athlete_basic", "prof_unarmed_familiar", "prof_unarmed_pro" ],
+    "proficiencies": [ "prof_athlete_basic", "prof_unarmed_familiar", "prof_unarmed_pro", "prof_gross_anatomy" ],
     "traits": [ "FAST_REFLEXES" ]
   },
   {
@@ -373,7 +382,14 @@
     "description": "You were likely on the 100+ wins list back in school and maybe you're a collegiate wrestler or you're using it as part of something like MMA.  Considering how grabby those zombies are, you should get plenty of use out of your skills.",
     "points": 8,
     "skills": [ { "level": 5, "name": "melee" }, { "level": 6, "name": "unarmed" }, { "level": 6, "name": "dodge" } ],
-    "proficiencies": [ "prof_athlete_basic", "prof_athlete_expert", "prof_unarmed_familiar", "prof_unarmed_pro", "prof_unarmed_master" ],
+    "proficiencies": [
+      "prof_athlete_basic",
+      "prof_athlete_expert",
+      "prof_unarmed_familiar",
+      "prof_unarmed_pro",
+      "prof_unarmed_master",
+      "prof_gross_anatomy"
+    ],
     "traits": [ "FAST_REFLEXES", "GOODCARDIO" ]
   },
   {
@@ -572,7 +588,7 @@
     "description": "You've been in quite a few fights in the street.  You can throw and dodge a punch better than most.",
     "points": 3,
     "skills": [ { "level": 2, "name": "melee" }, { "level": 3, "name": "unarmed" }, { "level": 2, "name": "dodge" } ],
-    "proficiencies": [ "prof_unarmed_familiar", "prof_unarmed_pro" ]
+    "proficiencies": [ "prof_unarmed_familiar", "prof_unarmed_pro", "prof_gross_anatomy" ]
   },
   {
     "type": "profession",
@@ -583,7 +599,7 @@
     "points": 6,
     "skills": [ { "level": 5, "name": "melee" }, { "level": 6, "name": "unarmed" }, { "level": 4, "name": "dodge" } ],
     "traits": [ "PAINRESIST" ],
-    "proficiencies": [ "prof_unarmed_familiar", "prof_unarmed_pro", "prof_unarmed_master" ]
+    "proficiencies": [ "prof_unarmed_familiar", "prof_unarmed_pro", "prof_unarmed_master", "prof_gross_anatomy" ]
   },
   {
     "type": "profession",
@@ -635,7 +651,7 @@
     "points": 6,
     "skills": [ { "level": 3, "name": "stabbing" }, { "level": 3, "name": "melee" }, { "level": 3, "name": "dodge" } ],
     "traits": [ "MARTIAL_FENCING" ],
-    "proficiencies": [ "prof_fencing_weapons_familiar", "prof_fencing_weapons_pro" ]
+    "proficiencies": [ "prof_fencing_weapons_familiar", "prof_fencing_weapons_pro", "prof_gross_anatomy" ]
   },
   {
     "type": "profession",
@@ -646,7 +662,7 @@
     "points": 10,
     "skills": [ { "level": 6, "name": "stabbing" }, { "level": 5, "name": "melee" }, { "level": 5, "name": "dodge" } ],
     "traits": [ "MARTIAL_FENCING" ],
-    "proficiencies": [ "prof_fencing_weapons_familiar", "prof_fencing_weapons_pro", "prof_fencing_weapons_master" ]
+    "proficiencies": [ "prof_fencing_weapons_familiar", "prof_fencing_weapons_pro", "prof_fencing_weapons_master", "prof_gross_anatomy" ]
   },
   {
     "type": "profession",
@@ -731,7 +747,7 @@
       { "level": 3, "name": "swimming" }
     ],
     "traits": [ "PROF_MA_BLACK" ],
-    "proficiencies": [ "prof_unarmed_familiar", "prof_unarmed_pro", "prof_unarmed_master" ]
+    "proficiencies": [ "prof_unarmed_familiar", "prof_unarmed_pro", "prof_unarmed_master", "prof_gross_anatomy" ]
   },
   {
     "type": "profession",
@@ -754,7 +770,8 @@
       "prof_long_swords_familiar",
       "prof_hooking_familiar",
       "prof_fencing_weapons_familiar",
-      "prof_spears_familiar"
+      "prof_spears_familiar",
+      "prof_gross_anatomy"
     ]
   },
   {
@@ -785,7 +802,8 @@
       "prof_fencing_weapons_familiar",
       "prof_fencing_weapons_pro",
       "prof_spears_familiar",
-      "prof_spears_pro"
+      "prof_spears_pro",
+      "prof_gross_anatomy"
     ]
   },
   {
@@ -836,7 +854,14 @@
     "points": -3,
     "traits": [ "ANTIFRUIT", "MEATARIAN" ],
     "skills": [ { "level": 2, "name": "survival" }, { "level": 2, "name": "cooking" } ],
-    "proficiencies": [ "prof_knives_familiar", "prof_knife_skills", "prof_butchering_basic", "prof_skinning_basic" ]
+    "proficiencies": [
+      "prof_knives_familiar",
+      "prof_knife_skills",
+      "prof_butchering_basic",
+      "prof_skinning_basic",
+      "prof_gross_anatomy",
+      "prof_intro_biology"
+    ]
   },
   {
     "type": "profession",
@@ -1141,7 +1166,8 @@
     "points": 1,
     "description": "A quiet day at the lake would be a welcome break from the hordes.  Though, now that you think about it, the fish have been acting strangely vicious lately too.",
     "skills": [ { "level": 2, "name": "survival" }, { "level": 1, "name": "swimming" } ],
-    "traits": [ "OUTDOORSMAN" ]
+    "traits": [ "OUTDOORSMAN" ],
+    "proficiencies": [ "prof_butchering_basic" ]
   },
   {
     "subtype": "hobby",

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -937,7 +937,9 @@
       "prof_food_prep",
       "prof_knife_skills",
       "prof_intro_biology",
+      "prof_gross_anatomy",
       "prof_wp_basic_bird",
+      "prof_wp_ungulate",
       "prof_knives_familiar",
       "prof_butchering_basic",
       "prof_butchering_adv",
@@ -1345,6 +1347,7 @@
       "prof_gunsmithing_basic",
       "prof_gun_cleaning",
       "prof_knives_familiar",
+      "prof_gross_anatomy",
       "prof_auto_rifles_familiar",
       "prof_auto_pistols_familiar"
     ],
@@ -1462,6 +1465,7 @@
       "prof_gunsmithing_basic",
       "prof_gun_cleaning",
       "prof_knives_familiar",
+      "prof_gross_anatomy",
       "prof_auto_rifles_familiar",
       "prof_auto_pistols_familiar"
     ],
@@ -1828,6 +1832,7 @@
       "prof_wound_care",
       "prof_gun_cleaning",
       "prof_knives_familiar",
+      "prof_gross_anatomy",
       "prof_auto_rifles_familiar",
       "prof_auto_pistols_familiar"
     ],
@@ -1887,6 +1892,7 @@
       "prof_wound_care",
       "prof_gun_cleaning",
       "prof_knives_familiar",
+      "prof_gross_anatomy",
       "prof_auto_rifles_familiar",
       "prof_auto_pistols_familiar"
     ],
@@ -1953,6 +1959,7 @@
       "prof_spotting",
       "prof_gun_cleaning",
       "prof_knives_familiar",
+      "prof_gross_anatomy",
       "prof_auto_rifles_familiar"
     ],
     "skills": [
@@ -2269,7 +2276,7 @@
     "requirement": "achievement_kill_100_monsters",
     "description": "The boss always said he could rely on you to pull through on the tough jobs.  Shame he got himself smoked.  No problem; the world's always got a place for someone with your kind of talents.",
     "points": 4,
-    "proficiencies": [ "prof_knives_familiar", "prof_unarmed_familiar", "prof_shivs_familiar" ],
+    "proficiencies": [ "prof_knives_familiar", "prof_unarmed_familiar", "prof_shivs_familiar", "prof_gross_anatomy" ],
     "skills": [
       { "level": 3, "name": "gun" },
       { "level": 3, "name": "pistol" },
@@ -2849,7 +2856,8 @@
       "prof_batons_pro",
       "prof_unarmed_familiar",
       "prof_unarmed_pro",
-      "prof_auto_pistols_familiar"
+      "prof_auto_pistols_familiar",
+      "prof_gross_anatomy"
     ],
     "items": {
       "both": {
@@ -2892,7 +2900,8 @@
       "prof_spotting",
       "prof_gun_cleaning",
       "prof_auto_rifles_familiar",
-      "prof_auto_pistols_familiar"
+      "prof_auto_pistols_familiar",
+      "prof_gross_anatomy"
     ],
     "skills": [
       { "level": 7, "name": "gun" },
@@ -2951,7 +2960,7 @@
       { "level": 3, "name": "swimming" }
     ],
     "traits": [ "PROF_POLICE" ],
-    "proficiencies": [ "prof_spotting", "prof_gun_cleaning", "prof_batons_familiar", "prof_auto_pistols_familiar" ],
+    "proficiencies": [ "prof_spotting", "prof_gun_cleaning", "prof_batons_familiar", "prof_gross_anatomy", "prof_auto_pistols_familiar" ],
     "items": {
       "both": {
         "entries": [
@@ -3086,7 +3095,15 @@
     "name": "Bow Hunter",
     "description": "Ever since you were a child you loved hunting, and quickly developed a talent for archery.  Why, if the world ended, there's nothing you'd want at your side more than your trusty bow.  So, when it did, you made sure to bring it along.",
     "points": 3,
-    "proficiencies": [ "prof_bow_basic", "prof_bowyery", "prof_knives_familiar" ],
+    "proficiencies": [
+      "prof_bow_basic",
+      "prof_bowyery",
+      "prof_knives_familiar",
+      "prof_butchering_basic",
+      "prof_skinning_basic",
+      "prof_gross_anatomy",
+      "prof_wp_ungulate"
+    ],
     "skills": [
       { "level": 4, "name": "gun" },
       { "level": 4, "name": "archery" },
@@ -3124,7 +3141,15 @@
     "name": "Crossbow Hunter",
     "description": "Ever since you were a child you loved hunting, and crossbow hunting was always your favorite.  Why, if the world ended, there's nothing you'd want at your side more than your trusty crossbow.  So, when it did, you made sure to bring it along, though most of your bolts were lost during the escape.",
     "points": 3,
-    "proficiencies": [ "prof_bow_basic", "prof_gunsmithing_spring", "prof_knives_familiar" ],
+    "proficiencies": [
+      "prof_bow_basic",
+      "prof_gunsmithing_spring",
+      "prof_knives_familiar",
+      "prof_butchering_basic",
+      "prof_skinning_basic",
+      "prof_gross_anatomy",
+      "prof_wp_ungulate"
+    ],
     "skills": [
       { "level": 4, "name": "rifle" },
       { "level": 4, "name": "gun" },
@@ -3166,7 +3191,15 @@
     "name": "Shotgun Hunter",
     "description": "Ever since you were a child you loved hunting, and one year you got a shotgun for your birthday.  Why, if the world ended, there's nothing you'd want at your side more than your trusty shotgun.  So, when it did, you made sure to bring it along.",
     "points": 3,
-    "proficiencies": [ "prof_gun_cleaning", "prof_knives_familiar" ],
+    "proficiencies": [
+      "prof_gun_cleaning",
+      "prof_knives_familiar",
+      "prof_gross_anatomy",
+      "prof_butchering_basic",
+      "prof_skinning_basic",
+      "prof_wp_basic_bird",
+      "prof_wp_ungulate"
+    ],
     "skills": [ { "level": 4, "name": "gun" }, { "level": 4, "name": "shotgun" }, { "level": 3, "name": "survival" } ],
     "items": {
       "both": {
@@ -3205,7 +3238,14 @@
     "name": "Rifle Hunter",
     "description": "Ever since you were a child you loved hunting, and you fancy yourself a crack shot.  Why, if the world ended, there's nothing you'd want at your side more than your trusty rifle.  So, when it did, you made sure to bring it along.",
     "points": 3,
-    "proficiencies": [ "prof_gun_cleaning", "prof_knives_familiar" ],
+    "proficiencies": [
+      "prof_gun_cleaning",
+      "prof_knives_familiar",
+      "prof_butchering_basic",
+      "prof_skinning_basic",
+      "prof_gross_anatomy",
+      "prof_wp_ungulate"
+    ],
     "skills": [ { "level": 4, "name": "gun" }, { "level": 4, "name": "rifle" }, { "level": 3, "name": "survival" } ],
     "items": {
       "both": {
@@ -3244,7 +3284,14 @@
     "name": "Big-Bore Hunter",
     "description": "You always harbored a passion for hunting and a particular fondness for big-bore rifle calibers and affordable conversion kits.  Whether it was their cost-effective nature or the simple, testosterone-amplifying notion that you could retool your rifle to belt out .50-caliber bullets, you preferred them for your hunting trips.  Now, with your converted rifle in hand, you fancy that there isn't any game too large for you to take down.",
     "points": 3,
-    "proficiencies": [ "prof_gun_cleaning", "prof_knives_familiar" ],
+    "proficiencies": [
+      "prof_gun_cleaning",
+      "prof_knives_familiar",
+      "prof_butchering_basic",
+      "prof_skinning_basic",
+      "prof_gross_anatomy",
+      "prof_wp_ungulate"
+    ],
     "skills": [ { "level": 4, "name": "gun" }, { "level": 4, "name": "rifle" }, { "level": 3, "name": "survival" } ],
     "items": {
       "both": {
@@ -3996,7 +4043,15 @@
     "description": "You spent most of your life trapping with your father.  Both of you made a decent living selling your catches and running trapping tutorials.  Hopefully, your skills will come in useful against less conventional game.",
     "points": 3,
     "skills": [ { "level": 6, "name": "traps" }, { "level": 4, "name": "survival" } ],
-    "proficiencies": [ "prof_fibers", "prof_fibers_rope", "prof_traps", "prof_trapsetting", "prof_knives_familiar" ],
+    "proficiencies": [
+      "prof_fibers",
+      "prof_fibers_rope",
+      "prof_traps",
+      "prof_trapsetting",
+      "prof_knives_familiar",
+      "prof_butchering_basic",
+      "prof_skinning_basic"
+    ],
     "recipes": [ "beartrap" ],
     "items": {
       "both": {
@@ -4409,7 +4464,14 @@
       { "level": 3, "name": "unarmed" },
       { "level": 3, "name": "dodge" }
     ],
-    "proficiencies": [ "prof_knives_familiar", "prof_knives_pro", "prof_unarmed_familiar", "prof_unarmed_pro", "prof_shivs_familiar" ],
+    "proficiencies": [
+      "prof_knives_familiar",
+      "prof_knives_pro",
+      "prof_unarmed_familiar",
+      "prof_unarmed_pro",
+      "prof_shivs_familiar",
+      "prof_gross_anatomy"
+    ],
     "traits": [ "PROF_ASSASSIN_CONVICT" ],
     "items": {
       "both": {
@@ -4842,7 +4904,7 @@
       "style_wingchun",
       "style_zui_quan"
     ],
-    "proficiencies": [ "prof_unarmed_familiar", "prof_unarmed_pro" ],
+    "proficiencies": [ "prof_unarmed_familiar", "prof_unarmed_pro", "prof_gross_anatomy" ],
     "skills": [
       { "level": 4, "name": "melee" },
       { "level": 4, "name": "unarmed" },
@@ -4881,7 +4943,7 @@
       "style_wingchun",
       "style_zui_quan"
     ],
-    "proficiencies": [ "prof_unarmed_familiar", "prof_unarmed_pro", "prof_unarmed_master" ],
+    "proficiencies": [ "prof_unarmed_familiar", "prof_unarmed_pro", "prof_unarmed_master", "prof_gross_anatomy" ],
     "skills": [
       { "level": 8, "name": "melee" },
       { "level": 8, "name": "unarmed" },
@@ -5080,7 +5142,10 @@
       "prof_knitting",
       "prof_closures",
       "prof_long_swords_familiar",
-      "prof_auto_rifles_familiar"
+      "prof_auto_rifles_familiar",
+      "prof_gross_anatomy",
+      "prof_butchering_basic",
+      "prof_skinning_basic"
     ],
     "skills": [
       { "level": 4, "name": "gun" },
@@ -5275,7 +5340,7 @@
     "description": "You spent most of your days fishing in the swamp, getting by quietly on your catch.  You found the buzzing of insects enjoyable, but recently they've gotten bigger and meaner.  Now their horrible noises have you spooked - you just hope the fish aren't as nasty.",
     "points": 2,
     "skills": [ { "level": 5, "name": "survival" }, { "level": 2, "name": "swimming" } ],
-    "proficiencies": [ "prof_fibers", "prof_knives_familiar" ],
+    "proficiencies": [ "prof_fibers", "prof_knives_familiar", "prof_butchering_basic" ],
     "items": {
       "both": {
         "entries": [
@@ -5923,7 +5988,7 @@
       { "level": 6, "name": "dodge" },
       { "level": 4, "name": "swimming" }
     ],
-    "proficiencies": [ "prof_fencing_weapons_familiar", "prof_fencing_weapons_pro" ],
+    "proficiencies": [ "prof_fencing_weapons_familiar", "prof_fencing_weapons_pro", "prof_gross_anatomy" ],
     "starting_styles": [ "style_fencing" ],
     "items": {
       "both": {
@@ -5982,6 +6047,7 @@
     "description": "Taking care of cows, horses, and other animals is your passion, but the ways things are going, this isn't going to be just another day at the ranch.",
     "points": 2,
     "skills": [ { "level": 5, "name": "survival" } ],
+    "proficiencies": [ "prof_gross_anatomy", "prof_wp_ungulate" ],
     "items": {
       "both": {
         "entries": [
@@ -6209,7 +6275,8 @@
       "prof_gun_cleaning",
       "prof_knives_familiar",
       "prof_auto_rifles_familiar",
-      "prof_auto_pistols_familiar"
+      "prof_auto_pistols_familiar",
+      "prof_gross_anatomy"
     ],
     "skills": [
       { "level": 4, "name": "gun" },
@@ -6452,7 +6519,8 @@
       "prof_gun_cleaning",
       "prof_knives_familiar",
       "prof_auto_rifles_familiar",
-      "prof_auto_pistols_familiar"
+      "prof_auto_pistols_familiar",
+      "prof_gross_anatomy"
     ],
     "skills": [
       { "level": 7, "name": "gun" },
@@ -6666,7 +6734,7 @@
     "description": "You were responding to a call with your partner before you got separated.  Now all you have is your trusty ambulance, ready to transport patients through the apocalypse.",
     "points": 3,
     "skills": [ { "level": 5, "name": "firstaid" }, { "level": 4, "name": "driving" }, { "level": 2, "name": "mechanics" } ],
-    "proficiencies": [ "prof_wound_care", "prof_intro_biology", "prof_physiology", "prof_burn_care", "prof_driver" ],
+    "proficiencies": [ "prof_wound_care", "prof_intro_biology", "prof_physiology", "prof_burn_care", "prof_driver", "prof_gross_anatomy" ],
     "traits": [ "PROF_MED" ],
     "vehicle": "ambulance",
     "items": {
@@ -6703,7 +6771,8 @@
       "prof_intro_biology",
       "prof_physiology",
       "prof_burn_care",
-      "prof_dissect_humans"
+      "prof_dissect_humans",
+      "prof_gross_anatomy"
     ],
     "traits": [ "PROF_MED" ],
     "items": {
@@ -6763,7 +6832,8 @@
       "prof_gun_cleaning",
       "prof_knives_familiar",
       "prof_auto_rifles_familiar",
-      "prof_auto_pistols_familiar"
+      "prof_auto_pistols_familiar",
+      "prof_gross_anatomy"
     ],
     "items": {
       "both": {
@@ -6879,7 +6949,8 @@
       "prof_intro_biology",
       "prof_physiology",
       "prof_burn_care",
-      "prof_dissect_humans"
+      "prof_dissect_humans",
+      "prof_gross_anatomy"
     ],
     "traits": [ "PROF_MED" ],
     "items": {
@@ -6950,7 +7021,7 @@
       { "level": 3, "name": "unarmed" },
       { "level": 3, "name": "dodge" }
     ],
-    "proficiencies": [ "prof_unarmed_familiar", "prof_unarmed_pro", "prof_auto_pistols_familiar" ],
+    "proficiencies": [ "prof_unarmed_familiar", "prof_unarmed_pro", "prof_auto_pistols_familiar", "prof_gross_anatomy" ],
     "items": {
       "both": {
         "entries": [
@@ -7085,7 +7156,7 @@
       { "level": 4, "name": "throw" },
       { "level": 2, "name": "swimming" }
     ],
-    "proficiencies": [ "prof_long_swords_familiar" ],
+    "proficiencies": [ "prof_long_swords_familiar", "prof_gross_anatomy" ],
     "items": {
       "both": {
         "entries": [
@@ -7407,7 +7478,8 @@
       "prof_auto_pistols_familiar",
       "prof_auto_pistols_pro",
       "prof_unarmed_familiar",
-      "prof_unarmed_pro"
+      "prof_unarmed_pro",
+      "prof_gross_anatomy"
     ],
     "items": {
       "both": {
@@ -7471,7 +7543,14 @@
       { "level": 5, "name": "dodge" },
       { "level": 4, "name": "speech" }
     ],
-    "proficiencies": [ "prof_spotting", "prof_wp_syn_armored", "prof_knives_familiar", "prof_knives_pro", "prof_knives_master" ],
+    "proficiencies": [
+      "prof_spotting",
+      "prof_wp_syn_armored",
+      "prof_knives_familiar",
+      "prof_knives_pro",
+      "prof_knives_master",
+      "prof_gross_anatomy"
+    ],
     "items": {
       "both": {
         "entries": [
@@ -7630,7 +7709,14 @@
     "name": "RV Hunter",
     "description": "Ever since you were a child you loved hunting and traveling; so when you scraped enough money, you bought yourself an old RV, a gun, and hit the road.  You've been all over the country, hunting for good game.  Unfortunately the country is all over this time, and even more unfortunately you've lost your ol' reliable in the chaos.  Now you gotta find a new reliable.",
     "points": 4,
-    "proficiencies": [ "prof_driver", "prof_knives_familiar" ],
+    "proficiencies": [
+      "prof_driver",
+      "prof_knives_familiar",
+      "prof_gross_anatomy",
+      "prof_wp_ungulate",
+      "prof_butchering_basic",
+      "prof_skinning_basic"
+    ],
     "skills": [
       { "level": 3, "name": "rifle" },
       { "level": 3, "name": "gun" },
@@ -7762,7 +7848,7 @@
       "style_wingchun"
     ],
     "starting_styles_choices_amount": 3,
-    "proficiencies": [ "prof_unarmed_familiar" ],
+    "proficiencies": [ "prof_unarmed_familiar", "prof_gross_anatomy" ],
     "items": {
       "both": { "entries": [ { "item": "gloves_fingerless" }, { "item": "b_shorts" }, { "item": "mouthpiece" } ] },
       "male": { "entries": [ { "item": "boxer_shorts" } ] },

--- a/data/mods/Aftershock/player/professions.json
+++ b/data/mods/Aftershock/player/professions.json
@@ -100,7 +100,7 @@
     "type": "profession",
     "id": "afs_captain_bearman",
     "name": "Captain Schwarz Walder, Cannibal",
-    "description": "Several years ago, you were newly stationed at a remote corporate facility when it came under a personality rewrite attack that affected all of your human coworkers.  It had seemed likely that the few Uplifted staff would perish and most did.  But you disappeared into the wilderness surrounding the facilities and began hunting the things that had been your friends.  Eating them to stay alive and to power your bionics.  Recapturing the facility earned you a buyout of the remainder of your contract, but most people are uncomfortable around you once they realize how very different you are.  Now you are here on a mostly abandoned planet hunting a bounty.",
+    "description": "Several years ago, you were newly stationed at a remote corporate facility when it came under a personality rewrite attack that affected all of your human coworkers.  It had seemed likely that the few Uplifted staff would perish and most did.  But you disappeared into the wilderness surrounding the facilities and began hunting the things that had been your friends, eating them to stay alive and to power your bionics.  Recapturing the facility earned you a buyout of the remainder of your contract, but most people are uncomfortable around you once they realize how very different you are.  Now you are here on a mostly abandoned planet hunting a bounty.",
     "points": 10,
     "CBMs": [
       "bio_targeting",
@@ -119,7 +119,9 @@
       "prof_disarming",
       "prof_knives_familiar",
       "prof_auto_rifles_familiar",
-      "prof_auto_pistols_familiar"
+      "prof_auto_pistols_familiar",
+      "prof_butchering_basic",
+      "prof_gross_anatomy"
     ],
     "skills": [
       { "level": 3, "name": "gun" },
@@ -134,7 +136,7 @@
       { "level": 4, "name": "survival" }
     ],
     "traits": [ "STR_UP_3", "UPLIFTED", "THRESH_URSINE", "URSINE_FUR", "CANNIBAL", "HUGE_OK" ],
-    "//": "replace esapu armor with an XL environmentally controlled armor once those exist",
+    "//": "replace esapi armor with an XL environmentally controlled armor once those exist",
     "items": {
       "both": {
         "entries": [
@@ -225,6 +227,8 @@
     "description": "Grown in some corporate laboratory to provide the perfect bodyguard, with nothing to live for but your client.  The Cataclysm ignored social strata and somehow you outlived your master.  Now no one knows the conditioning words to force your obedience.  While the world burns, you get your first taste of life.",
     "points": 3,
     "traits": [ "AFS_BRUTAL_STRENGTH", "SLOWREADER", "LIGHTWEIGHT" ],
+    "proficiencies": [ "prof_unarmed_familiar", "prof_knives_familiar" ],
+    "skills": [ { "level": 2, "name": "unarmed" }, { "level": 2, "name": "stabbing" } ],
     "items": {
       "both": { "entries": [ { "item": "suit" }, { "item": "dress_shoes" }, { "item": "bootsheath" }, { "item": "ceramic_knife" } ] },
       "male": { "entries": [ { "item": "briefs" }, { "item": "undershirt" } ] },
@@ -424,7 +428,7 @@
       { "level": 1, "name": "melee" },
       { "level": 2, "name": "dodge" }
     ],
-    "proficiencies": [ "prof_auto_rifles_familiar", "prof_auto_pistols_familiar" ],
+    "proficiencies": [ "prof_auto_rifles_familiar", "prof_auto_pistols_familiar", "prof_gross_anatomy" ],
     "items": {
       "both": {
         "entries": [

--- a/data/mods/MMA/professions.json
+++ b/data/mods/MMA/professions.json
@@ -11,7 +11,9 @@
       "prof_unarmed_pro",
       "prof_bionic_swords_familiar",
       "prof_bionic_swords_pro",
-      "prof_bionics_familiar"
+      "prof_bionics_familiar",
+      "prof_gross_anatomy",
+      "prof_wp_cyborg"
     ],
     "skills": [ { "level": 3, "name": "unarmed" }, { "level": 3, "name": "melee" }, { "level": 1, "name": "dodge" } ],
     "items": {
@@ -43,7 +45,7 @@
     "points": 6,
     "traits": [ "ELFAEYES", "ELFA_EARS" ],
     "starting_styles": [ "style_mma_hylian" ],
-    "proficiencies": [ "prof_medium_swords_familiar", "prof_medium_swords_pro" ],
+    "proficiencies": [ "prof_medium_swords_familiar", "prof_medium_swords_pro", "prof_gross_anatomy" ],
     "skills": [ { "level": 3, "name": "cutting" }, { "level": 3, "name": "melee" }, { "level": 1, "name": "dodge" } ],
     "items": {
       "both": {

--- a/data/mods/Magiclysm/professions.json
+++ b/data/mods/Magiclysm/professions.json
@@ -701,7 +701,7 @@
       { "id": "druid_summon_brambles", "level": 3 }
     ],
     "skills": [ { "level": 4, "name": "survival" }, { "level": 3, "name": "spellcraft" } ],
-    "proficiencies": [ "prof_knives_familiar" ],
+    "proficiencies": [ "prof_knives_familiar", "prof_butchering_basic", "prof_skinning_basic" ],
     "traits": [ "ANIMALEMPATH", "SLOWREADER", "DRUID" ],
     "items": {
       "both": {
@@ -726,9 +726,17 @@
     "type": "profession",
     "id": "archer_druid",
     "name": "Archer Druid",
-    "description": "You were a skillful and committed archer druid, making constant excursions to the forests in which you dedicated yourself to living of and with what nature had to offer you.  You were returning from your last travel when civilization fell upon itself.",
+    "description": "You were a skillful and committed archer druid, making constant excursions to the forests in which you dedicated yourself to living off of and with what nature had to offer you.  You were returning from your last travel when civilization fell upon itself.",
     "points": 5,
-    "proficiencies": [ "prof_bowyery", "prof_bow_basic", "prof_bow_expert", "prof_knives_familiar" ],
+    "proficiencies": [
+      "prof_bowyery",
+      "prof_bow_basic",
+      "prof_bow_expert",
+      "prof_knives_familiar",
+      "prof_gross_anatomy",
+      "prof_butchering_basic",
+      "prof_skinning_basic"
+    ],
     "spells": [
       { "id": "druid_naturebow1", "level": 4 },
       { "id": "druid_natures_commune", "level": 3 },
@@ -985,7 +993,7 @@
       { "id": "recover_stamina", "level": 2 }
     ],
     "traits": [ "PROF_BOXER", "EARTHSHAPER" ],
-    "proficiencies": [ "prof_unarmed_familiar", "prof_unarmed_pro" ],
+    "proficiencies": [ "prof_unarmed_familiar", "prof_unarmed_pro", "prof_gross_anatomy" ],
     "skills": [
       { "level": 2, "name": "melee" },
       { "level": 3, "name": "unarmed" },
@@ -1016,7 +1024,7 @@
     "points": 4,
     "spells": [ { "id": "light_healing", "level": 3 }, { "id": "biomancer_cure_disease_minor", "level": 3 } ],
     "skills": [ { "level": 3, "name": "firstaid" }, { "level": 2, "name": "spellcraft" } ],
-    "proficiencies": [ "prof_wound_care", "prof_intro_biology", "prof_burn_care" ],
+    "proficiencies": [ "prof_wound_care", "prof_intro_biology", "prof_burn_care", "prof_gross_anatomy" ],
     "items": {
       "both": {
         "entries": [
@@ -1044,7 +1052,16 @@
     "name": "Wildborne Rider",
     "description": "Abandoned at a young age and raised by moose, you had to master the wilds to survive.  While the modern world has been devoured, you and your steed are no stranger to hardship.",
     "points": 6,
-    "proficiencies": [ "prof_bowyery", "prof_fibers", "prof_knapping", "prof_bow_basic", "prof_bow_expert" ],
+    "proficiencies": [
+      "prof_bowyery",
+      "prof_fibers",
+      "prof_knapping",
+      "prof_bow_basic",
+      "prof_bow_expert",
+      "prof_butchering_basic",
+      "prof_skinning_basic",
+      "prof_gross_anatomy"
+    ],
     "spells": [
       { "id": "druidic_healing", "level": 4 },
       { "id": "purify_seed", "level": 4 },
@@ -1100,7 +1117,13 @@
       { "level": 2, "name": "survival" },
       { "level": 1, "name": "fabrication" }
     ],
-    "proficiencies": [ "prof_gunsmithing_basic", "prof_gun_cleaning", "prof_auto_rifles_familiar", "prof_auto_pistols_familiar" ],
+    "proficiencies": [
+      "prof_gunsmithing_basic",
+      "prof_gun_cleaning",
+      "prof_auto_rifles_familiar",
+      "prof_auto_pistols_familiar",
+      "prof_gross_anatomy"
+    ],
     "traits": [ "KELVINIST" ],
     "items": {
       "both": {

--- a/data/mods/innawood/professions.json
+++ b/data/mods/innawood/professions.json
@@ -74,7 +74,14 @@
     "description": "You've trained in the medical arts, refining natural remedies into real cures for disease.  Your tribe would have lived long and healthy lives, were they still here.",
     "points": 3,
     "skills": [ { "level": 3, "name": "firstaid" }, { "level": 2, "name": "chemistry" }, { "level": 1, "name": "survival" } ],
-    "proficiencies": [ "prof_wound_care", "prof_wound_care_expert", "prof_intro_biology", "prof_physiology", "prof_burn_care" ],
+    "proficiencies": [
+      "prof_wound_care",
+      "prof_wound_care_expert",
+      "prof_intro_biology",
+      "prof_physiology",
+      "prof_gross_anatomy",
+      "prof_burn_care"
+    ],
     "items": {
       "both": {
         "entries": [
@@ -141,7 +148,16 @@
     "name": "Bow Hunter",
     "description": "Ever since you were a child you loved hunting, and quickly developed a talent for archery.  Why, if the world ended, there's nothing you'd want at your side more than your trusty bow.  So, when it did, you made sure to bring it along.",
     "points": 3,
-    "proficiencies": [ "prof_bow_basic", "prof_bow_expert", "prof_fletching", "prof_knives_familiar" ],
+    "proficiencies": [
+      "prof_bow_basic",
+      "prof_bow_expert",
+      "prof_fletching",
+      "prof_knives_familiar",
+      "prof_butchering_basic",
+      "prof_skinning_basic",
+      "prof_gross_anatomy",
+      "prof_wp_ungulate"
+    ],
     "skills": [
       { "level": 2, "name": "archery" },
       { "level": 1, "name": "gun" },
@@ -175,7 +191,14 @@
       { "level": 1, "name": "dodge" },
       { "level": 1, "name": "survival" }
     ],
-    "proficiencies": [ "prof_spears_familiar", "prof_knives_familiar" ],
+    "proficiencies": [
+      "prof_spears_familiar",
+      "prof_knives_familiar",
+      "prof_butchering_basic",
+      "prof_skinning_basic",
+      "prof_gross_anatomy",
+      "prof_wp_ungulate"
+    ],
     "items": {
       "both": {
         "entries": [
@@ -201,7 +224,14 @@
       { "level": 1, "name": "swimming" },
       { "level": 1, "name": "survival" }
     ],
-    "proficiencies": [ "prof_spears_familiar", "prof_knives_familiar" ],
+    "proficiencies": [
+      "prof_spears_familiar",
+      "prof_knives_familiar",
+      "prof_butchering_basic",
+      "prof_skinning_basic",
+      "prof_gross_anatomy",
+      "prof_wp_ungulate"
+    ],
     "items": {
       "both": {
         "entries": [
@@ -221,7 +251,15 @@
     "name": "Crossbow Hunter",
     "description": "Ever since you were a child you loved hunting, and crossbow hunting was always your favorite.  Why, if the world ended, there's nothing you'd want at your side more than your trusty crossbow.  So, when it did, you made sure to bring it along, though most of your bolts were lost during the escape.",
     "points": 3,
-    "proficiencies": [ "prof_bow_basic", "prof_fletching", "prof_knives_familiar" ],
+    "proficiencies": [
+      "prof_bow_basic",
+      "prof_fletching",
+      "prof_knives_familiar",
+      "prof_butchering_basic",
+      "prof_skinning_basic",
+      "prof_gross_anatomy",
+      "prof_wp_ungulate"
+    ],
     "skills": [
       { "level": 2, "name": "rifle" },
       { "level": 1, "name": "gun" },
@@ -256,7 +294,7 @@
     "points": 3,
     "skills": [ { "level": 2, "name": "swimming" }, { "level": 2, "name": "survival" } ],
     "traits": [ "OUTDOORSMAN" ],
-    "proficiencies": [ "prof_fibers", "prof_knives_familiar" ],
+    "proficiencies": [ "prof_fibers", "prof_knives_familiar", "prof_butchering_basic" ],
     "items": {
       "both": {
         "entries": [
@@ -351,7 +389,15 @@
     "description": "You spent most of your life trapping with your father.  Both of you made a decent living selling your catches and running trapping tutorials.  Hopefully, your skills will come in useful against less conventional game.",
     "points": 2,
     "skills": [ { "level": 4, "name": "traps" }, { "level": 2, "name": "survival" } ],
-    "proficiencies": [ "prof_fibers", "prof_carving", "prof_traps", "prof_trapsetting", "prof_knives_familiar" ],
+    "proficiencies": [
+      "prof_fibers",
+      "prof_carving",
+      "prof_traps",
+      "prof_trapsetting",
+      "prof_knives_familiar",
+      "prof_butchering_basic",
+      "prof_skinning_basic"
+    ],
     "items": {
       "both": {
         "entries": [
@@ -508,7 +554,7 @@
       { "level": 2, "name": "dodge" },
       { "level": 2, "name": "swimming" }
     ],
-    "proficiencies": [ "prof_short_swords_familiar", "prof_short_swords_pro", "prof_knives_familiar" ],
+    "proficiencies": [ "prof_short_swords_familiar", "prof_short_swords_pro", "prof_knives_familiar", "prof_gross_anatomy" ],
     "items": {
       "both": {
         "entries": [
@@ -532,7 +578,7 @@
     "name": "Tribal Arbalist",
     "description": "From your first hunt, you showed talent with a crossbow.  While the tribe was well guarded by your aim, you're all alone now.",
     "points": 3,
-    "proficiencies": [ "prof_bow_basic", "prof_bow_expert", "prof_fletching", "prof_knives_familiar" ],
+    "proficiencies": [ "prof_bow_basic", "prof_bow_expert", "prof_fletching", "prof_knives_familiar", "prof_gross_anatomy" ],
     "skills": [
       { "level": 3, "name": "rifle" },
       { "level": 3, "name": "gun" },

--- a/data/mods/package_bionic_professions/bionic_professions.json
+++ b/data/mods/package_bionic_professions/bionic_professions.json
@@ -13,6 +13,7 @@
     "points": 5,
     "skills": [ { "level": 3, "name": "swimming" } ],
     "CBMs": [ "bio_str_enhancer", "bio_adrenaline", "bio_hydraulics", "bio_metabolics", "bio_power_storage_mkII" ],
+    "proficiencies": [ "prof_athlete_basic", "prof_athlete_expert" ]
     "items": {
       "both": {
         "entries": [
@@ -309,7 +310,7 @@
     "points": 6,
     "CBMs": [ "bio_surgical_razor", "bio_flashlight", "bio_batteries", "bio_power_storage_mkII" ],
     "skills": [ { "level": 8, "name": "firstaid" } ],
-    "proficiencies": [ "prof_intro_biology", "prof_physiology", "prof_wound_care", "prof_wound_care_expert", "prof_dissect_humans" ],
+    "proficiencies": [ "prof_intro_biology", "prof_physiology", "prof_wound_care", "prof_wound_care_expert", "prof_dissect_humans", "prof_gross_anatomy" ],
     "traits": [ "PROF_MED" ],
     "items": {
       "both": {
@@ -449,6 +450,7 @@
     "points": 4,
     "skills": [ { "level": 2, "name": "swimming" } ],
     "CBMs": [ "bio_adrenaline", "bio_torsionratchet", "bio_power_storage_mkII", "bio_jointservo" ],
+    "proficiencies": [ "prof_athlete_basic", "prof_athlete_expert" ],
     "items": {
       "both": {
         "entries": [
@@ -481,7 +483,8 @@
       "prof_gun_cleaning",
       "prof_knives_familiar",
       "prof_auto_rifles_familiar",
-      "prof_auto_pistols_familiar"
+      "prof_auto_pistols_familiar",
+      "prof_gross_anatomy"
     ],
     "CBMs": [
       "bio_eye_enhancer",
@@ -554,7 +557,8 @@
       "prof_gun_cleaning",
       "prof_knives_familiar",
       "prof_auto_rifles_familiar",
-      "prof_auto_pistols_familiar"
+      "prof_auto_pistols_familiar",
+      "prof_gross_anatomy"
     ],
     "CBMs": [
       "bio_targeting",
@@ -934,7 +938,7 @@
     "points": 5,
     "CBMs": [ "bio_razors", "bio_armor_eyes", "bio_sunglasses", "bio_dex_enhancer", "bio_ears", "bio_carbon" ],
     "skills": [ { "level": 2, "name": "melee" }, { "level": 2, "name": "unarmed" }, { "level": 2, "name": "dodge" } ],
-    "proficiencies": [ "prof_unarmed_familiar", "prof_claws_familiar", "prof_bionics_familiar" ],
+    "proficiencies": [ "prof_unarmed_familiar", "prof_claws_familiar", "prof_bionics_familiar", "prof_gross_anatomy" ],
     "items": {
       "both": {
         "entries": [

--- a/data/mods/package_bionic_professions/bionic_professions.json
+++ b/data/mods/package_bionic_professions/bionic_professions.json
@@ -13,7 +13,7 @@
     "points": 5,
     "skills": [ { "level": 3, "name": "swimming" } ],
     "CBMs": [ "bio_str_enhancer", "bio_adrenaline", "bio_hydraulics", "bio_metabolics", "bio_power_storage_mkII" ],
-    "proficiencies": [ "prof_athlete_basic", "prof_athlete_expert" ]
+    "proficiencies": [ "prof_athlete_basic", "prof_athlete_expert" ],
     "items": {
       "both": {
         "entries": [
@@ -310,7 +310,14 @@
     "points": 6,
     "CBMs": [ "bio_surgical_razor", "bio_flashlight", "bio_batteries", "bio_power_storage_mkII" ],
     "skills": [ { "level": 8, "name": "firstaid" } ],
-    "proficiencies": [ "prof_intro_biology", "prof_physiology", "prof_wound_care", "prof_wound_care_expert", "prof_dissect_humans", "prof_gross_anatomy" ],
+    "proficiencies": [
+      "prof_intro_biology",
+      "prof_physiology",
+      "prof_wound_care",
+      "prof_wound_care_expert",
+      "prof_dissect_humans",
+      "prof_gross_anatomy"
+    ],
     "traits": [ "PROF_MED" ],
     "items": {
       "both": {


### PR DESCRIPTION
#### Summary
Content "Professions & hobbies know gross anatomy & new butchering profs"

#### Purpose of change

Professions & hobbies were not updated in #75340 to give Gross Anatomy, when some of these would contain knowledge of _where_ to hit something. Continuation of #76156.

#### Describe the solution

Add Gross Anatomy to intermediate/expert melee hobbies, snipers, hunters, CQC/riot police, assassins, doctors, and the Marine(all Marines are trained in knife combat IRL)
Add Ungulate Anatomy to the hunters, because of deer. The shotgun hunter also gets Birds of Flight.
Hunters know basic butchering and skinning.

#### Describe alternatives you've considered

Also grant Physiology(thus also prereq. Introduction to Biology) to the expert melee hobbies, assassins & snipers.

MMA: Add additional weakpoints referring to combat versus the various enemies of LoZ.

#### Testing

Create world w/ all changed mods, changes load, scroll the professions.

#### Additional context

~~Dr. Erk is still the best melee combatant among the devs~~