### PR TITLE
Remove the music action from AR bionic

### DIFF
--- a/data/json/items/fake.json
+++ b/data/json/items/fake.json
@@ -54,7 +54,6 @@
     "description": "Extremely thin lenses provides user with augmented reality overlay allowing the user to zoom, and it displays handy information about local topology.",
     "charges_per_use": 1,
     "use_action": [ "CAMERA", "PORTABLE_GAME", "EINKTABLETPC", "ELECTRICSTORAGE", "EBOOKSAVE", "EBOOKREAD" ],
-    "tick_action": [ "EPIC_MUSIC" ],
     "pocket_data": [
       {
         "pocket_type": "EBOOK",


### PR DESCRIPTION
This looks like it was accidentally added in #67532


#### Summary
None

#### Purpose of change
Ran across this while looking at #76084 
It's just lenses, it shouldn't play music.
It was added in #67532 with no commentary, looks like a mistake and definitely doesn't fit.
Not clear if it even works?

#### Describe the solution
Just remove the tick action.
