### PR TITLE
Re-added ability to launch nuclear missile to No Hope mod, once again

### DIFF
--- a/data/mods/No_Hope/Mapgen/missile_silo.json
+++ b/data/mods/No_Hope/Mapgen/missile_silo.json
@@ -1,0 +1,70 @@
+[
+  {
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": [ "silo_finale" ],
+    "//": "Adds a missile launch option to the finale's computer",
+    "weight": 400,
+    "object": {
+      "fill_ter": "t_thconc_floor",
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "  │││││││││││           ",
+        " ││~~~~~~~~~│││││ │││││ ",
+        "││~~~~~~~~~~~││Y│││4│a││",
+        "│~~~~~~~~~~~~~+........│",
+        "│~~~~~~~~~~~~~|.││││││.│",
+        "│~~~~~~~~~~~~~|.|x..a│.│",
+        "│~~~~~~~~~~~~~|.|x...│.│",
+        "│~~~~~~~~~~~~~|.|6c..+.│",
+        "│~~~~~~~~~~~~~|.|x...│Y│",
+        "│~~~~~~~~~~~~~|.|x...│││",
+        "│~~~~~~~~~~~~~|.│....│  ",
+        "│~~~~~~~~~~~~~│.│%%%%│││",
+        "││~~~~~~~~~~~││.││││││^│",
+        " ││~~~~~~~~~│││..+....$│",
+        "  │││││││││││ ││││Y│<│$│",
+        "                 │││││││"
+      ],
+      "terrain": {
+        " ": "t_rock",
+        "│": "t_wall_metal",
+        ".": "t_thconc_floor",
+        "~": "t_metal_floor_no_roof",
+        "|": "t_reinforced_glass_shutter_open",
+        "?": "t_door_metal_c_peep",
+        "+": "t_door_metal_locked",
+        "<": "t_stairs_up",
+        "Y": "t_card_military",
+        "^": "t_elevator_control_off",
+        "$": "t_elevator"
+      },
+      "furniture": {
+        "x": "f_console_broken",
+        "%": "f_machinery_electronic",
+        "1": "f_speaker_cabinet",
+        "4": "f_speaker_cabinet",
+        "a": "f_air_conditioner",
+        "c": "f_chair"
+      },
+      "computers": {
+        "6": {
+          "name": "Missile Controls",
+          "access_denied": "ERROR!  Access denied!  Unauthorized access will be met with lethal force!",
+          "security": 1,
+          "failures": [ { "action": "alarm" }, { "action": "damage" }, { "action": "secubots" } ],
+          "options": [ { "name": "Launch Missile", "action": "miss_launch" }, { "name": "Disarm Missile", "action": "miss_disarm" } ]
+        }
+      },
+      "place_graffiti": [ { "text": "Warning!  Automatic security measures engaged due to the lockdown order!", "x": 17, "y": 20 } ],
+      "place_monster": [ { "monster": "mon_zombie_hazmat", "x": 8, "y": 15 } ]
+    }
+  }
+]

--- a/data/mods/No_Hope/modinfo.json
+++ b/data/mods/No_Hope/modinfo.json
@@ -4,10 +4,11 @@
     "id": "no_hope",
     "name": "No Hope",
     "authors": [ "Night_Pryanik" ],
+    "maintainers": [ "Night_Pryanik" ],
     "description": "- Significantly reduced amount of places with guaranteed loot spawns.\n- Loot spawn in buildings is drastically reduced, especially for food, tools, guns etc.\n- Most buildings are destroyed, vandalized, or looted.\n- Most cars are destroyed or at least damaged.  Intact cars are nearly impossible to find.\n- Fuel is much harder to find, almost all cars have no fuel in tanks.\n- Marauders, looters, and bandits everywhere.\n\nSee extended description in README.md.\n\nTo get the mod author's intended playing experience, consider:\n- Enabling wandering hordes.\n- Setting item spawn scaling factor to 0.5 or lower.\n- Setting spawn rate scaling factor to 1.5 or higher.",
     "category": "content",
     "dependencies": [ "dda" ],
