### PR TITLE
Audit NPCs with debug traits

### DIFF
--- a/data/json/npcs/refugee_center/surface_staff/NPC_old_guard_doctor.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_old_guard_doctor.json
@@ -4,6 +4,7 @@
     "id": "NC_FM_DOCTOR",
     "name": { "str": "Doctor" },
     "job_description": "I'm looking for wounded to help.",
+    "common": false,
     "traits": [
       { "group": "BG_survival_story_MEDICAL" },
       { "group": "NPC_starting_traits" },


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Same as #75681

Random NPCs could spawn with crippling traits intended for static NPCs

#### Describe the solution
Don't make these special classes spawn randomly, by marking them as not being common

#### Describe alternatives you've considered
this could be checked during finalization but the compiler did not like accessing trait_group::has_trait()

#### Testing
Spawned about 50-60 NPCs ingame with some code to check for debug traits (points cost >=99), this class was the only one that got caught, and it got caught 4 times. Grepped through the NPC folders for RETURN_TO_START_POS, IGNORE_SOUND, and NO_BASH, this was again the only common result. Grepped through data/mods/ too, to be sure


#### Additional context
