### PR TITLE
[Magiclysm] Add Catoblepas monster

### DIFF
--- a/data/mods/Magiclysm/Spells/monsterspells.json
+++ b/data/mods/Magiclysm/Spells/monsterspells.json
@@ -393,36 +393,52 @@
         "run_eocs": [
           {
             "id": "EOC_CATOBLEPAS_GAZE_2",
-            "condition": "u_is_npc",
+            "condition": "u_is_character",
             "effect": [
-              { "u_add_effect": "effect_catoblepas_gaze", "duration": { "math": [ "rand(10) + 5" ] }, "target_part": "head" },
               {
                 "u_add_effect": "effect_catoblepas_gaze",
                 "duration": { "math": [ "rand(10) + 5" ] },
-                "target_part": "torso"
+                "target_part": "head",
+                "intensity": { "math": [ "u_effect_intensity('effect_catoblepas_gaze', 'bodypart': 'head') + 1" ] }
               },
               {
                 "u_add_effect": "effect_catoblepas_gaze",
                 "duration": { "math": [ "rand(10) + 5" ] },
-                "target_part": "arm_l"
+                "target_part": "torso",
+                "intensity": { "math": [ "u_effect_intensity('effect_catoblepas_gaze', 'bodypart': 'torso') + 1" ] }
               },
               {
                 "u_add_effect": "effect_catoblepas_gaze",
                 "duration": { "math": [ "rand(10) + 5" ] },
-                "target_part": "arm_r"
+                "target_part": "arm_l",
+                "intensity": { "math": [ "u_effect_intensity('effect_catoblepas_gaze', 'bodypart': 'arm_l') + 1" ] }
               },
               {
                 "u_add_effect": "effect_catoblepas_gaze",
                 "duration": { "math": [ "rand(10) + 5" ] },
-                "target_part": "leg_l"
+                "target_part": "arm_r",
+                "intensity": { "math": [ "u_effect_intensity('effect_catoblepas_gaze', 'bodypart': 'arm_r') + 1" ] }
               },
               {
                 "u_add_effect": "effect_catoblepas_gaze",
                 "duration": { "math": [ "rand(10) + 5" ] },
-                "target_part": "leg_r"
+                "target_part": "leg_l",
+                "intensity": { "math": [ "u_effect_intensity('effect_catoblepas_gaze', 'bodypart': 'leg_l') + 1" ] }
+              },
+              {
+                "u_add_effect": "effect_catoblepas_gaze",
+                "duration": { "math": [ "rand(10) + 5" ] },
+                "target_part": "leg_r",
+                "intensity": { "math": [ "u_effect_intensity('effect_catoblepas_gaze', 'bodypart': 'leg_r') + 1" ] }
               }
             ],
-            "false_effect": [ { "u_add_effect": "effect_catoblepas_gaze_monster", "duration": { "math": [ "rand(10) + 5" ] } } ]
+            "false_effect": [
+              {
+                "u_add_effect": "effect_catoblepas_gaze_monster",
+                "duration": { "math": [ "rand(10) + 5" ] },
+                "intensity": { "math": [ "u_effect_intensity('effect_catoblepas_gaze_monster') + 1" ] }
+              }
+            ]
           }
         ]
       }

--- a/data/mods/Magiclysm/Spells/monsterspells.json
+++ b/data/mods/Magiclysm/Spells/monsterspells.json
@@ -363,7 +363,7 @@
     "min_duration": 720000,
     "max_duration": 2160000
   },
