### PR TITLE
[MoM] Replace specific effect check in monster powers with check for `NO_PSIONICS` flag

### DIFF
--- a/data/mods/MindOverMatter/monsters/animal_psychics.json
+++ b/data/mods/MindOverMatter/monsters/animal_psychics.json
@@ -153,9 +153,7 @@
         "type": "spell",
         "spell_data": { "id": "biokinetic_hardened_skin_monster" },
         "cooldown": 1,
-        "condition": {
-          "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_monster_hardened_skin" } } ]
-        },
+        "condition": { "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_monster_hardened_skin" } } ] },
         "monster_message": "%1$s's skin takes on a slightly waxen appearance."
       }
     ],

--- a/data/mods/MindOverMatter/monsters/animal_psychics.json
+++ b/data/mods/MindOverMatter/monsters/animal_psychics.json
@@ -30,7 +30,7 @@
       {
         "id": "ranged_pull",
         "cooldown": { "math": [ "7 + rand(14)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "hit_dmg_u": "%1$s growls and a powerful forces seizes your %2$s and drags you in!",
         "hit_dmg_npc": "%1$s growls and <npcname> is dragged towards it!",
         "miss_msg_u": "",
@@ -44,7 +44,7 @@
         "spell_data": { "id": "telekinetic_barrier_monster" },
         "cooldown": 1,
         "condition": {
-          "and": [ { "not": { "u_has_effect": "effect_psi_null" } }, { "not": { "u_has_effect": "effect_monster_inertial_barrier" } } ]
+          "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_monster_inertial_barrier" } } ]
         },
         "monster_message": "The air around %1$s distorts."
       }
@@ -90,7 +90,7 @@
         "range": 3,
         "dodgeable": false,
         "blockable": false,
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "damage_max_instance": [ { "damage_type": "psi_telepathic_damage", "amount": 10 } ],
         "hit_dmg_u": "%1$s shrieks at you!",
         "hit_dmg_npc": "%1$s shrieks at <npcname>!",
@@ -143,7 +143,7 @@
       {
         "id": "psi_hodag_speed_boost",
         "type": "spell",
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "spell_data": { "id": "biokinetic_speed_boost_monster_01", "min_level": 5 },
         "cooldown": { "math": [ "9 + rand(18)" ] },
         "monster_message": "%1$s moves too quickly for the eye to follow!"
@@ -154,7 +154,7 @@
         "spell_data": { "id": "biokinetic_hardened_skin_monster" },
         "cooldown": 1,
         "condition": {
-          "and": [ { "not": { "u_has_effect": "effect_psi_null" } }, { "not": { "u_has_effect": "effect_monster_hardened_skin" } } ]
+          "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_monster_hardened_skin" } } ]
         },
         "monster_message": "%1$s's skin takes on a slightly waxen appearance."
       }
@@ -206,7 +206,7 @@
         "type": "spell",
         "spell_data": { "id": "telepathic_fear_blast_monster", "min_level": 6 },
         "cooldown": { "math": [ "9 + rand(18)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "%1$s stares and lets out a silent cry!"
       }
     ],
@@ -269,7 +269,7 @@
         "type": "spell",
         "spell_data": { "id": "telepathic_fear_blast_monster", "min_level": 2 },
         "cooldown": { "math": [ "9 + rand(18)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "%1$'s third eye opens and it coos!"
       },
       { "id": "pigeon_aura", "type": "spell", "spell_data": { "id": "pigeon_aura", "min_level": 4 }, "cooldown": 200 }
@@ -310,7 +310,7 @@
         "spell_data": { "id": "electrokinetic_power_draining" },
         "cooldown": { "math": [ "5 + rand(45)" ] },
         "allow_no_target": true,
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "Sparks flicker over %1$s's fur."
       }
     ],
@@ -359,7 +359,7 @@
         "type": "spell",
         "spell_data": { "id": "telepathic_network_monster", "min_level": 5 },
         "cooldown": 50,
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "The direhound gazes upon its allies, and lets out a howl!"
       },
       {

--- a/data/mods/MindOverMatter/monsters/civilian_psychics.json
+++ b/data/mods/MindOverMatter/monsters/civilian_psychics.json
@@ -28,7 +28,7 @@
         "attack_upper": true,
         "throw_strength": 40,
         "cooldown": { "math": [ "5 + rand(10)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } }
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } }
       },
       { "id": "bio_op_takedown", "cooldown": 20, "condition": { "not": { "u_has_effect": "effect_psi_null" } } }
     ]
@@ -97,7 +97,7 @@
         "type": "spell",
         "spell_data": { "id": "electrokinetic_shock_touch_monster", "min_level": 0 },
         "cooldown": { "math": [ "5 + rand(10)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "%1$s unleashes a burst of sparks!"
       }
     ],
@@ -132,7 +132,7 @@
         "type": "spell",
         "spell_data": { "id": "photokinetic_light_beam_monster", "min_level": 0 },
         "cooldown": { "math": [ "5 + rand(10)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "%1$s fires a photon beam!"
       }
     ]
