### PR TITLE
Marking strings as untranslatable

### DIFF
--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -459,6 +459,21 @@ order of the entries does not matter.
 
 Currently, only some JSON values support this syntax (see [here](/doc/TRANSLATING.md#translation) for a list of supported values and more detailed explanation).
 
+The string extractor will extract all encountered strings from JSON for translation. But if some string should not be translated, such as text that is not normally visible to the player (names and descriptions of monster-only effects and spells), then you can write `"NO_I18N"` in the comment for translators:
+
+```JSON
+"name": {
+    "//~": "NO_I18N",
+    "str": "Fake Monster-Only Spell"
+},
+"description": {
+    "//~": "NO_I18N",
+    "str": "Fake Monster-Only Spell Description"
+}
+```
+
+The extractor will skip these two specified strings and only these, extracting the remaining unmarked strings from the same JSON object.
+
 ## Comments
 
 JSON has no intrinsic support for comments.  However, by convention in CDDA

--- a/doc/TRANSLATING.md
+++ b/doc/TRANSLATING.md
@@ -312,6 +312,16 @@ you also need to update `extract_json_strings.py` and run `lang/update_pot.sh`
 to ensure that the strings are correctly extracted for translation, and run the
 unit test to fix text styling issues reported by the `translation` class.
 
+If a string doesn't need to be translated, you can write `"NO_I18N"` in the
+`"//~"` comment, and this string will not be available to translators (see [here](/doc/JSON_INFO.md#translatable-strings)):
+
+```JSON
+"name": {
+    "//~": "NO_I18N",
+    "str": "Fake Monster-Only Spell"
+}
+```
+
 ### Static string variables
 
 Translation functions should not be called when initializing a static variable.

--- a/lang/string_extractor/write_text.py
+++ b/lang/string_extractor/write_text.py
@@ -53,7 +53,7 @@ def write_text(json, origin, context="", comment="",
             else:
                 text_plural = "{}s".format(text)
 
-    if not text:
+    if not text or "NO_I18N" in comments:
         return
 
     format_tag = ""


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
I18N "Omit unnecessary lines from translations"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Translation files contain many strings that are usually not visible to the player and do not make sense to translate.
```
#. ~ Spell name
#: data/mods/MindOverMatter/monsters/monsters_spells.json
msgid "[Ψ]Network Effect Monster"

#. ~ Description of spell "[Ψ]Network Effect Monster"
#: data/mods/MindOverMatter/monsters/monsters_spells.json
msgid "AI trigger for only casting when hostiles are present."
```
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Make it possible to specify a "flag" for the string extractor in the comment for translators:
```JSON
"name": {
    "str": "[Ψ]Nether Banish Monster",
    "//~": "NO_I18N"
},
"description": {
    "str": "A spell for the zombie null to try to banish nether monsters.  It's a bug if you have it.",
    "//~": "NO_I18N"
},
```
The extractor will skip such marked strings.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
This `//~` comment for the translators must be inside a text object and be a string. But overall, it is a universal and simple solution, I don't think doing it any other way would be worth it.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
For now (not in this PR) I've added these flags to vanilla game spells and monster's pseudo guns. 96967 vs 96680 = -287 strings in .pot file. There should be more after the mods.
Diff file between these two translation files: [pot.txt](https://github.com/user-attachments/files/16872806/pot.txt).
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
