### PR TITLE
[Magiclysm] Add `NO_SPELLCASTING` flag to magic-using monster conditions

### DIFF
--- a/data/mods/Magiclysm/monsters/feral_wizards.json
+++ b/data/mods/Magiclysm/monsters/feral_wizards.json
@@ -34,7 +34,9 @@
         "type": "spell",
         "spell_data": { "id": "spell_feral_wizard_base" },
         "monster_message": "%1$s chants and gestures erratically!",
-        "condition": { "not": { "u_has_flag": "MUTE" } },
+        "condition": {
+          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
+        },
         "cooldown": 10
       },
       [ "BROWSE", 100 ],
@@ -94,7 +96,9 @@
         "damage_max_instance": [ { "damage_type": "nether", "amount": 7 } ],
         "dodgeable": false,
         "blockable": false,
-        "condition": { "not": { "u_has_flag": "MUTE" } },
+        "condition": {
+          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
+        },
         "hit_dmg_u": "%1$s screams words of magic and an eldritch bolt impacts your %2$s!",
         "hit_dmg_npc": "%1$s screams words of magic and an eldritch bolt impacts <npcname>'s %2$s!",
         "miss_msg_u": "%1$s screams words of magic and you narrowly avoid an eldritch bolt!",
@@ -107,6 +111,7 @@
         "type": "spell",
         "spell_data": { "id": "blinding_flash", "min_level": 0 },
         "cooldown": 15,
+        "condition": { "not": { "u_has_flag": "NO_SPELLCASTING" } },
         "monster_message": "%1$s gestures and light explodes everywhere!"
       },
       {
@@ -118,7 +123,9 @@
         "range": 8,
         "throw_strength": 40,
         "blockable": false,
-        "condition": { "not": { "u_has_flag": "MUTE" } },
+        "condition": {
+          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
+        },
         "hit_dmg_u": "%1$s gestures at you and a powerful force hurls you through the air!",
         "hit_dmg_npc": "%1$s gestures at <npcname> and a powerful force hurls them through the air!",
         "miss_msg_u": "%s gestures at you, and you feel a crushing pressure for a moment before the feeling vanishes!",
@@ -171,6 +178,7 @@
         "type": "spell",
         "spell_data": { "id": "stormshaper_wall_of_fog", "min_level": 3 },
         "cooldown": 15,
+        "condition": { "not": { "u_has_flag": "NO_SPELLCASTING" } },
         "monster_message": "%1$s gestures and a sudden force slams you to the ground!"
       },
       {
@@ -178,7 +186,9 @@
         "type": "spell",
         "spell_data": { "id": "feral_rad_mage_rad_spell", "min_level": 5 },
         "cooldown": 25,
-        "condition": { "not": { "u_has_flag": "MUTE" } },
+        "condition": {
+          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
+        },
         "monster_message": "%1$s makes arcane motions and the air is filled with burning gas!"
       },
       {
@@ -186,7 +196,9 @@
         "type": "spell",
         "spell_data": { "id": "mirror_image_rad_mage", "min_level": 0 },
         "cooldown": 15,
-        "condition": { "not": { "u_has_flag": "MUTE" } },
+        "condition": {
+          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
+        },
         "monster_message": "%1$s smiles and duplicates appear!"
       },
       {
@@ -194,7 +206,9 @@
         "type": "spell",
         "spell_data": { "id": "feral_rad_mage_summon_spell", "min_level": 0 },
         "cooldown": 30,
-        "condition": { "not": { "u_has_flag": "MUTE" } },
+        "condition": {
+          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
+        },
         "monster_message": "%1$s intones words of power and a corpse claws its way out of the ground!"
       },
       {
@@ -202,7 +216,9 @@
         "type": "spell",
         "spell_data": { "id": "disjunction_monster", "min_level": 8 },
         "cooldown": 50,
-        "condition": { "not": { "u_has_flag": "MUTE" } },
+        "condition": {
+          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
+        },
         "monster_message": "%1$s waves their hands in a gesture of negation!"
       },
       [ "BROWSE", 100 ],
@@ -267,7 +283,9 @@
         "type": "spell",
         "spell_data": { "id": "monster_heal_spell", "min_level": 10, "hit_self": true },
         "cooldown": 25,
-        "condition": { "not": { "u_has_flag": "MUTE" } },
+        "condition": {
+          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
+        },
         "monster_message": "%1$s weaves their hands in a complicated gesture!"
       },
       {
@@ -280,7 +298,9 @@
         "damage_max_instance": [ { "damage_type": "bash", "amount": 12 } ],
         "dodgeable": true,
         "blockable": false,
-        "condition": { "not": { "u_has_flag": "MUTE" } },
+        "condition": {
+          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
+        },
         "hit_dmg_u": "%1$s screams words of magic and jagged shards of wood impact your %2$s!",
         "hit_dmg_npc": "%1$s screams words of magic and jagged shards of wood impact <npcname>'s %2$s!",
         "miss_msg_u": "%1$s screams words of magic and you narrowly avoid jagged shards of wood!",
@@ -293,7 +313,9 @@
         "type": "spell",
         "spell_data": { "id": "druid_veggrasp", "min_level": 5 },
         "cooldown": 35,
-        "condition": { "not": { "u_has_flag": "MUTE" } },
+        "condition": {
+          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
+        },
         "monster_message": "%1$s waves their hands and roots burst from the ground around you!"
       },
       [ "BROWSE", 100 ],
