### PR TITLE
Allow magic rings to resize to fit anyone

### DIFF
--- a/data/mods/Magiclysm/items/enchanted_rings.json
+++ b/data/mods/Magiclysm/items/enchanted_rings.json
@@ -14,7 +14,7 @@
     "looks_like": "copper_ring",
     "sided": true,
     "warmth": 0,
-    "flags": [ "WATER_FRIENDLY", "ALLOWS_NATURAL_ATTACKS", "FANCY", "ONE_PER_LAYER", "SKINTIGHT", "ALLOWS_TALONS" ],
+    "flags": [ "WATER_FRIENDLY", "ALLOWS_NATURAL_ATTACKS", "FANCY", "ONE_PER_LAYER", "SKINTIGHT", "UNRESTRICTED" ],
     "armor": [
       {
         "encumbrance": 0,
@@ -40,7 +40,7 @@
     "looks_like": "silver_ring",
     "sided": true,
     "warmth": 0,
-    "flags": [ "WATER_FRIENDLY", "ALLOWS_NATURAL_ATTACKS", "FANCY", "ONE_PER_LAYER", "SKINTIGHT", "ALLOWS_TALONS" ],
+    "flags": [ "WATER_FRIENDLY", "ALLOWS_NATURAL_ATTACKS", "FANCY", "ONE_PER_LAYER", "SKINTIGHT", "UNRESTRICTED" ],
     "armor": [
       {
         "encumbrance": 0,
@@ -66,7 +66,7 @@
     "looks_like": "gold_ring",
     "sided": true,
     "warmth": 0,
-    "flags": [ "WATER_FRIENDLY", "ALLOWS_NATURAL_ATTACKS", "FANCY", "ONE_PER_LAYER", "SKINTIGHT", "ALLOWS_TALONS" ],
+    "flags": [ "WATER_FRIENDLY", "ALLOWS_NATURAL_ATTACKS", "FANCY", "ONE_PER_LAYER", "SKINTIGHT", "UNRESTRICTED" ],
     "armor": [
       {
         "encumbrance": 0,
@@ -92,7 +92,7 @@
     "looks_like": "platinum_ring",
     "sided": true,
     "warmth": 0,
-    "flags": [ "WATER_FRIENDLY", "ALLOWS_NATURAL_ATTACKS", "FANCY", "ONE_PER_LAYER", "SKINTIGHT", "ALLOWS_TALONS" ],
+    "flags": [ "WATER_FRIENDLY", "ALLOWS_NATURAL_ATTACKS", "FANCY", "ONE_PER_LAYER", "SKINTIGHT", "UNRESTRICTED" ],
     "armor": [
       {
         "encumbrance": 0,


### PR DESCRIPTION
This commit allows magic rings to resize themselves to fit any sort of anatomy.

#### Summary

Features "Magic rings resize to fit even mutated anatomy"

#### Purpose of change

Magiclysm takes a lot from Dungeons and Dragons, which takes a lot from The Lord of the Rings.
The One Ring famously could resize itself to fit its wearer, and in the table-top game, magic rings would also resize themselves to fit creatures by size and shape.

If they could resize, why not allow a character with tentacle arms to wear up to two magic rings like everyone else?

#### Describe the solution

This replaces the `ALLOW_TALONS` flag with the `UNRESTRICTED` flag.
This would allow characters with the following mutations to wear magic rings:
* Exodii cyborg framework
* Giant Pincer
* Bat Wings, Bird Wings
* Huge, Freakishly Huge
* Paws, Broad Paws
* Tentacle Arms, 4 Tentacles, 8 Tentacles
* [Aftershock] Three Fingered
* [Magiclysm] Scaled Hands, Black Dragon Talons, Draconic Maturity, Freakish Draconic Maturity
* [Xedra Evolved] Giant-Sized

Unfortunately this also means the character can somehow wear the ring when missing arms ([Limb WIP]), due to the game not really supporting a limb missing.

#### Describe alternatives you've considered

The only other flag that would achieve this is `SEMITANGIBLE`. This commit is not meant to make rings better, only more widely usable.

#### Testing

I tested by creating a character and giving that character the tentacle arms trait and wearing some of these rings.

#### Additional context

[The One Ring - Wikipedia](https://en.wikipedia.org/wiki/One_Ring)
[Size and Magic Items - Dungeons and Dragons, third edition](https://www.d20srd.org/srd/magicItems/magicItemBasics.htm#sizeAndMagicItems)
[Wearing and Wielding Items - Dungeons and Dragons, fifth edition](https://5e.d20srd.org/srd/magicItems/magicItemBasics.htm#wearingAndWieldingMagicItems)
