### PR TITLE
bump version of actions/download-artifact

### DIFF
--- a/.github/workflows/format_emscripten.yml
+++ b/.github/workflows/format_emscripten.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           ref: gh-pages
 
-      - uses: actions/download-artifact@v3.1.4
+      - uses: actions/download-artifact@v4
         with:
           name: formatter
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Got a notice that actions/download-artifact is deprecated

#### Describe the solution
Bump the version to v4


#### Additional context
Read docs at https://github.com/actions/download-artifact?tab=readme-ov-file and none of the migration instructions seem to apply since our use case is very simple.