@@ -345,7 +367,9 @@
         "type": "spell",
         "spell_data": { "id": "monster_heal_spell", "min_level": 25, "hit_self": true },
         "cooldown": 20,
-        "condition": { "not": { "u_has_flag": "MUTE" } },
+        "condition": {
+          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
+        },
         "monster_message": "%1$s weaves their hands in a complicated gesture!"
       },
       {
@@ -359,7 +383,9 @@
         "effects": [ { "id": "root_impale", "duration": 60, "chance": 100, "affect_hit_bp": false } ],
         "dodgeable": true,
         "blockable": false,
-        "condition": { "not": { "u_has_flag": "MUTE" } },
+        "condition": {
+          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
+        },
         "hit_dmg_u": "%1$s screams words of magic and sharp roots thrust from the ground into your %2$s!",
         "hit_dmg_npc": "%1$s screams words of magic and sharp roots thrust from the ground into <npcname>'s %2$s!",
         "miss_msg_u": "%1$s screams words of magic and you narrowly avoid sharp roots thrusting from the ground!",
@@ -372,7 +398,9 @@
         "type": "spell",
         "spell_data": { "id": "druid_veggrasp", "min_level": 5 },
         "cooldown": 25,
-        "condition": { "not": { "u_has_flag": "MUTE" } },
+        "condition": {
+          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
+        },
         "monster_message": "%1$s waves their hands and roots burst from the ground around you!"
       },
       {
@@ -380,7 +408,9 @@
         "type": "spell",
         "spell_data": { "id": "summon_wolf_druid_monster", "min_level": 10 },
         "cooldown": 45,
-        "condition": { "not": { "u_has_flag": "MUTE" } },
+        "condition": {
+          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
+        },
         "monster_message": "%1$s throws back their head and howls!"
       },
       [ "BROWSE", 100 ],
@@ -443,6 +473,7 @@
         "effects_require_dmg": false,
         "dodgeable": false,
         "blockable": false,
+        "condition": { "not": { "u_has_flag": "NO_SPELLCASTING" } }
         "hit_dmg_u": "%1$s stomps heavily and the ground shakes!",
         "hit_dmg_npc": "%1$s stomps heavily and the ground shakes!",
         "miss_msg_u": "%1$s stomps heavily and the ground shakes!",
@@ -458,12 +489,13 @@
         "move_cost": 100,
         "range": 12,
         "damage_max_instance": [ { "damage_type": "bash", "amount": 25 } ],
-        "hit_dmg_u": "%1$s rumbles words of magic and heavy chunks of rock impact your %2$s!",
-        "hit_dmg_npc": "%1$s rumbles words of magic and heavy chunks of rock impact <npcname>'s %2$s!",
-        "miss_msg_u": "%1$s rumbles words of magic and you narrowly avoid heavy chunks of rock!",
-        "miss_msg_npc": "%1$s rumbles words of magic and <npcname> narrowly avoids heavy chunks of rock!",
-        "no_dmg_msg_u": "%1$s rumbles words of magic your %2$s is impacted by heavy chunks of rock, but they do no damage.",
-        "no_dmg_msg_npc": "%1$s rumbles words of magic and <npcname>'s %2$s is impacted by heavy chunks of rock, but they do no damage."
+        "condition": { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+        "hit_dmg_u": "%1$s makes a throwing gesture and heavy chunks of rock impact your %2$s!",
+        "hit_dmg_npc": "%1$s makes a throwing gesture and heavy chunks of rock impact <npcname>'s %2$s!",
+        "miss_msg_u": "%1$s makes a throwing gesture and you narrowly avoid heavy chunks of rock!",
+        "miss_msg_npc": "%1$s makes a throwing gesture and <npcname> narrowly avoids heavy chunks of rock!",
+        "no_dmg_msg_u": "%1$s makes a throwing gesture your %2$s is impacted by heavy chunks of rock, but they do no damage.",
+        "no_dmg_msg_npc": "%1$s makes a throwing gesture and <npcname>'s %2$s is impacted by heavy chunks of rock, but they do no damage."
       },
       [ "BROWSE", 100 ],
       [ "EAT_FOOD", 100 ]
@@ -522,6 +554,7 @@
         "effects_require_dmg": false,
         "dodgeable": false,
         "blockable": false,
+        "condition": { "not": { "u_has_flag": "NO_SPELLCASTING" } },
         "hit_dmg_u": "%1$s stomps heavily and the ground shakes!",
         "hit_dmg_npc": "%1$s stomps heavily and the ground shakes!",
         "miss_msg_u": "%1$s stomps heavily and the ground shakes!",
@@ -537,12 +570,13 @@
         "move_cost": 100,
         "range": 12,
         "damage_max_instance": [ { "damage_type": "bash", "amount": 35 } ],