@@ -165,7 +165,7 @@
         "type": "spell",
         "spell_data": { "id": "pyrokinetic_eruption_monster", "min_level": 0 },
         "cooldown": { "math": [ "5 + rand(10)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "%1$s summons a blast of flame!"
       }
     ]
@@ -202,7 +202,7 @@
         "throw_strength": 40,
         "blockable": false,
         "effects_require_dmg": false,
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "hit_dmg_u": "%1$s stares at you and a powerful force hurls you through the air!",
         "hit_dmg_npc": "%1$s stares at <npcname> and a powerful force hurls them through the air!",
         "miss_msg_u": "%s stares at you, and you feel a crushing pressure for a moment before the feeling vanishes!",
@@ -247,7 +247,7 @@
         "type": "spell",
         "spell_data": { "id": "teleport_blink_monster", "min_level": 0 },
         "cooldown": { "math": [ "2 + rand(4)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "%1$s suddenly vanishes!"
       }
     ]

--- a/data/mods/MindOverMatter/monsters/feral_lab_psychics.json
+++ b/data/mods/MindOverMatter/monsters/feral_lab_psychics.json
@@ -40,7 +40,7 @@
         "type": "spell",
         "spell_data": { "id": "telepathic_confusion_monster", "min_level": 5 },
         "cooldown": { "math": [ "6 + rand(12)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "A roar fills %3$s's mind and the world is blotted out!"
       },
       {
@@ -48,7 +48,7 @@
         "type": "spell",
         "spell_data": { "id": "telepathic_blast_monster", "min_level": 4 },
         "cooldown": { "math": [ "5 + rand(10)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "%1$s stares at %3$s!"
       },
       {
@@ -62,7 +62,7 @@
         "dodgeable": false,
         "uncanny_dodgeable": true,
         "blockable": false,
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "hit_dmg_u": "%1$s stares at you and your %2$s is hammered with psionic force!",
         "hit_dmg_npc": "%1$s stares at <npcname> and their %2$s is hammered with psionic force!",
         "miss_msg_u": "%1$s stares at you and you narrowly avoid an unseen attack!",
@@ -82,7 +82,7 @@
         "uncanny_dodgeable": true,
         "blockable": false,
         "effects_require_dmg": false,
-        "condition": { "and": [ { "not": { "u_has_effect": "effect_psi_null" } }, { "not": { "npc_has_flag": "TELEKIN_SHIELD" } } ] },
+        "condition": { "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "npc_has_flag": "TELEKIN_SHIELD" } } ] },
         "hit_dmg_u": "%1$s stares at you and a powerful force hurls you through the air!",
         "hit_dmg_npc": "%1$s stares at <npcname> and a powerful force hurls them through the air!",
         "miss_msg_u": "%s stares at you, and you feel a crushing pressure for a moment before the feeling vanishes!",
@@ -95,7 +95,7 @@
         "cooldown": 1,
         "condition": {
           "and": [
-            { "not": { "u_has_effect": "effect_psi_null" } },
+            { "not": { "u_has_flag": "NO_PSIONICS" } },
             { "not": { "u_has_effect": "effect_monster_momentum_alteration" } }
           ]
         },
@@ -107,7 +107,7 @@
         "spell_data": { "id": "telekinetic_barrier_monster" },
         "cooldown": 1,
         "condition": {
-          "and": [ { "not": { "u_has_effect": "effect_psi_null" } }, { "not": { "u_has_effect": "effect_monster_inertial_barrier" } } ]
+          "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_monster_inertial_barrier" } } ]
         },
         "monster_message": "The air around %1$s distorts."
       },
@@ -167,13 +167,13 @@
         "attack_upper": true,
         "throw_strength": 50,
         "cooldown": { "math": [ "7 + rand(14)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } }
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } }
       },
       [ "BIO_OP_DISARM", 15 ],
       {
         "id": "bio_op_takedown",
         "cooldown": { "math": [ "5 + rand(10)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } }
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } }
       },
       {
         "id": "psi_biokin_guard_hardened_skin",
@@ -181,7 +181,7 @@
         "spell_data": { "id": "biokinetic_hardened_skin_monster" },
         "cooldown": 120,
         "condition": {
-          "and": [ { "not": { "u_has_effect": "effect_psi_null" } }, { "not": { "u_has_effect": "effect_monster_hardened_skin" } } ]
+          "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_monster_hardened_skin" } } ]
         },
         "monster_message": "%1$s's skin takes on a slightly waxen appearance."
       }

--- a/data/mods/MindOverMatter/monsters/feral_lab_psychics.json
+++ b/data/mods/MindOverMatter/monsters/feral_lab_psychics.json
@@ -94,10 +94,7 @@
         "spell_data": { "id": "telekinetic_momentum_monster" },
         "cooldown": 1,
         "condition": {
-          "and": [
-            { "not": { "u_has_flag": "NO_PSIONICS" } },
-            { "not": { "u_has_effect": "effect_monster_momentum_alteration" } }
-          ]
+          "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_monster_momentum_alteration" } } ]
         },
         "monster_message": "The air around %1$s wavers."
       },
@@ -180,9 +177,7 @@
         "type": "spell",
         "spell_data": { "id": "biokinetic_hardened_skin_monster" },
         "cooldown": 120,
