### PR TITLE
Implement a better way to wrap text containing color tags

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -1,8 +1,5 @@
 #include "cata_imgui.h"
 
-#include <stack>
-#include <type_traits>
-
 #define IMGUI_DEFINE_MATH_OPERATORS
 #include <imgui/imgui.h>
 #include <imgui/imgui_internal.h>
@@ -10,7 +7,6 @@
 #include <imgui/imgui_freetype.h>
 
 #include "color.h"
-#include "filesystem.h"
 #include "input.h"
 #include "output.h"
 #include "system_locale.h"
@@ -1041,4 +1037,21 @@ void cataimgui::PushMonoFont()
 #ifdef TILES
     ImGui::PushFont( ImGui::GetIO().Fonts->Fonts[1] );
 #endif
+}
+
+bool cataimgui::RightAlign( const char *str_id )
+{
+    if( ImGui::BeginTable( str_id, 2, ImGuiTableFlags_SizingFixedFit, ImVec2( -1, 0 ) ) ) {
+        ImGui::TableSetupColumn( "a", ImGuiTableColumnFlags_WidthStretch );
+
+        ImGui::TableNextColumn();
+        ImGui::TableNextColumn();
+        return true;
+    }
+    return false;
+}
+
+void cataimgui::EndRightAlign()
+{
+    ImGui::EndTable();
 }

--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -1039,7 +1039,7 @@ void cataimgui::PushMonoFont()
 #endif
 }
 
-bool cataimgui::RightAlign( const char *str_id )
+bool cataimgui::BeginRightAlign( const char *str_id )
 {
     if( ImGui::BeginTable( str_id, 2, ImGuiTableFlags_SizingFixedFit, ImVec2( -1, 0 ) ) ) {
         ImGui::TableSetupColumn( "a", ImGuiTableColumnFlags_WidthStretch );

--- a/src/cata_imgui.h
+++ b/src/cata_imgui.h
@@ -153,6 +153,6 @@ void load_colors();
 void PushGuiFont();
 void PushMonoFont();
 
-bool RightAlign( const char *str_id );
+bool BeginRightAlign( const char *str_id );
 void EndRightAlign();
 } // namespace cataimgui

--- a/src/cata_imgui.h
+++ b/src/cata_imgui.h
@@ -17,6 +17,7 @@ struct input_event;
 #include "sdl_wrappers.h"
 #include "color_loader.h"
 #endif
+#include "text.h"
 
 struct point;
 struct ImVec2;
@@ -151,4 +152,7 @@ void load_colors();
 
 void PushGuiFont();
 void PushMonoFont();
+
+bool RightAlign( const char *str_id );
+void EndRightAlign();
 } // namespace cataimgui

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -1249,6 +1249,7 @@ void item_pocket::contents_info( std::vector<iteminfo> &info, int pocket_number,
                                            contains_weight() ) );
         info.emplace_back( weight_to_info( cont_type_str, _( " of " ),
                                            weight_capacity() ) );