-        "hit_dmg_u": "%1$s rumbles words of magic and heavy chunks of rock impact your %2$s!",
-        "hit_dmg_npc": "%1$s rumbles words of magic and heavy chunks of rock impact <npcname>'s %2$s!",
-        "miss_msg_u": "%1$s rumbles words of magic and you narrowly avoid heavy chunks of rock!",
-        "miss_msg_npc": "%1$s rumbles words of magic and <npcname> narrowly avoids heavy chunks of rock!",
-        "no_dmg_msg_u": "%1$s rumbles words of magic and your %2$s is impacted by heavy chunks of rock, but they do no damage.",
-        "no_dmg_msg_npc": "%1$s rumbles words of magic and <npcname>'s %2$s is impacted by heavy chunks of rock, but they do no damage."
+        "condition": { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+        "hit_dmg_u": "%1$s makes a throwing gesture and heavy chunks of rock impact your %2$s!",
+        "hit_dmg_npc": "%1$s makes a throwing gesture and heavy chunks of rock impact <npcname>'s %2$s!",
+        "miss_msg_u": "%1$s makes a throwing gesture and you narrowly avoid heavy chunks of rock!",
+        "miss_msg_npc": "%1$s makes a throwing gesture and <npcname> narrowly avoids heavy chunks of rock!",
+        "no_dmg_msg_u": "%1$s makes a throwing gesture your %2$s is impacted by heavy chunks of rock, but they do no damage.",
+        "no_dmg_msg_npc": "%1$s makes a throwing gesture and <npcname>'s %2$s is impacted by heavy chunks of rock, but they do no damage."
       },
       {
         "type": "monster_attack",
@@ -626,7 +660,9 @@
         "damage_max_instance": [ { "damage_type": "nether", "amount": 9 } ],
         "dodgeable": false,
         "blockable": false,
-        "condition": { "not": { "u_has_flag": "MUTE" } },
+        "condition": {
+          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
+        },
         "hit_dmg_u": "%1$s screams words of magic and an eldritch bolt impacts your %2$s!",
         "hit_dmg_npc": "%1$s screams words of magic and an eldritch bolt impacts <npcname>'s %2$s!",
         "miss_msg_u": "%1$s screams words of magic and you narrowly avoid an eldritch bolt!",
@@ -639,7 +675,9 @@
         "type": "spell",
         "spell_data": { "id": "dispel_magic_monster", "min_level": 5 },
         "cooldown": 30,
-        "condition": { "not": { "u_has_flag": "MUTE" } },
+        "condition": {
+          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
+        },
         "monster_message": "%1$s screams words of magic."
       },
       {
@@ -647,7 +685,9 @@
         "type": "spell",
         "spell_data": { "id": "magus_light_target", "min_level": 5 },
         "cooldown": 15,
-        "condition": { "not": { "u_has_flag": "MUTE" } },
+        "condition": {
+          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
+        },
         "monster_message": "%1$s screams words of magic and waves their hands."
       },
       {
@@ -655,7 +695,8 @@
         "type": "spell",
         "spell_data": { "id": "phase_door", "min_level": 6 },
         "cooldown": 15,
-        "monster_message": "%1$s screams words of magic and disappears."
+        "condition": { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+        "monster_message": "%1$s makes a quick gesture and disappears."
       },
       [ "BROWSE", 100 ],
       [ "EAT_FOOD", 100 ]
@@ -706,7 +747,9 @@
         "range": 15,
         "damage_max_instance": [ { "damage_type": "nether", "amount": 30 } ],
         "blockable": false,
-        "condition": { "not": { "u_has_flag": "MUTE" } },
+        "condition": {
+          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
+        },
         "hit_dmg_u": "%1$s screams words of magic and an eldritch bolt impacts your %2$s!",
         "hit_dmg_npc": "%1$s screams words of magic and an eldritch bolt impacts <npcname>'s %2$s!",
         "miss_msg_u": "%1$s screams words of magic and you narrowly avoid an eldritch bolt!",
@@ -719,6 +762,9 @@
         "type": "spell",
         "spell_data": { "id": "dispel_magic_monster", "min_level": 5 },
         "cooldown": 30,
+        "condition": {
+          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
+        },
         "monster_message": "%1$s screams words of magic."
       },
       {
@@ -726,7 +772,9 @@
         "type": "spell",
         "spell_data": { "id": "magus_light_target", "min_level": 5 },
         "cooldown": 15,
-        "condition": { "not": { "u_has_flag": "MUTE" } },
+        "condition": {
+          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
+        },
         "monster_message": "%1$s screams words of magic and waves their hands."
       },
       {
@@ -734,7 +782,9 @@
         "type": "spell",
         "spell_data": { "id": "magus_slow", "min_level": 3 },
         "cooldown": 35,
-        "condition": { "not": { "u_has_flag": "MUTE" } },
+        "condition": {
+          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
+        },
         "monster_message": "%1$s screams words of magic and the world suddenly starts moving much slower."
       },
       {
@@ -742,15 +792,18 @@
         "type": "spell",
         "spell_data": { "id": "phase_door", "min_level": 10 },
         "cooldown": 15,
-        "condition": { "not": { "u_has_flag": "MUTE" } },
-        "monster_message": "%1$s screams words of magic and disappears."
+        "condition": { "not": { "u_has_flag": "NO_SPELLCASTING" } },
+        "monster_message": "%1$s makes a quick gesture and disappears."
       },
       {
         "id": "feral_high_magus_silence",
         "type": "spell",
         "spell_data": { "id": "magus_silence", "min_level": 5 },
         "cooldown": 25,
-        "monster_message": "%1$s screams words of magic and disappears."
+        "condition": {
+          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
+        },
+        "monster_message": "%1$s screams words of magic."
       },
       [ "BROWSE", 100 ],
       [ "EAT_FOOD", 100 ]

