### PR TITLE
New Mod: Martial Mastery

### DIFF
--- a/data/mods/Perk_melee/EOC/_reusable_conditions.json
+++ b/data/mods/Perk_melee/EOC/_reusable_conditions.json
@@ -1,0 +1,8 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CONDITION_has_mind",
+    "condition": { "or": [ { "u_has_flag": "HAS_MIND" }, { "u_has_flag": "HUMAN" }, "u_is_character" ] },
+    "effect": [  ]
+  }
+]

--- a/data/mods/Perk_melee/EOC/eoc_clears.json
+++ b/data/mods/Perk_melee/EOC/eoc_clears.json
@@ -1,0 +1,21 @@
+[
+  {
+    "id": "EOC_CLEAR_BUFFS",
+    "type": "effect_on_condition",
+    "effect": [
+      { "u_lose_effect": "mabuff:buff_perk_tempo" },
+      { "u_lose_effect": "mabuff:buff_perk_momentum" },
+      { "u_lose_effect": "perk_dex_bonus" }
+    ]
+  },
+  {
+    "id": "EOC_CLEAR_COMBAT_TEMPO",
+    "type": "effect_on_condition",
+    "effect": [ { "u_lose_effect": "mabuff:buff_perk_tempo" } ]
+  },
+  {
+    "id": "EOC_CLEAR_MOMENTUM",
+    "type": "effect_on_condition",
+    "effect": [ { "u_lose_effect": "mabuff:buff_perk_momentum" }, { "u_lose_effect": "perk_dex_bonus" } ]
+  }
+]

