### PR TITLE
[DinoMod] monster attack fixes

### DIFF
--- a/data/mods/DinoMod/monsters/dinosaur_CBM.json
+++ b/data/mods/DinoMod/monsters/dinosaur_CBM.json
@@ -44,6 +44,7 @@
         "targeting_timeout_extend": -1,
         "targeting_sound": "\"TARGET ACQUIRED.\"",
         "targeting_volume": 70,
+        "ammo_type": "battery",
         "no_ammo_sound": "TARGET ACQUIRED.  *beeeeeeeeep*.  OUT OF AMMO."
       }
     ],

--- a/data/mods/DinoMod/monsters/zed-dinosaur_CBM.json
+++ b/data/mods/DinoMod/monsters/zed-dinosaur_CBM.json
@@ -47,6 +47,7 @@
         "targeting_timeout_extend": -1,
         "targeting_sound": "\"TARGET *zZzZzz* ACQUIRED.\"",
         "targeting_volume": 70,
+        "ammo_type": "battery",
         "no_ammo_sound": "*zZzzz*-TARGET ACQUIRED.  *beeeeeeeeep*.  OUT OF AMMO.-*zZzZ*"
       }
     ],

--- a/data/mods/DinoMod/monsters/zinosaur_upgrade.json
+++ b/data/mods/DinoMod/monsters/zinosaur_upgrade.json
@@ -4749,6 +4749,7 @@
     "bleed_rate": 50,
     "extend": { "flags": [ "DRIPS_GASOLINE", "LOUDMOVES" ] },
     "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology", "prof_wp_zombie", "prof_wp_syn_armored" ],
+    "starting_ammo": { "napalm": 100 },
     "special_attacks": [
       { "id": "bite_grab", "cooldown": 30 },
       {
@@ -4791,6 +4792,7 @@
     "bleed_rate": 50,
     "extend": { "flags": [ "DRIPS_GASOLINE", "LOUDMOVES" ] },
     "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology", "prof_wp_zombie", "prof_wp_syn_armored" ],
+    "starting_ammo": { "napalm": 100 },
     "special_attacks": [
       { "id": "bite_grab", "cooldown": 30 },
       {


### PR DESCRIPTION
#### Summary
Mods "[DinoMod] monster attack fixes"

#### Purpose of change

Fix broken content

#### Describe the solution

Assigns ammo_type or starting_ammo fixes so that late game and high difficulty monsters can use their special attacks again.

#### Describe alternatives you've considered

Roll this into a larger and more complicated monster attack rebalancing

#### Testing

Lasers and flamethrowers fire as desired

<img width="1371" alt="Screenshot 2024-09-16 at 9 37 23 AM" src="https://github.com/user-attachments/assets/dcbf3b68-b254-4c70-ac1c-e34731106b4f">

<img width="1144" alt="Screenshot 2024-09-16 at 9 39 46 AM" src="https://github.com/user-attachments/assets/5b937b1d-8b2f-484c-a029-94c176cdad29">


#### Additional context

Intended to fix DinoMod elements from #76097 