### PR TITLE
discount loaded ammo from smoking rack even when not allowing removal

### DIFF
--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -4811,9 +4811,11 @@ static void reload_furniture( Character &you, const tripoint &examp, bool allow_
         int amount_tmp = use_ammotype ?
                          count_charges_in_list( &ammo->ammo->type, here.i_at( examp ), ammo_itypeID ) :
                          count_charges_in_list( ammo, here.i_at( examp ) );
-        if( allow_unload && amount_tmp > 0 ) {
+        if( amount_tmp > 0 ) {
             ammo_loaded = ammo;
             amount_in_furn = amount_tmp;
+        }
+        if( allow_unload && amount_tmp > 0 ) {
             if( you.query_yn( _( "The %1$s contains %2$d %3$s.  Unload?" ), f.name(), amount_in_furn,
                               ammo_itypeID->nname( amount_in_furn ) ) ) {
                 map_stack items = here.i_at( examp );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Address one issue related to #59189, i.e. charcoal kiln reloading reloads max capacity even when partially filled.
Not sure if it does address the whole issue.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Move the code for detecting existing contents out of the remove allowed only section so the existing contents is actually discounted when refilling the furniture.

The operation changed has a parameter specifying whether contents can be removed in the operation or not, and it cannot be removed in this call chain. There is another call chain where removal is permitted, though. There's no need for removal within the loading in this call chain, as there's a separate removal choice in the menu invoking the operation.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
The code is weird in that it allows for multiple types of "ammo", but only carries a single pointer out of the loop. The check further down complaining about mixing ammo seems to indicate you're only supposed to have a single type of ammo at a time in furniture (e.g. either coal or charcoal, but not a bit of both). Thus, the moved code doesn't add up different kinds of ammo (it didn't for the remove permitted case either). The option would be to somehow permit a mixture of ammo, but that seems to be an expansion of functionality out of scope and with the potential of bringing in new worm cans.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
- Load a save with an overloaded smoking rack (because of this bug).
- Empty the rack.
- Load the rack, and the code selects a box with 200 charcoal.
- Load the rack again and the UI states that it can take 89800 charcoal and it selects another box with 200 charcoal (I'm given a choice in neither case).
- Load the rack again and the UI states that it can take 89600 charcoal and it selects a pile of more than 90000 charcoal (possibly the pile just unloaded, but who knows what pile it selects).
- The rack now contains 90000 charcoal and is claimed to be full.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I have made no attempt to check whether the error message about overloaded racks goes away when you no longer can overload racks (and have emptied and optionally reloaded ones already overloaded, of course), but expect that to be the case.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
