### PR TITLE
[Magiclysm] Feral ravenfolk are blinged out

### DIFF
--- a/data/mods/Magiclysm/itemgroups/death_drops.json
+++ b/data/mods/Magiclysm/itemgroups/death_drops.json
@@ -105,6 +105,7 @@
     "id": "feral_ravenfolk_death_drops",
     "entries": [
       { "group": "default_ravenfolk_clothes", "prob": 100, "damage": [ 1, 4 ] },
+      { "group": "ravenfolk_jewelry", "prob": 100, "count": [ 2, 4 ] },
       { "group": "default_zombie_items", "count": [ 1, 3 ], "prob": 50 },
       { "group": "wallets", "prob": 50 },
       { "item": "denarius", "prob": 5 }

--- a/data/mods/Magiclysm/itemgroups/death_drops.json
+++ b/data/mods/Magiclysm/itemgroups/death_drops.json
@@ -105,7 +105,7 @@
     "id": "feral_ravenfolk_death_drops",
     "entries": [
       { "group": "default_ravenfolk_clothes", "prob": 100, "damage": [ 1, 4 ] },
-      { "group": "ravenfolk_jewelry", "prob": 100, "count": [ 2, 4 ] },
+      { "group": "ravenfolk_jewelry", "prob": 100, "count": [ 0, 4 ] },
       { "group": "default_zombie_items", "count": [ 1, 3 ], "prob": 50 },
       { "group": "wallets", "prob": 50 },
       { "item": "denarius", "prob": 5 }

--- a/data/mods/Magiclysm/itemgroups/itemgroups.json
+++ b/data/mods/Magiclysm/itemgroups/itemgroups.json
@@ -1856,5 +1856,43 @@
     "subtype": "collection",
     "id": "group_forge_warp_items",
     "items": [ { "item": "forge_warp_scroll", "count": [ 1, 3 ] } ]
+  },
+  {
+    "type": "item_group",
+    "id": "ravenfolk_jewelry",
+    "//": "copied from jewelry_accessories with ear and teeth jewelry removed, plus no wedding/engagement rings",
+    "items": [
+      [ "gold_ring", 30 ],
+      [ "gold_bracelet", 30 ],
+      [ "gold_necklace", 30 ],
+      [ "gold_locket", 20 ],
+      [ "gold_hairpin", 20 ],
+      [ "platinum_ring", 2 ],
+      [ "platinum_bracelet", 2 ],
+      [ "platinum_necklace", 2 ],
+      [ "platinum_locket", 1 ],
+      [ "platinum_hairpin", 1 ],
+      [ "silver_necklace", 40 ],
+      [ "silver_bracelet", 40 ],
+      [ "silver_ring", 40 ],
+      [ "silver_locket", 30 ],
+      [ "silver_hairpin", 30 ],
+      [ "copper_bracelet", 15 ],
+      [ "copper_ring", 15 ],
+      [ "copper_necklace", 15 ],
+      [ "cowrie_necklace", 15 ],
+      [ "copper_locket", 15 ],
+      [ "copper_hairpin", 10 ],
+      [ "ring_purity", 5 ],
+      [ "cufflinks", 25 ],
+      [ "cufflinks_intricate", 15 ],
+      [ "diamond_ring", 10 ],
+      [ "jade_brooch", 30 ],
+      [ "tieclip", 35 ],
+      [ "pearl_collar", 30 ],
+      [ "holy_symbol", 20 ],
+      [ "gold_anklet", 20 ],
+      [ "silver_anklet", 30 ]
+    ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Magiclysm] Feral ravenfolk are blinged out"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Ravens like shiny objects.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add a bunch of jewelry to ravenfolk death drops. This does not include dental grills or earrings (for obvious reasons), and has wedding and engagement rings cut out too (so you don't have one person with 3 wedding rings).
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Items appear in loot.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

PC Ravenfolk needing shiny objects instead of having a modified HOARDER trait is coming. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
