### PR TITLE
Martial Mastery: Insight.

### DIFF
--- a/data/mods/Perk_melee/EOC/Insight_eocs.json
+++ b/data/mods/Perk_melee/EOC/Insight_eocs.json
@@ -1,0 +1,92 @@
+[
+  {
+    "id": "EOC_PERK_insight",
+    "type": "effect_on_condition",
+    "recurrence": "1 seconds",
+    "condition": {
+      "and": [ { "u_has_flag": "MELEE_PERK_INSIGHT" }, { "x_in_y_chance": { "x": { "math": [ "u_val('perception')" ] }, "y": 20 } } ]
+    },
+    "effect": [
+      {
+        "if": { "u_has_flag": "MELEE_PERK_SIXTH_SENSE" },
+        "then": [
+          {
+            "if": { "math": [ "u_monsters_nearby('radius': 20)", ">", "0" ] },
+            "then": [ { "run_eoc_with": "EOC_GAIN_INSIGHT", "beta_talker": "avatar" } ]
+          }
+        ],
+        "else": [ { "u_cast_spell": { "id": "perk_insight_spell" }, "targeted": true } ]
+      }
+    ]
+  },
+  {
+    "id": "EOC_PERK_SPEND_INSIGHT",
+    "type": "effect_on_condition",
+    "condition": { "u_has_flag": "MELEE_PERK_INSIGHT" },
+    "effect": [
+      { "math": [ "u_perk_last_insight", "=", "u_effect_intensity('perk_insight')" ] },
+      { "u_lose_effect": "perk_insight" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PERK_MYSTIC_SHOT_CHAR",
+    "eoc_type": "EVENT",
+    "required_event": "character_ranged_attacks_character",
+    "condition": { "u_has_flag": "MELEE_PERK_MYSTIC_SHOT" },
+    "effect": [ { "run_eocs": "EOC_PERK_SPEND_INSIGHT" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PERK_MYSTIC_SHOT_MON",
+    "eoc_type": "EVENT",
+    "required_event": "character_ranged_attacks_monster",
+    "condition": { "u_has_flag": "MELEE_PERK_MYSTIC_SHOT" },
+    "effect": [ { "run_eocs": "EOC_PERK_SPEND_INSIGHT" } ]
+  },
+  {
+    "id": "EOC_PERK_CLEAR_INSIGHT",
+    "type": "effect_on_condition",
+    "condition": { "math": [ "u_monsters_nearby('radius': 20)", "==", "0" ] },
+    "deactivate_condition": { "not": { "u_has_flag": "MELEE_PERK_INSIGHT" } },
+    "recurrence": "20 seconds",
+    "effect": [ { "u_lose_effect": "perk_insight" } ]
+  },
+  {
+    "id": "EOC_PERK_TWILIGHT_FORM",
+    "type": "effect_on_condition",
+    "condition": { "u_has_flag": "MELEE_PERK_TWILIGHT_FORM" },
+    "effect": [ { "u_add_effect": "perk_insight", "intensity": { "math": [ "u_perk_last_insight * 0.5" ] }, "duration": "4 days" } ]
+  },
+  {
+    "id": "perk_insight_spell",
+    "type": "SPELL",
+    "name": "Insight",
+    "description": "",
+    "shape": "blast",
+    "valid_targets": [ "hostile" ],
+    "flags": [ "RANDOM_CRITTER", "RANDOM_TARGET", "NO_EXPLOSION_SFX", "SILENT" ],
+    "min_range": 20,
+    "max_range": 20,
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_GAIN_INSIGHT"
+  },
+  {
+    "id": "EOC_GAIN_INSIGHT",
+    "type": "effect_on_condition",
+    "effect": [
+      {
+        "if": {
+          "or": [ { "npc_has_flag": "MELEE_PERK_INSIGHT_INFINITE" }, { "math": [ "n_effect_intensity('perk_insight')", "<", "19" ] } ]
+        },
+        "then": [
+          {
+            "npc_add_effect": "perk_insight",
+            "intensity": { "math": [ "n_effect_intensity('perk_insight') + perk_insight_scaling_factor()" ] },
+            "duration": "4 days"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/data/mods/Perk_melee/EOC/jmath.json
+++ b/data/mods/Perk_melee/EOC/jmath.json
@@ -1,0 +1,8 @@
+[
+  {
+    "type": "jmath_function",
+    "id": "perk_insight_scaling_factor",
+    "num_args": 0,
+    "return": "( n_effect_intensity('perk_blind_check') > 14 ? 5 : 1 )"
+  }
+]

--- a/data/mods/Perk_melee/EOC/shared_eocs.json
+++ b/data/mods/Perk_melee/EOC/shared_eocs.json
@@ -8,7 +8,32 @@
       {
         "u_run_inv_eocs": "all",
         "search_data": [ { "wielded_only": true } ],
-        "true_eocs": [ { "id": "_EOC_STATS", "effect": [ { "math": [ "u_perk_mymelee", "=", "n_melee_damage('ALL')" ] } ] } ]
+        "true_eocs": [
+          {
+            "id": "PERK_MELEE_EOC_STATS",
+            "effect": [
+              { "math": [ "u_perk_mymelee", "=", "n_melee_damage('ALL')" ] },
+              { "math": [ "u_perk_mymelee_bash", "=", "n_melee_damage('bash')" ] },
+              { "math": [ "u_perk_mymelee_cut", "=", "n_melee_damage('cut')" ] },
+              { "math": [ "u_perk_mymelee_stab", "=", "n_melee_damage('stab')" ] },
+              { "math": [ "u_perk_insight_cut_scaling", "=", "0" ] },
+              { "math": [ "u_perk_insight_stab_scaling", "=", "0" ] },
+              { "math": [ "u_perk_insight_bash_scaling", "=", "0" ] },
+              {
+                "math": [ "u_perk_mymelee_best_damage", "=", "max( u_perk_mymelee_bash, u_perk_mymelee_cut, u_perk_mymelee_stab)" ]
+              },
+              {
+                "if": { "math": [ "u_perk_mymelee_cut", "==", "u_perk_mymelee_best_damage" ] },
+                "then": [ { "math": [ "u_perk_insight_cut_scaling", "=", "1" ] } ],
+                "else": {
+                  "if": { "math": [ "u_perk_mymelee_stab", "==", "u_perk_mymelee_best_damage" ] },
+                  "then": [ { "math": [ "u_perk_insight_stab_scaling", "=", "1" ] } ],
+                  "else": { "math": [ "u_perk_insight_bash_scaling", "=", "1" ] }
+                }
+              }
+            ]
+          }
+        ]
       }
     ]
   },

--- a/data/mods/Perk_melee/enchantments.json
+++ b/data/mods/Perk_melee/enchantments.json
@@ -1,0 +1,43 @@
+[
+  {
+    "type": "enchantment",
+    "id": "melee_perk_ench_insight",
+    "condition": { "u_has_effect": "perk_insight" },
+    "values": [
+      { "value": "ITEM_DAMAGE_BASH", "add": { "math": [ "u_effect_intensity('perk_insight')*u_perk_insight_bash_scaling" ] } },
+      {
+        "value": "ITEM_DAMAGE_CUT",
+        "add": { "math": [ "u_effect_intensity('perk_insight')*u_perk_insight_cut_scaling" ] }
+      },
+      {
+        "value": "ITEM_DAMAGE_STAB",
+        "add": { "math": [ "u_effect_intensity('perk_insight')*u_perk_insight_stab_scaling" ] }
+      }
+    ]
+  },
+  {
+    "type": "enchantment",
+    "id": "melee_perk_ench_six_sense",
+    "condition": { "math": [ "u_effect_intensity('perk_insight')", ">", "9" ] },
+    "values": [ { "value": "MOTION_VISION_RANGE", "add": 10 } ]
+  },
+  {
+    "type": "enchantment",
+    "id": "melee_perk_ench_insight_mystic_shot",
+    "name": { "str": "Mystic Shot" },
+    "description": "Insight empowers your ranged attacks with bows and crossbows.",
+    "condition": { "and": [ { "u_has_wielded_with_flag": "PRIMITIVE_RANGED_WEAPON" }, { "u_has_effect": "perk_insight" } ] },
+    "values": [
+      {
+        "value": "WEAPON_DISPERSION",
+        "multiply": { "math": [ "u_effect_intensity('perk_insight')* -0.02 < -0.9 ? u_effect_intensity('perk_insight')* -0.02 : -0.9" ] }
+      }
+    ]
+  },
+  {
+    "type": "enchantment",
+    "id": "melee_perk_ench_insight_mystic_shot_2",
+    "condition": { "and": [ { "u_has_wielded_with_flag": "PRIMITIVE_RANGED_WEAPON" }, { "u_has_effect": "perk_insight" } ] },
+    "values": [ { "value": "RANGED_DAMAGE", "multiply": { "math": [ "u_effect_intensity('perk_insight')* 0.01" ] } } ]
+  }
+]

--- a/data/mods/Perk_melee/martial_arts.json
+++ b/data/mods/Perk_melee/martial_arts.json
@@ -43,7 +43,7 @@
     ],
     "onblock_buffs": [
       {
-        "id": "buff_perk_block",
+        "id": "MELEE_PERK_RIPOSTE",
         "name": "Parry",
         "description": "Successful blocking has left you in a favorable position.",
         "melee_allowed": true,
@@ -51,6 +51,16 @@
         "flat_bonuses": [ { "stat": "hit", "scale": 1.0 } ]
       }
     ],
+    "static_eocs": [
+      {
+        "id": "EOC_PERK_CHECK_BLIND",
+        "condition": { "and": [ { "u_has_flag": "MELEE_PERK_BLIND_CALCULUS" }, { "not": "u_can_see" } ] },
+        "effect": { "u_add_effect": "perk_blind_check", "duration": "4 days" },
+        "false_effect": { "u_lose_effect": "perk_blind_check" }
+      }
+    ],
+    "onhit_eocs": [ "EOC_PERK_SPEND_INSIGHT" ],
+    "onkill_eocs": [ "EOC_PERK_TWILIGHT_FORM" ],
     "onmove_eocs": [ "EOC_PERK_MOMENTUM_2" ],
     "ondodge_eocs": [
       {

--- a/data/mods/Perk_melee/menu.json
+++ b/data/mods/Perk_melee/menu.json
@@ -11,8 +11,9 @@
     "responses": [
       { "text": "Tempo Techniques.", "topic": "TALK_MA_PERK_MENU_TEMPO" },
       { "text": "Momentum Techniques.", "topic": "TALK_MA_PERK_MENU_MOMENTUM" },
+      { "text": "Insight Techniques.", "topic": "TALK_MA_PERK_MENU_INSIGHT" },
       { "text": "Standalone Techniques.", "topic": "TALK_MA_PERK_MENU_STANDALONE" },
-      { "text": "Help.", "topic": "TALK_MA_PERK_MENU_STANDALONE" },
+      { "text": "Help.", "topic": "TALK_MA_PERK_MENU_HELP" },
       { "text": "Quit.", "topic": "TALK_DONE" }
     ]
   },
@@ -217,6 +218,148 @@
             "i18n": true
           },
           { "set_condition": "perk_condition", "condition": { "u_has_trait": "MELEE_PERK_MOMENTUM" } }
+        ],
+        "topic": "TALK_MA_PERK_MENU_SELECT"
+      },
+      { "text": "Go back", "topic": "TALK_MA_PERK_MENU_MAIN" },
+      { "text": "Quit.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_MA_PERK_MENU_INSIGHT",
+    "dynamic_line": "Level <u_val:ma_current_level>.\n<u_val:num_ma_perks> perk points to spend.\nCurrent EXP: <u_val:ma_available_exp>.\nEXP to next level: <u_val:ma_exp_to_perk>.",
+    "responses": [
+      {
+        "condition": { "not": { "u_has_trait": "MELEE_PERK_INSIGHT" } },
+        "text": "Learn [<trait_name:MELEE_PERK_INSIGHT>]",
+        "effect": [
+          { "set_string_var": "<trait_name:MELEE_PERK_INSIGHT>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:MELEE_PERK_INSIGHT>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "MELEE_PERK_INSIGHT", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
+        ],
+        "topic": "TALK_MA_PERK_MENU_SELECT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "MELEE_PERK_INSIGHT_INFINITE" } },
+        "text": "Learn [<trait_name:MELEE_PERK_INSIGHT_INFINITE>]",
+        "effect": [
+          { "set_string_var": "<trait_name:MELEE_PERK_INSIGHT_INFINITE>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:MELEE_PERK_INSIGHT_INFINITE>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "MELEE_PERK_INSIGHT_INFINITE", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Requires Insight I",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "u_has_trait": "MELEE_PERK_INSIGHT" } }
+        ],
+        "topic": "TALK_MA_PERK_MENU_SELECT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "MELEE_PERK_TWILIGHT_FORM" } },
+        "text": "Learn [<trait_name:MELEE_PERK_TWILIGHT_FORM>]",
+        "effect": [
+          { "set_string_var": "<trait_name:MELEE_PERK_TWILIGHT_FORM>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:MELEE_PERK_TWILIGHT_FORM>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "MELEE_PERK_TWILIGHT_FORM", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Requires Insight I",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "u_has_trait": "MELEE_PERK_INSIGHT" } }
+        ],
+        "topic": "TALK_MA_PERK_MENU_SELECT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "MELEE_PERK_MYSTIC_SHOT" } },
+        "text": "Learn [<trait_name:MELEE_PERK_MYSTIC_SHOT>]",
+        "effect": [
+          { "set_string_var": "<trait_name:MELEE_PERK_MYSTIC_SHOT>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:MELEE_PERK_MYSTIC_SHOT>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "MELEE_PERK_MYSTIC_SHOT", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Requires Insight I",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "u_has_trait": "MELEE_PERK_INSIGHT" } }
+        ],
+        "topic": "TALK_MA_PERK_MENU_SELECT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "MELEE_PERK_MYSTIC_SHOT_2" } },
+        "text": "Learn [<trait_name:MELEE_PERK_MYSTIC_SHOT_2>]",
+        "effect": [
+          { "set_string_var": "<trait_name:MELEE_PERK_MYSTIC_SHOT_2>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:MELEE_PERK_MYSTIC_SHOT_2>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "MELEE_PERK_MYSTIC_SHOT_2", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Requires Insight I and Mystic Shot I",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "u_has_trait": "MELEE_PERK_MYSTIC_SHOT" } }
+        ],
+        "topic": "TALK_MA_PERK_MENU_SELECT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "MELEE_PERK_SIXTH_SENSE" } },
+        "text": "Learn [<trait_name:MELEE_PERK_SIXTH_SENSE>]",
+        "effect": [
+          { "set_string_var": "<trait_name:MELEE_PERK_SIXTH_SENSE>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:MELEE_PERK_SIXTH_SENSE>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "MELEE_PERK_SIXTH_SENSE", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Requires Insight I",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "u_has_trait": "MELEE_PERK_INSIGHT" } }
+        ],
+        "topic": "TALK_MA_PERK_MENU_SELECT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "MELEE_PERK_BLIND_CALCULUS" } },
+        "text": "Learn [<trait_name:MELEE_PERK_BLIND_CALCULUS>]",
+        "effect": [
+          { "set_string_var": "<trait_name:MELEE_PERK_BLIND_CALCULUS>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:MELEE_PERK_BLIND_CALCULUS>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "MELEE_PERK_BLIND_CALCULUS", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Requires Insight I and Sixth Sense",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "u_has_trait": "MELEE_PERK_SIXTH_SENSE" } }
         ],
         "topic": "TALK_MA_PERK_MENU_SELECT"
       },

--- a/data/mods/Perk_melee/perk_effects.json
+++ b/data/mods/Perk_melee/perk_effects.json
@@ -9,5 +9,19 @@
     "int_decay_tick": 150,
     "base_mods": { "dex_mod": [ 0.5 ] },
     "scaling_mods": { "dex_mod": [ 0.5 ] }
+  },
+  {
+    "type": "effect_type",
+    "id": "perk_insight",
+    "name": [ "Insight" ],
+    "desc": [ "Each stack increases the damage of your weapon's main damage type by 1." ],
+    "max_intensity": 200000,
+    "int_add_val": 1
+  },
+  {
+    "type": "effect_type",
+    "id": "perk_blind_check",
+    "max_intensity": 15,
+    "int_add_val": 1
   }
 ]

