### PR TITLE
[Xedra Evolved] Add more Brownie changeling traits +bugfixes

### DIFF
--- a/data/mods/Xedra_Evolved/items/armor/integrated.json
+++ b/data/mods/Xedra_Evolved/items/armor/integrated.json
@@ -882,5 +882,30 @@
       }
     ],
     "melee_damage": { "stab": 13 }
+  },
+  {
+    "id": "integrated_brownie_fur",
+    "type": "ARMOR",
+    "category": "armor",
+    "name": { "str_sp": "brownie fur" },
+    "description": "Thick fur-like hair covering your entire body.",
+    "weight": "300 g",
+    "volume": "300 ml",
+    "price": "0 cent",
+    "price_postapoc": "0 cent",
+    "material": [ "mut_fur" ],
+    "symbol": "x",
+    "color": "brown",
+    "warmth": 15,
+    "environmental_protection": 1,
+    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "PERSONAL", "WATER_FRIENDLY" ],
+    "armor": [
+      {
+        "material": [ { "type": "mut_fur", "covered_by_mat": 100, "thickness": 2 } ],
+        "covers": [ "hand_l", "hand_r", "foot_l", "foot_r", "leg_l", "leg_r", "arm_l", "arm_r", "torso" ],
+        "coverage": 100,
+        "encumbrance": 0
+      }
+    ]
   }
 ]

--- a/data/mods/Xedra_Evolved/mutations/playable_changeling.json
+++ b/data/mods/Xedra_Evolved/mutations/playable_changeling.json
@@ -291,7 +291,7 @@
     "name": { "str": "Right of Passage" },
     "points": 8,
     "description": "The Fair Folk have dealt with many mortal civilizations over the aeons, and have come to mutually beneficial arrangements with some of them.  Activate this trait to make your fae nature obvious, invoking those ancient agreements.  This <color_yellow>may anger</color> some who have especially bad relationships with the fae.",
-    "prereqs": [ "PRETTY" ],
+    "prereqs": [ "PRETTY", "BEAUTIFUL", "BEAUTIFUL2", "BEAUTIFUL3" ],
     "category": [ "FAIR_FOLK_NOBLE" ],
     "active": true,
     "activated_is_setup": true,
@@ -406,6 +406,105 @@
         "values": [ { "value": "STEALTH_MODIFIER", "add": 50 } ]
       }
     ]
