### PR TITLE
avoid crashing on SIGINT by not redrawing the UI

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -176,10 +176,11 @@ void exit_handler( int s )
             imclient.reset();
             exit( exit_status );
         }
+    } else {
+        inp_mngr.set_timeout( old_timeout );
+        ui_manager::redraw_invalidated();
+        catacurses::doupdate();
     }
-    inp_mngr.set_timeout( old_timeout );
-    ui_manager::redraw_invalidated();
-    catacurses::doupdate();
 }
 
 struct arg_handler {


### PR DESCRIPTION
#### Summary
Bugfixes "avoid crashing on SIGINT by not redrawing the UI"

#### Purpose of change
Fixes #76130
