### PR TITLE
fix sweet cataclysm incorrect baby type

### DIFF
--- a/data/mods/My_Sweet_Cataclysm/sweet_monsters.json
+++ b/data/mods/My_Sweet_Cataclysm/sweet_monsters.json
@@ -485,7 +485,7 @@
     "harvest": "caff_gum_spider",
     "anger_triggers": [ "STALK", "PLAYER_WEAK", "HURT", "PLAYER_CLOSE" ],
     "flags": [ "SEES", "SMELLS", "HEARS", "CLIMBS", "PATH_AVOID_FIRE", "PATH_AVOID_FALL" ],
-    "reproduction": { "baby_egg": "caff_gum", "baby_count": 10, "baby_timer": 5 },
+    "reproduction": { "baby_type": { "baby_egg": "caff_gum" }, "baby_count": 10, "baby_timer": 5 },
     "armor": { "bash": 4, "cut": 8, "bullet": 6 }
   },
   {


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fix #76337
#### Describe the solution
Replace
#### Additional context
Collision between #76297 and #76266
If i've got a cent each time 76266 caused problems with merge collisions, i'd have two cents