### PR TITLE
MORPHIC Sizing Flag

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -1539,6 +1539,11 @@
     "info": "This is <info>integrated into the body</info>."
   },
   {
+    "id": "MORPHIC",
+    "type": "json_flag",
+    "info": "This is <info>naturally sized to the body</info>."
+  },
+  {
     "id": "IR_EFFECT",
     "type": "json_flag"
   },

--- a/data/mods/Xedra_Evolved/items/armor/armor.json
+++ b/data/mods/Xedra_Evolved/items/armor/armor.json
@@ -870,7 +870,7 @@
     "material_thickness": 1.4,
     "environmental_protection": 2,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY", "PADDED" ]
+    "flags": [ "WATERPROOF", "STURDY", "PADDED", "MORPHIC" ]
   },
   {
     "id": "dreamforged_helmet",
@@ -887,7 +887,7 @@
     "warmth": 10,
     "material_thickness": 1.4,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY", "PADDED" ],
+    "flags": [ "MORPHIC", "WATERPROOF", "STURDY", "PADDED" ],
     "armor": [ { "encumbrance_modifiers": [ "NONE" ], "coverage": 85, "covers": [ "head" ] } ]
   },
   {
@@ -907,7 +907,7 @@
     "longest_side": "60 cm",
     "material_thickness": 2,
     "use_action": [ { "type": "attach_molle", "size": 4 }, { "type": "detach_molle" } ],
-    "flags": [ "OUTER", "STURDY", "ONLY_ONE", "BLOCK_WHILE_WORN", "PADDED" ],
+    "flags": [ "OUTER", "STURDY", "ONLY_ONE", "BLOCK_WHILE_WORN", "PADDED", "MORPHIC" ],
     "armor": [
       {
         "material": [ { "type": "forged_dreamstuff", "covered_by_mat": 100, "thickness": 2 } ],
@@ -944,7 +944,7 @@
     "color": "dark_gray",
     "warmth": 10,
     "material_thickness": 1.2,
-    "flags": [ "VARSIZE", "OUTER", "STURDY", "BLOCK_WHILE_WORN", "PADDED" ],
+    "flags": [ "MORPHIC", "OUTER", "STURDY", "BLOCK_WHILE_WORN", "PADDED" ],
     "armor": [
       {
         "covers": [ "arm_l", "arm_r" ],
@@ -972,7 +972,7 @@
     "warmth": 10,
     "material_thickness": 1.5,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY", "PADDED" ],
+    "flags": [ "MORPHIC", "WATERPROOF", "STURDY", "PADDED" ],
     "armor": [
       {
         "covers": [ "foot_l", "foot_r" ],
@@ -1065,7 +1065,7 @@
     "warmth": 5,
     "material_thickness": 0.7,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "VARSIZE", "WATERPROOF", "STURDY", "PADDED" ]
+    "flags": [ "MORPHIC", "WATERPROOF", "STURDY", "PADDED" ]
   },
   {
     "id": "dreamforged_armguard_plate_gunslinger",

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -142,7 +142,7 @@ ret_val<void> Character::can_wear( const item &it, bool with_equip_change ) cons
     }
 
     if( !it.has_flag( flag_OVERSIZE ) && !it.has_flag( flag_INTEGRATED ) &&
-        !it.has_flag( flag_SEMITANGIBLE ) &&
+        !it.has_flag( flag_SEMITANGIBLE ) && !it.has_flag( flag_MORPHIC ) &&
         !it.has_flag( flag_UNRESTRICTED ) ) {
         for( const trait_id &mut : get_mutations() ) {
             const mutation_branch &branch = mut.obj();

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -193,6 +193,7 @@ const flag_id flag_MELTS( "MELTS" );
 const flag_id flag_MESSY( "MESSY" );
 const flag_id flag_MISSION_ITEM( "MISSION_ITEM" );
 const flag_id flag_MODULE_HOLDER( "MODULE_HOLDER" );
+const flag_id flag_MORPHIC( "MORPHIC" );
 const flag_id flag_MOUNTED_GUN( "MOUNTED_GUN" );
 const flag_id flag_MOUSE( "MOUSE" );
 const flag_id flag_MUNDANE( "MUNDANE" );

--- a/src/flag.h
+++ b/src/flag.h
@@ -201,6 +201,7 @@ extern const flag_id flag_MELTS;
 extern const flag_id flag_MESSY;
 extern const flag_id flag_MISSION_ITEM;
 extern const flag_id flag_MODULE_HOLDER;
+extern const flag_id flag_MORPHIC;
 extern const flag_id flag_MOUNTED_GUN;
 extern const flag_id flag_MOUSE;
 extern const flag_id flag_MUNDANE;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -2061,6 +2061,16 @@ item::sizing item::get_sizing( const Character &p ) const
             }
         }
 
+        if( has_flag( flag_MORPHIC ) ) {
+            if( big ) {
+                return sizing::big_sized_big_char;
+            } else if( small ) {
+                return sizing::small_sized_small_char;
+            } else {
+                return sizing::human_sized_human_char;
+            }
+        }
+
         // due to the iterative nature of these features, something can fit and be undersized/oversized
         // but that is fine because we have separate logic to adjust encumbrance per each. One day we
         // may want to have fit be a flag that only applies if a piece of clothing is sized for you as there


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Morphic Sizing flag for summoned/magickal items"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I think there is some appropriate space in Magiclysm, Aftershock, MoM and XE for self sizing armor that doesn't ignore limb changes or drastic mutation.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Creates a flag that will ignore sizing.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Many many things
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested and Morphic gear goes on huge mutants no problem while non morphic gear is blocked.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
