### PR TITLE
HULK NO SMASH! fungal spires

### DIFF
--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -881,7 +881,7 @@ bool melee_actor::call( monster &z ) const
             }
         }
     }
-    if( throw_strength > 0 ) {
+    if( throw_strength > 0 && !target->has_flag( mon_flag_IMMOBILE ) ) {
         if( g->fling_creature( target, coord_to_angle( z.pos(), target->pos() ),
                                throw_strength ) ) {
             target->add_msg_player_or_npc( msg_type, throw_msg_u,


### PR DESCRIPTION
#### Summary
Bugfixes "Monsters won't be sending immobile targets into fly anymore."

#### Purpose of change
#49316 unhardcoded `smash` monster special attack, but for some reason the check for immobile targets was forgotten (or omitted).

#### Describe the solution
Added check for `IMMOBLE` flag while deciding whether monster should fling target.

#### Describe alternatives you've considered
None.

#### Testing
Debug-spawned zombie hulk, fungal spire, debug monster. Checked that two latter monsters weren't sent into fly by hulk's attacks.

#### Additional context
None.