### PR TITLE
Toggle between the map and look around

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -1103,6 +1103,13 @@
   },
   {
     "type": "keybinding",
+    "id": "look",
+    "category": "OVERMAP",
+    "name": "Look around",
+    "bindings": [ { "input_method": "keyboard_any", "key": ";" } ]
+  },
+  {
+    "type": "keybinding",
     "id": "DELETE_NOTE",
     "category": "OVERMAP",
     "name": "Delete note",
@@ -2776,6 +2783,12 @@
     "category": "DEFAULTMODE",
     "id": "map",
     "bindings": [ { "input_method": "keyboard_any", "key": "m" } ]
+  },
+  {
+    "type": "keybinding",
+    "name": "View map",
+    "id": "map",
+    "bindings": [ { "input_method": "keyboard_any", "key": ";" } ]
   },
   {
     "type": "keybinding",

--- a/doc/POINTS_COORDINATES.md
+++ b/doc/POINTS_COORDINATES.md
@@ -40,7 +40,7 @@ Lastly, these is a system called **segment** (seg) coordinates.  These are only
 used in saving/loading submaps and you are unlikely to encounter them.
 
 As well as absolute and local coordinates, sometimes we need to use coordinates
-relative so some larger scale.  For example, when performing mapgen for a
+relative to some larger scale.  For example, when performing mapgen for a
 single overmap, we want to work with coordinates within that overmap.  This
 will be an overmap terrain-scale point relative to the corner of its containing
 overmap, and so typically take `x` and `y` values in the range [0,180).

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7421,6 +7421,9 @@ look_around_result game::look_around(
         ctxt.register_action( "LEVEL_DOWN" );
     }
     ctxt.register_action( "TOGGLE_FAST_SCROLL" );
+    if( !has_first_point && !select_zone && !peeking && !is_moving_zone ) {
+        ctxt.register_action( "map" );
+    }
     ctxt.register_action( "CHANGE_MONSTER_NAME" );
     ctxt.register_action( "EXTENDED_DESCRIPTION" );
     ctxt.register_action( "SELECT" );
@@ -7582,6 +7585,11 @@ look_around_result game::look_around(
             list_items_monsters();
         } else if( action == "TOGGLE_FAST_SCROLL" ) {
             fast_scroll = !fast_scroll;
+        } else if( action == "map" ) {
+            uistate.open_menu = [center]() {
+                ui::omap::look_around_map( get_map().getglobal( center ) );
+            };
+            break;
         } else if( action == "toggle_pixel_minimap" ) {
             toggle_pixel_minimap();
 

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -3012,6 +3012,11 @@ bool game::handle_action()
         // starts destination activity after the player successfully reached his destination
         player_character.start_destination_activity();
         return false;
+    } else if( uistate.open_menu ) {
+        std::optional<std::function<void()>> open_menu_tmp = std::nullopt;
+        std::swap( uistate.open_menu, open_menu_tmp );
+        open_menu_tmp.value()();
+        return false;
     } else {
         // No auto-move, ask player for input
         ctxt = get_player_input( action );

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1158,6 +1158,7 @@ static void draw_om_sidebar( ui_adaptor &ui,
 
     print_hint( "LEVEL_UP" );
     print_hint( "LEVEL_DOWN" );
+    print_hint( "look" );
     print_hint( "CENTER" );
     print_hint( "CENTER_ON_DESTINATION" );
     print_hint( "GO_TO_DESTINATION" );
@@ -1781,6 +1782,7 @@ static tripoint_abs_omt display()
     ictxt.register_action( "GO_TO_DESTINATION" );
 
     // Actions whose keys we want to display.
+    ictxt.register_action( "look" );
     ictxt.register_action( "CENTER" );
     ictxt.register_action( "CREATE_NOTE" );
     ictxt.register_action( "DELETE_NOTE" );
@@ -1866,6 +1868,14 @@ static tripoint_abs_omt display()
         } else if( action == "SELECT" &&
                    ( mouse_pos = ictxt.get_coordinates( g->w_overmap, point_zero, true ) ) ) {
             curs += mouse_pos->xy();
+        } else if( action == "look" ) {
+            tripoint_abs_ms pos = project_combine( curs, g->overmap_data.origin_remainder );
+            tripoint pos_rel = get_map().getlocal( pos );
+            uistate.open_menu = [pos_rel]() {
+                tripoint pos_cpy = pos_rel;
+                g->look_around( true, pos_cpy, pos_rel, false, false, false, false, pos_rel );
+            };
+            action = "QUIT";
         } else if( action == "CENTER" ) {
             curs = orig;
         } else if( action == "LEVEL_DOWN" && curs.z() > -OVERMAP_DEPTH ) {
@@ -2278,6 +2288,14 @@ void ui::omap::display()
 {
     g->overmap_data = overmap_ui::overmap_draw_data_t(); //reset data
     g->overmap_data.origin_pos = get_player_character().global_omt_location();
+    overmap_ui::display();
+}
+
+void ui::omap::look_around_map( tripoint_abs_ms starting_pos )
+{
+    g->overmap_data = overmap_ui::overmap_draw_data_t(); //reset data
+    std::tie( g->overmap_data.origin_pos,
+              g->overmap_data.origin_remainder ) = project_remain<coords::omt>( starting_pos );
     overmap_ui::display();
 }
 

--- a/src/overmap_ui.h
+++ b/src/overmap_ui.h
@@ -35,6 +35,10 @@ namespace omap
  */
 void display();
 /**
+ * Display overmap centered at starting_pos.
+ */
+void look_around_map( tripoint_abs_ms starting_pos );
+/**
  * Display overmap centered at the given NPC's position and visually move across their intended OMT path.
  */
 void display_npc_path( tripoint_abs_omt starting_pos,
@@ -117,6 +121,11 @@ struct overmap_draw_data_t {
     std::vector<tripoint_abs_omt> display_path = {};
     //center of UI view; usually player OMT position
     tripoint_abs_omt origin_pos = tripoint_abs_omt( -1, -1, -1 );
+    /**
+     * remainder for smooth toggle between map and look_around
+     * SEEX = SEEY is half of OMT, so point_rel_ms( SEEX, SEEY ) is middle of a tile
+     */
+    point_omt_ms origin_remainder = point_omt_ms( SEEX, SEEY );
     //UI view cursor position
     tripoint_abs_omt cursor_pos = tripoint_abs_omt( -1, -1, -1 );
     //the UI adaptor for the overmap; this can keep the overmap displayed while turns are processed

--- a/src/uistate.h
+++ b/src/uistate.h
@@ -214,6 +214,13 @@ class uistatedata
         std::vector<std::string> &gethistory( const std::string &id ) {
             return input_history[id];
         }
+        /**
+         * A function pointer to be run before the player's next action.
+         *
+         * Useful for opening a menu with passed arguments.
+         */
+        // NOLINTNEXTLINE(cata-serialize)
+        std::optional<std::function<void()>> open_menu;
 
         // nice little convenience function for serializing an array, regardless of amount. :^)
         template<typename T>


### PR DESCRIPTION
#### Summary
Interface "Toggle between the map and look around"

#### Purpose of change

 - Resolve #74470
 - Resolve #70072

#### Describe the solution

Add `uistate.open_menu`. It stores a function to be executed in the main loop. It is used to open a menu with arguments. Unlike ACTIONS arguments can be passed. Unlike ACTIVITY it doesn't take a turn for the player.

This is utilized to remember the position of look around/map when toggling to the other one. It can be used in more places, such as:
 - #62996, which currently takes a turn. I plan to do that next.

#### Describe alternatives you've considered

~Put `avatar.open_menu` somewhere else than into `avatar`. Could be in the `game`. I think of it as an ACTIVITY/ACTION, so I prefer `avatar` over `game`. `Creature`/`Character` cannot have it, only `avatar` can. But maybe it belongs to some `uistate` or how was it called.~ Done.

Don't use (and therefore implement) `uistate.open_menu`, but simply call the look_around from map directly (and vice versa). This approach would grow on the stack as the player would toggle from one to the other. The stack would then need to be collapsed again when the player finally closes look_around or map. The closing would require additional cleanup or maybe just `action = "QUIT"; break;`.

The function calls on the stack provide no additional benefit. The variables stored there aren't needed and therefore are confusing. A stack overflow error could also occur. This is why I decided on the `uistate.open_menu` which doesn't grow the stack at all and only useful variables are passed and remembered.

Opening map is forbidden (If I did it correctly) when working with zones. This is to prevent what you can see in **Bug** below.

#### Testing

Usecase from
 - #74470

https://github.com/user-attachments/assets/4d5cfab9-910b-4303-933e-5bc83b581336

#### Bug

When long-range teleporting, the player can do `;;` (Look around, View map). This returns an invalid point to the teleport, so the teleport doesn't happen. In this case, "Look around" should be forbidden. I don't know how to do that without additional parameter `bool forbid_open_map` to `look_around`. So I didn't do it.

#### Additional context

