### PR TITLE
[Xedra Evolved] Add more pooka changeling traits

### DIFF
--- a/data/mods/Xedra_Evolved/items/armor/integrated.json
+++ b/data/mods/Xedra_Evolved/items/armor/integrated.json
@@ -907,5 +907,30 @@
         "encumbrance": 0
       }
     ]
+  },
+  {
+    "id": "integrated_antlers",
+    "type": "ARMOR",
+    "category": "armor",
+    "name": { "str_sp": "deer antlers" },
+    "description": "You have a majestic crown of antlers.",
+    "weight": "2000 g",
+    "volume": "2500 ml",
+    "price": "0 cent",
+    "price_postapoc": "0 cent",
+    "material": [ "bone" ],
+    "symbol": "V",
+    "color": "dark_gray",
+    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "AURA", "PADDED", "NO_SALVAGE" ],
+    "armor": [
+      {
+        "material": [ { "type": "bone", "covered_by_mat": 100, "thickness": 3 } ],
+        "covers": [ "head" ],
+        "specifically_covers": [ "head_crown" ],
+        "coverage": 20,
+        "encumbrance": 2
+      }
+    ],
+    "melee_damage": { "bash": 6 }
   }
 ]

--- a/data/mods/Xedra_Evolved/jmath.json
+++ b/data/mods/Xedra_Evolved/jmath.json
@@ -142,6 +142,6 @@
     "type": "jmath_function",
     "id": "pooka_shapeshift_traits",
     "num_args": 0,
-    "return": "u_has_trait('ANTLERS') + u_has_trait('LUPINE_EARS') + u_has_trait('CLAWS') + u_has_trait('CLAWS_ST') + u_has_trait('TAIL_FLUFFY') + u_has_trait('TAIL_LONG')"
+    "return": "u_has_trait('ANTLERS') + u_has_trait('HORNS_CURLED') + u_has_trait('LUPINE_EARS') + u_has_trait('FELINE_EARS') + u_has_trait('CLAWS') + u_has_trait('CLAWS_ST') + u_has_trait('WINGS_BIRD') + u_has_trait('URSINE_FUR') + u_has_trait('CHITIN2') + u_has_trait('POOKA_QUADRUPED_TRAITS') + u_has_trait('LEAPING_LEGS') + u_has_trait('TAIL_FLUFFY') + u_has_trait('TAIL_LONG')"
   }
 ]

--- a/data/mods/Xedra_Evolved/mutations/mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/mutations.json
@@ -667,7 +667,7 @@
         ]
       },
       {
-        "condition": { "and": [ { "u_has_flag": "QUADRUPED_CROUCH" }, { "u_has_flag": "QUADRUPED_RUN" }, { "not": "u_can_drop_weapon" } ] },
+        "condition": { "and": [ { "not": "u_can_drop_weapon" } ] },
         "values": [ { "value": "MOVE_COST", "multiply": -0.15 } ],
         "ench_effects": [ { "effect": "natural_stance", "intensity": 1 }, { "effect": "quadruped_full", "intensity": 1 } ]
       },

--- a/data/mods/Xedra_Evolved/mutations/mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/mutations.json
@@ -677,7 +677,7 @@
         "values": [ { "value": "MELEE_DAMAGE", "multiply": -1 }, { "value": "RANGE", "multiply": -1 } ]
       }
     ],
-    "flags": [ "MUTE", "PRED3", "QUADRUPED_CROUCH", "QUADRUPED_RUN", "TEMPORARY_SHAPESHIFT" ],
+    "flags": [ "MUTE", "PRED3", "QUADRUPED_CROUCH", "QUADRUPED_RUN", "TOUGH_FEET", "TEMPORARY_SHAPESHIFT" ],
     "override_look": { "id": "mon_wolf", "tile_category": "monster" },
     "integrated_armor": [ "integrated_fangs", "integrated_lupine_fur" ]
   },

--- a/data/mods/Xedra_Evolved/mutations/playable_changeling.json
+++ b/data/mods/Xedra_Evolved/mutations/playable_changeling.json
@@ -531,6 +531,19 @@
   },
   {
     "type": "mutation",
+    "id": "POOKA_HORNS",
+    "name": { "str": "Curled Horns (Shapeshift)" },
+    "points": 2,
+    "description": "Grow a set of spiraling curled horns, allowing you to make a headbutt attack but preventing you from wearing a helmet.",
+    "category": [ "FAIR_FOLK_COMMONER_POOKA" ],
+    "active": true,
+    "activated_is_setup": true,
+    "activated_eocs": [ "EOC_POOKA_HORNS_ON" ],
+    "processed_eocs": [ "EOC_POOKA_SHAPESHIFTING_MANA_CHECK" ],
+    "deactivated_eocs": [ "EOC_POOKA_HORNS_OFF" ]
+  },
+  {
+    "type": "mutation",
     "id": "POOKA_WOLF_EARS",
     "name": { "str": "Wolf Ears (Shapeshift)" },
     "points": 2,
@@ -541,6 +554,19 @@
     "activated_eocs": [ "EOC_POOKA_WOLF_EARS_ON" ],
     "processed_eocs": [ "EOC_POOKA_SHAPESHIFTING_MANA_CHECK" ],
     "deactivated_eocs": [ "EOC_POOKA_WOLF_EARS_OFF" ]
+  },
+  {
+    "type": "mutation",
+    "id": "POOKA_FELINE_EARS",
+    "name": { "str": "Feline Ears (Shapeshift)" },
+    "points": 2,
+    "description": "Change your ears into the ears of a great cat, granting you increased hearing.",
+    "category": [ "FAIR_FOLK_COMMONER_POOKA" ],
+    "active": true,
+    "activated_is_setup": true,
+    "activated_eocs": [ "EOC_POOKA_FELINE_EARS_ON" ],
+    "processed_eocs": [ "EOC_POOKA_SHAPESHIFTING_MANA_CHECK" ],
+    "deactivated_eocs": [ "EOC_POOKA_FELINE_EARS_OFF" ]
   },
   {
     "type": "mutation",
@@ -570,6 +596,105 @@
   },
   {
     "type": "mutation",
+    "id": "POOKA_BIRD_WINGS",
+    "name": { "str": "Bird Wings (Shapeshift)" },
+    "points": 2,
+    "description": "Transform your arms into bird wings, allow you to slow your fall when jumping from a high place and glide short distances.",
+    "category": [ "FAIR_FOLK_COMMONER_POOKA" ],
+    "active": true,
+    "activated_is_setup": true,
+    "activated_eocs": [ "EOC_POOKA_BIRD_WINGS_ON" ],
+    "processed_eocs": [ "EOC_POOKA_SHAPESHIFTING_MANA_CHECK" ],
+    "deactivated_eocs": [ "EOC_POOKA_BIRD_WINGS_OFF" ]
+  },
+  {
+    "type": "mutation",
+    "id": "POOKA_URSINE_FUR",
+    "name": { "str": "Thick Fur (Shapeshift)" },
+    "points": 2,
+    "description": "Grow a coat of thick fur, keeping you warm in the winter and protecting you from attacks.",
+    "category": [ "FAIR_FOLK_COMMONER_POOKA" ],
+    "active": true,
+    "activated_is_setup": true,
+    "activated_eocs": [ "EOC_POOKA_URSINE_FUR_ON" ],
+    "processed_eocs": [ "EOC_POOKA_SHAPESHIFTING_MANA_CHECK" ],
+    "deactivated_eocs": [ "EOC_POOKA_URSINE_FUR_OFF" ]
+  },
+  {
+    "type": "mutation",
+    "id": "POOKA_CHITIN",
+    "name": { "str": "Chitin Carapace (Shapeshift)" },
+    "points": 2,
+    "description": "Grow an armored suit of chitin, protecting you and making your punches hit harder.",
+    "category": [ "FAIR_FOLK_COMMONER_POOKA" ],
+    "active": true,
+    "activated_is_setup": true,
+    "activated_eocs": [ "EOC_POOKA_CHITIN_ON" ],
+    "processed_eocs": [ "EOC_POOKA_SHAPESHIFTING_MANA_CHECK" ],
+    "deactivated_eocs": [ "EOC_POOKA_CHITIN_OFF" ]
+  },
+  {
+    "type": "mutation",
+    "id": "POOKA_QUADRUPED",
+    "name": { "str": "Quadruped (Shapeshift)" },
+    "points": 2,
+    "description": "Grow paws and animal-like legs, allowing you to run much faster on all fours, but preventing you from wearing shoes or gloves.",
+    "category": [ "FAIR_FOLK_COMMONER_POOKA" ],
+    "active": true,
+    "activated_is_setup": true,
+    "activated_eocs": [ "EOC_POOKA_QUADRUPED_ON" ],
+    "processed_eocs": [ "EOC_POOKA_SHAPESHIFTING_MANA_CHECK" ],
+    "deactivated_eocs": [ "EOC_POOKA_QUADRUPED_OFF" ]
+  },
+  {
+    "//": "The existing quadruped mutations check for thresholds so we need this custom one.",
+    "type": "mutation",
+    "id": "POOKA_QUADRUPED_TRAITS",
+    "name": { "str": "Quadruped" },
+    "points": 2,
+    "visibility": 8,
+    "ugliness": 6,
+    "description": "Your arms, hands, and legs are animal-like, allowing you to move quickly when running on all fours, but preventing you from wearing shoes or gloves.",
+    "category": [ "FAIR_FOLK_COMMONER_POOKA" ],
+    "restricts_gear": [ "foot_l", "foot_r", "hand_l", "hand_r" ],
+    "triggers": [
+      [
+        {
+          "condition": {
+            "and": [
+              { "u_has_move_mode": "crouch" },
+              { "not": "u_can_drop_weapon" }
+            ]
+          },
+          "msg_on": { "text": "You drop down on all fours." },
+          "msg_off": { "text": "You come out of your quadrupedal posture." }
+        }
+      ]
+    ],
+    "enchantments": [
+      "ench_quadruped_movement_full",
+      {
+        "condition": { "and": [ { "u_has_move_mode": "crouch" }, { "not": "u_can_drop_weapon" } ] },
+        "values": [ { "value": "MOVE_COST", "multiply": -0.35 } ]
+      },
+      { "values": [ { "value": "CARRY_WEIGHT", "multiply": -0.2 } ] }
+    ]
+  },
+  {
+    "type": "mutation",
+    "id": "POOKA_LEAPING_LEGS",
+    "name": { "str": "Leaping Legs (Shapeshift)" },
+    "points": 2,
+    "description": "Grow strong frog- or cat-like legs, allowing you to leap great distances.",
+    "category": [ "FAIR_FOLK_COMMONER_POOKA" ],
+    "active": true,
+    "activated_is_setup": true,
+    "activated_eocs": [ "EOC_POOKA_LEAPING_LEGS_ON" ],
+    "processed_eocs": [ "EOC_POOKA_SHAPESHIFTING_MANA_CHECK" ],
+    "deactivated_eocs": [ "EOC_POOKA_LEAPING_LEGS_OFF" ]
+  },
+  {
+    "type": "mutation",
     "id": "POOKA_WOLF_TAIL",
     "name": { "str": "Wolf Tail (Shapeshift)" },
     "points": 2,
@@ -593,6 +718,35 @@
     "activated_eocs": [ "EOC_POOKA_TAIL_LONG_ON" ],
     "processed_eocs": [ "EOC_POOKA_SHAPESHIFTING_MANA_CHECK" ],
     "deactivated_eocs": [ "EOC_POOKA_TAIL_LONG_OFF" ]
+  },
+  {
+    "type": "mutation",
+    "id": "POOKA_SHAPESHIFT_GOOD",
+    "name": { "str": "Initiate of Forms" },
+    "points": 2,
+    "description": "You are getting better at shapeshifting and are able to maintain one more simultaneous shapeshift without drawing on your mana.",
+    "changes_to": [ "POOKA_SHAPESHIFT_GOOD2" ],
+    "category": [ "FAIR_FOLK_COMMONER_POOKA" ]
+  },
+  {
+    "type": "mutation",
+    "id": "POOKA_SHAPESHIFT_GOOD2",
+    "name": { "str": "Adept of Forms" },
+    "points": 4,
+    "description": "You are getting much better at shapeshifting and are able to maintain two more simultaneous shapeshifts without drawing on your mana.",
+    "prereqs": [ "POOKA_SHAPESHIFT_GOOD" ],
+    "changes_to": [ "POOKA_SHAPESHIFT_GOOD3" ],
+    "category": [ "FAIR_FOLK_COMMONER_POOKA" ]
+  },
+  {
+    "type": "mutation",
+    "id": "POOKA_SHAPESHIFT_GOOD3",
+    "name": { "str": "Master of Forms" },
+    "points": 6,
+    "description": "You are a master of shapeshifting and are able to maintain four more simultaneous shapeshifts without drawing on your mana.",
+    "prereqs": [ "POOKA_SHAPESHIFT_GOOD2" ],
+    "category": [ "FAIR_FOLK_COMMONER_POOKA" ]
+    "threshreq": [ "THRESH_FAIR_FOLK_COMMONER_POOKA" ]
   },
   {
     "type": "mutation",

--- a/data/mods/Xedra_Evolved/mutations/playable_changeling.json
+++ b/data/mods/Xedra_Evolved/mutations/playable_changeling.json
@@ -967,6 +967,18 @@
             { "not": { "u_has_worn_with_flag": "STURDY" } },
             {
               "u_has_any_trait": [ "ANTLERS", "HORNS_CURLED", "FANGS", "SABER_TEETH", "CLAWS", "CLAWS_ST", "TAIL_STING" ]
+            },
+            {
+              "not": {
+                "u_has_any_trait": [
+                  "VAMPIRE_BAT_FORM_TRAITS",
+                  "TURN_INTO_RAVEN_TRAITS",
+                  "TURN_INTO_BEAR_TRAITS",
+                  "TURN_INTO_DEER_TRAITS",
+                  "VAMPIRE_WOLF_FORM_TRAITS",
+                  "TURN_INTO_COUGAR_TRAITS"
+                ]
+              }
             }
           ]
         },
