### PR TITLE
Fix issues with beartrap

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2425,6 +2425,7 @@ bool monster::move_effects( bool )
         if( type->melee_dice * type->melee_sides >= 18 ) {
             if( x_in_y( type->melee_dice * type->melee_sides, 200 ) ) {
                 remove_effect( effect_beartrap );
+                here.spawn_item( pos_bub(), "beartrap" );
                 if( u_see_me && get_option<bool>( "LOG_MONSTER_MOVE_EFFECTS" ) ) {
                     add_msg( _( "The %s escapes the bear trap!" ), name() );
                 }

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3017,6 +3017,9 @@ void monster::die( Creature *nkiller )
             add_item( item( "rope_6", calendar::turn_zero ) );
             add_item( item( "snare_trigger", calendar::turn_zero ) );
         }
+        if( has_effect( effect_beartrap ) ) {
+            add_item( item( "beartrap", calendar::turn_zero ) );
+        }
     }
 
     if( death_drops && !no_extra_death_drops ) {

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -217,6 +217,8 @@ bool trapfunc::beartrap( const tripoint &p, Creature *c, item * )
             }
         }
         c->check_dead_state();
+    } else {
+        here.spawn_item( p, "beartrap" );
     }
 
     return true;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Closes #76454.

#### Describe the solution
Spawn deactivated bear trap after monster escapes it or dies on it, and also after triggering it with throwing.

#### Describe alternatives you've considered
None.

#### Testing
Set trap. Lured zombie brute into it. Waited for brute to escape from it. Checked that deactivated trap is correctly spawned after escaping.
Set trap. Threw rock at it. Checked that deactivated trap is still here after triggering.

#### Additional context
None.