### PR TITLE
fix compilation error calling Character::spawn_items

### DIFF
--- a/data/mods/My_Sweet_Cataclysm/sweet_monsters.json
+++ b/data/mods/My_Sweet_Cataclysm/sweet_monsters.json
@@ -485,7 +485,7 @@
     "harvest": "caff_gum_spider",
     "anger_triggers": [ "STALK", "PLAYER_WEAK", "HURT", "PLAYER_CLOSE" ],
     "flags": [ "SEES", "SMELLS", "HEARS", "CLIMBS", "PATH_AVOID_FIRE", "PATH_AVOID_FALL" ],
-    "reproduction": { "baby_egg": "caff_gum", "baby_count": 10, "baby_timer": 5 },
+    "reproduction": { "baby_type": { "baby_egg": "caff_gum" }, "baby_count": 10, "baby_timer": 5 },
     "armor": { "bash": 4, "cut": 8, "bullet": 6 }
   },
   {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -623,7 +623,7 @@ void monster::try_reproduce()
                 }
             }
             if( !type->baby_type.baby_egg_group.is_null() ) {
-                here.spawn_items( pos(), item_group::items_from( type->baby_type.baby_egg_group ) );
+                here.spawn_items( pos_bub(), item_group::items_from( type->baby_type.baby_egg_group ) );
             }
         }
         *baby_timer += *type->baby_timer;


### PR DESCRIPTION
#### Summary
Bugfixes "fix compilation error calling Character::spawn_items"

#### Purpose of change
Fix compilation error calling Character::spawn_items

#### Describe the solution
Call `pos_bub()` instead of `pos()`

#### Additional context
Seems to have been caused by pushing #75125 after #76266 without building first.