### PR TITLE
Hub01 now gives NRE recorder with fitting battery on their quest

### DIFF
--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
@@ -852,7 +852,7 @@
         "effect": [
           { "assign_mission": "MISSION_ROBOFAC_INTERCOM_PORTAL_SM_1" },
           { "u_spawn_item": "nre_recorder", "count": 1 },
-          { "u_spawn_item": "light_battery_cell", "count": 1 }
+          { "u_spawn_item": "medium_battery_cell", "count": 1 }
         ],
         "topic": "MISSION_ROBOFAC_INTERCOM_PORTAL_SM_1_ACCEPTED"
       },


### PR DESCRIPTION
#### Summary
Bugfixes "Hub01 now gives NRE recorder with fitting battery on their quest"

#### Purpose of change
Closes #76309.

#### Describe the solution
Replaced light battery with medium battery in quest definition.

#### Describe alternatives you've considered
None.

#### Testing
None, obvious change.

#### Additional context
None.