### PR TITLE
More NO_UNLOAD fixes

### DIFF
--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -4113,8 +4113,9 @@ void iexamine::keg( Character &you, const tripoint &examp )
     if( !liquid_present || has_container_with_liquid ) {
         add_msg( m_info, _( "It is empty." ) );
         // Get list of all drinks
-        auto drinks_inv = you.items_with( []( const item & it ) {
-            return it.made_of( phase_id::LIQUID );
+        auto drinks_inv = you.items_with( [&you]( const item & it ) {
+            item *parent_item = you.find_parent( it );
+            return it.made_of( phase_id::LIQUID ) && ( !parent_item || parent_item->can_unload() ) ;
         } );
         if( drinks_inv.empty() ) {
             add_msg( m_info, _( "You don't have any drinks to fill the %s with." ), keg_name );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
bathtubs could take liquids out of NO_UNLOAD containers

#### Describe the solution
Actually check to see if the item is legal to unload

#### Describe alternatives you've considered
Refactoring iexamine::keg completely... it's kind of crusty

#### Testing
had some clean water (bottled), sports drink(sealed can), and liquid ammonia(in a NO_UNLOAD pressure tank), examined a bathtub

Could put clean water or sports drink in, putting in the sports drink correctly unsealed the container

Under no circumstances did it let me take the ammonia out of the pressure tank

#### Additional context

