### PR TITLE
Actually check if faction is lone wolf instead of "no_faction" ID

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -276,8 +276,6 @@ static const efftype_id effect_tied( "tied" );
 static const efftype_id effect_transition_contacts( "transition_contacts" );
 static const efftype_id effect_winded( "winded" );
 
-static const faction_id faction_no_faction( "no_faction" );
-
 static const fault_id fault_bionic_salvaged( "fault_bionic_salvaged" );
 
 static const field_type_str_id field_fd_clairvoyant( "fd_clairvoyant" );
@@ -11901,7 +11899,7 @@ bool Character::add_faction_warning( const faction_id &id ) const
         warning_record[id] = std::make_pair( 1, calendar::turn );
     }
     faction *fac = g->faction_manager_ptr->get( id );
-    if( fac != nullptr && is_avatar() && fac->id != faction_no_faction ) {
+    if( fac != nullptr && is_avatar() && !fac->lone_wolf_faction ) {
         fac->likes_u -= 1;
         fac->respects_u -= 1;
         fac->trusts_u -= 1;

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1642,7 +1642,7 @@ void npc::make_angry()
     }
 
     // Make associated faction, if any, angry at the player too.
-    if( my_fac && my_fac->id != faction_no_faction && my_fac->id != faction_amf ) {
+    if( my_fac && !my_fac->lone_wolf_faction && my_fac->id != faction_amf ) {
         my_fac->likes_u = std::min( -15, my_fac->likes_u - 5 );
         my_fac->respects_u = std::min( -15, my_fac->respects_u - 5 );
         my_fac->trusts_u = std::min( -15, my_fac->trusts_u - 5 );

--- a/src/talker_npc.cpp
+++ b/src/talker_npc.cpp
@@ -48,8 +48,6 @@ static const efftype_id effect_narcosis( "narcosis" );
 static const efftype_id effect_npc_suspend( "npc_suspend" );
 static const efftype_id effect_sleep( "sleep" );
 
-static const faction_id faction_no_faction( "no_faction" );
-
 static const itype_id itype_foodperson_mask( "foodperson_mask" );
 static const itype_id itype_foodperson_mask_on( "foodperson_mask_on" );
 
@@ -562,7 +560,7 @@ void talker_npc::set_fac( const faction_id &new_fac_name )
 
 void talker_npc::add_faction_rep( const int rep_change )
 {
-    if( me_npc->get_faction()-> id != faction_no_faction ) {
+    if( !me_npc->get_faction()->lone_wolf_faction ) {
         me_npc->get_faction()->likes_u += rep_change;
         me_npc->get_faction()->respects_u += rep_change;
         me_npc->get_faction()->trusts_u += rep_change;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
It was brought to my attention that `lone_wolf_faction` is never actually used

#### Describe the solution
Properly check if the faction is tagged as lone_wolf_faction instead of just checking against the static no_faction ID

#### Describe alternatives you've considered


#### Testing
Needs testing, hasn't been tested. Hence draft

#### Additional context

