### PR TITLE
[XEDRA Evolved] Gracken Self-Defense

### DIFF
--- a/data/mods/Xedra_Evolved/monsters/monster.json
+++ b/data/mods/Xedra_Evolved/monsters/monster.json
@@ -555,5 +555,12 @@
     "flags": [ "SEES", "HEARS", "NO_BREATHE", "SMELLS" ],
     "vision_day": 9,
     "vision_night": 9
+  },
+  {
+    "id": "mon_gracke",
+    "type": "MONSTER",
+    "copy-from": "mon_gracke",
+    "name": { "str": "gracken" },
+    "anger_triggers": [ "HURT" ]
   }
 ]


### PR DESCRIPTION


#### Summary
Mods "[XEDRA Evolved] Make grackens be able to try defending themselves."


#### Purpose of change

I got the idea when i was playing as a gracken with XE and how they aren't as violence-averse as the basegame equivalent. I proposed the idea to Maleclypse and get the approval to make them be able to defend themselves.

#### Describe the solutions
Give `"anger_triggers": [ "HURT" ]` to gracken json through copy-from.
#### Describe alternatives you've considered

Adding it to base game, though considering the reaction i got when i propose the idea in the Devcord, i decided not to.

#### Testing

![Screenshot_20240916_174532_1](https://github.com/user-attachments/assets/d7f1064d-2f92-4124-9f56-d796f0e9c633)


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
