### PR TITLE
Bows don't accept ergonomic grip

### DIFF
--- a/data/json/items/gunmod/grip.json
+++ b/data/json/items/gunmod/grip.json
@@ -36,7 +36,7 @@
     "symbol": ":",
     "color": "dark_gray",
     "location": "grip",
-    "mod_targets": [ "smg", "rifle", "pistol", "shotgun", "crossbow", "launcher", "bow" ],
+    "mod_targets": [ "smg", "rifle", "pistol", "shotgun", "crossbow", "launcher" ],
     "handling_modifier": 2,
     "min_skills": [ [ "weapon", 2 ] ]
   },


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Judging by its `id` (`pistol_grip`), ergonomic grip is a set of forend and pistol handle for two-handed shoulder-rested weapons which lack such handle, like this:
![PISTOL_GRIP_LSIDE_BLACKLAMMONTE-scaled](https://github.com/user-attachments/assets/2af5a5e3-aede-4c73-b697-25d0a2edce9a)

It's obviously not intended to be used on bows. 
Also, bows (i.e. weapons with `RELOAD_AND_SHOOT` flag) don't benefit from any mod improving `handling_modifier`.

* Closes #75754.

#### Describe the solution
Removed 'bow' from 'mod_targets' of ergonomic grip.

#### Describe alternatives you've considered
None.

#### Testing
None, obvious json change.

#### Additional context
Maybe pistols should be removed from `mod_targets` of this mod too? They already have pistol grip, after all.