### PR TITLE
uilist line padding accounts for number of lines in text

### DIFF
--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -627,13 +627,15 @@ void uilist::calc_data()
     bool has_titlebar = !title.empty();
     if( has_titlebar ) {
         title_size = calc_size( title );
-        title_size.y += s.FramePadding.y * 2.0;
+        float expected_num_lines = title_size.y / ImGui::GetTextLineHeight();
+        title_size.y += ( s.ItemSpacing.y * expected_num_lines ) + ( s.ItemSpacing.y * 2.0 );
     }
 
     ImVec2 text_size = {};
     if( !text.empty() ) {
         text_size = calc_size( text );
-        text_size.y += s.ItemSpacing.y * 2.0;
+        float expected_num_lines = text_size.y / ImGui::GetTextLineHeight();
+        text_size.y += ( s.ItemSpacing.y * expected_num_lines ) + ( s.ItemSpacing.y * 2.0 );
     }
 
     ImVec2 desc_size = {};
@@ -647,7 +649,8 @@ void uilist::calc_data()
         if( desc_size.y <= 0.0 ) {
             desc_enabled = false;
         }
-        desc_size.y += s.ItemSpacing.y * 2.0;
+        float expected_num_lines = desc_size.y / ImGui::GetTextLineHeight();
+        desc_size.y += ( s.ItemSpacing.y * expected_num_lines ) + ( s.ItemSpacing.y * 2.0 );
     }
     float additional_height = title_size.y + text_size.y + desc_size.y + 2.0 *
                               ( s.FramePadding.y + s.WindowBorderSize );


### PR DESCRIPTION
#### Summary
Bugfixes "uilist line padding accounts for number of lines in text"

#### Purpose of change
* Fixes #75698

#### Describe the solution
Padding is applied between each line `( s.ItemSpacing.y * expected_num_lines )` and then also two at the top and bottom of the text: `( s.ItemSpacing.y * 2.0 )`. Previously the calculated padding area only account for the top and bottom, meaning that each additional line of text ate up more and more vertical space that the window wasn't expecting

I'm not sure why ImGui::CalcTextSize() isn't already returning this properly

#### Describe alternatives you've considered
There is probably somewhere more fundamental to apply this, like the static `calc_size`

title_size and desc_size are both calculated the previous way, and technically those ~~likely~~ **do** have the same error unless changes are made to them/`calc_size`

I am sure there is a better way to do this, I just don't know what it is!

#### Testing
See my beautiful images at [the comment I made](https://github.com/CleverRaven/Cataclysm-DDA/issues/75698#issuecomment-2343527258) in the linked issue

#### Additional context