+  },
+  {
+    "type": "mutation",
+    "id": "BROWNIE_COLD_TOLERANCE",
+    "name": { "str": "Cold Tolerance" },
+    "description": "The cold doesn't seem to bother you quite as much anymore.",
+    "points": 2,
+    "changes_to": [ "BROWNIE_COLD_TOLERANCE2" ],
+    "category": [ "FAIR_FOLK_COMMONER_BROWNIE" ],
+    "enchantments": [ { "values": [ { "value": "CLIMATE_CONTROL_HEAT", "add": 25 } ] } ]
+  },
+  {
+    "type": "mutation",
+    "id": "BROWNIE_COLD_TOLERANCE2",
+    "name": { "str": "Cold Endurance" },
+    "description": "Even on a winter day, you need only a light jacket now.",
+    "points": 4,
+    "prereqs": [ "PARACLESIAN_STR_DEX_1" ],
+    "prereqs2": [ "HIRSUTE_BROWNIE", "BROWNIE_FUR" ],
+    "changes_to": [ "BROWNIE_COLD_TOLERANCE3" ],
+    "category": [ "FAIR_FOLK_COMMONER_BROWNIE" ],
+    "enchantments": [ { "values": [ { "value": "CLIMATE_CONTROL_HEAT", "add": 50 } ] } ]
+  },
+  {
+    "type": "mutation",
+    "id": "BROWNIE_COLD_TOLERANCE3",
+    "name": { "str": "Inured to Cold" },
+    "description": "Legends say that brownies went about naked clad only in their almost-furry coat, and while you wouldn't go that far, you could wear a swimsuit in a blizzard without much trouble.",
+    "points": 8,
+    "prereqs": [ "PARACLESIAN_STR_DEX_2" ],
+    "prereqs2": [ "BROWNIE_FUR" ],
+    "category": [ "FAIR_FOLK_COMMONER_BROWNIE" ],
+    "threshreq": [ "THRESH_FAIR_FOLK_COMMONER_BROWNIE" ],
+    "enchantments": [ { "values": [ { "value": "CLIMATE_CONTROL_HEAT", "add": 120 } ] } ]
+  },
+  {
+    "type": "mutation",
+    "id": "BROWNIE_MAKE_CHEESE_AND_BUTTER",
+    "name": { "str": "Churning As Quick as a Wink" },
+    "points": 1,
+    "description": "Brownies are famous for their ability to do household chores, and you now have an instinctive understanding of making milk and cheese.",
+    "category": [ "FAIR_FOLK_COMMONER_BROWNIE" ]
+  },
+  {
+    "type": "mutation",
+    "id": "HIRSUTE_BROWNIE",
+    "copy-from": "HIRSUTE",
+    "changes_to": [ "BROWNIE_FUR" ],
+    "category": [ "FAIR_FOLK_COMMONER_BROWNIE" ]
+  },
+  {
+    "type": "mutation",
+    "id": "BROWNIE_FUR",
+    "name": { "str": "Coat of Fur" },
+    "description": "Your hair has thickened to almost the level of fur covering your entire body.  It's very warm and provides some level of protection against attacks.",
+    "points": 2,
+    "visibility": 6,
+    "ugliness": 2,
+    "prereqs": [ "HIRSUTE_BROWNIE" ],
+    "category": [ "FAIR_FOLK_COMMONER_BROWNIE" ],
+    "integrated_armor": [ "integrated_brownie_fur" ]
+  },
+  {
+    "type": "mutation",
+    "id": "BROWNIE_HOMEBODY",
+    "name": { "str": "Homebody" },
+    "description": "Brownies know every corner of their homes, all the well-worn grooves in the floor and the quick paths from place to place.  Your speed is increased the longer you spend in the same area.",
+    "points": 6,
+    "prereqs": [ "BROWNIE_EASY_OVERLOOK" ],
+    "prereqs2": [ "BROWNIE_CRAFTING_BONUS2", "BROWNIE_CRAFTING_BONUS3" ],
+    "category": [ "FAIR_FOLK_COMMONER_BROWNIE" ],
+    "enchantments": [ { "values": [ { "value": "SPEED", "add": { "math": [ "u_brownie_homebody_speed_bonus" ] } } ] } ]
+  },
+  {
+    "type": "mutation",
+    "id": "BROWNIE_SENSE_INTRUDERS",
+    "name": { "str": "Sense Intruders" },
+    "description": "With the knowledge of one's home comes the knowledge that something is off about it.  You can sense any intuders nearby, as long as you are indoors and have been in the same location for some time.",
+    "points": 8,
+    "prereqs": [ "BROWNIE_HOMEBODY" ],
+    "category": [ "FAIR_FOLK_COMMONER_BROWNIE" ],
+    "threshreq": [ "THRESH_FAIR_FOLK_COMMONER_BROWNIE" ],
+    "enchantments": [
+      {
+        "condition": { "and": [ { "not": "u_is_outside" }, { "math": [ "u_brownie_sense_intruders", "!=", "0" ] } ] },
+        "values": [ { "value": "MOTION_VISION_RANGE", "add": { "math": [ "u_val('perception')" ] } } ]
+      }
+    ]
+  },
+  {
+    "type": "mutation",
+    "id": "BROWNIE_BLINK_INDOORS",
+    "name": { "str": "Slip Through the Cracks" },
+    "points": 4,
+    "description": "Lughnasadh is a time for bringing in the harvest and for contests of skill and stamina.",
+    "prereqs": [ "BROWNIE_HOMEBODY" ],
+    "category": [ "FAIR_FOLK_COMMONER_BROWNIE" ],
+    "threshreq": [ "THRESH_FAIR_FOLK_COMMONER_BROWNIE" ],
+    "spells_learned": [ [ "changeling_brownie_blink_indoors_spell", 1 ] ]
   },
   {
     "type": "mutation",
@@ -645,7 +744,7 @@
     "type": "mutation",
     "id": "CHANGELING_INVISIBILITY",
     "name": { "str": "Hidden from Mortal Eyes" },
-    "points": 2,
+    "points": 6,
     "description": "Like the Fair Folk of legend, you can remain unseen when you wish.",
     "prereqs": [ "CHANGELING_DISGUISE_AS_NATURE" ],
     "category": [
@@ -654,6 +753,13 @@
       "FAIR_FOLK_COMMONER_POOKA",
       "FAIR_FOLK_COMMONER_SELKIE",
       "FAIR_FOLK_COMMONER_TROW"
+    ],
+    "threshreq": [
+      "THRESH_FAIR_FOLK_NOBLE",
+      "THRESH_FAIR_FOLK_COMMONER_BROWNIE",
+      "THRESH_FAIR_FOLK_COMMONER_POOKA",
+      "THRESH_FAIR_FOLK_COMMONER_SELKIE",
+      "THRESH_FAIR_FOLK_COMMONER_TROW"
     ],
     "spells_learned": [ [ "changeling_invisibility_spell", 1 ] ]
   },

