### PR TITLE
[Magiclysm] Fix meat component

### DIFF
--- a/data/mods/Magiclysm/items/comestibles.json
+++ b/data/mods/Magiclysm/items/comestibles.json
@@ -95,14 +95,11 @@
   {
     "id": "impure_meat",
     "type": "COMESTIBLE",
-    "copy-from": "meat",
+    "copy-from": "mutant_meat",
     "name": { "str_sp": "impure meat" },
     "description": "Not as tainted as previously and tastes like the real thing.  You do not want to cook this for your friends, though if you do they won't know the difference for a while.",
-    "looks_like": "mutant_meat",
-    "cooks_like": "mutant_meat_cooked",
-    "proportional": { "calories": 0.5 },
+    "calories": 201,
     "price": "1 USD",
-    "vitamins": [ [ "vitC", 2 ], [ "calcium", 1 ], [ "iron", 6 ], [ "mutant_toxin", 25 ], [ "meat_allergen", 1 ] ],
-    "flags": [ "SMOKABLE", "BAD_TASTE", "RAW", "PREDATOR_FUN", "NUTRIENT_OVERRIDE" ]
+    "extend": { "flags": [ "NUTRIENT_OVERRIDE" ] }
   }
 ]

--- a/data/mods/Magiclysm/items/comestibles.json
+++ b/data/mods/Magiclysm/items/comestibles.json
@@ -100,7 +100,7 @@
     "description": "Not as tainted as previously and tastes like the real thing.  You do not want to cook this for your friends, though if you do they won't know the difference for a while.",
     "looks_like": "mutant_meat",
     "cooks_like": "mutant_meat_cooked",
-    "proportional": [ "calories": 0.5 ],
+    "proportional": { "calories": 0.5 },
     "price": "1 USD"
     "vitamins": [ [ "vitC", 2 ], [ "calcium", 1 ], [ "iron", 6 ], [ "mutant_toxin", 25 ], [ "meat_allergen", 1 ] ],
     "flags": [ "SMOKABLE", "BAD_TASTE", "RAW", "PREDATOR_FUN", "NUTRIENT_OVERRIDE" ]

--- a/data/mods/Magiclysm/items/comestibles.json
+++ b/data/mods/Magiclysm/items/comestibles.json
@@ -90,6 +90,7 @@
     "extend": { "flags": [ "NUTRIENT_OVERRIDE" ] },
     "name": { "str_sp": "purified meat" },
     "description": "Indistinguishable from pre-Cataclysm lab grown beef.  It should be excellent but somehow it's just edible.",
+    "calories": 402,
     "price": "4 USD"
   },
   {

--- a/data/mods/Magiclysm/items/comestibles.json
+++ b/data/mods/Magiclysm/items/comestibles.json
@@ -101,8 +101,8 @@
     "looks_like": "mutant_meat",
     "cooks_like": "mutant_meat_cooked",
     "proportional": { "calories": 0.5 },
-    "price": "1 USD"
-    "vitamins": [ [ "vitC", 2 ], [ "calcium", 1 ], [ "iron", 6 ], [ "mutant_toxin", 25 ], [ "meat_allergen", 1 ] ],
+    "price": "1 USD",
+    "vitamins": { [ "vitC", 2 ], [ "calcium", 1 ], [ "iron", 6 ], [ "mutant_toxin", 25 ], [ "meat_allergen", 1 ] },
     "flags": [ "SMOKABLE", "BAD_TASTE", "RAW", "PREDATOR_FUN", "NUTRIENT_OVERRIDE" ]
   }
 ]

--- a/data/mods/Magiclysm/items/comestibles.json
+++ b/data/mods/Magiclysm/items/comestibles.json
@@ -97,6 +97,7 @@
     "type": "COMESTIBLE",
     "copy-from": "mutant_meat",
     "extend": { "flags": [ "NUTRIENT_OVERRIDE" ] },
+    "delete": { "proportional": [ "price": 0.2, "calories": 0.5 ] },
     "name": { "str_sp": "impure meat" },
     "description": "Not as tainted as previously and tastes like the real thing.  You do not want to cook this for your friends, though if you do they won't know the difference for a while.",
     "price": "1 USD"

--- a/data/mods/Magiclysm/items/comestibles.json
+++ b/data/mods/Magiclysm/items/comestibles.json
@@ -102,7 +102,7 @@
     "cooks_like": "mutant_meat_cooked",
     "proportional": { "calories": 0.5 },
     "price": "1 USD",
-    "vitamins": { [ "vitC", 2 ], [ "calcium", 1 ], [ "iron", 6 ], [ "mutant_toxin", 25 ], [ "meat_allergen", 1 ] },
+    "vitamins": [ [ "vitC", 2 ], [ "calcium", 1 ], [ "iron", 6 ], [ "mutant_toxin", 25 ], [ "meat_allergen", 1 ] ],
     "flags": [ "SMOKABLE", "BAD_TASTE", "RAW", "PREDATOR_FUN", "NUTRIENT_OVERRIDE" ]
   }
 ]

--- a/data/mods/Magiclysm/items/comestibles.json
+++ b/data/mods/Magiclysm/items/comestibles.json
@@ -100,7 +100,7 @@
     "name": { "str_sp": "impure meat" },
     "description": "Not as tainted as previously and tastes like the real thing.  You do not want to cook this for your friends, though if you do they won't know the difference for a while.",
     "delete": { "proportional": { "price": 0.2, "calories": 0.5 } },
-    "calories": 301,
+    "calories": 201,
     "price": "1 USD",
     "extend": { "flags": [ "NUTRIENT_OVERRIDE" ] }
   }