+        info.back().bNewLine = true;
     } else {
         // With ammo_restriction, total capacity does not matter, but show current volume/weight
         info.emplace_back( vol_to_info( cont_type_str, _( "Volume: " ),

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2519,10 +2519,11 @@ class spellcasting_callback : public uilist_callback
 
         void refresh( uilist *menu ) override {
             ImGui::TableSetColumnIndex( 2 );
+            ImGui::SameLine( 0.0, -1.0 );
             ImVec2 info_size = ImGui::GetContentRegionAvail();
-            info_size.y -= ( 1.0 * ImGui::GetTextLineHeightWithSpacing() ) - ImGui::GetFrameHeightWithSpacing();
+            info_size.y -= ImGui::GetTextLineHeightWithSpacing();
             if( ImGui::BeginChild( "spell info", info_size, false,
-                                   ImGuiWindowFlags_AlwaysAutoResize ) ) {
+                                   ImGuiWindowFlags_AlwaysVerticalScrollbar ) ) {
                 if( menu->previewing >= 0 && static_cast<size_t>( menu->previewing ) < known_spells.size() ) {
                     display_spell_info( menu->previewing );
                 }
@@ -2532,7 +2533,7 @@ class spellcasting_callback : public uilist_callback
                                         _( "Popup Distractions" );
             ImGui::TextColored( casting_ignore ? c_red : c_light_green, "%s %s", "[I]", ignore_string.c_str() );
             ImGui::SameLine();
-            if( cataimgui::RightAlign( "hotkeys" ) ) {
+            if( cataimgui::BeginRightAlign( "hotkeys" ) ) {
                 ImGui::TextColored( c_yellow, "%s", _( "Assign Hotkey [=]" ) );
                 cataimgui::EndRightAlign();
             }
@@ -2658,7 +2659,7 @@ void spellcasting_callback::display_spell_info( size_t index )
     }
     const bool is_psi = sp.has_flag( spell_flag::PSIONIC );
 
-    double column_width = desired_extra_space_right( ) / 2.0;
+    double column_width = ImGui::GetContentRegionAvail().x / 2.0;
     if( ImGui::BeginTable( "data", 2 ) ) {
         ImGui::TableSetupColumn( "current level", ImGuiTableColumnFlags_WidthFixed, column_width );
         ImGui::TableSetupColumn( "max level", ImGuiTableColumnFlags_WidthFixed, column_width );

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2519,22 +2519,23 @@ class spellcasting_callback : public uilist_callback
 
         void refresh( uilist *menu ) override {
             ImGui::TableSetColumnIndex( 2 );
-            std::string ignore_string = casting_ignore ? _( "Ignore Distractions" ) :
-                                        _( "Popup Distractions" );
-            ImGui::TextColored( casting_ignore ? c_red : c_light_green, "%s %s", "[I]", ignore_string.c_str() );
-            const std::string assign_letter = _( "Assign Hotkey [=]" );
-            float w = ImGui::CalcTextSize( assign_letter.c_str() ).x;
-            float x = ImGui::GetContentRegionAvail().x - w;
-            ImGui::SameLine( x, 0 );
-            ImGui::TextColored( c_yellow, "%s", assign_letter.c_str() );
-            ImGui::NewLine();
-            if( ImGui::BeginChild( "spell info", { desired_extra_space_right( ), 0 }, false,
+            ImVec2 info_size = ImGui::GetContentRegionAvail();
+            info_size.y -= ( 1.0 * ImGui::GetTextLineHeightWithSpacing() ) - ImGui::GetFrameHeightWithSpacing();
+            if( ImGui::BeginChild( "spell info", info_size, false,
                                    ImGuiWindowFlags_AlwaysAutoResize ) ) {
                 if( menu->previewing >= 0 && static_cast<size_t>( menu->previewing ) < known_spells.size() ) {
                     display_spell_info( menu->previewing );
                 }
             }
             ImGui::EndChild();
+            std::string ignore_string = casting_ignore ? _( "Ignore Distractions" ) :
+                                        _( "Popup Distractions" );
+            ImGui::TextColored( casting_ignore ? c_red : c_light_green, "%s %s", "[I]", ignore_string.c_str() );
+            ImGui::SameLine();
+            if( cataimgui::RightAlign( "hotkeys" ) ) {
+                ImGui::TextColored( c_yellow, "%s", _( "Assign Hotkey [=]" ) );
+                cataimgui::EndRightAlign();
+            }
         }
 };
 
@@ -2633,12 +2634,18 @@ void spellcasting_callback::display_spell_info( size_t index )
     cataimgui::set_scroll( spell_info_scroll );
     ImGui::TextColored( c_yellow, "%s", sp.spell_class() == trait_NONE ? _( "Classless" ) :
                         sp.spell_class()->name().c_str() );
-    // we remove 6 characteres from the width because there seems to be issues with wrapping in this menu (even with TextWrapped)
-    // TODO(thePotatomancer): investigate and fix the strange wrapping issues in this menu as well as oth er imgui menus
-    float spell_info_width = ImGui::GetContentRegionAvail().x - ( ImGui::CalcTextSize( " " ).x * 16 );
-    cataimgui::draw_colored_text( sp.description(), spell_info_width );
+    std::vector<std::string> lines = string_split( sp.description(), '\n' );
+    for( std::string &l : lines ) {
+        cataimgui::TextColoredParagraph( c_white, l );
+        ImGui::NewLine();
+    }
     ImGui::NewLine();
-    cataimgui::draw_colored_text( sp.enumerate_spell_data( pc ), spell_info_width );
+
+    std::vector<std::string> lines2 = string_split( sp.enumerate_spell_data( pc ), '\n' );
+    for( std::string &l : lines2 ) {
+        cataimgui::TextColoredParagraph( c_white, l );
+        ImGui::NewLine();
+    }
     ImGui::NewLine();
 
     // Calculates temp_level_adjust from EoC, saves it to the spell for later use, and prepares to display the result
@@ -2832,21 +2839,19 @@ void spellcasting_callback::display_spell_info( size_t index )
         ImGui::Text( "%s: %s", _( "Duration" ), sp.duration_string( pc ).c_str() );
     }
 
-    // TODO(db48x): rewrite to display via ImGui directly, so that wrapping can be done correctly
-    // TODO(thePotatomancer): once we do rewrite it make sure to pass wrapping info to draw_colored_text or skip it entirely
-    float width = ImGui::GetContentRegionAvail().x / ImGui::CalcTextSize( "X" ).x;
     if( sp.has_components() ) {
+        ImGui::NewLine();
         if( !sp.components().get_components().empty() ) {
             for( const std::string &line : sp.components().get_folded_components_list(
-                     width - 6, c_light_gray, pc.crafting_inventory( pc.pos(), 0, false ), return_true<item> ) ) {
-                cataimgui::draw_colored_text( line );
+                     0, c_light_gray, pc.crafting_inventory( pc.pos(), 0, false ), return_true<item> ) ) {
+                cataimgui::TextColoredParagraph( c_white, line );
                 ImGui::NewLine();
             }
         }
         if( !( sp.components().get_tools().empty() && sp.components().get_qualities().empty() ) ) {
             for( const std::string &line : sp.components().get_folded_tools_list(
-                     width - 6, c_light_gray, pc.crafting_inventory( pc.pos(), 0, false ) ) ) {
-                cataimgui::draw_colored_text( line );
+                     0, c_light_gray, pc.crafting_inventory( pc.pos(), 0, false ) ) ) {
+                cataimgui::TextColoredParagraph( c_white, line );
                 ImGui::NewLine();
             }
         }
@@ -3066,6 +3071,7 @@ static std::string color_number( const float num )
         return colorize( "0", c_white );
     }
 }
+
 static void draw_spellbook_info( const spell_type &sp )
 {
     const spell fake_spell( sp.id );
@@ -3086,7 +3092,11 @@ static void draw_spellbook_info( const spell_type &sp )
     ImGui::TextColored( c_yellow, "%s", spell_class.c_str() );
 
     ImGui::NewLine();
-    cataimgui::draw_colored_text( sp.description.translated() );
+    std::vector<std::string> lines = string_split( sp.description.translated(), '\n' );
+    for( std::string &l : lines ) {
+        cataimgui::TextColoredParagraph( c_white, l );
+        ImGui::NewLine();
+    }
     ImGui::NewLine();
 
     cataimgui::draw_colored_text( string_format( "%s: %d", _( "Difficulty" ),
@@ -3174,10 +3184,8 @@ float spellbook_callback::desired_extra_space_right( )
 
 void spellbook_callback::refresh( uilist *menu )
 {
-    ImVec2 info_size = { desired_extra_space_right( ),
-                         desired_extra_space_right( ) * 3.0f * 1.62f
-                       };
     ImGui::TableSetColumnIndex( 2 );
+    ImVec2 info_size = ImGui::GetContentRegionAvail();
     if( ImGui::BeginChild( "spellbook info", info_size, false,
                            ImGuiWindowFlags_AlwaysAutoResize ) ) {
         if( menu->selected >= 0 && static_cast<size_t>( menu->selected ) < spells.size() ) {

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2949,7 +2949,7 @@ spell &known_magic::select_spell( Character &guy )
     spell_menu.desired_bounds = {
         -1.0,
             -1.0,
-            std::max( 80, TERMX * 3 / 8 ) *ImGui::CalcTextSize( "X" ).x,
+            -1.0,
             clamp( static_cast<int>( known_spells_sorted.size() ), 24, TERMY * 9 / 10 ) *ImGui::GetTextLineHeight(),
         };
 

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -19,6 +19,7 @@
 
 #include "auto_pickup.h"
 #include "avatar.h"
+#include "cata_imgui.h"
 #include "cata_scope_helpers.h"
 #include "cata_utility.h"
 #include "catacharset.h"
@@ -52,7 +53,6 @@
 #include "wcwidth.h"
 #include "worldfactory.h"
 
-#include "cata_imgui.h"
 #include "imgui/imgui.h"
 
 class demo_ui : public cataimgui::window
@@ -68,10 +68,18 @@ class demo_ui : public cataimgui::window
         void on_resized() override {
             init();
         };
+
+    private:
+        std::shared_ptr<cataimgui::Paragraph> stuff;
 };
 
 demo_ui::demo_ui() : cataimgui::window( _( "ImGui Demo Screen" ) )
 {
+    // char *text = "Some long text that will wrap around nicely. </color> <color_green><color_red>Some red text in the </color>middle.</color>  Some long text that will <color_light_blue_yellow>wrap around nicely.";
+    std::string text =
+        "Some long text that will wrap around nicely.  <color_red>Some red text in the middle.</color>  Some long text that will wrap around nicely.";
+    stuff = std::make_shared<cataimgui::Paragraph>();
+    stuff->append_colored_text( text, c_white );
 }
 
 cataimgui::bounds demo_ui::get_bounds()
@@ -81,7 +89,85 @@ cataimgui::bounds demo_ui::get_bounds()
 
 void demo_ui::draw_controls()
 {
+#ifndef TUI
     ImGui::ShowDemoWindow();
+#endif
+
+#ifdef TUI
+    ImGui::SetNextWindowPos( { 0, 0 }, ImGuiCond_Once );
+    ImGui::SetNextWindowSize( { 60, 40 }, ImGuiCond_Once );
+#else
+    ImGui::SetNextWindowSize( { 620, 900 }, ImGuiCond_Once );
+#endif
+    if( ImGui::Begin( "test" ) ) {
+#ifdef TUI
+        static float wrap_width = 50.0f;
+        ImGui::SliderFloat( "Wrap width", &wrap_width, 1, 60, "%.0f" );
+        float marker_size = 0.0f;
+#else
+        static float wrap_width = 200.0f;
+        ImGui::SliderFloat( "Wrap width", &wrap_width, -20, 600, "%.0f" );
+        float marker_size = ImGui::GetTextLineHeight();
+#endif
+
+#define WRAP_START()                                                           \
+    ImDrawList *draw_list = ImGui::GetWindowDrawList();                        \
+    ImVec2 pos = ImGui::GetCursorScreenPos();                                  \
+    ImVec2 marker_min = ImVec2(pos.x + wrap_width, pos.y);                     \
+    ImVec2 marker_max =                                                        \
+            ImVec2(pos.x + wrap_width + marker_size, pos.y + marker_size);         \
+    ImGui::PushTextWrapPos(ImGui::GetCursorPos().x + wrap_width);
+
+#define WRAP_END()                                                             \
+    draw_list->AddRectFilled(marker_min, marker_max,                           \
+                             IM_COL32(255, 0, 255, 255));                      \
+    ImGui::PopTextWrapPos();
+
+        // three sentences in a nicely–wrapped paragraph
+        if( ImGui::CollapsingHeader( "Plain wrapped text" ) ) {
+            WRAP_START();
+            ImGui::TextWrapped( "%s",
+                                "Some long text that will wrap around nicely.  Some red text in the middle.  Some long text that will wrap around nicely." );
+            WRAP_END();
+            ImGui::NewLine();
+        }
+
+        if( ImGui::CollapsingHeader( "Styled Paragraph" ) ) {
+            WRAP_START();
+            cataimgui::TextStyled( stuff, wrap_width );
+            WRAP_END();
+            ImGui::NewLine();
+        }
+
+        if( ImGui::CollapsingHeader( "Unstyled Paragraph" ) ) {
+            WRAP_START();
+            cataimgui::TextUnstyled( stuff, wrap_width );
+            WRAP_END();
+            ImGui::NewLine();
+        }
+
+        if( ImGui::CollapsingHeader( "Styled Paragraph, no allocations" ) ) {
+            WRAP_START();
+            cataimgui::TextParagraph( c_white, "Some long text that will wrap around nicely.", wrap_width );
+            cataimgui::TextParagraph( c_red, "  Some red text in the middle.", wrap_width );
+            cataimgui::TextParagraph( c_white, "  Some long text that will wrap around nicely.", wrap_width );
+            ImGui::NewLine();
+            WRAP_END();
+            ImGui::NewLine();
+        }
+
+        if( ImGui::CollapsingHeader( "Naive attempt" ) ) {
+            WRAP_START();
+            // same three sentences, but the color breaks the wrapping
+            ImGui::TextUnformatted( "Some long text that will wrap around nicely." );
+            ImGui::SameLine();
+            ImGui::TextColored( c_red, "%s", "Some red text in the middle." );
+            ImGui::SameLine();
+            ImGui::TextUnformatted( "Some long text that will wrap around nicely." );
+            WRAP_END();
+        }
+    }
+    ImGui::End();
 }
 
 void demo_ui::init()

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -1184,88 +1184,101 @@ std::string format_item_info( const std::vector<iteminfo> &vItemDisplay,
     return buffer;
 }
 
+static nc_color get_comparison_color( const iteminfo &i,
+                                      const std::vector<iteminfo> &vItemCompare )
+{
+    nc_color thisColor = c_yellow;
+    for( const iteminfo &k : vItemCompare ) {
+        if( k.sValue != "-999" ) {
+            if( i.sName == k.sName && i.sType == k.sType ) {
+                double iVal = i.dValue;
+                double kVal = k.dValue;
+                if( i.sFmt != k.sFmt ) {
+                    // Different units, compare unit adjusted vals
+                    iVal = i.dUnitAdjustedVal;
+                    kVal = k.dUnitAdjustedVal;
+                }
+                if( iVal > kVal - .01 &&
+                    iVal < kVal + .01 ) {
+                    thisColor = c_light_gray;
+                } else if( iVal > kVal ) {
+                    if( i.bLowerIsBetter ) {
+                        thisColor = c_light_red;
+                    } else {
+                        thisColor = c_light_green;
+                    }
+                } else if( iVal < kVal ) {
+                    if( i.bLowerIsBetter ) {
+                        thisColor = c_light_green;
+                    } else {
+                        thisColor = c_light_red;
+                    }
+                }
+                break;
+            }
+        }
+    }
+    return thisColor;
+}
+
 void display_item_info( const std::vector<iteminfo> &vItemDisplay,
                         const std::vector<iteminfo> &vItemCompare )
 {
-    bool bIsNewLine = true;
-
+    bool bAlreadyHasNewLine = true;
     for( const iteminfo &i : vItemDisplay ) {
         if( i.bIsArt ) {
             cataimgui::PushMonoFont();
         }
         if( i.sType == "DESCRIPTION" ) {
-            // Always start a new line for sType == "DESCRIPTION"
-            if( !bIsNewLine ) {
-                ImGui::NewLine();
-            }
             if( i.bDrawName ) {
-                cataimgui::draw_colored_text( i.sName, c_white );
+                if( i.sName == "--" ) {
+                    if( !bAlreadyHasNewLine ) {
+                        ImGui::NewLine();
+                        bAlreadyHasNewLine = true;
+                    }
+                    ImGui::Separator();
+                } else {
+                    if( i.sName.find( '\n' ) != std::string::npos ) {
+                        std::vector<std::string> lines = string_split( i.sName, '\n' );
+                        for( std::string &line : lines ) {
+                            cataimgui::TextColoredParagraph( c_white, line );
+                            ImGui::NewLine();
+                        }
+                        ImGui::SameLine();
+                    } else {
+                        cataimgui::TextColoredParagraph( c_white, i.sName );
+                    }
+                    bAlreadyHasNewLine = false;
+                }
             }
         } else {
             if( i.bDrawName ) {
-                cataimgui::draw_colored_text( i.sName, c_white );
+                cataimgui::TextColoredParagraph( c_light_gray, i.sName );
+                bAlreadyHasNewLine = false;
             }
 
-            std::string sFmt = i.sFmt;
-            std::string sPost;
-            if( !sFmt.empty() ) {
-                //A bit tricky, find %d and split the string
-                size_t pos = sFmt.find( "<num>" );
-                if( pos != std::string::npos ) {
-                    cataimgui::draw_colored_text( sFmt.substr( 0, pos ), c_white );
-                    sPost = sFmt.substr( pos + 5 );
-                } else {
-                    cataimgui::draw_colored_text( sFmt, c_white );
-                }
-
+            if( !i.sFmt.empty() ) {
+                std::optional<cataimgui::Segment> value = std::nullopt;
                 if( i.sValue != "-999" ) {
-                    nc_color thisColor = c_yellow;
-                    for( const iteminfo &k : vItemCompare ) {
-                        if( k.sValue != "-999" ) {
-                            if( i.sName == k.sName && i.sType == k.sType ) {
-                                double iVal = i.dValue;
-                                double kVal = k.dValue;
-                                if( i.sFmt != k.sFmt ) {
-                                    // Different units, compare unit adjusted vals
-                                    iVal = i.dUnitAdjustedVal;
-                                    kVal = k.dUnitAdjustedVal;
-                                }
-                                if( iVal > kVal - .01 &&
-                                    iVal < kVal + .01 ) {
-                                    thisColor = c_light_gray;
-                                } else if( iVal > kVal ) {
-                                    if( i.bLowerIsBetter ) {
-                                        thisColor = c_light_red;
-                                    } else {
-                                        thisColor = c_light_green;
-                                    }
-                                } else if( iVal < kVal ) {
-                                    if( i.bLowerIsBetter ) {
-                                        thisColor = c_light_green;
-                                    } else {
-                                        thisColor = c_light_red;
-                                    }
-                                }
-                                break;
-                            }
-                        }
-                    }
-                    ImGui::SameLine( 0, 0 );
-                    ImGui::TextColored( thisColor, "%s", i.sValue.c_str() );
+                    value = std::make_optional( cataimgui::Segment( i.sValue, get_comparison_color( i,
+                                                vItemCompare ) ) );
                 }
-                if( !sPost.empty() ) {
-                    ImGui::SameLine( 0, 0 );
-                    cataimgui::draw_colored_text( sPost, c_white );
-                }
+                cataimgui::TextColoredParagraph( c_light_gray, i.sFmt, value );
+                bAlreadyHasNewLine = false;
+            } else if( i.sValue != "-999" ) {
+                cataimgui::TextColoredParagraph( get_comparison_color( i, vItemCompare ),
+                                                 i.sValue );
+                bAlreadyHasNewLine = false;
             }
         }
+
         if( i.bIsArt ) {
             ImGui::PopFont();
         }
 
-        // Set bIsNewLine in case the next line should always start in a new line
-        if( !( bIsNewLine = i.bNewLine ) ) {
-            ImGui::SameLine( 0, 0 );
+        if( i.bNewLine && !bAlreadyHasNewLine ) {
+            ImGui::NewLine();
+            bAlreadyHasNewLine = true;
         }
     }
 }

--- a/src/text.cpp
+++ b/src/text.cpp
@@ -1,0 +1,328 @@
+#define IMGUI_DEFINE_MATH_OPERATORS
+#include "third-party/imgui/imgui.h"
+#include "third-party/imgui/imgui_internal.h"
+#undef IMGUI_DEFINE_MATH_OPERATORS
+
+#include "color.h"
+#include "text.h"
+
+static uint32_t u32_from_color( nc_color color )
+{
+    return ImGui::ColorConvertFloat4ToU32( color );
+}
+
+namespace cataimgui
+{
+Segment::Segment( ) = default;
+Segment::Segment( const std::string_view( sv ), uint32_t c )
+    : str( sv )
+    , color( c )
+{}
+Segment::Segment( const std::string_view( sv ), nc_color c )
+    : str( sv )
+    , color( u32_from_color( c ) )
+{}
+
+std::shared_ptr<Paragraph> parse_colored_text( const std::string_view str, nc_color default_color )
+{
+    std::shared_ptr<Paragraph> p = std::make_shared<Paragraph>();
+    p->append_colored_text( str, default_color );
+    return p;
+}
+
+Paragraph::Paragraph( )
+    : segs( {} )
+{}
+Paragraph::Paragraph( std::vector<Segment> &s )
+    : segs( s )
+{}
+Paragraph::Paragraph( const std::string_view str )
+{
+    append_colored_text( str, 0 );
+}
+
+Paragraph *Paragraph::append( std::string_view str, uint32_t color )
+{
+    segs.emplace_back( str, color );
+    return this;
+}
+
+Paragraph *Paragraph::append( std::string_view str, nc_color color )
+{
+    return append( str, u32_from_color( color ) );
+}
+
+Paragraph *Paragraph::append_colored_text( std::string_view str, nc_color default_color )
+{
+    return append_colored_text( str, u32_from_color( default_color ) );
+}
+
+Paragraph *Paragraph::append_colored_text( std::string_view str, uint32_t default_color )
+{
+    if( str.empty() ) {
+        return this;
+    }
+
+    size_t s = 0;
+    size_t e = 0;
+    std::vector<uint32_t> colors = std::vector<uint32_t>( 1, default_color );
+    while( std::string::npos != ( e = str.find( '<', s ) ) ) {
+        append( str.substr( s, e - s ), colors.back() );
+        size_t ce = str.find( '>', e );
+        if( std::string::npos != ce ) {
+            color_tag_parse_result tag = get_color_from_tag( str.substr( e, ce - e + 1 ) );
+            switch( tag.type ) {
+                case color_tag_parse_result::open_color_tag:
+                    colors.push_back( u32_from_color( tag.color ) );
+                    break;
+                case color_tag_parse_result::close_color_tag:
+                    if( colors.size() > 1 ) {
+                        colors.pop_back();
+                    }
+                    break;
+                case color_tag_parse_result::non_color_tag:
+                    append( str.substr( e, ce - e + 1 ), colors.back() );
+                    break;
+            }
+            s = ce + 1;
+        } else {
+            break;
+        }
+    }
+    append( str.substr( s, std::string::npos ), colors.back() );
+    return this;
+}
+
+Paragraph *Paragraph::black( std::string_view str )
+{
+    append( str, c_black );
+    return this;
+}
+
+Paragraph *Paragraph::white( std::string_view str )
+{
+    append( str, c_white );
+    return this;
+}
+
+Paragraph *Paragraph::light_gray( std::string_view str )
+{
+    append( str, c_light_gray );
+    return this;
+}
+
+Paragraph *Paragraph::dark_gray( std::string_view str )
+{
+    append( str, c_dark_gray );
+    return this;
+}
+
+Paragraph *Paragraph::red( std::string_view str )
+{
+    append( str, c_red );
+    return this;
+}
+
+Paragraph *Paragraph::green( std::string_view str )
+{
+    append( str, c_green );
+    return this;
+}
+
+Paragraph *Paragraph::blue( std::string_view str )
+{
+    append( str, c_blue );
+    return this;
+}
+
+Paragraph *Paragraph::cyan( std::string_view str )
+{
+    append( str, c_cyan );
+    return this;
+}
+
+Paragraph *Paragraph::magenta( std::string_view str )
+{
+    append( str, c_magenta );
+    return this;
+}
+
+Paragraph *Paragraph::brown( std::string_view str )
+{
+    append( str, c_brown );
+    return this;
+}
+
+Paragraph *Paragraph::light_red( std::string_view str )
+{
+    append( str, c_light_red );
+    return this;
+}
+
+Paragraph *Paragraph::light_green( std::string_view str )
+{
+    append( str, c_light_green );
+    return this;
+}
+
+Paragraph *Paragraph::light_blue( std::string_view str )
+{
+    append( str, c_light_blue );
+    return this;
+}
+
+Paragraph *Paragraph::light_cyan( std::string_view str )
+{
+    append( str, c_light_cyan );
+    return this;
+}
+
+Paragraph *Paragraph::pink( std::string_view str )
+{
+    append( str, c_pink );
+    return this;
+}
+
+Paragraph *Paragraph::yellow( std::string_view str )
+{
+    append( str, c_yellow );
+    return this;
+}
+
+Paragraph *Paragraph::spaced()
+{
+    if( !segs.empty() && segs.back().str.back() != ' ' ) {
+        append( " ", 0 );
+    }
+    return this;
+}
+
+Paragraph *Paragraph::separated()
+{
+    separator_before = true;
+    return this;
+}
+
+static void TextEx( const std::string_view str, float wrap_width, uint32_t color )
+{
+    if( str.empty() ) {
+        return;
+    }
+    ImFont *Font = ImGui::GetFont();
+    const char *textStart = str.data();
+    const char *textEnd = textStart + str.length();
+
+    do {
+        float widthRemaining = ImGui::CalcWrapWidthForPos( ImGui::GetCursorScreenPos(), wrap_width );
+        const char *drawEnd = Font->CalcWordWrapPositionA( 1.0f, textStart, textEnd, widthRemaining );
+        if( textStart == drawEnd ) {
+            ImGui::NewLine();
+            // NewLine assumes that we are done with one item and are
+            // adding another so it advances CursorPos.y by
+            // ItemSpacing.y. Since we know that this is just part of
+            // a paragraph, undo just that small extra spacing.
+            ImGui::GetCurrentWindow()->DC.CursorPos.y -= ImGui::GetStyle().ItemSpacing.y;
+            drawEnd = Font->CalcWordWrapPositionA( 1.0f, textStart, textEnd, widthRemaining );
+        }
+
+        if( color ) {
+            ImGui::PushStyleColor( ImGuiCol_Text, color );
+        }
+        ImGui::TextUnformatted( textStart, textStart == drawEnd ? nullptr : drawEnd );
+        // see above
+        ImGui::GetCurrentWindow()->DC.CursorPos.y -= ImGui::GetStyle().ItemSpacing.y;
+        if( color ) {
+            ImGui::PopStyleColor();
+        }
+
+        if( textStart == drawEnd || drawEnd == textEnd ) {
+            ImGui::SameLine( 0.0f, 0.0f );
+            break;
+        }
+
+        textStart = drawEnd;
+
+        while( textStart < textEnd ) {
+            const char c = *textStart;
+            if( ImCharIsBlankA( c ) ) {
+                textStart++;
+            } else if( c == '\n' ) {
+                textStart++;
+                break;
+            } else {
+                break;
+            }
+        }
+    } while( true );
+}
+
+static void TextSegmentEx( const Segment &seg, float wrap_width, bool styled )
+{
+    TextEx( seg.str, wrap_width, styled ? seg.color : 0 );
+}
+
+static void TextParagraphEx( std::shared_ptr<Paragraph> &para, float wrap_width, bool styled )
+{
+    for( const Segment &seg : para->segs ) {
+        TextSegmentEx( seg, wrap_width, styled );
+    }
+    ImGui::NewLine();
+}
+
+void TextStyled( std::shared_ptr<Paragraph> para, float wrap_width )
+{
+    TextParagraphEx( para, wrap_width, true );
+}
+
+void TextUnstyled( std::shared_ptr<Paragraph> para, float wrap_width )
+{
+    TextParagraphEx( para, wrap_width, false );
+}
+
+void TextParagraph( nc_color color, const std::string_view para, float wrap_width )
+{
+    TextEx( para, wrap_width, u32_from_color( color ) );
+}
+
+void TextColoredParagraph( nc_color default_color, const std::string_view str,
+                           std::optional<Segment> value, float wrap_width )
+{
+    if( str.empty() ) {
+        return;
+    }
+
+    size_t s = 0;
+    size_t e = 0;
+    std::vector<uint32_t> colors = std::vector<uint32_t>( 1, u32_from_color( default_color ) );
+    while( std::string::npos != ( e = str.find( '<', s ) ) ) {
+        TextEx( str.substr( s, e - s ), wrap_width, colors.back() );
+        size_t ce = str.find( '>', e );
+        if( std::string::npos != ce ) {
+            std::string_view tagname = str.substr( e, ce - e + 1 );
+            if( "<num>" == tagname && value.has_value() ) {
+                TextSegmentEx( value.value(), wrap_width, true );
+            } else {
+                color_tag_parse_result tag = get_color_from_tag( str.substr( e, ce - e + 1 ) );
+                switch( tag.type ) {
+                    case color_tag_parse_result::open_color_tag:
+                        colors.push_back( u32_from_color( tag.color ) );
+                        break;
+                    case color_tag_parse_result::close_color_tag:
+                        if( colors.size() > 1 ) {
+                            colors.pop_back();
+                        }
+                        break;
+                    case color_tag_parse_result::non_color_tag:
+                        TextEx( tagname, wrap_width, colors.back() );
+                        break;
+                }
+            }
+            s = ce + 1;
+        } else {
+            break;
+        }
+    }
+    TextEx( str.substr( s, std::string::npos ), wrap_width, colors.back() );
+}
+
+} // namespace cataimgui

--- a/src/text.h
+++ b/src/text.h
@@ -1,0 +1,72 @@
+#pragma once
+#ifndef CATA_SRC_TEXT_H
+#define CATA_SRC_TEXT_H
+
+#include <cmath>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "color.h"
+
+// This is an experimental text API. Where possible, it is better to
+// use TextParagraph or TextColoredParagraph to wrap text rather than
+// allocating Segments and Paragraphs.
+
+namespace cataimgui
+{
+struct Segment {
+    std::string str;
+    uint32_t color;
+
+    Segment( );
+    // NOLINTBEGIN(google-explicit-constructor)
+    Segment( const std::string_view( sv ), uint32_t c = 0 );
+    Segment( const std::string_view( sv ), nc_color c );
+    // NOLINTEND(google-explicit-constructor)
+};
+
+struct Paragraph {
+    std::vector<Segment> segs;
+    bool separator_before = false;
+
+    Paragraph( );
+    explicit Paragraph( std::vector<Segment> &s );
+    explicit Paragraph( std::string_view str );
+    Paragraph *append( std::string_view str, uint32_t color );
+    Paragraph *append( std::string_view str, nc_color color );
+    Paragraph *append_colored_text( std::string_view str, uint32_t default_color );
+    Paragraph *append_colored_text( std::string_view str, nc_color default_color );
+
+    Paragraph *black( std::string_view str );
+    Paragraph *white( std::string_view str );
+    Paragraph *light_gray( std::string_view str );
+    Paragraph *dark_gray( std::string_view str );
+    Paragraph *red( std::string_view str );
+    Paragraph *green( std::string_view str );
+    Paragraph *blue( std::string_view str );
+    Paragraph *cyan( std::string_view str );
+    Paragraph *magenta( std::string_view str );
+    Paragraph *brown( std::string_view str );
+    Paragraph *light_red( std::string_view str );
+    Paragraph *light_green( std::string_view str );
+    Paragraph *light_blue( std::string_view str );
+    Paragraph *light_cyan( std::string_view str );
+    Paragraph *pink( std::string_view str );
+    Paragraph *yellow( std::string_view str );
+
+    Paragraph *spaced();
+    Paragraph *separated();
+};
+
+std::shared_ptr<Paragraph> parse_colored_text( std::string_view str, nc_color default_color );
+void TextStyled( std::shared_ptr<Paragraph> para, float wrap_width = 0.0f );
+void TextUnstyled( std::shared_ptr<Paragraph> para, float wrap_width = 0.0f );
+void TextParagraph( nc_color color, std::string_view para, float wrap_width = 0.0f );
+void TextColoredParagraph( nc_color color, std::string_view str,
+                           std::optional<Segment> value = std::nullopt, float wrap_width = 0.0f );
+
+} // namespace cataimgui
+
+#endif // CATA_SRC_TEXT_H

--- a/src/third-party/imgui/imgui.h
+++ b/src/third-party/imgui/imgui.h
@@ -47,6 +47,9 @@ Index of this file:
 */
 
 #pragma once
+// NOLINTBEGIN
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
 
 // Configuration file with compile-time options
 // (edit imconfig.h or '#define IMGUI_USER_CONFIG "myfilename.h" from your build system')
@@ -3171,3 +3174,5 @@ enum ImGuiModFlags_ { ImGuiModFlags_None = 0, ImGuiModFlags_Ctrl = ImGuiMod_Ctrl
 #endif
 
 #endif // #ifndef IMGUI_DISABLE
+#pragma GCC diagnostic pop
+// NOLINTEND

--- a/src/third-party/imgui/imgui_impl_sdl2.h
+++ b/src/third-party/imgui/imgui_impl_sdl2.h
@@ -18,6 +18,10 @@
 #pragma once
 #include "imgui.h"      // IMGUI_IMPL_API
 
+// NOLINTBEGIN
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+
 struct SDL_Window;
 struct SDL_Renderer;
 typedef union SDL_Event SDL_Event;
@@ -34,3 +38,6 @@ IMGUI_IMPL_API bool     ImGui_ImplSDL2_ProcessEvent(const SDL_Event* event);
 #ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
 static inline void ImGui_ImplSDL2_NewFrame(SDL_Window*) { ImGui_ImplSDL2_NewFrame(); } // 1.84: removed unnecessary parameter
 #endif
+
+#pragma GCC diagnostic pop
+// NOLINTEND

--- a/src/third-party/imgui/imgui_impl_sdlrenderer2.h
+++ b/src/third-party/imgui/imgui_impl_sdlrenderer2.h
@@ -15,6 +15,10 @@
 #include <functional>
 #include "imgui.h"      // IMGUI_IMPL_API
 
+// NOLINTBEGIN
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+
 struct SDL_Renderer;
 
 IMGUI_IMPL_API bool     ImGui_ImplSDLRenderer2_Init(SDL_Renderer* renderer);
@@ -28,3 +32,6 @@ IMGUI_IMPL_API bool     ImGui_ImplSDLRenderer2_CreateFontsTexture();
 IMGUI_IMPL_API void     ImGui_ImplSDLRenderer2_DestroyFontsTexture();
 IMGUI_IMPL_API bool     ImGui_ImplSDLRenderer2_CreateDeviceObjects();
 IMGUI_IMPL_API void     ImGui_ImplSDLRenderer2_DestroyDeviceObjects();
+
+#pragma GCC diagnostic pop
+// NOLINTEND

--- a/src/third-party/imgui/imgui_internal.h
+++ b/src/third-party/imgui/imgui_internal.h
@@ -42,6 +42,10 @@ Index of this file:
 */
 
 #pragma once
+// NOLINTBEGIN
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+
 #ifndef IMGUI_DISABLE
 
 //-----------------------------------------------------------------------------
@@ -3308,3 +3312,5 @@ extern const char*  ImGuiTestEngine_FindItemDebugLabel(ImGuiContext* ctx, ImGuiI
 #endif
 
 #endif // #ifndef IMGUI_DISABLE
+#pragma GCC diagnostic pop
+// NOLINTEND

--- a/src/third-party/imgui/imstb_rectpack.h
+++ b/src/third-party/imgui/imstb_rectpack.h
@@ -70,6 +70,10 @@
 #ifndef STB_INCLUDE_STB_RECT_PACK_H
 #define STB_INCLUDE_STB_RECT_PACK_H
 
+// NOLINTBEGIN
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+
 #define STB_RECT_PACK_VERSION  1
 
 #ifdef STBRP_STATIC
@@ -625,3 +629,6 @@ ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ------------------------------------------------------------------------------
 */
+
+#pragma GCC diagnostic pop
+// NOLINTEND

--- a/src/third-party/imgui/imstb_textedit.h
+++ b/src/third-party/imgui/imstb_textedit.h
@@ -277,6 +277,10 @@
 #ifndef INCLUDE_STB_TEXTEDIT_H
 #define INCLUDE_STB_TEXTEDIT_H
 
+// NOLINTBEGIN
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+
 ////////////////////////////////////////////////////////////////////////
 //
 //     STB_TexteditState
@@ -1435,3 +1439,6 @@ ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ------------------------------------------------------------------------------
 */
+
+#pragma GCC diagnostic pop
+// NOLINTEND

--- a/src/third-party/imgui/imstb_truetype.h
+++ b/src/third-party/imgui/imstb_truetype.h
@@ -271,6 +271,10 @@
 //   Inline sort     :  6.54 s     5.65 s
 //   New rasterizer  :  5.63 s     5.00 s
 
+// NOLINTBEGIN
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 ////
@@ -5083,3 +5087,6 @@ ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ------------------------------------------------------------------------------
 */
+
+#pragma GCC diagnostic pop
+// NOLINTEND

--- a/src/ui_iteminfo.cpp
+++ b/src/ui_iteminfo.cpp
@@ -5,105 +5,6 @@
 #include "imgui/imgui_internal.h"
 
 
-void draw_item_info_imgui( cataimgui::window &window, item_info_data &data, int width,
-                           cataimgui::scroll &s )
-{
-    cataimgui::set_scroll( s );
-
-    float wrap_width = window.str_width_to_pixels( width - 2 );
-    nc_color base_color = c_light_gray;
-
-    if( !data.get_item_name().empty() ) {
-        cataimgui::draw_colored_text( data.get_item_name(), base_color, wrap_width );
-        ImGui::Spacing();
-    }
-    if( !data.get_type_name().empty() &&
-        data.get_item_name().find( data.get_type_name() ) == std::string::npos ) {
-        cataimgui::draw_colored_text( data.get_type_name(), base_color, wrap_width );
-    }
-
-    bool same_line = false;
-    for( const iteminfo &i : data.get_item_display() ) {
-        if( i.bIsArt ) {
-            cataimgui::PushMonoFont();
-        }
-        if( i.sType == "DESCRIPTION" ) {
-            if( i.bDrawName ) {
-                if( i.sName == "--" ) {
-                    ImGui::Separator();
-                } else {
-                    cataimgui::draw_colored_text( i.sName, base_color, wrap_width );
-                }
-            }
-        } else {
-            std::string formatted_string;
-            if( i.bDrawName ) {
-                formatted_string = i.sName;
-            }
-
-            std::string sFmt = i.sFmt;
-
-            //A bit tricky, find %d and split the string
-            size_t pos = sFmt.find( "<num>" );
-            if( pos != std::string::npos ) {
-                formatted_string += sFmt.substr( 0, pos );
-            } else {
-                formatted_string += sFmt;
-            }
-
-            if( i.sValue != "-999" ) {
-                nc_color this_color = c_yellow;
-                for( const iteminfo &k : data.get_item_compare() ) {
-                    if( k.sValue != "-999" ) {
-                        if( i.sName == k.sName && i.sType == k.sType ) {
-                            double iVal = i.dValue;
-                            double kVal = k.dValue;
-                            if( i.sFmt != k.sFmt ) {
-                                // Different units, compare unit adjusted vals
-                                iVal = i.dUnitAdjustedVal;
-                                kVal = k.dUnitAdjustedVal;
-                            }
-                            if( iVal > kVal - .01 &&
-                                iVal < kVal + .01 ) {
-                                this_color = c_light_gray;
-                            } else if( iVal > kVal ) {
-                                if( i.bLowerIsBetter ) {
-                                    this_color = c_light_red;
-                                } else {
-                                    this_color = c_light_green;
-                                }
-                            } else if( iVal < kVal ) {
-                                if( i.bLowerIsBetter ) {
-                                    this_color = c_light_green;
-                                } else {
-                                    this_color = c_light_red;
-                                }
-                            }
-                            break;
-                        }
-                    }
-                }
-                formatted_string += colorize( i.sValue, this_color );
-            }
-
-            if( pos != std::string::npos ) {
-                formatted_string += sFmt.substr( pos + 5 );
-            }
-
-            if( !formatted_string.empty() ) {
-                if( same_line ) {
-                    ImGui::SameLine( 0, 0 );
-                }
-                cataimgui::draw_colored_text( formatted_string, base_color, wrap_width );
-            }
-            same_line = !i.bNewLine;
-        }
-        if( i.bIsArt ) {
-            ImGui::PopFont();
-        }
-    }
-}
-
 iteminfo_window::iteminfo_window( item_info_data &info, point pos, int width, int height,
                                   ImGuiWindowFlags flags ) :
     cataimgui::window( _( "Item info" ), flags ),
@@ -137,7 +38,19 @@ cataimgui::bounds iteminfo_window::get_bounds()
 
 void iteminfo_window::draw_controls()
 {
-    draw_item_info_imgui( *this, data, width, s );
+    cataimgui::set_scroll( s );
+
+    nc_color base_color = c_light_gray;
+    if( !data.get_item_name().empty() ) {
+        cataimgui::draw_colored_text( data.get_item_name(), base_color );
+        ImGui::Spacing();
+    }
+    if( !data.get_type_name().empty() &&
+        data.get_item_name().find( data.get_type_name() ) == std::string::npos ) {
+        cataimgui::draw_colored_text( data.get_type_name(), base_color );
+    }
+
+    display_item_info( data.get_item_display(), data.get_item_compare() );
 }
 
 void iteminfo_window::execute()

--- a/src/ui_iteminfo.h
+++ b/src/ui_iteminfo.h
@@ -7,9 +7,6 @@
 #include "output.h"
 #include "imgui/imgui.h"
 
-void draw_item_info_imgui( cataimgui::window &window, item_info_data &data, int width,
-                           cataimgui::scroll &s );
-
 class iteminfo_window : public cataimgui::window
 {
     public:

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -880,6 +880,11 @@ class wish_item_callback: public uilist_callback
         const std::vector<const itype_variant_data *> &itype_variants;
         std::string &last_snippet_id;
 
+        int entnum = -1;
+        std::string header;
+        std::vector<iteminfo> info;
+        item tmp;
+
         explicit wish_item_callback( const std::vector<const itype *> &ids,
                                      const std::vector<const itype_variant_data *> &variants, std::string &snippet_ids ) :
             incontainer( false ), spawn_everything( false ),
@@ -990,67 +995,65 @@ class wish_item_callback: public uilist_callback
         }
 
         float desired_extra_space_right( ) override {
-            return std::max( TERMX / 2, TERMX - 50 ) * ImGui::CalcTextSize( "X" ).x;
+            return std::min( ImGui::GetMainViewport()->Size.x / 2.0f,
+                             std::max( TERMX / 2, TERMX - 50 ) * ImGui::CalcTextSize( "X" ).x );
         }
 
         void refresh( uilist *menu ) override {
+            const int entnum = menu->previewing;
+            if( entnum >= 0 && static_cast<size_t>( entnum ) < standard_itype_ids.size() ) {
+                tmp = wishitem_produce( *standard_itype_ids[entnum], flags, false );
+
+                const itype_variant_data *variant = itype_variants[entnum];
+                if( variant != nullptr && tmp.has_itype_variant( false ) ) {
+                    // Set the variant type as shown in the selected list item.
+                    std::string variant_id = variant->id;
+                    tmp.set_itype_variant( variant_id );
+                }
+
+                if( !tmp.type->snippet_category.empty() ) {
+                    if( renew_snippet ) {
+                        last_snippet_id = tmp.snip_id.str();
+                        renew_snippet = false;
+                    } else if( chosen_snippet_id.first == entnum && !chosen_snippet_id.second.empty() ) {
+                        std::string snip = chosen_snippet_id.second;
+                        if( snippet_id( snip ).is_valid() || snippet_id( snip ) == snippet_id::NULL_ID() ) {
+                            tmp.snip_id = snippet_id( snip );
+                            last_snippet_id = snip;
+                        }
+                    } else {
+                        tmp.snip_id = snippet_id( last_snippet_id );
+                    }
+                }
+
+                header = string_format( "#%d: %s%s%s", entnum,
+                                        standard_itype_ids[entnum]->get_id().c_str(),
+                                        incontainer ? _( " (contained)" ) : "",
+                                        flags.empty() ? "" : _( " (flagged)" ) );
+                info = tmp.get_info( true );
+            }
+
             ImVec2 info_size = ImGui::GetContentRegionAvail();
             info_size.x = desired_extra_space_right( );
+            info_size.y -= ( 3.0 * ImGui::GetTextLineHeightWithSpacing() ) - ImGui::GetFrameHeightWithSpacing();
+
             ImGui::TableSetColumnIndex( 2 );
-            if( ImGui::BeginChild( "monster info", info_size ) ) {
-                const int entnum = menu->previewing;
-                if( entnum >= 0 && static_cast<size_t>( entnum ) < standard_itype_ids.size() ) {
-                    item tmp = wishitem_produce( *standard_itype_ids[entnum], flags, false );
-
-                    const itype_variant_data *variant = itype_variants[entnum];
-                    if( variant != nullptr && tmp.has_itype_variant( false ) ) {
-                        // Set the variant type as shown in the selected list item.
-                        std::string variant_id = variant->id;
-                        tmp.set_itype_variant( variant_id );
-                    }
-
-                    if( !tmp.type->snippet_category.empty() ) {
-                        if( renew_snippet ) {
-                            last_snippet_id = tmp.snip_id.str();
-                            renew_snippet = false;
-                        } else if( chosen_snippet_id.first == entnum && !chosen_snippet_id.second.empty() ) {
-                            std::string snip = chosen_snippet_id.second;
-                            if( snippet_id( snip ).is_valid() || snippet_id( snip ) == snippet_id::NULL_ID() ) {
-                                tmp.snip_id = snippet_id( snip );
-                                last_snippet_id = snip;
-                            }
-                        } else {
-                            tmp.snip_id = snippet_id( last_snippet_id );
-                        }
-                    }
-
-                    const std::string header = string_format( "#%d: %s%s%s", entnum,
-                                               standard_itype_ids[entnum]->get_id().c_str(),
-                                               incontainer ? _( " (contained)" ) : "",
-                                               flags.empty() ? "" : _( " (flagged)" ) );
-                    ImGui::SetCursorPosX( ( ImGui::GetContentRegionAvail().x - ImGui::CalcTextSize(
-                                                header.c_str() ).x ) * 0.5 );
-                    ImGui::TextColored( c_cyan, "%s", header.c_str() );
-
-                    display_item_info( tmp.get_info( true ), {} );
-                }
-
-                float y = ImGui::GetContentRegionMax().y - 3 * ImGui::GetTextLineHeightWithSpacing();
-                if( ImGui::GetCursorPosY() < y ) {
-                    ImGui::SetCursorPosY( y );
-                }
-                ImGui::TextColored( c_green, "%s", msg.c_str() );
-                msg.erase();
-                input_context ctxt( menu->input_category, keyboard_mode::keycode );
-                ImGui::Text( _( "[%s] find, [%s] container, [%s] flag, [%s] everything, [%s] snippet, [%s] quit" ),
-                             ctxt.get_desc( "FILTER" ).c_str(),
-                             ctxt.get_desc( "CONTAINER" ).c_str(),
-                             ctxt.get_desc( "FLAG" ).c_str(),
-                             ctxt.get_desc( "EVERYTHING" ).c_str(),
-                             ctxt.get_desc( "SNIPPET" ).c_str(),
-                             ctxt.get_desc( "QUIT" ).c_str() );
+            if( ImGui::BeginChild( "wish item", info_size ) ) {
+                ImGui::SetCursorPosX( ( info_size.x - ImGui::CalcTextSize( header.c_str() ).x ) * 0.5 );
+                ImGui::TextColored( c_cyan, "%s", header.c_str() );
+                display_item_info( info, {} );
             }
             ImGui::EndChild();
+
+            ImGui::TextColored( c_green, "%s", msg.c_str() );
+            input_context ctxt( menu->input_category, keyboard_mode::keycode );
+            ImGui::Text( _( "[%s] find, [%s] container, [%s] flag, [%s] everything, [%s] snippet, [%s] quit" ),
+                         ctxt.get_desc( "FILTER" ).c_str(),
+                         ctxt.get_desc( "CONTAINER" ).c_str(),
+                         ctxt.get_desc( "FLAG" ).c_str(),
+                         ctxt.get_desc( "EVERYTHING" ).c_str(),
+                         ctxt.get_desc( "SNIPPET" ).c_str(),
+                         ctxt.get_desc( "QUIT" ).c_str() );
         }
 };
 
@@ -1105,7 +1108,7 @@ void debug_menu::wishitem( Character *you, const tripoint &pos )
         { "SCROLL_DESC_UP", translation() },
         { "SCROLL_DESC_DOWN", translation() },
     };
-    wmenu.desired_bounds = { -1.0, -1.0, 1.0, 1.0 };
+    wmenu.desired_bounds = { -0.9, -0.9, 0.9, 0.9 };
     wmenu.selected = uistate.wishitem_selected;
     wish_item_callback cb( itypes, ivariants, snipped_id_str );
     wmenu.callback = &cb;


### PR DESCRIPTION
#### Summary
Interface "Improved text wrapping in spellbook and spellcasting menus"

#### Purpose of change
Long strings that need to wrap onto multiple lines and also contain color codes are hard to wrap correctly. This gets us most of the way to a correct solution.

It also lets us draw text with fewer allocations, allowing us to gradually get away from creating strings with color tags only to throw them away.

Fixes #77297
Also Fixes #76298 
Also fixes #75901

#### Testing
Best place to test it is in the spellcasting window, using psi abilities. These frequently include color.

#### Additional context
This isn’t a perfect solution. It relies on ImGui’s built‐in text wrapping in several significant ways, and this comes at the cost of some remaining imperfections. Luckily these imperfections are less intrusive than the existing problems, and we can fix them as we have time and inclination.