--- a/data/mods/Xedra_Evolved/mutations/playable_changeling.json
+++ b/data/mods/Xedra_Evolved/mutations/playable_changeling.json
@@ -483,7 +483,7 @@
     "type": "mutation",
     "id": "BROWNIE_SENSE_INTRUDERS",
     "name": { "str": "Sense Intruders" },
-    "description": "With the knowledge of one's home comes the knowledge that something is off about it.  You can sense any intuders nearby, as long as you are indoors and have been in the same location for some time.",
+    "description": "With the knowledge of one's home comes the knowledge that something is off about it.  You can sense any intruders nearby, as long as you are indoors and have been in the same location for some time.",
     "points": 8,
     "prereqs": [ "BROWNIE_HOMEBODY" ],
     "category": [ "FAIR_FOLK_COMMONER_BROWNIE" ],
@@ -500,11 +500,21 @@
     "id": "BROWNIE_BLINK_INDOORS",
     "name": { "str": "Slip Through the Cracks" },
     "points": 4,
-    "description": "Lughnasadh is a time for bringing in the harvest and for contests of skill and stamina.",
+    "description": "You can tell every nook and cranny of indoor spaces, and know how to quickly get from one place to another.",
     "prereqs": [ "BROWNIE_HOMEBODY" ],
     "category": [ "FAIR_FOLK_COMMONER_BROWNIE" ],
-    "threshreq": [ "THRESH_FAIR_FOLK_COMMONER_BROWNIE" ],
     "spells_learned": [ [ "changeling_brownie_blink_indoors_spell", 1 ] ]
+  },
+  {
+    "type": "mutation",
+    "id": "BROWNIE_TELEPORT_HOME",
+    "name": { "str": "Hurry Home" },
+    "points": 8,
+    "description": "You can return home from anywhere, as quick as a wink.",
+    "prereqs": [ "BROWNIE_BLINK_INDOORS" ],
+    "category": [ "FAIR_FOLK_COMMONER_BROWNIE" ],
+    "threshreq": [ "THRESH_FAIR_FOLK_COMMONER_BROWNIE" ],
+    "spells_learned": [ [ "changeling_teleport_home_spell", 1 ] ]
   },
   {
     "type": "mutation",

--- a/data/mods/Xedra_Evolved/mutations/playable_changeling.json
+++ b/data/mods/Xedra_Evolved/mutations/playable_changeling.json
@@ -491,7 +491,7 @@
     "enchantments": [
       {
         "condition": { "and": [ { "not": "u_is_outside" }, { "math": [ "u_brownie_sense_intruders", "!=", "0" ] } ] },
-        "values": [ { "value": "MOTION_VISION_RANGE", "add": { "math": [ "u_val('perception')" ] } } ]
+        "values": [ { "value": "MOTION_VISION_RANGE", "add": { "math": [ "u_val('perception') + u_brownie_homebody_speed_bonus" ] } } ]
       }
     ]
   },

--- a/data/mods/Xedra_Evolved/mutations/playable_changeling_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/playable_changeling_eocs.json
@@ -551,7 +551,13 @@
     "type": "effect_on_condition",
     "id": "EOC_BROWNIE_HOMEBODY_RAISING_EOC",
     "recurrence": [ "1 hours", "1 hours" ],
-    "condition": { "and": [ { "u_has_trait": "BROWNIE_HOMEBODY" }, { "math": [ "u_brownie_homebody_speed_bonus", "<=", "19" ] } ] },
+    "condition": {
+      "and": [
+        { "u_has_trait": "BROWNIE_HOMEBODY" },
+        { "math": [ "u_brownie_homebody_speed_bonus", "<=", "19" ] },
+        { "not": { "u_has_effect": "sleep" } }
+      ]
+    },
     "effect": [ { "math": [ "u_brownie_homebody_speed_bonus", "++" ] }, { "math": [ "u_brownie_sense_intruders", "++" ] } ]
   },
   {
@@ -690,6 +696,67 @@
       }
     ],
     "false_effect": { "u_message": "You must be indoors to slip through the cracks.", "type": "bad" }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_BROWNIE_HOME_TELEPORT_SET_DESTINATION",
