### PR TITLE
Fix pulp acid-filled corpses

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -8023,7 +8023,7 @@ void pulp_activity_actor::do_turn( player_activity &act, Character &you )
             const mtype *corpse_mtype = corpse.get_mtype();
             const bool acid_immune = you.is_immune_damage( damage_acid ) ||
                                      you.is_immune_field( fd_acid );
-            if( corpse_mtype->bloodType().obj().has_acid && ( !acid_immune || !pulp_acid ) ) {
+            if( !pulp_acid && corpse_mtype->bloodType().obj().has_acid  && !acid_immune ) {
                 //don't smash acid zombies when auto pulping unprotected
                 continue;
             }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10931,11 +10931,11 @@ point game::place_player( const tripoint &dest_loc, bool quick )
                     }
                 }
                 if( !places.empty() ) {
-                    u.assign_activity( pulp_activity_actor( places, true ) );
+                    u.assign_activity( pulp_activity_actor( places ) );
                 }
             } else {
                 if( corpse_available( u.pos_bub() ) ) {
-                    u.assign_activity( pulp_activity_actor( m.getglobal( u.pos_bub() ), true ) );
+                    u.assign_activity( pulp_activity_actor( m.getglobal( u.pos_bub() ) ) );
                 }
             }
         }

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -974,7 +974,7 @@ static void smash()
     }
 
     if( should_pulp ) {
-        player_character.assign_activity( pulp_activity_actor( here.getglobal( smashp ) ) );
+        player_character.assign_activity( pulp_activity_actor( here.getglobal( smashp ), true ) );
         return; // don't smash terrain if we've smashed a corpse
     }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix pulp acid-filled corpses"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #76236
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
It was an oversight when migrating ACT_PULP. `pulp_acid` should be the indicator of whether the character has made their mind to pulp acid-filled corpses. If `pulp_acid` is true, the character will always pulp acid-filled corpses.

In the original implementation, only auto-pulping will use this value ( in fact, its equivalent ) to actually check acid immunity when dealing with acid-filled corpses. I added this ability to NPCs to avoid them being burned by pulping acid zombies.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
1. Wear regular outfit, pulp an acid corpse: the player gets a prompt as comfirmation, then the corpse gets pulped.
2. Wear hub01 env suit, pulp an acid corpse: no prompt, and the corpse gets pulped.
3. NPC with regular outfit, around a **non-acid** corpse: the corpse gets pulped.
4. NPC with regular outfit, around an acid corpse: the corpse **doesn't** get pulped.
5. NPC with hub01 env suit, around an acid corpse: the corpse gets pulped.
6. Auto-pulp on, wear regular outfit, walk around an acid corpse: the corpse **doesn't** get pulped.
7. Auto-pulp on, wear hub01 env suit, walk around an acid corpse: the corpse gets pulped.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
