### PR TITLE
[Magiclysm] Fantasy species zombies

### DIFF
--- a/data/mods/Magiclysm/monstergroup_upgrades.json
+++ b/data/mods/Magiclysm/monstergroup_upgrades.json
@@ -31,18 +31,18 @@
     "type": "monstergroup",
     "name": "GROUP_ZOMBIE_ELF_UPGRADE",
     "monsters": [
-      { "monster": "mon_zombie_tough", "weight": 50 },
+      { "monster": "mon_zombie_tough", "weight": 25 },
       { "monster": "mon_zombie_grabber", "weight": 25 },
       { "monster": "mon_zombie_grappler", "weight": 50 },
       { "monster": "mon_zombie_hunter", "weight": 60 },
-      { "monster": "mon_zombie_runner", "weight": 120 },
+      { "monster": "mon_zombie_runner", "weight": 165 },
       { "monster": "mon_zombie_smoker", "weight": 30 },
       { "monster": "mon_zombie_shady", "weight": 30 },
       { "monster": "mon_zombie_shrieker", "weight": 90 },
       { "monster": "mon_zombie_acidic", "weight": 80 },
       { "monster": "mon_zombie_necro", "weight": 25 },
       { "monster": "mon_zombie_brute", "weight": 15 },
-      { "monster": "mon_zombie_bruiser", "weight": 25 },
+      { "monster": "mon_zombie_bruiser", "weight": 15 },
       { "monster": "mon_zombie_master", "weight": 8 },
       { "monster": "mon_zombie_lashing", "weight": 75 },
       { "monster": "mon_zombie_ocular", "weight": 12 },
@@ -53,6 +53,54 @@
       { "monster": "mon_zombie_regenerating", "weight": 10 },
       { "monster": "mon_zombie_pupa", "weight": 10 },
       { "monster": "mon_zombie_pupa_decoy", "weight": 10 }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_ZOMBIE_GOBLIN_UPGRADE",
+    "//": "Child-type zombies that evoke no guilt.",
+    "monsters": [
+      { "monster": "mon_zombie_anklebiter", "weight": 300 },
+      { "monster": "mon_zombie_sproglodyte", "weight": 100 },
+      { "monster": "mon_zombie_creepy", "weight": 300 },
+      { "monster": "mon_zombie_snotgobbler", "weight": 300 },
+      { "monster": "mon_zombie_wretch", "weight": 100 }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_ZOMBIE_RAVENFOLK_UPGRADE",
+    "monsters": [
+      { "monster": "mon_zombie_necro", "weight": 30 },
+      { "monster": "mon_zombie_necro_boomer", "weight": 20 },
+      { "monster": "mon_boomer", "weight": 200 },
+      { "monster": "mon_zombie_master", "weight": 10 },
+      { "monster": "mon_zombie_winged", "weight": 750 },
+      { "monster": "mon_zombie_pupa", "weight": 200 },
+      { "monster": "mon_zombie_pupa_decoy", "weight": 100 }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_ZOMBIE_LIZARDFOLK_UPGRADE",
+    "//": "Heavily weighted toward the more feral variants but with some other options too.",
+    "monsters": [
+      { "monster": "mon_zombie_hunter", "weight": 200 },
+      { "monster": "mon_skeleton", "weight": 200 },
+      { "monster": "mon_zombie_smoker", "weight": 30 },
+      { "monster": "mon_zombie_shady", "weight": 30 },
+      { "monster": "mon_zombie_biter", "weight": 500 },
+      { "monster": "mon_zombie_shrieker", "weight": 90 },
+      { "monster": "mon_zombie_necro", "weight": 15 },
+      { "monster": "mon_zombie_necro_boomer", "weight": 12 },
+      { "monster": "mon_boomer", "weight": 90 },
+      { "monster": "mon_zombie_brute", "weight": 20 },
+      { "monster": "mon_zombie_bruiser", "weight": 30 },
+      { "monster": "mon_zombie_master", "weight": 3 },
+      { "monster": "mon_zombie_lashing", "weight": 60 },
+      { "monster": "mon_zombie_static", "weight": 50 },
+      { "monster": "mon_zombie_winged", "weight": 60 },
+      { "monster": "mon_zombie_regenerating", "weight": 10 }
     ]
   }
 ]

--- a/data/mods/Magiclysm/monstergroup_upgrades.json
+++ b/data/mods/Magiclysm/monstergroup_upgrades.json
@@ -1,0 +1,58 @@
+[
+  {
+    "type": "monstergroup",
+    "name": "GROUP_ZOMBIE_DWARF_UPGRADE",
+    "monsters": [
+      { "monster": "mon_zombie_tough", "weight": 110 },
+      { "monster": "mon_zombie_grabber", "weight": 30 },
+      { "monster": "mon_zombie_grappler", "weight": 120 },
+      { "monster": "mon_zombie_hunter", "weight": 100 },
+      { "monster": "mon_skeleton", "weight": 150 },
+      { "monster": "mon_zombie_smoker", "weight": 50 },
+      { "monster": "mon_zombie_gasbag", "weight": 30 },
+      { "monster": "mon_zombie_acidic", "weight": 110 },
+      { "monster": "mon_zombie_necro", "weight": 15 },
+      { "monster": "mon_zombie_necro_boomer", "weight": 12 },
+      { "monster": "mon_boomer", "weight": 90 },
+      { "monster": "mon_zombie_brute", "weight": 25 },
+      { "monster": "mon_zombie_bruiser", "weight": 35 },
+      { "monster": "mon_zombie_master", "weight": 3 },
+      { "monster": "mon_zombie_lashing", "weight": 40 },
+      { "monster": "mon_zombie_ocular", "weight": 5 },
+      { "monster": "mon_zombie_hollow", "weight": 3 },
+      { "monster": "mon_zombie_thorny", "weight": 25 },
+      { "monster": "mon_zombie_static", "weight": 50 },
+      { "monster": "mon_zombie_regenerating", "weight": 15 },
+      { "monster": "mon_zombie_pupa", "weight": 10 },
+      { "monster": "mon_zombie_pupa_decoy", "weight": 10 }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_ZOMBIE_ELF_UPGRADE",
+    "monsters": [
+      { "monster": "mon_zombie_tough", "weight": 50 },
+      { "monster": "mon_zombie_grabber", "weight": 25 },
+      { "monster": "mon_zombie_grappler", "weight": 50 },
+      { "monster": "mon_zombie_hunter", "weight": 60 },
+      { "monster": "mon_zombie_runner", "weight": 120 },
+      { "monster": "mon_zombie_smoker", "weight": 30 },
+      { "monster": "mon_zombie_shady", "weight": 30 },
+      { "monster": "mon_zombie_shrieker", "weight": 90 },
+      { "monster": "mon_zombie_acidic", "weight": 80 },
+      { "monster": "mon_zombie_necro", "weight": 25 },
+      { "monster": "mon_zombie_brute", "weight": 15 },
+      { "monster": "mon_zombie_bruiser", "weight": 25 },
+      { "monster": "mon_zombie_master", "weight": 8 },
+      { "monster": "mon_zombie_lashing", "weight": 75 },
+      { "monster": "mon_zombie_ocular", "weight": 12 },
+      { "monster": "mon_zombie_hollow", "weight": 10 },
+      { "monster": "mon_zombie_thorny", "weight": 80 },
+      { "monster": "mon_zombie_static", "weight": 40 },
+      { "monster": "mon_zombie_winged", "weight": 50 },
+      { "monster": "mon_zombie_regenerating", "weight": 10 },
+      { "monster": "mon_zombie_pupa", "weight": 10 },
+      { "monster": "mon_zombie_pupa_decoy", "weight": 10 }
+    ]
+  }
+]

--- a/data/mods/Magiclysm/monstergroups.json
+++ b/data/mods/Magiclysm/monstergroups.json
@@ -127,6 +127,58 @@
     ]
   },
   {
+    "name": "GROUP_ZOMBIE_FANTASY_SPECIES",
+    "type": "monstergroup",
+    "//": "same ratio as ferals",
+    "monsters": [
+      { "monster": "mon_zombie_dwarf", "weight": 40 },
+      { "monster": "mon_zombie_elf", "weight": 40 },
+      { "monster": "mon_zombie_goblin", "weight": 20 },
+      { "monster": "mon_zombie_ravenfolk", "weight": 15 },
+      { "monster": "mon_zombie_lizardfolk", "weight": 10 }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_ZOMBIE",
+    "monsters": [
+      { "group": "GROUP_ZOMBIE_FANTASY_SPECIES", "weight": 4720 },
+      { "group": "GROUP_ZOMBIE_FANTASY_SPECIES", "weight": 10, "cost_multiplier": 7, "pack_size": [ 5, 20 ] },
+      { "group": "GROUP_ZOMBIE_FANTASY_SPECIES", "weight": 10, "cost_multiplier": 13, "pack_size": [ 15, 40 ] },
+      { "group": "GROUP_ZOMBIE_FANTASY_SPECIES", "weight": 10, "cost_multiplier": 20, "pack_size": [ 25, 60 ] }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_ZOMBIE_GASSTATION",
+    "monsters": [
+      { "group": "GROUP_ZOMBIE_FANTASY_SPECIES", "weight": 472 },
+      { "group": "GROUP_ZOMBIE_FANTASY_SPECIES", "weight": 1, "cost_multiplier": 7, "pack_size": [ 5, 20 ] },
+      { "group": "GROUP_ZOMBIE_FANTASY_SPECIES", "weight": 1, "cost_multiplier": 13, "pack_size": [ 15, 40 ] },
+      { "group": "GROUP_ZOMBIE_FANTASY_SPECIES", "weight": 1, "cost_multiplier": 20, "pack_size": [ 25, 60 ] }
+    ]
+  },
+  {
+    "name": "GROUP_PARK_DOG",
+    "type": "monstergroup",
+    "monsters": [ { "group": "GROUP_ZOMBIE_FANTASY_SPECIES", "weight": 125 } ]
+  },
+  {
+    "name": "GROUP_PARK_PLAYGROUND",
+    "type": "monstergroup",
+    "monsters": [ { "group": "GROUP_ZOMBIE_FANTASY_SPECIES", "weight": 100 } ]
+  },
+  {
+    "name": "GROUP_PARK_SCENIC",
+    "type": "monstergroup",
+    "monsters": [ { "group": "GROUP_ZOMBIE_FANTASY_SPECIES", "weight": 100 } ]
+  },
+  {
+    "name": "GROUP_ROOF_ZOMBIE",
+    "type": "monstergroup",
+    "monsters": [ { "group": "GROUP_ZOMBIE_FANTASY_SPECIES", "weight": 100, "pack_size": [ 2, 3 ] } ]
+  },
+  {
     "type": "monstergroup",
     "name": "DUMP_ANIMALS",
     "monsters": [ { "monster": "mon_otyugh", "weight": 5 } ]

--- a/data/mods/Magiclysm/monsters/feral_fantasy_species.json
+++ b/data/mods/Magiclysm/monsters/feral_fantasy_species.json
@@ -29,6 +29,7 @@
     "dodge": 3,
     "vision_night": 8,
     "harvest": "demihuman",
+    "zombify_into": "mon_zombie_elf",
     "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_wp_demihuman" ],
     "extend": { "flags": [ "QUIETMOVES" ] }
   },
@@ -64,6 +65,7 @@
     "vision_day": 15,
     "vision_night": 20,
     "harvest": "demihuman",
+    "zombify_into": "mon_zombie_dwarf",
     "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_wp_demihuman" ]
   },
   {
@@ -94,6 +96,7 @@
     "dodge": 3,
     "vision_night": 8,
     "harvest": "demihuman",
+    "zombify_into": "mon_zombie_elf",
     "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_wp_demihuman" ],
     "extend": { "flags": [ "QUIETMOVES" ] }
   },
