### PR TITLE
Refactor: Remove unnecessary parameter `avatar`

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6348,7 +6348,7 @@ void pickup_menu_activity_actor::do_turn( player_activity &, Character &who )
     std::optional<tripoint_bub_ms> p( where );
     std::vector<drop_location> s( selection );
     who.cancel_activity();
-    who.pick_up( game_menus::inv::pickup( *who.as_avatar(), p, s ) );
+    who.pick_up( game_menus::inv::pickup( p, s ) );
 }
 
 void pickup_menu_activity_actor::serialize( JsonOut &jsout ) const

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2809,27 +2809,27 @@ void activity_handlers::eat_menu_do_turn( player_activity *, Character *you )
     }
 
     avatar &player_character = get_avatar();
-    avatar_action::eat_or_use( player_character, game_menus::inv::consume( player_character ) );
+    avatar_action::eat_or_use( player_character, game_menus::inv::consume() );
 }
 
 void activity_handlers::consume_food_menu_do_turn( player_activity *, Character * )
 {
     avatar &player_character = get_avatar();
-    item_location loc = game_menus::inv::consume_food( player_character );
+    item_location loc = game_menus::inv::consume_food();
     avatar_action::eat( player_character, loc );
 }
 
 void activity_handlers::consume_drink_menu_do_turn( player_activity *, Character * )
 {
     avatar &player_character = get_avatar();
-    item_location loc = game_menus::inv::consume_drink( player_character );
+    item_location loc = game_menus::inv::consume_drink();
     avatar_action::eat( player_character, loc );
 }
 
 void activity_handlers::consume_meds_menu_do_turn( player_activity *, Character * )
 {
     avatar &player_character = get_avatar();
-    avatar_action::eat_or_use( player_character, game_menus::inv::consume_meds( player_character ) );
+    avatar_action::eat_or_use( player_character, game_menus::inv::consume_meds() );
 }
 
 void activity_handlers::view_recipe_do_turn( player_activity *act, Character *you )

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -1134,7 +1134,7 @@ void avatar_action::use_item( avatar &you, item_location &loc, std::string const
     bool use_in_place = false;
 
     if( !loc ) {
-        loc = game_menus::inv::use( you );
+        loc = game_menus::inv::use();
 
         if( !loc ) {
             add_msg( _( "Never mind." ) );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2327,7 +2327,7 @@ int game::inventory_item_menu( item_location locThisItem,
                     break;
                 case 'o':
                     if( oThisItem.is_container() && oThisItem.num_item_stacks() > 0 ) {
-                        game_menus::inv::common( locThisItem, u );
+                        game_menus::inv::common( locThisItem );
                     }
                     break;
                 case '=':

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8414,7 +8414,7 @@ game::vmenu_ret game::list_items( const std::vector<map_item_stack> &item_list )
     do {
         bool recalc_unread = false;
         if( action == "COMPARE" && activeItem ) {
-            game_menus::inv::compare( u, active_pos );
+            game_menus::inv::compare( active_pos );
             recalc_unread = highlight_unread_items;
         } else if( action == "FILTER" ) {
             ui.invalidate_ui();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10011,7 +10011,7 @@ void game::wield( item_location loc )
 
 void game::wield()
 {
-    item_location loc = game_menus::inv::wield( u );
+    item_location loc = game_menus::inv::wield();
 
     if( loc ) {
         wield( loc );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2322,7 +2322,7 @@ int game::inventory_item_menu( item_location locThisItem,
                 }
                 case 'i':
                     if( oThisItem.is_container() ) {
-                        game_menus::inv::insert_items( u, locThisItem );
+                        game_menus::inv::insert_items( locThisItem );
                     }
                     break;
                 case 'o':
@@ -9044,7 +9044,7 @@ void game::insert_item()
         return;
     }
 
-    game_menus::inv::insert_items( u, item_loc );
+    game_menus::inv::insert_items( item_loc );
 }
 
 void game::unload_container()

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2238,7 +2238,7 @@ int game::inventory_item_menu( item_location locThisItem,
                     if( !locThisItem.get_item()->is_container() ) {
                         avatar_action::eat( u, locThisItem );
                     } else {
-                        avatar_action::eat_or_use( u, game_menus::inv::consume( u, locThisItem ) );
+                        avatar_action::eat_or_use( u, game_menus::inv::consume( locThisItem ) );
                     }
                     break;
                 case 'W': {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2331,7 +2331,7 @@ int game::inventory_item_menu( item_location locThisItem,
                     }
                     break;
                 case '=':
-                    game_menus::inv::reassign_letter( u, oThisItem );
+                    game_menus::inv::reassign_letter( oThisItem );
                     break;
                 case KEY_PPAGE:
                     iScrollPos -= iScrollHeight;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -9050,7 +9050,7 @@ void game::insert_item()
 void game::unload_container()
 {
     if( const std::optional<tripoint> pnt = choose_adjacent( _( "Unload where?" ) ) ) {
-        u.drop( game_menus::inv::unload_container( u ), *pnt );
+        u.drop( game_menus::inv::unload_container(), *pnt );
     }
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6023,13 +6023,13 @@ void game::pickup()
         return;
     }
     // Pick up items only from the selected tile
-    u.pick_up( game_menus::inv::pickup( u, *where_ ) );
+    u.pick_up( game_menus::inv::pickup( *where_ ) );
 }
 
 void game::pickup_all()
 {
     // Pick up items from current and all adjacent tiles
-    u.pick_up( game_menus::inv::pickup( u ) );
+    u.pick_up( game_menus::inv::pickup() );
 }
 
 void game::pickup( const tripoint &p )
@@ -6046,7 +6046,7 @@ void game::pickup( const tripoint_bub_ms &p )
     add_draw_callback( hilite_cb );
 
     // Pick up items only from the selected tile
-    u.pick_up( game_menus::inv::pickup( u, p ) );
+    u.pick_up( game_menus::inv::pickup( p ) );
 }
 
 //Shift player by one tile, look_around(), then restore previous position.

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -2462,8 +2462,9 @@ void game_menus::inv::reassign_letter( item &it )
     }
 }
 
-void game_menus::inv::swap_letters( avatar &you )
+void game_menus::inv::swap_letters()
 {
+    avatar &you = get_avatar();
     you.inv->restack( you );
 
     inventory_pick_selector inv_s( you );

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1659,8 +1659,8 @@ drop_locations game_menus::inv::ebooksave( Character &who, item_location &ereade
 class steal_inventory_preset : public pickup_inventory_preset
 {
     public:
-        steal_inventory_preset( const avatar &you, const Character &victim ) :
-            pickup_inventory_preset( you ), victim( victim ) {}
+        explicit steal_inventory_preset( const Character &victim ) :
+            pickup_inventory_preset( get_avatar() ), victim( victim ) {}
 
         bool is_shown( const item_location &loc ) const override {
             return !victim.is_worn( *loc ) && victim.get_wielded_item() != loc;
@@ -1670,9 +1670,9 @@ class steal_inventory_preset : public pickup_inventory_preset
         const Character &victim;
 };
 
-item_location game_menus::inv::steal( avatar &you, Character &victim )
+item_location game_menus::inv::steal( Character &victim )
 {
-    return inv_internal( victim, steal_inventory_preset( you, victim ),
+    return inv_internal( victim, steal_inventory_preset( victim ),
                          string_format( _( "Steal from %s" ), victim.get_name() ), -1,
                          string_format( _( "%s's inventory is empty." ), victim.get_name() ) );
 }

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -244,8 +244,9 @@ static drop_locations inv_internal_multi( Character &u, const inventory_selector
     return inv_s.execute();
 }
 
-void game_menus::inv::common( avatar &you )
+void game_menus::inv::common()
 {
+    avatar &you = get_avatar();
     // Return to inventory menu on those inputs
     static const std::set<int> loop_options = { { '\0', '=', 'f', '<', '>'}};
 
@@ -283,8 +284,9 @@ void game_menus::inv::common( avatar &you )
     } while( loop_options.count( res ) != 0 );
 }
 
-void game_menus::inv::common( item_location &loc, avatar &you )
+void game_menus::inv::common( item_location &loc )
 {
+    avatar &you = get_avatar();
     // Return to inventory menu on those inputs
     static const std::set<int> loop_options = { { '\0', '=', 'f' } };
 

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1776,9 +1776,9 @@ class weapon_inventory_preset: public inventory_selector_preset
         const Character &you;
 };
 
-item_location game_menus::inv::wield( avatar &you )
+item_location game_menus::inv::wield()
 {
-    return inv_internal( you, weapon_inventory_preset( you ), _( "Wield item" ), 1,
+    return inv_internal( get_avatar(), weapon_inventory_preset( get_avatar() ), _( "Wield item" ), 1,
                          _( "You have nothing to wield." ) );
 }
 

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1086,8 +1086,8 @@ item_location game_menus::inv::consume_meds()
 class activatable_inventory_preset : public pickup_inventory_preset
 {
     public:
-        explicit activatable_inventory_preset( const Character &you ) : pickup_inventory_preset( you ),
-            you( you ) {
+        explicit activatable_inventory_preset() : pickup_inventory_preset( get_avatar() ),
+            you( get_avatar() ) {
             _collate_entries = true;
             if( get_option<bool>( "INV_USE_ACTION_NAMES" ) ) {
                 append_cell( [ this ]( const item_location & loc ) {
@@ -1189,9 +1189,9 @@ class activatable_inventory_preset : public pickup_inventory_preset
         const Character &you;
 };
 
-item_location game_menus::inv::use( avatar &you )
+item_location game_menus::inv::use()
 {
-    return inv_internal( you, activatable_inventory_preset( you ),
+    return inv_internal( get_avatar(), activatable_inventory_preset(),
                          _( "Use item" ), 1,
                          _( "You don't have any items you can use." ) );
 }

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1782,22 +1782,6 @@ item_location game_menus::inv::wield( avatar &you )
                          _( "You have nothing to wield." ) );
 }
 
-class holster_inventory_preset: public weapon_inventory_preset
-{
-    public:
-        holster_inventory_preset( const Character &you, const holster_actor &actor, const item &holster ) :
-            weapon_inventory_preset( you ), actor( actor ), holster( holster ) {
-        }
-
-        bool is_shown( const item_location &loc ) const override {
-            return actor.can_holster( holster, *loc );
-        }
-
-    private:
-        const holster_actor &actor;
-        const item &holster;
-};
-
 drop_locations game_menus::inv::holster( avatar &you, const item_location &holster )
 {
     const std::string holster_name = holster->tname( 1, false );

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -2403,8 +2403,9 @@ bool game_menus::inv::compare_items( const item &first, const item &second,
     return action == "CONFIRM";
 }
 
-void game_menus::inv::compare( avatar &you, const std::optional<tripoint> &offset )
+void game_menus::inv::compare( const std::optional<tripoint> &offset )
 {
+    avatar &you = get_avatar();
     you.inv->restack( you );
 
     inventory_compare_selector inv_s( you );

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1810,8 +1810,9 @@ drop_locations game_menus::inv::holster( const item_location &holster )
     return insert_menu.execute();
 }
 
-void game_menus::inv::insert_items( avatar &you, item_location &holster )
+void game_menus::inv::insert_items( item_location &holster )
 {
+    avatar &you = get_avatar();
     if( holster->will_spill_if_unsealed()
         && holster.where() != item_location::type::map
         && !you.is_wielding( *holster ) ) {

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1001,8 +1001,9 @@ static std::string get_consume_needs_hint( Character &you )
     return hint;
 }
 
-item_location game_menus::inv::consume( avatar &you, const item_location &loc )
+item_location game_menus::inv::consume( const item_location &loc )
 {
+    avatar &you = get_avatar();
     static item_location container_location;
     if( !you.has_activity( ACT_EAT_MENU ) ) {
         you.assign_activity( ACT_EAT_MENU );
@@ -1032,8 +1033,9 @@ class comestible_filtered_inventory_preset : public comestible_inventory_preset
         bool( *predicate )( const item &it );
 };
 
-item_location game_menus::inv::consume_food( avatar &you )
+item_location game_menus::inv::consume_food()
 {
+    avatar &you = get_avatar();
     if( !you.has_activity( ACT_CONSUME_FOOD_MENU ) ) {
         you.assign_activity( ACT_CONSUME_FOOD_MENU );
     }
@@ -1048,8 +1050,9 @@ item_location game_menus::inv::consume_food( avatar &you )
     get_consume_needs_hint( you ) );
 }
 
-item_location game_menus::inv::consume_drink( avatar &you )
+item_location game_menus::inv::consume_drink()
 {
+    avatar &you = get_avatar();
     if( !you.has_activity( ACT_CONSUME_DRINK_MENU ) ) {
         you.assign_activity( ACT_CONSUME_DRINK_MENU );
     }
@@ -1064,8 +1067,9 @@ item_location game_menus::inv::consume_drink( avatar &you )
     get_consume_needs_hint( you ) );
 }
 
-item_location game_menus::inv::consume_meds( avatar &you )
+item_location game_menus::inv::consume_meds()
 {
+    avatar &you = get_avatar();
     if( !you.has_activity( ACT_CONSUME_MEDS_MENU ) ) {
         you.assign_activity( ACT_CONSUME_MEDS_MENU );
     }

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1782,8 +1782,9 @@ item_location game_menus::inv::wield()
                          _( "You have nothing to wield." ) );
 }
 
-drop_locations game_menus::inv::holster( avatar &you, const item_location &holster )
+drop_locations game_menus::inv::holster( const item_location &holster )
 {
+    avatar &you = get_avatar();
     const std::string holster_name = holster->tname( 1, false );
     const use_function *use = holster->type->get_use( "holster" );
     const holster_actor *actor = use == nullptr ? nullptr : dynamic_cast<const holster_actor *>
@@ -1819,7 +1820,7 @@ void game_menus::inv::insert_items( avatar &you, item_location &holster )
                                holster->type_name() );
         return;
     }
-    drop_locations holstered_list = game_menus::inv::holster( you, holster );
+    drop_locations holstered_list = game_menus::inv::holster( holster );
 
     if( !holstered_list.empty() ) {
         you.assign_activity( insert_item_activity_actor( holster, holstered_list ) );

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -2206,9 +2206,10 @@ drop_locations game_menus::inv::multidrop( Character &you )
     return inv_s.execute();
 }
 
-drop_locations game_menus::inv::pickup( avatar &you,
-                                        const std::optional<tripoint> &target, const std::vector<drop_location> &selection )
+drop_locations game_menus::inv::pickup( const std::optional<tripoint> &target,
+                                        const std::vector<drop_location> &selection )
 {
+    avatar &you = get_avatar();
     pickup_inventory_preset preset( you, /*skip_wield_check=*/true, /*ignore_liquidcont=*/true );
     preset.save_state = &pickup_ui_default_state;
 
@@ -2239,14 +2240,14 @@ drop_locations game_menus::inv::pickup( avatar &you,
     return pick_s.execute();
 }
 
-drop_locations game_menus::inv::pickup( avatar &you,
-                                        const std::optional<tripoint_bub_ms> &target, const std::vector<drop_location> &selection )
+drop_locations game_menus::inv::pickup( const std::optional<tripoint_bub_ms> &target,
+                                        const std::vector<drop_location> &selection )
 {
     std::optional<tripoint> tmp;
     if( target.has_value() ) {
         tmp = target.value().raw();
     }
-    return game_menus::inv::pickup( you, tmp, selection );
+    return game_menus::inv::pickup( tmp, selection );
 }
 
 class smokable_selector_preset : public inventory_selector_preset

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -435,8 +435,8 @@ item_location game_menus::inv::wear( Character &you, const bodypart_id &bp )
 class take_off_inventory_preset: public armor_inventory_preset
 {
     public:
-        take_off_inventory_preset( Character &you, const std::string &color ) :
-            armor_inventory_preset( you, color )
+        explicit take_off_inventory_preset( const std::string &color ) :
+            armor_inventory_preset( get_avatar(), color )
         {}
 
         bool is_shown( const item_location &loc ) const override {
@@ -454,10 +454,10 @@ class take_off_inventory_preset: public armor_inventory_preset
         }
 };
 
-item_location game_menus::inv::take_off( avatar &you )
+item_location game_menus::inv::take_off()
 {
-    return inv_internal( you, take_off_inventory_preset( you, "color_red" ), _( "Take off item" ), 1,
-                         _( "You're not wearing anything." ) );
+    return inv_internal( get_avatar(), take_off_inventory_preset( "color_red" ), _( "Take off item" ),
+                         1, _( "You're not wearing anything." ) );
 }
 
 item_location game::inv_map_splice( const item_filter &filter, const std::string &title, int radius,

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -2437,8 +2437,9 @@ void game_menus::inv::compare( const std::optional<tripoint> &offset )
     } while( true );
 }
 
-void game_menus::inv::reassign_letter( avatar &you, item &it )
+void game_menus::inv::reassign_letter( item &it )
 {
+    avatar &you = get_avatar();
     while( true ) {
         const int invlet = popup_getkey(
                                _( "Enter new letter.  Press SPACE to clear a manually-assigned letter, ESCAPE to cancel." ) );
@@ -2496,7 +2497,7 @@ void game_menus::inv::swap_letters( avatar &you )
             break;
         }
 
-        reassign_letter( you, *loc );
+        reassign_letter( *loc );
     }
 }
 

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1841,8 +1841,9 @@ static bool valid_unload_container( const item_location &container )
         && !container->contains_no_solids();
 }
 
-drop_locations game_menus::inv::unload_container( avatar &you )
+drop_locations game_menus::inv::unload_container()
 {
+    avatar &you = get_avatar();
     inventory_filter_preset unload_preset( valid_unload_container );
 
     inventory_drop_selector insert_menu( you, unload_preset, _( "CONTAINERS TO UNLOAD" ),

--- a/src/game_inventory.h
+++ b/src/game_inventory.h
@@ -131,7 +131,7 @@ item_location use();
 /** Item wielding/unwielding menu. */
 item_location wield();
 /** Item wielding/unwielding menu. */
-drop_locations holster( avatar &you, const item_location &holster );
+drop_locations holster( const item_location &holster );
 void insert_items( avatar &you, item_location &holster );
 drop_locations unload_container( avatar &you );
 /** Choosing a gun to saw down it's barrel. */

--- a/src/game_inventory.h
+++ b/src/game_inventory.h
@@ -133,7 +133,7 @@ item_location wield();
 /** Item wielding/unwielding menu. */
 drop_locations holster( const item_location &holster );
 void insert_items( item_location &holster );
-drop_locations unload_container( avatar &you );
+drop_locations unload_container();
 /** Choosing a gun to saw down it's barrel. */
 item_location saw_barrel( Character &you, item &tool );
 /** Choosing a gun to saw down its barrel. */

--- a/src/game_inventory.h
+++ b/src/game_inventory.h
@@ -64,7 +64,7 @@ void common();
 void common( item_location &loc );
 void compare( const std::optional<tripoint> &offset );
 void reassign_letter( item &it );
-void swap_letters( avatar &you );
+void swap_letters();
 
 /**
 * Compares two items, if confirm_message isn't empty then it will be printed

--- a/src/game_inventory.h
+++ b/src/game_inventory.h
@@ -63,7 +63,7 @@ drop_locations titled_multi_filter_menu( const item_location_filter &filter, Cha
 void common();
 void common( item_location &loc );
 void compare( const std::optional<tripoint> &offset );
-void reassign_letter( avatar &you, item &it );
+void reassign_letter( item &it );
 void swap_letters( avatar &you );
 
 /**

--- a/src/game_inventory.h
+++ b/src/game_inventory.h
@@ -132,7 +132,7 @@ item_location use();
 item_location wield();
 /** Item wielding/unwielding menu. */
 drop_locations holster( const item_location &holster );
-void insert_items( avatar &you, item_location &holster );
+void insert_items( item_location &holster );
 drop_locations unload_container( avatar &you );
 /** Choosing a gun to saw down it's barrel. */
 item_location saw_barrel( Character &you, item &tool );

--- a/src/game_inventory.h
+++ b/src/game_inventory.h
@@ -14,7 +14,6 @@
 class Character;
 struct tripoint;
 
-class avatar;
 class repair_item_actor;
 class salvage_actor;
 
@@ -146,7 +145,7 @@ item_location veh_tool_attach( Character &you, const std::string &vp_name,
 /** Choose item to wear. */
 item_location wear( Character &you, const bodypart_id &bp = bodypart_id( "bp_null" ) );
 /** Choose item to take off. */
-item_location take_off( avatar &you );
+item_location take_off();
 /** Item cut up menu. */
 item_location salvage( Character &you, const salvage_actor *actor );
 /** Repair menu. */

--- a/src/game_inventory.h
+++ b/src/game_inventory.h
@@ -88,9 +88,9 @@ drop_locations multidrop( Character &you );
  */
 // TODO: Get rid of untyped overload. Restore the target default while doing so (removed
 // to allow profiles to be distinguished.
-drop_locations pickup( avatar &you, const std::optional<tripoint> &target = std::nullopt,
+drop_locations pickup( const std::optional<tripoint> &target = std::nullopt,
                        const std::vector<drop_location> &selection = {} );
-drop_locations pickup( avatar &you, const std::optional<tripoint_bub_ms> &target,
+drop_locations pickup( const std::optional<tripoint_bub_ms> &target,
                        const std::vector<drop_location> &selection = {} );
 
 drop_locations smoke_food( Character &you, units::volume total_capacity,

--- a/src/game_inventory.h
+++ b/src/game_inventory.h
@@ -60,8 +60,8 @@ drop_locations titled_multi_filter_menu( const item_location_filter &filter, Cha
 */
 /*@{*/
 
-void common( avatar &you );
-void common( item_location &loc, avatar &you );
+void common();
+void common( item_location &loc );
 void compare( avatar &you, const std::optional<tripoint> &offset );
 void reassign_letter( avatar &you, item &it );
 void swap_letters( avatar &you );

--- a/src/game_inventory.h
+++ b/src/game_inventory.h
@@ -100,13 +100,13 @@ drop_locations smoke_food( Character &you, units::volume total_capacity,
 * Consume an item via a custom menu.
 * If item_location is provided then consume only from the contents of that container.
 */
-item_location consume( avatar &you, const item_location &loc = item_location() );
+item_location consume( const item_location &loc = item_location() );
 /** Consuming a food item via a custom menu. */
-item_location consume_food( avatar &you );
+item_location consume_food();
 /** Consuming a drink item via a custom menu. */
-item_location consume_drink( avatar &you );
+item_location consume_drink();
 /** Consuming a medication item via a custom menu. */
-item_location consume_meds( avatar &you );
+item_location consume_meds();
 /** Choosing a container for liquid. */
 item_location container_for( Character &you, const item &liquid, int radius = 0,
                              const item *avoid = nullptr );

--- a/src/game_inventory.h
+++ b/src/game_inventory.h
@@ -127,7 +127,7 @@ drop_locations ebooksave( Character &who, item_location &ereader );
 /** Menu for stealing stuff. */
 item_location steal( Character &victim );
 /** Item activation menu. */
-item_location use( avatar &you );
+item_location use();
 /** Item wielding/unwielding menu. */
 item_location wield( avatar &you );
 /** Item wielding/unwielding menu. */

--- a/src/game_inventory.h
+++ b/src/game_inventory.h
@@ -129,7 +129,7 @@ item_location steal( Character &victim );
 /** Item activation menu. */
 item_location use();
 /** Item wielding/unwielding menu. */
-item_location wield( avatar &you );
+item_location wield();
 /** Item wielding/unwielding menu. */
 drop_locations holster( avatar &you, const item_location &holster );
 void insert_items( avatar &you, item_location &holster );

--- a/src/game_inventory.h
+++ b/src/game_inventory.h
@@ -62,7 +62,7 @@ drop_locations titled_multi_filter_menu( const item_location_filter &filter, Cha
 
 void common();
 void common( item_location &loc );
-void compare( avatar &you, const std::optional<tripoint> &offset );
+void compare( const std::optional<tripoint> &offset );
 void reassign_letter( avatar &you, item &it );
 void swap_letters( avatar &you );
 

--- a/src/game_inventory.h
+++ b/src/game_inventory.h
@@ -125,7 +125,7 @@ item_location ebookread( Character &you, item_location &ereader );
 /** Select books to save to E-Book reader menu. */
 drop_locations ebooksave( Character &who, item_location &ereader );
 /** Menu for stealing stuff. */
-item_location steal( avatar &you, Character &victim );
+item_location steal( Character &victim );
 /** Item activation menu. */
 item_location use( avatar &you );
 /** Item wielding/unwielding menu. */

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2456,7 +2456,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             break;
 
         case ACTION_ORGANIZE:
-            game_menus::inv::swap_letters( player_character );
+            game_menus::inv::swap_letters();
             break;
 
         case ACTION_USE:

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1624,7 +1624,7 @@ static void wear()
 static void takeoff()
 {
     avatar &player_character = get_avatar();
-    item_location loc = game_menus::inv::take_off( player_character );
+    item_location loc = game_menus::inv::take_off();
 
     if( loc ) {
         player_character.takeoff( loc.obtain( player_character ) );

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2448,7 +2448,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             break;
 
         case ACTION_INVENTORY:
-            game_menus::inv::common( player_character );
+            game_menus::inv::common();
             break;
 
         case ACTION_COMPARE:

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1885,17 +1885,17 @@ void game::open_consume_item_menu()
     avatar &player_character = get_avatar();
     switch( as_m.ret ) {
         case 0: {
-            item_location loc = game_menus::inv::consume_food( player_character );
+            item_location loc = game_menus::inv::consume_food();
             avatar_action::eat( player_character, loc );
             break;
         }
         case 1: {
-            item_location loc = game_menus::inv::consume_drink( player_character );
+            item_location loc = game_menus::inv::consume_drink();
             avatar_action::eat( player_character, loc );
             break;
         }
         case 2:
-            avatar_action::eat_or_use( player_character, game_menus::inv::consume_meds( player_character ) );
+            avatar_action::eat_or_use( player_character, game_menus::inv::consume_meds() );
             break;
         default:
             break;
@@ -2479,7 +2479,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
 
         case ACTION_EAT:
             if( !avatar_action::eat_here( player_character ) ) {
-                avatar_action::eat_or_use( player_character, game_menus::inv::consume( player_character ) );
+                avatar_action::eat_or_use( player_character, game_menus::inv::consume() );
             }
             break;
 

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2452,7 +2452,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             break;
 
         case ACTION_COMPARE:
-            game_menus::inv::compare( player_character, std::nullopt );
+            game_menus::inv::compare( std::nullopt );
             break;
 
         case ACTION_ORGANIZE:

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -2621,7 +2621,7 @@ std::optional<int> holster_actor::use( Character *you, item &it, const tripoint 
 
         // iuse_actor really needs to work with item_location
         item_location item_loc = form_loc( *you, p, it );
-        game_menus::inv::insert_items( *you->as_avatar(), item_loc );
+        game_menus::inv::insert_items( item_loc );
     }
 
     return 0;

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -2862,7 +2862,7 @@ void avatar::steal( npc &target )
         return;
     }
 
-    item_location loc = game_menus::inv::steal( *this, target );
+    item_location loc = game_menus::inv::steal( target );
     if( !loc ) {
         return;
     }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

There are a lot of menus that take avatar as an argument. They are menus, so there is no need for them to ask for the avatar in parameters since they can just get_avatar(). Other `Character` than the avatar can never open menus, since they are not a player.

The benefit of removing the avatar from the parameter is that the callee may not need to `#include avatar.h`. Didn't happen, unfortunately.

Found some dead code as well.

#### Describe the solution

Remove parameter avatar where possible within `src/game_menus.h`

#### Describe alternatives you've considered

Remove some `Character` too, since it always probably is an avatar. I want this as simple as possible, since I don't want to do anything more with this.

#### Testing

Compiles?

#### Additional context
