### PR TITLE
[DEBUG] Modify hordes through overmap editor

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -1236,6 +1236,13 @@
   },
   {
     "type": "keybinding",
+    "id": "MODIFY_HORDE",
+    "category": "OVERMAP",
+    "name": "Modify existing horde or place new one",
+    "bindings": [ { "input_method": "keyboard_any", "key": "p" } ]
+  },
+  {
+    "type": "keybinding",
     "name": "View missions",
     "category": "OVERMAP",
     "id": "MISSIONS",

--- a/src/debug_menu.h
+++ b/src/debug_menu.h
@@ -12,6 +12,7 @@
 
 class Character;
 class Creature;
+struct mongroup;
 struct tripoint;
 
 template <typename E> struct enum_traits;
@@ -121,6 +122,8 @@ void wishitem( Character *you = nullptr );
 void wishitem( Character *you, const tripoint & );
 void wishitem( Character *you, const tripoint_bub_ms & );
 void wishmonster( const std::optional<tripoint> &p );
+void wishmonstergroup( tripoint_abs_omt &loc );
+void wishmonstergroup_mon_selection( mongroup &group );
 void wishmutate( Character *you );
 void wishbionics( Character *you );
 /*

--- a/src/mongroup.cpp
+++ b/src/mongroup.cpp
@@ -449,6 +449,11 @@ void MonsterGroupManager::FinalizeMonsterGroups()
     }
 }
 
+std::map<mongroup_id, MonsterGroup> &MonsterGroupManager::Get_all_Groups()
+{
+    return MonsterGroupManager::monsterGroupMap;
+}
+
 void MonsterGroupManager::LoadMonsterGroup( const JsonObject &jo )
 {
     float mon_upgrade_factor = get_option<float>( "MONSTER_UPGRADE_FACTOR" );

--- a/src/mongroup.h
+++ b/src/mongroup.h
@@ -224,6 +224,9 @@ class MonsterGroupManager
 
         static bool is_animal( const mongroup_id &group );
 
+        // Public getter for private monsterGroupMap, do not use if you don't know what you're doing.
+        static std::map<mongroup_id, MonsterGroup> &Get_all_Groups();
+
     private:
         static std::map<mongroup_id, MonsterGroup> monsterGroupMap;
         using t_string_set = std::set<std::string>;

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -7553,6 +7553,23 @@ void overmap::debug_force_add_group( const mongroup &group )
     add_mon_group( group, 1 );
 }
 
+std::vector<std::reference_wrapper<mongroup>> overmap::debug_unsafe_get_groups_at(
+            tripoint_abs_omt &loc )
+{
+    point_abs_om overmap;
+    tripoint_om_omt omt_within_overmap;
+    std::tie( overmap, omt_within_overmap ) = project_remain<coords::om>( loc );
+    tripoint_om_sm om_sm_pos = project_to<coords::sm>( omt_within_overmap );
+
+    std::vector<std::reference_wrapper <mongroup>> groups_at;
+    for( std::pair<const tripoint_om_sm, mongroup> &pair : zg ) {
+        if( pair.first == om_sm_pos ) {
+            groups_at.emplace_back( pair.second );
+        }
+    }
+    return groups_at;
+}
+
 void overmap::add_mon_group( const mongroup &group )
 {
     zg.emplace( group.rel_pos(), group );

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -540,6 +540,7 @@ class overmap
 
         // DEBUG ONLY!
         void debug_force_add_group( const mongroup &group );
+        std::vector<std::reference_wrapper<mongroup>> debug_unsafe_get_groups_at( tripoint_abs_omt &loc );
     private:
         /**
          * Iterate over the overmap and place the quota of specials.

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -29,7 +29,10 @@
 #include "item_factory.h"
 #include "itype.h"
 #include "localized_comparator.h"
+#include "overmap.h"
+#include "overmapbuffer.h"
 #include "map.h"
+#include "mongroup.h"
 #include "monster.h"
 #include "monstergenerator.h"
 #include "mtype.h"
@@ -48,6 +51,8 @@
 #include "units.h"
 
 static const efftype_id effect_pet( "pet" );
+
+static const mongroup_id GROUP_ZOMBIE( "GROUP_ZOMBIE" );
 
 class ui_adaptor;
 
@@ -713,25 +718,96 @@ class wish_monster_callback: public uilist_callback
         ~wish_monster_callback() override = default;
 };
 
+static void setup_wishmonster( uilist &pick_a_monster, std::vector<const mtype *> &mtypes )
+{
+    pick_a_monster.desired_bounds = { -1.0, -1.0, 1.0, 1.0 };
+    pick_a_monster.selected = uistate.wishmonster_selected;
+    int i = 0;
+    for( const mtype &montype : MonsterGenerator::generator().get_all_mtypes() ) {
+        pick_a_monster.addentry( i, true, 0, montype.nname() );
+        pick_a_monster.entries[i].extratxt.txt = montype.sym;
+        pick_a_monster.entries[i].extratxt.color = montype.color;
+        pick_a_monster.entries[i].extratxt.left = 1;
+        ++i;
+        mtypes.push_back( &montype );
+    }
+}
+
+void debug_menu::wishmonstergroup( tripoint_abs_omt &loc )
+{
+    bool population_group = query_yn(
+                                _( "Is this a population-based horde, based on an existing monster group?  Select \"No\" to manually assign monsters." ) );
+    mongroup new_group;
+    // Just in case, we manually set some values
+    new_group.abs_pos = project_to<coords::sm>( loc );
+    new_group.target = new_group.abs_pos.xy();
+    new_group.population = 1; // overwritten if population_group
+    new_group.horde = true;
+    new_group.type = GROUP_ZOMBIE; // overwritten if population_group
+    if( population_group ) {
+        uilist type_selection;
+        std::vector<mongroup_id> possible_groups;
+        int i = 0;
+        for( auto &group_pair : MonsterGroupManager::Get_all_Groups() ) {
+            possible_groups.emplace_back( group_pair.first );
+            type_selection.addentry( i, true, -1, group_pair.first.c_str() );
+            i++;
+        }
+        type_selection.query();
+        int &selected = type_selection.ret;
+        if( selected < 0 || static_cast<size_t>( selected ) >= possible_groups.size() ) {
+            return;
+        }
+        const mongroup_id selected_group( possible_groups[selected] );
+        new_group.type = selected_group;
+        int new_value = 0;
+        query_int( new_value, _( "Set population to what value?  Currently %d" ), new_group.population );
+        overmap &there = overmap_buffer.get( project_to<coords::om>( loc ).xy() );
+        there.debug_force_add_group( new_group );
+        return; // Don't go to adding individual monsters, they'll override the values we just set
+    }
+
+
+    wishmonstergroup_mon_selection( new_group );
+    overmap &there = overmap_buffer.get( project_to<coords::om>( loc ).xy() );
+    there.debug_force_add_group( new_group );
+}
+
+void debug_menu::wishmonstergroup_mon_selection( mongroup &group )
+{
+
+    std::vector<const mtype *> mtypes;
+    uilist new_mon_selection;
+    setup_wishmonster( new_mon_selection, mtypes );
+    wish_monster_callback cb( mtypes );
+    new_mon_selection.callback = &cb;
+    new_mon_selection.query();
+    int &selected = new_mon_selection.ret;
+    if( selected < 0 || static_cast<size_t>( selected ) >= mtypes.size() ) {
+        return;
+    }
+    const mtype_id &mon_type = mtypes[ selected ]->id;
+    for( int i = 0; i < cb.group; i++ ) {
+        monster new_mon( mon_type );
+        if( cb.friendly ) {
+            new_mon.friendly = -1;
+            new_mon.add_effect( effect_pet, 1_turns, true );
+        }
+        if( cb.hallucination ) {
+            new_mon.hallucination = true;
+        }
+        group.monsters.emplace_back( new_mon );
+    }
+}
+
 void debug_menu::wishmonster( const std::optional<tripoint> &p )
 {
     std::vector<const mtype *> mtypes;
 
     uilist wmenu;
-    wmenu.desired_bounds = { -1.0, -1.0, 1.0, 1.0 };
-    wmenu.selected = uistate.wishmonster_selected;
+    setup_wishmonster( wmenu, mtypes );
     wish_monster_callback cb( mtypes );
     wmenu.callback = &cb;
-
-    int i = 0;
-    for( const mtype &montype : MonsterGenerator::generator().get_all_mtypes() ) {
-        wmenu.addentry( i, true, 0, montype.nname() );
-        wmenu.entries[i].extratxt.txt = montype.sym;
-        wmenu.entries[i].extratxt.color = montype.color;
-        wmenu.entries[i].extratxt.left = 1;
-        ++i;
-        mtypes.push_back( &montype );
-    }
 
     do {
         wmenu.query();


### PR DESCRIPTION
#### Summary
Infrastructure "[DEBUG] Modify hordes through overmap editor"

#### Purpose of change
I need to be able to modify hordes' values to debug them, and to test some possible upcoming content.

#### Describe the solution
Hook it into the existing overmap editor, and then write a bunch of new code to handle all the horde stuff

Also changed the overmap UI to always enable debug editor functions if debug mode is enabled, for ease of use. You can still access the overmap editor through the debug menu, but you don't *have to*.

#### Describe alternatives you've considered


#### Testing

https://github.com/user-attachments/assets/e4db511c-8bf8-467c-8714-b502da15ff8a



#### Additional context
PR as originally submitted **is not finished**. Notably the ability to modify monsters into existing hordes is just plain not implemented. Draft until it's done.
(It is done!)
