### PR TITLE
Rodentkin fixes

### DIFF
--- a/data/json/monstergroups/lab.json
+++ b/data/json/monstergroups/lab.json
@@ -326,13 +326,15 @@
   {
     "name": "GROUP_RATKIN_LAB",
     "type": "monstergroup",
-    "default": "mon_big_rat",
     "monsters": [
-      { "monster": "mon_big_rat", "pack_size": [ 2, 6 ] },
-      { "monster": "mon_zap_rat", "weight": 280, "pack_size": [ 1, 3 ] },
-      { "monster": "mon_tunnel_rat", "weight": 180, "pack_size": [ 2, 5 ] },
-      { "monster": "mon_teke_mouse", "weight": 160, "pack_size": [ 1, 2 ] },
-      { "monster": "mon_mausketeer", "weight": 90, "pack_size": [ 1, 3 ] }
+      { "monster": "mon_lab_ratkin", "weight": 250, "pack_size": [ 2, 6 ] },
+      { "monster": "mon_black_ratkin", "weight": 200, "pack_size": [ 2, 6 ] },
+      { "monster": "mon_big_rat", "weight": 150, "pack_size": [ 2, 6 ] },
+      { "monster": "mon_zap_rat", "weight": 100, "pack_size": [ 1, 3 ] },
+      { "monster": "mon_tunnel_rat", "weight": 90, "pack_size": [ 2, 5 ] },
+      { "monster": "mon_pack_rat", "weight": 80, "pack_size": [ 1, 3 ] },
+      { "monster": "mon_teke_mouse", "weight": 70, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_mausketeer", "weight": 60, "pack_size": [ 1, 3 ] }
     ]
   }
 ]

--- a/data/json/monstergroups/mutant_upgrades.json
+++ b/data/json/monstergroups/mutant_upgrades.json
@@ -48,16 +48,12 @@
   {
     "name": "GROUP_RATKIN_EVOLVED",
     "type": "monstergroup",
-    "default": "mon_black_ratkin",
     "monsters": [
-      { "monster": "mon_black_ratkin" },
-      { "monster": "mon_lab_ratkin", "weight": 200 },
-      { "monster": "mon_big_rat", "weight": 320 },
-      { "monster": "mon_zap_rat", "weight": 280 },
-      { "monster": "mon_tunnel_rat", "weight": 180 },
-      { "monster": "mon_pack_rat", "weight": 170 },
-      { "monster": "mon_teke_mouse", "weight": 160 },
-      { "monster": "mon_mausketeer", "weight": 90 }
+      { "monster": "mon_zap_rat", "weight": 300 },
+      { "monster": "mon_tunnel_rat", "weight": 250 },
+      { "monster": "mon_pack_rat", "weight": 200 },
+      { "monster": "mon_teke_mouse", "weight": 150 },
+      { "monster": "mon_mausketeer", "weight": 100 }
     ]
   }
 ]

--- a/data/json/monsters/rodentkin.json
+++ b/data/json/monsters/rodentkin.json
@@ -7,7 +7,7 @@
     "name": { "str": "black rat" },
     "description": "The black rat, an omnivorous rodent with sheer black fur and a long, rough tail.  Harbinger of pestilence, famine, and mange, it will sometimes swarm over the dead or dying.",
     "default_faction": "ratkin",
-    "upgrades": { "half_life": 42, "into_group": "GROUP_RATKIN_EVOLVED" }
+    "upgrades": { "half_life": 15, "into": "mon_big_rat" }
   },
   {
     "id": "mon_lab_ratkin",
@@ -16,7 +16,7 @@
     "//": "Duplicate rats created to prevent all rats from evolving into mutant rats, any monster ending in ratkin should only appear in places where mutant rats can evolve.",
     "description": "The albino Norway rat, an omnivorous rodent with sleek white fur and a long, rough tail.  While its ancestors were harbingers of plague, these clever animals are omnipresent in modern biomedical research.",
     "default_faction": "ratkin",
-    "upgrades": { "half_life": 42, "into_group": "GROUP_RATKIN_EVOLVED" },
+    "upgrades": { "half_life": 15, "into": "mon_big_rat" },
     "categories": [ "WILDLIFE" ],
     "species": [ "MAMMAL" ],
     "volume": "320 ml",
@@ -83,7 +83,7 @@
     "vision_day": 30,
     "vision_night": 10,
     "path_settings": { "max_dist": 50, "avoid_sharp": true },
-    "upgrades": { "half_life": 42, "into_group": "GROUP_RATKIN_EVOLVED" },
+    "upgrades": { "half_life": 30, "into_group": "GROUP_RATKIN_EVOLVED" },
     "anger_triggers": [ "PLAYER_WEAK", "PLAYER_CLOSE", "FRIEND_ATTACKED" ],
     "fear_triggers": [ "HURT", "FIRE" ],
     "regen_morale": true,
@@ -120,7 +120,7 @@
     "special_when_hit": [ "ZAPBACK", 100 ],
     "special_attacks": [ [ "EAT_FOOD", 120 ], [ "EAT_CARRION", 120 ] ],
     "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology", "prof_electromagnetics" ],