-        "condition": {
-          "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_monster_hardened_skin" } } ]
-        },
+        "condition": { "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_monster_hardened_skin" } } ] },
         "monster_message": "%1$s's skin takes on a slightly waxen appearance."
       }
     ],

--- a/data/mods/MindOverMatter/monsters/feral_psychics.json
+++ b/data/mods/MindOverMatter/monsters/feral_psychics.json
@@ -112,9 +112,7 @@
         "type": "spell",
         "spell_data": { "id": "biokinetic_hardened_skin_monster" },
         "cooldown": 1,
-        "condition": {
-          "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_monster_hardened_skin" } } ]
-        },
+        "condition": { "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_monster_hardened_skin" } } ] },
         "monster_message": "%1$s's skin takes on a slightly waxen appearance."
       }
     ],
@@ -197,9 +195,7 @@
         "type": "spell",
         "spell_data": { "id": "biokinetic_hardened_skin_monster" },
         "cooldown": 1,
-        "condition": {
-          "and": [ { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_monster_hardened_skin" } } ]
-        },
+        "condition": { "and": [ { "u_has_flag": "NO_PSIONICS" }, { "not": { "u_has_effect": "effect_monster_hardened_skin" } } ] },
         "monster_message": "%1$s's skin takes on a slightly waxen appearance."
       }
     ],
@@ -1257,10 +1253,7 @@
         "spell_data": { "id": "telekinetic_momentum_monster" },
         "cooldown": { "math": [ "5 + rand(10)" ] },
         "condition": {
-          "and": [
-            { "not": { "u_has_flag": "NO_PSIONICS" } },
-            { "not": { "u_has_effect": "effect_monster_momentum_alteration" } }
-          ]
+          "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_monster_momentum_alteration" } } ]
         },
         "monster_message": "The air around %1$s wavers."
       },
@@ -1370,10 +1363,7 @@
         "spell_data": { "id": "telekinetic_momentum_monster" },
         "cooldown": 1,
         "condition": {
-          "and": [
-            { "not": { "u_has_flag": "NO_PSIONICS" } },
-            { "not": { "u_has_effect": "effect_monster_momentum_alteration" } }
-          ]
+          "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_monster_momentum_alteration" } } ]
         },
         "monster_message": "The air around %1$s wavers."
       },

--- a/data/mods/MindOverMatter/monsters/feral_psychics.json
+++ b/data/mods/MindOverMatter/monsters/feral_psychics.json
@@ -40,7 +40,7 @@
         "attack_upper": true,
         "throw_strength": 30,
         "cooldown": { "math": [ "7 + rand(14)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } }
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } }
       },
       [ "BIO_OP_DISARM", 10 ]
     ],
@@ -99,13 +99,13 @@
         "attack_upper": true,
         "throw_strength": 50,
         "cooldown": { "math": [ "5 + rand(10)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } }
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } }
       },
       [ "BIO_OP_DISARM", 10 ],
       {
         "id": "bio_op_takedown",
         "cooldown": { "math": [ "7 + rand(14)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } }
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } }
       },
       {
         "id": "psi_biokin2_hardened_skin",
@@ -113,7 +113,7 @@
         "spell_data": { "id": "biokinetic_hardened_skin_monster" },
         "cooldown": 1,
         "condition": {
-          "and": [ { "not": { "u_has_effect": "effect_psi_null" } }, { "not": { "u_has_effect": "effect_monster_hardened_skin" } } ]
+          "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_monster_hardened_skin" } } ]
         },
         "monster_message": "%1$s's skin takes on a slightly waxen appearance."
       }
