### PR TITLE
Correct some ``copy-from`` weirdness caught in #76180

### DIFF
--- a/data/json/monsters/fungus.json
+++ b/data/json/monsters/fungus.json
@@ -179,7 +179,7 @@
     "name": { "str": "fungaloid shambler" },
     "description": "A large white fungus, a bulging gray stalk supporting a bloom at the top.  Spores float from its gills and tendrils extend from the base.  Chunks of rock, metal, bone, and wood are held by tendrils as a kind of armor.",
     "copy-from": "mon_fungaloid",
-    "volume": "12 L",
+    "volume": "120 L",
     "weight": "160 kg",
     "hp": 150,
     "speed": 20,

--- a/data/json/monsters/zanimal_upgrade.json
+++ b/data/json/monsters/zanimal_upgrade.json
@@ -81,7 +81,7 @@
     "hp": 34,
     "speed": 85,
     "color": "magenta",
-    "upgrades": { "half_life": 56, "into_group": "GROUP_ZOMBIE_DOG_UPGRADE" },
+    "upgrades": false,
     "extend": { "special_attacks": [ [ "PARROT_AT_DANGER", 2 ], [ "SHRIEK", 2 ] ] }
   },
   {

--- a/data/json/monsters/zed-classic.json
+++ b/data/json/monsters/zed-classic.json
@@ -163,7 +163,6 @@
       }
     ],
     "death_drops": "mon_zombie_hazmat_death_drops",
-    "upgrades": false,
     "armor": { "bash": 5, "cut": 4, "bullet": 3, "electric": 5 },
     "extend": { "weakpoint_sets": [ "wps_humanoid_gasmask" ], "families": [ "prof_wp_syn_armored" ], "flags": [ "ACIDPROOF" ] },
     "delete": { "special_attacks": [ "bite_humanoid", "scratch_humanoid" ] }

--- a/data/json/monsters/zed-pupating.json
+++ b/data/json/monsters/zed-pupating.json
@@ -137,7 +137,7 @@
   {
     "id": "mon_zombie_pupa_shady",
     "type": "MONSTER",
-    "copy-from": "mon_zombie_pupa_decoy",
+    "copy-from": "mon_zombie_pupa_decoy_shady",
     "extend": {
       "special_attacks": [
         {

--- a/data/json/monsters/zed-winged.json
+++ b/data/json/monsters/zed-winged.json
@@ -73,6 +73,7 @@
       { "type": "leap", "cooldown": 2, "max_range": 8 }
     ],
     "burn_into": "mon_zombie_scorched_lasher",
+    "upgrades": false,
     "armor": { "bash": 2, "cut": 2, "bullet": 2, "electric": 1 },
     "extend": { "families": [ "prof_wp_flying" ], "flags": [ "SMELLS" ] }
   },

--- a/data/json/monsters/zed_ferrous.json
+++ b/data/json/monsters/zed_ferrous.json
@@ -75,6 +75,7 @@
     "grab_strength": 35,
     "attack_effs": [ { "id": "tetanus", "duration": 300, "chance": 20 } ],
     "burn_into": "mon_zombie_scorched_rust",
+    "upgrades": false,
     "armor": { "bash": 5, "cut": 5, "stab": 5, "bullet": 5 },
     "extend": { "flags": [ "SMELLS" ], "special_attacks": [ { "id": "impale" } ] }
   },
@@ -107,6 +108,7 @@
     ],
     "attack_effs": [ { "id": "tetanus", "duration": 300, "chance": 10 } ],
     "burn_into": "mon_zombie_fiend_rust",
+    "upgrades": false,
     "armor": { "bash": 8, "cut": 8, "stab": 8, "bullet": 8 },
     "extend": { "flags": [ "SMELLS", "PUSH_VEH" ] },
     "delete": { "flags": [ "GRABS" ] }

--- a/data/json/monsters/zed_skeletal.json
+++ b/data/json/monsters/zed_skeletal.json
@@ -75,6 +75,7 @@
     ],
     "special_when_hit": [ "ZAPBACK", 100 ],
     "fungalize_into": "mon_skeleton_fungus",
+    "upgrades": false,
     "armor": { "cut": 15, "stab": 30, "acid": 3, "bullet": 30 },
     "extend": {
       "weakpoint_sets": [ "wps_bone_armor" ],

--- a/data/json/monsters/zed_soldiers.json
+++ b/data/json/monsters/zed_soldiers.json
@@ -117,7 +117,8 @@
     "diff": 20,
     "bleed_rate": 50,
     "harvest": "zombie_humanoid_acid",
-    "delete": { "upgrades": { "half_life": 42, "into_group": "GROUP_SOLDIER_UPGRADE" }, "categories": [ "CLASSIC" ] },
+    "delete": { "categories": [ "CLASSIC" ] },
+    "upgrades": false,
     "relative": { "hp": 40, "speed": -10, "melee_skill": 2, "armor": { "bash": 5 } },
     "extend": {
       "special_attacks": [

--- a/data/json/monsters/zed_tentacle.json
+++ b/data/json/monsters/zed_tentacle.json
@@ -90,6 +90,7 @@
         "ignore_dest_danger": true,
         "message": "The zombie strider takes a long step!"
       }
-    ]
+    ],
+    "upgrades": false
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
#76180 pointed out some upgrade issues (and unrelated stuff, shame on you for including monster sizes in there). I was the one who hooked up the ``copy-from`` between zombies, and at least a few issues pointed out there were my oversights and not intended changes. So here I am to change those oversights, or some other points from that issue I agree with.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
The following monsters no longer upgrade:
- Garghoul
- Skeletal shocker
- Howling dog
- Rust urchin
- Rustfist Brute
- Zombie Strider
- Caustic Soldier Zombie (replaced nonfunctional ``delete`` syntax. I have horrible deja vu because I could swear I already did it once)

Other changes:
- Hazmat zombies now actually do upgrade. I always thought it was silly they didn't
- Shady pupating zombie now copies from the proper decoy
- Fungaloid shambler now has more accurate volume
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Most other changes in the issue I either disagree with, require new mongroups, or I cannot see being actual issues. The ones I tackled here I agreed with and wanted to correct. But I do not consider this PR to be closing the attached issue
- I ignored the scorched line for this entirely because I still intend to give them unique evolutions in the future, and they're rare enough to where I don't see this as being a problem for the time being
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
