### PR TITLE
Autodrive works on forest trails again (for tiny vehicles)

### DIFF
--- a/data/json/overmap/overmap_terrain/overmap_terrain_transportation.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_transportation.json
@@ -114,6 +114,7 @@
     "color": "green",
     "vision_levels": "forested",
     "see_cost": "spaced_high",
+    "travel_cost_type": "trail",
     "flags": [ "LINEAR", "REQUIRES_PREDECESSOR" ],
     "land_use_code": "forest"
   },
@@ -122,6 +123,7 @@
     "id": [ "trailhead", "trailhead_shack_z0", "trailhead_outhouse_z0" ],
     "name": "trailhead",
     "vision_levels": "blends_till_details",
+    "travel_cost_type": "trail",
     "see_cost": "none",
     "sym": "T",
     "color": "brown"


### PR DESCRIPTION
#### Summary
Bugfixes "Autodrive works on forest trails again (for tiny vehicles)"

#### Purpose of change
During some sleuthing on the development discord we found this was accidentally removed in #67470

#### Describe the solution
Re-add trail travel_cost_type to forest trail, duh

Also add it to trailheads, so you can path onto the trails in the first place

#### Describe alternatives you've considered
#76142

#### Testing
(This image was without the trailhead type changing, so it takes a really roundabout route to get there. But it does path through trails)
![image](https://github.com/user-attachments/assets/cb6fcc72-b08e-407b-b2b4-1d81c12f9159)


#### Additional context