+    "eoc_type": "EVENT",
+    "required_event": "character_wakes_up",
+    "condition": { "and": [ { "u_has_trait": "BROWNIE_TELEPORT_HOME" }, { "math": [ "u_brownie_homebody_speed_bonus", ">=", "12" ] } ] },
+    "effect": [ { "u_location_variable": { "u_val": "brownie_home_teleport_loc" } } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_BROWNIE_HOME_TELEPORT_ACTUAL_TELEPORT",
+    "condition": {
+      "and": [
+        { "not": "u_is_outside" },
+        {
+          "or": [
+            { "u_is_on_terrain": "t_door_white_frame" },
+            { "u_is_on_terrain": "t_door_frame" },
+            { "u_is_on_terrain": "t_door_lab_frame" },
+            { "u_is_on_terrain": "t_door_red_frame" },
+            { "u_is_on_terrain": "t_door_green_frame" },
+            { "u_is_on_terrain": "t_door_gray_frame" },
+            { "u_is_on_terrain": "t_mdoor_lab_frame" },
+            { "u_is_on_terrain": "t_mdoor_frame" },
+            { "u_is_on_terrain": "t_door_bar_o" },
+            { "u_is_on_terrain": "t_door_o" },
+            { "u_is_on_terrain": "t_door_lab_o" },
+            { "u_is_on_terrain": "t_door_green_o" },
+            { "u_is_on_terrain": "t_door_gray_o" },
+            { "u_is_on_terrain": "t_door_red_o" },
+            { "u_is_on_terrain": "t_door_white_o" },
+            { "u_is_on_terrain": "t_door_glass_gray_o" },
+            { "u_is_on_terrain": "t_door_glass_green_o" },
+            { "u_is_on_terrain": "t_door_glass_red_o" },
+            { "u_is_on_terrain": "t_door_glass_lab_o" },
+            { "u_is_on_terrain": "t_door_glass_o" },
+            { "u_is_on_terrain": "t_door_metal_lab_o" },
+            { "u_is_on_terrain": "t_door_metal_o" },
+            { "u_is_on_terrain": "t_door_glass_white_o" },
+            { "u_is_on_terrain": "t_secretdoor_concrete_o" },
+            { "u_is_on_terrain": "t_secretdoor_metal_o" },
+            { "u_is_on_terrain": "t_screen_door_o" },
+            { "u_is_on_terrain": "t_door_metal_bulkhead_o" },
+            { "u_is_on_terrain": "t_door_glass_frosted_lab_o" },
+            { "u_is_on_terrain": "t_door_glass_frosted_o" },
+            { "u_is_on_terrain": "t_laminated_door_glass_o" },
+            { "u_is_on_terrain": "t_rdoor_o" },
+            { "u_is_on_terrain": "t_ballistic_door_glass_o" },
+            { "u_is_on_terrain": "t_door_metal_corrugated_o" },
+            { "u_is_on_terrain": "t_reinforced_door_glass_o" },
+            { "u_is_on_terrain": "t_reinforced_door_glass_lab_o" }
+          ]
+        }
+      ]
+    },
+    "effect": [
+      { "u_teleport": { "u_val": "brownie_home_teleport_loc" } },
+      { "u_message": "You slip through the door and head straight home.", "type": "good" }
+    ],
+    "false_effect": { "u_message": "You must be in a doorway to hurry home.", "type": "bad" }
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/Xedra_Evolved/mutations/playable_changeling_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/playable_changeling_eocs.json
@@ -549,6 +549,150 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_BROWNIE_HOMEBODY_RAISING_EOC",
+    "recurrence": [ "1 hours", "1 hours" ],
+    "condition": { "and": [ { "u_has_trait": "BROWNIE_HOMEBODY" }, { "math": [ "u_brownie_homebody_speed_bonus", "<=", "19" ] } ] },
+    "effect": [ { "math": [ "u_brownie_homebody_speed_bonus", "++" ] }, { "math": [ "u_brownie_sense_intruders", "++" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_BROWNIE_HOMEBODY_LOWERING_EOC",
+    "required_event": "avatar_enters_omt",
+    "eoc_type": "EVENT",
+    "condition": {
+      "and": [
+        "u_is_outside",
+        { "math": [ "u_brownie_homebody_speed_bonus", ">", "0" ] },
+        {
+          "not": {
+            "or": [
+              { "u_at_om_location": "FACTION_CAMP_ANY" },
+              { "u_at_om_location": "mansion_e1" },
+              { "u_at_om_location": "mansion_boarded_e1" },
+              { "u_at_om_location": "mansion_e2" },
+              { "u_at_om_location": "mansion_+1" },
+              { "u_at_om_location": "mansion_+1d" },
+              { "u_at_om_location": "mansion_+1u" },
+              { "u_at_om_location": "mansion_+1_roof" },
+              { "u_at_om_location": "mansion_+2" },
+              { "u_at_om_location": "mansion_+2d" },
+              { "u_at_om_location": "mansion_+2u" },
+              { "u_at_om_location": "mansion_+2_roof" },
+              { "u_at_om_location": "mansion_+3" },
+              { "u_at_om_location": "mansion_+3u" },
+              { "u_at_om_location": "mansion_+3_roof" },
+              { "u_at_om_location": "mansion_+4" },
+              { "u_at_om_location": "mansion_+4d" },
+              { "u_at_om_location": "mansion_+4u" },
+              { "u_at_om_location": "mansion_+4_roof" },
+              { "u_at_om_location": "mansion_boarded_c1" },
+              { "u_at_om_location": "mansion_c1" },
+              { "u_at_om_location": "mansion_c1d" },
+              { "u_at_om_location": "mansion_boarded_c1u" },
+              { "u_at_om_location": "mansion_c1u" },
+              { "u_at_om_location": "mansion_c1_roof" },
+              { "u_at_om_location": "mansion_boarded_c2" },
+              { "u_at_om_location": "mansion_c2" },
+              { "u_at_om_location": "mansion_c2d" },
+              { "u_at_om_location": "mansion_boarded_c2u" },
+              { "u_at_om_location": "mansion_c2u" },
+              { "u_at_om_location": "mansion_c2_roof" },
+              { "u_at_om_location": "mansion_boarded_c3" },
+              { "u_at_om_location": "mansion_c3" },
+              { "u_at_om_location": "mansion_c3d" },
+              { "u_at_om_location": "mansion_boarded_c3u" },
+              { "u_at_om_location": "mansion_c3u" },
+              { "u_at_om_location": "mansion_c3_roof" },
+              { "u_at_om_location": "mansion_boarded_c4" },
+              { "u_at_om_location": "mansion_c4" },
+              { "u_at_om_location": "mansion_c4d" },
+              { "u_at_om_location": "mansion_boarded_c4u" },
+              { "u_at_om_location": "mansion_c4u" },
+              { "u_at_om_location": "mansion_c4_roof" },
+              { "u_at_om_location": "mansion_c5" },
+              { "u_at_om_location": "mansion_c5d" },
+              { "u_at_om_location": "mansion_c5u" },
+              { "u_at_om_location": "mansion_c5_roof" },
+              { "u_at_om_location": "mansion_e1d" },
+              { "u_at_om_location": "mansion_boarded_e1u" },
+              { "u_at_om_location": "mansion_e1u" },
+              { "u_at_om_location": "mansion_e1_roof" },
+              { "u_at_om_location": "mansion_e2d" },
+              { "u_at_om_location": "mansion_e2u" },
+              { "u_at_om_location": "mansion_e2_roof" },
+              { "u_at_om_location": "mansion_t1" },
+              { "u_at_om_location": "mansion_t1d" },
+              { "u_at_om_location": "mansion_t1u" },
+              { "u_at_om_location": "mansion_t1_roof" },
+              { "u_at_om_location": "mansion_boarded_t2" },
+              { "u_at_om_location": "mansion_boarded_t2_start" },
+              { "u_at_om_location": "mansion_t2" },
+              { "u_at_om_location": "mansion_boarded_t2d" },
+              { "u_at_om_location": "mansion_boarded_t2d_start" },
+              { "u_at_om_location": "mansion_t2d" },
+              { "u_at_om_location": "mansion_boarded_t2u" },
+              { "u_at_om_location": "mansion_t2u" },
+              { "u_at_om_location": "mansion_t2_roof" },
+              { "u_at_om_location": "mansion_boarded_t4" },
+              { "u_at_om_location": "mansion_t4" },
+              { "u_at_om_location": "mansion_t4d" },
+              { "u_at_om_location": "mansion_boarded_t4u" },
+              { "u_at_om_location": "mansion_t4u" },
+              { "u_at_om_location": "mansion_t4_roof" },
+              { "u_at_om_location": "mansion_t5" },
+              { "u_at_om_location": "mansion_t5d" },
+              { "u_at_om_location": "mansion_t5u" },
+              { "u_at_om_location": "mansion_t5_roof" },
+              { "u_at_om_location": "mansion_t6" },
+              { "u_at_om_location": "mansion_t6d" },
+              { "u_at_om_location": "mansion_t6u" },
+              { "u_at_om_location": "mansion_t6_roof" },
+              { "u_at_om_location": "mansion_t7" },
+              { "u_at_om_location": "mansion_t7d" },
+              { "u_at_om_location": "mansion_t7u" },
+              { "u_at_om_location": "mansion_t7_roof" }
+            ]
+          }
+        }
+      ]
+    },
+    "effect": [ { "math": [ "u_brownie_homebody_speed_bonus", "--" ] }, { "math": [ "u_brownie_sense_intruders", "=", "0" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_BROWNIE_LEARN_CHEESE_AND_BUTTER",
+    "required_event": "gains_mutation",
+    "eoc_type": "EVENT",
+    "condition": { "compare_string": [ "BROWNIE_MAKE_CHEESE_AND_BUTTER", { "context_val": "trait" } ] },
+    "effect": [ { "u_learn_recipe": "cheese_hard_brownie" }, { "u_learn_recipe": "butter_brownie" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_BROWNIE_INDOOR_BLINK",
+    "condition": { "not": "u_is_outside" },
+    "effect": [
+      {
+        "u_location_variable": { "context_val": "brownie_teleport" },
+        "passable_only": true,
+        "min_radius": 5,
+        "max_radius": 10,
+        "true_eocs": [
+          {
+            "id": "EOC_BROWNIE_INDOOR_BLINK_SUCCESS",
+            "condition": { "map_terrain_with_flag": "INDOORS", "loc": { "context_val": "brownie_teleport" } },
+            "effect": [
+              { "u_teleport": { "context_val": "brownie_teleport" } },
+              { "u_message": "You carefully slip through the cracks.", "type": "good" }
+            ],
+            "false_effect": [ { "run_eocs": "EOC_BROWNIE_INDOOR_BLINK" } ]
+          }
+        ]
+      }
+    ],
+    "false_effect": { "u_message": "You must be indoors to slip through the cracks.", "type": "bad" }
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_POOKA_SHAPESHIFTING_MANA_CHECK",
     "condition": { "math": [ "u_val('mana')", ">=", "1" ] },
     "effect": [

--- a/data/mods/Xedra_Evolved/mutations/playable_changeling_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/playable_changeling_eocs.json
@@ -753,8 +753,27 @@
       ]
     },
     "effect": [
-      { "u_teleport": { "u_val": "brownie_home_teleport_loc" } },
-      { "u_message": "You slip through the door and head straight home.", "type": "good" }
+      { "math": [ "brownie_home_teleport", "=", "0" ] },
+      {
+        "u_run_monster_eocs": [
+          { "id": "EOC_BROWNIE_HOME_TELEPORT_SIGHT_CHECK_MONSTER", "effect": { "math": [ "brownie_home_teleport", "=", "1" ] } }
+        ],
+        "monster_range": 45,
+        "monster_must_see": true
+      },
+      {
+        "u_run_npc_eocs": [ { "id": "EOC_BROWNIE_HOME_TELEPORT_SIGHT_CHECK_NPC", "effect": { "math": [ "brownie_home_teleport", "=", "1" ] } } ],
+        "npc_range": 45,
+        "npc_must_see": true
+      },
+      {
+        "if": { "math": [ "brownie_home_teleport", "==", "0" ] },
+        "then": [
+          { "u_teleport": { "u_val": "brownie_home_teleport_loc" } },
+          { "u_message": "You slip through the door and head straight home.", "type": "good" }
+        ],
+        "else": { "u_message": "You must be unobserved to hurry home!", "type": "bad" }
+      }
     ],
     "false_effect": { "u_message": "You must be in a doorway to hurry home.", "type": "bad" }
   },

--- a/data/mods/Xedra_Evolved/recipes/changeling/brownie.json
+++ b/data/mods/Xedra_Evolved/recipes/changeling/brownie.json
@@ -1,0 +1,42 @@
+[
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "result": "butter",
+    "id_suffix": "brownie",
+    "category": "CC_FOOD",
+    "subcategory": "CSC_FOOD_OTHER",
+    "skill_used": "cooking",
+    "difficulty": 5,
+    "batch_time_factors": [ 95, 2 ],
+    "time": "15 m",
+    "qualities": [ { "id": "CHURN", "level": 1 } ],
+    "components": [ [ [ "milk", 5 ] ] ],
+    "charges": 99
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "result": "cheese_hard",
+    "id_suffix": "brownie",
+    "category": "CC_FOOD",
+    "subcategory": "CSC_FOOD_OTHER",
+    "skill_used": "cooking",
+    "difficulty": 5,
+    "time": "30 m",
+    "batch_time_factors": [ 50, 5 ],
+    "charges": 1,
+    "qualities": [
+      { "id": "CUT", "level": 2 },
+      { "id": "COOK", "level": 3 },
+      { "id": "CONTAIN", "level": 1 },
+      { "id": "STRAIN", "level": 2 }
+    ],
+    "proficiencies": [
+      { "proficiency": "prof_food_prep" },
+      { "proficiency": "prof_cheesemaking_1" },
+      { "proficiency": "prof_cheesemaking_2" }
+    ],
+    "components": [ [ [ "milk", 2 ] ], [ [ "salt", 1 ] ] ]
+  }
+]

--- a/data/mods/Xedra_Evolved/spells/changeling_spells.json
+++ b/data/mods/Xedra_Evolved/spells/changeling_spells.json
@@ -235,7 +235,7 @@
     "id": "changeling_teleport_home_spell",
     "type": "SPELL",
     "name": "Hurry Home",
-    "description": "You always know your home and can return to it at need.  When standing in a doorway, you can use this glamour to return to the last place you slept, as long as you spent at least a day at that place previously.",
+    "description": "You always know your home and can return to it at need.  When standing in a doorway, you can use this glamour to return to the last place you slept, as long as you spent at least a day at that place previously and as long as you are unobserved.",
     "flags": [ "NO_FAIL", "SOMATIC" ],
     "valid_targets": [ "self" ],
     "spell_class": "CHANGELING_MAGIC",

--- a/data/mods/Xedra_Evolved/spells/changeling_spells.json
+++ b/data/mods/Xedra_Evolved/spells/changeling_spells.json
@@ -230,5 +230,31 @@
         "max(( 150 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_BROWNIE') * 1) - (u_skill('deduction') * 4)), 50)"
       ]
     }
+  },
+  {
+    "id": "changeling_teleport_home_spell",
+    "type": "SPELL",
+    "name": "Hurry Home",
+    "description": "You always know your home and can return to it at need.  When standing in a doorway, you can use this glamour to return to the last place you slept, as long as you spent at least a day at that place previously.",
+    "flags": [ "NO_FAIL", "SOMATIC" ],
+    "valid_targets": [ "self" ],
+    "spell_class": "CHANGELING_MAGIC",
+    "difficulty": 9,
+    "skill": "deduction",
+    "max_level": 1,
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_BROWNIE_HOME_TELEPORT_ACTUAL_TELEPORT",
+    "shape": "blast",
+    "energy_source": "MANA",
+    "base_energy_cost": {
+      "math": [
+        "max(( 800 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_BROWNIE') * 10) - (u_skill('deduction') * 25)), 400)"
+      ]
+    },
+    "base_casting_time": {
+      "math": [
+        "max(( 100 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_BROWNIE') * 3) - (u_skill('deduction') * 5)), 25)"
+      ]
+    }
   }
 ]

--- a/data/mods/Xedra_Evolved/spells/changeling_spells.json
+++ b/data/mods/Xedra_Evolved/spells/changeling_spells.json
@@ -17,8 +17,8 @@
     "min_duration": { "math": [ "(changeling_common_traits() * 2250) + (u_skill('deduction') * 23400) + 35100" ] },
     "max_duration": { "math": [ "(changeling_common_traits() * 5750) + (u_skill('deduction') * 56300) + 78900" ] },
     "energy_source": "MANA",
-    "base_energy_cost": 75,
-    "base_casting_time": 50
+    "base_energy_cost": { "math": [ "max(( 150 - (changeling_common_traits() * 2) - (u_skill('deduction') * 3)), 50)" ] },
+    "base_casting_time": { "math": [ "max(( 100 - changeling_common_traits() - (u_skill('deduction') * 3)), 30)" ] }
   },
   {
     "id": "changeling_invisibility_spell",
@@ -38,8 +38,8 @@
     "min_duration": { "math": [ "(changeling_common_traits() * 50) + (u_skill('deduction') * 500) + 2600" ] },
     "max_duration": { "math": [ "(changeling_common_traits() * 163) + (u_skill('deduction') * 1200) + 13900" ] },
     "energy_source": "MANA",
-    "base_energy_cost": 450,
-    "base_casting_time": 150
+    "base_energy_cost": { "math": [ "max(( 750 - (changeling_common_traits() * 5) - (u_skill('deduction') * 20)), 350)" ] },
+    "base_casting_time": { "math": [ "max(( 250 - (changeling_common_traits() * 3) - (u_skill('deduction') * 8)), 50)" ] }
   },
   {
     "id": "changeling_summon_will_o_the_wisps_spell",
@@ -65,8 +65,8 @@
     "min_aoe": 3,
     "max_aoe": 3,
     "energy_source": "MANA",
-    "base_energy_cost": 150,
-    "base_casting_time": 75
+    "base_energy_cost": { "math": [ "max(( 300 - (changeling_common_traits() * 3) - (u_skill('deduction') * 10)), 100)" ] },
+    "base_casting_time": { "math": [ "max(( 100 - changeling_common_traits() - (u_skill('deduction') * 3)), 50)" ] }
   },
   {
     "id": "changeling_noble_cure_bad_conditions_spell",
@@ -202,6 +202,33 @@
     },
     "base_casting_time": {
       "math": [ "max(( 400 - (u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 8) - (u_skill('deduction') * 15)), 150)" ]
+    }
+  },
+  {
+    "id": "changeling_brownie_blink_indoors_spell",
+    "type": "SPELL",
+    "name": "Slip Through the Cracks",
+    "description": "When in danger of being discovered, brownies can slip away in moments.  This glamour allows you to vanish and reappear elsewhere in the house.  It cannot be used outdoors.",
+    "message": "",
+    "flags": [ "NO_FAIL", "SOMATIC" ],
+    "valid_targets": [ "self" ],
+    "spell_class": "CHANGELING_MAGIC",
+    "difficulty": 7,
+    "skill": "deduction",
+    "max_level": 1,
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_BROWNIE_INDOOR_BLINK",
+    "shape": "blast",
+    "energy_source": "MANA",
+    "base_energy_cost": {
+      "math": [
+        "max(( 500 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_BROWNIE') * 3) - (u_skill('deduction') * 15)), 250)"
+      ]
+    },
+    "base_casting_time": {
+      "math": [
+        "max(( 150 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_BROWNIE') * 1) - (u_skill('deduction') * 4)), 50)"
+      ]
     }
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Xedra Evolved] Add more Brownie changeling traits +bugfixes"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Add more traits to brownies
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add more traits. 

- Growing hair. Folklore often depicts brownies covered with hair
- Recipes to easily turn milk straight into cheese or butter
- Homebody: A speed boost the longer you stay inside a single place. This goes down if you're outdoors and pass across an OMT boundary. Mansions and faction camps do not reduce this bonus even though they're multiple OMTs, some of which are outdoors. 
- sense Intruders: If you're getting the speed bonus, you can sense nearby creatures.
- Slip Through the Cracks, a blink spell that only works indoors and only takes you to another place indoors.
- Hurry Home, a spell that can only be cast on a doorway out of sight of from enemies but returns you to the last place you slept (defined as "the last place you slept with a high enough Homebody speed boost", so if you crash out in a random building it shouldn't reset the location). 
- Cold Tolerance (3 levels, ending up with being able to be naked in winter).

I also fixed several bugs here and there related to trait prerequisites to prevent trait downgrading. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Traits work. 

Spells work.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Based on how long the EoC thinks before doing hurry home (not super long but still obvious computation time), adapting that for crafting unobserved and running it even every minute is not a good idea.

Going to keep this small and add more Brownie traits when I think of them (already thought of a couple --opening locked doors as long as you're unobserved, and being able to repair nearly anything as long as you have a hammer, a needle and thread, and some odds and ends).
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
