### PR TITLE
New characters get random natural hair color during character generation

### DIFF
--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -75,6 +75,7 @@ static const std::string flag_CHALLENGE( "CHALLENGE" );
 static const std::string flag_CITY_START( "CITY_START" );
 static const std::string flag_SECRET( "SECRET" );
 
+static const std::string type_hair_color( "hair_color" );
 static const std::string type_hair_style( "hair_style" );
 static const std::string type_skin_tone( "skin_tone" );
 static const std::string type_facial_hair( "facial_hair" );
@@ -600,6 +601,7 @@ void avatar::randomize( const bool random_scenario, bool play_now )
 
 void avatar::randomize_cosmetics()
 {
+    randomize_cosmetic_trait( type_hair_color );
     randomize_cosmetic_trait( type_hair_style );
     randomize_cosmetic_trait( type_skin_tone );
     randomize_cosmetic_trait( type_eye_color );


### PR DESCRIPTION
#### Summary
Features "New characters get random natural hair color during character generation"

#### Purpose of change
I suppose every person has a natural hair color, but for some reason this cosmetic is turned off by default during character generation.

#### Describe the solution
Add a random natural hair color during character generation.

#### Describe alternatives you've considered
None.

#### Testing
Created character with red natural hair color and a purple haircut style. Made haircut with a haircut kit, checked that my new haircut is red.

#### Additional context
None.