-    "version": "3.4"
+    "version": "3.5"
   },
   {
     "type": "monster_adjustment",

--- a/src/computer_session.cpp
+++ b/src/computer_session.cpp
@@ -104,6 +104,8 @@ static const mtype_id mon_secubot( "mon_secubot" );
 static const oter_type_str_id oter_type_sewer( "sewer" );
 static const oter_type_str_id oter_type_subway( "subway" );
 
+static const overmap_special_id overmap_special_Crater( "Crater" );
+
 static const skill_id skill_computer( "computer" );
 
 static const species_id species_HUMAN( "HUMAN" );
@@ -779,16 +781,8 @@ void computer_session::action_miss_launch()
         tmpmap.save();
     }
 
-    for( const tripoint_abs_omt &p : points_in_radius( target, 2 ) ) {
-        // give it a nice rounded shape
-        if( !( p.x() == target.x() - 2 && p.y() == target.y() - 2 ) &&
-            !( p.x() == target.x() - 2 && p.y() == target.y() + 2 ) &&
-            !( p.x() == target.x() + 2 && p.y() == target.y() - 2 ) &&
-            !( p.x() == target.x() + 2 && p.y() == target.y() + 2 ) ) {
-            overmap_buffer.ter_set( p, oter_id( "field" ) );
-        }
-    }
-    explosion_handler::nuke( target );
+    overmap_buffer.place_special( *overmap_special_Crater, target, om_direction::type::north, false,
+                                  true );
 
     activate_failure( COMPFAIL_SHUTDOWN );
 }

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -844,18 +844,6 @@ void emp_blast( const tripoint &p )
     // TODO: Drain NPC energy reserves
 }
 
-void nuke( const tripoint_abs_omt &p )
-{
-    tinymap tmpmap;
-    tmpmap.load( p, false );
-
-    item mininuke( itype_mininuke_act );
-    mininuke.set_flag( json_flag_ACTIVATE_ON_PLACE );
-    tmpmap.add_item( { SEEX - 1, SEEY - 1, 0 }, mininuke );
-
-    tmpmap.save();
-}
-
 void resonance_cascade( const tripoint &p )
 {
     Character &player_character = get_player_character();

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -77,13 +77,10 @@ static const efftype_id effect_emp( "emp" );
 static const efftype_id effect_stunned( "stunned" );
 static const efftype_id effect_teleglow( "teleglow" );
 
-static const flag_id json_flag_ACTIVATE_ON_PLACE( "ACTIVATE_ON_PLACE" );
-
 static const furn_str_id furn_f_machinery_electronic( "f_machinery_electronic" );
 
 static const itype_id fuel_type_none( "null" );
 static const itype_id itype_e_handcuffs( "e_handcuffs" );
-static const itype_id itype_mininuke_act( "mininuke_act" );
 static const itype_id itype_rm13_armor_on( "rm13_armor_on" );
 
 static const json_character_flag json_flag_EMP_IMMUNE( "EMP_IMMUNE" );

--- a/src/explosion.h
+++ b/src/explosion.h
@@ -95,8 +95,6 @@ void resonance_cascade( const tripoint &p );
 void scrambler_blast( const tripoint &p );
 /** Triggers an EMP blast at p. */
 void emp_blast( const tripoint &p );
-/** Nuke the area at p - global overmap terrain coordinates! */
-void nuke( const tripoint_abs_omt &p );
 // shockwave applies knockback to all targets within radius of p
 // parameters force, stun, and dam_mult are passed to knockback()
 // ignore_player determines if player is affected, useful for bionic, etc.


### PR DESCRIPTION
#### Summary
Mods "Re-added ability to launch nuclear missile to No Hope mod, once again"

#### Purpose of change
One of the mod's players informed me that he can't find an option to launch a nuclear missile from the missile silo's finale. After an investigation I realized that I myself accidentally removed a mod's exclusive variant of silo's finale computer back in 2022 (#56850).

Also I noticed that my previous implementation of nuclear explosion no longer works for some reason, so I needed to fix that too.

Closes #73629.

#### Describe the solution
- Re-added accidentally deleted mapgen.
- Replaced manual placing of mininuke with spawing of `Crater` mutable overmap special, which does all the destruction by itself.
- Removed no longer needed `nuke` explosion handler.
- Returned myself back as a maintainer of the mod.

#### Describe alternatives you've considered
None.

#### Testing
Activated missile launch option, checked on the map and the overmap that crater is correctly spawned.

#### Additional context
None.
