### PR TITLE
replace mon_turret_riot with better suited enemies

### DIFF
--- a/data/json/mapgen/map_extras/roadblock.json
+++ b/data/json/mapgen/map_extras/roadblock.json
@@ -42,8 +42,8 @@
       ],
       "furniture": { "s": "f_sandbag_half", "g": "f_active_backup_generator", "b": "f_barricade_road" },
       "monster": {
-        "T": { "monster": "mon_turret_riot", "chance": 100 },
-        "t": { "monster": "mon_turret_riot", "chance": 60 },
+        "T": { "monster": "mon_feral_cop", "chance": 100 },
+        "t": { "monster": "mon_feral_cop", "chance": 60 },
         "L": { "monster": "mon_turret_searchlight" }
       },
       "place_vehicles": [

--- a/data/json/mapgen/map_extras/roadblock_mil.json
+++ b/data/json/mapgen/map_extras/roadblock_mil.json
@@ -31,7 +31,7 @@
         "                        "
       ],
       "furniture": { "s": "f_sandbag_half", "g": "f_active_backup_generator", "b": "f_barricade_road" },
-      "monster": { "t": { "monster": "mon_turret_riot" }, "L": { "monster": "mon_turret_searchlight" } },
+      "monster": { "t": { "monster": "mon_feral_soldier" }, "L": { "monster": "mon_turret_searchlight" } },
       "place_vehicles": [
         { "vehicle": "armored_car", "x": 6, "y": 7, "chance": 100, "status": 1, "rotation": 270 },
         { "vehicle": "military_cargo_truck", "x": 7, "y": 17, "chance": 100, "status": 1, "rotation": 180 },

--- a/data/json/mapgen/office_tower_2.json
+++ b/data/json/mapgen/office_tower_2.json
@@ -299,7 +299,7 @@
       },
       "item": { "c": [ { "item": "microwave", "chance": 75 }, { "item": "coffeemaker", "chance": 75 } ] },
       "place_monster": [ { "monster": "mon_zombie_scientist", "x": [ 7, 21 ], "y": [ 4, 10 ], "repeat": [ 1, 3 ] } ],
-      "monster": { "@": { "monster": "mon_turret_riot" } }
+      "monster": { "@": { "monster": "mon_feral_labsecurity_9mm" } }
     }
   },
   {

--- a/data/json/monstergroups/robots.json
+++ b/data/json/monstergroups/robots.json
@@ -28,11 +28,6 @@
     ]
   },
   {
-    "name": "GROUP_HAZMATBOT",
-    "type": "monstergroup",
-    "monsters": [ { "monster": "mon_hazmatbot" } ]
-  },
-  {
     "type": "monstergroup",
     "name": "GROUP_ROBOT_SECUBOT",
     "monsters": [ { "monster": "mon_secubot", "cost_multiplier": 0, "spawn_data": { "ammo": [ { "ammo_id": "556", "qty": 30 } ] } } ]
@@ -41,15 +36,5 @@
     "type": "monstergroup",
     "name": "GROUP_TURRET_SPEAKER",
     "monsters": [ { "monster": "mon_turret_speaker" } ]
-  },
-  {
-    "type": "monstergroup",
-    "name": "GROUP_TURRET_RIOT",
-    "monsters": [ { "monster": "mon_turret_riot", "cost_multiplier": 0 } ]
-  },
-  {
-    "type": "monstergroup",
-    "name": "GROUP_TURRET_SEARCHLIGHT",
-    "monsters": [ { "monster": "mon_turret_searchlight", "cost_multiplier": 0 } ]
   }
 ]


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
They are still spawning around wtf
#### Describe the solution
Replace with better suited enemies, mostly ferals (that will later transform into zombies for obv reasons)
Didn't touch lab lines of turrets because dunno what to do with them
Also removed few bot mongroups that are not used at all
#### Describe alternatives you've considered
Left them here, and just strip their ammo from them