@@ -127,6 +130,7 @@
     "vision_day": 15,
     "vision_night": 20,
     "harvest": "demihuman",
+    "zombify_into": "mon_zombie_dwarf",
     "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_wp_demihuman" ]
   },
   {
@@ -140,6 +144,7 @@
     "dodge": 3,
     "vision_night": 8,
     "harvest": "demihuman",
+    "zombify_into": "mon_zombie_elf",
     "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_wp_demihuman" ],
     "extend": { "flags": [ "QUIETMOVES" ] }
   },
@@ -156,6 +161,7 @@
     "vision_day": 15,
     "vision_night": 20,
     "harvest": "demihuman",
+    "zombify_into": "mon_zombie_dwarf",
     "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_wp_demihuman" ]
   },
   {

--- a/data/mods/Magiclysm/monsters/feral_fantasy_species.json
+++ b/data/mods/Magiclysm/monsters/feral_fantasy_species.json
@@ -205,11 +205,23 @@
     "vision_night": 25,
     "path_settings": { "max_dist": 30, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true },
     "death_drops": "feral_goblin_death_drops",
-    "upgrades": { "half_life": 90, "into_group": "GROUP_ZOMBIE_UPGRADE" },
-    "zombify_into": "mon_zombie",
+    "upgrades": { "half_life": 90, "into_group": "GROUP_ZOMBIE_GOBLIN_UPGRADE" },
+    "zombify_into": "mon_zombie_goblin",
     "fungalize_into": "mon_feral_human_axe_fungal_infected",
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "WARM", "BASHES", "GRABS", "GROUP_BASH", "HUMAN", "CAN_OPEN_DOORS", "PATH_AVOID_DANGER" ]
+    "flags": [
+      "SEES",
+      "HEARS",
+      "SMELLS",
+      "WARM",
+      "BASHES",
+      "GRABS",
+      "GROUP_BASH",
+      "HUMAN",
+      "REVIVES",
+      "CAN_OPEN_DOORS",
+      "PATH_AVOID_DANGER"
+    ]
   },
   {
     "id": "mon_feral_ravenfolk",
@@ -278,10 +290,10 @@
     "path_settings": { "max_dist": 30, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true },
     "death_drops": "feral_ravenfolk_death_drops",
     "upgrades": { "half_life": 90, "into_group": "GROUP_ZOMBIE_UPGRADE" },
-    "zombify_into": "mon_zombie",
+    "zombify_into": "mon_zombie_ravenfolk",
     "fungalize_into": "mon_feral_human_axe_fungal_infected",
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "WARM", "BASHES", "GROUP_BASH", "HUMAN", "CAN_OPEN_DOORS", "PATH_AVOID_DANGER" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "WARM", "BASHES", "GROUP_BASH", "REVIVES", "HUMAN", "CAN_OPEN_DOORS", "PATH_AVOID_DANGER" ]
   },
   {
     "id": "mon_feral_lizardfolk",
@@ -340,9 +352,20 @@
     "path_settings": { "max_dist": 30, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true },
     "death_drops": "feral_lizardfolk_death_drops",
     "upgrades": { "half_life": 90, "into_group": "GROUP_ZOMBIE_UPGRADE" },
-    "zombify_into": "mon_zombie",
+    "zombify_into": "mon_zombie_lizardfolk",
     "fungalize_into": "mon_feral_human_axe_fungal_infected",
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "BASHES", "SWIMS", "GROUP_BASH", "HUMAN", "CAN_OPEN_DOORS", "PATH_AVOID_DANGER" ]
+    "flags": [
+      "SEES",
+      "HEARS",
+      "SMELLS",
+      "BASHES",
+      "SWIMS",
+      "GROUP_BASH",
+      "REVIVES",
+      "HUMAN",
+      "CAN_OPEN_DOORS",
+      "PATH_AVOID_DANGER"
+    ]
   }
 ]

