### PR TITLE
Clamp size of loading screen image so loading screen text always shows

### DIFF
--- a/src/loading_ui.cpp
+++ b/src/loading_ui.cpp
@@ -112,7 +112,16 @@ static void update_state( const std::string &context, const std::string &step )
             }
         }
         SDL_Surface_Ptr surf = load_image( gLUI->chosen_load_img.get_unrelative_path().u8string().c_str() );
-        gLUI->splash_size = { static_cast<float>( surf->w ), static_cast<float>( surf->h ) };
+        // leave some space for the loading text...
+        ImVec2 max_size = ImGui::GetMainViewport()->Size * 0.9;
+        // preserve aspect ratio by finding the longest **relative** side and scaling both sides by its ratio to max_size
+        // scales both "up" and "down"
+        float width_ratio = static_cast<float>( surf->w ) / max_size.x;
+        float height_ratio = static_cast<float>( surf->h ) / max_size.y;
+        float longest_side_ratio = width_ratio > height_ratio ? width_ratio : height_ratio;
+        gLUI->splash_size = { static_cast<float>( surf->w ) / longest_side_ratio,
+                              static_cast<float>( surf->h ) / longest_side_ratio
+                            };
         gLUI->splash = CreateTextureFromSurface( get_sdl_renderer(), surf );
         gLUI->window_size = gLUI->splash_size + ImVec2{ 0.0f, 2.0f * ImGui::GetTextLineHeightWithSpacing() };
 #else


### PR DESCRIPTION
#### Summary
Bugfixes "GUI Loading screen shows progress again"

#### Purpose of change
* Fixes #76359

#### Describe the solution
Clamp the size of the loading screen image so that there's always room for the text
![image](https://github.com/user-attachments/assets/ff32c4be-97e7-432f-8340-4af4660d9c59)

This should preserve aspect ratio of the image, for real this time!


#### Describe alternatives you've considered
~~Stretch the image to use all available space?!~~ I am actually doing that...

#### Testing
Here's another one, with a dummy 1 pixel wide blank image
![image](https://github.com/user-attachments/assets/24db152b-c5f5-4575-b0d8-7b0a888ad2fe)




#### Additional context