-   {
+  {
     "type": "SPELL",
     "id": "catoblepas_gaze_spell",
     "name": { "str": "catoblepas gaze" },

--- a/data/mods/Magiclysm/Spells/monsterspells.json
+++ b/data/mods/Magiclysm/Spells/monsterspells.json
@@ -362,5 +362,70 @@
     "shape": "blast",
     "min_duration": 720000,
     "max_duration": 2160000
+  },
+   {
+    "type": "SPELL",
+    "id": "catoblepas_gaze_spell",
+    "name": { "str": "catoblepas gaze" },
+    "description": "Does a big thwack of damage if the target can see the catoblepas",
+    "valid_targets": [ "hostile" ],
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_CATOBLEPAS_GAZE",
+    "shape": "blast",
+    "message": "",
+    "max_level": 20,
+    "min_range": 15,
+    "max_range": 15,
+    "flags": [ "SILENT", "NO_EXPLOSION_SFX" ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CATOBLEPAS_GAZE",
+    "condition": {
+      "and": [
+        { "not": { "u_has_flag": "BLIND" } },
+        { "not": { "u_has_effect": "BLIND" } },
+        { "not": { "u_has_worn_with_flag": "BLIND" } }
+      ]
+    },
+    "effect": [
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_CATOBLEPAS_GAZE_2",
+            "condition": "u_is_npc",
+            "effect": [
+              { "u_add_effect": "effect_catoblepas_gaze", "duration": { "math": [ "rand(10) + 5" ] }, "target_part": "head" },
+              {
+                "u_add_effect": "effect_catoblepas_gaze",
+                "duration": { "math": [ "rand(10) + 5" ] },
+                "target_part": "torso"
+              },
+              {
+                "u_add_effect": "effect_catoblepas_gaze",
+                "duration": { "math": [ "rand(10) + 5" ] },
+                "target_part": "arm_l"
+              },
+              {
+                "u_add_effect": "effect_catoblepas_gaze",
+                "duration": { "math": [ "rand(10) + 5" ] },
+                "target_part": "arm_r"
+              },
+              {
+                "u_add_effect": "effect_catoblepas_gaze",
+                "duration": { "math": [ "rand(10) + 5" ] },
+                "target_part": "leg_l"
+              },
+              {
+                "u_add_effect": "effect_catoblepas_gaze",
+                "duration": { "math": [ "rand(10) + 5" ] },
+                "target_part": "leg_r"
+              }
+            ],
+            "false_effect": [ { "u_add_effect": "effect_catoblepas_gaze_monster", "duration": { "math": [ "rand(10) + 5" ] } } ]
+          }
+        ]
+      }
+    ]
   }
 ]

