### PR TITLE
Remove milk_allergen from hard cheeses

### DIFF
--- a/data/json/items/comestibles/dairy.json
+++ b/data/json/items/comestibles/dairy.json
@@ -226,7 +226,7 @@
     "description": "Hard, dry cheese made to last, unlike modern processed cheese.  Will make you thirsty though.",
     "price": "3 USD 85 cent",
     "price_postapoc": "1 USD 50 cent",
-    "vitamins": [ [ "calcium", 32 ], [ "iron", 2 ] ],
+    "vitamins": [ [ "calcium", 32 ], [ "iron", 2 ], [ "milk_allergen", 0 ] ],
     "fun": 5,
     "flags": [ "NUTRIENT_OVERRIDE" ]
   },
@@ -540,6 +540,6 @@
     "volume": "62 ml",
     "flags": [ "EDIBLE_FROZEN" ],
     "fun": 2,
-    "vitamins": [ [ "calcium", 19 ], [ "iron", 5 ], [ "milk_allergen", 1 ] ]
+    "vitamins": [ [ "calcium", 19 ], [ "iron", 5 ] ]
   }
 ]

--- a/data/json/items/comestibles/dairy.json
+++ b/data/json/items/comestibles/dairy.json
@@ -226,7 +226,7 @@
     "description": "Hard, dry cheese made to last, unlike modern processed cheese.  Will make you thirsty though.",
     "price": "3 USD 85 cent",
     "price_postapoc": "1 USD 50 cent",
-    "vitamins": [ [ "calcium", 32 ], [ "iron", 2 ], [ "milk_allergen", 0 ] ]
+    "vitamins": [ [ "calcium", 32 ], [ "iron", 2 ], [ "milk_allergen", 0 ] ],
     "fun": 5,
     "flags": [ "NUTRIENT_OVERRIDE" ]
   },

--- a/data/json/items/comestibles/dairy.json
+++ b/data/json/items/comestibles/dairy.json
@@ -226,7 +226,7 @@
     "description": "Hard, dry cheese made to last, unlike modern processed cheese.  Will make you thirsty though.",
     "price": "3 USD 85 cent",
     "price_postapoc": "1 USD 50 cent",
-    "vitamins": [ [ "calcium", 32 ], [ "iron", 2 ], [ "milk_allergen", 0 ] ],
+    "vitamins": [ [ "calcium", 32 ], [ "iron", 2 ], [ "milk_allergen", 0 ] ]
     "fun": 5,
     "flags": [ "NUTRIENT_OVERRIDE" ]
   },


### PR DESCRIPTION
#### Summary
Bugfixes "Remove milk_allergen from hard cheeses"

#### Purpose of change

In real life, many cheeses do not contain enough lactose to cause issues for people without lactase persistence. Only cheeses that have not been aged significantly should still contain enough lactose to cause discomfort.

#### Describe the solution

This commit removes the milk_allergen vitamin from `cheese_hard` and `pecorino_cheese`. I'm assuming the hard cheese is something like cheddar, or anything else appropriately aged. See the references below.

#### Describe alternatives you've considered

I also considered removing it from `cheese_powder`, but it might be possible to make a powdered cheese with lactose.
Understanding the impacts of adding additional items is currently beyond me.

#### Testing

I made the changes and created a character with the `Lactose Intolerance` trait. The character did not receive an allergen warning in the description for the adjusted items.

#### Additional context

References:
* [13 Types Of Cheese That Are Safe For Lactose Intolerance](https://www.tastingtable.com/1186997/types-of-cheese-that-are-safe-for-lactose-intolerance/)
* [What Types of Cheese Are Lactose Free? (Lab Tested)](https://cheesescientist.com/science/what-cheeses-are-lactose-free/)
* [The 9 Cheeses Lowest In Lactose](https://www.mindbodygreen.com/articles/cheeses-lowest-in-lactose-best-for-lactose-intolerance)

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->