--- a/data/mods/Magiclysm/monsters/feral_wizards.json
+++ b/data/mods/Magiclysm/monsters/feral_wizards.json
@@ -34,9 +34,7 @@
         "type": "spell",
         "spell_data": { "id": "spell_feral_wizard_base" },
         "monster_message": "%1$s chants and gestures erratically!",
-        "condition": {
-          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
-        },
+        "condition": { "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ] },
         "cooldown": 10
       },
       [ "BROWSE", 100 ],
@@ -96,9 +94,7 @@
         "damage_max_instance": [ { "damage_type": "nether", "amount": 7 } ],
         "dodgeable": false,
         "blockable": false,
-        "condition": {
-          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
-        },
+        "condition": { "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ] },
         "hit_dmg_u": "%1$s screams words of magic and an eldritch bolt impacts your %2$s!",
         "hit_dmg_npc": "%1$s screams words of magic and an eldritch bolt impacts <npcname>'s %2$s!",
         "miss_msg_u": "%1$s screams words of magic and you narrowly avoid an eldritch bolt!",
@@ -123,9 +119,7 @@
         "range": 8,
         "throw_strength": 40,
         "blockable": false,
-        "condition": {
-          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
-        },
+        "condition": { "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ] },
         "hit_dmg_u": "%1$s gestures at you and a powerful force hurls you through the air!",
         "hit_dmg_npc": "%1$s gestures at <npcname> and a powerful force hurls them through the air!",
         "miss_msg_u": "%s gestures at you, and you feel a crushing pressure for a moment before the feeling vanishes!",
@@ -186,9 +180,7 @@
         "type": "spell",
         "spell_data": { "id": "feral_rad_mage_rad_spell", "min_level": 5 },
         "cooldown": 25,
-        "condition": {
-          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
-        },
+        "condition": { "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ] },
         "monster_message": "%1$s makes arcane motions and the air is filled with burning gas!"
       },
       {
@@ -196,9 +188,7 @@
         "type": "spell",
         "spell_data": { "id": "mirror_image_rad_mage", "min_level": 0 },
         "cooldown": 15,
-        "condition": {
-          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
-        },
+        "condition": { "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ] },
         "monster_message": "%1$s smiles and duplicates appear!"
       },
       {
@@ -206,9 +196,7 @@
         "type": "spell",
         "spell_data": { "id": "feral_rad_mage_summon_spell", "min_level": 0 },
         "cooldown": 30,
-        "condition": {
-          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
-        },
+        "condition": { "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ] },
         "monster_message": "%1$s intones words of power and a corpse claws its way out of the ground!"
       },
       {
@@ -216,9 +204,7 @@
         "type": "spell",
         "spell_data": { "id": "disjunction_monster", "min_level": 8 },
         "cooldown": 50,
-        "condition": {
-          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
-        },
+        "condition": { "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ] },
         "monster_message": "%1$s waves their hands in a gesture of negation!"
       },
       [ "BROWSE", 100 ],
@@ -283,9 +269,7 @@
         "type": "spell",
         "spell_data": { "id": "monster_heal_spell", "min_level": 10, "hit_self": true },
         "cooldown": 25,
-        "condition": {
-          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
-        },
+        "condition": { "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ] },
         "monster_message": "%1$s weaves their hands in a complicated gesture!"
       },
       {
@@ -298,9 +282,7 @@
         "damage_max_instance": [ { "damage_type": "bash", "amount": 12 } ],
         "dodgeable": true,
         "blockable": false,
-        "condition": {
-          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
-        },
+        "condition": { "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ] },
         "hit_dmg_u": "%1$s screams words of magic and jagged shards of wood impact your %2$s!",
         "hit_dmg_npc": "%1$s screams words of magic and jagged shards of wood impact <npcname>'s %2$s!",
         "miss_msg_u": "%1$s screams words of magic and you narrowly avoid jagged shards of wood!",
@@ -313,9 +295,7 @@
         "type": "spell",
         "spell_data": { "id": "druid_veggrasp", "min_level": 5 },
         "cooldown": 35,
-        "condition": {
-          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
-        },
+        "condition": { "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ] },
         "monster_message": "%1$s waves their hands and roots burst from the ground around you!"
       },
       [ "BROWSE", 100 ],
@@ -367,9 +347,7 @@
         "type": "spell",
         "spell_data": { "id": "monster_heal_spell", "min_level": 25, "hit_self": true },
         "cooldown": 20,
-        "condition": {
-          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
-        },
+        "condition": { "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ] },
         "monster_message": "%1$s weaves their hands in a complicated gesture!"
       },
       {
@@ -383,9 +361,7 @@
         "effects": [ { "id": "root_impale", "duration": 60, "chance": 100, "affect_hit_bp": false } ],
         "dodgeable": true,
         "blockable": false,
-        "condition": {
-          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
-        },
+        "condition": { "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ] },
         "hit_dmg_u": "%1$s screams words of magic and sharp roots thrust from the ground into your %2$s!",
         "hit_dmg_npc": "%1$s screams words of magic and sharp roots thrust from the ground into <npcname>'s %2$s!",
         "miss_msg_u": "%1$s screams words of magic and you narrowly avoid sharp roots thrusting from the ground!",
@@ -398,9 +374,7 @@
         "type": "spell",
         "spell_data": { "id": "druid_veggrasp", "min_level": 5 },
         "cooldown": 25,
-        "condition": {
-          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
-        },
+        "condition": { "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ] },
         "monster_message": "%1$s waves their hands and roots burst from the ground around you!"
       },
       {
@@ -408,9 +382,7 @@
         "type": "spell",
         "spell_data": { "id": "summon_wolf_druid_monster", "min_level": 10 },
         "cooldown": 45,
-        "condition": {
-          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
-        },
+        "condition": { "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ] },
         "monster_message": "%1$s throws back their head and howls!"
       },
       [ "BROWSE", 100 ],
@@ -473,7 +445,7 @@
         "effects_require_dmg": false,
         "dodgeable": false,
         "blockable": false,
-        "condition": { "not": { "u_has_flag": "NO_SPELLCASTING" } }
+        "condition": { "not": { "u_has_flag": "NO_SPELLCASTING" } },
         "hit_dmg_u": "%1$s stomps heavily and the ground shakes!",
         "hit_dmg_npc": "%1$s stomps heavily and the ground shakes!",
         "miss_msg_u": "%1$s stomps heavily and the ground shakes!",
@@ -660,9 +632,7 @@
         "damage_max_instance": [ { "damage_type": "nether", "amount": 9 } ],
         "dodgeable": false,
         "blockable": false,
-        "condition": {
-          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
-        },
+        "condition": { "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ] },
         "hit_dmg_u": "%1$s screams words of magic and an eldritch bolt impacts your %2$s!",
         "hit_dmg_npc": "%1$s screams words of magic and an eldritch bolt impacts <npcname>'s %2$s!",
         "miss_msg_u": "%1$s screams words of magic and you narrowly avoid an eldritch bolt!",
@@ -675,9 +645,7 @@
         "type": "spell",
         "spell_data": { "id": "dispel_magic_monster", "min_level": 5 },
         "cooldown": 30,
-        "condition": {
-          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
-        },
+        "condition": { "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ] },
         "monster_message": "%1$s screams words of magic."
       },
       {
@@ -685,9 +653,7 @@
         "type": "spell",
         "spell_data": { "id": "magus_light_target", "min_level": 5 },
         "cooldown": 15,
-        "condition": {
-          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
-        },
+        "condition": { "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ] },
         "monster_message": "%1$s screams words of magic and waves their hands."
       },
       {
@@ -747,9 +713,7 @@
         "range": 15,
         "damage_max_instance": [ { "damage_type": "nether", "amount": 30 } ],
         "blockable": false,
-        "condition": {
-          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
-        },
+        "condition": { "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ] },
         "hit_dmg_u": "%1$s screams words of magic and an eldritch bolt impacts your %2$s!",
         "hit_dmg_npc": "%1$s screams words of magic and an eldritch bolt impacts <npcname>'s %2$s!",
         "miss_msg_u": "%1$s screams words of magic and you narrowly avoid an eldritch bolt!",
@@ -762,9 +726,7 @@
         "type": "spell",
         "spell_data": { "id": "dispel_magic_monster", "min_level": 5 },
         "cooldown": 30,
-        "condition": {
-          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
-        },
+        "condition": { "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ] },
         "monster_message": "%1$s screams words of magic."
       },
       {
@@ -772,9 +734,7 @@
         "type": "spell",
         "spell_data": { "id": "magus_light_target", "min_level": 5 },
         "cooldown": 15,
-        "condition": {
-          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
-        },
+        "condition": { "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ] },
         "monster_message": "%1$s screams words of magic and waves their hands."
       },
       {
@@ -782,9 +742,7 @@
         "type": "spell",
         "spell_data": { "id": "magus_slow", "min_level": 3 },
         "cooldown": 35,
-        "condition": {
-          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
-        },
+        "condition": { "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ] },
         "monster_message": "%1$s screams words of magic and the world suddenly starts moving much slower."
       },
       {
@@ -800,9 +758,7 @@
         "type": "spell",
         "spell_data": { "id": "magus_silence", "min_level": 5 },
         "cooldown": 25,
-        "condition": {
-          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
-        },
+        "condition": { "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ] },
         "monster_message": "%1$s screams words of magic."
       },
       [ "BROWSE", 100 ],

--- a/data/mods/Magiclysm/monsters/feral_wizards.json
+++ b/data/mods/Magiclysm/monsters/feral_wizards.json
@@ -759,7 +759,7 @@
         "spell_data": { "id": "magus_silence", "min_level": 5 },
         "cooldown": 25,
         "condition": { "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ] },
-        "monster_message": "%1$s screams words of magic."
+        "monster_message": "%1$s screams words of magic and the sounds around you grow muffled."
       },
       [ "BROWSE", 100 ],
       [ "EAT_FOOD", 100 ]

--- a/data/mods/Magiclysm/monsters/goblin.json
+++ b/data/mods/Magiclysm/monsters/goblin.json
@@ -169,9 +169,7 @@
         "uncanny_dodgeable": true,
         "dodgeable": false,
         "blockable": false,
-        "condition": {
-          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
-        },
+        "condition": { "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ] },
         "hit_dmg_u": "%1$s chatters words of magic and your %2$s is surrounded by a cloud of scratching thorns!",
         "hit_dmg_npc": "%1$s chatters words of magic and <npcname>'s %2$s is surrounded by a cloud of scratching thorns!",
         "miss_msg_u": "%1$s chatters words of magic and you narrowly avoid a cloud of scratching thorns!",

--- a/data/mods/Magiclysm/monsters/goblin.json
+++ b/data/mods/Magiclysm/monsters/goblin.json
@@ -190,9 +190,7 @@
         "type": "spell",
         "spell_data": { "id": "monster_ranged_gas_attack", "min_level": 5 },
         "cooldown": 30,
-        "condition": {
-          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
-        },
+        "condition": { "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ] },
         "monster_message": "%1$s waves their hands and %1$s is surrounded in greenish vapors."
       }
     ],

--- a/data/mods/Magiclysm/monsters/goblin.json
+++ b/data/mods/Magiclysm/monsters/goblin.json
@@ -169,6 +169,9 @@
         "uncanny_dodgeable": true,
         "dodgeable": false,
         "blockable": false,
+        "condition": {
+          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
+        },
         "hit_dmg_u": "%1$s chatters words of magic and your %2$s is surrounded by a cloud of scratching thorns!",
         "hit_dmg_npc": "%1$s chatters words of magic and <npcname>'s %2$s is surrounded by a cloud of scratching thorns!",
         "miss_msg_u": "%1$s chatters words of magic and you narrowly avoid a cloud of scratching thorns!",
@@ -181,6 +184,9 @@
         "type": "spell",
         "spell_data": { "id": "druid_veggrasp", "min_level": 5 },
         "cooldown": 20,
+        "condition": {
+          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
+        },
         "monster_message": "%1$s waves their hands and roots burst from the ground around you!"
       },
       {
@@ -188,6 +194,9 @@
         "type": "spell",
         "spell_data": { "id": "monster_ranged_gas_attack", "min_level": 5 },
         "cooldown": 30,
+        "condition": {
+          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
+        },
         "monster_message": "%1$s waves their hands and %1$s is surrounded in greenish vapors."
       }
     ],

--- a/data/mods/Magiclysm/monsters/goblin.json
+++ b/data/mods/Magiclysm/monsters/goblin.json
@@ -182,9 +182,7 @@
         "type": "spell",
         "spell_data": { "id": "druid_veggrasp", "min_level": 5 },
         "cooldown": 20,
-        "condition": {
-          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
-        },
+        "condition": { "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ] },
         "monster_message": "%1$s waves their hands and roots burst from the ground around you!"
       },
       {

--- a/data/mods/Magiclysm/monsters/lizardfolk.json
+++ b/data/mods/Magiclysm/monsters/lizardfolk.json
@@ -92,14 +92,12 @@
     "melee_skill": 3,
     "melee_dice": 2,
     "melee_dice_sides": 6,
-    "special_attacks": [ 
-      { 
-        "type": "spell", 
-        "spell_data": { "id": "spell_shaman_base" }, 
-        "condition": {
-          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
-        },
-        "cooldown": 10 
+    "special_attacks": [
+      {
+        "type": "spell",
+        "spell_data": { "id": "spell_shaman_base" },
+        "condition": { "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ] },
+        "cooldown": 10
       },
       [ "scratch", 5 ]
     ],

--- a/data/mods/Magiclysm/monsters/lizardfolk.json
+++ b/data/mods/Magiclysm/monsters/lizardfolk.json
@@ -92,7 +92,17 @@
     "melee_skill": 3,
     "melee_dice": 2,
     "melee_dice_sides": 6,
-    "special_attacks": [ { "type": "spell", "spell_data": { "id": "spell_shaman_base" }, "cooldown": 10 }, [ "scratch", 5 ] ],
+    "special_attacks": [ 
+      { 
+        "type": "spell", 
+        "spell_data": { "id": "spell_shaman_base" }, 
+        "condition": {
+          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
+        },
+        "cooldown": 10 
+      },
+      [ "scratch", 5 ]
+    ],
     "death_drops": {
       "subtype": "distribution",
       "items": [

--- a/data/mods/Magiclysm/monsters/mi-go.json
+++ b/data/mods/Magiclysm/monsters/mi-go.json
@@ -45,6 +45,7 @@
         "type": "spell",
         "spell_data": { "id": "migo_fleshwarper_blood_poison_spell", "min_level": 5 },
         "cooldown": 20,
+        "condition": { "not": { "u_has_flag": "NO_SPELLCASTING" } },
         "monster_message": "%1$s's numerous antennae move rhythmically for a moment."
       },
       {
@@ -52,6 +53,7 @@
         "type": "spell",
         "spell_data": { "id": "monster_heal_spell", "hit_self": true, "min_level": 15 },
         "cooldown": 30,
+        "condition": { "not": { "u_has_flag": "NO_SPELLCASTING" } },
         "monster_message": "%1$s's numerous antennae twitch in all directions for a moment."
       },
       {
@@ -59,6 +61,7 @@
         "type": "spell",
         "spell_data": { "id": "migo_fleshwarper_mutate", "min_level": 1 },
         "cooldown": 50,
+        "condition": { "not": { "u_has_flag": "NO_SPELLCASTING" } },
         "monster_message": "As %1$s touches %3$s, the flesh warps and twists!"
       }
     ],
@@ -119,6 +122,7 @@
         "type": "spell",
         "spell_data": { "id": "sorcerer_hand_monster", "min_level": 2 },
         "cooldown": 15,
+        "condition": { "not": { "u_has_flag": "NO_SPELLCASTING" } },
         "monster_message": "%1$s twitches its antennae at %3$s and %3$s is lifted up and pulled towards them!"
       },
       {
@@ -126,6 +130,7 @@
         "type": "spell",
         "spell_data": { "id": "teleport_anchor_monster", "min_level": 4 },
         "cooldown": 30,
+        "condition": { "not": { "u_has_flag": "NO_SPELLCASTING" } },
         "monster_message": "%1$s's numerous antennae sync their movements for a brief moment."
       },
       {
@@ -133,6 +138,7 @@
         "type": "spell",
         "spell_data": { "id": "migo_nethermancer_summon_nether", "min_level": 0 },
         "cooldown": 40,
+        "condition": { "not": { "u_has_flag": "NO_SPELLCASTING" } },
         "monster_message": "%1$s's numerous antennae weave in a complicated pattern."
       },
       {
@@ -140,6 +146,7 @@
         "type": "spell",
         "spell_data": { "id": "dispel_magic_monster", "min_level": 8 },
         "cooldown": 30,
+        "condition": { "not": { "u_has_flag": "NO_SPELLCASTING" } },
         "monster_message": "%1$s numerous antennae point directly at %3$s."
       }
     ],

--- a/data/mods/Magiclysm/monsters/ogre.json
+++ b/data/mods/Magiclysm/monsters/ogre.json
@@ -93,9 +93,7 @@
         "damage_max_instance": [ { "damage_type": "nether", "amount": 25 } ],
         "dodgeable": true,
         "blockable": false,
-        "condition": {
-          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
-        },
+        "condition": { "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ] },
         "hit_dmg_u": "%1$s rumbles words of magic and an eldritch bolt impacts your %2$s!",
         "hit_dmg_npc": "%1$s rumbles words of magic and an eldritch bolt impacts <npcname>'s %2$s!",
         "miss_msg_u": "%1$s rumbles words of magic and you narrowly avoid an eldritch bolt!",

--- a/data/mods/Magiclysm/monsters/ogre.json
+++ b/data/mods/Magiclysm/monsters/ogre.json
@@ -93,6 +93,9 @@
         "damage_max_instance": [ { "damage_type": "nether", "amount": 25 } ],
         "dodgeable": true,
         "blockable": false,
+        "condition": {
+          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
+        },
         "hit_dmg_u": "%1$s rumbles words of magic and an eldritch bolt impacts your %2$s!",
         "hit_dmg_npc": "%1$s rumbles words of magic and an eldritch bolt impacts <npcname>'s %2$s!",
         "miss_msg_u": "%1$s rumbles words of magic and you narrowly avoid an eldritch bolt!",
@@ -105,6 +108,7 @@
         "type": "spell",
         "spell_data": { "id": "shadow_field", "min_level": 25, "hit_self": true },
         "cooldown": 25,
+        "condition": { "not": { "u_has_flag": "NO_SPELLCASTING" } },
         "monster_message": "%1$s gestures and %1$s is enveloped in darkness!"
       },
       {
@@ -112,6 +116,7 @@
         "type": "spell",
         "spell_data": { "id": "monster_invisibility_spell", "min_level": 10, "hit_self": true },
         "cooldown": 40,
+        "condition": { "not": { "u_has_flag": "NO_SPELLCASTING" } },
         "condition": { "math": [ "u_hp('ALL')", "<", "150" ] }
       },
       { "id": "smash", "throw_strength": 40 },

--- a/data/mods/Magiclysm/monsters/ogre.json
+++ b/data/mods/Magiclysm/monsters/ogre.json
@@ -114,8 +114,7 @@
         "type": "spell",
         "spell_data": { "id": "monster_invisibility_spell", "min_level": 10, "hit_self": true },
         "cooldown": 40,
-        "condition": { "not": { "u_has_flag": "NO_SPELLCASTING" } },
-        "condition": { "math": [ "u_hp('ALL')", "<", "150" ] }
+        "condition": { "and": [ { "math": [ "u_hp('ALL')", "<", "150" ] }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ] }
       },
       { "id": "smash", "throw_strength": 40 },
       [ "EAT_FOOD", 120 ]

--- a/data/mods/Magiclysm/monsters/orcs.json
+++ b/data/mods/Magiclysm/monsters/orcs.json
@@ -223,6 +223,9 @@
         "effects": [ { "id": "bleed", "duration": 60, "chance": 33, "intensity": 3, "affect_hit_bp": true } ],
         "dodgeable": true,
         "blockable": false,
+        "condition": {
+          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
+        },
         "hit_dmg_u": "%1$s growls words of magic and your %2$s is impacted by a bolt of carmine energy!",
         "hit_dmg_npc": "%1$s growls words of magic and <npcname>'s %2$s is impacted by a bolt of carmine energy!",
         "miss_msg_u": "%1$s growls words of magic and you narrowly avoid a bolt of carmine energy!",
@@ -235,6 +238,7 @@
         "type": "spell",
         "spell_data": { "id": "mon_bloodlust_spell" },
         "cooldown": 20,
+        "condition": { "not": { "u_has_flag": "NO_SPELLCASTING" } },
         "monster_message": "%1$s makes a frenzied cry and as they point, %3$s is surrounded by a red glow."
       }
     ],

--- a/data/mods/Magiclysm/monsters/orcs.json
+++ b/data/mods/Magiclysm/monsters/orcs.json
@@ -223,9 +223,7 @@
         "effects": [ { "id": "bleed", "duration": 60, "chance": 33, "intensity": 3, "affect_hit_bp": true } ],
         "dodgeable": true,
         "blockable": false,
-        "condition": {
-          "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ]
-        },
+        "condition": { "and": [ { "not": { "u_has_flag": "MUTE" } }, { "not": { "u_has_flag": "NO_SPELLCASTING" } } ] },
         "hit_dmg_u": "%1$s growls words of magic and your %2$s is impacted by a bolt of carmine energy!",
         "hit_dmg_npc": "%1$s growls words of magic and <npcname>'s %2$s is impacted by a bolt of carmine energy!",
         "miss_msg_u": "%1$s growls words of magic and you narrowly avoid a bolt of carmine energy!",

--- a/data/mods/Magiclysm/monsters/triffids.json
+++ b/data/mods/Magiclysm/monsters/triffids.json
@@ -26,6 +26,7 @@
         "type": "spell",
         "spell_data": { "id": "triffid_brambles_arc", "min_level": 5 },
         "cooldown": 25,
+        "condition": { "not": { "u_has_flag": "NO_SPELLCASTING" } },
         "monster_message": "%1$s waves its fronds in a deliberate pattern."
       },
       {
@@ -33,6 +34,7 @@
         "type": "spell",
         "spell_data": { "id": "triffid_summon_tanglevine", "min_level": 6 },
         "cooldown": 50,
+        "condition": { "not": { "u_has_flag": "NO_SPELLCASTING" } },
         "monster_message": "%1$s waves its fronds toward the ground."
       },
       {
@@ -40,6 +42,7 @@
         "type": "spell",
         "spell_data": { "id": "druid_veggrasp", "min_level": 2 },
         "cooldown": 30,
+        "condition": { "not": { "u_has_flag": "NO_SPELLCASTING" } },
         "monster_message": "%1$s twitches its base and roots burst from the ground around %3$s."
       }
     ],
@@ -83,6 +86,7 @@
         "type": "spell",
         "spell_data": { "id": "triffid_pollen_cone", "min_level": 3 },
         "cooldown": 15,
+        "condition": { "not": { "u_has_flag": "NO_SPELLCASTING" } },
         "monster_message": "%1$s waves its fronds and pollen erupts out in a cone!"
       },
       {
@@ -90,6 +94,7 @@
         "type": "spell",
         "spell_data": { "id": "triffid_pollen_heal", "min_level": 4 },
         "cooldown": 30,
+        "condition": { "not": { "u_has_flag": "NO_SPELLCASTING" } },
         "monster_message": "%1$s waves its fronds and a glow surrounds %3$s."
       },
       {
@@ -97,6 +102,7 @@
         "type": "spell",
         "spell_data": { "id": "triffid_pollen_speed", "min_level": 6 },
         "cooldown": 25,
+        "condition": { "not": { "u_has_flag": "NO_SPELLCASTING" } },
         "monster_message": "%1$s waves its fronds and %3$s starts moving faster!"
       },
       {
@@ -104,6 +110,7 @@
         "type": "spell",
         "spell_data": { "id": "triffid_pollen_blind", "min_level": 6 },
         "cooldown": 35,
+        "condition": { "not": { "u_has_flag": "NO_SPELLCASTING" } },
         "monster_message": "%1$s waves its fronds and golden pollen cascades down over %3$s!"
       }
     ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Magiclysm] Add `NO_SPELLCASTING` flag to magic-using monster conditions"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Since it's so easy to prevent monsters from using attacks with flags, the flags should be set up.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Set up magic-using monsters so that if they have the NO_SPELLCASTING flag, they can't cast spells. This also applies to alien mages like triffids who can't be silenced. 

At the moment there aren't any ways to apply `NO_SPELLCASTING` through spells or items, but better to future-proof (and some effects like `stunned` do have the `NO_SPELLCASTING` flag on them).
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

They still use magic, Silence still works.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
