### PR TITLE
allow scrolling of spell info again

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -451,6 +451,40 @@ static void PushOrPopColor( const std::string_view seg, int minimumColorStackSiz
     }
 }
 
+/**
+ * Scrolls the current ImGui window by a scroll action
+ *
+ * Setting scroll needs to happen before drawing contents for page scroll to work properly
+ * @param s an enum for the currently pending scroll action
+ */
+void cataimgui::set_scroll( scroll &s )
+{
+    int scroll_px = 0;
+    int line_height = ImGui::GetTextLineHeightWithSpacing();
+    int page_height = ImGui::GetContentRegionAvail().y;
+
+    switch( s ) {
+        case scroll::none:
+            break;
+        case scroll::line_up:
+            scroll_px = -line_height;
+            break;
+        case scroll::line_down:
+            scroll_px = line_height;
+            break;
+        case scroll::page_up:
+            scroll_px = -page_height;
+            break;
+        case scroll::page_down:
+            scroll_px = page_height;
+            break;
+    }
+
+    ImGui::SetScrollY( ImGui::GetScrollY() + scroll_px );
+
+    s = scroll::none;
+}
+
 void cataimgui::draw_colored_text( std::string const &text, const nc_color &color,
                                    float wrap_width, bool *is_selected, bool *is_focused, bool *is_hovered )
 {

--- a/src/cata_imgui.h
+++ b/src/cata_imgui.h
@@ -48,6 +48,14 @@ enum class dialog_result {
     NoClicked
 };
 
+enum class scroll : int {
+    none = 0,
+    line_up,
+    line_down,
+    page_up,
+    page_down
+};
+
 class client
 {
         std::vector<int> cata_input_trail;
@@ -86,6 +94,8 @@ void point_to_imvec2( point *src, ImVec2 *dest );
 void imvec2_to_point( ImVec2 *src, point *dest );
 
 ImVec4 imvec4_from_color( nc_color &color );
+
+void set_scroll( scroll &s );
 
 void draw_colored_text( std::string const &text, const nc_color &color,
                         float wrap_width = 0.0F, bool *is_selected = nullptr,

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2405,8 +2405,8 @@ static void reflesh_favorite( uilist *menu, std::vector<spell *> known_spells )
 class spellcasting_callback : public uilist_callback
 {
     private:
-        int scroll_pos = 0;
         std::vector<spell *> known_spells;
+        cataimgui::scroll spell_info_scroll = cataimgui::scroll::none;
         void display_spell_info( size_t index );
     public:
         // invlets reserved for special functions
@@ -2442,11 +2442,13 @@ class spellcasting_callback : public uilist_callback
                     get_player_character().magic->rem_invlet( known_spells[entnum]->id() );
                 }
                 return true;
-            } else if( action == "SCROLL_UP_SPELL_MENU" || action == "SCROLL_DOWN_SPELL_MENU" ) {
-                scroll_pos += action == "SCROLL_DOWN_SPELL_MENU" ? 1 : -1;
             } else if( action == "SCROLL_FAVORITE" ) {
                 get_player_character().magic->toggle_favorite( known_spells[entnum]->id() );
                 reflesh_favorite( menu, known_spells );
+            } else if( action == "SCROLL_UP_SPELL_MENU" ) {
+                spell_info_scroll = cataimgui::scroll::line_up;
+            } else if( action == "SCROLL_DOWN_SPELL_MENU" ) {
+                spell_info_scroll = cataimgui::scroll::line_down;
             }
             return false;
         }
@@ -2568,11 +2570,12 @@ void spellcasting_callback::display_spell_info( size_t index )
     const spell &sp = *known_spells[ index ];
     Character &pc = get_player_character();
 
+    cataimgui::set_scroll( spell_info_scroll );
     ImGui::TextColored( c_yellow, "%s", sp.spell_class() == trait_NONE ? _( "Classless" ) :
                         sp.spell_class()->name().c_str() );
     // we remove 6 characteres from the width because there seems to be issues with wrapping in this menu (even with TextWrapped)
-    // TODO(thePotatomancer): investigate and fix the strange wrapping issues in this menu as well as other imgui menus
-    float spell_info_width = ImGui::GetContentRegionAvail().x - ( ImGui::CalcTextSize( " " ).x * 6 );
+    // TODO(thePotatomancer): investigate and fix the strange wrapping issues in this menu as well as oth er imgui menus
+    float spell_info_width = ImGui::GetContentRegionAvail().x - ( ImGui::CalcTextSize( " " ).x * 16 );
     cataimgui::draw_colored_text( sp.description(), spell_info_width );
     ImGui::NewLine();
     cataimgui::draw_colored_text( sp.enumerate_spell_data( pc ), spell_info_width );

--- a/src/ui_iteminfo.cpp
+++ b/src/ui_iteminfo.cpp
@@ -5,38 +5,10 @@
 #include "imgui/imgui_internal.h"
 
 
-static void set_scroll( scroll &s )
+void draw_item_info_imgui( cataimgui::window &window, item_info_data &data, int width,
+                           cataimgui::scroll &s )
 {
-    int scroll_px = 0;
-    int line_height = ImGui::GetTextLineHeightWithSpacing();
-    int page_height = ImGui::GetContentRegionAvail().y;
-
-    switch( s ) {
-        case scroll::none:
-            break;
-        case scroll::line_up:
-            scroll_px = -line_height;
-            break;
-        case scroll::line_down:
-            scroll_px = line_height;
-            break;
-        case scroll::page_up:
-            scroll_px = -page_height;
-            break;
-        case scroll::page_down:
-            scroll_px = page_height;
-            break;
-    }
-
-    ImGui::SetScrollY( ImGui::GetScrollY() + scroll_px );
-
-    s = scroll::none;
-}
-
-void draw_item_info_imgui( cataimgui::window &window, item_info_data &data, int width, scroll &s )
-{
-    // Setting scroll needs to happen before drawing contents for page scroll to work properly
-    set_scroll( s );
+    cataimgui::set_scroll( s );
 
     float wrap_width = window.str_width_to_pixels( width - 2 );
     nc_color base_color = c_light_gray;
@@ -174,13 +146,13 @@ void iteminfo_window::execute()
         std::string action = ctxt.handle_input();
 
         if( data.handle_scrolling && data.arrow_scrolling && action == "UP" ) {
-            s = scroll::line_up;
+            s = cataimgui::scroll::line_up;
         } else if( data.handle_scrolling && data.arrow_scrolling && action == "DOWN" ) {
-            s = scroll::line_down;
+            s = cataimgui::scroll::line_down;
         } else if( data.handle_scrolling && action == "PAGE_UP" ) {
-            s = scroll::page_up;
+            s = cataimgui::scroll::page_up;
         } else if( data.handle_scrolling && action == "PAGE_DOWN" ) {
-            s = scroll::page_down;
+            s = cataimgui::scroll::page_down;
         } else if( action == "CONFIRM" || action == "QUIT" ||
                    ( data.any_input && action == "ANY_INPUT" && !ctxt.get_raw_input().sequence.empty() ) ) {
             break;

--- a/src/ui_iteminfo.h
+++ b/src/ui_iteminfo.h
@@ -7,16 +7,8 @@
 #include "output.h"
 #include "imgui/imgui.h"
 
-enum class scroll : int {
-    none = 0,
-    line_up,
-    line_down,
-    page_up,
-    page_down
-};
-
 void draw_item_info_imgui( cataimgui::window &window, item_info_data &data, int width,
-                           scroll &s );
+                           cataimgui::scroll &s );
 
 class iteminfo_window : public cataimgui::window
 {
@@ -36,7 +28,7 @@ class iteminfo_window : public cataimgui::window
         int height;
         input_context ctxt;
 
-        scroll s;
+        cataimgui::scroll s;
 };
 
 #endif // CATA_SRC_UI_ITEMINFO_H


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Fix scrolling spell info in spell casting menu"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
spell info scrolling was broken when the spell menu migrated to uilist.
Before this PR the only way to scroll the spell info of spells with long descriptions (like the first circle spells) 
was by focusing and scrolling the spell info window with the mouse (which is not obvious as a possibility at all).
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
I extracted the already existing scrolling logic in item menu to our helper class `cataimgui`, and used it both in item menu 
and in the casting menu. It uses the existing previous keybinds for scrolling that were defined but non-functioning.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I tried to figure out how to make the scrollbar visible for spell info, but got stumped and decided it's better to leave it for another PR.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
1. create a world with the `magicalysm` mod
2. once in game, open the debug menu, the player subsection, and the modify spells section
3. filter for 'first circle' to find one of the mana upgrade ritual spells, and edit to learn it at any level
4. open the spellcasting menu, and have the selection hover over the spell
5. use the default keybinds (`<` and `>`) to scroll the spell info to show the spell components

I also tested rebinding the keys in the `?` menu, and tested that the item menu scrolling still functions as before.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
