### PR TITLE
Improved companion order failure reporting somewhat

### DIFF
--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -41,6 +41,12 @@ std::vector<tripoint_bub_ms> route_adjacent( const Character &you, const tripoin
 
 enum class requirement_check_result : int {
     SKIP_LOCATION = 0,
+    SKIP_LOCATION_NO_ZONE,  // Zone activity but no zone found
+    SKIP_LOCATION_NO_SKILL, // Insufficient npc skill for task.
+    SKIP_LOCATION_BLOCKING, // Something is blocking the target location for companion.
+    SKIP_LOCATION_UNKNOWN_ACTIVITY, // This is probably an error: failed to find matching activity.
+    SKIP_LOCATION_NO_LOCATION, // No candidate locations found
+    SKIP_LOCATION_NO_MATCH, // No matches found
     CAN_DO_LOCATION,
     RETURN_EARLY       //another activity like a fetch activity has been started.
 };

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -3366,7 +3366,7 @@ bool generic_multi_activity_handler( player_activity &act, Character &you, bool 
                      _( "%1$s failed to perform the %2$s activity because the target location is blocked or cannot be reached." ),
                      you.disp_name(), activity_to_restore.c_str() );
         } else if( reason.skip_location_no_skill ) {
-            add_msg( m_neutral, _( "%1$s failed to perform the %2$s activity because of unsufficient skills." ),
+            add_msg( m_neutral, _( "%1$s failed to perform the %2$s activity because of insufficient skills." ),
                      you.disp_name(), activity_to_restore.c_str() );
         } else if( reason.skip_location_unknown_activity ) {
             add_msg( m_neutral,

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -2733,7 +2733,7 @@ static requirement_check_result generic_multi_activity_check_requirement(
     // tidy up activity doesn't - it wants things that may not be in a zone already - things that may have been left lying around.
     if( needs_to_be_in_zone && !zone ) {
         can_do_it = false;
-        return requirement_check_result::SKIP_LOCATION;
+        return requirement_check_result::SKIP_LOCATION_NO_ZONE;
     }
     if( can_do_it ) {
         return requirement_check_result::CAN_DO_LOCATION;
@@ -2746,7 +2746,7 @@ static requirement_check_result generic_multi_activity_check_requirement(
         // we can discount this tile, the work can't be done.
         if( reason == do_activity_reason::DONT_HAVE_SKILL ) {
             if( zone ) {
-                you.add_msg_if_player( m_info, _( "You don't have the skill for the %s task at zone %s." ),
+                you.add_msg_if_player( m_info, _( "You don't have the skill for the %1$s task at zone %2$s." ),
                                        act_id.c_str(), zone->get_name() );
             } else {
                 you.add_msg_if_player( m_info, _( "You don't have the skill for the %s task." ), act_id.c_str() );
@@ -2754,14 +2754,29 @@ static requirement_check_result generic_multi_activity_check_requirement(
         } else if( reason == do_activity_reason::BLOCKING_TILE ) {
             if( zone ) {
                 you.add_msg_if_player( m_info,
-                                       _( "There is something blocking the location for the %s task at zone %s." ), act_id.c_str(),
+                                       _( "There is something blocking the location for the %1$s task at zone %2$s." ), act_id.c_str(),
                                        zone->get_name() );
             } else {
                 you.add_msg_if_player( m_info, _( "There is something blocking the location for the %s task." ),
                                        act_id.c_str() );
             }
         }
-        return requirement_check_result::SKIP_LOCATION;
+        if( you.is_npc() ) {
+            if( reason == do_activity_reason::DONT_HAVE_SKILL ) {
+                return requirement_check_result::SKIP_LOCATION_NO_SKILL;
+
+            } else if( reason == do_activity_reason::NO_ZONE ) {
+                return requirement_check_result::SKIP_LOCATION_NO_ZONE;
+            } else if( reason == do_activity_reason::ALREADY_DONE ) {
+                return requirement_check_result::SKIP_LOCATION;
+            } else if( reason == do_activity_reason::BLOCKING_TILE ) {
+                return requirement_check_result::SKIP_LOCATION_BLOCKING;
+            } else if( reason == do_activity_reason::UNKNOWN_ACTIVITY ) {
+                return requirement_check_result::SKIP_LOCATION_UNKNOWN_ACTIVITY;
+            }
+        } else {
+            return requirement_check_result::SKIP_LOCATION;
+        }
     } else if( reason == do_activity_reason::NO_COMPONENTS ||
                reason == do_activity_reason::NEEDS_CUT_HARVESTING ||
                reason == do_activity_reason::NEEDS_PLANTING ||
@@ -2952,7 +2967,7 @@ static requirement_check_result generic_multi_activity_check_requirement(
                         you.activity = player_activity();
                         you.backlog.clear();
                         check_npc_revert( you );
-                        return requirement_check_result::SKIP_LOCATION;
+                        return requirement_check_result::SKIP_LOCATION_NO_LOCATION;
                     }
                     act_prev.coords.push_back(
                         here.getabs(
@@ -2964,7 +2979,7 @@ static requirement_check_result generic_multi_activity_check_requirement(
             return requirement_check_result::RETURN_EARLY;
         }
     }
-    return requirement_check_result::SKIP_LOCATION;
+    return requirement_check_result::SKIP_LOCATION_NO_MATCH;
 }
 
 /** Do activity at this location */
@@ -3152,6 +3167,18 @@ static bool generic_multi_activity_do(
     return true;
 }
 
+struct failure_reasons {
+    bool no_path = false;
+    bool skip_location_no_zone = false;
+    bool skip_location_blocking = false;
+    bool skip_location_no_skill = false;
+    bool skip_location_unknown_activity = false;
+    bool skip_location_no_location = false;
+    bool skip_location_no_match = false;
+    bool skip_location = false;
+    bool no_craft_disassembly_location_route_found = false;
+};
+
 bool generic_multi_activity_handler( player_activity &act, Character &you, bool check_only )
 {
     map &here = get_map();
@@ -3184,6 +3211,9 @@ bool generic_multi_activity_handler( player_activity &act, Character &you, bool 
         }
         return true;
     }
+
+    failure_reasons reason;
+
     for( const tripoint_abs_ms &src : src_sorted ) {
         const tripoint_bub_ms &src_loc = here.bub_from_abs( src );
         if( !here.inbounds( src_loc ) && !check_only ) {
@@ -3198,6 +3228,7 @@ bool generic_multi_activity_handler( player_activity &act, Character &you, bool 
             const std::vector<tripoint_bub_ms> route = route_adjacent( you, src_loc );
             if( route.empty() ) {
                 // can't get there, can't do anything, skip it
+                reason.no_path = true;
                 continue;
             }
             you.set_moves( 0 );
@@ -3210,7 +3241,33 @@ bool generic_multi_activity_handler( player_activity &act, Character &you, bool 
         const requirement_check_result req_res = generic_multi_activity_check_requirement(
                     you, activity_to_restore, act_info, src, src_loc, src_set, check_only );
         if( req_res == requirement_check_result::SKIP_LOCATION ) {
+            reason.skip_location = true;
             continue;
+
+        } else if( req_res == requirement_check_result::SKIP_LOCATION_NO_ZONE ) {
+            reason.skip_location_no_zone = true;
+            continue;
+
+        }      else if( req_res == requirement_check_result::SKIP_LOCATION_NO_SKILL ) {
+            reason.skip_location_no_skill = true;
+            continue;
+
+        }        else if( req_res == requirement_check_result::SKIP_LOCATION_BLOCKING ) {
+            reason.skip_location_blocking = true;
+            continue;
+
+        } else if( req_res == requirement_check_result::SKIP_LOCATION_UNKNOWN_ACTIVITY ) {
+            reason.skip_location_unknown_activity = true;
+            continue;
+
+        } else if( req_res == requirement_check_result::SKIP_LOCATION_NO_LOCATION ) {
+            reason.skip_location_no_location = true;
+            continue;
+
+        } else if( req_res == requirement_check_result::SKIP_LOCATION_NO_MATCH ) {
+            reason.skip_location_no_match = true;
+            continue;
+
         } else if( req_res == requirement_check_result::RETURN_EARLY ) {
             return true;
         }
@@ -3232,6 +3289,7 @@ bool generic_multi_activity_handler( player_activity &act, Character &you, bool 
             // check if we found path to source / adjacent tile
             if( route.empty() ) {
                 check_npc_revert( you );
+                reason.no_craft_disassembly_location_route_found = true;
                 continue;
             }
             if( !check_only ) {
@@ -3290,6 +3348,46 @@ bool generic_multi_activity_handler( player_activity &act, Character &you, bool 
         you.activity_vehicle_part_index = -1;
     }
     // scanned every location, tried every path.
+    if( !check_only && you.is_npc() ) {
+        if( src_sorted.empty() ) {
+            add_msg( m_neutral,
+                     _( "%1s failed to perform the %2$s activity because no suitable locations were found." ),
+                     you.disp_name(), activity_to_restore.c_str() );
+        } else if( reason.no_path ) {
+            add_msg( m_neutral,
+                     _( "%1$s failed to perform the %2$s activity because no path to a suitable location could be found." ),
+                     you.disp_name(), activity_to_restore.c_str() );
+        } else if( reason.skip_location_no_zone ) {
+            add_msg( m_neutral,
+                     _( "%1$s failed to perform the %2$s activity because no required zone was found." ),
+                     you.disp_name(), activity_to_restore.c_str() );
+        } else if( reason.skip_location_blocking ) {
+            add_msg( m_neutral,
+                     _( "%1$s failed to perform the %2$s activity because the target location is blocked or cannot be reached." ),
+                     you.disp_name(), activity_to_restore.c_str() );
+        } else if( reason.skip_location_no_skill ) {
+            add_msg( m_neutral, _( "%1$s failed to perform the %2$s activity because of unsufficient skills." ),
+                     you.disp_name(), activity_to_restore.c_str() );
+        } else if( reason.skip_location_unknown_activity ) {
+            add_msg( m_neutral,
+                     _( "%1$s failed to perform the %2$s activity because of the activity couldn't be found.  This is probably an error." ),
+                     you.disp_name(), activity_to_restore.c_str() );
+        } else if( reason.skip_location_no_location ) {
+            add_msg( m_neutral,
+                     _( "%1$s failed to perform the %2$s activity because no suitable location could be found." ),
+                     you.disp_name(), activity_to_restore.c_str() );
+        } else if( reason.skip_location_no_match ) {
+            add_msg( m_neutral,
+                     _( "%1$s failed to perform the %2$s activity because of no criteria could be matched." ),
+                     you.disp_name(), activity_to_restore.c_str() );
+        } else if( reason.skip_location ) {
+            // Assumed to have been reported already.
+        } else if( reason.no_craft_disassembly_location_route_found ) {
+            add_msg( m_neutral,
+                     _( "%1$s failed to perform the %2$s activity because no path to a suitable crafting/disassembly location could be found." ),
+                     you.disp_name(), activity_to_restore.c_str() );
+        }
+    }
     return false;
 }
 

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -3370,7 +3370,7 @@ bool generic_multi_activity_handler( player_activity &act, Character &you, bool 
                      you.disp_name(), activity_to_restore.c_str() );
         } else if( reason.skip_location_unknown_activity ) {
             add_msg( m_neutral,
-                     _( "%1$s failed to perform the %2$s activity because of the activity couldn't be found.  This is probably an error." ),
+                     _( "%1$s failed to perform the %2$s activity because the activity couldn't be found.  This is probably an error." ),
                      you.disp_name(), activity_to_restore.c_str() );
         } else if( reason.skip_location_no_location ) {
             add_msg( m_neutral,

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -3378,7 +3378,7 @@ bool generic_multi_activity_handler( player_activity &act, Character &you, bool 
                      you.disp_name(), activity_to_restore.c_str() );
         } else if( reason.skip_location_no_match ) {
             add_msg( m_neutral,
-                     _( "%1$s failed to perform the %2$s activity because of no criteria could be matched." ),
+                     _( "%1$s failed to perform the %2$s activity because no criteria could be matched." ),
                      you.disp_name(), activity_to_restore.c_str() );
         } else if( reason.skip_location ) {
             // Assumed to have been reported already.


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Try to improve feedback on companion activity failure reasons.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Split "SKIP_LOCATION" generic failure result on attempts to perform companion activities into several variants to indicate the reason for the failure and than use that result to generate a feedback message.
The reason the reports aren't generated inside the operation is that it's inside a loop where potentially a large number of variants can be checked, which can potentially clutter the log.
One of these failures is then selected for the report if none of the attempts succeeded.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Somehow build more detailed error reports inside the operation, feed those back, and have logic to keep one as the "best" failure report to be the one printed if none of the attempts succeeds. That would probably have to be done to be able to produce useful error reports that would say what's missing rather than providing a broad indication (I'm thinking of things like Skill X at level Y, 3 Planks, tool providing the Z capability, etc.). As it currently stands, the only additional info available at the lower level is a potential zone name (and those reports remain inside and are duplicated in the log).
- Prettify the reports by setting up a translation array indexed by the activities containing UI oriented strings representing the activities rather than using the string version directly.
- Debate whether reports always should be generated or only when the PC can see the companion. I went for the "always" option, as you'd want to know your companion has failed to perform a task after walking out of view (and from a realism perspective, the companion could have shouted the result to you).

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Much less than I'd like, because I've failed to arrange for most of the error situations.
Failure to reach a construction zone at a roof was produced (and I also found the companion can't use ladders, but will use stairs).
Failure to find a zone was also arranged (dismantle vehicles when the zone doesn't have any vehicle in it).

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
