### PR TITLE
Fix GCC9 compilation error

### DIFF
--- a/src/mtype.h
+++ b/src/mtype.h
@@ -280,10 +280,10 @@ struct mount_item_data {
 };
 
 struct reproduction_type {
-    mtype_id baby_monster;
-    mongroup_id baby_monster_group;
-    itype_id baby_egg;
-    item_group_id baby_egg_group;
+    mtype_id baby_monster = mtype_id::NULL_ID();
+    mongroup_id baby_monster_group = mongroup_id::NULL_ID();
+    itype_id baby_egg = itype_id::NULL_ID();
+    item_group_id baby_egg_group = item_group_id::NULL_ID();
 };
 
 struct mtype {

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -279,7 +279,7 @@ struct mount_item_data {
     itype_id storage;
 };
 
-struct baby_type {
+struct reproduction_type {
     mtype_id baby_monster;
     mongroup_id baby_monster_group;
     itype_id baby_egg;
@@ -317,7 +317,7 @@ struct mtype {
         mtype_id zombify_into; // mtype_id this monster zombifies into
         mtype_id fungalize_into; // mtype_id this monster fungalize into
 
-        baby_type baby_type;
+        reproduction_type baby_type;
 
         // Monster biosignature variables
         itype_id biosig_item;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

CI fix.
Fixes #76357
Fixes #76384

#### Describe the solution

Rename the baby_type struct to reproduction_type.

#### Describe alternatives you've considered

Think of some other name or rename the mtype member instead.

#### Testing

See CI.

#### Additional context