--- a/data/mods/Magiclysm/effects/effects.json
+++ b/data/mods/Magiclysm/effects/effects.json
@@ -404,20 +404,24 @@
   {
     "type": "effect_type",
     "id": "effect_catoblepas_gaze",
-    "name": [ "Necrosis" ],
+    "name": [ "Rotting Gaze" ],
     "desc": [ "You flesh is rotting off!" ],
     "apply_message": "Searing pain fills your body.",
     "rating": "bad",
-    "base_mods": { "hurt_min": [ 1 ], "hurt_max": [ 3 ], "hurt_chance": [ 2 ] }
+    "max_intensity": 3,
+    "base_mods": { "hurt_min": [ 1 ], "hurt_max": [ 3 ], "hurt_chance": [ 2 ] },
+    "scaling_mods": { "hurt_min": [ 1 ], "hurt_max": [ 3 ] }
   },
   {
     "type": "effect_type",
     "id": "effect_catoblepas_gaze_monster",
-    "name": [ "Necrosis" ],
+    "name": [ "Rotting Gaze" ],
     "desc": [ "You flesh is rotting off!" ],
     "apply_message": "Searing pain fills your body.",
     "rating": "bad",
-    "base_mods": { "hurt_min": [ 4 ], "hurt_max": [ 9 ], "hurt_chance": [ 2 ] }
+    "max_intensity": 3,
+    "base_mods": { "hurt_min": [ 4 ], "hurt_max": [ 9 ], "hurt_chance": [ 2 ] },
+    "scaling_mods": { "hurt_min": [ 3 ], "hurt_max": [ 6 ] }
   },
   {
     "type": "effect_type",

--- a/data/mods/Magiclysm/effects/effects.json
+++ b/data/mods/Magiclysm/effects/effects.json
@@ -403,6 +403,24 @@
   },
   {
     "type": "effect_type",
+    "id": "effect_catoblepas_gaze",
+    "name": [ "Necrosis" ],
+    "desc": [ "You flesh is rotting off!" ],
+    "apply_message": "Searing pain fills your body.",
+    "rating": "bad",
+    "base_mods": { "hurt_min": [ 1 ], "hurt_max": [ 3 ], "hurt_chance": [ 2 ] }
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_catoblepas_gaze_monster",
+    "name": [ "Necrosis" ],
+    "desc": [ "You flesh is rotting off!" ],
+    "apply_message": "Searing pain fills your body.",
+    "rating": "bad",
+    "base_mods": { "hurt_min": [ 4 ], "hurt_max": [ 9 ], "hurt_chance": [ 2 ] }
+  },
+  {
+    "type": "effect_type",
     "id": "biomancer_visceral_side_effects",
     "name": [ "Visceral Overexertion" ],
     "desc": [ "You feel sickened from overtaxing your body, having extended your influence over such a wide area." ],

--- a/data/mods/Magiclysm/monstergroups.json
+++ b/data/mods/Magiclysm/monstergroups.json
@@ -89,6 +89,7 @@
       { "monster": "mon_null", "weight": 940 },
       { "monster": "mon_black_pudding", "weight": 14, "pack_size": [ 4, 6 ] },
       { "monster": "mon_stirge", "weight": 7, "pack_size": [ 2, 8 ] },
+      { "monster": "mon_catoblepas", "weight": 3, "cost_multiplier": 10 },
       { "monster": "mon_wisp", "weight": 5, "cost_multiplier": 10, "conditions": [ "NIGHT" ] },
       { "monster": "mon_wisp", "weight": 1, "cost_multiplier": 10, "conditions": [ "NIGHT" ], "pack_size": [ 1, 3 ] },
       { "monster": "mon_dragon_black_wyrmling", "weight": 2, "cost_multiplier": 50 },

--- a/data/mods/Magiclysm/monsters/monsters.json
+++ b/data/mods/Magiclysm/monsters/monsters.json
@@ -895,5 +895,43 @@
     "fear_triggers": [ "BRIGHT_LIGHT" ],
     "flags": [ "SEES", "HEARS", "SMELLS", "GRABS", "HAS_MIND", "PATH_AVOID_DANGER", "PATH_AVOID_FIRE", "WARM" ],
     "armor": { "bash": 15, "cut": 2, "heat": 10, "necrotic": 5, "poison": 100 }
+  },
+  {
+    "id": "mon_catoblepas",
+    "type": "MONSTER",
+    "name": { "str": "catoblepas", "str_pl": "catoblepases" },
+    "description": "A terrible stench is the first sign of this monster's presence.  It has an ox-like body and warthog-like head, with a neck almost as long as a giraffe's.  It keeps its head low to the ground, but there's something odd about its eyes.",
+    "default_faction": "magical_beast",
+    "bodytype": "bear",
+    "species": [ "MAGICAL_BEAST" ],
+    "volume": "560000 ml",
+    "weight": "500 kg",
+    "hp": 350,
+    "speed": 90,
+    "material": [ "flesh" ],
+    "symbol": "C",
+    "color": "brown",
+    "aggression": 100,
+    "morale": 100,
+    "melee_skill": 5,
+    "melee_dice": 2,
+    "melee_dice_sides": 6,
+    "dodge": 1,
+    "vision_night": 5,
+    "path_settings": { "max_dist": 25 },
+    "harvest": "owlbear",
+    "dissect": "dissect_beast_sample_large",
+    "special_attacks": [ 
+      { "type": "stretch_bite", "cooldown": 1, "range": 2 },
+      {
+        "id": "catoblepas_gaze",
+        "type": "spell",
+        "spell_data": { "id": "catoblepas_gaze_spell", "min_level": 20 },
+        "monster_message": "The catoblepas looks at <npcname>!",
+        "cooldown": 15
+      },
+    ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "KEENNOSE", "PATH_AVOID_DANGER", "WARM" ],
+    "armor": { "bash": 5, "cut": 2, "bullet": 2 }
   }
 ]

--- a/data/mods/Magiclysm/monsters/monsters.json
+++ b/data/mods/Magiclysm/monsters/monsters.json
@@ -933,6 +933,6 @@
     ],
     "flags": [ "SEES", "HEARS", "SMELLS", "KEENNOSE", "REVIVES", "PATH_AVOID_DANGER", "PATH_AVOID_FIRE", "WARM" ],
     "zombify_into": "mon_catoblepas_zombie",