-    "upgrades": { "half_life": 42, "into_group": "GROUP_RATKIN_EVOLVED" },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "HEARS", "WARM", "SWIMS", "ELECTRIC", "ANIMAL", "PATH_AVOID_DANGER", "EATS", "SMALL_HIDER" ],
     "emit_fields": [ { "emit_id": "emit_shock_burst_rat", "delay": "5 s" } ]
   },
@@ -144,7 +144,7 @@
     "melee_damage": [ { "damage_type": "cut", "amount": 4 } ],
     "dodge": 3,
     "stomach_size": 120,
-    "upgrades": { "half_life": 42, "into_group": "GROUP_RATKIN_EVOLVED" },
+    "upgrades": false,
     "path_settings": { "max_dist": 50, "avoid_traps": true, "avoid_sharp": true },
     "special_attacks": [
       { "id": "scratch", "damage_max_instance": [ { "damage_type": "cut", "amount": 17, "armor_multiplier": 0.8 } ] },
@@ -186,6 +186,7 @@
     "melee_damage": [ { "damage_type": "cut", "amount": 5 } ],
     "dodge": 3,
     "anger_triggers": [ "PLAYER_WEAK", "PLAYER_CLOSE", "FRIEND_ATTACKED", "STALK" ],
+    "upgrades": false,
     "path_settings": { "max_dist": 50, "avoid_traps": true, "avoid_sharp": true },
     "death_drops": "ratkin_death_drops_pack_rat",
     "stomach_size": 800,
@@ -233,10 +234,10 @@
     "death_drops": "ratkin_death_drops_teke",
     "dissect": "dissect_alpha_sample_small",
     "path_settings": { "max_dist": 50, "avoid_traps": true, "avoid_sharp": true },
-    "special_when_hit": [ "ZAPBACK", 100 ],
     "special_attacks": [ { "id": "teke_push" }, [ "EAT_FOOD", 120 ], [ "EAT_CARRION", 120 ] ],
     "zombify_into": "mon_meat_cocoon_tiny",
-    "flags": [ "SEES", "SMELLS", "HEARS", "WARM", "RANGED_ATTACKER", "ELECTRIC", "PATH_AVOID_DANGER", "EATS" ],
+    "upgrades": false,
+    "flags": [ "SEES", "SMELLS", "HEARS", "WARM", "RANGED_ATTACKER", "PATH_AVOID_DANGER", "EATS" ],
     "armor": { "bash": 15, "cut": 3, "bullet": 26 }
   },
   {
@@ -272,7 +273,8 @@
       [ "EAT_CARRION", 120 ]
     ],
     "zombify_into": "mon_meat_cocoon_tiny",
-    "flags": [ "SEES", "SMELLS", "HEARS", "WARM", "SWIMS", "ELECTRIC", "PATH_AVOID_DANGER", "EATS" ],
+    "upgrades": false,
+    "flags": [ "SEES", "SMELLS", "HEARS", "WARM", "SWIMS", "PATH_AVOID_DANGER", "EATS" ],
     "dissect": "dissect_rat_sample_small",
     "armor": { "bash": 10, "cut": 10, "bullet": 6 }
   }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Rodentkin fixes"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

There were few issues with rodentkin. 
**First**, basic ones, black ratkin, lab ratkin etc. didn't spawn naturally. They could only (d)evolve from more advanced ones like mausketeer or mouse of nema.
**Second**, every one of ratkin could evolve into every other form. Basic ones into medium or most evolved, most evolved ones into basic or into midforms, or they could just evolve into themselves.
**Third**, at day one rodentkin microlab had only 4, most advanced evolutions spawning. No blackrat, labrat, big rat or packrat.
**Fourth**, mausketeer and mouse of nema had "eletric" flag. Mouse of Nema had zapback as well. Nothing in their descrieption sugests they have such powers. If for example mouse of nema was intended to have electric powers as well, is should get other aspects of it, electromagnetic proficiency, luminescence or emit_field.

#### Describe the solution

Change spawngroup of rodentkin to include all rodentkins, with most of them being basic, unevolved rats.
Change evolutiongroup of rodentkin to include only evolved versions of rats.
Make basic rodentkins evolve into big rats. Big rats still evolve into rodentkin evolutiongroup. Final evolutions dont evolve.
Remove electricity from mausketeer and mouse of nema.

#### Describe alternatives you've considered

Dont touch mausketeer and mouse of nema. If any maintaineer tells me to not touch it, I will omit these changes.
Change descrieption of mouse of nema and give it other elcetric perks

#### Testing

Debbugged my way arround world to see rodentkin microlabs before and after changes. Spawns and evolutions seem fine.

#### Additional context

Part 1 of #76180


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
