### PR TITLE
Replace activity `ACT_PICKUP_MENU` with `uistate.open_menu`

### DIFF
--- a/data/json/player_activities.json
+++ b/data/json/player_activities.json
@@ -918,15 +918,6 @@
     "can_resume": false
   },
   {
-    "id": "ACT_PICKUP_MENU",
-    "type": "activity_type",
-    "activity_level": "NO_EXERCISE",
-    "verb": "picking up",
-    "rooted": true,
-    "based_on": "neither",
-    "can_resume": false
-  },
-  {
     "id": "ACT_CONSUME_FOOD_MENU",
     "type": "activity_type",
     "activity_level": "NO_EXERCISE",

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -156,7 +156,6 @@ static const activity_id ACT_MULTIPLE_CHOP_TREES( "ACT_MULTIPLE_CHOP_TREES" );
 static const activity_id ACT_OPEN_GATE( "ACT_OPEN_GATE" );
 static const activity_id ACT_OXYTORCH( "ACT_OXYTORCH" );
 static const activity_id ACT_PICKUP( "ACT_PICKUP" );
-static const activity_id ACT_PICKUP_MENU( "ACT_PICKUP_MENU" );
 static const activity_id ACT_PLAY_WITH_PET( "ACT_PLAY_WITH_PET" );
 static const activity_id ACT_PRYING( "ACT_PRYING" );
 static const activity_id ACT_PULP( "ACT_PULP" );
@@ -6347,36 +6346,6 @@ std::unique_ptr<activity_actor> invoke_item_activity_actor::deserialize( JsonVal
     return actor.clone();
 }
 
-void pickup_menu_activity_actor::do_turn( player_activity &, Character &who )
-{
-    std::optional<tripoint_bub_ms> p( where );
-    std::vector<drop_location> s( selection );
-    who.cancel_activity();
-    who.pick_up( game_menus::inv::pickup( p, s ) );
-}
-
-void pickup_menu_activity_actor::serialize( JsonOut &jsout ) const
-{
-    jsout.start_object();
-
-    jsout.member( "where", where );
-    jsout.member( "selection", selection );
-
-    jsout.end_object();
-}
-
-std::unique_ptr<activity_actor> pickup_menu_activity_actor::deserialize( JsonValue &jsin )
-{
-    pickup_menu_activity_actor actor( {}, {} );
-
-    JsonObject data = jsin.get_object();
-
-    data.read( "where", actor.where );
-    data.read( "selection", actor.selection );
-
-    return actor.clone();
-}
-
 static void chop_single_do_turn( player_activity &act )
 {
     const map &here = get_map();
@@ -8223,7 +8192,6 @@ deserialize_functions = {
     { ACT_OPEN_GATE, &open_gate_activity_actor::deserialize },
     { ACT_OXYTORCH, &oxytorch_activity_actor::deserialize },
     { ACT_PICKUP, &pickup_activity_actor::deserialize },
-    { ACT_PICKUP_MENU, &pickup_menu_activity_actor::deserialize },
     { ACT_PLAY_WITH_PET, &play_with_pet_activity_actor::deserialize },
     { ACT_PRYING, &prying_activity_actor::deserialize },
     { ACT_PULP, &pulp_activity_actor::deserialize },

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -1839,32 +1839,6 @@ class invoke_item_activity_actor : public activity_actor
         std::string method;
 };
 
-class pickup_menu_activity_actor : public activity_actor
-{
-    public:
-        pickup_menu_activity_actor( std::optional<tripoint> where,
-                                    std::vector<drop_location> selection ) : where( where ),
-            selection( std::move( selection ) ) {};
-        activity_id get_type() const override {
-            return activity_id( "ACT_PICKUP_MENU" );
-        }
-
-        void start( player_activity &, Character & ) override {};
-        void do_turn( player_activity &, Character &who ) override;
-        void finish( player_activity &, Character & ) override {};
-
-        std::unique_ptr<activity_actor> clone() const override {
-            return std::make_unique<pickup_menu_activity_actor>( *this );
-        }
-
-        void serialize( JsonOut & ) const override;
-        static std::unique_ptr<activity_actor> deserialize( JsonValue & );
-
-    private:
-        std::optional<tripoint> where;
-        std::vector<drop_location> selection;
-};
-
 class chop_logs_activity_actor : public activity_actor
 {
     public:

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -3023,6 +3023,8 @@ bool game::handle_action()
         player_character.start_destination_activity();
         return false;
     } else if( uistate.open_menu ) {
+        // make a copy so that uistate.open_menu can be assigned a new function
+        // during the execution of the copied old function
         std::optional<std::function<void()>> open_menu_tmp = std::nullopt;
         std::swap( uistate.open_menu, open_menu_tmp );
         open_menu_tmp.value()();

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -13,6 +13,7 @@
 #include "debug.h"
 #include "enums.h"
 #include "flag.h"
+#include "game_inventory.h"
 #include "inventory.h"
 #include "input.h"
 #include "item.h"
@@ -4246,7 +4247,7 @@ bool pickup_selector::wield( int &count )
 
     if( u.can_wield( *it ).success() ) {
         remove_from_to_use( it );
-        add_reopen_activity();
+        reopen_menu();
         u.assign_activity( wield_activity_actor( it, charges ) );
         return true;
     } else {
@@ -4268,7 +4269,7 @@ bool pickup_selector::wear()
 
     if( u.can_wear( *items.front() ).success() ) {
         remove_from_to_use( items.front() );
-        add_reopen_activity();
+        reopen_menu();
         u.assign_activity( wear_activity_actor( items, quantities ) );
         return true;
     } else {
@@ -4278,10 +4279,12 @@ bool pickup_selector::wear()
     return false;
 }
 
-void pickup_selector::add_reopen_activity()
+void pickup_selector::reopen_menu()
 {
-    u.assign_activity( pickup_menu_activity_actor( where, to_use ) );
-    u.activity.auto_resume = true;
+    // copy the member variables to still be valid on call
+    uistate.open_menu = [where = where, to_use = to_use]() {
+        get_player_character().pick_up( game_menus::inv::pickup( where, to_use ) );
+    };
 }
 
 void pickup_selector::remove_from_to_use( item_location &it )

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -1057,7 +1057,7 @@ class pickup_selector : public inventory_multiselector
         bool wield( int &count );
         bool wear();
         void remove_from_to_use( item_location &it );
-        void add_reopen_activity();
+        void reopen_menu();
         const std::optional<tripoint> where;
 };
 

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -48,7 +48,6 @@ static const activity_id ACT_JACKHAMMER( "ACT_JACKHAMMER" );
 static const activity_id ACT_MIGRATION_CANCEL( "ACT_MIGRATION_CANCEL" );
 static const activity_id ACT_NULL( "ACT_NULL" );
 static const activity_id ACT_PICKAXE( "ACT_PICKAXE" );
-static const activity_id ACT_PICKUP_MENU( "ACT_PICKUP_MENU" );
 static const activity_id ACT_READ( "ACT_READ" );
 static const activity_id ACT_SPELLCASTING( "ACT_SPELLCASTING" );
 static const activity_id ACT_TRAVELLING( "ACT_TRAVELLING" );
@@ -147,8 +146,7 @@ std::optional<std::string> player_activity::get_progress_message( const avatar &
         type == ACT_CONSUME_FOOD_MENU ||
         type == ACT_CONSUME_MEDS_MENU ||
         type == ACT_EAT_MENU ||
-        type == ACT_INVOKE_ITEM ||
-        type == ACT_PICKUP_MENU
+        type == ACT_INVOKE_ITEM
       ) {
         return std::nullopt;
     }

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -369,6 +369,7 @@ void player_activity::deserialize( const JsonObject &data )
 
     bool is_obsolete = false;
     std::set<std::string> obs_activities {
+        "ACT_PICKUP_MENU", // Remove after 0.I
         "ACT_VIEW_RECIPE", // Remove after 0.I
         "ACT_ADV_INVENTORY" // Remove after 0.I
     };


### PR DESCRIPTION
#### Summary
Infrastructure "Replace activity `ACT_PICKUP_MENU` with `uistate.open_menu`"

#### Purpose of change

 - Continue with #76490.
- Reducing code complexity.

#### Describe the solution

1. Replace activity `ACT_PICKUP_MENU` with `uistate.open_menu`. Copy member variables for the lambda.
2. Migration for activity.

#### Side effect

The pickup menu doesn't open when it should after the save/load cycle if autosave is triggered during the "return to pickup menu" activity - see testing. This is fine. I prefer it.

#### Describe alternatives you've considered

N/A

#### Testing

**Test reopening menu still works:**
I tried wearing and wielding various things. The menu reopened as it should. Nothing else triggers reopening, so nothing else needs to be tested.


**Test migration**
What I did:

1. Load the save in the old version.
4. Set the saving interval to 0 min and save after 10 actions.
5. Open Pick up menu.
7. `w`ield blade or something. (repeat 10 times)
   - Drop what I have in hand on the floor, when asked.
   - The autosave will save during the activity.
9. alt+F4

There is the save:
[TEST migration AIM & VIEW.zip](https://github.com/user-attachments/files/17089629/TEST.migration.AIM.VIEW.zip)

Note it has `ACT_PICKUP` in it in the .sav file

On master:
1. Load save.
2. It opens the Pickup menu after loading.

In the new version:
1. Load save.
2. Pickup menu doesn't open and the game doesn't complain about missing `ACT_PICKUP`. It also doesn't endlessly perform `THIS IS A BUG` activity.

#### Future

 - Maybe the four activities `ACT_EAT_MENU` and `ACT_CONSUME_*_MENU` could be next. It has some logic, unlike this one.
 - There is also an ATM activity I should investigate.
 - Apart from those there seem to be no more activities that could be changed to `uistate.open_menu`. Let me know if that is not true!

#### Additional context


Unlike AIM, there is no in-game one-second time savings, as the menu was reopened with an activity only when the player was already performing an activity. Activities don't waste an additional turn for each activity on the stack, only one turn is wasted in total.
