### PR TITLE
fix you being able to "see" impossible shape when blind

### DIFF
--- a/data/json/monster_special_attacks/spells.json
+++ b/data/json/monster_special_attacks/spells.json
@@ -703,7 +703,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_impossible_shape_attack",
-    "condition": { "and": [ "npc_can_see", { "math": [ "u_madness", ">", "10" ] } ] },
+    "condition": { "and": [ { "or": [ "u_can_see", { "u_has_flag": "BLIND" } ] }, { "math": [ "u_madness", ">", "10" ] } ] },
     "effect": [
       { "u_add_effect": "nightmares", "duration": "18 hours" },
       { "u_add_effect": "disrupted_sleep", "duration": "18 hours" },

--- a/data/json/monster_special_attacks/spells.json
+++ b/data/json/monster_special_attacks/spells.json
@@ -703,7 +703,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_impossible_shape_attack",
-    "condition": { "and": [ "u_can_see", { "math": [ "u_madness", ">", "10" ] } ] },
+    "condition": { "and": [ "npc_can_see", { "math": [ "u_madness", ">", "10" ] } ] },
     "effect": [
       { "u_add_effect": "nightmares", "duration": "18 hours" },
       { "u_add_effect": "disrupted_sleep", "duration": "18 hours" },


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fix #76202
#### Describe the solution
~~Make EoC check your ability to see, not shape's one~~ EoC do check your ability to see already, but it only checks you have blind effect, when it actually need to check BLIND flag also (given by blindfold and maybe few more stuff)

maybe some psionic mod would add ability to make enemy look vague to counter mental attack, in this case i'd need to add effect that check if alpha talker can see beta talker and vice versa