### PR TITLE
Maybe fix 0.H tests

### DIFF
--- a/tests/reloading_test.cpp
+++ b/tests/reloading_test.cpp
@@ -799,8 +799,6 @@ TEST_CASE( "reload_gun_with_integral_magazine_using_speedloader", "[reload],[gun
     // Make sure the player doesn't drop anything :P
     dummy.wear_item( item( "backpack", calendar::turn_zero ) );
 
-    item_location ammo = dummy.i_add( item( "38_special", calendar::turn_zero,
-                                            item::default_charges_tag{} ) );
     item_location speedloader = dummy.i_add( item( "38_speedloader", calendar::turn_zero, false ) );
     item_location ammo = dummy.i_add( item( "38_special", calendar::turn_zero,
                                             speedloader->remaining_ammo_capacity() ) );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Basic build is failing on 0.H branch due to redefinition of the `ammo` variable in this test

#### Describe the solution
Remove one leftover definition, keep the newer one

#### Describe alternatives you've considered


#### Testing
Did not run clang locally, github CI guide my PR! (Though this should work just fine tbh)

#### Additional context