-    "armor": { "bash": 5, "cut": 2, "bullet": 2 }
+    "armor": { "bash": 4, "cut": 2, "necrotic": 25, "poison": 30 }
   }
 ]

--- a/data/mods/Magiclysm/monsters/monsters.json
+++ b/data/mods/Magiclysm/monsters/monsters.json
@@ -918,20 +918,21 @@
     "melee_dice_sides": 6,
     "dodge": 1,
     "vision_night": 5,
-    "path_settings": { "max_dist": 25 },
-    "harvest": "owlbear",
+    "path_settings": { "max_dist": 25, "avoid_sharp": true },
+    "harvest": "mutant_mammal_large_fur",
     "dissect": "dissect_beast_sample_large",
-    "special_attacks": [ 
-      { "type": "stretch_bite", "cooldown": 1, "range": 2 },
+    "special_attacks": [
+      { "id": "stretch_bite", "cooldown": 1, "range": 2 },
       {
         "id": "catoblepas_gaze",
         "type": "spell",
         "spell_data": { "id": "catoblepas_gaze_spell", "min_level": 20 },
-        "monster_message": "The catoblepas looks at <npcname>!",
+        "monster_message": "The catoblepas looks at %3$s!",
         "cooldown": 15
-      },
+      }
     ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "KEENNOSE", "PATH_AVOID_DANGER", "WARM" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "KEENNOSE", "REVIVES", "PATH_AVOID_DANGER", "PATH_AVOID_FIRE", "WARM" ],
+    "zombify_into": "mon_catoblepas_zombie",
     "armor": { "bash": 5, "cut": 2, "bullet": 2 }
   }
 ]

--- a/data/mods/Magiclysm/monsters/zombified_monsters.json
+++ b/data/mods/Magiclysm/monsters/zombified_monsters.json
@@ -227,7 +227,7 @@
   {
     "type": "MONSTER",
     "id": "mon_catoblepas_zombie",
-    "name": "zombified catoblepas",
+    "name": { "str": "zombified catoblepas", "str_pl": "zombified catoblepases" },
     "description": "Already foul in life, this catoblepas now has oozing sores on its body and an even more rank odor.  At least whatever was odd about its eyes is gone, now that they're black and filled with rage.",
     "looks_like": "mon_catoblepas",
     "default_faction": "zombie",

--- a/data/mods/Magiclysm/monsters/zombified_monsters.json
+++ b/data/mods/Magiclysm/monsters/zombified_monsters.json
@@ -250,6 +250,7 @@
     "harvest": "zombie_leather",
     "//": "No deathgaze for the zombie",
     "special_attacks": [ { "id": "stretch_bite", "cooldown": 1, "range": 2 } ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "KEENNOSE", "WARM", "STUMBLES", "BASHES", "POISON", "NO_BREATHE", "REVIVES" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "KEENNOSE", "WARM", "STUMBLES", "BASHES", "POISON", "NO_BREATHE", "REVIVES" ],
+    "armor": { "bash": 4, "cut": 2, "necrotic": 75, "poison": 30 }
   }
 ]

--- a/data/mods/Magiclysm/monsters/zombified_monsters.json
+++ b/data/mods/Magiclysm/monsters/zombified_monsters.json
@@ -223,5 +223,33 @@
     "type": "MONSTER",
     "name": { "str": "wolf" },
     "default_faction": "zombie"
