### PR TITLE
Map UI: hint custom keybind for `CHOOSE_DESTINATION`

### DIFF
--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1135,7 +1135,8 @@ static void draw_om_sidebar( ui_adaptor &ui,
     }
 
     mvwprintz( wbar, point( 1, 12 ), c_magenta, _( "Use movement keys to pan." ) );
-    mvwprintz( wbar, point( 1, 13 ), c_magenta, _( "Press W to preview route." ) );
+    mvwprintz( wbar, point( 1, 13 ), c_magenta, _( string_format( "Press %s to preview route.",
+               inp_ctxt.get_desc( "CHOOSE_DESTINATION" ) ) ) );
     mvwprintz( wbar, point( 1, 14 ), c_magenta, _( "Press again to confirm." ) );
     int y = 16;
 


### PR DESCRIPTION
#### Summary
Interface "Map UI: hint custom keybind for `CHOOSE_DESTINATION`"

#### Purpose of change

It hints the default keybinding, even when there is a custom keybinding.

#### Describe the solution

Show the custom keybinding.

#### Describe alternatives you've considered

Also do wrapping, if it is too long:
![image](https://github.com/user-attachments/assets/8d39fb91-e27f-4c3d-bba5-425e6f6deaf7)

I decided to let the wrapping be solved by migrating to ImGui (later, by someone else).

#### Testing

1. Open the map UI and see the current hint.
   - ![image](https://github.com/user-attachments/assets/9d9827c8-9739-4a86-9e7c-b14b668779b2)
2. Set CHOOSE_DESTINATION to `T` (from `W`).
   - ![image](https://github.com/user-attachments/assets/0d886bd4-6f41-4989-b2f6-79aedb8f76c1)
3. See that the hint changed (immediately).
   - ![image](https://github.com/user-attachments/assets/63042945-730e-462d-8e07-415447dc7d4b)


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