@@ -1008,6 +1020,18 @@
                 "TAIL_FLUFFY",
                 "TAIL_LONG"
               ]
+            },
+            {
+              "not": {
+                "u_has_any_trait": [
+                  "VAMPIRE_BAT_FORM_TRAITS",
+                  "TURN_INTO_RAVEN_TRAITS",
+                  "TURN_INTO_BEAR_TRAITS",
+                  "TURN_INTO_DEER_TRAITS",
+                  "VAMPIRE_WOLF_FORM_TRAITS",
+                  "TURN_INTO_COUGAR_TRAITS"
+                ]
+              }
             }
           ]
         },
@@ -1053,6 +1077,18 @@
                 "TAIL_FLUFFY",
                 "TAIL_LONG"
               ]
+            },
+            {
+              "not": {
+                "u_has_any_trait": [
+                  "VAMPIRE_BAT_FORM_TRAITS",
+                  "TURN_INTO_RAVEN_TRAITS",
+                  "TURN_INTO_BEAR_TRAITS",
+                  "TURN_INTO_DEER_TRAITS",
+                  "VAMPIRE_WOLF_FORM_TRAITS",
+                  "TURN_INTO_COUGAR_TRAITS"
+                ]
+              }
             }
           ]
         },

--- a/data/mods/Xedra_Evolved/mutations/playable_changeling.json
+++ b/data/mods/Xedra_Evolved/mutations/playable_changeling.json
@@ -907,7 +907,7 @@
             "value": "SPEED",
             "add": {
               "math": [
-                "min( (3 + (u_has_trait('ANTLERS') + (u_has_trait('HORNS_CURLED') + (u_has_trait('FANGS') + (u_has_trait('SABER_TEETH') + (u_has_trait('CLAWS') + (u_has_trait('CLAWS_ST') + (u_has_trait('WINGS_BIRD') + (u_has_trait('URSINE_FUR') + (u_has_trait('CHITIN2') + (u_has_trait('TAIL_FLUFFY') + (u_has_trait('TAIL_LONG') + )),30)"
+                "min( (3 + (u_has_trait('ANTLERS') * 2) + (u_has_trait('HORNS_CURLED') * 2) + (u_has_trait('FANGS') * 2) + (u_has_trait('SABER_TEETH') * 2) + (u_has_trait('CLAWS') * 2) + (u_has_trait('CLAWS_ST') * 2) + (u_has_trait('WINGS_BIRD') * 2) + (u_has_trait('URSINE_FUR') * 2) + (u_has_trait('CHITIN2') * 2) + (u_has_trait('TAIL_FLUFFY') * 2) + (u_has_trait('TAIL_LONG') * 2) ),30)"
               ]
             }
           }