--- a/data/mods/Perk_melee/EOC/leveling.json
+++ b/data/mods/Perk_melee/EOC/leveling.json
@@ -1,0 +1,57 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_perk_ma_open_perk_menu",
+    "effect": [ { "open_dialogue": { "topic": "TALK_MA_PERK_MENU_MAIN" } } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_perk_ma_level_up",
+    "condition": { "math": [ "u_ma_available_exp", ">", "u_ma_exp_to_perk" ] },
+    "effect": [
+      { "u_message": "Your experience with martial arts has increased!" },
+      { "run_eocs": "EOC_give_ma_perk_point" },
+      { "math": [ "u_ma_used_exp", "+=", "u_ma_exp_to_perk" ] },
+      { "math": [ "u_ma_available_exp", "=", "u_val('exp') - u_ma_used_exp" ] },
+      { "math": [ "u_ma_exp_to_perk", "+=", "u_ma_exp_per_level" ] },
+      { "math": [ "u_ma_current_level", "+=", "1" ] }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_perk_ma_level_up_notification",
+    "condition": { "math": [ "u_no_notifications", "!=", "1" ] },
+    "effect": [ { "open_dialogue": { "topic": "TALK_PERK_MENU_MAIN" } } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_perk_ma_kill_check_exp",
+    "eoc_type": "EVENT",
+    "required_event": "character_kills_monster",
+    "effect": [ { "math": [ "u_ma_available_exp", "=", "u_val('exp') - u_ma_used_exp" ] }, { "run_eocs": "EOC_perk_ma_level_up" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_perk_ma_initialize",
+    "eoc_type": "EVENT",
+    "required_event": "game_begin",
+    "condition": { "and": [ { "not": { "u_has_trait": "perk_ma_perk_menu" } } ] },
+    "effect": [
+      {
+        "u_message": "Martial Mastery mod is active.  Interact with the \"Practice Martial Arts\" trait from the mutation menu to learn new techniques and perks."
+      },
+      { "math": [ "u_ma_perks", "=", "0" ] },
+      { "math": [ "u_ma_exp_to_perk", "=", "100" ] },
+      { "math": [ "u_ma_exp_per_level", "=", "300" ] },
+      { "math": [ "u_ma_available_exp", "=", "0" ] },
+      { "math": [ "u_ma_current_level", "=", "0" ] },
+      { "math": [ "u_num_ma_perks", "=", "0" ] },
+      { "u_add_trait": "perk_ma_perk_menu" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_give_ma_perk_point",
+    "effect": [ { "math": [ "u_num_ma_perks", "++" ] } ]
+  }
+]

--- a/data/mods/Perk_melee/EOC/shared_eocs.json
+++ b/data/mods/Perk_melee/EOC/shared_eocs.json
@@ -1,0 +1,93 @@
+[
+  {
+    "id": "EOC_UPDATE_WEAPON_STATS",
+    "type": "effect_on_condition",
+    "eoc_type": "EVENT",
+    "required_event": "character_wields_item",
+    "effect": [
+      {
+        "u_run_inv_eocs": "all",
+        "search_data": [ { "wielded_only": true } ],
+        "true_eocs": [ { "id": "_EOC_STATS", "effect": [ { "math": [ "u_perk_mymelee", "=", "n_melee_damage('ALL')" ] } ] } ]
+      }
+    ]
+  },
+  {
+    "id": "EOC_EXECUTION_EXTA_EFFECTS",
+    "type": "effect_on_condition",
+    "effect": [
+      { "math": [ "u_val('stamina')", "+=", "1200" ] },
+      {
+        "run_eocs": [
+          {
+            "id": "_EOC_EXECUTION_BRUTALITY",
+            "condition": { "u_has_flag": "MELEE_PERK_BRUTALITY" },
+            "effect": {
+              "u_run_monster_eocs": [
+                {
+                  "id": "brutality_stun",
+                  "condition": { "test_eoc": "EOC_CONDITION_has_mind" },
+                  "effect": [ { "u_add_effect": "stunned", "duration": "2 seconds" } ]
+                }
+              ],
+              "monster_range": 60,
+              "monster_must_see": true
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "EOC_PERK_DODGE_RETREAT_MANUAL",
+    "type": "effect_on_condition",
+    "condition": { "and": [ { "u_has_flag": "MELEE_PERK_MOVING_DODGE" } ] },
+    "effect": [
+      {
+        "run_eoc_until": "EOC_PERK_TRY_RETREAT",
+        "condition": { "math": [ "u_monsters_nearby('radius': 1)", ">", "0" ] },
+        "iteration": 10
+      }
+    ]
+  },
+  {
+    "id": "EOC_PERK_TEMPO_MANUAL",
+    "type": "effect_on_condition",
+    "condition": { "u_has_trait": "MELEE_PERK_TEMPO" },
+    "effect": { "u_add_effect": "mabuff:buff_perk_tempo", "duration": "2 seconds" }
+  },
+  {
+    "id": "EOC_PERK_MOMENTUM_MANUAL",
+    "type": "effect_on_condition",
+    "condition": { "u_has_trait": "MELEE_PERK_MOMENTUM" },
+    "effect": { "u_add_effect": "mabuff:buff_perk_momentum", "duration": "2 seconds" }
+  },
+  {
+    "id": "EOC_PERK_MOMENTUM_2",
+    "type": "effect_on_condition",
+    "condition": { "u_has_trait": "MELEE_PERK_MOMENTUM_2" },
+    "effect": { "u_add_effect": "perk_dex_bonus", "duration": "2 seconds" }
+  },
+  {
+    "id": "EOC_PERK_TRY_RETREAT",
+    "type": "effect_on_condition",
+    "effect": [
+      { "u_location_variable": { "context_val": "original_pos" }, "min_radius": 0, "max_radius": 0 },
+      { "u_location_variable": { "context_val": "attempt" }, "min_radius": 1, "max_radius": 1 },
+      { "u_teleport": { "context_val": "attempt" } },
+      {
+        "run_eocs": [
+          {
+            "id": "_VALID_RETREAT",
+            "condition": { "math": [ "u_monsters_nearby('radius': 1)", "==", "0" ] },
+            "effect": [
+              { "u_add_effect": "mabuff:buff_perk_momentum", "duration": 2 },
+              { "run_eocs": [ "EOC_PERK_MOMENTUM_2", "EOC_PERK_MOMENTUM_MANUAL" ] }
+            ],
+            "false_effect": [ { "u_teleport": { "context_val": "original_pos" } } ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/data/mods/Perk_melee/martial_arts.json
+++ b/data/mods/Perk_melee/martial_arts.json
@@ -1,0 +1,96 @@
+[
+  {
+    "type": "martial_art",
+    "id": "style_none",
+    "//": "It all depends on this override, fighting with other styles will make perks useless.",
+    "name": { "str": "Fighting Style" },
+    "description": "Fight in accordance with your training or lack thereof.",
+    "initiate": [ "You focus on your training.", "%s remembers their training." ],
+    "arm_block": 1,
+    "leg_block": 99,
+    "allow_all_weapons": true,
+    "onmove_buffs": [
+      {
+        "id": "buff_perk_momentum",
+        "name": "Momentum",
+        "description": "Strike with the momentum of your previous movement.",
+        "max_stacks": 6,
+        "buff_duration": 2,
+        "unarmed_allowed": true,
+        "melee_allowed": true,
+        "required_char_flags": [ "MELEE_PERK_MOMENTUM" ],
+        "flat_bonuses": [
+          { "stat": "damage", "type": "cut", "scaling-stat": "dex", "scale": 0.2 },
+          { "stat": "damage", "type": "stab", "scaling-stat": "dex", "scale": 0.2 }
+        ]
+      }
+    ],
+    "onattack_buffs": [
+      {
+        "id": "buff_perk_tempo",
+        "name": "Tempo",
+        "description": "The rhythm of combat is in your favor.",
+        "max_stacks": 3,
+        "buff_duration": 2,
+        "unarmed_allowed": true,
+        "melee_allowed": true,
+        "required_char_flags": [ "MELEE_PERK_TEMPO" ],
+        "flat_bonuses": [
+          { "stat": "damage", "type": "bash", "scaling-stat": "str", "scale": 0.2 },
+          { "stat": "damage", "type": "stab", "scaling-stat": "str", "scale": 0.2 }
+        ]
+      }
+    ],
+    "onblock_buffs": [
+      {
+        "id": "buff_perk_block",
+        "name": "Parry",
+        "description": "Successful blocking has left you in a favorable position.",
+        "melee_allowed": true,
+        "buff_duration": 2,
+        "flat_bonuses": [ { "stat": "hit", "scale": 1.0 } ]
+      }
+    ],
+    "onmove_eocs": [ "EOC_PERK_MOMENTUM_2" ],
+    "ondodge_eocs": [
+      {
+        "id": "EOC_PERK_DODGE_RETREAT",
+        "condition": {
+          "and": [ { "u_has_flag": "MELEE_PERK_MOVING_DODGE" }, { "not": { "u_has_flag": "MELEE_PERK_KNIFE_COUNTER_DODGE" } } ]
+        },
+        "effect": [
+          {
+            "run_eoc_until": "EOC_PERK_TRY_RETREAT",
+            "condition": { "math": [ "u_monsters_nearby('radius': 1)", ">", "0" ] },
+            "iteration": 10
+          }
+        ]
+      }
+    ],
+    "onblock_eocs": [  ],
+    "onpause_eocs": [
+      {
+        "id": "EOC_PERK_CAREFREE_STANCE",
+        "condition": { "u_has_flag": "MELEE_PERK_CAREFREE_STANCE" },
+        "effect": { "run_eocs": "EOC_CLEAR_BUFFS" }
+      }
+    ],
+    "techniques": [
+      "tec_perk_stagger_strike",
+      "tec_perk_feint",
+      "tec_perk_fore",
+      "tec_perk_fore_stunned",
+      "tec_perk_execution_sword",
+      "tec_perk_execution_axe",
+      "tec_perk_execution_hammer",
+      "tec_perk_shoulder_tackle",
+      "tec_perk_vulgar_opening",
+      "tec_perk_coiling_strike",
+      "tec_perk_knife_counter_dodge",
+      "tec_perk_knife_finisher",
+      "tec_perk_make_way",
+      "tec_perk_estocada",
+      "tec_perk_staff_kick"
+    ]
+  }
+]

--- a/data/mods/Perk_melee/menu.json
+++ b/data/mods/Perk_melee/menu.json
@@ -1,0 +1,513 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_open_ma_perk_menu",
+    "effect": [ { "open_dialogue": { "topic": "TALK_MA_PERK_MENU_MAIN" } } ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_MA_PERK_MENU_MAIN",
+    "dynamic_line": "Level <u_val:ma_current_level>.\n<u_val:num_ma_perks> perk points to spend.\nCurrent EXP: <u_val:ma_available_exp>.\nEXP to next level: <u_val:ma_exp_to_perk>.",
+    "responses": [
+      { "text": "Tempo Techniques", "topic": "TALK_MA_PERK_MENU_TEMPO" },
+      { "text": "Momentum Techniques", "topic": "TALK_MA_PERK_MENU_MOMENTUM" },
+      { "text": "Standalone Techniques", "topic": "TALK_MA_PERK_MENU_STANDALONE" },
+      { "text": "Help", "topic": "TALK_PERK_MENU_CONFIG" },
+      { "text": "Quit.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_MA_PERK_MENU_TEMPO",
+    "dynamic_line": "Level <u_val:ma_current_level>.\n<u_val:num_ma_perks> perk points to spend.\nCurrent EXP: <u_val:ma_available_exp>.\nEXP to next level: <u_val:ma_exp_to_perk>.",
+    "responses": [
+      {
+        "condition": { "not": { "u_has_trait": "MELEE_PERK_COMBAT_TEMPO" } },
+        "text": "Learn [<trait_name:MELEE_PERK_COMBAT_TEMPO>]",
+        "effect": [
+          { "set_string_var": "<trait_name:MELEE_PERK_COMBAT_TEMPO>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:MELEE_PERK_COMBAT_TEMPO>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "MELEE_PERK_COMBAT_TEMPO", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
+        ],
+        "topic": "TALK_MA_PERK_MENU_SELECT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "MELEE_PERK_TEMPO_SHIFT" } },
+        "text": "Learn [<trait_name:MELEE_PERK_TEMPO_SHIFT>]",
+        "effect": [
+          { "set_string_var": "<trait_name:MELEE_PERK_TEMPO_SHIFT>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:MELEE_PERK_TEMPO_SHIFT>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "MELEE_PERK_TEMPO_SHIFT", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Requires Combat Tempo I",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "u_has_trait": "MELEE_PERK_COMBAT_TEMPO" } }
+        ],
+        "topic": "TALK_MA_PERK_MENU_SELECT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "MELEE_PERK_TEMPO_THROW" } },
+        "text": "Learn [<trait_name:MELEE_PERK_TEMPO_THROW>]",
+        "effect": [
+          { "set_string_var": "<trait_name:MELEE_PERK_TEMPO_THROW>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:MELEE_PERK_TEMPO_THROW>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "MELEE_PERK_TEMPO_THROW", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Requires Combat Tempo I",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "u_has_trait": "MELEE_PERK_COMBAT_TEMPO" } }
+        ],
+        "topic": "TALK_MA_PERK_MENU_SELECT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "MELEE_PERK_STAGGER_STRIKE" } },
+        "text": "Learn [<trait_name:MELEE_PERK_STAGGER_STRIKE>]",
+        "effect": [
+          { "set_string_var": "<trait_name:MELEE_PERK_STAGGER_STRIKE>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:MELEE_PERK_STAGGER_STRIKE>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "MELEE_PERK_STAGGER_STRIKE", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Requires Combat Tempo I",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "u_has_trait": "MELEE_PERK_COMBAT_TEMPO" } }
+        ],
+        "topic": "TALK_MA_PERK_MENU_SELECT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "MELEE_PERK_KNIFE_FINISHER" } },
+        "text": "Learn [<trait_name:MELEE_PERK_KNIFE_FINISHER>]",
+        "effect": [
+          { "set_string_var": "<trait_name:MELEE_PERK_KNIFE_FINISHER>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:MELEE_PERK_KNIFE_FINISHER>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "MELEE_PERK_KNIFE_FINISHER", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Requires Combat Tempo I",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "u_has_trait": "MELEE_PERK_COMBAT_TEMPO" } }
+        ],
+        "topic": "TALK_MA_PERK_MENU_SELECT"
+      },
+      { "text": "Go back", "topic": "TALK_MA_PERK_MENU_MAIN" },
+      { "text": "Quit.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_MA_PERK_MENU_MOMENTUM",
+    "dynamic_line": "Level <u_val:ma_current_level>.\n<u_val:num_ma_perks> perk points to spend.\nCurrent EXP: <u_val:ma_available_exp>.\nEXP to next level: <u_val:ma_exp_to_perk>.",
+    "responses": [
+      {
+        "condition": { "not": { "u_has_trait": "MELEE_PERK_MOMENTUM" } },
+        "text": "Learn [<trait_name:MELEE_PERK_MOMENTUM>]",
+        "effect": [
+          { "set_string_var": "<trait_name:MELEE_PERK_MOMENTUM>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:MELEE_PERK_MOMENTUM>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "MELEE_PERK_MOMENTUM", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
+        ],
+        "topic": "TALK_MA_PERK_MENU_SELECT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "MELEE_PERK_MOMENTUM_2" } },
+        "text": "Learn [<trait_name:MELEE_PERK_MOMENTUM_2>]",
+        "effect": [
+          { "set_string_var": "<trait_name:MELEE_PERK_MOMENTUM_2>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:MELEE_PERK_MOMENTUM_2>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "MELEE_PERK_MOMENTUM_2", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Requires Momentum I",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "u_has_trait": "MELEE_PERK_MOMENTUM" } }
+        ],
+        "topic": "TALK_MA_PERK_MENU_SELECT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "MELEE_PERK_COILING_STRIKE" } },
+        "text": "Learn [<trait_name:MELEE_PERK_COILING_STRIKE>]",
+        "effect": [
+          { "set_string_var": "<trait_name:MELEE_PERK_COILING_STRIKE>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:MELEE_PERK_COILING_STRIKE>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "MELEE_PERK_COILING_STRIKE", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Requires Momentum I",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "u_has_trait": "MELEE_PERK_MOMENTUM" } }
+        ],
+        "topic": "TALK_MA_PERK_MENU_SELECT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "MELEE_PERK_ESTOCADA" } },
+        "text": "Learn [<trait_name:MELEE_PERK_ESTOCADA>]",
+        "effect": [
+          { "set_string_var": "<trait_name:MELEE_PERK_ESTOCADA>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:MELEE_PERK_ESTOCADA>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "MELEE_PERK_ESTOCADA", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Requires Momentum I",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "u_has_trait": "MELEE_PERK_MOMENTUM" } }
+        ],
+        "topic": "TALK_MA_PERK_MENU_SELECT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "MELEE_PERK_TACKLE" } },
+        "text": "Learn [<trait_name:MELEE_PERK_TACKLE>]",
+        "effect": [
+          { "set_string_var": "<trait_name:MELEE_PERK_TACKLE>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:MELEE_PERK_TACKLE>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "MELEE_PERK_TACKLE", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Requires Momentum I",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "u_has_trait": "MELEE_PERK_MOMENTUM" } }
+        ],
+        "topic": "TALK_MA_PERK_MENU_SELECT"
+      },
+      { "text": "Go back", "topic": "TALK_MA_PERK_MENU_MAIN" },
+      { "text": "Quit.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_MA_PERK_MENU_STANDALONE",
+    "dynamic_line": "Level <u_val:ma_current_level>.\n<u_val:num_ma_perks> perk points to spend.\nCurrent EXP: <u_val:ma_available_exp>.\nEXP to next level: <u_val:ma_exp_to_perk>.",
+    "responses": [
+      {
+        "condition": { "not": { "u_has_trait": "MELEE_PERK_DODGE" } },
+        "text": "Learn [<trait_name:MELEE_PERK_DODGE>]",
+        "effect": [
+          { "set_string_var": "<trait_name:MELEE_PERK_DODGE>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:MELEE_PERK_DODGE>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "MELEE_PERK_DODGE", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
+        ],
+        "topic": "TALK_MA_PERK_MENU_SELECT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "MELEE_PERK_BLOCK" } },
+        "text": "Learn [<trait_name:MELEE_PERK_BLOCK>]",
+        "effect": [
+          { "set_string_var": "<trait_name:MELEE_PERK_BLOCK>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:MELEE_PERK_BLOCK>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "MELEE_PERK_BLOCK", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
+        ],
+        "topic": "TALK_MA_PERK_MENU_SELECT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "MELEE_PERK_RIPOSTE" } },
+        "text": "Learn [<trait_name:MELEE_PERK_RIPOSTE>]",
+        "effect": [
+          { "set_string_var": "<trait_name:MELEE_PERK_RIPOSTE>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:MELEE_PERK_RIPOSTE>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "MELEE_PERK_RIPOSTE", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
+        ],
+        "topic": "TALK_MA_PERK_MENU_SELECT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "MELEE_PERK_MOVING_DODGE" } },
+        "text": "Learn [<trait_name:MELEE_PERK_MOVING_DODGE>]",
+        "effect": [
+          { "set_string_var": "<trait_name:MELEE_PERK_MOVING_DODGE>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:MELEE_PERK_MOVING_DODGE>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "MELEE_PERK_MOVING_DODGE", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
+        ],
+        "topic": "TALK_MA_PERK_MENU_SELECT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "MELEE_PERK_CAREFREE_STANCE" } },
+        "text": "Learn [<trait_name:MELEE_PERK_CAREFREE_STANCE>]",
+        "effect": [
+          { "set_string_var": "<trait_name:MELEE_PERK_CAREFREE_STANCE>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:MELEE_PERK_CAREFREE_STANCE>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "MELEE_PERK_CAREFREE_STANCE", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
+        ],
+        "topic": "TALK_MA_PERK_MENU_SELECT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "MELEE_PERK_FEINT" } },
+        "text": "Learn [<trait_name:MELEE_PERK_FEINT>]",
+        "effect": [
+          { "set_string_var": "<trait_name:MELEE_PERK_FEINT>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:MELEE_PERK_FEINT>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "MELEE_PERK_FEINT", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
+        ],
+        "topic": "TALK_MA_PERK_MENU_SELECT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "MELEE_PERK_FORE" } },
+        "text": "Learn [<trait_name:MELEE_PERK_FORE>]",
+        "effect": [
+          { "set_string_var": "<trait_name:MELEE_PERK_FORE>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:MELEE_PERK_FORE>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "MELEE_PERK_FORE", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
+        ],
+        "topic": "TALK_MA_PERK_MENU_SELECT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "MELEE_PERK_MAKE_WAY" } },
+        "text": "Learn [<trait_name:MELEE_PERK_MAKE_WAY>]",
+        "effect": [
+          { "set_string_var": "<trait_name:MELEE_PERK_MAKE_WAY>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:MELEE_PERK_MAKE_WAY>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "MELEE_PERK_MAKE_WAY", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
+        ],
+        "topic": "TALK_MA_PERK_MENU_SELECT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "MELEE_PERK_STAFF_KICK" } },
+        "text": "Learn [<trait_name:MELEE_PERK_STAFF_KICK>]",
+        "effect": [
+          { "set_string_var": "<trait_name:MELEE_PERK_STAFF_KICK>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:MELEE_PERK_STAFF_KICK>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "MELEE_PERK_STAFF_KICK", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
+        ],
+        "topic": "TALK_MA_PERK_MENU_SELECT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "MELEE_PERK_KNIFE_COUNTER_DODGE" } },
+        "text": "Learn [<trait_name:MELEE_PERK_KNIFE_COUNTER_DODGE>]",
+        "effect": [
+          { "set_string_var": "<trait_name:MELEE_PERK_KNIFE_COUNTER_DODGE>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:MELEE_PERK_KNIFE_COUNTER_DODGE>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "MELEE_PERK_KNIFE_COUNTER_DODGE", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
+        ],
+        "topic": "TALK_MA_PERK_MENU_SELECT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "MELEE_PERK_JUST_HIT_IT" } },
+        "text": "Learn [<trait_name:MELEE_PERK_JUST_HIT_IT>]",
+        "effect": [
+          { "set_string_var": "<trait_name:MELEE_PERK_JUST_HIT_IT>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:MELEE_PERK_JUST_HIT_IT>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "MELEE_PERK_JUST_HIT_IT", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
+        ],
+        "topic": "TALK_MA_PERK_MENU_SELECT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "MELEE_PERK_EXECUTION" } },
+        "text": "Learn [<trait_name:MELEE_PERK_EXECUTION>]",
+        "effect": [
+          { "set_string_var": "<trait_name:MELEE_PERK_EXECUTION>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:MELEE_PERK_EXECUTION>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "MELEE_PERK_EXECUTION", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
+        ],
+        "topic": "TALK_MA_PERK_MENU_SELECT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "MELEE_PERK_BRUTALITY" } },
+        "text": "Learn [<trait_name:MELEE_PERK_BRUTALITY>]",
+        "effect": [
+          { "set_string_var": "<trait_name:MELEE_PERK_BRUTALITY>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:MELEE_PERK_BRUTALITY>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "MELEE_PERK_BRUTALITY", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Requires Execution",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "u_has_trait": "MELEE_PERK_EXECUTION" } }
+        ],
+        "topic": "TALK_MA_PERK_MENU_SELECT"
+      },
+      { "text": "Go back", "topic": "TALK_MA_PERK_MENU_MAIN" },
+      { "text": "Quit.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_MA_PERK_MENU_SELECT",
+    "dynamic_line": "<context_val:trait_name>: \"<context_val:trait_description>\"\n<context_val:trait_requirement_description>.\n<context_val:trait_additional_details>",
+    "responses": [
+      {
+        "text": "Select Perk.",
+        "topic": "TALK_MA_PERK_MENU_MAIN",
+        "condition": { "and": [ { "get_condition": "perk_condition" }, { "math": [ "u_num_ma_perks", ">", "0" ] } ] },
+        "failure_explanation": "Requirements Not Met",
+        "failure_topic": "TALK_NONE",
+        "effect": [
+          { "u_mutate_towards": { "context_val": "trait_id" }, "category": "ANY", "use_vitamins": false },
+          { "math": [ "u_num_ma_perks", "--" ] }
+        ]
+      },
+      {
+        "text": "Go Back.",
+        "effect": [ { "set_string_var": "", "target_var": { "context_val": "trait_additional_details" } } ],
+        "topic": "TALK_NONE"
+      },
+      { "text": "Quit.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_PERK_MENU_FAIL",
+    "dynamic_line": "You don't have a perk point, or meet the prerequisites for this perk.",
+    "responses": [ { "text": "Go Back.", "topic": "TALK_PERK_MENU_MAIN" }, { "text": "Quit.", "topic": "TALK_DONE" } ]
+  }
+]

--- a/data/mods/Perk_melee/modinfo.json
+++ b/data/mods/Perk_melee/modinfo.json
@@ -1,0 +1,12 @@
+[
+  {
+    "type": "MOD_INFO",
+    "id": "perk_melee_system",
+    "name": "Martial Mastery",
+    "authors": [ "John-Candlebury" ],
+    "maintainers": [ "John-Candlebury" ],
+    "description": "Fight enemies to level up and build your own fighting style.",
+    "category": "misc_additions",
+    "dependencies": [ "dda" ]
+  }
+]

--- a/data/mods/Perk_melee/perk_effects.json
+++ b/data/mods/Perk_melee/perk_effects.json
@@ -1,0 +1,13 @@
+[
+  {
+    "type": "effect_type",
+    "id": "perk_dex_bonus",
+    "name": [ "", "Momentum Dex (1)", "Momentum Dex (1)", "Momentum Dex (2)", "Momentum Dex (2)", "Momentum Dex (3)" ],
+    "max_intensity": 6,
+    "max_duration": "2 seconds",
+    "int_add_val": 1,
+    "int_decay_tick": 150,
+    "base_mods": { "dex_mod": [ 0.5 ] },
+    "scaling_mods": { "dex_mod": [ 0.5 ] }
+  }
+]

--- a/data/mods/Perk_melee/perk_techniques.json
+++ b/data/mods/Perk_melee/perk_techniques.json
@@ -1,0 +1,106 @@
+[
+  {
+    "type": "mutation",
+    "id": "MELEE_PERK_FEINT",
+    "copy-from": "MELEE_PERK_BASE",
+    "name": { "str": "Feint drills" },
+    "description": "Perform a feint whenever an attack would miss.",
+    "flags": "MELEE_PERK_FEINT"
+  },
+  {
+    "type": "mutation",
+    "id": "MELEE_PERK_STAGGER_STRIKE",
+    "copy-from": "MELEE_PERK_BASE",
+    "name": { "str": "Staggering Strikes" },
+    "description": "Attacks with bashing weapons are likely to stun their target if the full combat tempo bonus is active.",
+    "flags": "MELEE_PERK_STAGGER_STRIKE"
+  },
+  {
+    "type": "mutation",
+    "id": "MELEE_PERK_FORE",
+    "copy-from": "MELEE_PERK_BASE",
+    "name": { "str": "Fore!" },
+    "description": "Hah, just watch this.\nCritical strikes with bashing weapons can knock your targets backwards.  You are guaranteed to knock back stunned targets.",
+    "flags": "MELEE_PERK_FORE"
+  },
+  {
+    "type": "mutation",
+    "id": "MELEE_PERK_MAKE_WAY",
+    "copy-from": "MELEE_PERK_BASE",
+    "name": { "str": "Make Way" },
+    "description": "Perform an overhead attack with a polearm or staff.  The attack will knock back all targets hit.",
+    "flags": "MELEE_PERK_MAKE_WAY"
+  },
+  {
+    "type": "mutation",
+    "id": "MELEE_PERK_STAFF_KICK",
+    "copy-from": "MELEE_PERK_BASE",
+    "name": { "str": "Fulcrum Kick" },
+    "description": "Deliver a powerful flying kick using a polearm as a springboard.  The kick will knock back humanoid targets of similar or smaller size.",
+    "flags": "MELEE_PERK_STAFF_KICK"
+  },
+  {
+    "type": "mutation",
+    "id": "MELEE_PERK_COILING_STRIKE",
+    "copy-from": "MELEE_PERK_BASE",
+    "name": { "str": "Coiling Strikes" },
+    "description": "Perform a quick reach attack with a polearm or staff if you have at least 1 momentum stack.  The attack will heavily scale with perception.",
+    "flags": "MELEE_PERK_COILING_STRIKE"
+  },
+  {
+    "type": "mutation",
+    "id": "MELEE_PERK_KNIFE_COUNTER_DODGE",
+    "copy-from": "MELEE_PERK_BASE",
+    "name": { "str": "Snap slash" },
+    "description": "If you dodge an attack with a knife or dagger, you'll counterattack with a quick slash.",
+    "flags": "MELEE_PERK_KNIFE_COUNTER_DODGE"
+  },
+  {
+    "type": "mutation",
+    "id": "MELEE_PERK_KNIFE_FINISHER",
+    "copy-from": "MELEE_PERK_BASE",
+    "name": { "str": "Slaying strike" },
+    "description": "Perform a finishing attack with a knife or dagger when reaching 3 tempo stacks.  The attack will prioritize enemy weak points.",
+    "flags": "MELEE_PERK_KNIFE_FINISHER"
+  },
+  {
+    "type": "mutation",
+    "id": "MELEE_PERK_JUST_HIT_IT",
+    "copy-from": "MELEE_PERK_BASE",
+    "name": { "str": "Vulgar Opening" },
+    "description": "If you have no combat buffs active, perform an opening attack with armor penetration increased by 225% of your strength.  Just hit them with the damn thing.",
+    "flags": "MELEE_PERK_JUST_HIT_IT"
+  },
+  {
+    "type": "mutation",
+    "id": "MELEE_PERK_ESTOCADA",
+    "copy-from": "MELEE_PERK_BASE",
+    "name": { "str": "Estocada" },
+    "description": "Perform a quick lunging thrust with a long sword, thrusting sword or quarterstaff.  You must have exactly 1 momentum stack to perform this attack.",
+    "flags": "MELEE_PERK_ESTOCADA"
+  },
+  {
+    "type": "mutation",
+    "id": "MELEE_PERK_TACKLE",
+    "copy-from": "MELEE_PERK_BASE",
+    "name": { "str": "Charging Tackle" },
+    "description": "Your first attack after acquiring at least 3 momentum stacks will be replaced by a shoulder tackle.  The tackle will ground humanoid targets of similar or smaller size and consume all momentum stacks.",
+    "flags": "MELEE_PERK_TACKLE"
+  },
+  {
+    "type": "mutation",
+    "id": "MELEE_PERK_EXECUTION",
+    "copy-from": "MELEE_PERK_BASE",
+    "name": { "str": "Execution" },
+    "description": "Whenever you attack a human-sized target with a great axe, great sword or great hammer if the target has less health than the base attack rating of your weapon, you will execute them instead.  Execution attacks ignore armor and will restore 10% of your max stamina.",
+    "flags": "MELEE_PERK_EXECUTION"
+  },
+  {
+    "type": "mutation",
+    "id": "MELEE_PERK_BRUTALITY",
+    "copy-from": "MELEE_PERK_BASE",
+    "name": { "str": "Brutal Execution" },
+    "description": "You perform executions with such brutality that all minded enemies that witness them will become stunned for 2 turns.",
+    "flags": "MELEE_PERK_BRUTALITY"
+  }
+]

--- a/data/mods/Perk_melee/perks.json
+++ b/data/mods/Perk_melee/perks.json
@@ -27,7 +27,7 @@
     "id": "MELEE_PERK_CAREFREE_STANCE",
     "copy-from": "MELEE_PERK_BASE",
     "name": { "str": "Carefree Stance" },
-    "description": "You aren't even trying. \n You clear all combat buffs whenever you wait.",
+    "description": "You aren't even trying.\nYou clear all combat buffs whenever you wait.",
     "flags": "MELEE_PERK_CAREFREE_STANCE"
   },
   {
@@ -86,7 +86,7 @@
     "id": "MELEE_PERK_COMBAT_TEMPO",
     "copy-from": "MELEE_PERK_BASE",
     "name": { "str": "Combat Tempo I" },
-    "description": "Perfect. Now do it again.\nAttacks generate stacks of combat tempo.  Tempo greatly favors the strong.",
+    "description": "Perfect.  Now do it again.\nAttacks generate stacks of combat tempo.  Tempo greatly favors the strong.",
     "flags": "MELEE_PERK_TEMPO"
   },
   {

--- a/data/mods/Perk_melee/perks.json
+++ b/data/mods/Perk_melee/perks.json
@@ -1,0 +1,117 @@
+[
+  {
+    "type": "mutation_type",
+    "id": "perk"
+  },
+  {
+    "type": "mutation",
+    "id": "perk_ma_perk_menu",
+    "name": { "str": "Practice Martial Arts" },
+    "points": 0,
+    "purifiable": false,
+    "description": "Learn new martial arts techniques and perks.",
+    "active": true,
+    "activated_eocs": [ "EOC_open_ma_perk_menu" ]
+  },
+  {
+    "type": "mutation",
+    "id": "MELEE_PERK_BASE",
+    "name": { "str": "Melee Perk" },
+    "points": 0,
+    "description": "We copy from this one.",
+    "valid": false,
+    "purifiable": false
+  },
+  {
+    "type": "mutation",
+    "id": "MELEE_PERK_CAREFREE_STANCE",
+    "copy-from": "MELEE_PERK_BASE",
+    "name": { "str": "Carefree Stance" },
+    "description": "You aren't even trying. \n You clear all combat buffs whenever you wait.",
+    "flags": "MELEE_PERK_CAREFREE_STANCE"
+  },
+  {
+    "type": "mutation",
+    "id": "MELEE_PERK_MOVING_DODGE",
+    "copy-from": "MELEE_PERK_BASE",
+    "name": { "str": "Flowing retreat" },
+    "description": "You'll attempt to move away from your attackers when you successfully dodge an attack.  You'll gain a momentum stack if you can normally gain them.",
+    "flags": "MELEE_PERK_MOVING_DODGE"
+  },
+  {
+    "type": "mutation",
+    "id": "MELEE_PERK_RIPOSTE",
+    "copy-from": "MELEE_PERK_BASE",
+    "name": { "str": "Counter strikes" },
+    "description": "You gain +1 accuracy for two turns after a successful block.",
+    "flags": "MELEE_PERK_RIPOSTE"
+  },
+  {
+    "type": "mutation",
+    "id": "MELEE_PERK_BLOCK",
+    "copy-from": "MELEE_PERK_BASE",
+    "name": { "str": "Stalwart" },
+    "description": "You have an extra block attempt per turn.",
+    "flags": "MELEE_PERK_BLOCK",
+    "enchantments": [ { "values": [ { "value": "BONUS_BLOCK", "add": 1 } ] } ]
+  },
+  {
+    "type": "mutation",
+    "id": "MELEE_PERK_DODGE",
+    "copy-from": "MELEE_PERK_BASE",
+    "name": { "str": "Spry footwork" },
+    "description": "You have an extra dodge attempt per turn.",
+    "flags": "MELEE_PERK_DODGE",
+    "enchantments": [ { "values": [ { "value": "BONUS_DODGE", "add": 1 } ] } ]
+  },
+  {
+    "type": "mutation",
+    "id": "MELEE_PERK_MOMENTUM",
+    "copy-from": "MELEE_PERK_BASE",
+    "name": { "str": "Momentum I" },
+    "description": "Rapid movement generates momentum stacks.  Momentum greatly favors dextrous warriors.",
+    "changes_to": [ "MELEE_PERK_MOMENTUM_2" ],
+    "flags": "MELEE_PERK_MOMENTUM"
+  },
+  {
+    "type": "mutation",
+    "id": "MELEE_PERK_MOMENTUM_2",
+    "copy-from": "MELEE_PERK_BASE",
+    "name": { "str": "Momentum II" },
+    "description": "Rapid movement generates momentum stacks.  As long as momentum is active your attacks gain extra physical damage equal to 10% of your dexterity.  You gain a point of dexterity for every 2 momentum stacks.",
+    "flags": "MELEE_PERK_MOMENTUM"
+  },
+  {
+    "type": "mutation",
+    "id": "MELEE_PERK_COMBAT_TEMPO",
+    "copy-from": "MELEE_PERK_BASE",
+    "name": { "str": "Combat Tempo I" },
+    "description": "Perfect. Now do it again.\nAttacks generate stacks of combat tempo.  Tempo greatly favors the strong.",
+    "flags": "MELEE_PERK_TEMPO"
+  },
+  {
+    "type": "mutation",
+    "id": "MELEE_PERK_TEMPO_SHIFT",
+    "copy-from": "MELEE_PERK_BASE",
+    "name": { "str": "Tempo Shift" },
+    "description": "Gain a stack of combat tempo whenever you successfully block an attack.",
+    "flags": "MELEE_PERK_TEMPO_SHIFT"
+  },
+  {
+    "type": "mutation",
+    "id": "MELEE_PERK_TEMPO_THROW",
+    "copy-from": "MELEE_PERK_BASE",
+    "name": { "str": "Measured throws" },
+    "description": "Your throwing attacks deal 100% more damage for every combat tempo stack you have.",
+    "enchantments": [
+      {
+        "values": [
+          {
+            "value": "THROW_DAMAGE",
+            "multiply": { "math": [ "u_effect_intensity('mabuff:buff_perk_tempo') > 0 ? u_effect_intensity('mabuff:buff_perk_tempo') : 0" ] }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/data/mods/Perk_melee/spells.json
+++ b/data/mods/Perk_melee/spells.json
@@ -1,0 +1,21 @@
+[
+  {
+    "id": "make_way_push",
+    "type": "SPELL",
+    "name": "Make Way Push",
+    "description": "Pushes all objects outside.",
+    "message": "",
+    "effect": "area_push",
+    "shape": "blast",
+    "valid_targets": [ "ground", "hostile" ],
+    "min_range": 5,
+    "max_range": 15,
+    "range_increment": 2.5,
+    "min_aoe": 2,
+    "max_aoe": 2,
+    "max_level": 20,
+    "difficulty": 1,
+    "base_casting_time": 10,
+    "energy_source": "NONE"
+  }
+]

--- a/data/mods/Perk_melee/techniques/executions.json
+++ b/data/mods/Perk_melee/techniques/executions.json
@@ -1,0 +1,101 @@
+[
+  {
+    "type": "technique",
+    "id": "tec_perk_execution_sword",
+    "name": "Execution (Great Sword)",
+    "messages": [
+      "You deliver a rapid strike to the %s before cleaving them in two with a powerful blow",
+      "<npcname> cleaves %s in two with a powerful blow"
+    ],
+    "required_char_flags_all": [ "MELEE_PERK_EXECUTION" ],
+    "melee_allowed": true,
+    "crit_ok": true,
+    "weapon_categories_allowed": [ "GREAT_SWORDS" ],
+    "weighting": 10000,
+    "condition": {
+      "and": [
+        { "math": [ "u_perk_mymelee", ">=", "n_hp('torso')" ] },
+        { "math": [ "u_monsters_nearby('radius': 2)", "<", "2" ] },
+        { "math": [ "u_val('size') + 1", ">=", "n_val('size')" ] }
+      ]
+    },
+    "flat_bonuses": [
+      { "stat": "arpen", "type": "bash", "scale": 1000 },
+      { "stat": "arpen", "type": "cut", "scale": 1000 },
+      { "stat": "arpen", "type": "stab", "scale": 1000 }
+    ],
+    "mult_bonuses": [
+      { "stat": "damage", "type": "bash", "scale": 12.0 },
+      { "stat": "damage", "type": "cut", "scale": 12.0 },
+      { "stat": "damage", "type": "stab", "scale": 12.0 },
+      { "stat": "movecost", "scale": 1.5 }
+    ],
+    "eocs": [ "EOC_EXECUTION_EXTA_EFFECTS" ],
+    "attack_vectors": [ "vector_null" ]
+  },
+  {
+    "type": "technique",
+    "id": "tec_perk_execution_hammer",
+    "name": "Execution (Great Hammer)",
+    "messages": [
+      "You knock the %s to the ground before delivering a crushing blow",
+      "<npcname> knocks down and crushes %s with a powerful blow"
+    ],
+    "required_char_flags_all": [ "MELEE_PERK_EXECUTION" ],
+    "melee_allowed": true,
+    "crit_ok": true,
+    "weapon_categories_allowed": [ "GREAT_HAMMERS" ],
+    "weighting": 10000,
+    "condition": {
+      "and": [
+        { "math": [ "u_perk_mymelee", ">=", "n_hp('torso')" ] },
+        { "math": [ "u_monsters_nearby('radius': 2)", "<", "2" ] },
+        { "math": [ "u_val('size') + 1", ">=", "n_val('size')" ] }
+      ]
+    },
+    "flat_bonuses": [
+      { "stat": "arpen", "type": "bash", "scale": 1000 },
+      { "stat": "arpen", "type": "cut", "scale": 1000 },
+      { "stat": "arpen", "type": "stab", "scale": 1000 }
+    ],
+    "mult_bonuses": [
+      { "stat": "damage", "type": "bash", "scale": 12.0 },
+      { "stat": "damage", "type": "cut", "scale": 12.0 },
+      { "stat": "damage", "type": "stab", "scale": 12.0 },
+      { "stat": "movecost", "scale": 1.5 }
+    ],
+    "eocs": [ "EOC_EXECUTION_EXTA_EFFECTS" ],
+    "attack_vectors": [ "vector_null" ]
+  },
+  {
+    "type": "technique",
+    "id": "tec_perk_execution_axe",
+    "name": "Execution (Great Axe)",
+    "messages": [ "You cleave the %s asunder with a furious slash", "<npcname> cleaves into %s with a powerful blow" ],
+    "required_char_flags_all": [ "MELEE_PERK_EXECUTION" ],
+    "melee_allowed": true,
+    "crit_ok": true,
+    "weapon_categories_allowed": [ "GREAT_AXES" ],
+    "weighting": 10000,
+    "condition": {
+      "and": [
+        { "math": [ "u_perk_mymelee", ">=", "n_hp('torso')" ] },
+        { "math": [ "u_monsters_nearby('radius': 2)", "<", "2" ] },
+        { "math": [ "u_val('size') + 1", ">=", "n_val('size')" ] }
+      ]
+    },
+    "flat_bonuses": [
+      { "stat": "arpen", "type": "bash", "scale": 1000 },
+      { "stat": "arpen", "type": "cut", "scale": 1000 },
+      { "stat": "arpen", "type": "stab", "scale": 1000 }
+    ],
+    "mult_bonuses": [
+      { "stat": "damage", "type": "bash", "scale": 12.0 },
+      { "stat": "damage", "type": "cut", "scale": 12.0 },
+      { "stat": "damage", "type": "stab", "scale": 12.0 },
+      { "stat": "movecost", "scale": 1.5 }
+    ],
+    "eocs": [ "EOC_EXECUTION_EXTA_EFFECTS" ],
+    "attack_vectors": [ "vector_null" ]
+  }
+]

--- a/data/mods/Perk_melee/techniques/techniques.json
+++ b/data/mods/Perk_melee/techniques/techniques.json
@@ -1,0 +1,232 @@
+[
+  {
+    "type": "technique",
+    "id": "tec_perk_feint",
+    "name": "Feint",
+    "messages": [ "You fake a strike at %s!", "<npcname> fakes a strike at %s!" ],
+    "required_char_flags_all": [ "MELEE_PERK_FEINT" ],
+    "melee_allowed": true,
+    "defensive": true,
+    "miss_recovery": true,
+    "mult_bonuses": [ { "stat": "movecost", "scale": 0.8 } ]
+  },
+  {
+    "type": "technique",
+    "id": "tec_perk_stagger_strike",
+    "name": "Staggering Strike",
+    "weapon_damage_requirements": [ { "type": "bash", "min": 12 } ],
+    "melee_allowed": true,
+    "crit_ok": true,
+    "stun_dur": 100,
+    "weighting": 1,
+    "required_char_flags_all": [ "MELEE_PERK_STAGGER_STRIKE" ],
+    "condition": {
+      "and": [
+        { "math": [ "u_val('size') + 1", ">=", "n_val('size')" ] },
+        { "math": [ "u_effect_intensity('mabuff:buff_perk_tempo')", ">", "2" ] },
+        { "not": { "npc_has_effect": "stunned" } }
+      ]
+    },
+    "messages": [ "You deliver a stunning strike to %s", "<npcname> delivers a stunning strike to %s!" ],
+    "condition_desc": "* Only works on a <info>non-stunned</info> target of <info>similar or smaller</info> size.",
+    "description": "Stun for 1 turn",
+    "attack_vectors": [ "vector_null" ],
+    "mult_bonuses": [ { "stat": "movecost", "scale": 0.5 } ]
+  },
+  {
+    "type": "technique",
+    "id": "tec_perk_fore",
+    "name": "Brutal Swing",
+    "required_char_flags_all": [ "MELEE_PERK_FORE" ],
+    "weapon_damage_requirements": [ { "type": "bash", "min": 15 } ],
+    "melee_allowed": true,
+    "crit_ok": true,
+    "knockback_dist": 3,
+    "weighting": -4,
+    "messages": [ "You send %s reeling with a brutal strike", "<npcname> sends %s reeling" ],
+    "description": "Three tile knockback",
+    "attack_vectors": [ "vector_null" ]
+  },
+  {
+    "type": "technique",
+    "id": "tec_perk_fore_stunned",
+    "name": "Brutal Swing (Stunned target)",
+    "required_char_flags_all": [ "MELEE_PERK_FORE" ],
+    "weapon_damage_requirements": [ { "type": "bash", "min": 15 } ],
+    "melee_allowed": true,
+    "crit_ok": true,
+    "condition": { "and": [ { "npc_has_effect": "stunned" } ] },
+    "knockback_dist": 3,
+    "weighting": 100,
+    "messages": [ "You send %s reeling with a brutal strike", "<npcname> sends %s reeling" ],
+    "description": "Three tile knockback",
+    "attack_vectors": [ "vector_null" ]
+  },
+  {
+    "type": "technique",
+    "id": "tec_perk_shoulder_tackle",
+    "name": "Shoulder tackle",
+    "messages": [ "You ground %s with a shoulder bash", "<npcname> drops %s with a shoulder bash" ],
+    "required_char_flags_all": [ "MELEE_PERK_TACKLE" ],
+    "required_buffs_any": [ "buff_perk_momentum" ],
+    "weighting": 3,
+    "crit_ok": true,
+    "melee_allowed": true,
+    "unarmed_allowed": true,
+    "condition": {
+      "and": [
+        { "math": [ "u_val('size') + 1", ">=", "n_val('size')" ] },
+        { "math": [ "u_effect_intensity('mabuff:buff_perk_momentum')", ">", "2" ] },
+        { "not": { "npc_has_effect": "downed" } },
+        { "or": [ { "npc_bodytype": "human" }, { "npc_bodytype": "angel" } ] },
+        { "or": [ { "not": { "npc_has_flag": "FLIES" } }, { "npc_has_flag": "DISABLE_FLIGHT" } ] }
+      ]
+    },
+    "mult_bonuses": [ { "stat": "movecost", "scale": 0.75 }, { "stat": "damage", "type": "bash", "scale": 0.8 } ],
+    "condition_desc": "* Only works on a <info>non-downed humanoid</info> target of <info>similar or smaller</info> size incapable of flight. Requires <info>momentum(3)</info> or higher to trigger.",
+    "down_dur": 200,
+    "eocs": [ "EOC_CLEAR_MOMENTUM" ],
+    "attack_vectors": [ "vector_shoulder" ]
+  },
+  {
+    "type": "technique",
+    "id": "tec_perk_vulgar_opening",
+    "name": "Vulgar Opening",
+    "messages": [ "You cleave into %s with a mighty strike", "<npcname> cleaves into %s with a powerful blow" ],
+    "required_char_flags_all": [ "MELEE_PERK_JUST_HIT_IT" ],
+    "melee_allowed": true,
+    "condition": {
+      "and": [ { "not": { "u_has_effect": "mabuff:buff_perk_tempo" } }, { "not": { "u_has_effect": "mabuff:buff_perk_momentum" } } ]
+    },
+    "crit_ok": true,
+    "weapon_categories_allowed": [ "GREAT_AXES", "GREAT_SWORDS", "GREAT_HAMMERS", "AXE", "MEDIUM-SWORDS", "LONG_SWORDS", "MACES", "AXES", "FLAILS" ],
+    "weighting": 100,
+    "flat_bonuses": [
+      { "stat": "arpen", "type": "bash", "scaling-stat": "str", "scale": 2.25 },
+      { "stat": "arpen", "type": "cut", "scaling-stat": "str", "scale": 2.25 },
+      { "stat": "arpen", "type": "stab", "scaling-stat": "str", "scale": 2.25 }
+    ],
+    "attack_vectors": [ "vector_null" ]
+  },
+  {
+    "type": "technique",
+    "id": "tec_perk_coiling_strike",
+    "name": "Coiling strike",
+    "weapon_categories_allowed": [ "QUARTERSTAVES", "SPEARS", "POLEARMS" ],
+    "required_buffs_any": [ "buff_perk_momentum" ],
+    "melee_allowed": true,
+    "reach_tec": true,
+    "required_char_flags_all": [ "MELEE_PERK_COILING_STRIKE" ],
+    "flat_bonuses": [
+      { "stat": "damage", "type": "bash", "scaling-stat": "per", "scale": 0.5 },
+      { "stat": "damage", "type": "cut", "scaling-stat": "per", "scale": 0.5 },
+      { "stat": "damage", "type": "stab", "scaling-stat": "per", "scale": 0.5 }
+    ],
+    "mult_bonuses": [
+      { "stat": "movecost", "scale": 0.5 },
+      { "stat": "damage", "type": "bash", "scale": 0.25 },
+      { "stat": "damage", "type": "cut", "scale": 0.66 },
+      { "stat": "damage", "type": "stab", "scale": 0.66 }
+    ],
+    "messages": [ "You quickly stab %s with a sideways thrust", "<npcname> stabs %s with a quick thrust" ],
+    "description": "A quick reach attack that scales heavily with perception.",
+    "attack_vectors": [ "vector_null" ]
+  },
+  {
+    "type": "technique",
+    "id": "tec_perk_make_way",
+    "name": "Make Way",
+    "required_char_flags_all": [ "MELEE_PERK_MAKE_WAY" ],
+    "weapon_categories_allowed": [ "QUARTERSTAVES", "SPEARS", "POLEARMS" ],
+    "melee_allowed": true,
+    "weighting": 2,
+    "condition": { "and": [ { "math": [ "u_monsters_nearby('radius': 1)", ">", "1" ] } ] },
+    "mult_bonuses": [
+      { "stat": "damage", "type": "bash", "scale": 0.5 },
+      { "stat": "damage", "type": "cut", "scale": 0.25 },
+      { "stat": "damage", "type": "stab", "scale": 0.01 }
+    ],
+    "messages": [
+      "You swing through %s and everything nearby with an overhead attack",
+      "<npcname> swings at %s and everything nearby with an overhead attack"
+    ],
+    "eocs": [ { "id": "EOC_tec_perk_make_way", "effect": [ { "u_cast_spell": { "id": "make_way_push" } } ] } ],
+    "attack_vectors": [ "vector_null" ]
+  },
+  {
+    "type": "technique",
+    "id": "tec_perk_staff_kick",
+    "name": "Fulcrum Kick",
+    "required_char_flags_all": [ "MELEE_PERK_STAFF_KICK" ],
+    "weapon_categories_allowed": [ "QUARTERSTAVES", "SPEARS", "POLEARMS" ],
+    "weighting": -2,
+    "knockback_dist": 2,
+    "crit_ok": true,
+    "melee_allowed": true,
+    "condition": {
+      "and": [
+        { "math": [ "u_val('size') + 1", ">=", "n_val('size')" ] },
+        { "not": { "npc_has_effect": "downed" } },
+        { "or": [ { "npc_bodytype": "human" }, { "npc_bodytype": "angel" } ] },
+        { "or": [ { "not": { "npc_has_flag": "FLIES" } }, { "npc_has_flag": "DISABLE_FLIGHT" } ] }
+      ]
+    },
+    "mult_bonuses": [
+      { "stat": "damage", "type": "bash", "scale": 0.5 },
+      { "stat": "damage", "type": "cut", "scale": 0.015 },
+      { "stat": "damage", "type": "stab", "scale": 0.01 }
+    ],
+    "messages": [ "You use your polearm as a springboard to kick %s", "<npcname> kicks %s" ],
+    "condition_desc": "* Only works on a <info>non-downed humanoid</info> target of <info>similar or smaller</info> size incapable of flight.",
+    "attack_vectors": [ "vector_foot_heel" ]
+  },
+  {
+    "type": "technique",
+    "id": "tec_perk_estocada",
+    "name": "Estocada",
+    "required_char_flags_all": [ "MELEE_PERK_ESTOCADA" ],
+    "messages": [ "You lunge and thrust your weapon into %s", "<npcname> lunges and thrusts their weapon into %s!" ],
+    "melee_allowed": true,
+    "weighting": 10,
+    "weapon_categories_allowed": [ "QUARTERSTAVES", "LONG_SWORDS", "MEDIUM-SWORDS", "LONG_THRUSTING_SWORDS", "FENCING_WEAPONRY" ],
+    "condition": { "and": [ { "math": [ "u_effect_intensity('mabuff:buff_perk_momentum')", "==", "1" ] } ] },
+    "condition_desc": "* Requires <info>momentum(1)</info> to trigger.",
+    "mult_bonuses": [ { "stat": "damage", "type": "stab", "scale": 1.1 }, { "stat": "movecost", "scale": 0.5 } ],
+    "attack_vectors": [ "vector_null" ]
+  },
+  {
+    "type": "technique",
+    "id": "tec_perk_knife_counter_dodge",
+    "name": "Knife Counter",
+    "required_char_flags_all": [ "MELEE_PERK_KNIFE_COUNTER_DODGE" ],
+    "weapon_categories_allowed": [ "KNIVES", "SHIVS" ],
+    "melee_allowed": true,
+    "crit_ok": true,
+    "dodge_counter": true,
+    "weighting": 100,
+    "mult_bonuses": [
+      { "stat": "movecost", "scale": 0.1 },
+      { "stat": "damage", "type": "bash", "scale": 0.02 },
+      { "stat": "damage", "type": "cut", "scale": 0.2 },
+      { "stat": "damage", "type": "stab", "scale": 0.2 }
+    ],
+    "messages": [ "You slash at the %s as you dodge", "<npcname> shaleshes at the %s as they dodge" ],
+    "eocs": [ "EOC_PERK_DODGE_RETREAT_MANUAL" ],
+    "attack_vectors": [ "vector_null" ]
+  },
+  {
+    "type": "technique",
+    "id": "tec_perk_knife_finisher",
+    "name": "Slaying Strike",
+    "required_char_flags_all": [ "MELEE_PERK_KNIFE_FINISHER" ],
+    "weapon_categories_allowed": [ "KNIVES", "SHIVS" ],
+    "melee_allowed": true,
+    "crit_ok": true,
+    "weighting": 1,
+    "condition": { "and": [ { "math": [ "u_effect_intensity('mabuff:buff_perk_tempo')", ">", "2" ] } ] },
+    "condition_desc": "* Requires <info>tempo(3)</info> to trigger.",
+    "flat_bonuses": [ { "stat": "hit", "scale": 5.0 } ],
+    "messages": [ "You viciously wound %s", "<npcname> viciously wounds %s!" ],
+    "attack_vectors": [ "vector_null" ]
+  }
+]

--- a/data/mods/Perk_melee/techniques/techniques.json
+++ b/data/mods/Perk_melee/techniques/techniques.json
@@ -210,7 +210,7 @@
       { "stat": "damage", "type": "cut", "scale": 0.2 },
       { "stat": "damage", "type": "stab", "scale": 0.2 }
     ],
-    "messages": [ "You slash at the %s as you dodge", "<npcname> shaleshes at the %s as they dodge" ],
+    "messages": [ "You slash at the %s as you dodge", "<npcname> slashes at %s as they dodge" ],
     "eocs": [ "EOC_PERK_DODGE_RETREAT_MANUAL" ],
     "attack_vectors": [ "vector_null" ]
   },


### PR DESCRIPTION
#### Summary
Mods "Create the Martial Mastery mod, which allows you to develop your own martial art using a level up system "

#### Purpose of change
The spell system and related enchantment content currently covers the make your own wizard part of the fantasy RPG trio, but there's very little for players that would like to play warrior or rogue archetypes.  This mod seeks to resolve that by letting players build a custom fighting style by selecting different perk locked abilities. 

The mod seeks to respect the main game's outlook on the melee combat system. The player imput's for combat will be limited to movement, waiting and attacking,  but complex actions can be set up by different rhythms in how these actions are chosen. 

#### Describe the solution
This mod overwrites the default martial art and plugs a wide variety of perks that unlock new techniques and buffs as in bombastic perks, you earn XP by defeating enemies and can level up to unlock new abilities.

This first release focuses on the attack and movement actions, and principally adds techniques for knives, swords and spears. It includes 20+ new perks that have some basic synergies between them.

#### Describe alternatives you've considered

A larger release but I think this is a good starting point atm.

#### Testing
A lot of combat.