--- a/data/mods/Magiclysm/monsters/goblin.json
+++ b/data/mods/Magiclysm/monsters/goblin.json
@@ -58,7 +58,8 @@
       ]
     },
     "armor": { "bash": 12, "cut": 12, "bullet": 4 },
-    "flags": [ "SEES", "HEARS", "HAS_MIND", "WARM", "BASHES", "PATH_AVOID_DANGER", "GROUP_MORALE", "WIELDED_WEAPON" ]
+    "zombify_into": "mon_zombie_goblin",
+    "flags": [ "SEES", "HEARS", "HAS_MIND", "WARM", "BASHES", "PATH_AVOID_DANGER", "REVIVES", "GROUP_MORALE", "WIELDED_WEAPON" ]
   },
   {
     "type": "MONSTER",

--- a/data/mods/Magiclysm/monsters/zombified_fantasy_species.json
+++ b/data/mods/Magiclysm/monsters/zombified_fantasy_species.json
@@ -1,0 +1,26 @@
+[
+  {
+    "type": "MONSTER",
+    "id": "mon_zombie_dwarf",
+    "name": { "str": "zombie dwarf" },
+    "copy-from": "mon_zombie_tough",
+    "description": "Once a proud dwarf, this zombie now has rent flesh and a beard in tatters.  Its face is twisted in an expression of rage.",
+    "proportional": { "speed": 0.9, "volume": 0.7, "weight": 0.9 },
+    "//": "Better night vision than default zombies, but not as good as living dwarves, and worse day vision.",
+    "vision_day": 15,
+    "vision_night": 8,
+    "upgrades": { "half_life": 30, "into_group": "GROUP_ZOMBIE_DWARF_UPGRADE" }
+  },
+  {
+    "type": "MONSTER",
+    "id": "mon_zombie_elf",
+    "name": { "str": "zombie elf" },
+    "copy-from": "mon_zombie",
+    "description": "Its face twisted in an expression of pure rage and with glassy eyes, this elf looks nothing like the ethereal elves from before the Cataclysm.  Though it also lacks the elves' characteristic grace, its movements are quieter than the other dead.",
+    "proportional": { "hp": 0.82, "speed": 1.03, "weight": 0.85 },
+    "//": "Better night vision than default zombies, but not as good as living dwarves, and worse day vision.",
+    "vision_night": 5,
+    "upgrades": { "half_life": 30, "into_group": "GROUP_ZOMBIE_ELF_UPGRADE" },
+    "extend": { "flags": [ "QUIETMOVES" ] }
+  }
+]

--- a/data/mods/Magiclysm/monsters/zombified_fantasy_species.json
+++ b/data/mods/Magiclysm/monsters/zombified_fantasy_species.json
@@ -2,9 +2,9 @@
   {
     "type": "MONSTER",
     "id": "mon_zombie_dwarf",
-    "name": { "str": "zombie dwarf" },
+    "name": { "str": "zombie dwarf", "str_pl": "zombie dwarves" },
     "copy-from": "mon_zombie_tough",
-    "description": "Once a proud dwarf, this zombie now has rent flesh and a beard in tatters.  Its face is twisted in an expression of rage.",
+    "description": "Once a dwarf, this zombie now has rent flesh and a beard in tatters.  Its face is twisted in an expression of rage.",
     "proportional": { "speed": 0.9, "volume": 0.7, "weight": 0.9 },
     "//": "Better night vision than default zombies, but not as good as living dwarves, and worse day vision.",
     "vision_day": 15,
@@ -14,13 +14,140 @@
   {
     "type": "MONSTER",
     "id": "mon_zombie_elf",
-    "name": { "str": "zombie elf" },
+    "name": { "str": "zombie elf", "str_pl": "zombie elves" },
     "copy-from": "mon_zombie",
     "description": "Its face twisted in an expression of pure rage and with glassy eyes, this elf looks nothing like the ethereal elves from before the Cataclysm.  Though it also lacks the elves' characteristic grace, its movements are quieter than the other dead.",
     "proportional": { "hp": 0.82, "speed": 1.03, "weight": 0.85 },
-    "//": "Better night vision than default zombies, but not as good as living dwarves, and worse day vision.",
+    "//": "Better night vision than default zombies, but not as good as living elves.",
     "vision_night": 5,
     "upgrades": { "half_life": 30, "into_group": "GROUP_ZOMBIE_ELF_UPGRADE" },
     "extend": { "flags": [ "QUIETMOVES" ] }
+  },
+  {
+    "id": "mon_zombie_goblin",
+    "type": "MONSTER",
+    "name": { "str": "zombie goblin" },
+    "copy-from": "mon_zombie",
+    "description": "With bared teeth and black eyes filled with rage, this formerly-living goblin is now a walking nightmare.  While small, unlike the human zombies it was born with teeth and claws.",
+    "proportional": { "hp": 0.5, "speed": 1.05, "volume": 0.5, "weight": 0.5 },
+    "bodytype": "human",
+    "species": [ "ZOMBIE", "GOBLIN" ],
+    "weakpoint_sets": [ "wps_humanoid_body", "wps_humanoid_child_body" ],
+    "special_attacks": [
+      [ "PARROT", 400 ],
+      [ "PARROT_AT_DANGER", 0 ],
+      { "id": "grab" },
+      { "id": "bite_humanoid", "cooldown": 5, "attack_upper": false },
+      {
+        "id": "scratch",
+        "attack_upper": false,
+        "cooldown": 4,
+        "condition": { "not": { "u_has_effect": "maimed_arm" } },
+        "damage_max_instance": [ { "damage_type": "cut", "amount": 8 } ]
+      }
+    ],
+    "//": "zombie goblins are basically blind during the day",
+    "vision_day": 3,
+    "vision_night": 15,
+    "death_drops": "feral_goblin_death_drops",
+    "upgrades": { "half_life": 30, "into_group": "GROUP_ZOMBIE_GOBLIN_UPGRADE" }
+  },
+  {
+    "id": "mon_zombie_ravenfolk",
+    "type": "MONSTER",
+    "name": { "str_sp": "zombie ravenfolk" },
+    "copy-from": "mon_zombie",
+    "description": "With bedraggled wings, dull eyes, and beak hanging open, this ravenfolk body still walks, a slight sway as it moves.",
+    "proportional": { "hp": 0.6, "speed": 1.1, "weight": 0.75 },
+    "bodytype": "angel",
+    "species": [ "RAVENFOLK", "ZOMBIE" ],
+    "volume": "62500 ml",
+    "weakpoint_sets": [ "wps_humanoid_body" ],
+    "weakpoints": [
+      {
+        "id": "wing",
+        "name": "the wings",
+        "crit_mult": { "all": 0.75 },
+        "difficulty": { "ranged": 2, "melee": 1 },
+        "coverage_mult": { "point": 0.25 },
+        "effects": [ { "effect": "staggered", "chance": 15, "message": "The %s is knocked off-balance!", "damage_required": [ 10, 100 ] } ],
+        "coverage": 12
+      }
+    ],
+    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_wp_demihuman", "prof_wp_basic_bird" ],
+    "harvest": "demihuman",
+    "special_attacks": [
+      [ "SHRIEK_ALERT", 15 ],
+      {
+        "type": "monster_attack",
+        "attack_type": "melee",
+        "id": "feral_ravenfolk_peck",
+        "cooldown": 15,
+        "move_cost": 100,
+        "damage_max_instance": [ { "damage_type": "stab", "amount": 12, "armor_penetration": 8 } ],
+        "hitsize_min": 4,
+        "hit_dmg_u": "%1$s buries its beak in your %2$s!",
+        "hit_dmg_npc": "%1$s buries its beak in <npcname>!",
+        "miss_msg_u": "%1$s tries to peck you, but you dodge!",
+        "miss_msg_npc": "%1$s tries to peck <npcname>, but they dodge!",
+        "no_dmg_msg_u": "%1$s tries to peck your %2$s, but fails to penetrate your armor.",
+        "no_dmg_msg_npc": "%1$s tries to peck <npcname>, but fails to penetrate their armor."
+      },
+      {
+        "id": "scratch",
+        "attack_upper": true,
+        "cooldown": 2,
+        "damage_max_instance": [ { "damage_type": "cut", "amount": 8 } ]
+      },
+      { "type": "leap", "cooldown": 15, "max_range": 6, "message": "%1$s leaps with a flutter of wings!" }
+    ],
+    "vision_day": 35,
+    "death_drops": "feral_ravenfolk_death_drops",
+    "upgrades": { "half_life": 90, "into_group": "GROUP_ZOMBIE_RAVENFOLK_UPGRADE" }
+  },
+  {
+    "id": "mon_zombie_lizardfolk",
+    "copy-from": "mon_zombie",
+    "type": "MONSTER",
+    "name": { "str_sp": "zombie lizardfolk" },
+    "description": "A proud servant of dragons reduced to a walking corpse, this lizardfolk's scales are streaked with grime and its black eyes burn with rage.  It has not lost its teeth and claws in the transition to undeath.",
+    "species": [ "LIZARDFOLK" ],
+    "volume": "80 L",
+    "weight": "100 kg",
+    "weakpoint_sets": [ "wps_humanoid_body" ],
+    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_wp_demihuman" ],
+    "armor": { "bash": 3, "cut": 4, "stab": 4, "bullet": 2 },
+    "harvest": "lizardfolk",
+    "//": "No grab--they have multiple natural weapons so they just attack",
+    "special_attacks": [
+      [ "PARROT", 400 ],
+      [ "PARROT_AT_DANGER", 0 ],
+      {
+        "id": "scratch",
+        "attack_upper": true,
+        "cooldown": 1,
+        "condition": { "not": { "u_has_effect": "maimed_arm" } },
+        "damage_max_instance": [ { "damage_type": "cut", "amount": 11 } ]
+      },
+      {
+        "type": "monster_attack",
+        "attack_type": "melee",
+        "id": "lizardfolk_zombie_bite",
+        "cooldown": 10,
+        "move_cost": 200,
+        "range": 1,
+        "//": "With their long muzzles lizardfolk can bite without grabbing, but it's still a little awkward, hence the move cost.",
+        "damage_max_instance": [ { "damage_type": "stab", "amount": 15 } ],
+        "min_mul": 0.3,
+        "hit_dmg_u": "%1$s's lunges forward, and its teeth sink into your %2$s!",
+        "hit_dmg_npc": "%1$s's lunges forward, and its teeth sink into <npcname>!",
+        "no_dmg_msg_u": "%1$s's lunges at your %2$s, but its teeth glance off your armor.",
+        "no_dmg_msg_npc": "%1$s's lunges at <npcname>, but its teeth glance off their armor.",
+        "miss_msg_u": "%s lunges forward to bite you, but you dodge!",
+        "miss_msg_npc": "%s lunges forward to bite <npcname>, but they dodge!"
+      }
+    ],
+    "death_drops": "feral_lizardfolk_death_drops",
+    "upgrades": { "half_life": 30, "into_group": "GROUP_ZOMBIE_LIZARDFOLK_UPGRADE" }
   }
 ]

--- a/data/mods/Magiclysm/snippets/monster_parrots.json
+++ b/data/mods/Magiclysm/snippets/monster_parrots.json
@@ -59,5 +59,23 @@
       "str": "\"Ogthrod ai'f geb'l-ee'h 'ngah'ng ai'y zhro!\""
     },
     "volume": 20
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_zombie_dwarf", "mon_zombie_elf", "mon_zombie_goblin", "mon_zombie_ravenfolk", "mon_zombie_lizardfolk" ],
+    "sound": "wheezing.",
+    "volume": 10
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_zombie_dwarf", "mon_zombie_elf", "mon_zombie_goblin", "mon_zombie_lizardfolk" ],
+    "sound": "moaning.",
+    "volume": 20
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_zombie_ravenfolk" ],
+    "sound": "screeching.",
+    "volume": 20
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Magiclysm] Fantasy species zombies"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Elves, ravenfolk, dwarves, etc. were a normal part of life before the Cataclysm, and they should be reflected in the zombie population.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add zombie versions of elves, dwarves, goblins, ravenfolk, and lizardfolk. Elves and dwarves are mostly like existing zombies (elves are faster and quieter, dwarves are tough zombies but smaller), but the others have special considerations (natural weapons, wings, etc) that will probably change up the early game quite a bunch. 

Add special upgrade groups for the zombie species. Zombie elves are more likely to become runners and go down the predator line, zombie lizardfolk are more likely to become bone zombies, goblins become the various non-human-looking child zombie variants, etc. Once they start mutating, the initial distinctions don't matter that much.

Make sure feral elves, etc., zombify into the appropriate type of zombies.

Make the goblins in the villages zombify (they currently do not). 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Zombies appear in cities and behave appropriately.  Spawned a bunch of them and did the teleport in, teleport away and advance time, teleport back dance--they upgraded (zombie elves turned into a bunch of predators and weird spindly-limbed monsters. Ew). 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

No, I am not going to call them "zelves", "zoblins", etc.

Ideally there would be completely separate zombie types for elves, lizardfolk, etc. vs humans, but that would be a ridiculous amount of work and require months of balance. Maybe we'll get there eventually.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