--- a/data/mods/Xedra_Evolved/mutations/playable_changeling.json
+++ b/data/mods/Xedra_Evolved/mutations/playable_changeling.json
@@ -746,6 +746,19 @@
   },
   {
     "type": "mutation",
+    "id": "POOKA_TAIL_STING",
+    "name": { "str": "Spiked Tail (Shapeshift)" },
+    "points": 2,
+    "description": "Grow the tail of a scorpion, making it harder to wear pants but allowing you to attack with the stinger.",
+    "category": [ "FAIR_FOLK_COMMONER_POOKA" ],
+    "active": true,
+    "activated_is_setup": true,
+    "activated_eocs": [ "EOC_POOKA_TAIL_STING_ON" ],
+    "processed_eocs": [ "EOC_POOKA_SHAPESHIFTING_MANA_CHECK" ],
+    "deactivated_eocs": [ "EOC_POOKA_TAIL_STING_OFF" ]
+  },
+  {
+    "type": "mutation",
     "id": "POOKA_SHAPESHIFT_GOOD",
     "name": { "str": "Initiate of Forms" },
     "points": 2,

--- a/data/mods/Xedra_Evolved/mutations/playable_changeling.json
+++ b/data/mods/Xedra_Evolved/mutations/playable_changeling.json
@@ -544,6 +544,34 @@
   },
   {
     "type": "mutation",
+    "id": "POOKA_FANGS",
+    "name": { "str": "Fangs (Shapeshift)" },
+    "points": 2,
+    "description": "Grow a set of sharp fangs, allowing you to make a bite attack.",
+    "category": [ "FAIR_FOLK_COMMONER_POOKA" ],
+    "changes_to": [ "POOKA_SABER_TEETH" ],
+    "active": true,
+    "activated_is_setup": true,
+    "activated_eocs": [ "EOC_POOKA_FANGS_ON" ],
+    "processed_eocs": [ "EOC_POOKA_SHAPESHIFTING_MANA_CHECK" ],
+    "deactivated_eocs": [ "EOC_POOKA_FANGS_OFF" ]
+  },
+  {
+    "type": "mutation",
+    "id": "POOKA_SABER_TEETH",
+    "name": { "str": "Vicious Fangs (Shapeshift)" },
+    "points": 2,
+    "description": "Grow a set of long, saber-like fangs, preventing you from wearing mouth gear but allowing you to make rending bite attacks.",
+    "category": [ "FAIR_FOLK_COMMONER_POOKA" ],
+    "prereqs": [ "POOKA_FANGS" ],
+    "active": true,
+    "activated_is_setup": true,
+    "activated_eocs": [ "EOC_POOKA_SABER_TEETH_ON" ],
+    "processed_eocs": [ "EOC_POOKA_SHAPESHIFTING_MANA_CHECK" ],
+    "deactivated_eocs": [ "EOC_POOKA_SABER_TEETH_OFF" ]
+  },
+  {
+    "type": "mutation",
     "id": "POOKA_WOLF_EARS",
     "name": { "str": "Wolf Ears (Shapeshift)" },
     "points": 2,
@@ -575,6 +603,7 @@
     "points": 2,
     "description": "Grow a set of claws, improving your unarmed damage if you aren't wearing gloves.",
     "category": [ "FAIR_FOLK_COMMONER_POOKA" ],
+    "changes_to": [ "POOKA_STAINLESS_CLAWS" ],
     "active": true,
     "activated_is_setup": true,
     "activated_eocs": [ "EOC_POOKA_CLAWS_ON" ],
@@ -585,9 +614,10 @@
     "type": "mutation",
     "id": "POOKA_STAINLESS_CLAWS",
     "name": { "str": "Vicious Claws (Shapeshift)" },
-    "points": 2,
+    "points": 4,
     "description": "Grow a powerful set of claws, nearly as hard as steel, greatly improving your unarmed damage if you aren't wearing gloves.",
     "category": [ "FAIR_FOLK_COMMONER_POOKA" ],
+    "prereqs": [ "POOKA_CLAWS" ],
     "active": true,
     "activated_is_setup": true,
     "activated_eocs": [ "EOC_POOKA_STAINLESS_CLAWS_ON" ],
@@ -742,6 +772,78 @@
     "prereqs": [ "POOKA_SHAPESHIFT_GOOD2" ],
     "category": [ "FAIR_FOLK_COMMONER_POOKA" ],
     "threshreq": [ "THRESH_FAIR_FOLK_COMMONER_POOKA" ]
+  },
+  {
+    "type": "mutation",
+    "id": "POOKA_UNARMED_ATTACK_BONUSES",
+    "name": { "str": "Instinctive Attacks" },
+    "points": 3,
+    "description": "You're getting used to moving and reacting like an animal.  When without weapons or armor and using your gifts of shapeshifting, your natural attacks do more damage.",
+    "prereqs": [ "POOKA_ANTLERS", "POOKA_HORNS" ],
+    "prereqs2": [ "POOKA_CLAWS", "POOKA_STAINLESS_CLAWS" ],
+    "category": [ "FAIR_FOLK_COMMONER_POOKA" ],
+    "enchantments": [
+      {
+        "condition": {
+          "and": [
+            { "not": "u_can_drop_weapon" },
+            { "not": { "u_has_worn_with_flag": "STURY" } },
+            { "u_has_any_trait": [ "ANTLERS", "HORNS_CURLED", "FANGS", "SABER_TEETH", "CLAWS", "CLAWS_ST" ] }
+          ]
+        },
+        "values": [
+          {
+            "value": "MELEE_DAMAGE",
+            "multiply": { "math": [ "0.1 + (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_POOKA') * 0.01)" ] }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "mutation",
+    "id": "POOKA_UNARMED_DODGE_BONUSES",
+    "name": { "str": "Animalistic Defense" },
+    "points": 5,
+    "description": "The best defense is not getting hit, especially if you're a wild animal.  When using your shapeshifting and not wearing armor or using a weapon, you gain a bonus to your dodging.",
+    "prereqs": [ "POOKA_UNARMED_ATTACK_BONUSES" ],
+    "category": [ "FAIR_FOLK_COMMONER_POOKA" ],
+    "enchantments": [
+      {
+        "condition": {
+          "and": [
+            { "not": "u_can_drop_weapon" },
+            { "not": { "u_has_worn_with_flag": "STURY" } },
+            {
+              "u_has_any_trait": [ 
+                "ANTLERS", 
+                "HORNS_CURLED", 
+                "FANGS",
+                "SABER_TEETH",
+                "CLAWS", 
+                "CLAWS_ST", 
+                "WINGS_BIRD", 
+                "URSINE_FUR", 
+                "CHITIN2", 
+                "POOKA_QUADRUPED_TRAITS", 
+                "TAIL_FLUFFY", 
+                "TAIL_LONG" 
+              ]
+            }
+          ]
+        },
+        "values": [
+          {
+            "value": "BONUS_DODGE",
+            "add": { "math": [ "min( (1 + (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_POOKA') * 0.1)),4)" ] }
+          },
+          {
+            "value": "DODGE_CHANCE",
+            "add": { "math": [ "min( (2 + (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_POOKA') * 0.25) ),12)" ] }
+          }
+        ]
+      }
+    ]
   },
   {
     "type": "mutation",

--- a/data/mods/Xedra_Evolved/mutations/playable_changeling.json
+++ b/data/mods/Xedra_Evolved/mutations/playable_changeling.json
@@ -200,14 +200,32 @@
   },
   {
     "type": "mutation",
+    "id": "STR_UP_4",
+    "copy-from": "STR_UP_4",
+    "extend": { "category": [ "FAIR_FOLK_COMMONER_TROW" ], "threshreq": [ "THRESH_FAIR_FOLK_COMMONER_TROW" ] }
+  },
+  {
+    "type": "mutation",
     "id": "DEX_UP_3",
     "copy-from": "DEX_UP_3",
     "extend": { "category": [ "FAIR_FOLK_COMMONER_BROWNIE" ], "threshreq": [ "THRESH_FAIR_FOLK_COMMONER_BROWNIE" ] }
   },
   {
     "type": "mutation",
+    "id": "DEX_UP_4",
+    "copy-from": "DEX_UP_4",
+    "extend": { "category": [ "FAIR_FOLK_COMMONER_BROWNIE" ], "threshreq": [ "THRESH_FAIR_FOLK_COMMONER_BROWNIE" ] }
+  },
+  {
+    "type": "mutation",
     "id": "PER_UP_3",
     "copy-from": "PER_UP_3",
+    "extend": { "category": [ "FAIR_FOLK_COMMONER_POOKA" ], "threshreq": [ "THRESH_FAIR_FOLK_COMMONER_POOKA" ] }
+  },
+  {
+    "type": "mutation",
+    "id": "PER_UP_4",
+    "copy-from": "PER_UP_4",
     "extend": { "category": [ "FAIR_FOLK_COMMONER_POOKA" ], "threshreq": [ "THRESH_FAIR_FOLK_COMMONER_POOKA" ] }
   },
   {
@@ -470,6 +488,26 @@
   },
   {
     "type": "mutation",
+    "id": "PER_UP_BROWNIE",
+    "name": { "str": "Seneschal's Gaze" },
+    "points": 3,
+    "description": "With a few quick glances you can take in the contents of an entire room.  +3 Perception.",
+    "prereqs": [ "PARACLESIAN_INT_PER_1", "PARACLESIAN_INT_PER_2" ],
+    "category": [ "FAIR_FOLK_COMMONER_BROWNIE" ],
+    "enchantments": [ { "values": [ { "value": "PERCEPTION", "add": 3 } ] } ]
+  },
+  {
+    "type": "mutation",
+    "id": "INT_UP_BROWNIE",
+    "name": { "str": "Chatelain's Mind" },
+    "points": 2,
+    "description": "It takes a keen mind to keep a household running smoothly.  +2 Intelligence.",
+    "prereqs": [ "PARACLESIAN_INT_PER_1", "PARACLESIAN_INT_PER_2" ],
+    "category": [ "FAIR_FOLK_COMMONER_BROWNIE" ],
+    "enchantments": [ { "values": [ { "value": "INTELLIGENCE", "add": 2 } ] } ]
+  },
+  {
+    "type": "mutation",
     "id": "BROWNIE_HOMEBODY",
     "name": { "str": "Homebody" },
     "description": "Brownies know every corner of their homes, all the well-worn grooves in the floor and the quick paths from place to place.  Your speed is increased the longer you spend in the same area.",
@@ -707,12 +745,13 @@
       ]
     ],
     "enchantments": [
-      "ench_quadruped_movement_full",
       {
-        "condition": { "and": [ { "u_has_move_mode": "crouch" }, { "not": "u_can_drop_weapon" } ] },
-        "values": [ { "value": "MOVE_COST", "multiply": -0.35 } ]
-      },
-      { "values": [ { "value": "CARRY_WEIGHT", "multiply": -0.2 } ] }
+        "condition": {
+          "and": [ { "or": [ { "u_has_move_mode": "crouch" }, { "u_has_move_mode": "run" } ] }, { "not": "u_can_drop_weapon" } ]
+        },
+        "values": [ { "value": "MOVE_COST", "multiply": -0.5 }, { "value": "CARRY_WEIGHT", "multiply": 0.35 } ],
+        "ench_effects": [ { "effect": "natural_stance", "intensity": 1 }, { "effect": "quadruped_full", "intensity": 1 } ]
+      }
     ]
   },
   {
@@ -769,6 +808,26 @@
   },
   {
     "type": "mutation",
+    "id": "STR_UP_POOKA",
+    "name": { "str": "Bestial Strength" },
+    "points": 2,
+    "description": "Even when not shapeshifted you can bring part of a wild animal's strength to bear.  +2 Strength.",
+    "prereqs": [ "PARACLESIAN_STR_DEX_1", "PARACLESIAN_STR_DEX_2" ],
+    "category": [ "FAIR_FOLK_COMMONER_POOKA" ],
+    "enchantments": [ { "values": [ { "value": "STRENGTH", "add": 2 } ] } ]
+  },
+  {
+    "type": "mutation",
+    "id": "DEX_UP_POOKA",
+    "name": { "str": "Untamed Agility" },
+    "points": 3,
+    "description": "You have the quick reactions of a wild animal.  +3 Dexterity.",
+    "prereqs": [ "PARACLESIAN_STR_DEX_1", "PARACLESIAN_STR_DEX_2" ],
+    "category": [ "FAIR_FOLK_COMMONER_POOKA" ],
+    "enchantments": [ { "values": [ { "value": "DEXTERITY", "add": 3 } ] } ]
+  },
+  {
+    "type": "mutation",
     "id": "POOKA_SHAPESHIFT_GOOD",
     "name": { "str": "Initiate of Forms" },
     "points": 2,
@@ -798,6 +857,101 @@
   },
   {
     "type": "mutation",
+    "id": "POOKA_SHAPESHIFT_FULL_SELECTOR",
+    "name": { "str": "Pinnacle of Forms" },
+    "points": 6,
+    "description": "This gives you access to the full shapeshift traits.  You should never seen it.",
+    "prereqs": [ "POOKA_SHAPESHIFT_GOOD2", "POOKA_SHAPESHIFT_GOOD3" ],
+    "player_display": false,
+    "category": [ "FAIR_FOLK_COMMONER_POOKA" ],
+    "threshreq": [ "THRESH_FAIR_FOLK_COMMONER_POOKA" ]
+  },
+  {
+    "type": "mutation",
+    "id": "POOKA_SHAPESHIFT_FULL_BAT",
+    "name": { "str": "Spirit of the Bat" },
+    "points": 10,
+    "description": "You can transform yourself into a bat.",
+    "purifiable": false,
+    "valid": false,
+    "active": true,
+    "activated_is_setup": true,
+    "activated_eocs": [ "EOC_POOKA_SHAPESHIFT_FULL_BAT_activated" ],
+    "processed_eocs": [ "EOC_POOKA_SHAPESHIFT_FULL_PROCESSED" ],
+    "deactivated_eocs": [ "EOC_POOKA_SHAPESHIFT_FULL_BAT_deactivated" ]
+  },
+  {
+    "type": "mutation",
+    "id": "POOKA_SHAPESHIFT_FULL_RAVEN",
+    "name": { "str": "Spirit of the Raven" },
+    "points": 10,
+    "description": "You can transform yourself into a raven.",
+    "purifiable": false,
+    "valid": false,
+    "active": true,
+    "activated_is_setup": true,
+    "activated_eocs": [ "EOC_POOKA_SHAPESHIFT_FULL_RAVEN_activated" ],
+    "processed_eocs": [ "EOC_POOKA_SHAPESHIFT_FULL_PROCESSED" ],
+    "deactivated_eocs": [ "EOC_POOKA_SHAPESHIFT_FULL_RAVEN_deactivated" ]
+  },
+  {
+    "type": "mutation",
+    "id": "POOKA_SHAPESHIFT_FULL_BEAR",
+    "name": { "str": "Spirit of the Bear" },
+    "points": 10,
+    "description": "You can transform yourself into a bear.",
+    "purifiable": false,
+    "valid": false,
+    "active": true,
+    "activated_is_setup": true,
+    "activated_eocs": [ "EOC_POOKA_SHAPESHIFT_FULL_BEAR_activated" ],
+    "processed_eocs": [ "EOC_POOKA_SHAPESHIFT_FULL_PROCESSED" ],
+    "deactivated_eocs": [ "EOC_POOKA_SHAPESHIFT_FULL_BEAR_deactivated" ]
+  },
+  {
+    "type": "mutation",
+    "id": "POOKA_SHAPESHIFT_FULL_DEER",
+    "name": { "str": "Spirit of the Deer" },
+    "points": 10,
+    "description": "You can transform yourself into a deer.",
+    "purifiable": false,
+    "valid": false,
+    "active": true,
+    "activated_is_setup": true,
+    "activated_eocs": [ "EOC_POOKA_SHAPESHIFT_FULL_DEER_activated" ],
+    "processed_eocs": [ "EOC_POOKA_SHAPESHIFT_FULL_PROCESSED" ],
+    "deactivated_eocs": [ "EOC_POOKA_SHAPESHIFT_FULL_DEER_deactivated" ]
+  },
+  {
+    "type": "mutation",
+    "id": "POOKA_SHAPESHIFT_FULL_WOLF",
+    "name": { "str": "Spirit of the Wolf" },
+    "points": 10,
+    "description": "You can transform yourself into a wolf.",
+    "purifiable": false,
+    "valid": false,
+    "active": true,
+    "activated_is_setup": true,
+    "activated_eocs": [ "EOC_POOKA_SHAPESHIFT_FULL_WOLF_activated" ],
+    "processed_eocs": [ "EOC_POOKA_SHAPESHIFT_FULL_PROCESSED" ],
+    "deactivated_eocs": [ "EOC_POOKA_SHAPESHIFT_FULL_WOLF_deactivated" ]
+  },
+  {
+    "type": "mutation",
+    "id": "POOKA_SHAPESHIFT_FULL_COUGAR",
+    "name": { "str": "Spirit of the Cougar" },
+    "points": 10,
+    "description": "You can transform yourself into a cougar.",
+    "purifiable": false,
+    "valid": false,
+    "active": true,
+    "activated_is_setup": true,
+    "activated_eocs": [ "EOC_POOKA_SHAPESHIFT_FULL_COUGAR_activated" ],
+    "processed_eocs": [ "EOC_POOKA_SHAPESHIFT_FULL_PROCESSED" ],
+    "deactivated_eocs": [ "EOC_POOKA_SHAPESHIFT_FULL_COUGAR_deactivated" ]
+  },
+  {
+    "type": "mutation",
     "id": "POOKA_UNARMED_ATTACK_BONUSES",
     "name": { "str": "Instinctive Attacks" },
     "points": 3,
@@ -810,7 +964,7 @@
         "condition": {
           "and": [
             { "not": "u_can_drop_weapon" },
-            { "not": { "u_has_worn_with_flag": "STURY" } },
+            { "not": { "u_has_worn_with_flag": "STURDY" } },
             {
               "u_has_any_trait": [ "ANTLERS", "HORNS_CURLED", "FANGS", "SABER_TEETH", "CLAWS", "CLAWS_ST", "TAIL_STING" ]
             }
@@ -838,7 +992,7 @@
         "condition": {
           "and": [
             { "not": "u_can_drop_weapon" },
-            { "not": { "u_has_worn_with_flag": "STURY" } },
+            { "not": { "u_has_worn_with_flag": "STURDY" } },
             {
               "u_has_any_trait": [
                 "ANTLERS",
@@ -884,7 +1038,7 @@
         "condition": {
           "and": [
             { "not": "u_can_drop_weapon" },
-            { "not": { "u_has_worn_with_flag": "STURY" } },
+            { "not": { "u_has_worn_with_flag": "STURDY" } },
             {
               "u_has_any_trait": [
                 "ANTLERS",

--- a/data/mods/Xedra_Evolved/mutations/playable_changeling.json
+++ b/data/mods/Xedra_Evolved/mutations/playable_changeling.json
@@ -559,7 +559,7 @@
     "id": "POOKA_CHARM_ANIMALS",
     "name": { "str": "Friend to Birds and Beasts" },
     "points": 3,
-    "description": "You are close enough to the birds and beasts that you can speak their langauge and ask them for aid.",
+    "description": "You are close enough to the birds and beasts that you can speak their language and ask them for aid.",
     "prereqs": [ "ANIMALEMPATH2" ],
     "category": [ "FAIR_FOLK_COMMONER_POOKA" ],
     "spells_learned": [ [ "changeling_pooka_charm_animals_spell", 1 ] ]

--- a/data/mods/Xedra_Evolved/mutations/playable_changeling.json
+++ b/data/mods/Xedra_Evolved/mutations/playable_changeling.json
@@ -518,6 +518,16 @@
   },
   {
     "type": "mutation",
+    "id": "POOKA_CHARM_ANIMALS",
+    "name": { "str": "Friend to Birds and Beasts" },
+    "points": 3,
+    "description": "You are close enough to the birds and beasts that you can speak their langauge and ask them for aid.",
+    "prereqs": [ "ANIMALEMPATH2" ],
+    "category": [ "FAIR_FOLK_COMMONER_POOKA" ],
+    "spells_learned": [ [ "changeling_pooka_charm_animals_spell", 1 ] ]
+  },
+  {
+    "type": "mutation",
     "id": "POOKA_ANTLERS",
     "name": { "str": "Antlers (Shapeshift)" },
     "points": 2,
@@ -792,8 +802,8 @@
     "name": { "str": "Instinctive Attacks" },
     "points": 3,
     "description": "You're getting used to moving and reacting like an animal.  When without weapons or armor and using your gifts of shapeshifting, your natural attacks do more damage.",
-    "prereqs": [ "POOKA_ANTLERS", "POOKA_HORNS" ],
-    "prereqs2": [ "POOKA_CLAWS", "POOKA_STAINLESS_CLAWS" ],
+    "prereqs": [ "POOKA_ANTLERS", "POOKA_HORNS", "POOKA_FANGS", "POOKA_SABER_TEETH" ],
+    "prereqs2": [ "POOKA_CLAWS", "POOKA_STAINLESS_CLAWS", "POOKA_TAIL_STING" ],
     "category": [ "FAIR_FOLK_COMMONER_POOKA" ],
     "enchantments": [
       {
@@ -801,7 +811,9 @@
           "and": [
             { "not": "u_can_drop_weapon" },
             { "not": { "u_has_worn_with_flag": "STURY" } },
-            { "u_has_any_trait": [ "ANTLERS", "HORNS_CURLED", "FANGS", "SABER_TEETH", "CLAWS", "CLAWS_ST", "TAIL_STING" ] }
+            {
+              "u_has_any_trait": [ "ANTLERS", "HORNS_CURLED", "FANGS", "SABER_TEETH", "CLAWS", "CLAWS_ST", "TAIL_STING" ]
+            }
           ]
         },
         "values": [
@@ -828,19 +840,19 @@
             { "not": "u_can_drop_weapon" },
             { "not": { "u_has_worn_with_flag": "STURY" } },
             {
-              "u_has_any_trait": [ 
-                "ANTLERS", 
-                "HORNS_CURLED", 
+              "u_has_any_trait": [
+                "ANTLERS",
+                "HORNS_CURLED",
                 "FANGS",
                 "SABER_TEETH",
-                "CLAWS", 
-                "CLAWS_ST", 
-                "WINGS_BIRD", 
-                "URSINE_FUR", 
-                "CHITIN2", 
-                "POOKA_QUADRUPED_TRAITS", 
-                "TAIL_FLUFFY", 
-                "TAIL_LONG" 
+                "CLAWS",
+                "CLAWS_ST",
+                "WINGS_BIRD",
+                "URSINE_FUR",
+                "CHITIN2",
+                "POOKA_QUADRUPED_TRAITS",
+                "TAIL_FLUFFY",
+                "TAIL_LONG"
               ]
             }
           ]
@@ -853,6 +865,51 @@
           {
             "value": "DODGE_CHANCE",
             "add": { "math": [ "min( (2 + (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_POOKA') * 0.25) ),12)" ] }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "mutation",
+    "id": "POOKA_SPEED_BONUSES",
+    "name": { "str": "Primal Alacrity" },
+    "points": 3,
+    "description": "Like the animals you mimic, you're quicker than you seem.  You gain a speed bonus while shapeshifted as long as you're unarmed and unarmored.",
+    "prereqs": [ "POOKA_UNARMED_ATTACK_BONUSES" ],
+    "prereqs2": [ "WINGS_BIRD", "POOKA_LEAPING_LEGS", "POOKA_QUADRUPED", "TAIL_FLUFFY", "TAIL_LONG" ],
+    "category": [ "FAIR_FOLK_COMMONER_POOKA" ],
+    "enchantments": [
+      {
+        "condition": {
+          "and": [
+            { "not": "u_can_drop_weapon" },
+            { "not": { "u_has_worn_with_flag": "STURY" } },
+            {
+              "u_has_any_trait": [
+                "ANTLERS",
+                "HORNS_CURLED",
+                "FANGS",
+                "SABER_TEETH",
+                "CLAWS",
+                "CLAWS_ST",
+                "WINGS_BIRD",
+                "URSINE_FUR",
+                "CHITIN2",
+                "TAIL_FLUFFY",
+                "TAIL_LONG"
+              ]
+            }
+          ]
+        },
+        "values": [
+          {
+            "value": "SPEED",
+            "add": {
+              "math": [
+                "min( (3 + (u_has_trait('ANTLERS') + (u_has_trait('HORNS_CURLED') + (u_has_trait('FANGS') + (u_has_trait('SABER_TEETH') + (u_has_trait('CLAWS') + (u_has_trait('CLAWS_ST') + (u_has_trait('WINGS_BIRD') + (u_has_trait('URSINE_FUR') + (u_has_trait('CHITIN2') + (u_has_trait('TAIL_FLUFFY') + (u_has_trait('TAIL_LONG') + )),30)"
+              ]
+            }
           }
         ]
       }

--- a/data/mods/Xedra_Evolved/mutations/playable_changeling.json
+++ b/data/mods/Xedra_Evolved/mutations/playable_changeling.json
@@ -660,12 +660,7 @@
     "triggers": [
       [
         {
-          "condition": {
-            "and": [
-              { "u_has_move_mode": "crouch" },
-              { "not": "u_can_drop_weapon" }
-            ]
-          },
+          "condition": { "and": [ { "u_has_move_mode": "crouch" }, { "not": "u_can_drop_weapon" } ] },
           "msg_on": { "text": "You drop down on all fours." },
           "msg_off": { "text": "You come out of your quadrupedal posture." }
         }
@@ -745,7 +740,7 @@
     "points": 6,
     "description": "You are a master of shapeshifting and are able to maintain four more simultaneous shapeshifts without drawing on your mana.",
     "prereqs": [ "POOKA_SHAPESHIFT_GOOD2" ],
-    "category": [ "FAIR_FOLK_COMMONER_POOKA" ]
+    "category": [ "FAIR_FOLK_COMMONER_POOKA" ],
     "threshreq": [ "THRESH_FAIR_FOLK_COMMONER_POOKA" ]
   },
   {

--- a/data/mods/Xedra_Evolved/mutations/playable_changeling.json
+++ b/data/mods/Xedra_Evolved/mutations/playable_changeling.json
@@ -801,7 +801,7 @@
           "and": [
             { "not": "u_can_drop_weapon" },
             { "not": { "u_has_worn_with_flag": "STURY" } },
-            { "u_has_any_trait": [ "ANTLERS", "HORNS_CURLED", "FANGS", "SABER_TEETH", "CLAWS", "CLAWS_ST" ] }
+            { "u_has_any_trait": [ "ANTLERS", "HORNS_CURLED", "FANGS", "SABER_TEETH", "CLAWS", "CLAWS_ST", "TAIL_STING" ] }
           ]
         },
         "values": [

--- a/data/mods/Xedra_Evolved/mutations/playable_changeling_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/playable_changeling_eocs.json
@@ -1040,6 +1040,11 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_POOKIE_GAIN_PINNACLE_OF_FORMS_TRAIT_BAT",
+    "effect": [ { "u_add_trait": "POOKA_SHAPESHIFT_FULL_BAT" } ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_POOKA_SHAPESHIFT_FULL_BAT_activated",
     "condition": { "not": { "u_has_trait": "VAMPIRE_BAT_FORM_TRAITS" } },
     "effect": [

--- a/data/mods/Xedra_Evolved/mutations/playable_changeling_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/playable_changeling_eocs.json
@@ -787,7 +787,11 @@
           {
             "id": "EOC_POOKA_SHAPESHIFTING_MANA_CHECK_2",
             "condition": {
-              "math": [ "pooka_shapeshift_traits()", ">=", "1 + u_has_trait('POOKA_SHAPESHIFT_GOOD') + (u_has_trait('POOKA_SHAPESHIFT_GOOD2') * 2) + (u_has_trait('POOKA_SHAPESHIFT_GOOD3') * 4) + (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_POOKA') / 25)" ]
+              "math": [
+                "pooka_shapeshift_traits()",
+                ">=",
+                "1 + u_has_trait('POOKA_SHAPESHIFT_GOOD') + (u_has_trait('POOKA_SHAPESHIFT_GOOD2') * 2) + (u_has_trait('POOKA_SHAPESHIFT_GOOD3') * 4) + (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_POOKA') / 25)"
+              ]
             },
             "effect": [ { "math": [ "u_val('mana')", "--" ] } ]
           }

--- a/data/mods/Xedra_Evolved/mutations/playable_changeling_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/playable_changeling_eocs.json
@@ -808,9 +808,17 @@
     "id": "EOC_POOKA_SHAPESHIFTS_REMOVE_deactivate_future",
     "effect": [
       { "u_deactivate_trait": "POOKA_ANTLERS" },
+      { "u_deactivate_trait": "POOKA_HORNS" },
+      { "u_deactivate_trait": "POOKA_FANGS" },
+      { "u_deactivate_trait": "POOKA_SABER_TEETH" },
       { "u_deactivate_trait": "POOKA_WOLF_EARS" },
+      { "u_deactivate_trait": "POOKA_FELINE_EARS" },
       { "u_deactivate_trait": "POOKA_CLAWS" },
       { "u_deactivate_trait": "POOKA_STAINLESS_CLAWS" },
+      { "u_deactivate_trait": "POOKA_URSINE_FUR" },
+      { "u_deactivate_trait": "POOKA_CHITIN" },
+      { "u_deactivate_trait": "POOKA_QUADRUPED" },
+      { "u_deactivate_trait": "POOKA_LEAPING_LEGS" },
       { "u_deactivate_trait": "POOKA_WOLF_TAIL" },
       { "u_deactivate_trait": "POOKA_TAIL_LONG" }
     ]
@@ -834,6 +842,26 @@
     "type": "effect_on_condition",
     "id": "EOC_POOKA_HORNS_OFF",
     "effect": [ { "u_lose_trait": "HORNS_CURLED" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_FANGS_ON",
+    "effect": [ { "u_add_trait": "FANGS" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_FANGS_OFF",
+    "effect": [ { "u_lose_trait": "FANGS" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_SABER_TEETH_ON",
+    "effect": [ { "u_add_trait": "SABER_TEETH" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_SABER_TEETH_OFF",
+    "effect": [ { "u_lose_trait": "SABER_TEETH" } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/Xedra_Evolved/mutations/playable_changeling_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/playable_changeling_eocs.json
@@ -790,7 +790,7 @@
               "math": [
                 "pooka_shapeshift_traits()",
                 ">=",
-                "1 + u_has_trait('POOKA_SHAPESHIFT_GOOD') + (u_has_trait('POOKA_SHAPESHIFT_GOOD2') * 2) + (u_has_trait('POOKA_SHAPESHIFT_GOOD3') * 4) + (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_POOKA') / 25)"
+                "1 + u_has_trait('POOKA_SHAPESHIFT_GOOD') + (u_has_trait('POOKA_SHAPESHIFT_GOOD2') * 2) + (u_has_trait('POOKA_SHAPESHIFT_GOOD3') * 4) + (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_POOKA') / 50)"
               ]
             },
             "effect": [ { "math": [ "u_val('mana')", "--" ] } ]

--- a/data/mods/Xedra_Evolved/mutations/playable_changeling_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/playable_changeling_eocs.json
@@ -787,7 +787,7 @@
           {
             "id": "EOC_POOKA_SHAPESHIFTING_MANA_CHECK_2",
             "condition": {
-              "math": [ "pooka_shapeshift_traits()", ">=", "2 + (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_POOKA') / 25)" ]
+              "math": [ "pooka_shapeshift_traits()", ">=", "1 + u_has_trait('POOKA_SHAPESHIFT_GOOD') + (u_has_trait('POOKA_SHAPESHIFT_GOOD2') * 2) + (u_has_trait('POOKA_SHAPESHIFT_GOOD3') * 4) + (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_POOKA') / 25)" ]
             },
             "effect": [ { "math": [ "u_val('mana')", "--" ] } ]
           }
@@ -814,7 +814,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_POOKA_ANTLERS_ON",
-    "effect": [ { "u_add_trait": "ANTLERS" } ]
+    "effect": [ { "u_deactivate_trait": "POOKA_HORNS" }, { "u_add_trait": "ANTLERS" } ]
   },
   {
     "type": "effect_on_condition",
@@ -823,13 +823,33 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_POOKA_HORNS_ON",
+    "effect": [ { "u_deactivate_trait": "POOKA_ANTLERS" }, { "u_add_trait": "HORNS_CURLED" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_HORNS_OFF",
+    "effect": [ { "u_lose_trait": "HORNS_CURLED" } ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_POOKA_WOLF_EARS_ON",
-    "effect": [ { "u_lose_trait": "ELFA_EARS" }, { "u_add_trait": "LUPINE_EARS" } ]
+    "effect": [ { "u_lose_trait": "ELFA_EARS" }, { "u_deactivate_trait": "POOKA_ANTLERS" }, { "u_add_trait": "LUPINE_EARS" } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_POOKA_WOLF_EARS_OFF",
     "effect": [ { "u_lose_trait": "LUPINE_EARS" }, { "u_add_trait": "ELFA_EARS" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_FELINE_EARS_ON",
+    "effect": [ { "u_lose_trait": "ELFA_EARS" }, { "u_deactivate_trait": "POOKA_ANTLERS" }, { "u_add_trait": "FELINE_EARS" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_FELINE_EARS_OFF",
+    "effect": [ { "u_lose_trait": "FELINE_EARS" }, { "u_add_trait": "ELFA_EARS" } ]
   },
   {
     "type": "effect_on_condition",
@@ -850,6 +870,56 @@
     "type": "effect_on_condition",
     "id": "EOC_POOKA_STAINLESS_CLAWS_OFF",
     "effect": [ { "u_lose_trait": "CLAWS_ST" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_BIRD_WINGS_ON",
+    "effect": [ { "u_add_trait": "WINGS_BIRD" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_BIRD_WINGS_OFF",
+    "effect": [ { "u_lose_trait": "WINGS_BIRD" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_URSINE_FUR_ON",
+    "effect": [ { "u_deactivate_trait": "POOKA_CHITIN" }, { "u_add_trait": "URSINE_FUR" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_URSINE_FUR_OFF",
+    "effect": [ { "u_lose_trait": "URSINE_FUR" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_CHITIN_ON",
+    "effect": [ { "u_deactivate_trait": "POOKA_URSINE_FUR" }, { "u_add_trait": "CHITIN2" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_CHITIN_OFF",
+    "effect": [ { "u_lose_trait": "CHITIN2" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_QUADRUPED_ON",
+    "effect": [ { "u_deactivate_trait": "POOKA_LEAPING_LEGS" }, { "u_add_trait": "POOKA_QUADRUPED_TRAITS" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_QUADRUPED_OFF",
+    "effect": [ { "u_lose_trait": "POOKA_QUADRUPED_TRAITS" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_LEAPING_LEGS_ON",
+    "effect": [ { "u_deactivate_trait": "POOKA_QUADRUPED_TRAITS" }, { "u_add_trait": "LEAPING_LEGS" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_LEAPING_LEGS_OFF",
+    "effect": [ { "u_lose_trait": "LEAPING_LEGS" } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/Xedra_Evolved/mutations/playable_changeling_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/playable_changeling_eocs.json
@@ -831,7 +831,7 @@
     "effect": [ { "u_deactivate_trait": "POOKA_HORNS" }, { "u_add_trait": "ANTLERS" } ],
     "false_effect": [
       {
-        "u_message": "You are in the form of an animal.  You must turn back bfore shapeshifting individual parts of your body.",
+        "u_message": "You are in the form of an animal.  You must turn back before shapeshifting individual parts of your body.",
         "type": "bad"
       },
       { "run_eocs": "EOC_POOKA_SHAPESHIFTS_REMOVE_deactivate_future" }
@@ -849,7 +849,7 @@
     "effect": [ { "u_deactivate_trait": "POOKA_ANTLERS" }, { "u_add_trait": "HORNS_CURLED" } ],
     "false_effect": [
       {
-        "u_message": "You are in the form of an animal.  You must turn back bfore shapeshifting individual parts of your body.",
+        "u_message": "You are in the form of an animal.  You must turn back before shapeshifting individual parts of your body.",
         "type": "bad"
       },
       { "run_eocs": "EOC_POOKA_SHAPESHIFTS_REMOVE_deactivate_future" }
@@ -867,7 +867,7 @@
     "effect": [ { "u_add_trait": "FANGS" } ],
     "false_effect": [
       {
-        "u_message": "You are in the form of an animal.  You must turn back bfore shapeshifting individual parts of your body.",
+        "u_message": "You are in the form of an animal.  You must turn back before shapeshifting individual parts of your body.",
         "type": "bad"
       },
       { "run_eocs": "EOC_POOKA_SHAPESHIFTS_REMOVE_deactivate_future" }
@@ -885,7 +885,7 @@
     "effect": [ { "u_add_trait": "SABER_TEETH" } ],
     "false_effect": [
       {
-        "u_message": "You are in the form of an animal.  You must turn back bfore shapeshifting individual parts of your body.",
+        "u_message": "You are in the form of an animal.  You must turn back before shapeshifting individual parts of your body.",
         "type": "bad"
       },
       { "run_eocs": "EOC_POOKA_SHAPESHIFTS_REMOVE_deactivate_future" }
@@ -903,7 +903,7 @@
     "effect": [ { "u_lose_trait": "ELFA_EARS" }, { "u_deactivate_trait": "POOKA_FELINE_EARS" }, { "u_add_trait": "LUPINE_EARS" } ],
     "false_effect": [
       {
-        "u_message": "You are in the form of an animal.  You must turn back bfore shapeshifting individual parts of your body.",
+        "u_message": "You are in the form of an animal.  You must turn back before shapeshifting individual parts of your body.",
         "type": "bad"
       },
       { "run_eocs": "EOC_POOKA_SHAPESHIFTS_REMOVE_deactivate_future" }
@@ -921,7 +921,7 @@
     "effect": [ { "u_lose_trait": "ELFA_EARS" }, { "u_deactivate_trait": "POOKA_WOLF_EARS" }, { "u_add_trait": "FELINE_EARS" } ],
     "false_effect": [
       {
-        "u_message": "You are in the form of an animal.  You must turn back bfore shapeshifting individual parts of your body.",
+        "u_message": "You are in the form of an animal.  You must turn back before shapeshifting individual parts of your body.",
         "type": "bad"
       },
       { "run_eocs": "EOC_POOKA_SHAPESHIFTS_REMOVE_deactivate_future" }
@@ -939,7 +939,7 @@
     "effect": [ { "u_add_trait": "CLAWS" } ],
     "false_effect": [
       {
-        "u_message": "You are in the form of an animal.  You must turn back bfore shapeshifting individual parts of your body.",
+        "u_message": "You are in the form of an animal.  You must turn back before shapeshifting individual parts of your body.",
         "type": "bad"
       },
       { "run_eocs": "EOC_POOKA_SHAPESHIFTS_REMOVE_deactivate_future" }
@@ -957,7 +957,7 @@
     "effect": [ { "u_add_trait": "CLAWS_ST" } ],
     "false_effect": [
       {
-        "u_message": "You are in the form of an animal.  You must turn back bfore shapeshifting individual parts of your body.",
+        "u_message": "You are in the form of an animal.  You must turn back before shapeshifting individual parts of your body.",
         "type": "bad"
       },
       { "run_eocs": "EOC_POOKA_SHAPESHIFTS_REMOVE_deactivate_future" }
@@ -975,7 +975,7 @@
     "effect": [ { "u_add_trait": "WINGS_BIRD" } ],
     "false_effect": [
       {
-        "u_message": "You are in the form of an animal.  You must turn back bfore shapeshifting individual parts of your body.",
+        "u_message": "You are in the form of an animal.  You must turn back before shapeshifting individual parts of your body.",
         "type": "bad"
       },
       { "run_eocs": "EOC_POOKA_SHAPESHIFTS_REMOVE_deactivate_future" }
@@ -993,7 +993,7 @@
     "effect": [ { "u_deactivate_trait": "POOKA_CHITIN" }, { "u_add_trait": "URSINE_FUR" } ],
     "false_effect": [
       {
-        "u_message": "You are in the form of an animal.  You must turn back bfore shapeshifting individual parts of your body.",
+        "u_message": "You are in the form of an animal.  You must turn back before shapeshifting individual parts of your body.",
         "type": "bad"
       },
       { "run_eocs": "EOC_POOKA_SHAPESHIFTS_REMOVE_deactivate_future" }
@@ -1011,7 +1011,7 @@
     "effect": [ { "u_deactivate_trait": "POOKA_URSINE_FUR" }, { "u_add_trait": "CHITIN2" } ],
     "false_effect": [
       {
-        "u_message": "You are in the form of an animal.  You must turn back bfore shapeshifting individual parts of your body.",
+        "u_message": "You are in the form of an animal.  You must turn back before shapeshifting individual parts of your body.",
         "type": "bad"
       },
       { "run_eocs": "EOC_POOKA_SHAPESHIFTS_REMOVE_deactivate_future" }
@@ -1029,7 +1029,7 @@
     "effect": [ { "u_deactivate_trait": "POOKA_LEAPING_LEGS" }, { "u_add_trait": "POOKA_QUADRUPED_TRAITS" } ],
     "false_effect": [
       {
-        "u_message": "You are in the form of an animal.  You must turn back bfore shapeshifting individual parts of your body.",
+        "u_message": "You are in the form of an animal.  You must turn back before shapeshifting individual parts of your body.",
         "type": "bad"
       },
       { "run_eocs": "EOC_POOKA_SHAPESHIFTS_REMOVE_deactivate_future" }
@@ -1047,7 +1047,7 @@
     "effect": [ { "u_deactivate_trait": "POOKA_QUADRUPED_TRAITS" }, { "u_add_trait": "LEAPING_LEGS" } ],
     "false_effect": [
       {
-        "u_message": "You are in the form of an animal.  You must turn back bfore shapeshifting individual parts of your body.",
+        "u_message": "You are in the form of an animal.  You must turn back before shapeshifting individual parts of your body.",
         "type": "bad"
       },
       { "run_eocs": "EOC_POOKA_SHAPESHIFTS_REMOVE_deactivate_future" }
@@ -1069,7 +1069,7 @@
     ],
     "false_effect": [
       {
-        "u_message": "You are in the form of an animal.  You must turn back bfore shapeshifting individual parts of your body.",
+        "u_message": "You are in the form of an animal.  You must turn back before shapeshifting individual parts of your body.",
         "type": "bad"
       },
       { "run_eocs": "EOC_POOKA_SHAPESHIFTS_REMOVE_deactivate_future" }
@@ -1091,7 +1091,7 @@
     ],
     "false_effect": [
       {
-        "u_message": "You are in the form of an animal.  You must turn back bfore shapeshifting individual parts of your body.",
+        "u_message": "You are in the form of an animal.  You must turn back before shapeshifting individual parts of your body.",
         "type": "bad"
       },
       { "run_eocs": "EOC_POOKA_SHAPESHIFTS_REMOVE_deactivate_future" }
@@ -1113,7 +1113,7 @@
     ],
     "false_effect": [
       {
-        "u_message": "You are in the form of an animal.  You must turn back bfore shapeshifting individual parts of your body.",
+        "u_message": "You are in the form of an animal.  You must turn back before shapeshifting individual parts of your body.",
         "type": "bad"
       },
       { "run_eocs": "EOC_POOKA_SHAPESHIFTS_REMOVE_deactivate_future" }

--- a/data/mods/Xedra_Evolved/mutations/playable_changeling_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/playable_changeling_eocs.json
@@ -867,7 +867,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_POOKA_WOLF_EARS_ON",
-    "effect": [ { "u_lose_trait": "ELFA_EARS" }, { "u_deactivate_trait": "POOKA_ANTLERS" }, { "u_add_trait": "LUPINE_EARS" } ]
+    "effect": [ { "u_lose_trait": "ELFA_EARS" }, { "u_deactivate_trait": "POOKA_FELINE_EARS" }, { "u_add_trait": "LUPINE_EARS" } ]
   },
   {
     "type": "effect_on_condition",
@@ -877,7 +877,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_POOKA_FELINE_EARS_ON",
-    "effect": [ { "u_lose_trait": "ELFA_EARS" }, { "u_deactivate_trait": "POOKA_ANTLERS" }, { "u_add_trait": "FELINE_EARS" } ]
+    "effect": [ { "u_lose_trait": "ELFA_EARS" }, { "u_deactivate_trait": "POOKA_WOLF_EARS" }, { "u_add_trait": "FELINE_EARS" } ]
   },
   {
     "type": "effect_on_condition",
@@ -995,5 +995,393 @@
     "type": "effect_on_condition",
     "id": "EOC_POOKA_TAIL_STING_OFF",
     "effect": [ { "u_lose_trait": "TAIL_STING" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKIE_GAIN_PINNACLE_OF_FORMS_TRAIT",
+    "required_event": "gains_mutation",
+    "eoc_type": "EVENT",
+    "condition": { "compare_string": [ "POOKA_SHAPESHIFT_FULL_SELECTOR", { "context_val": "trait" } ] },
+    "effect": [
+      {
+        "run_eoc_selector": [
+          "EOC_POOKIE_GAIN_PINNACLE_OF_FORMS_TRAIT_BAT",
+          "EOC_POOKIE_GAIN_PINNACLE_OF_FORMS_TRAIT_RAVEN",
+          "EOC_POOKIE_GAIN_PINNACLE_OF_FORMS_TRAIT_BEAR",
+          "EOC_POOKIE_GAIN_PINNACLE_OF_FORMS_TRAIT_DEER",
+          "EOC_POOKIE_GAIN_PINNACLE_OF_FORMS_TRAIT_WOLF",
+          "EOC_POOKIE_GAIN_PINNACLE_OF_FORMS_TRAIT_COUGAR"
+        ],
+        "title": "What form will you be able to assume?",
+        "names": [ "Bat", "Raven", "Bear", "Deer", "Wolf", "Cougar" ],
+        "keys": [ "1", "2", "3", "4", "5", "6" ],
+        "descriptions": [
+          "You will be able to assume the form of a bat.",
+          "You will be able to assume the form of a raven.",
+          "You will be able to assume the form of a bear.",
+          "You will be able to assume the form of a deer.",
+          "You will be able to assume the form of a wolf.",
+          "You will be able to assume the form of a cougar."
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_SHAPESHIFT_FULL_PROCESSED",
+    "condition": { "math": [ "u_val('mana')", ">=", "2" ] },
+    "effect": [ { "math": [ "u_val('mana')", "-=", "1" ] }, { "run_eocs": "EOC_POOKA_SHAPESHIFTS_REMOVE_deactivate_future" } ],
+    "false_effect": [
+      { "u_deactivate_trait": "POOKA_SHAPESHIFT_FULL_BAT" },
+      { "u_deactivate_trait": "POOKA_SHAPESHIFT_FULL_RAVEN" },
+      { "u_deactivate_trait": "POOKA_SHAPESHIFT_FULL_BEAR" },
+      { "u_deactivate_trait": "POOKA_SHAPESHIFT_FULL_DEER" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_SHAPESHIFT_FULL_BAT_activated",
+    "condition": { "not": { "u_has_trait": "VAMPIRE_BAT_FORM_TRAITS" } },
+    "effect": [
+      {
+        "run_eocs": [
+          "EOC_POOKA_SHAPESHIFTS_REMOVE_deactivate_future",
+          {
+            "id": "EOC_POOKA_SHAPESHIFT_FULL_BAT_activated_2",
+            "condition": { "math": [ "u_val('mana')", ">=", "2" ] },
+            "effect": [
+              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+              { "u_add_trait": "VAMPIRE_BAT_FORM_TRAITS" },
+              { "u_add_trait": "ECHOLOCATION" },
+              { "math": [ "u_calories()", "/=", "4" ] },
+              {
+                "u_message": "Your fingers lengthen as flaps of skin grow between them and as your legs shorten, you take to the air.",
+                "type": "good"
+              }
+            ],
+            "false_effect": [
+              { "u_message": "You don't have enough mana to transform into a bat.", "type": "bad" },
+              { "queue_eocs": "EOC_POOKA_SHAPESHIFT_FULL_BAT_deactivate_future", "time_in_future": 0 }
+            ]
+          }
+        ]
+      }
+    ],
+    "false_effect": [
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_POOKA_SHAPESHIFT_FULL_BAT_deactivated",
+            "condition": { "u_has_trait": "VAMPIRE_BAT_FORM_TRAITS" },
+            "effect": [
+              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+              { "u_lose_trait": "ECHOLOCATION" },
+              { "math": [ "u_calories()", "*=", "4" ] },
+              { "u_lose_trait": "VAMPIRE_BAT_FORM_TRAITS" },
+              {
+                "u_message": "Your body shifts and your fingers separate as you return to your previous form.",
+                "type": "neutral"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_SHAPESHIFT_FULL_BAT_deactivate_future",
+    "//": "This is necessary because calling u_deactivate_trait from within the trait EoC does not work",
+    "effect": { "u_deactivate_trait": "POOKA_SHAPESHIFT_FULL_BAT" }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKIE_GAIN_PINNACLE_OF_FORMS_TRAIT_RAVEN",
+    "effect": [ { "u_add_trait": "POOKA_SHAPESHIFT_FULL_RAVEN" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_SHAPESHIFT_FULL_RAVEN_activated",
+    "condition": { "not": { "u_has_trait": "TURN_INTO_RAVEN_TRAITS" } },
+    "effect": [
+      {
+        "run_eocs": [
+          "EOC_POOKA_SHAPESHIFTS_REMOVE_deactivate_future",
+          {
+            "id": "EOC_POOKA_SHAPESHIFT_FULL_RAVEN_activated_2",
+            "condition": { "math": [ "u_val('mana')", ">=", "2" ] },
+            "effect": [
+              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+              { "u_add_trait": "TURN_INTO_RAVEN_TRAITS" },
+              { "math": [ "u_calories()", "/=", "4" ] },
+              {
+                "u_message": "Your body shifts and warps as your fingers extend into wings and feathers burst from your skin as you take to the air.",
+                "type": "good"
+              }
+            ],
+            "false_effect": [
+              { "u_message": "You don't have enough mana to transform into a raven.", "type": "bad" },
+              { "queue_eocs": "EOC_POOKA_SHAPESHIFT_FULL_RAVEN_deactivate_future", "time_in_future": 0 }
+            ]
+          }
+        ]
+      }
+    ],
+    "false_effect": [
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_POOKA_SHAPESHIFT_FULL_RAVEN_deactivated",
+            "condition": { "u_has_trait": "TURN_INTO_RAVEN_TRAITS" },
+            "effect": [
+              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+              { "math": [ "u_calories()", "*=", "4" ] },
+              { "u_lose_trait": "TURN_INTO_RAVEN_TRAITS" },
+              {
+                "u_message": "Your body shifts and your feathers vanish as you return to your previous form.",
+                "type": "neutral"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_SHAPESHIFT_FULL_RAVEN_deactivate_future",
+    "//": "This is necessary because calling u_deactivate_trait from within the trait EoC does not work",
+    "effect": { "u_deactivate_trait": "POOKA_SHAPESHIFT_FULL_RAVEN" }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKIE_GAIN_PINNACLE_OF_FORMS_TRAIT_BEAR",
+    "effect": [ { "u_add_trait": "POOKA_SHAPESHIFT_FULL_BEAR" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_SHAPESHIFT_FULL_BEAR_activated",
+    "condition": { "not": { "u_has_trait": "TURN_INTO_BEAR_TRAITS" } },
+    "effect": [
+      {
+        "run_eocs": [
+          "EOC_POOKA_SHAPESHIFTS_REMOVE_deactivate_future",
+          {
+            "id": "EOC_POOKA_SHAPESHIFT_FULL_BEAR_activated_2",
+            "condition": { "math": [ "u_val('mana')", ">=", "2" ] },
+            "effect": [
+              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+              { "u_add_trait": "TURN_INTO_BEAR_TRAITS" },
+              { "math": [ "u_calories()", "*=", "3" ] },
+              {
+                "u_message": "Your body shifts and expands as fur sprouts from your skin and your mouth and teeth lengthen.",
+                "type": "good"
+              }
+            ],
+            "false_effect": [
+              { "u_message": "You don't have enough mana to transform into a bear.", "type": "bad" },
+              { "queue_eocs": "EOC_POOKA_SHAPESHIFT_FULL_BEAR_deactivate_future", "time_in_future": 0 }
+            ]
+          }
+        ]
+      }
+    ],
+    "false_effect": [
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_POOKA_SHAPESHIFT_FULL_BEAR_deactivated",
+            "condition": { "u_has_trait": "TURN_INTO_BEAR_TRAITS" },
+            "effect": [
+              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+              { "math": [ "u_calories()", "/=", "3" ] },
+              { "u_lose_trait": "TURN_INTO_BEAR_TRAITS" },
+              {
+                "u_message": "Your body shifts and contracts and you return to your humanoid form.",
+                "type": "neutral"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_SHAPESHIFT_FULL_BEAR_deactivate_future",
+    "//": "This is necessary because calling u_deactivate_trait from within the trait EoC does not work",
+    "effect": { "u_deactivate_trait": "POOKA_SHAPESHIFT_FULL_BEAR" }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKIE_GAIN_PINNACLE_OF_FORMS_TRAIT_DEER",
+    "effect": [ { "u_add_trait": "POOKA_SHAPESHIFT_FULL_DEER" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_SHAPESHIFT_FULL_DEER_activated",
+    "condition": { "not": { "u_has_trait": "TURN_INTO_DEER_TRAITS" } },
+    "effect": [
+      {
+        "run_eocs": [
+          "EOC_POOKA_SHAPESHIFTS_REMOVE_deactivate_future",
+          {
+            "id": "EOC_POOKA_SHAPESHIFT_FULL_DEER_activated_2",
+            "condition": { "math": [ "u_val('mana')", ">=", "2" ] },
+            "effect": [
+              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+              { "u_add_trait": "TURN_INTO_DEER_TRAITS" },
+              {
+                "u_message": "Your body shifts and warps as your fingers and feet fuse into hooves and majestic antlers sprout from your head.",
+                "type": "good"
+              }
+            ],
+            "false_effect": [
+              { "u_message": "You don't have enough mana to transform into a deer.", "type": "bad" },
+              { "queue_eocs": "EOC_POOKA_SHAPESHIFT_FULL_DEER_deactivate_future", "time_in_future": 0 }
+            ]
+          }
+        ]
+      }
+    ],
+    "false_effect": [
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_POOKA_SHAPESHIFT_FULL_DEER_deactivated",
+            "condition": { "u_has_trait": "TURN_INTO_DEER_TRAITS" },
+            "effect": [
+              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+              { "u_lose_trait": "TURN_INTO_DEER_TRAITS" },
+              {
+                "u_message": "Your body shifts and contracts and you return to your humanoid form.",
+                "type": "neutral"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_SHAPESHIFT_FULL_DEER_deactivate_future",
+    "//": "This is necessary because calling u_deactivate_trait from within the trait EoC does not work",
+    "effect": { "u_deactivate_trait": "POOKA_SHAPESHIFT_FULL_DEER" }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKIE_GAIN_PINNACLE_OF_FORMS_TRAIT_WOLF",
+    "effect": [ { "u_add_trait": "POOKA_SHAPESHIFT_FULL_WOLF" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_SHAPESHIFT_FULL_WOLF_activated",
+    "condition": { "not": { "u_has_trait": "VAMPIRE_WOLF_FORM_TRAITS" } },
+    "effect": [
+      {
+        "run_eocs": [
+          "EOC_POOKA_SHAPESHIFTS_REMOVE_deactivate_future",
+          {
+            "id": "EOC_POOKA_SHAPESHIFT_FULL_WOLF_activated_2",
+            "condition": { "math": [ "u_val('mana')", ">=", "2" ] },
+            "effect": [
+              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+              { "u_add_trait": "VAMPIRE_WOLF_FORM_TRAITS" },
+              {
+                "u_message": "Your nose pushes out into a muzzle as you fall forward on all fours and let out a snarl.",
+                "type": "good"
+              }
+            ],
+            "false_effect": [
+              { "u_message": "You don't have enough mana to transform into a wolf.", "type": "bad" },
+              { "queue_eocs": "EOC_POOKA_SHAPESHIFT_FULL_WOLF_deactivate_future", "time_in_future": 0 }
+            ]
+          }
+        ]
+      }
+    ],
+    "false_effect": [
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_POOKA_SHAPESHIFT_FULL_WOLF_deactivated",
+            "condition": { "u_has_trait": "VAMPIRE_WOLF_FORM_TRAITS" },
+            "effect": [
+              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+              { "u_lose_trait": "VAMPIRE_WOLF_FORM_TRAITS" },
+              { "u_message": "Your fur disappears and you walk once again on two legs.", "type": "neutral" }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_SHAPESHIFT_FULL_WOLF_deactivate_future",
+    "//": "This is necessary because calling u_deactivate_trait from within the trait EoC does not work",
+    "effect": { "u_deactivate_trait": "POOKA_SHAPESHIFT_FULL_WOLF" }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKIE_GAIN_PINNACLE_OF_FORMS_TRAIT_COUGAR",
+    "effect": [ { "u_add_trait": "POOKA_SHAPESHIFT_FULL_COUGAR" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_SHAPESHIFT_FULL_COUGAR_activated",
+    "condition": { "not": { "u_has_trait": "TURN_INTO_COUGAR_TRAITS" } },
+    "effect": [
+      {
+        "run_eocs": [
+          "EOC_POOKA_SHAPESHIFTS_REMOVE_deactivate_future",
+          {
+            "id": "EOC_POOKA_SHAPESHIFT_FULL_COUGAR_activated_2",
+            "condition": { "math": [ "u_val('mana')", ">=", "2" ] },
+            "effect": [
+              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+              { "u_add_trait": "TURN_INTO_COUGAR_TRAITS" },
+              { "u_add_trait": "FELINE_LEAP" },
+              { "u_add_trait": "WHISKERS" },
+              {
+                "u_message": "Your nose pushes out into a muzzle and whiskers sprout from it as you fall forward on all fours and let out a growl.",
+                "type": "good"
+              }
+            ],
+            "false_effect": [
+              { "u_message": "You don't have enough mana to transform into a cougar.", "type": "bad" },
+              { "queue_eocs": "EOC_POOKA_SHAPESHIFT_FULL_COUGAR_deactivate_future", "time_in_future": 0 }
+            ]
+          }
+        ]
+      }
+    ],
+    "false_effect": [
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_POOKA_SHAPESHIFT_FULL_COUGAR_deactivated",
+            "condition": { "u_has_trait": "TURN_INTO_COUGAR_TRAITS" },
+            "effect": [
+              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+              { "u_lose_trait": "TURN_INTO_COUGAR_TRAITS" },
+              { "u_lose_trait": "FELINE_LEAP" },
+              { "u_lose_trait": "WHISKERS" },
+              {
+                "u_message": "Your fur and whiskers disappear and you walk once again on two legs.",
+                "type": "neutral"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_SHAPESHIFT_FULL_COUGAR_deactivate_future",
+    "//": "This is necessary because calling u_deactivate_trait from within the trait EoC does not work",
+    "effect": { "u_deactivate_trait": "POOKA_SHAPESHIFT_FULL_WOLF" }
   }
 ]

--- a/data/mods/Xedra_Evolved/mutations/playable_changeling_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/playable_changeling_eocs.json
@@ -957,10 +957,11 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_POOKA_WOLF_TAIL_ON",
-    "effect": [ 
-      { "u_deactivate_trait": "POOKA_TAIL_LONG" }, 
-      { "u_deactivate_trait": "POOKA_TAIL_STING" }, 
-      { "u_add_trait": "TAIL_FLUFFY" } ]
+    "effect": [
+      { "u_deactivate_trait": "POOKA_TAIL_LONG" },
+      { "u_deactivate_trait": "POOKA_TAIL_STING" },
+      { "u_add_trait": "TAIL_FLUFFY" }
+    ]
   },
   {
     "type": "effect_on_condition",
@@ -970,23 +971,25 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_POOKA_TAIL_LONG_ON",
-    "effect": [ 
-      { "u_deactivate_trait": "POOKA_WOLF_TAIL" }, 
+    "effect": [
+      { "u_deactivate_trait": "POOKA_WOLF_TAIL" },
       { "u_deactivate_trait": "POOKA_TAIL_STING" },
-      { "u_add_trait": "TAIL_LONG" } ]
+      { "u_add_trait": "TAIL_LONG" }
+    ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_POOKA_TAIL_LONG_OFF",
     "effect": [ { "u_lose_trait": "TAIL_LONG" } ]
   },
-    {
+  {
     "type": "effect_on_condition",
     "id": "EOC_POOKA_TAIL_STING_ON",
-    "effect": [       
-      { "u_deactivate_trait": "POOKA_WOLF_TAIL" }, 
+    "effect": [
+      { "u_deactivate_trait": "POOKA_WOLF_TAIL" },
       { "u_deactivate_trait": "POOKA_TAIL_LONG" },
-      { "u_add_trait": "TAIL_STING" } ] ]
+      { "u_add_trait": "TAIL_STING" }
+    ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/Xedra_Evolved/mutations/playable_changeling_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/playable_changeling_eocs.json
@@ -1035,7 +1035,9 @@
       { "u_deactivate_trait": "POOKA_SHAPESHIFT_FULL_BAT" },
       { "u_deactivate_trait": "POOKA_SHAPESHIFT_FULL_RAVEN" },
       { "u_deactivate_trait": "POOKA_SHAPESHIFT_FULL_BEAR" },
-      { "u_deactivate_trait": "POOKA_SHAPESHIFT_FULL_DEER" }
+      { "u_deactivate_trait": "POOKA_SHAPESHIFT_FULL_DEER" },
+      { "u_deactivate_trait": "POOKA_SHAPESHIFT_FULL_WOLF" },
+      { "u_deactivate_trait": "POOKA_SHAPESHIFT_FULL_COUGAR" }
     ]
   },
   {
@@ -1387,6 +1389,6 @@
     "type": "effect_on_condition",
     "id": "EOC_POOKA_SHAPESHIFT_FULL_COUGAR_deactivate_future",
     "//": "This is necessary because calling u_deactivate_trait from within the trait EoC does not work",
-    "effect": { "u_deactivate_trait": "POOKA_SHAPESHIFT_FULL_WOLF" }
+    "effect": { "u_deactivate_trait": "POOKA_SHAPESHIFT_FULL_COUGAR" }
   }
 ]

--- a/data/mods/Xedra_Evolved/mutations/playable_changeling_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/playable_changeling_eocs.json
@@ -827,7 +827,15 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_POOKA_ANTLERS_ON",
-    "effect": [ { "u_deactivate_trait": "POOKA_HORNS" }, { "u_add_trait": "ANTLERS" } ]
+    "condition": { "not": { "u_has_flag": "TEMPORARY_SHAPESHIFT" } },
+    "effect": [ { "u_deactivate_trait": "POOKA_HORNS" }, { "u_add_trait": "ANTLERS" } ],
+    "false_effect": [
+      {
+        "u_message": "You are in the form of an animal.  You must turn back bfore shapeshifting individual parts of your body.",
+        "type": "bad"
+      },
+      { "run_eocs": "EOC_POOKA_SHAPESHIFTS_REMOVE_deactivate_future" }
+    ]
   },
   {
     "type": "effect_on_condition",
@@ -837,7 +845,15 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_POOKA_HORNS_ON",
-    "effect": [ { "u_deactivate_trait": "POOKA_ANTLERS" }, { "u_add_trait": "HORNS_CURLED" } ]
+    "condition": { "not": { "u_has_flag": "TEMPORARY_SHAPESHIFT" } },
+    "effect": [ { "u_deactivate_trait": "POOKA_ANTLERS" }, { "u_add_trait": "HORNS_CURLED" } ],
+    "false_effect": [
+      {
+        "u_message": "You are in the form of an animal.  You must turn back bfore shapeshifting individual parts of your body.",
+        "type": "bad"
+      },
+      { "run_eocs": "EOC_POOKA_SHAPESHIFTS_REMOVE_deactivate_future" }
+    ]
   },
   {
     "type": "effect_on_condition",
@@ -847,7 +863,15 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_POOKA_FANGS_ON",
-    "effect": [ { "u_add_trait": "FANGS" } ]
+    "condition": { "not": { "u_has_flag": "TEMPORARY_SHAPESHIFT" } },
+    "effect": [ { "u_add_trait": "FANGS" } ],
+    "false_effect": [
+      {
+        "u_message": "You are in the form of an animal.  You must turn back bfore shapeshifting individual parts of your body.",
+        "type": "bad"
+      },
+      { "run_eocs": "EOC_POOKA_SHAPESHIFTS_REMOVE_deactivate_future" }
+    ]
   },
   {
     "type": "effect_on_condition",
@@ -857,7 +881,15 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_POOKA_SABER_TEETH_ON",
-    "effect": [ { "u_add_trait": "SABER_TEETH" } ]
+    "condition": { "not": { "u_has_flag": "TEMPORARY_SHAPESHIFT" } },
+    "effect": [ { "u_add_trait": "SABER_TEETH" } ],
+    "false_effect": [
+      {
+        "u_message": "You are in the form of an animal.  You must turn back bfore shapeshifting individual parts of your body.",
+        "type": "bad"
+      },
+      { "run_eocs": "EOC_POOKA_SHAPESHIFTS_REMOVE_deactivate_future" }
+    ]
   },
   {
     "type": "effect_on_condition",
@@ -867,7 +899,15 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_POOKA_WOLF_EARS_ON",
-    "effect": [ { "u_lose_trait": "ELFA_EARS" }, { "u_deactivate_trait": "POOKA_FELINE_EARS" }, { "u_add_trait": "LUPINE_EARS" } ]
+    "condition": { "not": { "u_has_flag": "TEMPORARY_SHAPESHIFT" } },
+    "effect": [ { "u_lose_trait": "ELFA_EARS" }, { "u_deactivate_trait": "POOKA_FELINE_EARS" }, { "u_add_trait": "LUPINE_EARS" } ],
+    "false_effect": [
+      {
+        "u_message": "You are in the form of an animal.  You must turn back bfore shapeshifting individual parts of your body.",
+        "type": "bad"
+      },
+      { "run_eocs": "EOC_POOKA_SHAPESHIFTS_REMOVE_deactivate_future" }
+    ]
   },
   {
     "type": "effect_on_condition",
@@ -877,7 +917,15 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_POOKA_FELINE_EARS_ON",
-    "effect": [ { "u_lose_trait": "ELFA_EARS" }, { "u_deactivate_trait": "POOKA_WOLF_EARS" }, { "u_add_trait": "FELINE_EARS" } ]
+    "condition": { "not": { "u_has_flag": "TEMPORARY_SHAPESHIFT" } },
+    "effect": [ { "u_lose_trait": "ELFA_EARS" }, { "u_deactivate_trait": "POOKA_WOLF_EARS" }, { "u_add_trait": "FELINE_EARS" } ],
+    "false_effect": [
+      {
+        "u_message": "You are in the form of an animal.  You must turn back bfore shapeshifting individual parts of your body.",
+        "type": "bad"
+      },
+      { "run_eocs": "EOC_POOKA_SHAPESHIFTS_REMOVE_deactivate_future" }
+    ]
   },
   {
     "type": "effect_on_condition",
@@ -887,7 +935,15 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_POOKA_CLAWS_ON",
-    "effect": [ { "u_add_trait": "CLAWS" } ]
+    "condition": { "not": { "u_has_flag": "TEMPORARY_SHAPESHIFT" } },
+    "effect": [ { "u_add_trait": "CLAWS" } ],
+    "false_effect": [
+      {
+        "u_message": "You are in the form of an animal.  You must turn back bfore shapeshifting individual parts of your body.",
+        "type": "bad"
+      },
+      { "run_eocs": "EOC_POOKA_SHAPESHIFTS_REMOVE_deactivate_future" }
+    ]
   },
   {
     "type": "effect_on_condition",
@@ -897,7 +953,15 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_POOKA_STAINLESS_CLAWS_ON",
-    "effect": [ { "u_add_trait": "CLAWS_ST" } ]
+    "condition": { "not": { "u_has_flag": "TEMPORARY_SHAPESHIFT" } },
+    "effect": [ { "u_add_trait": "CLAWS_ST" } ],
+    "false_effect": [
+      {
+        "u_message": "You are in the form of an animal.  You must turn back bfore shapeshifting individual parts of your body.",
+        "type": "bad"
+      },
+      { "run_eocs": "EOC_POOKA_SHAPESHIFTS_REMOVE_deactivate_future" }
+    ]
   },
   {
     "type": "effect_on_condition",
@@ -907,7 +971,15 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_POOKA_BIRD_WINGS_ON",
-    "effect": [ { "u_add_trait": "WINGS_BIRD" } ]
+    "condition": { "not": { "u_has_flag": "TEMPORARY_SHAPESHIFT" } },
+    "effect": [ { "u_add_trait": "WINGS_BIRD" } ],
+    "false_effect": [
+      {
+        "u_message": "You are in the form of an animal.  You must turn back bfore shapeshifting individual parts of your body.",
+        "type": "bad"
+      },
+      { "run_eocs": "EOC_POOKA_SHAPESHIFTS_REMOVE_deactivate_future" }
+    ]
   },
   {
     "type": "effect_on_condition",
@@ -917,7 +989,15 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_POOKA_URSINE_FUR_ON",
-    "effect": [ { "u_deactivate_trait": "POOKA_CHITIN" }, { "u_add_trait": "URSINE_FUR" } ]
+    "condition": { "not": { "u_has_flag": "TEMPORARY_SHAPESHIFT" } },
+    "effect": [ { "u_deactivate_trait": "POOKA_CHITIN" }, { "u_add_trait": "URSINE_FUR" } ],
+    "false_effect": [
+      {
+        "u_message": "You are in the form of an animal.  You must turn back bfore shapeshifting individual parts of your body.",
+        "type": "bad"
+      },
+      { "run_eocs": "EOC_POOKA_SHAPESHIFTS_REMOVE_deactivate_future" }
+    ]
   },
   {
     "type": "effect_on_condition",
@@ -927,7 +1007,15 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_POOKA_CHITIN_ON",
-    "effect": [ { "u_deactivate_trait": "POOKA_URSINE_FUR" }, { "u_add_trait": "CHITIN2" } ]
+    "condition": { "not": { "u_has_flag": "TEMPORARY_SHAPESHIFT" } },
+    "effect": [ { "u_deactivate_trait": "POOKA_URSINE_FUR" }, { "u_add_trait": "CHITIN2" } ],
+    "false_effect": [
+      {
+        "u_message": "You are in the form of an animal.  You must turn back bfore shapeshifting individual parts of your body.",
+        "type": "bad"
+      },
+      { "run_eocs": "EOC_POOKA_SHAPESHIFTS_REMOVE_deactivate_future" }
+    ]
   },
   {
     "type": "effect_on_condition",
@@ -937,7 +1025,15 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_POOKA_QUADRUPED_ON",
-    "effect": [ { "u_deactivate_trait": "POOKA_LEAPING_LEGS" }, { "u_add_trait": "POOKA_QUADRUPED_TRAITS" } ]
+    "condition": { "not": { "u_has_flag": "TEMPORARY_SHAPESHIFT" } },
+    "effect": [ { "u_deactivate_trait": "POOKA_LEAPING_LEGS" }, { "u_add_trait": "POOKA_QUADRUPED_TRAITS" } ],
+    "false_effect": [
+      {
+        "u_message": "You are in the form of an animal.  You must turn back bfore shapeshifting individual parts of your body.",
+        "type": "bad"
+      },
+      { "run_eocs": "EOC_POOKA_SHAPESHIFTS_REMOVE_deactivate_future" }
+    ]
   },
   {
     "type": "effect_on_condition",
@@ -947,7 +1043,15 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_POOKA_LEAPING_LEGS_ON",
-    "effect": [ { "u_deactivate_trait": "POOKA_QUADRUPED_TRAITS" }, { "u_add_trait": "LEAPING_LEGS" } ]
+    "condition": { "not": { "u_has_flag": "TEMPORARY_SHAPESHIFT" } },
+    "effect": [ { "u_deactivate_trait": "POOKA_QUADRUPED_TRAITS" }, { "u_add_trait": "LEAPING_LEGS" } ],
+    "false_effect": [
+      {
+        "u_message": "You are in the form of an animal.  You must turn back bfore shapeshifting individual parts of your body.",
+        "type": "bad"
+      },
+      { "run_eocs": "EOC_POOKA_SHAPESHIFTS_REMOVE_deactivate_future" }
+    ]
   },
   {
     "type": "effect_on_condition",
@@ -957,10 +1061,18 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_POOKA_WOLF_TAIL_ON",
+    "condition": { "not": { "u_has_flag": "TEMPORARY_SHAPESHIFT" } },
     "effect": [
       { "u_deactivate_trait": "POOKA_TAIL_LONG" },
       { "u_deactivate_trait": "POOKA_TAIL_STING" },
       { "u_add_trait": "TAIL_FLUFFY" }
+    ],
+    "false_effect": [
+      {
+        "u_message": "You are in the form of an animal.  You must turn back bfore shapeshifting individual parts of your body.",
+        "type": "bad"
+      },
+      { "run_eocs": "EOC_POOKA_SHAPESHIFTS_REMOVE_deactivate_future" }
     ]
   },
   {
@@ -971,10 +1083,18 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_POOKA_TAIL_LONG_ON",
+    "condition": { "not": { "u_has_flag": "TEMPORARY_SHAPESHIFT" } },
     "effect": [
       { "u_deactivate_trait": "POOKA_WOLF_TAIL" },
       { "u_deactivate_trait": "POOKA_TAIL_STING" },
       { "u_add_trait": "TAIL_LONG" }
+    ],
+    "false_effect": [
+      {
+        "u_message": "You are in the form of an animal.  You must turn back bfore shapeshifting individual parts of your body.",
+        "type": "bad"
+      },
+      { "run_eocs": "EOC_POOKA_SHAPESHIFTS_REMOVE_deactivate_future" }
     ]
   },
   {
@@ -985,10 +1105,18 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_POOKA_TAIL_STING_ON",
+    "condition": { "not": { "u_has_flag": "TEMPORARY_SHAPESHIFT" } },
     "effect": [
       { "u_deactivate_trait": "POOKA_WOLF_TAIL" },
       { "u_deactivate_trait": "POOKA_TAIL_LONG" },
       { "u_add_trait": "TAIL_STING" }
+    ],
+    "false_effect": [
+      {
+        "u_message": "You are in the form of an animal.  You must turn back bfore shapeshifting individual parts of your body.",
+        "type": "bad"
+      },
+      { "run_eocs": "EOC_POOKA_SHAPESHIFTS_REMOVE_deactivate_future" }
     ]
   },
   {
@@ -1030,7 +1158,7 @@
     "type": "effect_on_condition",
     "id": "EOC_POOKA_SHAPESHIFT_FULL_PROCESSED",
     "condition": { "math": [ "u_val('mana')", ">=", "2" ] },
-    "effect": [ { "math": [ "u_val('mana')", "-=", "1" ] }, { "run_eocs": "EOC_POOKA_SHAPESHIFTS_REMOVE_deactivate_future" } ],
+    "effect": [ { "math": [ "u_val('mana')", "-=", "1" ] } ],
     "false_effect": [
       { "u_deactivate_trait": "POOKA_SHAPESHIFT_FULL_BAT" },
       { "u_deactivate_trait": "POOKA_SHAPESHIFT_FULL_RAVEN" },

--- a/data/mods/Xedra_Evolved/mutations/playable_changeling_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/playable_changeling_eocs.json
@@ -820,7 +820,8 @@
       { "u_deactivate_trait": "POOKA_QUADRUPED" },
       { "u_deactivate_trait": "POOKA_LEAPING_LEGS" },
       { "u_deactivate_trait": "POOKA_WOLF_TAIL" },
-      { "u_deactivate_trait": "POOKA_TAIL_LONG" }
+      { "u_deactivate_trait": "POOKA_TAIL_LONG" },
+      { "u_deactivate_trait": "POOKA_TAIL_STING" }
     ]
   },
   {
@@ -956,7 +957,10 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_POOKA_WOLF_TAIL_ON",
-    "effect": [ { "u_deactivate_trait": "POOKA_TAIL_LONG" }, { "u_add_trait": "TAIL_FLUFFY" } ]
+    "effect": [ 
+      { "u_deactivate_trait": "POOKA_TAIL_LONG" }, 
+      { "u_deactivate_trait": "POOKA_TAIL_STING" }, 
+      { "u_add_trait": "TAIL_FLUFFY" } ]
   },
   {
     "type": "effect_on_condition",
@@ -966,11 +970,27 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_POOKA_TAIL_LONG_ON",
-    "effect": [ { "u_deactivate_trait": "POOKA_WOLF_TAIL" }, { "u_add_trait": "TAIL_LONG" } ]
+    "effect": [ 
+      { "u_deactivate_trait": "POOKA_WOLF_TAIL" }, 
+      { "u_deactivate_trait": "POOKA_TAIL_STING" },
+      { "u_add_trait": "TAIL_LONG" } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_POOKA_TAIL_LONG_OFF",
     "effect": [ { "u_lose_trait": "TAIL_LONG" } ]
+  },
+    {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_TAIL_STING_ON",
+    "effect": [       
+      { "u_deactivate_trait": "POOKA_WOLF_TAIL" }, 
+      { "u_deactivate_trait": "POOKA_TAIL_LONG" },
+      { "u_add_trait": "TAIL_STING" } ] ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_POOKA_TAIL_STING_OFF",
+    "effect": [ { "u_lose_trait": "TAIL_STING" } ]
   }
 ]

--- a/data/mods/Xedra_Evolved/mutations/temporary.json
+++ b/data/mods/Xedra_Evolved/mutations/temporary.json
@@ -127,7 +127,7 @@
     "type": "mutation",
     "id": "TURN_INTO_BEAR_TRAITS",
     "name": { "str": "Bear Form" },
-    "points": 99,
+    "points": 98,
     "description": "You are a bear.  This provides the actual effects of bear form.  Should not be player-visible",
     "valid": false,
     "starting_trait": false,
@@ -175,6 +175,146 @@
     ],
     "override_look": { "id": "mon_bear", "tile_category": "monster" },
     "integrated_armor": [ "integrated_claws_st", "integrated_fangs", "integrated_ursine_fur" ]
+  },
+  {
+    "type": "mutation",
+    "id": "TURN_INTO_DEER_TRAITS",
+    "name": { "str": "Deer Form" },
+    "points": 98,
+    "description": "You are a deer.  This provides the actual effects of deer form.  Should not be player-visible",
+    "valid": false,
+    "starting_trait": false,
+    "purifiable": false,
+    "player_display": false,
+    "enchantments": [
+      {
+        "condition": "ALWAYS",
+        "values": [
+          { "value": "MAX_HP", "multiply": 0.1 },
+          { "value": "SPEED", "multiply": 0.2 },
+          { "value": "MOVE_COST", "multiply": -0.5 },
+          { "value": "DEXTERITY", "add": 3 },
+          { "value": "NIGHT_VIS", "add": 6 },
+          { "value": "CRAFTING_SPEED_MULTIPLIER", "multiply": -1000 }
+        ],
+        "skills": [ { "value": "dodge", "add": 2 } ],
+        "mutations": [ "ANTLERS", "HOOVES" ]
+      },
+      {
+        "condition": { "and": [ { "u_has_flag": "QUADRUPED_CROUCH" }, { "u_has_flag": "QUADRUPED_RUN" }, { "not": "u_can_drop_weapon" } ] },
+        "ench_effects": [ { "effect": "natural_stance", "intensity": 1 }, { "effect": "quadruped_full", "intensity": 1 } ]
+      },
+      { "condition": { "u_has_move_mode": "run" }, "values": [ { "value": "MOVE_COST", "multiply": -0.25 } ] },
+      {
+        "condition": "u_has_weapon",
+        "values": [ { "value": "MELEE_DAMAGE", "multiply": -1 }, { "value": "RANGE", "multiply": -1 } ]
+      }
+    ],
+    "attacks": {
+      "attack_text_u": "You kick %s with your hooves!",
+      "attack_text_npc": "%1$s kicks %2$s with their hooves!",
+      "chance": 15,
+      "strength_damage": { "damage_type": "bash", "amount": 3 }
+    },
+    "flags": [ "MUTE", "NO_SPELLCASTING", "QUADRUPED_CROUCH", "QUADRUPED_RUN", "TOUGH_FEET", "TEMPORARY_SHAPESHIFT" ],
+    "override_look": { "id": "mon_deer", "tile_category": "monster" },
+    "integrated_armor": [ "integrated_antlers", "integrated_feline_fur" ]
+  },
+  {
+    "type": "mutation",
+    "id": "TURN_INTO_COUGAR_TRAITS",
+    "name": { "str": "Cougar Form" },
+    "points": 98,
+    "description": "You are a cougar.  This provides the actual effects of cougar form.  Should not be player-visible.",
+    "starting_trait": false,
+    "purifiable": false,
+    "valid": false,
+    "player_display": false,
+    "//": "The second enchantment takes into account the effects of the mutations added by the first enchantment, whose own enchantments do not transfer over due to bug #74994.  If that bug is fixed, it can be deleted.",
+    "enchantments": [
+      {
+        "condition": "ALWAYS",
+        "values": [
+          { "value": "SPEED", "multiply": 0.2 },
+          { "value": "RANGE", "multiply": -1 },
+          { "value": "DEXTERITY", "add": 4 },
+          { "value": "NIGHT_VIS", "add": 11 },
+          { "value": "MELEE_DAMAGE", "multiply": 0.2 },
+          { "value": "CLIMATE_CONTROL_HEAT", "add": 25 },
+          { "value": "FOOTSTEP_NOISE", "multiply": -0.6 },
+          { "value": "MOVECOST_OBSTACLE_MOD", "multiply": -0.5 },
+          { "value": "CRAFTING_SPEED_MULTIPLIER", "multiply": -1000 }
+        ],
+        "mutations": [ "FANGS", "TAIL_LONG", "PAWS", "FELINE_FUR", "FELINE_EARS", "PRED3", "WHISKERS", "FELINE_LEAP" ]
+      },
+      {
+        "condition": "ALWAYS",
+        "values": [
+          { "value": "HEARING_MULT", "multiply": 0.25 },
+          { "value": "COMBAT_CATCHUP", "multiply": 2 },
+          { "value": "DODGE_CHANCE", "add": 5 }
+        ]
+      },
+      {
+        "condition": { "and": [ { "u_has_flag": "QUADRUPED_CROUCH" }, { "u_has_flag": "QUADRUPED_RUN" }, { "not": "u_can_drop_weapon" } ] },
+        "values": [ { "value": "MOVE_COST", "multiply": -0.15 } ],
+        "ench_effects": [ { "effect": "natural_stance", "intensity": 1 }, { "effect": "quadruped_full", "intensity": 1 } ]
+      },
+      { "condition": { "u_has_move_mode": "run" }, "values": [ { "value": "MOVE_COST", "multiply": -0.25 } ] },
+      {
+        "condition": "u_has_weapon",
+        "values": [ { "value": "MELEE_DAMAGE", "multiply": -1 }, { "value": "RANGE", "multiply": -1 } ]
+      }
+    ],
+    "flags": [ "MUTE", "PRED3", "QUADRUPED_CROUCH", "QUADRUPED_RUN", "TOUGH_FEET", "TEMPORARY_SHAPESHIFT" ],
+    "override_look": { "id": "mon_cougar", "tile_category": "monster" },
+    "integrated_armor": [ "integrated_fangs", "integrated_feline_fur", "integrated_claws" ]
+  },
+  {
+    "type": "mutation",
+    "id": "TURN_INTO_RAVEN_TRAITS",
+    "name": { "str": "Raven Form" },
+    "points": 98,
+    "description": "You are a raven.  This provides the actual effects of raven form.  Should not be player-visible.",
+    "starting_trait": false,
+    "purifiable": false,
+    "valid": false,
+    "player_display": false,
+    "//": "The second enchantment, as well as bodytemp modifiers, takes into account the effects of the mutations added by the first enchantment, whose own enchantments do not transfer over due to bug #74994.  If that bug is fixed, it can be deleted.",
+    "bodytemp_modifiers": [ 300, 800 ],
+    "enchantments": [
+      {
+        "condition": "ALWAYS",
+        "values": [
+          { "value": "MAX_HP", "multiply": -0.75 },
+          { "value": "SPEED", "multiply": 0.1 },
+          { "value": "MELEE_DAMAGE", "multiply": -0.95 },
+          { "value": "DEXTERITY", "add": 8 },
+          { "value": "PERCEPTION", "add": 4 },
+          { "value": "NIGHT_VIS", "add": 4 },
+          { "value": "CRAFTING_SPEED_MULTIPLIER", "multiply": -1000 }
+        ],
+        "ench_effects": [ { "effect": "effect_vampire_bat_form_levitation", "intensity": 1 } ],
+        "skills": [ { "value": "dodge", "add": 6 } ],
+        "mutations": [ "BIRD_EYE", "DOWN", "EAGLEEYED", "LIGHTEATER" ]
+      },
+      {
+        "condition": "ALWAYS",
+        "values": [
+          { "value": "PERCEPTION", "add": 4 },
+          { "value": "BODYTEMP_SLEEP", "add": 0.5 },
+          { "value": "OVERMAP_SIGHT", "add": 4 },
+          { "value": "METABOLISM", "multiply": -0.333 }
+        ]
+      },
+      {
+        "condition": "u_has_weapon",
+        "values": [ { "value": "MELEE_DAMAGE", "multiply": -1 }, { "value": "RANGE", "multiply": -1 } ]
+      },
+      { "condition": { "u_is_on_terrain": "t_open_air" }, "values": [ { "value": "MOVE_COST", "multiply": -0.6 } ] }
+    ],
+    "flags": [ "LEVITATION", "MUTE", "NO_SPELLCASTING", "TEMPORARY_SHAPESHIFT", "SHAPESHIFT_SIZE_TINY" ],
+    "override_look": { "id": "mon_raven", "tile_category": "monster" }
   },
   {
     "type": "mutation",

--- a/data/mods/Xedra_Evolved/spells/changeling_spells.json
+++ b/data/mods/Xedra_Evolved/spells/changeling_spells.json
@@ -256,5 +256,36 @@
         "max(( 100 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_BROWNIE') * 3) - (u_skill('deduction') * 5)), 25)"
       ]
     }
+  },
+  {
+    "id": "changeling_pooka_charm_animals_spell",
+    "type": "SPELL",
+    "name": "Friend to Birds and Beasts",
+    "description": "You have learned to speak the secret tongues of birds and beasts and may use it to ask them for aid.  Casting this spell on a mammal or a bird will ally them with you, causing them to defend you against your enemies.",
+    "valid_targets": [ "ally", "hostile" ],
+    "flags": [ "VERBAL", "RECHARM", "RANDOM_DAMAGE", "RANDOM_DURATION", "NO_FAIL", "NO_PROJECTILE" ],
+    "effect": "charm_monster",
+    "shape": "blast",
+    "spell_class": "CHANGELING_MAGIC",
+    "difficulty": 6,
+    "max_level": 1,
+    "min_damage": { "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_POOKA') * 3) + (u_skill('deduction') * 10) + 15" ] },
+    "max_damage": { "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_POOKA') * 7) + (u_skill('deduction') * 25) + 60" ] },
+    "min_duration": {
+      "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_POOKA') * 286) + (u_skill('deduction') * 3455) + 9450" ]
+    },
+    "max_duration": {
+      "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_POOKA') * 850) + (u_skill('deduction') * 8641) + 33145" ]
+    },
+    "energy_source": "MANA",
+    "base_energy_cost": {
+      "math": [
+        "max(( 600 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_POOKA') * 8) - (u_skill('deduction') * 25)), 250)"
+      ]
+    },
+    "base_casting_time": {
+      "math": [ "max(( 200 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_POOKA') * 4) - (u_skill('deduction') * 8)), 50)" ]
+    },
+    "targeted_monster_species": [ "MAMMAL", "BIRD" ]
   }
 ]

--- a/data/mods/Xedra_Evolved/spells/changeling_spells.json
+++ b/data/mods/Xedra_Evolved/spells/changeling_spells.json
@@ -263,7 +263,7 @@
     "name": "Friend to Birds and Beasts",
     "description": "You have learned to speak the secret tongues of birds and beasts and may use it to ask them for aid.  Casting this spell on a mammal or a bird will ally them with you, causing them to defend you against your enemies.",
     "valid_targets": [ "ally", "hostile" ],
-    "flags": [ "VERBAL", "RECHARM", "RANDOM_DAMAGE", "RANDOM_DURATION", "NO_FAIL", "NO_PROJECTILE" ],
+    "flags": [ "VERBAL", "RECHARM", "RANDOM_DAMAGE", "RANDOM_DURATION", "NO_FAIL", "NO_PROJECTILE", "SILENT" ],
     "effect": "charm_monster",
     "shape": "blast",
     "spell_class": "CHANGELING_MAGIC",
@@ -277,6 +277,8 @@
     "max_duration": {
       "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_POOKA') * 850) + (u_skill('deduction') * 8641) + 33145" ]
     },
+    "min_range": 10,
+    "max_range": 10,
     "energy_source": "MANA",
     "base_energy_cost": {
       "math": [

--- a/tools/spell_checker/dictionary.txt
+++ b/tools/spell_checker/dictionary.txt
@@ -5474,6 +5474,8 @@ shantak
 Shaolin
 shapechangers
 shapeshift
+shapeshifting
+shapeshifts
 shapeshifter
 Shardspray
 Shardstorm


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Xedra Evolved] Add more pooka changeling traits"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Splitting up more traits into smaller PRs.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add more pooka traits:

- A bunch of body part shapeshifts
- Master of Forms traitline, increasing the number of simultaneous shapeshifts the pooka can have without it costing mana.
- Instinctive Attacks: Trait to increase your unarmed damage when using shapeshifts and not using weapons or wearing armor
- Animalistic Defense:  Trait to increase your dodge if you aren’t wearing armor and using shapeshifts
- Primal Alacrity: Trait to increase your speed if you're using shapeshifts and aren't wearing armor or using weapons.
- Friend to Birds and Beasts: Spell to charm animals (prerequisite of Animal Kinship)
- Custom Strength and Dexterity boosting mutations
- Post-threshold power to pick a single animal transformation (raven, wolf, bear, deer, bat, cougar) and be able to assume that form.

Unarmored here means "not wearing gear with the `STURDY` flag"
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Shapeshifting works, selection of form works, you can't shapeshift a body part if you're fully in animal form, the spell works.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I think I am going to let selkies transform into seals...once they make their pelts using the tutelage they get in their dreams.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
