### PR TITLE
Remove instances of the magic number 60.

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -779,7 +779,7 @@ action_id handle_action_menu()
 
     Character &player_character = get_player_character();
     // Check if we're in a potential combat situation, if so, sort a few actions to the top.
-    if( !player_character.get_hostile_creatures( 60 ).empty() ) {
+    if( !player_character.get_hostile_creatures( MAX_VIEW_DISTANCE ).empty() ) {
         // Only prioritize movement options if we're not driving.
         if( !player_character.controlling_vehicle ) {
             action_weightings[ACTION_CYCLE_MOVE] = 400;

--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -699,9 +699,9 @@ void basecamp::form_storage_zones( map &here, const tripoint_abs_ms &abspos )
     validate_bb_pos( project_to<coords::ms>( omt_pos ) );
     tripoint src_loc = here.getlocal( bb_pos ) + point_north;
     std::vector<tripoint_abs_ms> possible_liquid_dumps;
-    if( mgr.has_near( zone_type_CAMP_STORAGE, abspos, 60 ) ) {
+    if( mgr.has_near( zone_type_CAMP_STORAGE, abspos, ACTIVITY_SEARCH_DISTANCE ) ) {
         const std::vector<const zone_data *> zones = mgr.get_near_zones( zone_type_CAMP_STORAGE, abspos,
-                60, get_owner() );
+                ACTIVITY_SEARCH_DISTANCE, get_owner() );
         // Find the nearest unsorted zone to dump objects at
         if( !zones.empty() ) {
             if( zones != storage_zones ) {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1255,7 +1255,7 @@ int Character::sight_range( float light_level ) const
 
 int Character::unimpaired_range() const
 {
-    return std::min( sight_max, 60 );
+    return std::min( sight_max, MAX_VIEW_DISTANCE );
 }
 
 bool Character::overmap_los( const tripoint_abs_omt &omt, int sight_points ) const

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8061,8 +8061,8 @@ void game::list_items_monsters()
 {
     // Search whole reality bubble because each function internally verifies
     // the visibility of the items / monsters in question.
-    std::vector<Creature *> mons = u.get_visible_creatures( 60 );
-    const std::vector<map_item_stack> items = find_nearby_items( 60 );
+    std::vector<Creature *> mons = u.get_visible_creatures( MAX_VIEW_DISTANCE );
+    const std::vector<map_item_stack> items = find_nearby_items( MAX_VIEW_DISTANCE );
 
     if( mons.empty() && items.empty() ) {
         add_msg( m_info, _( "You don't see any items or monsters around you!" ) );

--- a/src/game_constants.h
+++ b/src/game_constants.h
@@ -50,6 +50,9 @@ constexpr int HALF_MAPSIZE_X = SEEX * HALF_MAPSIZE;
 constexpr int HALF_MAPSIZE_Y = SEEY * HALF_MAPSIZE;
 
 constexpr int MAX_VIEW_DISTANCE = SEEX * HALF_MAPSIZE;
+// Currently defined the same as MAX_VIEW_DISTANCE, with a
+// different name for semantic benefits.
+constexpr int REALITY_BUBBLE_RADIUS = SEEX * HALF_MAPSIZE;
 
 /**
  * Size of the overmap. This is the number of overmap terrain tiles per dimension in one overmap,

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -7061,7 +7061,7 @@ std::optional<int> iuse::radiocaron( Character *p, item *it, const tripoint & )
 static void sendRadioSignal( Character &p, const flag_id &signal )
 {
     map &here = get_map();
-    for( const tripoint &loc : here.points_in_radius( p.pos(), 60 ) ) {
+    for( const tripoint &loc : here.points_in_radius( p.pos(), REALITY_BUBBLE_RADIUS ) ) {
         for( item &it : here.i_at( loc ) ) {
             if( it.has_flag( flag_RADIO_ACTIVATION ) && it.has_flag( signal ) ) {
                 sounds::sound( p.pos(), 6, sounds::sound_t::alarm, _( "beep" ), true, "misc", "beep" );

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -2694,7 +2694,7 @@ static void CheckMessages()
 
                 Character &player_character = get_player_character();
                 // Check if we're in a potential combat situation, if so, sort a few actions to the top.
-                if( !player_character.get_hostile_creatures( 60 ).empty() ) {
+                if( !player_character.get_hostile_creatures( MAX_VIEW_DISTANCE ).empty() ) {
                     // Only prioritize movement options if we're not driving.
                     if( !player_character.controlling_vehicle ) {
                         actions.insert( ACTION_CYCLE_MOVE );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -664,7 +664,7 @@ void vehicle::autopilot_patrol()
     }
     zone_manager &mgr = zone_manager::get_manager();
     const auto &zone_src_set =
-        mgr.get_near( zone_type_VEHICLE_PATROL, global_square_location(), 60 );
+        mgr.get_near( zone_type_VEHICLE_PATROL, global_square_location(), ACTIVITY_SEARCH_DISTANCE );
     if( zone_src_set.empty() ) {
         is_patrolling = false;
         return;

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -486,7 +486,7 @@ void vehicle::smash_security_system()
 void vehicle::autopilot_patrol_check()
 {
     zone_manager &mgr = zone_manager::get_manager();
-    if( mgr.has_near( zone_type_VEHICLE_PATROL, global_square_location(), 60 ) ) {
+    if( mgr.has_near( zone_type_VEHICLE_PATROL, global_square_location(), ACTIVITY_SEARCH_DISTANCE ) ) {
         enable_patrol();
     } else {
         g->zones_manager();


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Avoid using magic numbers.

#### Describe the solution

Run a quick find for the number 60 and replace any instances of distances with 

#### Describe alternatives you've considered

Some of these might not semantically be the actual maximum view distance, but right now they are exactly the same.

#### Testing

Only replaced a number with a compile time constant equal to that number. If it compiles, it will work exactly the same as before.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->