### PR TITLE
Binoculars now also increase "detailed" vision range, not only max vision range

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -12691,7 +12691,6 @@ void game::update_overmap_seen()
 {
     const tripoint_abs_omt ompos = u.global_omt_location();
     const int dist = u.overmap_modified_sight_range( light_level( u.posz() ) );
-    const int base_sight = u.overmap_sight_range( light_level( u.posz() ) );
     const int dist_squared = dist * dist;
     // We can always see where we're standing
     overmap_buffer.set_seen( ompos, om_vision_level::full );
@@ -12728,11 +12727,11 @@ void game::update_overmap_seen()
             } while( seen.z() >= 0 );
         };
         int tiles_from = rl_dist( p, ompos );
-        if( tiles_from < std::floor( base_sight / 2 ) ) {
+        if( tiles_from < std::floor( dist / 2 ) ) {
             set_seen( p, om_vision_level::full );
-        } else if( tiles_from < base_sight ) {
+        } else if( tiles_from < dist ) {
             set_seen( p, om_vision_level::details );
-        } else if( tiles_from < base_sight * 2 ) {
+        } else if( tiles_from < dist * 2 ) {
             set_seen( p, om_vision_level::outlines );
         } else {
             set_seen( p, om_vision_level::vague );


### PR DESCRIPTION
#### Summary
Features "Binoculars now also increase 'detailed' vision range, not only max vision range"

#### Purpose of change
* Closes #75950.

#### Describe the solution
Update overmap details based on modified sight range (if any) rather than on base vision range.

#### Describe alternatives you've considered
None.

#### Testing
Stood rather far away from some city building, so that I can only see outlines. Traveled to that building, checked distance at which I start to see details of it with and without change from this PR.

#### Additional context
Initial disposition
![333333333333333333](https://github.com/user-attachments/assets/79cc2d59-af48-4083-a7e8-e9bcca4c9351)

Pre-change
![11111111111111111](https://github.com/user-attachments/assets/362caf32-301b-488d-8742-8c579b8a5038)

Post-change
![44444444444444](https://github.com/user-attachments/assets/f6ffd432-a470-458c-a073-568a72a5eaa6)