### PR TITLE
Cleanup loading screen when loading fails

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -35,6 +35,7 @@
 #include "filesystem.h"
 #include "get_version.h"
 #include "input.h"
+#include "loading_ui.h"
 #include "mod_manager.h"
 #include "options.h"
 #include "output.h"
@@ -311,6 +312,8 @@ static void debug_error_prompt(
     if( !force && ignored_messages.count( msg_key ) > 0 ) {
         return;
     }
+    // gui loading screen might be drawing an image, we need to clean it up
+    loading_ui::done();
 
     std::string formatted_report =
         string_format( // developer-facing error report. INTENTIONALLY UNTRANSLATED!


### PR DESCRIPTION
#### Summary
Bugfixes "Cleanup loading screen when loading fails"

#### Purpose of change
* Fixes #76249

#### Describe the solution
Call loading_ui::done() when we throw an error. This has no effect if the loading screen isn't running, but if the loading screen *is* active, it'll stop it.



#### Describe alternatives you've considered


#### Testing

https://github.com/user-attachments/assets/7cb34db3-30bb-47a3-b1c9-7c11f06f582e


Should probably check the behavior of what happens when loading throws **non-fatal** errors? I just don't know off-hand how to introduce a loading error that *isn't* fatal.


#### Additional context

