### PR TITLE
[Magiclysm] Add cat form as possible shifter druid form

### DIFF
--- a/data/mods/Magiclysm/effects/eoc_game_start.json
+++ b/data/mods/Magiclysm/effects/eoc_game_start.json
@@ -12,14 +12,20 @@
     "id": "EOC_DRUID_SHIFTER_GIVE_FORM_2",
     "effect": [
       {
-        "run_eoc_selector": [ "EOC_DRUID_SHIFTER_GIVE_FORM_BEAR", "EOC_DRUID_SHIFTER_GIVE_FORM_DEER", "EOC_DRUID_SHIFTER_GIVE_FORM_RAVEN" ],
+        "run_eoc_selector": [
+          "EOC_DRUID_SHIFTER_GIVE_FORM_BEAR",
+          "EOC_DRUID_SHIFTER_GIVE_FORM_COUGAR",
+          "EOC_DRUID_SHIFTER_GIVE_FORM_DEER",
+          "EOC_DRUID_SHIFTER_GIVE_FORM_RAVEN"
+        ],
         "title": "Which form did you learn how to shift into?",
-        "names": [ "Bear Form", "Deer Form", "Raven Form" ],
-        "keys": [ "a", "b", "c" ],
+        "names": [ "Bear Form", "Cougar Form", "Deer Form", "Raven Form" ],
+        "keys": [ "a", "b", "c", "d" ],
         "descriptions": [
-          "You learned how to transform into a bear",
-          "You learned how to transform into a deer",
-          "You learned how to transform into a raven"
+          "You learned how to transform into a bear.",
+          "You learned how to transform into a cougar.",
+          "You learned how to transform into a deer.",
+          "You learned how to transform into a raven."
         ]
       }
     ]
