### PR TITLE
Migrate ACT_WAIT_STAMINA to the activity_actor system.

### DIFF
--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -2220,4 +2220,35 @@ class pulp_activity_actor : public activity_actor
         bool pulp_acid;
 };
 
+class wait_stamina_activity_actor : public activity_actor
+{
+
+    public:
+        // Wait until stamina is at the maximum.
+        wait_stamina_activity_actor() = default;
+
+        // If we're given a threshold, wait until stamina is at least this value.
+        explicit wait_stamina_activity_actor( int stamina_threshold ) : stamina_threshold(
+                stamina_threshold ) {};
+
+        void start( player_activity &act, Character &who ) override;
+        void do_turn( player_activity &act, Character &you ) override;
+        void finish( player_activity &act, Character &you ) override;
+
+        activity_id get_type() const override {
+            return activity_id( "ACT_WAIT_STAMINA" );
+        }
+
+        std::unique_ptr<activity_actor> clone() const override {
+            return std::make_unique<wait_stamina_activity_actor>( *this );
+        }
+
+        void serialize( JsonOut &jsout ) const override;
+        static std::unique_ptr<activity_actor> deserialize( JsonValue &jsin );
+
+    private:
+        int stamina_threshold = -1;
+        int initial_stamina = -1;
+};
+
 #endif // CATA_SRC_ACTIVITY_ACTOR_DEFINITIONS_H

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -171,7 +171,6 @@ static const activity_id ACT_VIBE( "ACT_VIBE" );
 static const activity_id ACT_VIEW_RECIPE( "ACT_VIEW_RECIPE" );
 static const activity_id ACT_WAIT( "ACT_WAIT" );
 static const activity_id ACT_WAIT_NPC( "ACT_WAIT_NPC" );
-static const activity_id ACT_WAIT_STAMINA( "ACT_WAIT_STAMINA" );
 static const activity_id ACT_WAIT_WEATHER( "ACT_WAIT_WEATHER" );
 
 static const ammotype ammo_battery( "battery" );
@@ -297,7 +296,6 @@ activity_handlers::do_turn_functions = {
     { ACT_ROBOT_CONTROL, robot_control_do_turn },
     { ACT_TREE_COMMUNION, tree_communion_do_turn },
     { ACT_STUDY_SPELL, study_spell_do_turn },
-    { ACT_WAIT_STAMINA, wait_stamina_do_turn },
     { ACT_MULTIPLE_CRAFT, multiple_craft_do_turn },
     { ACT_MULTIPLE_DIS, multiple_dis_do_turn },
     { ACT_MULTIPLE_READ, multiple_read_do_turn },
@@ -337,7 +335,6 @@ activity_handlers::finish_functions = {
     { ACT_WAIT, wait_finish },
     { ACT_WAIT_WEATHER, wait_weather_finish },
     { ACT_WAIT_NPC, wait_npc_finish },
-    { ACT_WAIT_STAMINA, wait_stamina_finish },
     { ACT_SOCIALIZE, socialize_finish },
     { ACT_OPERATION, operation_finish },
     { ACT_VIBE, vibe_finish },
@@ -3114,38 +3111,6 @@ void activity_handlers::find_mount_do_turn( player_activity *act, Character *you
 void activity_handlers::wait_npc_finish( player_activity *act, Character *you )
 {
     you->add_msg_if_player( _( "%s finishes with you…" ), act->str_values[0] );
-    act->set_to_null();
-}
-
-void activity_handlers::wait_stamina_do_turn( player_activity *act, Character *you )
-{
-    int stamina_threshold = you->get_stamina_max();
-    if( !act->values.empty() ) {
-        stamina_threshold = act->values[0];
-        // remember initial stamina, only for waiting-with-threshold
-        if( act->values.size() == 1 ) {
-            act->values.push_back( you->get_stamina() );
-        }
-    }
-    if( you->get_stamina() >= stamina_threshold ) {
-        wait_stamina_finish( act, you );
-    }
-}
-
-void activity_handlers::wait_stamina_finish( player_activity *act, Character *you )
-{
-    if( !act->values.empty() ) {
-        const int stamina_threshold = act->values[0];
-        const int stamina_initial = ( act->values.size() > 1 ) ? act->values[1] : you->get_stamina();
-        if( you->get_stamina() < stamina_threshold && you->get_stamina() <= stamina_initial ) {
-            debugmsg( "Failed to wait until stamina threshold %d reached, only at %d. You may not be regaining stamina.",
-                      act->values.front(), you->get_stamina() );
-        }
-    } else if( you->get_stamina() < you->get_stamina_max() ) {
-        you->add_msg_if_player( _( "You are bored of waiting, so you stop." ) );
-    } else {
-        you->add_msg_if_player( _( "You finish waiting and feel refreshed." ) );
-    }
     act->set_to_null();
 }
 

--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -242,7 +242,6 @@ void vehicle_deconstruction_do_turn( player_activity *act, Character *you );
 void vehicle_repair_do_turn( player_activity *act, Character *you );
 void vibe_do_turn( player_activity *act, Character *you );
 void view_recipe_do_turn( player_activity *act, Character *you );
-void wait_stamina_do_turn( player_activity *act, Character *you );
 
 // defined in activity_handlers.cpp
 extern const std::map< activity_id, std::function<void( player_activity *, Character * )> >
@@ -277,7 +276,6 @@ void vibe_finish( player_activity *act, Character *you );
 void view_recipe_finish( player_activity *act, Character *you );
 void wait_finish( player_activity *act, Character *you );
 void wait_npc_finish( player_activity *act, Character *you );
-void wait_stamina_finish( player_activity *act, Character *you );
 void wait_weather_finish( player_activity *act, Character *you );
 
 int move_cost( const item &it, const tripoint_bub_ms &src, const tripoint_bub_ms &dest );

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1234,9 +1234,12 @@ static void wait()
             actType = ACT_WAIT;
         }
 
-        player_activity new_act( actType, 100 * to_turns<int>( time_to_wait ), 0 );
-
-        player_character.assign_activity( new_act );
+        if( actType == ACT_WAIT_STAMINA ) {
+            player_character.assign_activity( wait_stamina_activity_actor() );
+        } else {
+            player_activity new_act( actType, 100 * to_turns<int>( time_to_wait ), 0 );
+            player_character.assign_activity( new_act );
+        }
     }
 }
 

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <new>
 