@@ -175,7 +175,7 @@
         "attack_upper": true,
         "throw_strength": 50,
         "cooldown": { "math": [ "5 + rand(10)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } }
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } }
       },
       {
         "type": "leap",
@@ -183,14 +183,14 @@
         "move_cost": 50,
         "allow_no_target": true,
         "max_range": 5,
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "message": "%1$s moves so quickly your eyes can barely follow them!"
       },
       [ "BIO_OP_DISARM", 10 ],
       {
         "id": "bio_op_takedown",
         "cooldown": { "math": [ "5 + rand(10)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } }
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } }
       },
       {
         "id": "psi_biokin3_hardened_skin",
@@ -198,7 +198,7 @@
         "spell_data": { "id": "biokinetic_hardened_skin_monster" },
         "cooldown": 1,
         "condition": {
-          "and": [ { "not": { "u_has_effect": "effect_psi_null" } }, { "not": { "u_has_effect": "effect_monster_hardened_skin" } } ]
+          "and": [ { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_monster_hardened_skin" } } ]
         },
         "monster_message": "%1$s's skin takes on a slightly waxen appearance."
       }
@@ -395,7 +395,7 @@
         "type": "spell",
         "spell_data": { "id": "telepathic_shrieking_monster", "min_level": 3 },
         "cooldown": { "math": [ "7 + rand(14)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "Static fills your hearing for a moment, blotting out all other sounds!"
       }
     ],
@@ -459,7 +459,7 @@
         "type": "spell",
         "spell_data": { "id": "electrokinetic_shock_touch_monster", "min_level": 3 },
         "cooldown": { "math": [ "7 + rand(14)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "%1$s's touches %3$s with a jolt!"
       }
     ],
@@ -519,7 +519,7 @@
         "type": "spell",
         "spell_data": { "id": "electrokinetic_shock_touch_monster", "min_level": 3 },
         "cooldown": { "math": [ "4 + rand(8)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "%1$s's touches %3$s with a jolt!"
       },
       {
@@ -527,7 +527,7 @@
         "type": "spell",
         "spell_data": { "id": "electrokinetic_lightning_bolt_monster", "min_level": 4 },
         "cooldown": { "math": [ "10 + rand(20)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "%1$s's unleashes a bolt of lightning!"
       },
       {
@@ -535,7 +535,7 @@
         "type": "spell",
         "spell_data": { "id": "electrokinetic_paralysis_monster", "min_level": 5 },
         "cooldown": { "math": [ "15 + rand(30)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "%1$s's waves a hand at %3$s and sparks crackle over their skin!"
       }
     ],
@@ -596,7 +596,7 @@
         "type": "spell",
         "spell_data": { "id": "electrokinetic_shock_touch_monster", "min_level": 5 },
         "cooldown": { "math": [ "4 + rand(8)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "%1$s's touches %3$s with a jolt!"
       },
       {
@@ -604,7 +604,7 @@
         "type": "spell",
         "spell_data": { "id": "electrokinetic_lightning_blast_monster", "min_level": 8 },
         "cooldown": { "math": [ "7 + rand(14)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "%1$s's unleashes a bolt of lightning!"
       },
       {
@@ -612,7 +612,7 @@
         "type": "spell",
         "spell_data": { "id": "electrokinetic_paralysis_monster", "min_level": 8 },
         "cooldown": { "math": [ "12 + rand(24)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "%1$s's waves a hand at %3$s and sparks crackle over their skin!"
       },
       {
@@ -621,7 +621,7 @@
         "spell_data": { "id": "electrokinetic_revive_monster", "min_level": 5 },
         "cooldown": { "math": [ "25 + rand(50)" ] },
         "allow_no_target": true,
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "%1$s's gestures and lighting crackles around them!"
       }
     ],
@@ -681,7 +681,7 @@
         "type": "spell",
         "spell_data": { "id": "photokinetic_light_dodge_monster", "min_level": 3 },
         "cooldown": { "math": [ "7 + rand(14)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "%1$s's form is shifting with illusions!"
       },
       {
@@ -689,7 +689,7 @@
         "type": "spell",
         "spell_data": { "id": "photokinetic_light_beam_monster", "min_level": 2 },
         "cooldown": { "math": [ "10 + rand(20)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "%1$s fires a photon beam!"
       },
       {
@@ -697,7 +697,7 @@
         "type": "spell",
         "spell_data": { "id": "photokinetic_illumination_monster", "min_level": 5 },
         "cooldown": { "math": [ "15 + rand(30)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "%1$s's looks at you for a moment."
       }
     ],
@@ -757,7 +757,7 @@
         "type": "spell",
         "spell_data": { "id": "photokinetic_light_dodge_monster", "min_level": 6 },
         "cooldown": { "math": [ "5 + rand(10)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "%1$s's form is shifting with illusions!"
       },
       {
@@ -765,7 +765,7 @@
         "type": "spell",
         "spell_data": { "id": "photokinetic_light_beam_monster", "min_level": 5 },
         "cooldown": { "math": [ "7 + rand(14)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "%1$s fires a photon beam!"
       },
       {
@@ -773,7 +773,7 @@
         "type": "spell",
         "spell_data": { "id": "photokinetic_light_flash_monster", "min_level": 4 },
         "cooldown": { "math": [ "10 + rand(20)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "%1$s concentrates and unleashes a super-luminous flash!"
       },
       {
@@ -781,7 +781,7 @@
         "type": "spell",
         "spell_data": { "id": "photokinetic_radiation_attack_monster", "min_level": 7 },
         "cooldown": { "math": [ "12 + rand(24)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "%1$s stares at %3$s and %3$s is enveloped in an eerie glow!"
       },
       {
@@ -789,7 +789,7 @@
         "type": "spell",
         "spell_data": { "id": "photokinetic_illumination_monster", "min_level": 10 },
         "cooldown": { "math": [ "15 + rand(30)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "%1$s's looks at you for a moment."
       }
     ],
@@ -855,7 +855,7 @@
         "type": "spell",
         "spell_data": { "id": "photokinetic_light_dodge_monster", "min_level": 7 },
         "cooldown": { "math": [ "5 + rand(10)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "%1$s's form is shifting with illusions!"
       },
       {
@@ -863,7 +863,7 @@
         "type": "spell",
         "spell_data": { "id": "photokinetic_light_beam_monster", "min_level": 6 },
         "cooldown": { "math": [ "7 + rand(14)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "%1$s fires a photon beam!"
       },
       {
@@ -871,7 +871,7 @@
         "type": "spell",
         "spell_data": { "id": "photokinetic_light_flash_monster", "min_level": 6 },
         "cooldown": { "math": [ "7 + rand(14)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "%1$s concentrates and unleashes a super-luminous flash!"
       },
       {
@@ -879,7 +879,7 @@
         "type": "spell",
         "spell_data": { "id": "photokinetic_radiation_attack_monster", "min_level": 10 },
         "cooldown": { "math": [ "10 + rand(20)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "%1$s stares at you and you are enveloped in an eerie glow!"
       },
       {
@@ -887,7 +887,7 @@
         "type": "spell",
         "spell_data": { "id": "photokinetic_illumination_monster", "min_level": 15 },
         "cooldown": { "math": [ "15 + rand(30)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "%1$s's looks at you for a moment."
       }
     ],
@@ -952,7 +952,7 @@
         "dodgeable": true,
         "blockable": false,
         "effects": [ { "id": "onfire", "duration": 60, "chance": 25, "affect_hit_bp": true } ],
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "hit_dmg_u": "%1$s gestures and your %2$s is engulfed in flames!",
         "hit_dmg_npc": "%1$s gestures and <npcname>'s %2$s is engulfed in flames!",
         "miss_msg_u": "%1$s gestures and you narrowly avoid a burst of flame!",
@@ -965,7 +965,7 @@
         "type": "spell",
         "spell_data": { "id": "pyrokinetic_flash_monster", "min_level": 1 },
         "cooldown": { "math": [ "7 + rand(14)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "The air erupts into an eye-searing flash!"
       }
     ],
@@ -1035,7 +1035,7 @@
         "dodgeable": true,
         "blockable": false,
         "effects": [ { "id": "onfire", "duration": 60, "chance": 50, "affect_hit_bp": true } ],
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "hit_dmg_u": "%1$s gestures and your %2$s is engulfed in flames!",
         "hit_dmg_npc": "%1$s gestures and <npcname>'s %2$s is engulfed in flames!",
         "miss_msg_u": "%1$s gestures and you narrowly avoid a burst of flame!",
@@ -1048,7 +1048,7 @@
         "type": "spell",
         "spell_data": { "id": "pyrokinetic_flash_monster", "min_level": 4 },
         "cooldown": { "math": [ "7 + rand(14)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "The air erupts into an eye-searing flash!"
       },
       {
@@ -1056,7 +1056,7 @@
         "type": "spell",
         "spell_data": { "id": "pyrokinetic_blast_monster", "min_level": 4 },
         "cooldown": { "math": [ "7 + rand(14)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "%1$s gestures and summons a conflagration!"
       }
     ],
@@ -1131,7 +1131,7 @@
         "dodgeable": true,
         "blockable": false,
         "effects": [ { "id": "onfire", "duration": 60, "chance": 75, "affect_hit_bp": true } ],
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "hit_dmg_u": "%1$s gestures and your %2$s is engulfed in flames!",
         "hit_dmg_npc": "%1$s gestures and <npcname>'s %2$s is engulfed in flames!",
         "miss_msg_u": "%1$s gestures and you narrowly avoid a burst of flame!",
@@ -1144,7 +1144,7 @@
         "type": "spell",
         "spell_data": { "id": "pyrokinetic_flash_monster", "min_level": 5 },
         "cooldown": { "math": [ "7 + rand(14)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "The air erupts into an eye-searing flash!"
       },
       {
@@ -1152,7 +1152,7 @@
         "type": "spell",
         "spell_data": { "id": "pyrokinetic_blast_monster", "min_level": 6 },
         "cooldown": { "math": [ "7 + rand(14)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "%1$s gestures and summons a conflagration!"
       }
     ],
@@ -1216,7 +1216,7 @@
         "type": "spell",
         "spell_data": { "id": "telekinetic_pull_monster", "min_level": 2 },
         "cooldown": { "math": [ "7 + rand(14)" ] },
-        "condition": { "and": [ { "not": { "u_has_effect": "effect_psi_null" } }, { "not": { "npc_has_flag": "TELEKIN_SHIELD" } } ] },
+        "condition": { "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "npc_has_flag": "TELEKIN_SHIELD" } } ] },
         "monster_message": "%1$s stares at %3$s and %3$s is lifted up and pulled towards them!"
       },
       {
@@ -1229,7 +1229,7 @@
         "fake_skills": [ [ "throw", 6 ] ],
         "fake_str": 11,
         "require_targeting_player": false,
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "ranges": [ [ 2, 10, "DEFAULT" ] ],
         "description": "%1$s makes a throwing motion and one of the rocks around them suddenly launches like a bullet!"
       },
@@ -1245,7 +1245,7 @@
         "uncanny_dodgeable": true,
         "blockable": false,
         "effects_require_dmg": false,
-        "condition": { "and": [ { "not": { "u_has_effect": "effect_psi_null" } }, { "not": { "npc_has_flag": "TELEKIN_SHIELD" } } ] },
+        "condition": { "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "npc_has_flag": "TELEKIN_SHIELD" } } ] },
         "hit_dmg_u": "%1$s stares at you and a powerful force hurls you through the air!",
         "hit_dmg_npc": "%1$s stares at <npcname> and a powerful force hurls them through the air!",
         "miss_msg_u": "%s stares at you, and you feel a crushing pressure for a moment before the feeling vanishes!",
@@ -1258,7 +1258,7 @@
         "cooldown": { "math": [ "5 + rand(10)" ] },
         "condition": {
           "and": [
-            { "not": { "u_has_effect": "effect_psi_null" } },
+            { "not": { "u_has_flag": "NO_PSIONICS" } },
             { "not": { "u_has_effect": "effect_monster_momentum_alteration" } }
           ]
         },
@@ -1325,7 +1325,7 @@
         "type": "spell",
         "spell_data": { "id": "telekinetic_pull_monster", "min_level": 3 },
         "cooldown": { "math": [ "5 + rand(10)" ] },
-        "condition": { "and": [ { "not": { "u_has_effect": "effect_psi_null" } }, { "not": { "npc_has_flag": "TELEKIN_SHIELD" } } ] },
+        "condition": { "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "npc_has_flag": "TELEKIN_SHIELD" } } ] },
         "monster_message": "%1$s stares at %3$s and %3$s is lifted up and pulled towards them!"
       },
       {
@@ -1339,7 +1339,7 @@
         "dodgeable": false,
         "uncanny_dodgeable": true,
         "blockable": false,
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "hit_dmg_u": "%1$s stares at you and your %2$s is hammered with psionic force!",
         "hit_dmg_npc": "%1$s stares at <npcname> and their %2$s is hammered with psionic force!",
         "miss_msg_u": "%1$s stares at you and you narrowly avoid an unseen attack!",
@@ -1358,7 +1358,7 @@
         "dodgeable": false,
         "uncanny_dodgeable": true,
         "blockable": false,
-        "condition": { "and": [ { "not": { "u_has_effect": "effect_psi_null" } }, { "not": { "npc_has_flag": "TELEKIN_SHIELD" } } ] },
+        "condition": { "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "npc_has_flag": "TELEKIN_SHIELD" } } ] },
         "hit_dmg_u": "%1$s stares at you and a powerful force hurls you through the air!",
         "hit_dmg_npc": "%1$s stares at <npcname> and a powerful force hurls them through the air!",
         "miss_msg_u": "%s stares at you, and you feel a crushing pressure for a moment before the feeling vanishes!",
@@ -1371,7 +1371,7 @@
         "cooldown": 1,
         "condition": {
           "and": [
-            { "not": { "u_has_effect": "effect_psi_null" } },
+            { "not": { "u_has_flag": "NO_PSIONICS" } },
             { "not": { "u_has_effect": "effect_monster_momentum_alteration" } }
           ]
         },
@@ -1383,7 +1383,7 @@
         "spell_data": { "id": "telekinetic_barrier_monster" },
         "cooldown": 1,
         "condition": {
-          "and": [ { "not": { "u_has_effect": "effect_psi_null" } }, { "not": { "u_has_effect": "effect_monster_inertial_barrier" } } ]
+          "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_monster_inertial_barrier" } } ]
         },
         "monster_message": "The air around %1$s distorts."
       },
@@ -1452,7 +1452,7 @@
         "type": "spell",
         "spell_data": { "id": "telepathic_confusion_monster", "min_level": 3 },
         "cooldown": { "math": [ "10 + rand(20)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "A roar fills %3$s's mind and the world is blotted out!"
       },
       {
@@ -1460,7 +1460,7 @@
         "type": "spell",
         "spell_data": { "id": "telepathic_blast_monster", "min_level": 1 },
         "cooldown": { "math": [ "9 + rand(18)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "%1$s stares at %3$s!"
       }
     ],
@@ -1521,7 +1521,7 @@
         "type": "spell",
         "spell_data": { "id": "telepathic_confusion_monster", "min_level": 3 },
         "cooldown": { "math": [ "8 + rand(16)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "A roar fills %3$s's mind and the world is blotted out!"
       },
       {
@@ -1529,7 +1529,7 @@
         "type": "spell",
         "spell_data": { "id": "telepathic_blast_monster", "min_level": 2 },
         "cooldown": { "math": [ "7 + rand(14)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "%1$s stares at %3$s!"
       },
       {
@@ -1537,7 +1537,7 @@
         "type": "spell",
         "spell_data": { "id": "telepathic_horror_monster", "min_level": 4 },
         "cooldown": { "math": [ "12 + rand(24)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "%1$s stares at %3$s!"
       }
     ],
@@ -1599,7 +1599,7 @@
         "type": "spell",
         "spell_data": { "id": "telepathic_confusion_monster", "min_level": 5 },
         "cooldown": { "math": [ "7 + rand(14)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "A roar fills %3$s's mind and the world is blotted out!"
       },
       {
@@ -1607,7 +1607,7 @@
         "type": "spell",
         "spell_data": { "id": "telepathic_blast_monster", "min_level": 5 },
         "cooldown": { "math": [ "5 + rand(10)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "%1$s stares at %3$s!"
       },
       {
@@ -1616,7 +1616,7 @@
         "spell_data": { "id": "telepathic_horror_aoe_monster", "min_level": 15 },
         "allow_no_target": true,
         "cooldown": { "math": [ "12 + rand(24)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "%1$s eyes suddenly go wide!"
       },
       {
@@ -1624,7 +1624,7 @@
         "type": "spell",
         "spell_data": { "id": "telepathic_primal_fear_monster", "min_level": 5 },
         "cooldown": { "math": [ "17 + rand(34)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "%1$s stares at %3$s and they freeze like a frightened rabbit!"
       }
     ],
@@ -1681,7 +1681,7 @@
         "type": "spell",
         "spell_data": { "id": "teleport_slow_monster", "min_level": 2 },
         "cooldown": { "math": [ "7 + rand(14)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "%1$s looks at %3$s and the world lurches."
       },
       {
@@ -1689,7 +1689,7 @@
         "cooldown": { "math": [ "4 + rand(8)" ] },
         "allow_no_target": true,
         "max_range": 8,
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "message": "%1$s vanishes and reappears elsewhere!"
       }
     ],
@@ -1748,7 +1748,7 @@
         "type": "spell",
         "spell_data": { "id": "teleport_slow_monster", "min_level": 4 },
         "cooldown": { "math": [ "5 + rand(10)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "%1$s glances at %3$s and the world lurches."
       },
       {
@@ -1760,7 +1760,7 @@
         "accuracy": 5,
         "damage_max_instance": [ { "damage_type": "psi_teleporter_teleporting_damage", "amount": 2, "armor_penetration": 10 } ],
         "blockable": false,
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "hit_dmg_u": "%1$s touches you and the world shifts around you!",
         "hit_dmg_npc": "%1$s touches <npcname> and the world shifts around them!",
         "miss_msg_u": "%s reaches for you but you avoid their touch!",
@@ -1773,7 +1773,7 @@
         "allow_no_target": true,
         "max_range": 12,
         "message": "%1$s vanishes and reappears elsewhere!",
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } }
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } }
       }
     ],
     "flags": [
@@ -1841,7 +1841,7 @@
         "accuracy": 6,
         "damage_max_instance": [ { "damage_type": "psi_teleporter_teleporting_damage", "amount": 2, "armor_penetration": 10 } ],
         "blockable": false,
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "hit_dmg_u": "%1$s touches you and the world warps around you!",
         "hit_dmg_npc": "%1$s touches <npcname> and the world warps around them!",
         "miss_msg_u": "%s reaches for you but you avoid their touch!",
@@ -1852,7 +1852,7 @@
         "type": "spell",
         "spell_data": { "id": "teleport_slow_monster", "min_level": 6 },
         "cooldown": { "math": [ "5 + rand(10)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "%1$s glances at %3$s and the world lurches."
       },
       {
@@ -1860,7 +1860,7 @@
         "type": "spell",
         "spell_data": { "id": "teleport_blink_attack_monster", "min_level": 4 },
         "cooldown": { "math": [ "10 + rand(20)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "%1$s touches %3$s and the world around %3$s wavers."
       },
       {
@@ -1870,7 +1870,7 @@
         "allow_no_target": true,
         "max_range": 16,
         "message": "%1$s vanishes and reappears elsewhere!",
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } }
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } }
       }
     ],
     "flags": [
@@ -1940,7 +1940,7 @@
         "dodgeable": true,
         "blockable": true,
         "effects": [ { "id": "effect_vitakinetic_health_down", "duration": [ 620000, 1620000 ] } ],
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "hit_dmg_u": "%1$s touches you and you feel weaker!",
         "hit_dmg_npc": "%1$s touches <npcname> and they flinch!",
         "miss_msg_u": "%1$s tries to touch you, but you dodge!",
@@ -2016,7 +2016,7 @@
         ],
         "dodgeable": true,
         "blockable": true,
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "hit_dmg_u": "%1$s touches you and wounds open on your flesh!",
         "hit_dmg_npc": "%1$s touches <npcname> and wounds open on their flesh!",
         "miss_msg_u": "%1$s tries to touch you, but you dodge!",
@@ -2034,7 +2034,7 @@
         "dodgeable": true,
         "blockable": true,
         "effects": [ { "id": "effect_vitakinetic_healing_down", "duration": [ 920000, 2120000 ] } ],
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "hit_dmg_u": "%1$s touches you and you feel weaker!",
         "hit_dmg_npc": "%1$s touches <npcname> and they flinch!",
         "miss_msg_u": "%1$s tries to touch you, but you dodge!",
@@ -2048,7 +2048,7 @@
         "spell_data": { "id": "vitakinetic_regeneration_monster" },
         "cooldown": { "math": [ "10 + rand(20)" ] },
         "allow_no_target": true,
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "%1$s closes their eyes and their wounds begin healing at a rapid pace!"
       }
     ],

--- a/data/mods/MindOverMatter/monsters/mi_go.json
+++ b/data/mods/MindOverMatter/monsters/mi_go.json
@@ -50,7 +50,7 @@
         "move_cost": 50,
         "allow_no_target": true,
         "max_range": 7,
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "message": "%1$s moves so quickly your eyes can barely follow it!"
       },
       {
@@ -58,7 +58,7 @@
         "type": "spell",
         "spell_data": { "id": "biokinetic_speed_boost_monster_01", "min_level": 5 },
         "cooldown": { "math": [ "9 + rand(18)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "%1$s moves so quickly it's nothing but a blur!"
       }
     ],
@@ -123,7 +123,7 @@
         "type": "spell",
         "spell_data": { "id": "photokinetic_illumination_migo", "min_level": 5 },
         "cooldown": { "math": [ "15 + rand(30)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "The mi-go's numerous antennae sync their movements for a brief moment."
       },
       {
@@ -131,7 +131,7 @@
         "type": "spell",
         "spell_data": { "id": "photokinetic_light_beam_monster", "min_level": 7 },
         "cooldown": { "math": [ "10 + rand(20)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "The mi-go's numerous antennae sync their movements for a brief moment."
       },
       {
@@ -139,7 +139,7 @@
         "type": "spell",
         "spell_data": { "id": "photokinetic_radiation_attack_monster", "min_level": 10 },
         "cooldown": { "math": [ "12 + rand(24)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "The mi-go's numerous antennae sync their movements for a brief moment."
       }
     ],
@@ -209,7 +209,7 @@
         "damage_max_instance": [ { "damage_type": "psi_telepathic_damage", "amount": 15, "armor_penetration": 0 } ],
         "dodgeable": false,
         "blockable": false,
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "hit_dmg_u": "%1$s looks at you and your mind reels!",
         "hit_dmg_npc": "%1$s looks at <npcname> and they flinch as if struck!",
         "miss_msg_u": "%s looks at you but nothing happens!",
@@ -220,7 +220,7 @@
         "type": "spell",
         "spell_data": { "id": "telepathic_hallucinations_monster", "min_level": 10 },
         "cooldown": { "math": [ "10 + rand(20)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "The mi-go's numerous antennae sync their movements for a brief moment."
       },
       {
@@ -228,7 +228,7 @@
         "type": "spell",
         "spell_data": { "id": "telepathic_confusion_monster", "min_level": 3 },
         "cooldown": { "math": [ "15 + rand(30)" ] },
-        "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
         "monster_message": "A roar fills %3$s's mind and the world is blotted out!"
       }
     ],

--- a/data/mods/MindOverMatter/monsters/triffids.json
+++ b/data/mods/MindOverMatter/monsters/triffids.json
@@ -44,7 +44,7 @@
           "dodgeable": true,
           "blockable": false,
           "effects": [ { "id": "onfire", "duration": 60, "chance": 50, "affect_hit_bp": true } ],
-          "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
           "hit_dmg_u": "%1$s waves its fronds and your %2$s is engulfed in flames!",
           "hit_dmg_npc": "%1$s waves its fronds and <npcname>'s %2$s is engulfed in flames!",
           "miss_msg_u": "%1$s waves its fronds and you narrowly avoid a burst of flame!",
@@ -58,7 +58,7 @@
           "spell_data": { "id": "pyrokinetic_quell_flames_monster", "min_level": 10 },
           "allow_no_target": true,
           "cooldown": 1,
-          "condition": { "and": [ { "not": { "u_has_effect": "effect_psi_null" } }, { "u_is_in_field": "fd_fire" } ] },
+          "condition": { "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "u_is_in_field": "fd_fire" } ] },
           "monster_message": "%1$s waves its fronds and the flames gutter and die."
         },
         {
@@ -68,7 +68,7 @@
           "cooldown": { "math": [ "10 + rand(25)" ] },
           "condition": {
             "and": [
-              { "not": { "u_has_effect": "effect_psi_null" } },
+              { "not": { "u_has_flag": "NO_PSIONICS" } },
               { "not": { "npc_has_effect": "effect_monster_pyrokinetic_fire_immunity" } }
             ]
           },
@@ -91,7 +91,7 @@
           "type": "spell",
           "spell_data": { "id": "teleport_slow_monster", "min_level": 8 },
           "cooldown": { "math": [ "7 + rand(14)" ] },
-          "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
           "monster_message": "%1$s waves its fronds at %3$s."
         },
         {
@@ -100,15 +100,15 @@
           "move_cost": 50,
           "allow_no_target": true,
           "max_range": 10,
-          "message": "%1$s vanishes and reappears elsewhere!",
-          "condition": { "not": { "u_has_effect": "effect_psi_null" } }
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "message": "%1$s vanishes and reappears elsewhere!"
         },
         {
           "id": "psi_triffid_teleporter_ally_teleport",
           "type": "spell",
           "spell_data": { "id": "teleporter_triffid_summon_allies", "min_level": 10 },
           "cooldown": { "math": [ "17 + rand(32)" ] },
-          "condition": { "not": { "u_has_effect": "effect_psi_null" } },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
           "monster_message": "%1$s waves its fronds at %3$s and the air around %3$s solidifies into shapes."
         }
       ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Replace specific effect check in monster powers with check for `NO_PSIONICS` flag"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Mirror of #76497.

This allows better compatibility going forward.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Replace conditions.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Tested on alien psions and a nether void. They flailed away at each other until the mi-go lightbringer killed the triffid flamebreaker and the nether-void, then the mi-go unleashed all of its psionic power on me once the effect faded.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I'll finally make those null grenades.

Ran into something weird when testing: 

![Untitled](https://github.com/user-attachments/assets/bbfaa100-b09e-42fa-b53b-87cae2a7d0f1)

Once the effect faded, the mi-go used multiple psionic powers and a physical attack all in one second. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
