### PR TITLE
Remove spacing at start of ImGui uilist and right-align context text.

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -264,6 +264,11 @@ cataimgui::client::client( const SDL_Renderer_Ptr &sdl_renderer, const SDL_Windo
 
     // Setup Dear ImGui style
     ImGui::StyleColorsDark();
+
+    ImGuiStyle &style = ImGui::GetStyle();
+    // Default cellPadding is {4, 2}. We reduce this to {3, 2}.
+    ImGui::PushStyleVar( ImGuiStyleVar_CellPadding, ImVec2( 3, style.CellPadding.y ) );
+
     ImGui_ImplSDL2_InitForSDLRenderer( sdl_window.get(), sdl_renderer.get() );
     ImGui_ImplSDLRenderer2_Init( sdl_renderer.get() );
 }

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -1167,17 +1167,18 @@ bool main_menu::load_character_tab( const std::string &worldname )
     for( const save_t &s : savegames ) {
         std::optional<std::chrono::seconds> playtime = get_playtime_from_save( cur_world, s );
         std::string save_str = s.decoded_name();
+        std::string playtime_str = "";
         if( playtime ) {
             int padding = std::max( 16 - utf8_width( save_str ), 0 ) + 2;
             std::chrono::seconds::rep tmp_sec = playtime->count();
             int pt_sec = static_cast<int>( tmp_sec % 60 );
             int pt_min = static_cast<int>( tmp_sec % 3600 ) / 60;
             int pt_hrs = static_cast<int>( tmp_sec / 3600 );
-            save_str = string_format( "%s%s<color_c_light_blue>[%02d:%02d:%02d]</color>",
-                                      save_str, std::string( padding, ' ' ), pt_hrs, pt_min,
-                                      static_cast<int>( pt_sec ) );
+            playtime_str = string_format( "<color_c_light_blue>[%02d:%02d:%02d]</color>",
+                                          pt_hrs, pt_min, static_cast<int>( pt_sec ) );
         }
-        mmenu.entries.emplace_back( opt_val++, true, MENU_AUTOASSIGN, save_str );
+        // TODO: Replace this API to allow adding context without an empty description.
+        mmenu.entries.emplace_back( opt_val++, true, MENU_AUTOASSIGN, save_str, "", playtime_str );
     }
     mmenu.entries.emplace_back( opt_val, true, 'q', _( "<- Back to Main Menu" ), c_yellow, c_yellow );
     mmenu.query();

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -1167,9 +1167,8 @@ bool main_menu::load_character_tab( const std::string &worldname )
     for( const save_t &s : savegames ) {
         std::optional<std::chrono::seconds> playtime = get_playtime_from_save( cur_world, s );
         std::string save_str = s.decoded_name();
-        std::string playtime_str = "";
+        std::string playtime_str;
         if( playtime ) {
-            int padding = std::max( 16 - utf8_width( save_str ), 0 ) + 2;
             std::chrono::seconds::rep tmp_sec = playtime->count();
             int pt_sec = static_cast<int>( tmp_sec % 60 );
             int pt_min = static_cast<int>( tmp_sec % 3600 ) / 60;

--- a/src/third-party/imgui/imgui_widgets.cpp
+++ b/src/third-party/imgui/imgui_widgets.cpp
@@ -1490,8 +1490,9 @@ void ImGui::SeparatorEx(ImGuiSeparatorFlags flags, float thickness)
     else if (flags & ImGuiSeparatorFlags_Horizontal)
     {
         // Horizontal Separator
-        float x1 = window->Pos.x;
-        float x2 = window->Pos.x + window->Size.x;
+        // TODO: Remove this change when ImGui is updated to v1.90+
+        float x1 = window->DC.CursorPos.x;
+        float x2 = window->WorkRect.Max.x - 1;
 
         // FIXME-WORKRECT: old hack (#205) until we decide of consistent behavior with WorkRect/Indent and Separator
         if (g.GroupStack.Size > 0 && g.GroupStack.back().WindowID == window->ID)

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -89,6 +89,7 @@ void uilist_impl::draw_controls()
         ImGui::TableSetColumnIndex( 1 );
 
         float entry_height = ImGui::GetTextLineHeightWithSpacing();
+        ImGuiStyle &style = ImGui::GetStyle();
         if( ImGui::BeginChild( "scroll", parent.calculated_menu_size, false,
                                ImGuiWindowFlags_NavFlattened ) ) {
             if( ImGui::BeginTable( "menu items", 3, ImGuiTableFlags_SizingFixedFit ) ) {
@@ -139,7 +140,9 @@ void uilist_impl::draw_controls()
                             // this row is hovered and the hover state just changed, show context for it
                             parent.hovered = parent.fentries[ i ];
                         }
-                        ImGui::SameLine( 0, 0 );
+
+                        // Force the spacing to be set to the padding value.
+                        ImGui::SameLine( 0, style.CellPadding.x );
                         if( entry.hotkey.has_value() ) {
                             cataimgui::draw_colored_text( entry.hotkey.value().short_description(),
                                                           is_selected ? parent.hilight_color : parent.hotkey_color );
@@ -154,6 +157,10 @@ void uilist_impl::draw_controls()
                         cataimgui::draw_colored_text( entry.txt, color );
 
                         ImGui::TableSetColumnIndex( 2 );
+                        // Right-align text.
+                        ImVec2 curPos = ImGui::GetCursorScreenPos();
+                        // Remove the edge padding so that the last pixel just touches the border.
+                        ImGui::SetCursorScreenPos( ImVec2( ImMax( 0.0f, curPos.x + style.CellPadding.x ), curPos.y ) );
                         cataimgui::draw_colored_text( entry.ctxt, color );
 
                         ImGui::PopID();

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -37,12 +37,14 @@ class uilist_impl : cataimgui::window
         uilist &parent;
     public:
         explicit uilist_impl( uilist &parent ) : cataimgui::window( "UILIST",
-                    ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse ),
+                    ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse |
+                    ImGuiWindowFlags_NoNavInputs ),
             parent( parent ) {
         }
 
         uilist_impl( uilist &parent, const std::string &title ) : cataimgui::window( title,
-                    ImGuiWindowFlags_None | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse ),
+                    ImGuiWindowFlags_None | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse |
+                    ImGuiWindowFlags_NoNavInputs ),
             parent( parent ) {
         }
 
@@ -90,8 +92,7 @@ void uilist_impl::draw_controls()
 
         float entry_height = ImGui::GetTextLineHeightWithSpacing();
         ImGuiStyle &style = ImGui::GetStyle();
-        if( ImGui::BeginChild( "scroll", parent.calculated_menu_size, false,
-                               ImGuiWindowFlags_NavFlattened ) ) {
+        if( ImGui::BeginChild( "scroll", parent.calculated_menu_size, false ) ) {
             if( ImGui::BeginTable( "menu items", 3, ImGuiTableFlags_SizingFixedFit ) ) {
                 ImGui::TableSetupColumn( "hotkey", ImGuiTableColumnFlags_WidthFixed,
                                          parent.calculated_hotkey_width );

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -69,20 +69,26 @@ void uilist_impl::draw_controls()
         ImGui::Separator();
     }
 
-    // An invisible table with three columns. Center column is for the
-    // menu, left and right are usually invisible. Caller may use
+    // An invisible table with three columns. Used to create a sidebar effect.
+    // Ideally we would use a layout engine for this, but ImGui does not natively support any.
+    // TODO: Investigate using Stack Layout (https://github.com/thedmd/imgui/tree/feature/layout-external)
+    // Center column is for the menu, left and right are usually invisible. Caller may use
     // left/right column to add additional content to the
     // window. There should only ever be one row.
     if( ImGui::BeginTable( "table", 3,
-                           ImGuiTableFlags_SizingFixedFit | ImGuiTableFlags_NoPadInnerX | ImGuiTableFlags_NoPadOuterX ) ) {
+                           ImGuiTableFlags_SizingFixedFit | ImGuiTableFlags_NoPadInnerX | ImGuiTableFlags_NoPadOuterX | ImGuiTableFlags_Hideable) ) {
         ImGui::TableSetupColumn( "left", ImGuiTableColumnFlags_WidthFixed, parent.extra_space_left );
         ImGui::TableSetupColumn( "menu", ImGuiTableColumnFlags_WidthFixed, parent.calculated_menu_size.x );
         ImGui::TableSetupColumn( "right", ImGuiTableColumnFlags_WidthFixed, parent.extra_space_right );
+
+        ImGui::TableSetColumnEnabled(0, parent.extra_space_left < 1.0f ? false : true);
+        ImGui::TableSetColumnEnabled(2, parent.extra_space_right < 1.0f ? false : true);
+
         ImGui::TableNextRow();
         ImGui::TableSetColumnIndex( 1 );
 
         float entry_height = ImGui::GetTextLineHeightWithSpacing();
-        if( ImGui::BeginChild( "scroll", parent.calculated_menu_size, false ) ) {
+        if( ImGui::BeginChild( "scroll", parent.calculated_menu_size, false, ImGuiWindowFlags_NavFlattened ) ) {
             if( ImGui::BeginTable( "menu items", 3, ImGuiTableFlags_SizingFixedFit ) ) {
                 ImGui::TableSetupColumn( "hotkey", ImGuiTableColumnFlags_WidthFixed,
                                          parent.calculated_hotkey_width );

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -76,19 +76,21 @@ void uilist_impl::draw_controls()
     // left/right column to add additional content to the
     // window. There should only ever be one row.
     if( ImGui::BeginTable( "table", 3,
-                           ImGuiTableFlags_SizingFixedFit | ImGuiTableFlags_NoPadInnerX | ImGuiTableFlags_NoPadOuterX | ImGuiTableFlags_Hideable) ) {
+                           ImGuiTableFlags_SizingFixedFit | ImGuiTableFlags_NoPadInnerX | ImGuiTableFlags_NoPadOuterX |
+                           ImGuiTableFlags_Hideable ) ) {
         ImGui::TableSetupColumn( "left", ImGuiTableColumnFlags_WidthFixed, parent.extra_space_left );
         ImGui::TableSetupColumn( "menu", ImGuiTableColumnFlags_WidthFixed, parent.calculated_menu_size.x );
         ImGui::TableSetupColumn( "right", ImGuiTableColumnFlags_WidthFixed, parent.extra_space_right );
 
-        ImGui::TableSetColumnEnabled(0, parent.extra_space_left < 1.0f ? false : true);
-        ImGui::TableSetColumnEnabled(2, parent.extra_space_right < 1.0f ? false : true);
+        ImGui::TableSetColumnEnabled( 0, parent.extra_space_left < 1.0f ? false : true );
+        ImGui::TableSetColumnEnabled( 2, parent.extra_space_right < 1.0f ? false : true );
 
         ImGui::TableNextRow();
         ImGui::TableSetColumnIndex( 1 );
 
         float entry_height = ImGui::GetTextLineHeightWithSpacing();
-        if( ImGui::BeginChild( "scroll", parent.calculated_menu_size, false, ImGuiWindowFlags_NavFlattened ) ) {
+        if( ImGui::BeginChild( "scroll", parent.calculated_menu_size, false,
+                               ImGuiWindowFlags_NavFlattened ) ) {
             if( ImGui::BeginTable( "menu items", 3, ImGuiTableFlags_SizingFixedFit ) ) {
                 ImGui::TableSetupColumn( "hotkey", ImGuiTableColumnFlags_WidthFixed,
                                          parent.calculated_hotkey_width );


### PR DESCRIPTION
#### Summary
Interface "Improve ImGui uilist spacing and fix text alignment"

#### Purpose of change

Partially fixes #76373

#### Describe the solution

1. Rewrite the separator function to consider its starting point as the same starting point as the text.
2. Hide the unused invisible (well, 4px) columns from the menu. 
3. ~Set `CellPadding.y` to 3, and draw text in columns higher than they would otherwise be.~ Moved to #76420.
4. Right-align the text on the right side of the uilist. Mostly this means removing the excess padding - it was pretty much right-aligned anyway.

~This currently includes #76356, as it was difficult to test windows properly without it. I will remove it before this is ready to merge.~ Rebased and removed.

#### Describe alternatives you've considered

The additional padding could be reduced down to 1px to save screen space.

#### Testing

Unfortunately using the mouse to select filtered text doesn't work. I'm unsure if this is a regression, and if it is, what is causing it.

#### Additional context

There are a few more changes that I would like to make, though they are out of scope for this PR.
1. Increase the border thickness to 2 px. This is the same as the old border size. However, this is nontrivial as ImGui does not natively support borders with a thickness greater than 1 (https://github.com/ocornut/imgui/issues/3138).
2. Fix the issue where the highlighted region moves with the mouse keys out of sync with the selected text.
5. ~Right-align the third column. This is a regression, and one I am working on. It's complicated by the fact that ImGui has no native support for right-aligned text (https://github.com/ocornut/imgui/issues/7805 / https://github.com/ocornut/imgui/issues/7024)~. Done.
6. Properly fix the miscalculated text width instead of just papering over it in `SeparatorEx`.
7. Remove the close button from the window title (and potentiallly replace the entire title with a `TextSeparator`, similar to the old window title).