--- a/data/mods/Magiclysm/items/comestibles.json
+++ b/data/mods/Magiclysm/items/comestibles.json
@@ -98,6 +98,7 @@
     "copy-from": "mutant_meat",
     "name": { "str_sp": "impure meat" },
     "description": "Not as tainted as previously and tastes like the real thing.  You do not want to cook this for your friends, though if you do they won't know the difference for a while.",
+    "delete": { "proportional": { "price": 0.2, "calories": 0.5 } },
     "calories": 201,
     "price": "1 USD",
     "extend": { "flags": [ "NUTRIENT_OVERRIDE" ] }

--- a/data/mods/Magiclysm/items/comestibles.json
+++ b/data/mods/Magiclysm/items/comestibles.json
@@ -100,7 +100,7 @@
     "name": { "str_sp": "impure meat" },
     "description": "Not as tainted as previously and tastes like the real thing.  You do not want to cook this for your friends, though if you do they won't know the difference for a while.",
     "delete": { "proportional": { "price": 0.2, "calories": 0.5 } },
-    "calories": 251,
+    "calories": 301,
     "price": "1 USD",
     "extend": { "flags": [ "NUTRIENT_OVERRIDE" ] }
   }

--- a/data/mods/Magiclysm/items/comestibles.json
+++ b/data/mods/Magiclysm/items/comestibles.json
@@ -95,11 +95,14 @@
   {
     "id": "impure_meat",
     "type": "COMESTIBLE",
-    "copy-from": "mutant_meat",
-    "extend": { "flags": [ "NUTRIENT_OVERRIDE" ] },
-    "delete": { "proportional": [ "price": 0.2, "calories": 0.5 ] },
+    "copy-from": "meat",
     "name": { "str_sp": "impure meat" },
     "description": "Not as tainted as previously and tastes like the real thing.  You do not want to cook this for your friends, though if you do they won't know the difference for a while.",
+    "looks_like": "mutant_meat",
+    "cooks_like": "mutant_meat_cooked",
+    "proportional": [ "calories": 0.5 ],
     "price": "1 USD"
+    "vitamins": [ [ "vitC", 2 ], [ "calcium", 1 ], [ "iron", 6 ], [ "mutant_toxin", 25 ], [ "meat_allergen", 1 ] ],
+    "flags": [ "SMOKABLE", "BAD_TASTE", "RAW", "PREDATOR_FUN", "NUTRIENT_OVERRIDE" ]
   }
 ]

--- a/data/mods/Magiclysm/items/comestibles.json
+++ b/data/mods/Magiclysm/items/comestibles.json
@@ -100,7 +100,7 @@
     "name": { "str_sp": "impure meat" },
     "description": "Not as tainted as previously and tastes like the real thing.  You do not want to cook this for your friends, though if you do they won't know the difference for a while.",
     "delete": { "proportional": { "price": 0.2, "calories": 0.5 } },
-    "calories": 201,
+    "calories": 251,
     "price": "1 USD",
     "extend": { "flags": [ "NUTRIENT_OVERRIDE" ] }
   }

--- a/data/mods/Magiclysm/requirements/cooking_components.json
+++ b/data/mods/Magiclysm/requirements/cooking_components.json
@@ -3,5 +3,10 @@
     "id": "meat_red_raw_steak",
     "type": "requirement",
     "extend": { "components": [ [ [ "purified_meat", 1 ], [ "impure_meat", 1 ] ] ] }
+  },
+  {
+    "id": "meat_red_raw",
+    "type": "requirement",
+    "extend": { "components": [ [ [ "purified_meat", 1 ], [ "impure_meat", 1 ] ] ] }
   }
 ]

--- a/data/mods/Magiclysm/requirements/cooking_components.json
+++ b/data/mods/Magiclysm/requirements/cooking_components.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": "meat_raw_steak",
+    "id": "meat_red_raw_steak",
     "type": "requirement",
     "extend": { "components": [ [ [ "purified_meat", 1 ], [ "impure_meat", 1 ] ] ] }
   }

--- a/data/mods/Magiclysm/requirements/cooking_components.json
+++ b/data/mods/Magiclysm/requirements/cooking_components.json
@@ -2,7 +2,7 @@
   {
     "id": "meat_red_raw_steak",
     "type": "requirement",
-    "extend": { "components": [ [ [ "purified_meat", 1 ], [ "impure_meat", 1 ] ] ] }
+    "extend": { "components": [ [ [ "purified_meat", 1 ] ] ] }
   },
   {
     "id": "meat_red_raw",

--- a/data/mods/Magiclysm/requirements/cooking_components.json
+++ b/data/mods/Magiclysm/requirements/cooking_components.json
@@ -2,11 +2,11 @@
   {
     "id": "meat_red_raw_steak",
     "type": "requirement",
-    "extend": { "components": [ [ [ "purified_meat", 1 ] ] ] }
+    "extend": { "components": [ [ [ "purified_meat", 1 ], [ "impure_meat", 1 ] ] ] }
   },
   {
     "id": "meat_red_raw",
     "type": "requirement",
-    "extend": { "components": [ [ [ "purified_meat", 1 ], [ "impure_meat", 1 ] ] ] }
+    "extend": { "components": [ [ [ "purified_meat", 1 ] ] ] }
   }
 ]


### PR DESCRIPTION
#### Summary
Bugfixes "[Magiclysm] Fix meat component"

#### Purpose of change
#73439 change... a lot, make purified meat and impure meat can make almost nothing now. This will fix that.

#### Describe the solution
Change the component from `meat_raw_steak` to `meat_red_raw_steak`, and add them into `meat_red_raw` group

#### Describe alternatives you've considered
Don't

#### Testing
Everything looks fine. No error and meats can be cooked into dishes again.

#### Additional context
I have to remove impure meat from meat_raw_red cause calories check really don't like another mutant meat in there. Maybe kiymali pide's default calories is too hight.