### PR TITLE
Martial Mastery: Nerf Insight Stacking from Sixth Sense

### DIFF
--- a/data/mods/Perk_melee/EOC/Insight_eocs.json
+++ b/data/mods/Perk_melee/EOC/Insight_eocs.json
@@ -8,10 +8,12 @@
     },
     "effect": [
       {
-        "if": { "u_has_flag": "MELEE_PERK_SIXTH_SENSE" },
+        "if": {
+          "and": [ { "u_has_flag": "MELEE_PERK_SIXTH_SENSE" }, { "math": [ "u_effect_intensity('perk_insight')", "<", "20" ] } ]
+        },
         "then": [
           {
-            "if": { "math": [ "u_monsters_nearby('radius': 20)", ">", "0" ] },
+            "if": { "math": [ "u_monsters_nearby('radius': 15)", ">", "0" ] },
             "then": [ { "run_eoc_with": "EOC_GAIN_INSIGHT", "beta_talker": "avatar" } ]
           }
         ],
@@ -66,8 +68,8 @@
     "shape": "blast",
     "valid_targets": [ "hostile" ],
     "flags": [ "RANDOM_CRITTER", "RANDOM_TARGET", "NO_EXPLOSION_SFX", "SILENT" ],
-    "min_range": 20,
-    "max_range": 20,
+    "min_range": 15,
+    "max_range": 15,
     "effect": "effect_on_condition",
     "effect_str": "EOC_GAIN_INSIGHT"
   },
@@ -77,7 +79,7 @@
     "effect": [
       {
         "if": {
-          "or": [ { "npc_has_flag": "MELEE_PERK_INSIGHT_INFINITE" }, { "math": [ "n_effect_intensity('perk_insight')", "<", "19" ] } ]
+          "or": [ { "npc_has_flag": "MELEE_PERK_INSIGHT_INFINITE" }, { "math": [ "n_effect_intensity('perk_insight')", "<", "20" ] } ]
         },
         "then": [
           {

--- a/data/mods/Perk_melee/perks.json
+++ b/data/mods/Perk_melee/perks.json
@@ -78,7 +78,7 @@
     "id": "MELEE_PERK_SIXTH_SENSE",
     "copy-from": "MELEE_PERK_BASE",
     "name": { "str": "Sixth Sense" },
-    "description": "You accumulate insight stacks even from enemies you can't see.  You can perceive unseen enemies within 10 tiles if you have at least 5 insight stacks.",
+    "description": "You accumulate up to 20 insight stacks even from enemies you can't see.  You can perceive unseen enemies within 10 tiles if you have at least 5 insight stacks.",
     "flags": "MELEE_PERK_SIXTH_SENSE",
     "enchantments": [ "melee_perk_ench_six_sense" ]
   },


### PR DESCRIPTION
#### Summary
Mods "Martial Mastery: Nerf Insight Stacking from Sixth Sense"

#### Purpose of change
Fix: #76533 by limiting the ease with which insight stacks when you have Sixth Sense.

#### Describe the solution
Sixth Sense now can only give you up to twenty insight stacks. Fixing the bug where you could wait near an unreachable enemy to stack hundreds of thousands of insight stacks and then use those to clear entire towns using Twilight Form.

I have also reduced the range of insight stacking to 15 tiles.  The insight clear still checks for enemies within 20 tiles.

#### Describe alternatives you've considered
Tried to start with light nerfs.

#### Testing
Waited around unseen foes.