--- a/data/mods/Perk_melee/perks.json
+++ b/data/mods/Perk_melee/perks.json
@@ -66,6 +66,66 @@
   },
   {
     "type": "mutation",
+    "id": "MELEE_PERK_INSIGHT",
+    "copy-from": "MELEE_PERK_BASE",
+    "name": { "str": "Insight I" },
+    "description": "You passively accumulate up to 20 insight stacks while near enemies.  Each insight stack increases all damage dealt by 1 until your next attack.  Insight greatly favors perceptive warriors.",
+    "flags": "MELEE_PERK_INSIGHT",
+    "enchantments": [ "melee_perk_ench_insight" ]
+  },
+  {
+    "type": "mutation",
+    "id": "MELEE_PERK_SIXTH_SENSE",
+    "copy-from": "MELEE_PERK_BASE",
+    "name": { "str": "Sixth Sense" },
+    "description": "You accumulate insight stacks even from enemies you can't see.  You can perceive unseen enemies within 10 tiles if you have at least 5 insight stacks.",
+    "flags": "MELEE_PERK_SIXTH_SENSE",
+    "enchantments": [ "melee_perk_ench_six_sense" ]
+  },
+  {
+    "type": "mutation",
+    "id": "MELEE_PERK_INSIGHT_INFINITE",
+    "copy-from": "MELEE_PERK_BASE",
+    "name": { "str": "The psychic sea" },
+    "description": "You can accumulate an infinite number of insight stacks.",
+    "flags": "MELEE_PERK_INSIGHT_INFINITE"
+  },
+  {
+    "type": "mutation",
+    "id": "MELEE_PERK_TWILIGHT_FORM",
+    "copy-from": "MELEE_PERK_BASE",
+    "name": { "str": "Twilight Form" },
+    "description": "Whenever you kill an enemy in melee, you retain 50% of your insight stacks.",
+    "flags": "MELEE_PERK_TWILIGHT_FORM"
+  },
+  {
+    "type": "mutation",
+    "id": "MELEE_PERK_BLIND_CALCULUS",
+    "copy-from": "MELEE_PERK_BASE",
+    "name": { "str": "Blind Calculus" },
+    "description": "If you have been blind for at least 15 turns, every time you would gain an insight stack you instead gain 5.",
+    "flags": "MELEE_PERK_BLIND_CALCULUS"
+  },
+  {
+    "type": "mutation",
+    "id": "MELEE_PERK_MYSTIC_SHOT",
+    "copy-from": "MELEE_PERK_BASE",
+    "name": { "str": "Mystic Shot I" },
+    "description": "Insight stacks also increase the accuracy of ranged bow and crossbow attacks by 2% per stack.  Ranged attacks will consume insight stacks.",
+    "flags": "MELEE_PERK_MYSTIC_SHOT",
+    "enchantments": [ "melee_perk_ench_insight_mystic_shot" ]
+  },
+  {
+    "type": "mutation",
+    "id": "MELEE_PERK_MYSTIC_SHOT_2",
+    "copy-from": "MELEE_PERK_BASE",
+    "name": { "str": "Mystic Shot II" },
+    "description": "Insight stacks also increase the damage of ranged bow and crossbow attacks by 1% per stack.",
+    "flags": "MELEE_PERK_MYSTIC_SHOT_2",
+    "enchantments": [ "melee_perk_ench_insight_mystic_shot_2" ]
+  },
+  {
+    "type": "mutation",
     "id": "MELEE_PERK_MOMENTUM",
     "copy-from": "MELEE_PERK_BASE",
     "name": { "str": "Momentum I" },

--- a/data/mods/Perk_melee/techniques/techniques.json
+++ b/data/mods/Perk_melee/techniques/techniques.json
@@ -96,7 +96,11 @@
     "required_char_flags_all": [ "MELEE_PERK_JUST_HIT_IT" ],
     "melee_allowed": true,
     "condition": {
-      "and": [ { "not": { "u_has_effect": "mabuff:buff_perk_tempo" } }, { "not": { "u_has_effect": "mabuff:buff_perk_momentum" } } ]
+      "and": [
+        { "not": { "u_has_effect": "mabuff:buff_perk_tempo" } },
+        { "not": { "u_has_effect": "mabuff:buff_perk_momentum" } },
+        { "not": { "u_has_effect": "perk_insight" } }
+      ]
     },
     "crit_ok": true,
     "weapon_categories_allowed": [ "GREAT_AXES", "GREAT_SWORDS", "GREAT_HAMMERS", "AXE", "MEDIUM-SWORDS", "LONG_SWORDS", "MACES", "AXES", "FLAILS" ],

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -607,6 +607,8 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
         }
     }
 
