### PR TITLE
fix hallucinations making you speak with items in your hands if you have nothing in your hands

### DIFF
--- a/data/json/effects_on_condition/npc_eocs/hallucination_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/hallucination_eocs.json
@@ -122,7 +122,7 @@
           "else": {
             "if": { "and": [ "u_can_see", { "math": [ "u_monsters_nearby('radius': 10)", ">=", "1" ] } ] },
             "then": { "u_message": "Your <npc_name> says \"<schizo_weapon_talk_monster>\"" },
-            "else": { "run_eocs": { "id": "normal_talk", "effect": { "u_message": "Your <npc_name> says \"<schizo_weapon_talk_misc>\"" } } }
+            "else": { "u_message": "Your <npc_name> says \"<schizo_weapon_talk_misc>\"" }
           }
         }
       }

--- a/data/json/effects_on_condition/npc_eocs/hallucination_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/hallucination_eocs.json
@@ -92,31 +92,9 @@
     },
     "effect": [
       {
-        "u_run_inv_eocs": "random",
-        "search_data": [ { "wielded_only": true } ],
-        "true_eocs": [
-          {
-            "id": "injured_talk",
-            "condition": { "math": [ "n_hp('ALL')", "<", "n_hp_max('bp_null')" ] },
-            "effect": { "u_message": "Your <npc_name> says \"<schizo_weapon_talk_damaged>\"" },
-            "false_effect": {
-              "run_eocs": {
-                "id": "you_injured_talk",
-                "//": "Weapon will be concerned for you if you're significantly injured.",
-                "condition": { "math": [ "(u_hp('ALL') * 1.4)", "<", "u_hp_max('bp_null')" ] },
-                "effect": { "u_message": "Your <npc_name> says \"<schizo_weapon_talk_bleeding>\"" },
-                "false_effect": {
-                  "run_eocs": {
-                    "id": "monsters_nearby_talk",
-                    "condition": { "and": [ "u_can_see", { "math": [ "u_monsters_nearby('radius': 10)", ">=", "1" ] } ] },
-                    "effect": { "u_message": "Your <npc_name> says \"<schizo_weapon_talk_monster>\"" },
-                    "false_effect": { "run_eocs": { "id": "normal_talk", "effect": { "u_message": "Your <npc_name> says \"<schizo_weapon_talk_misc>\"" } } }
-                  }
-                }
-              }
-            }
-          }
-        ]
+        "if": "u_has_weapon",
+        "then": { "u_run_inv_eocs": "all", "search_data": [ { "wielded_only": true } ], "true_eocs": [ "item_talks_to_you" ] },
+        "else": { "run_eocs": "minor_hallucinations" }
       },
       {
         "run_eocs": {
@@ -129,6 +107,26 @@
       }
     ],
     "false_effect": { "run_eocs": "minor_hallucinations" }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "item_talks_to_you",
+    "effect": [
+      {
+        "if": { "math": [ "n_hp('ALL')", "<", "n_hp_max('bp_null')" ] },
+        "then": { "u_message": "Your <npc_name> says \"<schizo_weapon_talk_damaged>\"" },
+        "else": {
+          "if": { "math": [ "(u_hp('ALL') * 1.4)", "<", "u_hp_max('bp_null')" ] },
+          "//": "Weapon will be concerned for you if you're significantly injured.",
+          "then": { "u_message": "Your <npc_name> says \"<schizo_weapon_talk_bleeding>\"" },
+          "else": {
+            "if": { "and": [ "u_can_see", { "math": [ "u_monsters_nearby('radius': 10)", ">=", "1" ] } ] },
+            "then": { "u_message": "Your <npc_name> says \"<schizo_weapon_talk_monster>\"" },
+            "else": { "run_eocs": { "id": "normal_talk", "effect": { "u_message": "Your <npc_name> says \"<schizo_weapon_talk_misc>\"" } } }
+          }
+        }
+      }
+    ]
   },
   {
     "type": "effect_on_condition",


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Because lack of item in your hands make `u_run_inv_eocs` return `none`, so you speak to `none`
#### Describe the solution
You are not this mad to speak with `none`
Also clean up EoC a bit
#### Additional context
![image](https://github.com/user-attachments/assets/b23d59b8-765b-4588-980e-f7d4f9809cd5)