### PR TITLE
Spawn triggered bear trap only after creature escapes from it

### DIFF
--- a/src/character_escape.cpp
+++ b/src/character_escape.cpp
@@ -42,6 +42,7 @@ static const efftype_id effect_webbed( "webbed" );
 
 static const flag_id json_flag_GRAB( "GRAB" );
 
+static const itype_id itype_beartrap( "beartrap" );
 static const itype_id itype_rope_6( "rope_6" );
 static const itype_id itype_snare_trigger( "snare_trigger" );
 
@@ -89,7 +90,7 @@ void Character::try_remove_bear_trap()
     /* Real bear traps can't be removed without the proper tools or immense strength; eventually this should
        allow normal players two options: removal of the limb or removal of the trap from the ground
        (at which point the player could later remove it from the leg with the right tools).
-       As such we are currently making it a bit easier for players and NPC's to get out of bear traps.
+       As such we are currently making it a bit easier for players and NPCs to get out of bear traps.
     */
     // If is riding, then despite the character having the effect, it is the mounted creature that escapes.
     if( is_avatar() && is_mounted() ) {
@@ -98,6 +99,7 @@ void Character::try_remove_bear_trap()
             if( x_in_y( mon->type->melee_dice * mon->type->melee_sides, 200 ) ) {
                 mon->remove_effect( effect_beartrap );
                 remove_effect( effect_beartrap );
+                get_map().spawn_item( pos_bub(), itype_beartrap );
                 add_msg( _( "The %s escapes the bear trap!" ), mon->get_name() );
             } else {
                 add_msg_if_player( m_bad,
@@ -107,6 +109,7 @@ void Character::try_remove_bear_trap()
     } else {
         if( can_escape_trap( 100 ) ) {
             remove_effect( effect_beartrap );
+            get_map().spawn_item( pos_bub(), itype_beartrap );
             add_msg_player_or_npc( m_good, _( "You free yourself from the bear trap!" ),
                                    _( "<npcname> frees themselves from the bear trap!" ) );
         } else {

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -195,8 +195,8 @@ bool trapfunc::beartrap( const tripoint &p, Creature *c, item * )
 
         // Messages
         c->add_msg_player_or_npc( m_bad,
-                                  string_format( _( "A bear trap closes on your %s" ), body_part_name_accusative( hit ) ),
-                                  string_format( _( "A bear trap closes on <npcname>'s %s" ), body_part_name( hit ) ) );
+                                  string_format( _( "A bear trap closes on your %s!" ), body_part_name_accusative( hit ) ),
+                                  string_format( _( "A bear trap closes on <npcname>'s %s!" ), body_part_name( hit ) ) );
 
         if( c->has_effect( effect_ridden ) ) {
             add_msg( m_warning, _( "Your %s is caught by a beartrap!" ), c->get_name() );
@@ -219,7 +219,6 @@ bool trapfunc::beartrap( const tripoint &p, Creature *c, item * )
         c->check_dead_state();
     }
 
-    here.spawn_item( p, "beartrap" );
     return true;
 }
 


### PR DESCRIPTION
#### Summary
Bugfixes "Spawn triggered bear trap only after creature escapes from it"

#### Purpose of change
Closes #64587.

#### Describe the solution
Spawn triggered bear trap only after creature escapes from it, not after trap's trigger. This forbids picking up and other means of interacting with triggered trap until you're freed from it.

#### Describe alternatives you've considered
Convert bear trap into an "armor" which will be forcefully worn on affected limb (like a splint) on trigger, and be very hard to remove, and may even lead to a removal of a limb, as stated in comments:
https://github.com/CleverRaven/Cataclysm-DDA/blob/bbf007713d444a6477bacdb3276190de97b3d22c/src/character_escape.cpp#L89-L91
This is a preferred solution, but obviously it would require much more work to implement it properly.

#### Testing
Got caught in a trap. No trap (both as a _trap_ and as as item) on the ground. Tried to free. After escape, triggered bear trap is spawned on character's location.

#### Additional context
None.