+    recalculate_enchantment_cache();
+
     melee::melee_stats.attack_count += 1;
     int hit_spread = t.deal_melee_attack( this, hit_roll() );
     if( !t.is_avatar() ) {


### PR DESCRIPTION
#### Summary
Mods "Martial Mastery: Add insight buff and related perkline"

#### Purpose of change
Add a trait line focused on perception, complementing the dexterity and strength ones.

#### Describe the solution
The insight bonus accumulates passively as the player is in combat, with the rate of this depending on perception. Each stack of insight increases the highest type of  melee damage by +1 up to +20 or +infinity with the appropriate perk. Insight is lost on sucessful attacks or when the player exits combat.

| Perk | Description|
|-|-|
|Insight| The base Perk that enables the archetype. Grants 1 stack of insight every  per/20 turn in average while there are visible monsters in 20 tiles. |
|Sixth Sense | Removes the LOS requirement to gain insight stacks. Grants you motion vision if you have at least 5 insight stacks.|
|The psychic Sea| Lets you stack an infinite amount of insight. |
|Twilight form| You recover 50% of your insight stacks if your last attack killed an enemy.|
|Blind Calculus| You gain 5 insight stacks whenever you would have gained 1 insight stack if you have been blind for at least 15 turns|
|Mystic Shot| Each insight stack also makes you 1% more accurate with bows/slings/crossbows. Your ranged attacks now consume insight stacks. |
|Mystic Shot II | Each insight stack also increases the damage of attacks with bows/slings/crossbows by 1%|

Its all passive effects for now.

#### Testing

Tested in combat.