@@ -28,6 +34,11 @@
     "type": "effect_on_condition",
     "id": "EOC_DRUID_SHIFTER_GIVE_FORM_BEAR",
     "effect": [ { "u_add_trait": "DRUID_SHIFTER_BEAR_FORM" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_DRUID_SHIFTER_GIVE_FORM_COUGAR",
+    "effect": [ { "u_add_trait": "DRUID_SHIFTER_COUGAR_FORM" } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/Magiclysm/effects/eoc_transformations.json
+++ b/data/mods/Magiclysm/effects/eoc_transformations.json
@@ -2,7 +2,11 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_DRUID_SHIFTER_BEAR_FORM_activated",
-    "condition": { "not": { "u_has_any_trait": [ "DRUID_SHIFTER_DEER_FORM_TRAITS", "DRUID_SHIFTER_RAVEN_FORM_TRAITS" ] } },
+    "condition": {
+      "not": {
+        "u_has_any_trait": [ "DRUID_SHIFTER_COUGAR_FORM_TRAITS", "DRUID_SHIFTER_DEER_FORM_TRAITS", "DRUID_SHIFTER_RAVEN_FORM_TRAITS" ]
+      }
+    },
     "effect": [
       {
         "run_eocs": [
@@ -30,6 +34,7 @@
                         ]
                       },
                       { "u_add_trait": "DRUID_SHIFTER_BEAR_FORM_TRAITS" },
+                      { "u_add_trait": "DRUID_SHIFTER_MANA_REDUCER" },
                       {
                         "u_message": "Your body shifts and expands as fur sprouts from your skin and your mouth and teeth lengthen.",
                         "type": "good"
@@ -56,6 +61,7 @@
                         "type": "neutral"
                       },
                       { "u_lose_trait": "DRUID_SHIFTER_BEAR_FORM_TRAITS" },
+                      { "u_lose_trait": "DRUID_SHIFTER_MANA_REDUCER" },
                       { "math": [ "u_val('mana')", "=", "u_transformed_mana" ] },
                       {
                         "switch": { "math": [ "u_preshift_size" ] },
@@ -89,8 +95,111 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_DRUID_SHIFTER_COUGAR_FORM_activated",
+    "condition": {
+      "not": {
+        "u_has_any_trait": [ "DRUID_SHIFTER_BEAR_FORM_TRAITS", "DRUID_SHIFTER_DEER_FORM_TRAITS", "DRUID_SHIFTER_RAVEN_FORM_TRAITS" ]
+      }
+    },
+    "effect": [
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_DRUID_SHIFTER_COUGAR_FORM_activated_2",
+            "condition": { "not": { "u_has_trait": "DRUID_SHIFTER_COUGAR_FORM_TRAITS" } },
+            "effect": [
+              {
+                "run_eocs": [
+                  {
+                    "id": "EOC_DRUID_SHIFTER_COUGAR_FORM_activated_3",
+                    "condition": { "math": [ "u_val('mana')", ">=", "50" ] },
+                    "effect": [
+                      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+                      { "math": [ "u_transformed_mana", "=", "u_val('mana') - 50" ] },
+                      { "math": [ "u_preshift_size", "=", "u_val('size')" ] },
+                      {
+                        "switch": { "math": [ "u_preshift_size" ] },
+                        "cases": [
+                          { "case": 1, "effect": [ { "math": [ "u_calories()", "/=", "4" ] } ] },
+                          { "case": 2, "effect": [ { "math": [ "u_calories()", "/=", "2" ] } ] },
+                          { "case": 3, "effect": [  ] },
+                          { "case": 4, "effect": [ { "math": [ "u_calories()", "*=", "1.5" ] } ] },
+                          { "case": 5, "effect": [ { "math": [ "u_calories()", "*=", "3" ] } ] }
+                        ]
+                      },
+                      { "u_add_trait": "DRUID_SHIFTER_COUGAR_FORM_TRAITS" },
+                      { "u_add_trait": "DRUID_SHIFTER_MANA_REDUCER" },
+                      { "if": { "not": { "u_has_trait": "FELINE_LEAP" } }, "then": { "u_add_trait": "FELINE_LEAP" } },
+                      {
+                        "u_message": "Your body shifts and warps as fur sprouts from your skin, whiskers from your nose, and claws and fangs from your fingers and mouth.",
+                        "type": "good"
+                      }
+                    ],
+                    "false_effect": [
+                      { "u_message": "You don't have enough mana to transform into a cougar.", "type": "bad" },
+                      { "queue_eocs": "EOC_DRUID_SHIFTER_COUGAR_FORM_deactivate_future", "time_in_future": 0 }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "false_effect": [
+              {
+                "run_eocs": [
+                  {
+                    "id": "EOC_DRUID_SHIFTER_COUGAR_FORM_deactivated",
+                    "condition": { "u_has_trait": "DRUID_SHIFTER_COUGAR_FORM_TRAITS" },
+                    "effect": [
+                      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+                      {
+                        "u_message": "Your body shifts and your fur disappears as you return to your humanoid form.",
+                        "type": "neutral"
+                      },
+                      { "u_lose_trait": "DRUID_SHIFTER_COUGAR_FORM_TRAITS" },
+                      { "u_lose_trait": "DRUID_SHIFTER_MANA_REDUCER" },
+                      {
+                        "if": { "not": { "u_has_trait": "THRESH_FELINE" } },
+                        "then": { "u_lose_trait": "FELINE_LEAP" }
+                      },
+                      { "math": [ "u_val('mana')", "=", "u_transformed_mana" ] },
+                      {
+                        "switch": { "math": [ "u_preshift_size" ] },
+                        "cases": [
+                          { "case": 1, "effect": [ { "math": [ "u_calories()", "*=", "4" ] } ] },
+                          { "case": 2, "effect": [ { "math": [ "u_calories()", "*=", "2" ] } ] },
+                          { "case": 3, "effect": [  ] },
+                          { "case": 4, "effect": [ { "math": [ "u_calories()", "/=", "1.5" ] } ] },
+                          { "case": 5, "effect": [ { "math": [ "u_calories()", "/=", "3" ] } ] }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "false_effect": [
+      { "u_message": "You cannot transform into a cougar if you are already in an animal form.", "type": "mixed" },
+      { "queue_eocs": "EOC_DRUID_SHIFTER_COUGAR_FORM_deactivate_future", "time_in_future": 0 }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_DRUID_SHIFTER_COUGAR_FORM_deactivate_future",
+    "//": "This is necessary because calling u_deactivate_trait from within the trait EoC does not work",
+    "effect": { "u_deactivate_trait": "DRUID_SHIFTER_COUGAR_FORM" }
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_DRUID_SHIFTER_DEER_FORM_activated",
-    "condition": { "not": { "u_has_any_trait": [ "DRUID_SHIFTER_BEAR_FORM_TRAITS", "DRUID_SHIFTER_RAVEN_FORM_TRAITS" ] } },
+    "condition": {
+      "not": {
+        "u_has_any_trait": [ "DRUID_SHIFTER_BEAR_FORM_TRAITS", "DRUID_SHIFTER_COUGAR_FORM_TRAITS", "DRUID_SHIFTER_RAVEN_FORM_TRAITS" ]
+      }
+    },
     "effect": [
       {
         "run_eocs": [
@@ -118,6 +227,7 @@
                         ]
                       },
                       { "u_add_trait": "DRUID_SHIFTER_DEER_FORM_TRAITS" },
+                      { "u_add_trait": "DRUID_SHIFTER_MANA_REDUCER" },
                       {
                         "u_message": "Your body shifts and warps as your fingers and feet fuse into hooves and majestic antlers sprout from your head.",
                         "type": "good"
@@ -144,6 +254,7 @@
                         "type": "neutral"
                       },
                       { "u_lose_trait": "DRUID_SHIFTER_DEER_FORM_TRAITS" },
+                      { "u_lose_trait": "DRUID_SHIFTER_MANA_REDUCER" },
                       { "math": [ "u_val('mana')", "=", "u_transformed_mana" ] },
                       {
                         "switch": { "math": [ "u_preshift_size" ] },
@@ -178,7 +289,11 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_DRUID_SHIFTER_RAVEN_FORM_activated",
-    "condition": { "not": { "u_has_any_trait": [ "DRUID_SHIFTER_BEAR_FORM_TRAITS", "DRUID_SHIFTER_DEER_FORM_TRAITS" ] } },
+    "condition": {
+      "not": {
+        "u_has_any_trait": [ "DRUID_SHIFTER_BEAR_FORM_TRAITS", "DRUID_SHIFTER_COUGAR_FORM_TRAITS", "DRUID_SHIFTER_DEER_FORM_TRAITS" ]
+      }
+    },
     "effect": [
       {
         "run_eocs": [
@@ -207,6 +322,7 @@
                         ]
                       },
                       { "u_add_trait": "DRUID_SHIFTER_RAVEN_FORM_TRAITS" },
+                      { "u_add_trait": "DRUID_SHIFTER_MANA_REDUCER" },
                       {
                         "u_message": "Your body shifts and changes as you concentrate and you take wing as a raven.",
                         "type": "good"
@@ -233,6 +349,7 @@
                         "type": "neutral"
                       },
                       { "u_lose_trait": "DRUID_SHIFTER_RAVEN_FORM_TRAITS" },
+                      { "u_lose_trait": "DRUID_SHIFTER_MANA_REDUCER" },
                       { "math": [ "u_spell_level('druid_raven_form_fly_upward')", "=", "-1" ] },
                       { "math": [ "u_val('mana')", "=", "u_transformed_mana" ] },
                       {
@@ -264,16 +381,5 @@
     "id": "EOC_DRUID_SHIFTER_RAVEN_FORM_deactivate_future",
     "//": "This is necessary because calling u_deactivate_trait from within the trait EoC does not work",
     "effect": { "u_deactivate_trait": "DRUID_SHIFTER_RAVEN_FORM" }
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_DRUID_SHIFTER_RAVEN_FORM_ASCEND",
-    "condition": "u_is_outside",
-    "effect": [
-      { "u_location_variable": { "context_val": "raven_form_fly_up_location" }, "z_adjust": 1, "outdoor_only": true },
-      { "u_message": "Your wings carry you upward.", "type": "good" },
-      { "u_teleport": { "context_val": "raven_form_fly_up_location" } }
-    ],
-    "false_effect": [ { "u_message": "You cannot fly up with a ceiling above you!", "type": "bad" } ]
   }
 ]

--- a/data/mods/Magiclysm/mutations/magical.json
+++ b/data/mods/Magiclysm/mutations/magical.json
@@ -17,13 +17,13 @@
     "type": "mutation",
     "id": "DRUID_SHIFTER_BEAR_FORM_TRAITS",
     "name": { "str": "Bear Form" },
-    "points": 99,
+    "points": 98,
     "description": "You are a bear.  This provides the actual effects of bear form.  Should not be player-visible",
     "valid": false,
     "starting_trait": false,
     "purifiable": false,
     "player_display": false,
-    "//": "The second enchantment takes into account the effects of the mutations added by the first enchantment, whose own enchantments do not transfer over due to bug #74994.  If that bug is fixed, it can be deleted.",
+    "//": "The second enchantment takes into account the effects of the mutations added by the first enchantment, whose own enchantments do not transfer over due to bug #74984.  If that bug is fixed, it can be deleted.",
     "enchantments": [
       {
         "condition": "ALWAYS",
@@ -36,8 +36,7 @@
           { "value": "NIGHT_VIS", "add": 5 },
           { "value": "MELEE_DAMAGE", "multiply": 0.4 },
           { "value": "CLIMATE_CONTROL_HEAT", "add": 25 },
-          { "value": "CRAFTING_SPEED_MULTIPLIER", "multiply": -1000 },
-          { "value": "MAX_MANA", "multiply": -1000 }
+          { "value": "CRAFTING_SPEED_MULTIPLIER", "multiply": -1000 }
         ],
         "mutations": [ "FANGS", "MUZZLE_BEAR", "TAIL_STUB", "PAWS_LARGE", "URSINE_FUR", "URSINE_EARS", "PRED3" ]
       },
@@ -69,6 +68,70 @@
   },
   {
     "type": "mutation",
+    "id": "DRUID_SHIFTER_COUGAR_FORM",
+    "name": { "str": "Form of the Stalking Hunter" },
+    "points": 0,
+    "description": "You can transform yourself into a cougar and stalk your enemies.",
+    "starting_trait": false,
+    "purifiable": false,
+    "valid": false,
+    "active": true,
+    "activated_is_setup": true,
+    "activated_eocs": [ "EOC_DRUID_SHIFTER_COUGAR_FORM_activated" ],
+    "deactivated_eocs": [ "EOC_DRUID_SHIFTER_COUGAR_FORM_deactivated" ]
+  },
+  {
+    "type": "mutation",
+    "id": "DRUID_SHIFTER_COUGAR_FORM_TRAITS",
+    "name": { "str": "Cougar Form" },
+    "points": 98,
+    "description": "You are a cougar.  This provides the actual effects of cougar form.  Should not be player-visible.",
+    "starting_trait": false,
+    "purifiable": false,
+    "valid": false,
+    "player_display": false,
+    "//": "The second enchantment takes into account the effects of the mutations added by the first enchantment, whose own enchantments do not transfer over due to bug #74984.  If that bug is fixed, it can be deleted.",
+    "enchantments": [
+      {
+        "condition": "ALWAYS",
+        "values": [
+          { "value": "SPEED", "multiply": 0.2 },
+          { "value": "RANGE", "multiply": -1 },
+          { "value": "DEXTERITY", "add": 4 },
+          { "value": "NIGHT_VIS", "add": 11 },
+          { "value": "MELEE_DAMAGE", "multiply": 0.2 },
+          { "value": "CLIMATE_CONTROL_HEAT", "add": 25 },
+          { "value": "FOOTSTEP_NOISE", "multiply": -0.6 },
+          { "value": "MOVECOST_OBSTACLE_MOD", "multiply": -0.5 },
+          { "value": "CRAFTING_SPEED_MULTIPLIER", "multiply": -1000 }
+        ],
+        "mutations": [ "FANGS", "TAIL_LONG", "PAWS", "FELINE_FUR", "FELINE_EARS", "PRED3", "WHISKERS", "FELINE_LEAP" ]
+      },
+      {
+        "condition": "ALWAYS",
+        "values": [
+          { "value": "HEARING_MULT", "multiply": 0.25 },
+          { "value": "COMBAT_CATCHUP", "multiply": 2 },
+          { "value": "DODGE_CHANCE", "add": 5 }
+        ]
+      },
+      {
+        "condition": { "and": [ { "u_has_flag": "QUADRUPED_CROUCH" }, { "u_has_flag": "QUADRUPED_RUN" }, { "not": "u_can_drop_weapon" } ] },
+        "values": [ { "value": "MOVE_COST", "multiply": -0.15 } ],
+        "ench_effects": [ { "effect": "natural_stance", "intensity": 1 }, { "effect": "quadruped_full", "intensity": 1 } ]
+      },
+      { "condition": { "u_has_move_mode": "run" }, "values": [ { "value": "MOVE_COST", "multiply": -0.25 } ] },
+      {
+        "condition": "u_has_weapon",
+        "values": [ { "value": "MELEE_DAMAGE", "multiply": -1 }, { "value": "RANGE", "multiply": -1 } ]
+      }
+    ],
+    "flags": [ "MUTE", "PRED3", "QUADRUPED_CROUCH", "QUADRUPED_RUN", "TOUGH_FEET", "TEMPORARY_SHAPESHIFT" ],
+    "override_look": { "id": "mon_cougar", "tile_category": "monster" },
+    "integrated_armor": [ "integrated_fangs", "integrated_feline_fur", "integrated_claws" ]
+  },
+  {
+    "type": "mutation",
     "id": "DRUID_SHIFTER_DEER_FORM",
     "name": { "str": "Form of the Swift Runner" },
     "points": 0,
@@ -85,7 +148,7 @@
     "type": "mutation",
     "id": "DRUID_SHIFTER_DEER_FORM_TRAITS",
     "name": { "str": "Deer Form" },
-    "points": 99,
+    "points": 98,
     "description": "You are a deer.  This provides the actual effects of deer form.  Should not be player-visible",
     "valid": false,
     "starting_trait": false,
@@ -100,8 +163,7 @@
           { "value": "MOVE_COST", "multiply": -0.5 },
           { "value": "DEXTERITY", "add": 3 },
           { "value": "NIGHT_VIS", "add": 6 },
-          { "value": "CRAFTING_SPEED_MULTIPLIER", "multiply": -1000 },
-          { "value": "MAX_MANA", "multiply": -1000 }
+          { "value": "CRAFTING_SPEED_MULTIPLIER", "multiply": -1000 }
         ],
         "skills": [ { "value": "dodge", "add": 2 } ],
         "mutations": [ "ANTLERS", "HOOVES" ]
@@ -146,7 +208,7 @@
     "purifiable": false,
     "valid": false,
     "player_display": false,
-    "//": "The second enchantment, as well as bodytemp modifiers, takes into account the effects of the mutations added by the first enchantment, whose own enchantments do not transfer over due to bug #74994.  If that bug is fixed, it can be deleted.",
+    "//": "The second enchantment, as well as bodytemp modifiers, takes into account the effects of the mutations added by the first enchantment, whose own enchantments do not transfer over due to bug #74984.  If that bug is fixed, it can be deleted.",
     "bodytemp_modifiers": [ 300, 800 ],
     "enchantments": [
       {
@@ -158,8 +220,7 @@
           { "value": "DEXTERITY", "add": 8 },
           { "value": "PERCEPTION", "add": 4 },
           { "value": "NIGHT_VIS", "add": 4 },
-          { "value": "CRAFTING_SPEED_MULTIPLIER", "multiply": -1000 },
-          { "value": "MAX_MANA", "multiply": -1000 }
+          { "value": "CRAFTING_SPEED_MULTIPLIER", "multiply": -1000 }
         ],
         "ench_effects": [ { "effect": "effect_druid_shifter_raven_form_levitation", "intensity": 1 } ],
         "skills": [ { "value": "dodge", "add": 6 } ],
@@ -182,5 +243,16 @@
     ],
     "flags": [ "LEVITATION", "MUTE", "NO_SPELLCASTING", "TEMPORARY_SHAPESHIFT", "SHAPESHIFT_SIZE_TINY" ],
     "override_look": { "id": "mon_raven", "tile_category": "monster" }
+  },
+  {
+    "type": "mutation",
+    "id": "DRUID_SHIFTER_MANA_REDUCER",
+    "name": { "str": "Mana Reducer Druid Forms" },
+    "points": 0,
+    "description": "Prevents you from regenerating mana while in druid shapeshifting form.  You should never actually see this.",
+    "starting_trait": false,
+    "purifiable": false,
+    "valid": false,
+    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "MAX_MANA", "multiply": -1000 } ] } ]
   }
 ]

--- a/data/mods/Magiclysm/obsolete/eocs.json
+++ b/data/mods/Magiclysm/obsolete/eocs.json
@@ -100,5 +100,16 @@
       { "u_remove_item_with": "aura_druid_waterwalk" },
       { "u_message": "As you leave the water, your spell fades.", "type": "bad" }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_DRUID_SHIFTER_RAVEN_FORM_ASCEND",
+    "condition": "u_is_outside",
+    "effect": [
+      { "u_location_variable": { "context_val": "raven_form_fly_up_location" }, "z_adjust": 1, "outdoor_only": true },
+      { "u_message": "Your wings carry you upward.", "type": "good" },
+      { "u_teleport": { "context_val": "raven_form_fly_up_location" } }
+    ],
+    "false_effect": [ { "u_message": "You cannot fly up with a ceiling above you!", "type": "bad" } ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Magiclysm] Add cat form as possible shifter druid form"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I already did the work for a shapeshifted cat form, might as well let druids turn into it. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add cougar form as a possible druid shapeshift.

Also reworks the non-regeneration of mana as a separate mutation, so that I can reuse these forms for the shapeshifting cloaks (which should allow you to regenerate mana). 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Shifter druids can select cougar form, turning into cougar form works, turning back from cougar form works. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