+#include "activity_actor_definitions.h"
 #include "activity_handlers.h"
 #include "activity_type.h"
 #include "avatar.h"
@@ -54,7 +55,6 @@ static const activity_id ACT_SPELLCASTING( "ACT_SPELLCASTING" );
 static const activity_id ACT_TRAVELLING( "ACT_TRAVELLING" );
 static const activity_id ACT_VEHICLE( "ACT_VEHICLE" );
 static const activity_id ACT_VIEW_RECIPE( "ACT_VIEW_RECIPE" );
-static const activity_id ACT_WAIT_STAMINA( "ACT_WAIT_STAMINA" );
 static const activity_id ACT_WORKOUT_ACTIVE( "ACT_WORKOUT_ACTIVE" );
 static const activity_id ACT_WORKOUT_HARD( "ACT_WORKOUT_HARD" );
 static const activity_id ACT_WORKOUT_LIGHT( "ACT_WORKOUT_LIGHT" );
@@ -340,8 +340,6 @@ void player_activity::do_turn( Character &you )
         }
 
         auto_resume = true;
-        player_activity new_act( ACT_WAIT_STAMINA, to_moves<int>( 5_minutes ) );
-        new_act.values.push_back( you.get_stamina_max() );
         if( you.is_avatar() && !ignoreQuery ) {
             uilist tired_query;
             tired_query.text = _( "You struggle to continue.  Keep trying?" );
@@ -364,7 +362,7 @@ void player_activity::do_turn( Character &you )
             }
         }
         if( !ignoreQuery && auto_resume ) {
-            you.assign_activity( new_act );
+            you.assign_activity( wait_stamina_activity_actor( you.get_stamina_max() ) );
         }
         return;
     }

--- a/src/player_activity.h
+++ b/src/player_activity.h
@@ -144,7 +144,7 @@ class player_activity
         void deserialize_legacy_type( int legacy_type, activity_id &dest );
 
         /**
-         * Preform necessary initialization to start or resume the activity. Must be
+         * Perform necessary initialization to start or resume the activity. Must be
          * called whenever a Character starts a new activity.
          * When resuming an activity, do not call activity_actor::start
          */


### PR DESCRIPTION
#### Summary
Infrastructure "Migrate ACT_WAIT_STAMINA to an activity_actor"

#### Purpose of change

Work on #40013.

#### Describe the solution

The dependence on moves was removed as I couldn't see how it was anything but a placeholder value - wait_stamina_do_turn completely ignored the moves left. The actor also explicitly states that it can wait until a given threshold, whereas this functionality was implicit before.

#### Describe alternatives you've considered

Just leaving it, I suppose?

#### Testing

- [x] Waited until stamina was full.
- [x] Waited normally, and checked that the time was correct.
- [x] Smashed corpses until a break was needed, and checked that stamina was refilled correctly.

#### Additional context
I honestly thought this migration had been completed years ago.

Here's a step-by-step guide to the process for future reference.

1. Create a new class in `activity_actor_definitions.h`. This has to implement certain overrided methods. I've put a template below.
2. Create empty function definitions for the above mandatory functions in `activity_actor.cpp`
3. Remove the id definition from `activity_handlers.cpp` and copy-pasted it into `activity_actor.cpp` remove the `do_turn` and `finish` functions from the `do_turn_functions` and `finish_turn_functions` maps. The definitions of these functions can be copy-pasted into the respective implementations in `activity_actor.cpp`.
4. Remove the `do_turn` and `finish` functions from `activity_handlers.h`
5. Migrate state from the activity object into the new activity actor. e.g. for ACT_WAIT_STAMINA, the stamina threshold and initial stamina were stored in `player_activity.values`. These were moved to private variables, and an initialiser taking stamina threshold was created.
6. Search for all usages of the old function and migrate them to the new function.
7. Implement `serialize` and `deserialize`. These are pretty easy - just write the data you need to store in `serialize` and read it in `deserialize`. If you don't need to store across save files (e.g. waiting is not stored), then you can just write null. There are plenty of other activity actor examples.
8. TEST!!!

<details>
<summary> Activity actor generic template </summary> 

```c++
class activity_name_activity_actor : public activity_actor
{

    public:
        activity_name_activity_actor() = default;

        void start( player_activity &act, Character &who ) override;
        void do_turn( player_activity &act, Character &you ) override;
        void finish( player_activity &act, Character &you ) override;

        activity_id get_type() const override {
            return activity_id( "ACT_ACTIVITY_NAME" );
        }

        std::unique_ptr<activity_actor> clone() const override {
            return std::make_unique<activity_name_activity_actor>( *this );
        }

        void serialize( JsonOut &jsout ) const override;
        static std::unique_ptr<activity_actor> deserialize( JsonValue &jsin );

    private:
     /* Any state that the activity actor needs to contain belongs here. */
};
```

</details>