+  },
+  {
+    "type": "MONSTER",
+    "id": "mon_catoblepas_zombie",
+    "name": "zombified catoblepas",
+    "description": "Already foul in life, this catoblepas now has oozing sores on its body and an even more rank odor.  At least whatever was odd about its eyes is gone, now that they're black and filled with rage.",
+    "looks_like": "mon_catoblepas",
+    "default_faction": "zombie",
+    "species": [ "MAGICAL_BEAST", "ZOMBIE" ],
+    "symbol": "C",
+    "color": "light_gray",
+    "material": [ "flesh" ],
+    "bodytype": "lion",
+    "volume": "560000 ml",
+    "weight": "500 kg",
+    "hp": 350,
+    "speed": 75,
+    "aggression": 100,
+    "morale": 100,
+    "melee_skill": 5,
+    "melee_dice": 2,
+    "melee_dice_sides": 6,
+    "dodge": 3,
+    "vision_night": 5,
+    "harvest": "zombie_leather",
+    "//": "No deathgaze for the zombie",
+    "special_attacks": [ { "id": "stretch_bite", "cooldown": 1, "range": 2 } ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "KEENNOSE", "WARM", "STUMBLES", "BASHES", "POISON", "NO_BREATHE", "REVIVES" ]
   }
 ]

--- a/data/mods/Magiclysm/worldgen/map_extras.json
+++ b/data/mods/Magiclysm/worldgen/map_extras.json
@@ -1,0 +1,13 @@
+[
+  {
+    "id": "mx_catoblepas_lair",
+    "type": "map_extra",
+    "name": { "str": "Catoblepas Lair" },
+    "description": "There are catoblepases lairing here.",
+    "generator": { "generator_method": "update_mapgen", "generator_id": "mx_catoblepas_lair" },
+    "min_max_zlevel": [ 0, 0 ],
+    "sym": "C",
+    "color": "brown",
+    "autonote": false
+  }
+]

--- a/data/mods/Magiclysm/worldgen/map_extras/catoblepas_lair.json
+++ b/data/mods/Magiclysm/worldgen/map_extras/catoblepas_lair.json
@@ -1,0 +1,45 @@
+[
+  {
+    "type": "mapgen",
+    "method": "json",
+    "update_mapgen_id": "mx_catoblepas_lair",
+    "object": {
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "          ---           ",
+        "           TTT--        ",
+        "         -T---T-        ",
+        "        -T-----T        ",
+        "        T--C----T-      ",
+        "      --T-------T-      ",
+        "       -T----c--T       ",
+        "       --T-X---T        ",
+        "         -TX--T--       ",
+        "         --TTT--        ",
+        "            --          ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        "
+      ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "terrain": {
+        "T": [ [ "t_region_tree_forest", 1 ], [ "t_region_groundcover_swamp", 1 ], [ "t_region_shrub_swamp", 1 ] ],
+        "-": [ [ "t_region_groundcover_swamp", 3 ], [ "t_region_shrub_swamp", 1 ] ],
+        "C": [ [ "t_region_groundcover_swamp", 3 ], [ "t_region_shrub_swamp", 1 ] ],
+        "c": [ [ "t_region_groundcover_swamp", 3 ], [ "t_region_shrub_swamp", 1 ] ],
+        "X": "t_region_groundcover_swamp"
+      },
+      "items": { "X": [ { "item": "corpses", "chance": 5, "repeat": 1 }, { "item": "default_zombie_death_drops", "chance": 85 } ] },
+      "monster": { "C": { "monster": "mon_catoblepas" }, "c": { "monster": "mon_catoblepas", "chance": 80 } }
+    }
+  }
+]

--- a/data/mods/Magiclysm/worldgen/regional_overlay.json
+++ b/data/mods/Magiclysm/worldgen/regional_overlay.json
@@ -59,6 +59,7 @@
         }
       }
     },
+    "map_extras": { "forest_water": { "chance": 20, "extras": { "mx_catoblepas_lair": 1 } } },
     "forest_mapgen_settings": {
       "forest_thick": {
         "terrains": [


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Magiclysm] Add Catoblepas monster"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I don't think the wilderness in Magiclysm is dangerous enough, and especially not swamps. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the Catoblepas, one of the fantasy monsters so weird you know it's based on real mythology. It's an ox-like beast with a long neck that lives in swamps. It can bite at range, but its real dangerous feature is the necrotic gaze. If you can see it when it looks at your eyes, your flesh starts rotting off. Wear a blindfold or similar to avoid this. 

Still needs:

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Catoblepas gaze's works (but not against blinded targets), the lair spawns appropriately and most of the time has a mated pair. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
